### PR TITLE
fix(wecom): update connection status after WebSocket reconnection

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -345,6 +345,7 @@ class WeComAdapter(BasePlatformAdapter):
                 try:
                     await self._open_connection()
                     backoff_idx = 0
+                    self._mark_connected()
                     logger.info("[%s] Reconnected", self.name)
                 except Exception as reconnect_exc:
                     logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc)


### PR DESCRIPTION
The WeCom adapter's `_listen_loop()` automatically reconnects when the WebSocket drops, but it never called `_mark_connected()` after a successful reconnection. This left the runtime status file (`gateway_state.json`) stuck in `\"disconnected\"` even though the adapter was fully operational again.

Add `self._mark_connected()` right after `_open_connection()` succeeds so that the dashboard and health probes report the correct state.

**Tested by**: forcing a WebSocket close via the heartbeat loop and verifying that the status file updated from `\"disconnected\"` back to `\"connected\"`.