### PR TITLE
feat(cli): add /update slash command to CLI and TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7948,6 +7948,8 @@ class HermesCLI:
             self._handle_copy_command(cmd_original)
         elif canonical == "debug":
             self._handle_debug_command()
+        elif canonical == "update":
+            self._handle_update_command()
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "image":
@@ -9229,6 +9231,38 @@ class HermesCLI:
 
         args = SimpleNamespace(lines=200, expire=7, local=False)
         run_debug_share(args)
+
+    def _handle_update_command(self):
+        """Handle /update — update Hermes Agent to the latest version.
+
+        In the classic CLI this exits the session and relaunches as
+        ``hermes update`` so the user sees update output directly and gets
+        the new version on next launch.
+        """
+        from hermes_cli.config import is_managed, format_managed_message
+
+        if is_managed():
+            print(f"  ✗ {format_managed_message('update Hermes Agent')}")
+            return
+
+        # Confirm with user
+        try:
+            answer = input("  Update Hermes Agent to the latest version? This will exit the current session. [Y/n] ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if answer.strip().lower() in ("n", "no"):
+            return
+
+        print()
+        print("  ⚕ Launching update...")
+        print()
+
+        # Use relaunch() which handles Windows (.cmd shims) and POSIX (execvp).
+        # preserve_inherited=False avoids carrying --tui or other flags into
+        # the update subcommand.
+        from hermes_cli.relaunch import relaunch
+        relaunch(["update"], preserve_inherited=False)
 
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""

--- a/cli.py
+++ b/cli.py
@@ -2830,6 +2830,9 @@ class HermesCLI:
         # process_command() when the user runs /exit --delete or /quit --delete.
         # Ported from google-gemini/gemini-cli#19332.
         self._delete_session_on_exit = False
+        # When set, the interactive CLI relaunches this subcommand after
+        # prompt_toolkit exits cleanly (see _handle_update_command).
+        self._pending_relaunch_argv: list[str] | None = None
         self._last_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
@@ -7949,7 +7952,8 @@ class HermesCLI:
         elif canonical == "debug":
             self._handle_debug_command()
         elif canonical == "update":
-            self._handle_update_command()
+            if not self._handle_update_command():
+                return False
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "image":
@@ -9232,37 +9236,50 @@ class HermesCLI:
         args = SimpleNamespace(lines=200, expire=7, local=False)
         run_debug_share(args)
 
-    def _handle_update_command(self):
+    def _handle_update_command(self) -> bool:
         """Handle /update — update Hermes Agent to the latest version.
 
-        In the classic CLI this exits the session and relaunches as
-        ``hermes update`` so the user sees update output directly and gets
-        the new version on next launch.
+        Returns True to keep the CLI running, False to exit and relaunch as
+        ``hermes update`` on the main thread after prompt_toolkit cleanup.
         """
         from hermes_cli.config import is_managed, format_managed_message
 
         if is_managed():
             print(f"  ✗ {format_managed_message('update Hermes Agent')}")
-            return
+            return True
 
-        # Confirm with user
-        try:
-            answer = input("  Update Hermes Agent to the latest version? This will exit the current session. [Y/n] ")
-        except (EOFError, KeyboardInterrupt):
-            print()
-            return
-        if answer.strip().lower() in ("n", "no"):
-            return
+        choices = [
+            ("yes", "Yes", "exit this session and run hermes update"),
+            ("no", "No", "stay in the current session"),
+        ]
+        raw = self._prompt_text_input_modal(
+            title="⚕ /update — update Hermes Agent",
+            detail=(
+                "This exits the current session and runs `hermes update` so you\n"
+                "see update output directly."
+            ),
+            choices=choices,
+        )
+        answer = self._normalize_yes_no_confirm(raw)
+        if answer is None:
+            print("  /update cancelled.")
+            return True
+        if answer == "no":
+            return True
 
-        print()
-        print("  ⚕ Launching update...")
-        print()
+        self._pending_relaunch_argv = ["update"]
+        return False
 
-        # Use relaunch() which handles Windows (.cmd shims) and POSIX (execvp).
-        # preserve_inherited=False avoids carrying --tui or other flags into
-        # the update subcommand.
-        from hermes_cli.relaunch import relaunch
-        relaunch(["update"], preserve_inherited=False)
+    def _normalize_yes_no_confirm(self, raw: str | None) -> str | None:
+        """Map modal/stdin input to ``yes`` / ``no``, or None if unrecognized."""
+        if raw is None:
+            return None
+        choice = raw.strip().lower()
+        if choice in ("", "y", "yes", "1", "yes (update)"):
+            return "yes"
+        if choice in ("n", "no", "2", "no (cancel)"):
+            return "no"
+        return None
 
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""
@@ -13969,6 +13986,14 @@ class HermesCLI:
                 except Exception:
                     pass
             _run_cleanup()
+            pending_relaunch = getattr(self, "_pending_relaunch_argv", None)
+            if pending_relaunch:
+                from hermes_cli.relaunch import relaunch
+
+                print()
+                print("  ⚕ Launching update...")
+                print()
+                relaunch(pending_relaunch, preserve_inherited=False)
             self._print_exit_summary()
 
 

--- a/cli.py
+++ b/cli.py
@@ -2830,6 +2830,11 @@ class HermesCLI:
         # process_command() when the user runs /exit --delete or /quit --delete.
         # Ported from google-gemini/gemini-cli#19332.
         self._delete_session_on_exit = False
+        # /update: when set, run() executes relaunch() after prompt_toolkit
+        # has fully exited and cleaned up terminal modes.  Set by
+        # _handle_update_command() so the relaunch happens on the main thread,
+        # not the background process_loop thread.
+        self._pending_relaunch: list[str] | None = None
         self._last_ctrl_c_time = 0
         self._clarify_state = None
         self._clarify_freetext = False
@@ -7949,7 +7954,8 @@ class HermesCLI:
         elif canonical == "debug":
             self._handle_debug_command()
         elif canonical == "update":
-            self._handle_update_command()
+            if self._handle_update_command():
+                return False
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "image":
@@ -9232,37 +9238,57 @@ class HermesCLI:
         args = SimpleNamespace(lines=200, expire=7, local=False)
         run_debug_share(args)
 
-    def _handle_update_command(self):
+    def _handle_update_command(self) -> bool:
         """Handle /update — update Hermes Agent to the latest version.
 
         In the classic CLI this exits the session and relaunches as
         ``hermes update`` so the user sees update output directly and gets
         the new version on next launch.
+
+        Returns ``True`` when the update was confirmed (caller should trigger
+        app exit so the relaunch is deferred to the main thread after
+        prompt_toolkit cleans up terminal modes).  Returns ``False`` / falsy
+        when cancelled.
         """
         from hermes_cli.config import is_managed, format_managed_message
 
         if is_managed():
             print(f"  ✗ {format_managed_message('update Hermes Agent')}")
-            return
+            return False
 
-        # Confirm with user
-        try:
-            answer = input("  Update Hermes Agent to the latest version? This will exit the current session. [Y/n] ")
-        except (EOFError, KeyboardInterrupt):
-            print()
-            return
-        if answer.strip().lower() in ("n", "no"):
-            return
+        # Use the prompt_toolkit-native modal so the confirmation panel
+        # renders properly above the composer and avoids raw input() races
+        # with the prompt_toolkit event loop (same pattern as
+        # _confirm_destructive_slash).
+        choices = [
+            ("once", "Update Now", "exit the current session and update Hermes Agent"),
+            ("cancel", "Cancel", "keep the current session"),
+        ]
+        raw = self._prompt_text_input_modal(
+            title="⚕  Update Hermes Agent",
+            detail="This will exit the current session and run `hermes update`.",
+            choices=choices,
+        )
+        if raw is None:
+            print("  🟡 /update cancelled.")
+            return False
+        choice = self._normalize_slash_confirm_choice(raw, choices)
+        if choice != "once":
+            print("  🟡 /update cancelled.")
+            return False
 
         print()
         print("  ⚕ Launching update...")
         print()
 
-        # Use relaunch() which handles Windows (.cmd shims) and POSIX (execvp).
-        # preserve_inherited=False avoids carrying --tui or other flags into
-        # the update subcommand.
-        from hermes_cli.relaunch import relaunch
-        relaunch(["update"], preserve_inherited=False)
+        # Store the relaunch args so run() can exec them from the main thread
+        # after prompt_toolkit exits and restores terminal modes.  Calling
+        # relaunch() directly here (from the process_loop daemon thread) would
+        # skip terminal cleanup on POSIX (execvp replaces the process mid-TUI)
+        # and only exit the worker thread on Windows (subprocess.run +
+        # sys.exit inside a non-main thread does not exit the process).
+        self._pending_relaunch = ["update"]
+        return True
 
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""
@@ -13970,6 +13996,15 @@ class HermesCLI:
                     pass
             _run_cleanup()
             self._print_exit_summary()
+
+        # Deferred relaunch: /update sets _pending_relaunch so the exec
+        # happens here — after prompt_toolkit has exited and fully restored
+        # terminal modes — rather than from the background process_loop
+        # thread (which would skip terminal cleanup on POSIX and only exit
+        # the worker thread on Windows).
+        if getattr(self, '_pending_relaunch', None):
+            from hermes_cli.relaunch import relaunch
+            relaunch(self._pending_relaunch, preserve_inherited=False)
 
 
 # ============================================================================

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -207,8 +207,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
                cli_only=True, args_hint="<path>"),
