### PR TITLE
fix(kanban): use colLabel for column select-all aria-label

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${colLabel || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## Summary

Fix `ReferenceError: COLUMN_LABEL is not defined` in the Kanban dashboard column select-all checkbox `aria-label`.

## Root Cause

During the i18n refactor (commit `c3916845`), the top-level English dictionary `COLUMN_LABEL` was renamed to `FALLBACK_COLUMN_LABEL`, but the reference at `dist/index.js:1901` was not updated. This causes a `ReferenceError` at render time when the column checkbox input is mounted.

## Fix

Replace the undefined `COLUMN_LABEL[props.column.name]` with the already-computed `colLabel` local variable (line 1882), which goes through `getColumnLabel(t, props.column.name)` → `tx()` i18n fallback. This is the same pattern used by the column title span on the adjacent line.

**Before:**
```js
"aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
```

**After:**
```js
"aria-label": `Select all tasks in ${colLabel || props.column.name}`,
```

## Testing

Verified that `colLabel` is computed on line 1882 via `getColumnLabel(t, props.column.name)` and is already used by the column title span. The `aria-label` now respects translations instead of always falling back to English.

Fixes [Bug]: Kanban dashboard: COLUMN_LABEL undefined in aria-label at column select-all checkbox #23620
