### PR TITLE
fix(kanban): clear _INITIALIZED_PATHS in remove_board so recycled DBs re-init schema

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -533,6 +533,11 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     if get_current_board() == normed:
         clear_current_board()
 
+    # A concurrent connect(board=normed) after the rename/delete recreates
+    # an empty sqlite file via mkdir(exist_ok=True); the cache entry must be
+    # dropped first so the schema init pass re-runs on that fresh file.
+    _INITIALIZED_PATHS.discard(str((d / "kanban.db").resolve()))
+
     if archive:
         archive_root = boards_root() / "_archived"
         archive_root.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -258,6 +258,37 @@ class TestBoardCRUD:
         kb.remove_board("pinned")
         assert kb.get_current_board() == "default"
 
+    @pytest.mark.parametrize("archive", [True, False])
+    def test_remove_clears_init_cache_for_recreated_db(self, fresh_home, archive):
+        # Regression for #23833: poll loops that call connect(board=slug) right
+        # after remove_board() recreate an empty kanban.db at the same path
+        # (connect() does mkdir(exist_ok=True)). If _INITIALIZED_PATHS still
+        # contains the resolved path, the CREATE TABLE pass is skipped and
+        # downstream readers hit `no such table: task_events`.
+        kb.create_board("recycle")
+        # First connect populates _INITIALIZED_PATHS for this DB.
+        with kb.connect(board="recycle") as conn:
+            kb.create_task(conn, title="t1", assignee="dev")
+        db_path = kb.board_dir("recycle") / "kanban.db"
+        assert str(db_path.resolve()) in kb._INITIALIZED_PATHS
+
+        kb.remove_board("recycle", archive=archive)
+        # remove_board must drop the cache entry so a re-create through
+        # connect() gets a fresh schema-init pass.
+        assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS
+
+        # Simulate the event-stream poll: re-open the same slug. connect()
+        # recreates the directory + empty .db; the schema must be re-applied.
+        with kb.connect(board="recycle") as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        assert "task_events" in tables
+        assert "tasks" in tables
+
     def test_rename_updates_metadata(self, fresh_home):
         kb.create_board("slug-immutable")
         kb.write_board_metadata("slug-immutable", name="New Display Name")


### PR DESCRIPTION
## Summary

- Drop the resolved DB path from `_INITIALIZED_PATHS` inside `remove_board()` so a subsequent `connect(board=<slug>)` re-runs `CREATE TABLE IF NOT EXISTS` on the empty file that `mkdir(exist_ok=True)` recreates.
- Add a parametrized regression test (`archive=True` and `archive=False`) that exercises the full archive → poll-recreate → query path.

## The bug

`remove_board()` (`hermes_cli/kanban_db.py:512`) archives by `d.rename(target)` or hard-deletes by `shutil.rmtree(d)`, but it leaves `_INITIALIZED_PATHS` untouched. The dashboard's kanban event-stream WebSocket (`plugins/kanban/dashboard/plugin_api.py`) is a poll loop that calls `kanban_db.connect(board=<slug>)` every few seconds. After an archive:

1. `connect()` resolves the (now-deleted) board path.
2. `path.parent.mkdir(parents=True, exist_ok=True)` recreates the empty board directory.
3. `sqlite3.connect()` creates a new **empty** `kanban.db`.
4. `needs_init = resolved not in _INITIALIZED_PATHS` evaluates to `False` (still cached from the pre-archive connection), so the `CREATE TABLE IF NOT EXISTS` block is skipped.
5. The next `SELECT … FROM task_events …` fails with `OperationalError: no such table: task_events` and the dashboard logs `Kanban event stream error: no such table: task_events`.

## The fix

Compute the resolved DB path before mutating the filesystem and `discard()` it from the cache. This matches the existing pattern in `init_db()` (`kanban_db.py:964`), which also pre-clears the entry to force a re-init.

Both the `archive=True` and `archive=False` branches share the same cache-staleness window, so the discard is unconditional. The discard is a `set.discard` (no-op if not present), which keeps it safe for boards that were never connected to in the current process.

## Test plan

- [x] New parametrized test `test_remove_clears_init_cache_for_recreated_db[True|False]` in `tests/hermes_cli/test_kanban_boards.py`:
  - Creates a board, connects (populating `_INITIALIZED_PATHS`), removes it.
  - Asserts the resolved path is no longer cached.
  - Re-connects via `connect(board="recycle")` and verifies `tasks` + `task_events` tables exist in the recreated DB.
- [x] Full file passes: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_kanban_boards.py -v` → 52 passed.
- [x] Adjacent kanban suites pass: `test_kanban_db.py`, `test_kanban_core_functionality.py`, `test_pin_kanban_board_env.py` (the 2 failures in `test_kanban_core_functionality.py` are local-install artifacts — `ModuleNotFoundError: No module named 'fastapi'` — and pass cleanly with the `[all,dev]` extras CI uses).
- [x] Regression guard: with the production-side change reverted, both parametrized test cases fail at `assert str(db_path.resolve()) not in kb._INITIALIZED_PATHS` with identical error text on both `archive=True` and `archive=False`. Restoring the fix makes them pass.

## Related

Fixes #23833.

> The issue also suggests a defensive guard in the dashboard event-stream handler (`plugins/kanban/dashboard/plugin_api.py` ~line 1608) to close the WebSocket cleanly on `OperationalError`. That is a downstream workaround, not the root cause — intentionally left out of this PR's scope to keep the diff focused. Happy to widen if preferred.