### PR TITLE
fix(kanban): harden runtime recovery and worker startup

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -406,12 +406,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_edit = sub.add_parser(
         "edit",
-        help="Edit recovery fields on an already-completed task",
+        help="Edit recovery fields on a task",
     )
     p_edit.add_argument("task_id")
     p_edit.add_argument(
         "--result",
-        required=True,
+        default=None,
         help="Backfilled task result text for a done task",
     )
     p_edit.add_argument(
@@ -423,6 +423,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--metadata",
         default=None,
         help="JSON dict of structured facts to store on the latest completed run.",
+    )
+    p_edit.add_argument(
+        "--clear-skills",
+        action="store_true",
+        help="Clear persisted task skills on a non-running task.",
+    )
+    p_edit.add_argument(
+        "--reset-failures",
+        action="store_true",
+        help="Reset consecutive failure counter and last failure error.",
+    )
+    p_edit.add_argument(
+        "--clear-claim",
+        action="store_true",
+        help="Clear persisted claim fields on a non-running task.",
     )
 
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
@@ -1578,6 +1593,81 @@ def _cmd_complete(args: argparse.Namespace) -> int:
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:
+    recovery_flags = sum(bool(x) for x in [
+        getattr(args, "clear_skills", False),
+        getattr(args, "reset_failures", False),
+        getattr(args, "clear_claim", False),
+    ])
+    if recovery_flags > 1:
+        print(
+            "kanban: edit accepts at most one recovery action flag "
+            "(--clear-skills, --reset-failures, or --clear-claim)",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "clear_skills", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --clear-skills cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "reset_failures", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --reset-failures cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "clear_claim", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --clear-claim cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if not (
+        getattr(args, "clear_skills", False)
+        or getattr(args, "reset_failures", False)
+        or getattr(args, "clear_claim", False)
+    ) and args.result is None:
+        print("kanban: edit requires --result or a recovery action flag", file=sys.stderr)
+        return 2
+    if getattr(args, "reset_failures", False):
+        with kb.connect() as conn:
+            if not kb.reset_task_failures(conn, args.task_id):
+                print(f"cannot edit {args.task_id} (unknown id)", file=sys.stderr)
+                return 1
+        print(f"Edited {args.task_id}")
+        return 0
+    if getattr(args, "clear_claim", False):
+        with kb.connect() as conn:
+            ok = kb.edit_task_recovery_fields(
+                conn,
+                args.task_id,
+                clear_claim=True,
+            )
+            if not ok:
+                print(
+                    f"cannot clear claim on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
+        print(f"Edited {args.task_id}")
+        return 0
     raw_meta = getattr(args, "metadata", None)
     metadata = None
     if raw_meta:
@@ -1589,13 +1679,29 @@ def _cmd_edit(args: argparse.Namespace) -> int:
             print(f"kanban: --metadata: {exc}", file=sys.stderr)
             return 2
     with kb.connect() as conn:
-        if not kb.edit_completed_task_result(
+        if not kb.edit_task_recovery_fields(
             conn,
             args.task_id,
             result=args.result,
             summary=getattr(args, "summary", None),
             metadata=metadata,
+            clear_skills=bool(getattr(args, "clear_skills", False)),
+            clear_claim=bool(getattr(args, "clear_claim", False)),
         ):
+            if getattr(args, "clear_skills", False):
+                print(
+                    f"cannot clear skills on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
+            if getattr(args, "clear_claim", False):
+                print(
+                    f"cannot clear claim on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
             print(
                 f"cannot edit {args.task_id} (unknown id or task is not done)",
                 file=sys.stderr,
@@ -1698,6 +1804,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_invalid_skills": res.skipped_invalid_skills,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -1721,6 +1828,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.skipped_invalid_skills:
+        print(
+            f"Skipped (invalid task skills): "
+            f"{', '.join(res.skipped_invalid_skills)}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -727,6 +727,19 @@ class Run:
         )
 
 
+@dataclass(frozen=True)
+class WorkerStartupGuard:
+    """Read-only startup validation for dispatcher-spawned workers."""
+
+    allowed: bool
+    reason: Optional[str] = None
+    task_id: Optional[str] = None
+    run_id: Optional[int] = None
+    status: Optional[str] = None
+    current_run_id: Optional[int] = None
+    claim_lock: Optional[str] = None
+
+
 @dataclass
 class Comment:
     id: int
@@ -2185,6 +2198,80 @@ def reclaim_task(
     return True
 
 
+def check_worker_startup_guard(
+    conn: sqlite3.Connection,
+    *,
+    task_id: Optional[str],
+    expected_run_id: Optional[int],
+    expected_claim_lock: Optional[str],
+) -> WorkerStartupGuard:
+    """Validate that a dispatcher-spawned worker still owns its task."""
+    if not task_id:
+        return WorkerStartupGuard(False, reason="missing_task_id")
+
+    row = conn.execute(
+        "SELECT id, status, current_run_id, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return WorkerStartupGuard(False, reason="task_missing", task_id=task_id)
+
+    status = row["status"]
+    current_run_id = (
+        int(row["current_run_id"]) if row["current_run_id"] is not None else None
+    )
+    claim_lock = row["claim_lock"]
+
+    if status != "running":
+        return WorkerStartupGuard(
+            False,
+            reason=f"task_not_running:{status}",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if expected_run_id is not None and current_run_id != int(expected_run_id):
+        return WorkerStartupGuard(
+            False,
+            reason="run_mismatch",
+            task_id=task_id,
+            run_id=int(expected_run_id),
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if expected_claim_lock is None:
+        return WorkerStartupGuard(
+            False,
+            reason="missing_claim_lock",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if claim_lock != expected_claim_lock:
+        return WorkerStartupGuard(
+            False,
+            reason="claim_mismatch",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    return WorkerStartupGuard(
+        True,
+        task_id=task_id,
+        run_id=expected_run_id,
+        status=status,
+        current_run_id=current_run_id,
+        claim_lock=claim_lock,
+    )
+
+
 def reassign_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2514,21 +2601,102 @@ def complete_task(
     return True
 
 
-def edit_completed_task_result(
+def edit_task_recovery_fields(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    result: str,
+    result: Optional[str] = None,
     summary: Optional[str] = None,
     metadata: Optional[dict] = None,
+    clear_skills: bool = False,
+    clear_claim: bool = False,
 ) -> bool:
-    """Backfill the user-visible result for an already completed task."""
+    """Edit narrow recovery fields on a task."""
+    if not clear_skills and not clear_claim and result is None:
+        raise ValueError(
+            "result is required unless clear_skills=True or clear_claim=True"
+        )
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+            "SELECT status, claim_lock, claim_expires, worker_pid, current_run_id "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
-        if not row or row["status"] != "done":
+        if not row:
+            return False
+        if clear_claim:
+            if row["status"] == "running":
+                return False
+            had_claim_state = not (
+                row["claim_lock"] is None
+                and row["claim_expires"] is None
+                and row["worker_pid"] is None
+                and row["current_run_id"] is None
+            )
+            if not had_claim_state:
+                return True
+            run_id = row["current_run_id"]
+            if run_id is not None:
+                run_row = conn.execute(
+                    "SELECT status, outcome FROM task_runs WHERE id = ?",
+                    (int(run_id),),
+                ).fetchone()
+                if (
+                    run_row is not None
+                    and run_row["status"] == "running"
+                    and run_row["outcome"] is None
+                ):
+                    _end_run(
+                        conn, task_id,
+                        outcome="reclaimed", status="reclaimed",
+                        error="operator_clear_claim",
+                    )
+            conn.execute(
+                "UPDATE tasks SET claim_lock = NULL, claim_expires = NULL, "
+                "worker_pid = NULL, last_heartbeat_at = NULL, "
+                "current_run_id = NULL WHERE id = ?",
+                (task_id,),
+            )
+            _append_event(
+                conn, task_id, "edited",
+                {
+                    "fields": [
+                        "claim_lock",
+                        "claim_expires",
+                        "worker_pid",
+                        "last_heartbeat_at",
+                        "current_run_id",
+                    ],
+                    "claim_cleared": True,
+                },
+                run_id=run_id,
+            )
+            return True
+        if clear_skills:
+            if row["status"] == "running":
+                return False
+            run_id = None
+            if row["status"] == "done":
+                run = conn.execute(
+                    """
+                    SELECT id FROM task_runs
+                     WHERE task_id = ?
+                       AND outcome = 'completed'
+                     ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
+                     LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                run_id = int(run["id"]) if run else None
+            conn.execute("UPDATE tasks SET skills = NULL WHERE id = ?", (task_id,))
+            _append_event(
+                conn, task_id, "edited",
+                {"fields": ["skills"], "skills_cleared": True},
+                run_id=run_id,
+            )
+            return True
+        if row["status"] != "done":
             return False
         conn.execute(
             "UPDATE tasks SET result = ? WHERE id = ?",
@@ -2579,6 +2747,26 @@ def edit_completed_task_result(
             run_id=run_id,
         )
     return True
+
+
+def edit_completed_task_result(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    result: Optional[str] = None,
+    summary: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    clear_skills: bool = False,
+) -> bool:
+    """Back-compat wrapper for the broader recovery-field editor."""
+    return edit_task_recovery_fields(
+        conn,
+        task_id,
+        result=result,
+        summary=summary,
+        metadata=metadata,
+        clear_skills=clear_skills,
+    )
 
 
 def block_task(
@@ -2911,6 +3099,9 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_invalid_skills: list[str] = field(default_factory=list)
+    """Ready task ids skipped because persisted ``task.skills`` contains
+    invalid toolset names."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -3627,6 +3818,31 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def reset_task_failures(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Clear a task's consecutive-failure counter as an operator recovery action."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 0, "
+            "last_failure_error = NULL WHERE id = ?",
+            (task_id,),
+        )
+        _append_event(
+            conn, task_id, "edited",
+            {
+                "fields": ["consecutive_failures", "last_failure_error"],
+                "failures_reset": True,
+            },
+            run_id=row["current_run_id"],
+        )
+        return True
+
+
 # Legacy alias for test-code and anything else that still imports it.
 _clear_spawn_failures = _clear_failure_counter
 
@@ -3774,6 +3990,16 @@ def dispatch_once(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        task = get_task(conn, row["id"])
+        if task is not None:
+            invalid_skills = [
+                str(s).casefold()
+                for s in (task.skills or [])
+                if str(s).strip().casefold() in KNOWN_TOOLSET_NAMES
+            ]
+            if invalid_skills:
+                result.skipped_invalid_skills.append(row["id"])
+                continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -34,6 +34,8 @@ from typing import Any, Callable, Iterable, Optional
 import json
 import time
 
+from hermes_cli.kanban_db import KNOWN_TOOLSET_NAMES
+
 
 # Severity rungs, ordered least → most urgent. The UI colors them
 # amber (warning), orange (error), red (critical). Sorted outputs put
@@ -217,6 +219,17 @@ def _generic_recovery_actions(task: Any, *, running: bool) -> list[DiagnosticAct
         payload={"reclaim_first": running},
     ))
     return out
+
+
+def _profile_exists_safe(name: Optional[str]) -> Optional[bool]:
+    if not name:
+        return None
+    try:
+        from hermes_cli import profiles
+
+        return bool(profiles.profile_exists(name))
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -694,9 +707,138 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_invalid_task_skills(task, events, runs, now, cfg) -> list[Diagnostic]:
+    skills = _task_field(task, "skills") or []
+    if not skills:
+        return []
+    invalid = [s for s in skills if str(s).casefold() in KNOWN_TOOLSET_NAMES]
+    if not invalid:
+        return []
+    task_id = _task_field(task, "id") or "TASK_ID"
+    running = _task_field(task, "status") == "running"
+    actions: list[DiagnosticAction] = []
+    if not running:
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label=f"Clear invalid skills: hermes kanban edit {task_id} --clear-skills",
+            payload={"command": f"hermes kanban edit {task_id} --clear-skills"},
+            suggested=True,
+        ))
+    actions.append(DiagnosticAction(
+        kind="cli_hint",
+        label=f"Inspect task: hermes kanban show {task_id}",
+        payload={"command": f"hermes kanban show {task_id}"},
+    ))
+    actions.extend(_generic_recovery_actions(task, running=running))
+    return [Diagnostic(
+        kind="invalid_task_skills",
+        severity="error",
+        title="Task skills contain toolset names",
+        detail=(
+            "This task's skills list contains Hermes toolset names rather than "
+            "SKILL bundle names. Dispatcher-spawned workers forward task.skills "
+            "through `--skills ...`, so values like web/browser/terminal/file "
+            "eventually fail worker startup with unknown-skill errors."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=len(invalid),
+        data={"invalid_skills": invalid},
+    )]
+
+
+def _rule_assignee_profile_not_found(task, events, runs, now, cfg) -> list[Diagnostic]:
+    assignee = _task_field(task, "assignee")
+    status = _task_field(task, "status")
+    if not assignee or status not in ("triage", "todo", "ready", "running", "blocked"):
+        return []
+    exists = _profile_exists_safe(assignee)
+    if exists is not False:
+        return []
+    running = status == "running"
+    actions = [
+        DiagnosticAction(
+            kind="cli_hint",
+            label=f"Create profile: hermes profile create {assignee}",
+            payload={"command": f"hermes profile create {assignee}"},
+        ),
+    ]
+    actions.extend(_generic_recovery_actions(task, running=running))
+    if actions:
+        actions[-1].suggested = True
+    return [Diagnostic(
+        kind="assignee_profile_not_found",
+        severity="error",
+        title="Assigned profile does not exist",
+        detail=(
+            f"This task is assigned to profile '{assignee}', but Hermes "
+            "cannot resolve that profile on disk. Dispatcher-driven spawn "
+            "will skip or fail until the profile is created or the task is "
+            "reassigned."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=1,
+        data={"assignee": assignee},
+    )]
+
+
+def _rule_stale_running_claim(task, events, runs, now, cfg) -> list[Diagnostic]:
+    if _task_field(task, "status") != "running":
+        return []
+    claim_expires = _task_field(task, "claim_expires")
+    if claim_expires is None or int(claim_expires) >= now:
+        return []
+    task_id = _task_field(task, "id") or "TASK_ID"
+    age_seconds = max(0, now - int(claim_expires))
+    return [Diagnostic(
+        kind="stale_running_claim",
+        severity="critical",
+        title="Running task has an expired claim",
+        detail=(
+            "This task is still marked running, but its claim TTL has already "
+            "expired. The dispatcher normally reclaims expired claims on the "
+            "next tick; if it remains stuck, reclaim it manually and inspect "
+            "the worker log before retrying."
+        ),
+        actions=[
+            DiagnosticAction(
+                kind="reclaim",
+                label="Reclaim task",
+                payload={},
+                suggested=True,
+            ),
+            DiagnosticAction(
+                kind="cli_hint",
+                label=f"Check worker log: hermes kanban log {task_id}",
+                payload={"command": f"hermes kanban log {task_id}"},
+            ),
+            DiagnosticAction(
+                kind="reassign",
+                label="Reassign to different profile",
+                payload={"reclaim_first": True},
+            ),
+        ],
+        first_seen_at=int(claim_expires),
+        last_seen_at=now,
+        count=1,
+        data={
+            "claim_expires": int(claim_expires),
+            "age_seconds": age_seconds,
+            "worker_pid": _task_field(task, "worker_pid"),
+            "current_run_id": _task_field(task, "current_run_id"),
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
+    _rule_stale_running_claim,
+    _rule_invalid_task_skills,
+    _rule_assignee_profile_not_found,
     _rule_hallucinated_cards,
     _rule_prose_phantom_refs,
     _rule_repeated_failures,
@@ -709,6 +851,9 @@ _RULES: list[RuleFn] = [
 # Known kinds (for the UI's filter / legend / i18n keys). Update when
 # rules are added.
 DIAGNOSTIC_KINDS = (
+    "stale_running_claim",
+    "invalid_task_skills",
+    "assignee_profile_not_found",
     "hallucinated_cards",
     "prose_phantom_refs",
     "repeated_failures",

--- a/run_agent.py
+++ b/run_agent.py
@@ -100,6 +100,81 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()
 
+
+def _kanban_worker_startup_env() -> Optional[dict[str, Any]]:
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    if not task_id:
+        return None
+    run_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if not run_raw:
+        return {
+            "task_id": task_id,
+            "run_id": None,
+            "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+            "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+            "env_error": "missing_run_id",
+        }
+    try:
+        run_id: Optional[int] = int(run_raw)
+    except ValueError:
+        return {
+            "task_id": task_id,
+            "run_id": None,
+            "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+            "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+            "env_error": "invalid_run_id",
+        }
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+        "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+        "env_error": None,
+    }
+
+
+def _terminal_run_result(
+    agent,
+    *,
+    final_response: str,
+    turn_exit_reason: Optional[str],
+    completed: bool = False,
+    messages: Optional[list[dict[str, Any]]] = None,
+    api_calls: int = 0,
+    interrupted: bool = False,
+    response_previewed: bool = False,
+    partial: bool = False,
+    last_reasoning: Optional[str] = None,
+    last_prompt_tokens: int = 0,
+) -> dict[str, Any]:
+    """Build the standard run_conversation terminal result shape."""
+    return {
+        "final_response": final_response,
+        "last_reasoning": last_reasoning,
+        "messages": messages or [],
+        "api_calls": api_calls,
+        "completed": completed,
+        "turn_exit_reason": turn_exit_reason,
+        "partial": partial,
+        "interrupted": interrupted,
+        "response_previewed": response_previewed,
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "input_tokens": agent.session_input_tokens,
+        "output_tokens": agent.session_output_tokens,
+        "cache_read_tokens": agent.session_cache_read_tokens,
+        "cache_write_tokens": agent.session_cache_write_tokens,
+        "reasoning_tokens": agent.session_reasoning_tokens,
+        "prompt_tokens": agent.session_prompt_tokens,
+        "completion_tokens": agent.session_completion_tokens,
+        "total_tokens": agent.session_total_tokens,
+        "last_prompt_tokens": last_prompt_tokens,
+        "estimated_cost_usd": agent.session_estimated_cost_usd,
+        "cost_status": agent.session_cost_status,
+        "cost_source": agent.session_cost_source,
+    }
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -11523,6 +11598,58 @@ class AIAgent:
         # rejection and kept False for the rest of the session so we never re-send
         # images to a text-only endpoint.  Scoped per `_run()` call, not per instance.
         self._vision_supported = True
+
+        _kanban_startup = _kanban_worker_startup_env()
+        if _kanban_startup is not None:
+            if _kanban_startup.get("env_error"):
+                reason = str(_kanban_startup["env_error"])
+                return _terminal_run_result(
+                    self,
+                    final_response=(
+                        "Kanban worker startup skipped because worker ownership "
+                        f"metadata is invalid ({reason})."
+                    ),
+                    turn_exit_reason=f"kanban_startup_guard:{reason}",
+                    last_prompt_tokens=0,
+                )
+            try:
+                from hermes_cli import kanban_db as _kanban_db
+
+                db_path = _kanban_startup.get("db_path")
+                if db_path:
+                    conn = _kanban_db.connect(Path(db_path))
+                else:
+                    conn = _kanban_db.connect()
+                try:
+                    verdict = _kanban_db.check_worker_startup_guard(
+                        conn,
+                        task_id=_kanban_startup["task_id"],
+                        expected_run_id=_kanban_startup["run_id"],
+                        expected_claim_lock=_kanban_startup["claim_lock"],
+                    )
+                finally:
+                    conn.close()
+                if not verdict.allowed:
+                    logger.info(
+                        "Kanban startup guard skipped worker: task=%s reason=%s "
+                        "expected_run=%s current_run=%s status=%s",
+                        verdict.task_id,
+                        verdict.reason,
+                        verdict.run_id,
+                        verdict.current_run_id,
+                        verdict.status,
+                    )
+                    return _terminal_run_result(
+                        self,
+                        final_response=(
+                            "Kanban worker startup skipped because the task no longer "
+                            f"belongs to this worker ({verdict.reason})."
+                        ),
+                        turn_exit_reason=f"kanban_startup_guard:{verdict.reason}",
+                        last_prompt_tokens=0,
+                    )
+            except Exception:
+                logger.debug("kanban worker startup guard failed open", exc_info=True)
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -33,6 +33,16 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def profiles_resolve_by_default(monkeypatch):
+    """Most rule tests isolate one failure mode at a time.
+
+    Keep profile-existence diagnostics silent unless a test explicitly
+    overrides the helper to exercise that rule.
+    """
+    monkeypatch.setattr(kd, "_profile_exists_safe", lambda _name: True)
+
+
 def _task(**overrides):
     base = {
         "id": "t_demo00",

--- a/tests/run_agent/test_kanban_worker_startup_guard.py
+++ b/tests/run_agent/test_kanban_worker_startup_guard.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import run_agent
+from run_agent import AIAgent
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "description": "web_search tool",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_worker_startup_guard_exits_on_invalid_run_id(agent, kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_demo")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "not-an-int")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    result = agent.run_conversation("hello")
+
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] == "kanban_startup_guard:invalid_run_id"
+    assert "invalid" in result["final_response"].lower()
+
+
+def test_worker_startup_guard_exits_on_superseded_claim(agent, kanban_home, monkeypatch):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="startup-guard", assignee="worker")
+        first = kb.claim_task(conn, tid)
+        assert first is not None
+        run1 = first.current_run_id
+        lock1 = first.claim_lock
+        assert run1 is not None and lock1 is not None
+
+        assert kb.reclaim_task(conn, tid, reason="retry")
+        second = kb.claim_task(conn, tid)
+        assert second is not None
+        assert second.current_run_id is not None and second.current_run_id != run1
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run1))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", lock1)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    result = agent.run_conversation("hello")
+
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] == "kanban_startup_guard:run_mismatch"
+    assert "no longer belongs to this worker" in result["final_response"]
+
+
+def test_worker_startup_guard_allows_current_owner_to_continue(agent, kanban_home, monkeypatch):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="startup-guard", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        claim_lock = claimed.claim_lock
+        assert run_id is not None and claim_lock is not None
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_lock)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="OK", tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test/model",
+        usage=None,
+    )
+    agent.client.chat.completions.create.return_value = response
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["completed"] is True
+    assert result["api_calls"] == 1
+    assert result["final_response"] == "OK"


### PR DESCRIPTION
## What does this PR do?

This PR is a focused Kanban resubmission against current `main`.

After the earlier Kanban hardening work in #23334, `main` has since absorbed
many related Kanban PRs, including the create-time rejection path for toolset
names in `task.skills` and other dispatcher/runtime fixes. That made the older
stacked PR both partially superseded and broader than it needs to be now.

This PR intentionally narrows the scope and resubmits only the parts that still
add distinct value on top of current `main`:

- runtime diagnostics for persisted bad Kanban state
- narrow operator recovery commands
- worker startup ownership validation before any model API call

In other words, this is the reduced follow-up to #23334 after recent Kanban
changes landed separately on `main`.

## Related Issue

Related to #22925, #22926, #22927.

Follow-up to #23334.

This PR is a narrowed resubmission after recent Kanban merges on `main`
superseded part of the earlier stack.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add read-only diagnostics for persisted bad task state:
  - `invalid_task_skills`
  - `assignee_profile_not_found`
  - `stale_running_claim`
- Add narrow operator recovery commands:
  - `hermes kanban edit <task> --clear-skills`
  - `hermes kanban edit <task> --reset-failures`
  - `hermes kanban edit <task> --clear-claim`
- Teach dispatch to skip `ready` tasks whose persisted `task.skills` already
  contain toolset names, while leaving the task `ready` for operator recovery
- Add a read-only worker startup guard so dispatcher-spawned workers verify:
  - task is still `running`
  - `current_run_id` still matches the worker's expected run
  - `claim_lock` still belongs to that worker
- Treat malformed Kanban worker ownership env as a benign startup-guard skip
  rather than silently disabling the ownership check
- Add targeted regression coverage for diagnostics, recovery actions, dispatch
  skip behavior, and worker startup ownership checks

## How to Test

1. Run:
   `pytest -q tests/hermes_cli/test_kanban_diagnostics.py`
2. Run:
   `pytest -q tests/hermes_cli/test_kanban_db.py`
3. Run:
   `pytest -q tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/run_agent/test_kanban_worker_startup_guard.py`

Local targeted results:

- `tests/hermes_cli/test_kanban_diagnostics.py`: `31 passed`
- `tests/hermes_cli/test_kanban_db.py`: `82 passed`
- `tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/run_agent/test_kanban_worker_startup_guard.py`: `215 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (WSL-style dev environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted Kanban/runtime verification passed locally