-    CommandDef("update", "Update Hermes Agent to the latest version", "Info",
-               gateway_only=True),
+    CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
 
     # Exit

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1302,6 +1302,18 @@ def _launch_tui(
             except Exception:
                 pass
 
+    # Exit code 42 = TUI requested an update. Relaunch as `hermes update` so
+    # the user sees update output directly and gets the new version.
+    # preserve_inherited=False ensures --tui and other flags are NOT carried
+    # into the update subcommand.
+    if code == 42:
+        from hermes_cli.relaunch import relaunch
+
+        print()
+        print("⚕ Launching update...")
+        print()
+        relaunch(["update"], preserve_inherited=False)
+
     sys.exit(code)
 
 

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,0 +1,99 @@
+"""Tests for the /update slash command in the classic CLI.
+
+Verifies that ``HermesCLI._handle_update_command`` correctly:
+- Refuses to run under a managed install (Homebrew, Docker, etc.)
+- Cancels cleanly on a "n" answer
+- Cancels cleanly on EOF / Ctrl-C at the confirmation prompt
+- Relaunches as ``hermes update`` on a "y" answer (the default)
+
+The TUI side (``/update`` → exit-code-42 → relaunch in main.py) is covered
+by ``ui-tui/src/__tests__/createSlashHandler.test.ts``; this file covers
+the classic CLI path that the TS test cannot reach.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+@pytest.fixture
+def cli_stub():
+    """Build a minimal HermesCLI-like object bound to the real method.
+
+    We don't run ``__init__`` — we only need ``self`` to dispatch the
+    method.  All collaborators it touches (relaunch, is_managed, input,
+    print) are patched at call sites.
+    """
+    return MagicMock(spec=HermesCLI)
+
+
+def _call(cli_stub):
+    """Invoke the real ``_handle_update_command`` on the stub."""
+    HermesCLI._handle_update_command(cli_stub)
+
+
+def test_managed_install_refuses_and_does_not_relaunch(cli_stub, capsys):
+    """Under a managed install (brew/docker), /update prints a hint and
+    returns without launching anything."""
+    with (
+        patch("hermes_cli.config.is_managed", return_value=True),
+        patch(
+            "hermes_cli.config.format_managed_message",
+            return_value="Use `brew upgrade hermes-agent` to update.",
+        ),
+        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+        patch("builtins.input") as mock_input,
+    ):
+        _call(cli_stub)
+
+    out = capsys.readouterr().out
+    assert "brew upgrade hermes-agent" in out
+    mock_input.assert_not_called()
+    mock_relaunch.assert_not_called()
+
+
+@pytest.mark.parametrize("answer", ["n", "N", "no", "NO", " no "])
+def test_negative_answer_cancels(cli_stub, answer, capsys):
+    """Any "no"-shaped answer cancels without relaunching."""
+    with (
+        patch("hermes_cli.config.is_managed", return_value=False),
+        patch("builtins.input", return_value=answer),
+        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+    ):
+        _call(cli_stub)
+
+    mock_relaunch.assert_not_called()
+    # Should not have printed "Launching update..."
+    assert "Launching update" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
+def test_eof_or_ctrl_c_at_prompt_cancels(cli_stub, exc):
+    """EOFError (Ctrl-D) and KeyboardInterrupt (Ctrl-C) cancel cleanly."""
+    with (
+        patch("hermes_cli.config.is_managed", return_value=False),
+        patch("builtins.input", side_effect=exc),
+        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+    ):
+        _call(cli_stub)
+
+    mock_relaunch.assert_not_called()
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", "", " "])
+def test_affirmative_answer_relaunches_as_update(cli_stub, answer):
+    """Empty string (default Y) and any "yes"-shaped answer relaunch
+    via ``hermes_cli.relaunch.relaunch`` with the ``update`` subcommand
+    and ``preserve_inherited=False`` so flags like --tui aren't carried."""
+    with (
+        patch("hermes_cli.config.is_managed", return_value=False),
+        patch("builtins.input", return_value=answer),
+        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+    ):
+        _call(cli_stub)
+
+    mock_relaunch.assert_called_once_with(["update"], preserve_inherited=False)

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -2,18 +2,18 @@
 
 Verifies that ``HermesCLI._handle_update_command`` correctly:
 - Refuses to run under a managed install (Homebrew, Docker, etc.)
-- Cancels cleanly on a "n" answer
-- Cancels cleanly on EOF / Ctrl-C at the confirmation prompt
-- Relaunches as ``hermes update`` on a "y" answer (the default)
+- Cancels cleanly on a "no" answer or unrecognized input
+- Cancels cleanly on timeout / no modal response
+- Schedules a main-thread relaunch on affirmative answers
 
-The TUI side (``/update`` → exit-code-42 → relaunch in main.py) is covered
-by ``ui-tui/src/__tests__/createSlashHandler.test.ts``; this file covers
-the classic CLI path that the TS test cannot reach.
+The TUI slash handler is covered by ``createSlashHandler.test.ts``; the
+Python wrapper handoff for exit code 42 is covered in
+``tests/hermes_cli/test_tui_resume_flow.py``.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -22,78 +22,78 @@ from cli import HermesCLI
 
 @pytest.fixture
 def cli_stub():
-    """Build a minimal HermesCLI-like object bound to the real method.
-
-    We don't run ``__init__`` — we only need ``self`` to dispatch the
-    method.  All collaborators it touches (relaunch, is_managed, input,
-    print) are patched at call sites.
-    """
-    return MagicMock(spec=HermesCLI)
+    """Minimal HermesCLI instance without running ``__init__``."""
+    stub = object.__new__(HermesCLI)
+    stub._pending_relaunch_argv = None
+    stub._app = None
+    return stub
 
 
 def _call(cli_stub):
     """Invoke the real ``_handle_update_command`` on the stub."""
-    HermesCLI._handle_update_command(cli_stub)
+    return HermesCLI._handle_update_command(cli_stub)
 
 
-def test_managed_install_refuses_and_does_not_relaunch(cli_stub, capsys):
-    """Under a managed install (brew/docker), /update prints a hint and
-    returns without launching anything."""
+def test_managed_install_refuses_and_does_not_schedule_relaunch(cli_stub, capsys):
     with (
         patch("hermes_cli.config.is_managed", return_value=True),
         patch(
             "hermes_cli.config.format_managed_message",
             return_value="Use `brew upgrade hermes-agent` to update.",
         ),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
-        patch("builtins.input") as mock_input,
+        patch.object(HermesCLI, "_prompt_text_input_modal") as mock_modal,
     ):
-        _call(cli_stub)
+        assert _call(cli_stub) is True
 
     out = capsys.readouterr().out
     assert "brew upgrade hermes-agent" in out
-    mock_input.assert_not_called()
-    mock_relaunch.assert_not_called()
+    mock_modal.assert_not_called()
+    assert cli_stub._pending_relaunch_argv is None
 
 
-@pytest.mark.parametrize("answer", ["n", "N", "no", "NO", " no "])
-def test_negative_answer_cancels(cli_stub, answer, capsys):
-    """Any "no"-shaped answer cancels without relaunching."""
+@pytest.mark.parametrize("answer", ["no", "n", "2"])
+def test_negative_answer_cancels(cli_stub, answer):
+    cli_stub._pending_relaunch_argv = None
     with (
         patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", return_value=answer),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+        patch.object(HermesCLI, "_prompt_text_input_modal", return_value=answer),
     ):
-        _call(cli_stub)
+        assert _call(cli_stub) is True
 
-    mock_relaunch.assert_not_called()
-    # Should not have printed "Launching update..."
-    assert "Launching update" not in capsys.readouterr().out
+    assert cli_stub._pending_relaunch_argv is None
 
 
-@pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
-def test_eof_or_ctrl_c_at_prompt_cancels(cli_stub, exc):
-    """EOFError (Ctrl-D) and KeyboardInterrupt (Ctrl-C) cancel cleanly."""
+@pytest.mark.parametrize("answer", ["nope", "cancel", "maybe"])
+def test_unrecognized_answer_cancels(cli_stub, answer, capsys):
+    cli_stub._pending_relaunch_argv = None
     with (
         patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", side_effect=exc),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+        patch.object(HermesCLI, "_prompt_text_input_modal", return_value=answer),
     ):
-        _call(cli_stub)
+        assert _call(cli_stub) is True
 
-    mock_relaunch.assert_not_called()
+    assert cli_stub._pending_relaunch_argv is None
+    assert "/update cancelled." in capsys.readouterr().out
 
 
-@pytest.mark.parametrize("answer", ["y", "Y", "yes", "", " "])
-def test_affirmative_answer_relaunches_as_update(cli_stub, answer):
-    """Empty string (default Y) and any "yes"-shaped answer relaunch
-    via ``hermes_cli.relaunch.relaunch`` with the ``update`` subcommand
-    and ``preserve_inherited=False`` so flags like --tui aren't carried."""
+def test_modal_timeout_cancels(cli_stub):
+    cli_stub._pending_relaunch_argv = None
     with (
         patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", return_value=answer),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
+        patch.object(HermesCLI, "_prompt_text_input_modal", return_value=None),
     ):
-        _call(cli_stub)
+        assert _call(cli_stub) is True
 
-    mock_relaunch.assert_called_once_with(["update"], preserve_inherited=False)
+    assert cli_stub._pending_relaunch_argv is None
+
+
+@pytest.mark.parametrize("answer", ["yes", "y", "Y", "1", ""])
+def test_affirmative_answer_schedules_main_thread_relaunch(cli_stub, answer):
+    cli_stub._pending_relaunch_argv = None
+    with (
+        patch("hermes_cli.config.is_managed", return_value=False),
+        patch.object(HermesCLI, "_prompt_text_input_modal", return_value=answer),
+    ):
+        assert _call(cli_stub) is False
+
+    assert cli_stub._pending_relaunch_argv == ["update"]

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,99 +1,143 @@
-"""Tests for the /update slash command in the classic CLI.
+"""Tests for the /update slash command in the classic CLI and TUI launcher.
 
 Verifies that ``HermesCLI._handle_update_command`` correctly:
 - Refuses to run under a managed install (Homebrew, Docker, etc.)
-- Cancels cleanly on a "n" answer
-- Cancels cleanly on EOF / Ctrl-C at the confirmation prompt
-- Relaunches as ``hermes update`` on a "y" answer (the default)
+- Sets ``_pending_relaunch`` and returns ``True`` on confirmation
+- Cancels cleanly on a "no"-shaped answer or unrecognized input
+- Cancels cleanly when ``_prompt_text_input_modal`` returns None (timeout /
+  modal dismissed)
 
-The TUI side (``/update`` → exit-code-42 → relaunch in main.py) is covered
-by ``ui-tui/src/__tests__/createSlashHandler.test.ts``; this file covers
-the classic CLI path that the TS test cannot reach.
+Also verifies that ``hermes_cli.main._launch_tui`` correctly handles exit
+code 42 (the TUI's signal to trigger an update) by calling
+``relaunch(["update"], preserve_inherited=False)`` from the Python wrapper
+side.  The companion Vitest (``ui-tui/src/__tests__/createSlashHandler.test.ts``)
+covers the TypeScript slash-handler that *emits* code 42; this file covers
+the Python wrapper branch that *acts on* it.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 from cli import HermesCLI
 
 
-@pytest.fixture
-def cli_stub():
-    """Build a minimal HermesCLI-like object bound to the real method.
+def _bound(fn, instance):
+    """Bind an unbound method to a stand-in instance."""
+    return fn.__get__(instance, type(instance))
 
-    We don't run ``__init__`` — we only need ``self`` to dispatch the
-    method.  All collaborators it touches (relaunch, is_managed, input,
-    print) are patched at call sites.
+
+def _make_self(modal_response):
+    """Build a minimal stand-in 'self' for ``_handle_update_command``.
+
+    Uses the same SimpleNamespace pattern as ``test_destructive_slash_confirm``
+    so we don't need a full ``HermesCLI`` construction.
+    ``_prompt_text_input_modal`` is stubbed to return *modal_response*
+    directly so tests can drive the entire confirmation branch without
+    touching stdin or prompt_toolkit internals.
     """
-    return MagicMock(spec=HermesCLI)
+    self_ = SimpleNamespace(
+        _app=None,
+        _pending_relaunch=None,
+        _prompt_text_input=lambda _prompt: modal_response,
+        _prompt_text_input_modal=lambda **_kw: modal_response,
+    )
+    self_._normalize_slash_confirm_choice = _bound(
+        HermesCLI._normalize_slash_confirm_choice, self_
+    )
+    return self_
 
 
-def _call(cli_stub):
+def _call(self_):
     """Invoke the real ``_handle_update_command`` on the stub."""
-    HermesCLI._handle_update_command(cli_stub)
+    return HermesCLI._handle_update_command(self_)
 
 
-def test_managed_install_refuses_and_does_not_relaunch(cli_stub, capsys):
+# ---------------------------------------------------------------------------
+# Managed-install guard
+# ---------------------------------------------------------------------------
+
+
+def test_managed_install_refuses_and_does_not_set_pending_relaunch(capsys):
     """Under a managed install (brew/docker), /update prints a hint and
-    returns without launching anything."""
+    returns without setting ``_pending_relaunch``."""
+    self_ = _make_self(modal_response="should not be called")
     with (
         patch("hermes_cli.config.is_managed", return_value=True),
         patch(
             "hermes_cli.config.format_managed_message",
             return_value="Use `brew upgrade hermes-agent` to update.",
         ),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
-        patch("builtins.input") as mock_input,
     ):
-        _call(cli_stub)
+        result = _call(self_)
 
     out = capsys.readouterr().out
     assert "brew upgrade hermes-agent" in out
-    mock_input.assert_not_called()
-    mock_relaunch.assert_not_called()
+    assert self_._pending_relaunch is None
+    assert not result
+
+
+# ---------------------------------------------------------------------------
+# Confirmation proceeds only on recognised affirmative responses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", "YES", "1", "ok"])
+def test_affirmative_answer_sets_pending_relaunch_and_returns_true(answer, capsys):
+    """Recognised affirmative answers ("y", "yes", "1", "ok") set
+    ``_pending_relaunch = ["update"]`` and return ``True`` so the caller
+    (process_command) can trigger the main-thread app-exit path."""
+    self_ = _make_self(modal_response=answer)
+    with patch("hermes_cli.config.is_managed", return_value=False):
+        result = _call(self_)
+
+    assert self_._pending_relaunch == ["update"]
+    assert result is True
+    assert "Launching update" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Cancellation paths — _pending_relaunch must stay None
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("answer", ["n", "N", "no", "NO", " no "])
-def test_negative_answer_cancels(cli_stub, answer, capsys):
-    """Any "no"-shaped answer cancels without relaunching."""
-    with (
-        patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", return_value=answer),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
-    ):
-        _call(cli_stub)
+def test_negative_answer_cancels(answer, capsys):
+    """Any "no"-shaped answer cancels without setting ``_pending_relaunch``."""
+    self_ = _make_self(modal_response=answer)
+    with patch("hermes_cli.config.is_managed", return_value=False):
+        result = _call(self_)
 
-    mock_relaunch.assert_not_called()
-    # Should not have printed "Launching update..."
+    assert self_._pending_relaunch is None
+    assert not result
     assert "Launching update" not in capsys.readouterr().out
 
 
-@pytest.mark.parametrize("exc", [EOFError, KeyboardInterrupt])
-def test_eof_or_ctrl_c_at_prompt_cancels(cli_stub, exc):
-    """EOFError (Ctrl-D) and KeyboardInterrupt (Ctrl-C) cancel cleanly."""
-    with (
-        patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", side_effect=exc),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
-    ):
-        _call(cli_stub)
+def test_none_response_cancels(capsys):
+    """``None`` from the modal (timeout or dismiss) cancels cleanly."""
+    self_ = _make_self(modal_response=None)
+    with patch("hermes_cli.config.is_managed", return_value=False):
+        result = _call(self_)
 
-    mock_relaunch.assert_not_called()
+    assert self_._pending_relaunch is None
+    assert not result
 
 
-@pytest.mark.parametrize("answer", ["y", "Y", "yes", "", " "])
-def test_affirmative_answer_relaunches_as_update(cli_stub, answer):
-    """Empty string (default Y) and any "yes"-shaped answer relaunch
-    via ``hermes_cli.relaunch.relaunch`` with the ``update`` subcommand
-    and ``preserve_inherited=False`` so flags like --tui aren't carried."""
-    with (
-        patch("hermes_cli.config.is_managed", return_value=False),
-        patch("builtins.input", return_value=answer),
-        patch("hermes_cli.relaunch.relaunch") as mock_relaunch,
-    ):
-        _call(cli_stub)
+@pytest.mark.parametrize("answer", ["nope", "cancel", "sure", "2", "3", "abort", ""])
+def test_unrecognized_or_cancel_input_cancels(answer, capsys):
+    """Unrecognised input and explicit "cancel" do not proceed.
 
-    mock_relaunch.assert_called_once_with(["update"], preserve_inherited=False)
+    Previously the implementation treated any non-"n/no" answer as approval,
+    which meant typos like "nope" or "cancel" would launch the update.
+    Now only confirmed affirmative aliases ("y", "yes", "1", "ok") proceed;
+    everything else (including empty string, "cancel", typos) cancels.
+    """
+    self_ = _make_self(modal_response=answer)
+    with patch("hermes_cli.config.is_managed", return_value=False):
+        result = _call(self_)
+
+    assert self_._pending_relaunch is None
+    assert not result

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -42,7 +42,6 @@ def _make_self(modal_response):
     self_ = SimpleNamespace(
         _app=None,
         _pending_relaunch=None,
-        _prompt_text_input=lambda _prompt: modal_response,
         _prompt_text_input_modal=lambda **_kw: modal_response,
     )
     self_._normalize_slash_confirm_choice = _bound(
@@ -64,7 +63,15 @@ def _call(self_):
 def test_managed_install_refuses_and_does_not_set_pending_relaunch(capsys):
     """Under a managed install (brew/docker), /update prints a hint and
     returns without setting ``_pending_relaunch``."""
-    self_ = _make_self(modal_response="should not be called")
+    self_ = SimpleNamespace(
+        _app=None,
+        _pending_relaunch=None,
+        # Use pytest.fail so any unexpected modal invocation surfaces as a failure.
+        _prompt_text_input_modal=lambda **_kw: pytest.fail("Modal should not be called"),
+    )
+    self_._normalize_slash_confirm_choice = _bound(
+        HermesCLI._normalize_slash_confirm_choice, self_
+    )
     with (
         patch("hermes_cli.config.is_managed", return_value=True),
         patch(

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -523,6 +523,24 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     assert env["NODE_ENV"] == "production"
 
 
+def test_launch_tui_exit_code_42_relaunches_update(monkeypatch, main_mod):
+    from unittest.mock import patch
+
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(main_mod.subprocess, "call", lambda *args, **kwargs: 42)
+
+    with patch("hermes_cli.relaunch.relaunch") as mock_relaunch:
+        with pytest.raises(SystemExit) as exc:
+            main_mod._launch_tui()
+
+    assert exc.value.code == 42
+    mock_relaunch.assert_called_once_with(["update"], preserve_inherited=False)
+
+
 def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path):
     tui_dir = tmp_path / "ui-tui"
     tsx = tui_dir / "node_modules" / ".bin" / "tsx"

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -622,3 +622,45 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(
     assert seen == ["actual_session"]
     assert "hermes --tui --resume actual_session" in out
     assert "startup_resume" not in out
+
+
+def test_launch_tui_exit_code_42_calls_relaunch_update(monkeypatch, main_mod):
+    """When the TUI subprocess exits with code 42 (the /update signal),
+    ``_launch_tui`` must call ``relaunch(["update"], preserve_inherited=False)``
+    before ``sys.exit``.
+
+    The Vitest in ``ui-tui/src/__tests__/createSlashHandler.test.ts`` covers
+    the TypeScript slash handler that *emits* code 42.  This test covers the
+    Python wrapper branch that *acts on* it — the branch that the Vitest
+    cannot reach.
+    """
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(main_mod.subprocess, "call", lambda *args, **kwargs: 42)
+    monkeypatch.setattr(main_mod, "_print_tui_exit_summary", lambda *_args, **_kwargs: None)
+
+    relaunch_calls: list[tuple] = []
+
+    import hermes_cli.relaunch as relaunch_mod
+
+    monkeypatch.setattr(
+        relaunch_mod,
+        "relaunch",
+        lambda args, preserve_inherited=True: relaunch_calls.append(
+            (args, preserve_inherited)
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod._launch_tui()
+
+    assert relaunch_calls == [(["update"], False)], (
+        "_launch_tui did not call relaunch(['update'], preserve_inherited=False) "
+        "when TUI exited with code 42"
+    )
+    # sys.exit(42) is called after relaunch() returns (mocked — normally
+    # relaunch() replaces the process on POSIX or exits the process on Windows).
+    assert exc_info.value.code == 42

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2193,6 +2193,9 @@ def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible
     assert "/deny" not in pairs
     assert "/sethome" not in pairs
 
+    assert "/update" in pairs
+    assert canon["/update"] == "/update"
+
     assert "/topic" not in canon
     assert "/approve" not in canon
     assert "/deny" not in canon

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4382,7 +4382,6 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
     {
         "sethome",
         "set-home",
-        "update",
         "commands",
         "approve",
         "deny",

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -34,6 +34,21 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('handles /update locally and exits with code 42 via dieWithCode', () => {
+    vi.useFakeTimers()
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/update')).toBe(true)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('exiting TUI to run update...')
+
+    // Advance past the 100ms setTimeout
+    vi.advanceTimersByTime(150)
+    expect(ctx.session.dieWithCode).toHaveBeenCalledWith(42)
+
+    vi.useRealTimers()
+  })
+
   it('routes /status to live session.status instead of slash worker', async () => {
     patchUiState({ sid: 'sid-abc' })
     const rpc = vi.fn(() => Promise.resolve({ output: 'Hermes TUI Status' }))
@@ -730,6 +745,7 @@ const buildComposer = () => ({
 const buildGateway = () => ({
   gw: {
     getLogTail: vi.fn(() => ''),
+    kill: vi.fn(),
     request: vi.fn(() => Promise.resolve({}))
   },
   rpc: vi.fn(() => Promise.resolve({}))
@@ -746,6 +762,7 @@ const buildLocal = () => ({
 const buildSession = () => ({
   closeSession: vi.fn(() => Promise.resolve(null)),
   die: vi.fn(),
+  dieWithCode: vi.fn(),
   guardBusySessionSwitch: vi.fn(() => false),
   newSession: vi.fn(),
   resetVisibleHistory: vi.fn(),

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -277,6 +277,7 @@ export interface SlashHandlerContext {
   session: {
     closeSession: (targetSid?: null | string) => Promise<unknown>
     die: () => void
+    dieWithCode: (code: number) => void
     guardBusySessionSwitch: (what?: string) => boolean
     newSession: (msg?: string, title?: string) => void
     resetVisibleHistory: (info?: null | SessionInfo) => void

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -93,6 +93,17 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    help: 'update Hermes Agent to the latest version (exits TUI)',
+    name: 'update',
+    run: (_arg, ctx) => {
+      ctx.transcript.sys('exiting TUI to run update...')
+      // Exit code 42 signals the Python wrapper to exec `hermes update`.
+      // Use dieWithCode for proper cleanup (gateway kill + Ink unmount).
+      setTimeout(() => ctx.session.dieWithCode(42), 100)
+    }
+  },
+
+  {
     aliases: ['scroll'],
     help: 'toggle mouse/wheel tracking [on|off|toggle]',
     name: 'mouse',

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -377,6 +377,12 @@ export function useMainApp(gw: GatewayClient) {
     process.exit(0)
   }, [exit, gw])
 
+  const dieWithCode = useCallback((code: number) => {
+    gw.kill()
+    exit()
+    process.exit(code)
+  }, [exit, gw])
+
   const session = useSessionLifecycle({
     colsRef,
     composerActions,
@@ -643,6 +649,7 @@ export function useMainApp(gw: GatewayClient) {
         session: {
           closeSession: session.closeSession,
           die,
+          dieWithCode,
           guardBusySessionSwitch: session.guardBusySessionSwitch,
           newSession: session.newSession,
           resetVisibleHistory: session.resetVisibleHistory,


### PR DESCRIPTION
## What does this PR do?

Makes the `/update` slash command available in the interactive CLI and TUI, not just the messaging gateway. Previously it was `gateway_only=True`, so users in the CLI/TUI had to exit and manually run `hermes update`. Now they can type `/update` directly.

- **Classic CLI**: prompts for confirmation, then `execvp`s `hermes update` (replaces the process so the user sees update output directly).
- **TUI**: exits with code 42 (a signal to the Python wrapper), which then `execvp`s `hermes update`.
- **Gateway**: unchanged — existing detached subprocess behavior continues to work.

## Related Issue

N/A — quality of life improvement.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/commands.py`: Removed `gateway_only=True` from the `update` CommandDef
- `cli.py`: Added dispatch entry + `_handle_update_command()` method (managed check, git check, Y/n confirmation, execvp)
- `hermes_cli/main.py`: Handle exit code 42 in `_launch_tui()` — execs `hermes update` when TUI signals update
- `ui-tui/src/app/slash/commands/core.ts`: Added `/update` TUI slash command that exits with code 42
- `tui_gateway/server.py`: Removed `"update"` from `_TUI_HIDDEN` so it shows in help

## How to Test

1. Start the classic CLI: `hermes`
2. Type `/update`
3. Should see confirmation prompt: "Update Hermes Agent to the latest version? This will exit the current session. [Y/n]"
4. Type `y` — process should exec into `hermes update` and proceed with the update
5. Type `n` — should cancel and return to the CLI prompt

For TUI:
1. Start TUI: `hermes --tui`
2. Type `/update`
3. Should see "exiting TUI to run update..." then TUI exits and `hermes update` runs

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
