### PR TITLE
fix(memory): forward Discord source metadata to memory providers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10242,6 +10242,9 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    guild_id=source.guild_id,
+                    parent_chat_id=source.parent_chat_id,
+                    message_id=source.message_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
@@ -13618,7 +13621,7 @@ class GatewayRunner:
                 self._agent_cache.pop(session_key, None)
 
     @staticmethod
-    def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
+    def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int, source: Optional[SessionSource] = None) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
 
         Both _last_activity_ts and _last_activity_desc are only reset for
@@ -13635,6 +13638,18 @@ class GatewayRunner:
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
         agent._api_call_count = 0
+        if source is not None and hasattr(agent, "refresh_gateway_source_context"):
+            agent.refresh_gateway_source_context(
+                user_id=source.user_id,
+                user_name=source.user_name,
+                chat_id=source.chat_id,
+                chat_name=source.chat_name,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+                guild_id=source.guild_id,
+                parent_chat_id=source.parent_chat_id,
+                message_id=source.message_id,
+            )
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.
@@ -14831,7 +14846,7 @@ class GatewayRunner:
                                 _cache.move_to_end(session_key)
                             except KeyError:
                                 pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                        self._init_cached_agent_for_turn(agent, _interrupt_depth, source)
                         logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
@@ -14863,6 +14878,9 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    guild_id=source.guild_id,
+                    parent_chat_id=source.parent_chat_id,
+                    message_id=source.message_id,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -536,6 +536,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._chat_name = ""
         self._chat_type = ""
         self._thread_id = ""
+        self._guild_id = ""
+        self._parent_chat_id = ""
+        self._message_id = ""
         self._agent_identity = ""
         self._agent_workspace = ""
         self._turn_index = 0
@@ -1095,6 +1098,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._chat_name = str(kwargs.get("chat_name") or "").strip()
         self._chat_type = str(kwargs.get("chat_type") or "").strip()
         self._thread_id = str(kwargs.get("thread_id") or "").strip()
+        self._guild_id = str(kwargs.get("guild_id") or "").strip()
+        self._parent_chat_id = str(kwargs.get("parent_chat_id") or "").strip()
+        self._message_id = str(kwargs.get("message_id") or "").strip()
         self._agent_identity = str(kwargs.get("agent_identity") or "").strip()
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
@@ -1370,6 +1376,19 @@ class HindsightMemoryProvider(MemoryProvider):
             metadata["chat_type"] = self._chat_type
         if self._thread_id:
             metadata["thread_id"] = self._thread_id
+        if getattr(self, "_guild_id", ""):
+            metadata["guild_id"] = self._guild_id
+        if getattr(self, "_parent_chat_id", ""):
+            metadata["parent_chat_id"] = self._parent_chat_id
+            # Discord-specific alias: in Hermes Discord threads, chat_id is
+            # the effective conversation/thread id, while parent_chat_id is
+            # the human-facing channel id users organise messages by.
+            if self._platform == "discord":
+                metadata["discord_channel_id"] = self._parent_chat_id
+        if self._platform == "discord" and self._thread_id:
+            metadata["discord_thread_id"] = self._thread_id
+        if getattr(self, "_message_id", ""):
+            metadata["message_id"] = self._message_id
         if self._agent_identity:
             metadata["agent_identity"] = self._agent_identity
         return metadata

--- a/run_agent.py
+++ b/run_agent.py
@@ -1100,6 +1100,9 @@ class AIAgent:
         chat_name: str = None,
         chat_type: str = None,
         thread_id: str = None,
+        guild_id: str = None,
+        parent_chat_id: str = None,
+        message_id: str = None,
         gateway_session_key: str = None,
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
@@ -1182,6 +1185,9 @@ class AIAgent:
         self._chat_name = chat_name
         self._chat_type = chat_type
         self._thread_id = thread_id
+        self._guild_id = guild_id
+        self._parent_chat_id = parent_chat_id
+        self._message_id = message_id
         self._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
@@ -1949,6 +1955,12 @@ class AIAgent:
                             _init_kwargs["chat_type"] = self._chat_type
                         if self._thread_id:
                             _init_kwargs["thread_id"] = self._thread_id
