### PR TITLE
fix(kanban): use -z (one-shot) mode for worker spawn instead of chat -q

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3908,7 +3908,7 @@ def _default_spawn(
     *,
     board: Optional[str] = None,
 ) -> Optional[int]:
-    """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
+    """Fire-and-forget ``hermes -p <profile> -z ...`` one-shot subprocess.
 
     Returns the spawned child's PID so the dispatcher can detect crashes
     before the claim TTL expires. The child's completion is still observed
@@ -4001,8 +4001,7 @@ def _default_spawn(
             if sk and sk != "kanban-worker":
                 cmd.extend(["--skills", sk])
     cmd.extend([
-        "chat",
-        "-q", prompt,
+        "-z", prompt,
     ])
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2825,14 +2825,14 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     assert skill_names[0] == "kanban-worker", skill_names
     assert "translation" in skill_names
     assert "github-code-review" in skill_names
-    # --skills must appear BEFORE the `chat` subcommand so argparse
-    # attaches them to the top-level parser, not the subcommand.
-    chat_idx = cmd.index("chat")
+    # --skills must appear BEFORE the `-z` flag so argparse attaches them
+    # to the top-level parser, not treated as positional args.
+    z_idx = cmd.index("-z")
     last_skills_idx = max(
         i for i, tok in enumerate(cmd) if tok == "--skills"
     )
-    assert last_skills_idx < chat_idx, (
-        f"--skills must come before 'chat' in argv: {cmd}"
+    assert last_skills_idx < z_idx, (
+        f"--skills must come before '-z' in argv: {cmd}"
     )
 
 


### PR DESCRIPTION
## Description

The kanban dispatcher's `_default_spawn` function spawns workers using `hermes chat -q "work kanban task <id>"`. The `chat` command initializes the TUI subsystem, which requires a TTY. When spawned via `subprocess.Popen(stdin=subprocess.DEVNULL, ...)` in a headless gateway environment, there is no TTY available — the TUI prints `hermes-tui: no TTY` and exits before the model ever runs.

This causes every dispatched worker to immediately crash with a `protocol_violation` ("worker exited cleanly without calling kanban_complete") and the task gets auto-blocked after `failure_limit` consecutive failures.

## Fix

Replace `chat -q` with `-z` (one-shot mode) in `_default_spawn()`. The one-shot mode:

1. Does not initialize the TUI — no TTY dependency
2. Is documented as "intended for scripts/pipes"
3. Auto-bypasses approvals (correct subprocess behavior for a worker)
4. Supports `--skills`, `HERMES_KANBAN_TASK`, and all env vars correctly

## Testing

- **Unit tests**: All 5 spawn-related tests pass (3 in test_kanban_core_functionality.py, 2 in test_kanban_boards.py)
- **Full kanban test suite**: 283 passed, 2 pre-existing failures (missing fastapi dependency — dashboard tests, unrelated)
- **End-to-end manual test**: A dispatched worker using the `-z` mode successfully read its task via `kanban_show`, executed a web search, saved results, and called `kanban_complete`

## Files changed

- `hermes_cli/kanban_db.py` — Changed spawn command from `chat -q` to `-z`, updated docstring
- `tests/hermes_cli/test_kanban_core_functionality.py` — Updated assertion to check for `-z` instead of `chat`

Fixes #23844

## Checklist

- [x] Tests pass on macOS
- [x] Change is focused on one logical fix
- [x] Commit uses Conventional Commits format
- [x] Cross-platform impact considered (change removes TTY dependency — improves cross-platform compatibility)
