### PR TITLE
fix(gateway): dispatch fallback when final edit enters fallback mid-call (#21760)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -530,6 +530,20 @@ class GatewayStreamConsumer:
                             )
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
+                        # The final edit above may have exhausted the
+                        # flood-strike budget and entered fallback mode
+                        # mid-call (#21760).  In that case the edit returned
+                        # False without delivering the tail, and the
+                        # ``_fallback_final_send`` check at the top of this
+                        # block missed it — the strike count crossed the
+                        # threshold only *during* the edit.  Drive the
+                        # fallback continuation here so the tail is not
+                        # silently dropped.
+                        if (
+                            self._fallback_final_send
+                            and not self._final_response_sent
+                        ):
+                            await self._send_fallback_final(self._accumulated)
                     return
 
                 if commentary_text is not None:

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -867,6 +867,157 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer._final_response_sent is True
 
 
+class TestFallbackDispatchOnFinalEdit:
+    """Regression coverage for #21760 — when the final edit at got_done
+    exhausts the adaptive-backoff flood-strike budget and enters fallback
+    mode *during* the call, the existing ``if self._fallback_final_send:``
+    check at the top of the got_done block misses it (the strike count
+    crossed the threshold only after that check ran).  Without the
+    re-check after the final edit, the accumulated tail is silently
+    dropped — the user sees a frozen partial and the post-strike text
+    never lands.
+    """
+
+    @pytest.mark.asyncio
+    async def test_strike_3_during_final_edit_dispatches_fallback(self):
+        """Deterministic reproducer for #21760.
+
+        Seed the consumer to look like a streaming run that already delivered
+        a partial edit and accumulated two flood strikes from earlier
+        throttled edits.  When ``finish()`` triggers the got_done flush, the
+        first attempt (the ``should_edit`` block at line 501) fails with
+        flood (strike → MAX-1, no fallback yet, ``current_update_visible``
+        stays False).  The got_done block then falls through to the
+        ``elif self._message_id`` branch and retries — that retry fails too,
+        strike count crosses MAX, fallback mode is entered *inside* the
+        ``_send_or_edit`` call.
+
+        Without the re-check at the bottom of the got_done block,
+        ``_send_fallback_final`` is never called and the accumulated tail
+        is silently discarded — this is the exact bug #21760 describes.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_tail"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="flood_control:6"),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        # buffer_only=True avoids time-based mid-stream edits — the only
+        # edits run are the got_done finalize attempts.  That makes the
+        # "strike crosses threshold during the finalize" path deterministic.
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, buffer_only=True, cursor=" ▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Seed: a partial was already delivered as ``msg_1`` with prefix
+        # "Hello"; two flood strikes have accumulated from earlier edits.
+        # MAX_FLOOD_STRIKES is 3, so the NEXT failure brings us to MAX-1,
+        # and the one AFTER that crosses MAX → triggers fallback entry.
+        consumer._message_id = "msg_1"
+        consumer._last_sent_text = "Hello"
+        consumer._already_sent = True
+        consumer._flood_strikes = consumer._MAX_FLOOD_STRIKES - 2
+
+        consumer.on_delta(" world")
+        consumer.finish()
+
+        await consumer.run()
+
+        sent_texts = [call[1]["content"] for call in adapter.send.call_args_list]
+        # Without the fix: zero sends (the tail was dropped after fallback
+        # was entered inside _send_or_edit but never dispatched).
+        # With the fix: one send carrying the missing tail.
+        assert any("world" in t for t in sent_texts), (
+            f"Tail dropped — sends: {sent_texts!r}"
+        )
+        assert consumer._final_response_sent, (
+            "_fallback_final_send was set but _send_fallback_final never ran"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_already_active_path_unchanged(self):
+        """Pre-existing happy path: when ``_fallback_final_send`` is already
+        True at the top of the got_done block, fallback is dispatched there
+        and the re-check at the bottom must be a no-op (fallback clears the
+        flag).  Guards against double-dispatch from my fix.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, buffer_only=True,
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Hello world")
+        consumer.finish()
+
+        # Simulate state after a prior strike-3 failure during mid-stream:
+        # initial send already happened, fallback mode is set.
+        consumer._already_sent = True
+        consumer._message_id = "msg_1"
+        consumer._last_sent_text = "Hello"
+        consumer._fallback_final_send = True
+        consumer._fallback_prefix = "Hello"
+        consumer._edit_supported = False
+
+        await consumer.run()
+
+        # Exactly one fallback send (the tail) — not two.
+        tail_sends = [
+            call for call in adapter.send.call_args_list
+            if "world" in call[1].get("content", "")
+        ]
+        assert len(tail_sends) == 1, (
+            f"Tail was double-dispatched: {[c[1]['content'] for c in adapter.send.call_args_list]!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_final_edit_skips_fallback_recheck(self):
+        """Happy path: the final edit succeeds — fallback flag never flips,
+        the re-check is a no-op, no extra send.  Guards against fallback
+        dispatch firing when the final edit landed cleanly.
+        """
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, buffer_only=True,
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Hello world")
+        consumer.finish()
+
+        await consumer.run()
+
+        # One send (initial), zero or more edits (finalize) — but no second
+        # send call (which would mean fallback fired spuriously).
+        assert adapter.send.call_count == 1, (
+            f"Unexpected extra send: {[c[1]['content'] for c in adapter.send.call_args_list]!r}"
+        )
+        assert consumer._fallback_final_send is False
+
+
 class TestFinalResponseDeliveryGuard:
     """Regression coverage for #10748 — _final_response_sent must reflect
     actual delivery of the *current* chunked send, not the cumulative


### PR DESCRIPTION
## What does this PR do?

Fixes a tail-loss race in the streaming consumer: when the final edit at
`got_done` is the call that *itself* crosses `_MAX_FLOOD_STRIKES`, the
`if self._fallback_final_send:` check at the top of the got_done block has
already evaluated False — the strike count only crosses the threshold *inside*
`_send_or_edit`. The block then falls through to `return` without calling
`_send_fallback_final`, leaving `_final_response_sent=False`. The accumulated
tail is silently dropped at the stream-consumer layer; the gateway's outer base
fallback rescues most cases but masks the underlying bug and produces a
different code path (fresh `send` vs proper continuation).

Reported symptom: rapid Chinese-text generation followed by a tool-call
boundary truncates the last words of the pre-boundary segment. The reporter
blamed throttling, but the underlying mechanism is adaptive-backoff
(`d7607292d` — "fix(streaming): adaptive backoff + cursor strip to prevent
message truncation (#7683)") crossing the threshold *during* the finalize.

**Fix:** after the final `_send_or_edit` in the got_done block, re-check
`_fallback_final_send`. If it became True mid-call and the response wasn't
delivered, dispatch `_send_fallback_final` here. Mirrors how
`_flush_segment_tail_on_edit_failure` already handles the same race for
segment breaks (#8124).

## Related Issue

Fixes #21760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py` — 14-line re-check at the bottom of the
  `got_done` block: if the final `_send_or_edit` set `_fallback_final_send`
  mid-call without delivering the tail, dispatch `_send_fallback_final` here.
- `tests/gateway/test_stream_consumer.py` — new `TestFallbackDispatchOnFinalEdit`
  class with 3 deterministic regression tests.

## How to Test

### Unit tests

```bash
scripts/run_tests.sh tests/gateway/test_stream_consumer.py::TestFallbackDispatchOnFinalEdit
```

3 tests pass. Verified the new `test_strike_3_during_final_edit_dispatches_fallback`
fails without the fix (`AssertionError: Tail dropped — sends: []`).

The pre-existing flaky `test_edit_failure_sends_only_unsent_tail_at_finish`
is now stable (10/10 runs pass; was ~40-60% before the fix because it relied on
the exact same race firing through real `asyncio.sleep` timing).

Full `tests/gateway/test_stream_consumer*.py`: **125/125 green** under
CI-equivalent settings (`-n 4` xdist workers, hermetic env per `scripts/run_tests.sh`).
Rebased on current main (`7026af4e2`) and re-verified.

### End-to-end smoke test

Ran the real gateway against a real Feishu bot (WebSocket subscription) with a
real LLM (claude-haiku-4.5 via an OpenAI-compatible proxy), with a controlled
flood-injection harness that:

1. Pre-seeds `_flood_strikes = _MAX_FLOOD_STRIKES - 2` so the next two failed
   edits straddle the threshold, with strike-3 crossing *during* the got_done
   retry.
2. Pre-sets `_message_id` so the got_done flush hits the EDIT path (not
   first-send).
3. Forces `StreamConsumerConfig.buffer_only = True` to suppress mid-stream
   edit attempts.
4. Monkey-patches `FeishuAdapter.edit_message` to return synthetic
   `flood_control:6` errors.

Same harness on both branches, same prompt, same LLM:

| Signal | fix branch | clean main |
|---|---|---|
| `edit_message` blocked at line 501 + line 528 (got_done flush + retry) | ✓ | ✓ |
| `_flood_strikes` final state | 3 (crossed MAX) | 3 (crossed MAX) |
| `_fallback_final_send` final state | False (cleared by `_send_fallback_final`) | **True** (set but never dispatched) |
| `_final_response_sent` | ✅ True | ❌ False |
| Who sent the tail | stream consumer's `_send_fallback_final` (this PR's line 542 re-check) | `gateway.platforms.base` outer fallback (rescue) |
| `gateway.platforms.base [Feishu] Sending response` rescue log | absent | **present** |

Trimmed log snippets (`run() END` debug shows the consumer's final state):

```
=== fix branch (Phase A4) ===
[FLOOD] FeishuAdapter.edit_message → synthetic flood_control:6   ← line 501 attempt
[FLOOD] FeishuAdapter.edit_message → synthetic flood_control:6   ← line 528 retry, strikes 2→3
[TRANSCRIPT] adapter.send → '# LLM 流式输出（Streaming）详解...'   ← _send_fallback_final from re-check
[FLOOD-DBG] run() END — _final_response_sent=True _fallback_final_send=False _flood_strikes=3
gateway.run [INFO] response ready (no outer rescue)

=== clean main (Phase B3) ===
[FLOOD] FeishuAdapter.edit_message → synthetic flood_control:6   ← line 501 attempt
[FLOOD] FeishuAdapter.edit_message → synthetic flood_control:6   ← line 528 retry, strikes 2→3
[FLOOD-DBG] run() END — _final_response_sent=False _fallback_final_send=True _flood_strikes=3
gateway.platforms.base [INFO] [Feishu] Sending response (903 chars)   ← outer base rescue
[TRANSCRIPT] adapter.send (the outer rescue's call)
```

The diff matches the predicted code path exactly: on main the consumer leaves
`_fallback_final_send=True` and `_final_response_sent=False`, and the gateway
base fallback rescues at a higher layer. On the fix branch the consumer dispatches
its own fallback and returns clean state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) for #21760 — none in flight
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_stream_consumer*.py` — 125/125 pass on rebased current main
- [x] I've added tests for my changes (3 new deterministic regression tests, verified failing without the fix)
- [x] I've tested on my platform: Windows 11 (Python 3.12.13, uv-managed venv)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal control-flow fix, no API change)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — N/A: pure async control flow, no file I/O, process, signal, or shell code. `scripts/check-windows-footguns.py --diff upstream/main` passes clean.
- [x] I've updated tool descriptions/schemas — N/A