+                        if self._guild_id:
+                            _init_kwargs["guild_id"] = self._guild_id
+                        if self._parent_chat_id:
+                            _init_kwargs["parent_chat_id"] = self._parent_chat_id
+                        if self._message_id:
+                            _init_kwargs["message_id"] = self._message_id
                         # Thread gateway session key for stable per-chat Honcho session isolation
                         if self._gateway_session_key:
                             _init_kwargs["gateway_session_key"] = self._gateway_session_key
@@ -11415,6 +11427,47 @@ class AIAgent:
             final_response = f"I reached the maximum iterations ({self.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
         return final_response
+
+    def refresh_gateway_source_context(
+        self,
+        *,
+        user_id: str = None,
+        user_name: str = None,
+        chat_id: str = None,
+        chat_name: str = None,
+        chat_type: str = None,
+        thread_id: str = None,
+        guild_id: str = None,
+        parent_chat_id: str = None,
+        message_id: str = None,
+    ) -> None:
+        """Refresh per-turn gateway source metadata on cached agents.
+
+        Gateway sessions may reuse an AIAgent for prompt-cache efficiency, but
+        source metadata such as Discord message_id changes every turn. Keep the
+        agent and already-initialised memory providers aligned with the current
+        inbound message so retained memories remain traceable.
+        """
+        updates = {
+            "_user_id": user_id,
+            "_user_name": user_name,
+            "_chat_id": chat_id,
+            "_chat_name": chat_name,
+            "_chat_type": chat_type,
+            "_thread_id": thread_id,
+            "_guild_id": guild_id,
+            "_parent_chat_id": parent_chat_id,
+            "_message_id": message_id,
+        }
+        for attr, value in updates.items():
+            if value is not None:
+                setattr(self, attr, value)
+        manager = getattr(self, "_memory_manager", None)
+        providers = getattr(manager, "providers", []) if manager else []
+        for provider in providers:
+            for attr, value in updates.items():
+                if value is not None and hasattr(provider, attr):
+                    setattr(provider, attr, str(value).strip())
 
     def run_conversation(
         self,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -664,6 +664,9 @@ class TestSyncTurn:
             chat_name="fakeassistantname-forums",
             chat_type="thread",
             thread_id="1491249007475949698",
+            guild_id="111222333444555666",
+            parent_chat_id="1485316232612941897",
+            message_id="1500000000000000000",
             agent_identity="fakeassistantname",
         )
         p._client = _make_mock_client()
@@ -695,6 +698,11 @@ class TestSyncTurn:
         assert item["metadata"]["chat_name"] == "fakeassistantname-forums"
         assert item["metadata"]["chat_type"] == "thread"
         assert item["metadata"]["thread_id"] == "1491249007475949698"
+        assert item["metadata"]["guild_id"] == "111222333444555666"
+        assert item["metadata"]["parent_chat_id"] == "1485316232612941897"
+        assert item["metadata"]["discord_channel_id"] == "1485316232612941897"
+        assert item["metadata"]["discord_thread_id"] == "1491249007475949698"
+        assert item["metadata"]["message_id"] == "1500000000000000000"
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"


### PR DESCRIPTION
## Summary
- forward richer gateway source metadata (`guild_id`, `parent_chat_id`, `message_id`) from platform events into `AIAgent` and memory-provider initialisation
- refresh gateway source metadata on cached agents so per-turn values like `message_id` do not go stale when the gateway reuses an agent for prompt-cache efficiency
- persist the new fields in Hindsight metadata, including Discord aliases (`discord_channel_id`, `discord_thread_id`) so memories can be filtered by both the human-facing parent channel and the thread/effective chat

## Why
Discord threads currently make `chat_id`/`thread_id` sufficient for routing, but not always sufficient for human mental models or memory isolation. Users organise Discord conversations primarily by server/channel, while Hermes often routes thread sessions by the effective thread id. Passing the parent channel and guild through the generic memory initialisation path gives memory providers enough source context to implement per-user, per-channel, and per-thread separation under a single agent profile.

This PR implements Hindsight persistence for those fields immediately. Other memory providers can also consume the forwarded kwargs (`guild_id`, `parent_chat_id`, `message_id`) where their backends support richer filters/session keys.

## Test plan
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_retains_metadata_rich_turn tests/agent/test_memory_session_switch.py -q -o 'addopts='`
- `python -m py_compile run_agent.py gateway/run.py plugins/memory/hindsight/__init__.py`
