### PR TITLE
fix(model): reload direct aliases when config changes

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -174,6 +174,24 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
+_DIRECT_ALIASES_CACHE_KEY: Optional[tuple[str, int, int]] = None
+
+
+def _direct_aliases_cache_key() -> tuple[str, int, int]:
+    """Return a cache key for config-backed direct aliases.
+
+    Long-lived CLI/gateway processes need to notice when config.yaml changes
+    after startup. Keying on path + stat metadata keeps alias reloads cheap
+    while avoiding a stale module-level DIRECT_ALIASES dict.
+    """
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    try:
+        st = path.stat()
+        return (str(path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return (str(path), 0, 0)
 
 
 def _load_direct_aliases() -> dict[str, DirectAlias]:
@@ -244,15 +262,21 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
 
 
 def _ensure_direct_aliases() -> None:
-    """Lazy-load direct aliases on first use.
+    """Load direct aliases and refresh when config.yaml changes.
 
     Mutates the existing DIRECT_ALIASES dict in place rather than rebinding
     the module attribute. This keeps `from hermes_cli.model_switch import
     DIRECT_ALIASES` references valid in callers — rebinding would leave them
     pointing at a stale empty dict.
     """
-    if not DIRECT_ALIASES:
-        DIRECT_ALIASES.update(_load_direct_aliases())
+    global _DIRECT_ALIASES_CACHE_KEY
+
+    key = _direct_aliases_cache_key()
+    if DIRECT_ALIASES and key == _DIRECT_ALIASES_CACHE_KEY:
+        return
+    DIRECT_ALIASES.clear()
+    DIRECT_ALIASES.update(_load_direct_aliases())
+    _DIRECT_ALIASES_CACHE_KEY = key
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -524,6 +524,19 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
+_DIRECT_ALIASES_CACHE_KEY: Optional[tuple[str, int, int]] = None
+
+
+def _direct_aliases_cache_key() -> tuple[str, int, int]:
+    """Return the config identity used to cache direct aliases."""
+    from hermes_cli.config import get_config_path
+
+    path = get_config_path()
+    try:
+        st = path.stat()
+        return (str(path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return (str(path), 0, 0)
 
 
 def _load_direct_aliases() -> dict[str, DirectAlias]:
@@ -594,15 +607,21 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
 
 
 def _ensure_direct_aliases() -> None:
-    """Lazy-load direct aliases on first use.
+    """Load direct aliases and refresh them when config.yaml changes.
 
-    Mutates the existing DIRECT_ALIASES dict in place rather than rebinding
-    the module attribute. This keeps `from hermes_cli.model_switch import
-    DIRECT_ALIASES` references valid in callers — rebinding would leave them
-    pointing at a stale empty dict.
+    The cache key is the loaded sentinel, rather than the mapping's truthiness:
+    a valid config with no aliases must still be cached. The mapping is mutated
+    in place so imports that hold a reference to ``DIRECT_ALIASES`` remain
+    valid.
     """
-    if not DIRECT_ALIASES:
-        DIRECT_ALIASES.update(_load_direct_aliases())
+    global _DIRECT_ALIASES_CACHE_KEY
+
+    key = _direct_aliases_cache_key()
+    if key == _DIRECT_ALIASES_CACHE_KEY:
+        return
+    DIRECT_ALIASES.clear()
+    DIRECT_ALIASES.update(_load_direct_aliases())
+    _DIRECT_ALIASES_CACHE_KEY = key
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -618,15 +618,21 @@ def _ensure_direct_aliases() -> None:
     global _DIRECT_ALIASES_CACHE_KEY, _DIRECT_ALIASES_CACHE_SNAPSHOT
 
     key = _direct_aliases_cache_key()
+    if _DIRECT_ALIASES_CACHE_SNAPSHOT is None and DIRECT_ALIASES:
+        # A caller populated the public mapping before the first lazy load.
+        _DIRECT_ALIASES_CACHE_KEY = key
+        _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
+        return
+    if (
+        _DIRECT_ALIASES_CACHE_SNAPSHOT is not None
+        and DIRECT_ALIASES != _DIRECT_ALIASES_CACHE_SNAPSHOT
+    ):
+        # Preserve deliberate public-map mutations even if an unrelated config
+        # write changed the stat key between two lookups.
+        _DIRECT_ALIASES_CACHE_KEY = key
+        _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
+        return
     if key == _DIRECT_ALIASES_CACHE_KEY:
-        # DIRECT_ALIASES is a long-standing public mutable mapping. Preserve
-        # deliberate caller/test injections made in place while the config
-        # identity is unchanged; an empty loaded mapping remains cacheable.
-        if (
-            _DIRECT_ALIASES_CACHE_SNAPSHOT is not None
-            and DIRECT_ALIASES != _DIRECT_ALIASES_CACHE_SNAPSHOT
-        ):
-            _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
         return
     DIRECT_ALIASES.clear()
     DIRECT_ALIASES.update(_load_direct_aliases())

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -525,6 +525,7 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
 _DIRECT_ALIASES_CACHE_KEY: Optional[tuple[str, int, int]] = None
+_DIRECT_ALIASES_CACHE_SNAPSHOT: Optional[dict[str, DirectAlias]] = None
 
 
 def _direct_aliases_cache_key() -> tuple[str, int, int]:
@@ -614,14 +615,23 @@ def _ensure_direct_aliases() -> None:
     in place so imports that hold a reference to ``DIRECT_ALIASES`` remain
     valid.
     """
-    global _DIRECT_ALIASES_CACHE_KEY
+    global _DIRECT_ALIASES_CACHE_KEY, _DIRECT_ALIASES_CACHE_SNAPSHOT
 
     key = _direct_aliases_cache_key()
     if key == _DIRECT_ALIASES_CACHE_KEY:
+        # DIRECT_ALIASES is a long-standing public mutable mapping. Preserve
+        # deliberate caller/test injections made in place while the config
+        # identity is unchanged; an empty loaded mapping remains cacheable.
+        if (
+            _DIRECT_ALIASES_CACHE_SNAPSHOT is not None
+            and DIRECT_ALIASES != _DIRECT_ALIASES_CACHE_SNAPSHOT
+        ):
+            _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
         return
     DIRECT_ALIASES.clear()
     DIRECT_ALIASES.update(_load_direct_aliases())
     _DIRECT_ALIASES_CACHE_KEY = key
+    _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -618,6 +618,12 @@ def _ensure_direct_aliases() -> None:
     global _DIRECT_ALIASES_CACHE_KEY, _DIRECT_ALIASES_CACHE_SNAPSHOT
 
     key = _direct_aliases_cache_key()
+    if _DIRECT_ALIASES_CACHE_KEY is None and not DIRECT_ALIASES:
+        DIRECT_ALIASES.clear()
+        DIRECT_ALIASES.update(_load_direct_aliases())
+        _DIRECT_ALIASES_CACHE_KEY = key
+        _DIRECT_ALIASES_CACHE_SNAPSHOT = dict(DIRECT_ALIASES)
+        return
     if _DIRECT_ALIASES_CACHE_SNAPSHOT is None and DIRECT_ALIASES:
         # A caller populated the public mapping before the first lazy load.
         _DIRECT_ALIASES_CACHE_KEY = key

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -446,13 +446,16 @@ class TestEnsureDirectAliases:
         ms._ensure_direct_aliases()
         assert "test" in ms.DIRECT_ALIASES
 
-    def test_ensure_no_reload_when_populated(self, monkeypatch):
-        """_ensure_direct_aliases does not reload if already populated."""
+    def test_ensure_no_reload_when_config_unchanged(self, monkeypatch):
+        """_ensure_direct_aliases does not reload if config stat is unchanged."""
         import hermes_cli.model_switch as ms
         from hermes_cli.model_switch import DirectAlias
 
         existing = {"pre": DirectAlias("pre-model", "custom", "")}
         monkeypatch.setattr(ms, "DIRECT_ALIASES", existing)
+        cache_key = ("config.yaml", 123, 456)
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", cache_key)
+        monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: cache_key)
 
         call_count = [0]
         original_load = ms._load_direct_aliases
@@ -464,6 +467,28 @@ class TestEnsureDirectAliases:
         ms._ensure_direct_aliases()
         assert call_count[0] == 0
         assert "pre" in ms.DIRECT_ALIASES
+
+    def test_resolve_alias_reloads_when_config_stat_changes(self, monkeypatch):
+        """Long-running processes should see new direct aliases after config changes."""
+        import hermes_cli.model_switch as ms
+        from hermes_cli.model_switch import DirectAlias
+
+        keys = iter([
+            ("config.yaml", 123, 10),
+            ("config.yaml", 124, 12),
+        ])
+        loads = iter([
+            {"old": DirectAlias("old-model", "custom", "")},
+            {"new": DirectAlias("new-model", "custom", "")},
+        ])
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", None)
+        monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: next(keys))
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: next(loads))
+
+        assert ms.resolve_alias("old", "openrouter") == ("custom", "old-model", "old")
+        assert ms.resolve_alias("new", "openrouter") == ("custom", "new-model", "new")
+        assert "old" not in ms.DIRECT_ALIASES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_ollama_cloud_auth.py
+++ b/tests/hermes_cli/test_ollama_cloud_auth.py
@@ -12,6 +12,16 @@ Covers:
 import os
 
 
+def _set_injected_direct_aliases(monkeypatch, aliases):
+    """Keep test-injected aliases and their cache state explicit."""
+    import hermes_cli.model_switch as ms
+
+    cache_key = ("test-config.yaml", 0, 0)
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", aliases)
+    monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", cache_key)
+    monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: cache_key)
+
+
 # ---------------------------------------------------------------------------
 # OLLAMA_API_KEY credential resolution
 # ---------------------------------------------------------------------------
@@ -85,7 +95,7 @@ class TestDirectAliases:
         test_aliases = {
             "glm": DirectAlias("glm-4.7", "custom", "https://ollama.com/v1"),
         }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        _set_injected_direct_aliases(monkeypatch, test_aliases)
 
         result = resolve_alias("glm", "openrouter")
         assert result is not None
@@ -232,16 +242,65 @@ class TestEnsureDirectAliases:
             lambda: mock_config,
         )
         monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", None)
         ms._ensure_direct_aliases()
         assert "test" in ms.DIRECT_ALIASES
 
-    def test_ensure_no_reload_when_populated(self, monkeypatch):
-        """_ensure_direct_aliases does not reload if already populated."""
+    def test_ensure_caches_empty_config(self, monkeypatch):
+        """An empty alias config is loaded once, not on every lookup."""
+        import hermes_cli.model_switch as ms
+
+        calls = []
+        cache_key = ("config.yaml", 10, 0)
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", None)
+        monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: cache_key)
+        monkeypatch.setattr(
+            ms,
+            "_load_direct_aliases",
+            lambda: calls.append(True) or {},
+        )
+
+        ms._ensure_direct_aliases()
+        ms._ensure_direct_aliases()
+
+        assert calls == [True]
+        assert ms.DIRECT_ALIASES == {}
+
+    def test_ensure_refreshes_when_config_stat_changes(self, monkeypatch):
+        """A changed config identity refreshes aliases in a long-lived process."""
+        import hermes_cli.model_switch as ms
+        from hermes_cli.model_switch import DirectAlias
+
+        keys = iter([
+            ("config.yaml", 10, 1),
+            ("config.yaml", 11, 1),
+        ])
+        loads = iter([
+            {"old": DirectAlias("old-model", "custom", "")},
+            {"new": DirectAlias("new-model", "custom", "")},
+        ])
+        monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", None)
+        monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: next(keys))
+        monkeypatch.setattr(ms, "_load_direct_aliases", lambda: next(loads))
+
+        ms._ensure_direct_aliases()
+        assert "old" in ms.DIRECT_ALIASES
+        ms._ensure_direct_aliases()
+        assert "new" in ms.DIRECT_ALIASES
+        assert "old" not in ms.DIRECT_ALIASES
+
+
         import hermes_cli.model_switch as ms
         from hermes_cli.model_switch import DirectAlias
 
         existing = {"pre": DirectAlias("pre-model", "custom", "")}
         monkeypatch.setattr(ms, "DIRECT_ALIASES", existing)
+
+        cache_key = ("test-config.yaml", 123, 456)
+        monkeypatch.setattr(ms, "_DIRECT_ALIASES_CACHE_KEY", cache_key)
+        monkeypatch.setattr(ms, "_direct_aliases_cache_key", lambda: cache_key)
 
         call_count = [0]
         original_load = ms._load_direct_aliases
@@ -271,7 +330,7 @@ class TestResolveAliasEdgeCases:
         test_aliases = {
             "myalias": DirectAlias("my-model", "custom", "https://example.com"),
         }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        _set_injected_direct_aliases(monkeypatch, test_aliases)
 
         result = ms.resolve_alias("  myalias  ", "openrouter")
         assert result is not None
@@ -376,7 +435,7 @@ class TestSwitchModelDirectAliasOverride:
         test_aliases = {
             "qwen": DirectAlias("qwen3.5:397b", "custom", "https://ollama.com/v1"),
         }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        _set_injected_direct_aliases(monkeypatch, test_aliases)
 
         monkeypatch.setattr(ms, "resolve_alias",
             lambda raw, prov: ("custom", "qwen3.5:397b", "qwen"))
@@ -404,7 +463,7 @@ class TestSwitchModelDirectAliasOverride:
         test_aliases = {
             "local": DirectAlias("local-model", "custom", "http://localhost:11434/v1"),
         }
-        monkeypatch.setattr(ms, "DIRECT_ALIASES", test_aliases)
+        _set_injected_direct_aliases(monkeypatch, test_aliases)
         monkeypatch.setattr(ms, "resolve_alias",
             lambda raw, prov: ("custom", "local-model", "local"))
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

This PR fixes stale `/model` direct alias resolution in long-running CLI and gateway processes.

`hermes_cli/model_switch.py` loads direct aliases from `model_aliases` and `model.aliases` in `config.yaml`, which supports commands like `/model qwen` or `/model ds`. Before this change, `DIRECT_ALIASES` was populated once and never refreshed while the process stayed alive, so aliases changed with `hermes config set model.aliases...` could be ignored until restart.

This keeps the existing in-place `DIRECT_ALIASES` mutation behavior, but adds a config stat cache key so aliases reload when `config.yaml` changes.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added a direct-alias cache key based on config path, `st_mtime_ns`, and file size
- Updated `_ensure_direct_aliases()` to reload aliases when the config stat changes
- Preserved in-place mutation of `DIRECT_ALIASES` so existing imported references remain valid
- Added regression coverage for unchanged-config cache hits and changed-config reloads through `resolve_alias()`

## How to Test

1. Reproduce the old stale-cache behavior by loading one direct alias, changing the mocked config alias source, and calling `resolve_alias()` again without restarting the process.
2. Confirm the second alias is now visible after the simulated config stat changes.
3. Run targeted tests:

```bash
PYTHONPATH=. /tmp/hermes-model-alias-test-venv/bin/python -m pytest -q \
  tests/hermes_cli/test_ollama_cloud_auth.py::TestEnsureDirectAliases

PYTHONPATH=. /tmp/hermes-model-alias-test-venv/bin/python -m pytest -q \
  tests/hermes_cli/test_regression_16767.py::test_ensure_direct_aliases_mutates_in_place
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / WSL-style environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A
- [x] I've considered cross-platform impact - N/A
- [x] I've updated tool descriptions/schemas - N/A

## Screenshots / Logs

Targeted verification passed:

- `TestEnsureDirectAliases`: `3 passed`
- `test_ensure_direct_aliases_mutates_in_place`: `1 passed`

Note: local pytest emitted a `.pytest_cache` write warning due to `/mnt/d` filesystem permissions; tests passed.
