### PR TITLE
feat(usage): read DeepSeek prompt_cache_hit_tokens for accurate cache stats

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -715,6 +715,15 @@ def normalize_usage(
             cache_write_tokens = _to_int(
                 getattr(response_usage, "cache_creation_input_tokens", 0)
             )
+        # DeepSeek: implicit disk-based context caching returns
+        # prompt_cache_hit_tokens at the usage top level (not inside
+        # prompt_tokens_details).  Treated as cache reads — the tokens
+        # were served from the KV cache at a 90% discount.
+        # Ref: https://api-docs.deepseek.com/guides/kv_cache
+        if not cache_read_tokens:
+            cache_read_tokens = _to_int(
+                getattr(response_usage, "prompt_cache_hit_tokens", 0)
+            )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 
     reasoning_tokens = 0


### PR DESCRIPTION
## Problem

DeepSeek API returns `prompt_cache_hit_tokens` at the usage top level (not inside `prompt_tokens_details`). Hermes only checked `prompt_tokens_details.cached_tokens` and Anthropic-style fallbacks, missing DeepSeek cache hits entirely. Users on DeepSeek direct API saw `cache_read_tokens=0` in `/usage` even when the KV disk cache was serving >90% of tokens.

## Fix

Add a fallback in the chat-completions branch of `normalize_usage` (2 lines):

```python
if not cache_read_tokens:
    cache_read_tokens = _to_int(
        getattr(response_usage, "prompt_cache_hit_tokens", 0)
    )
```

Sits after existing fallbacks. Only activates when neither `prompt_tokens_details.cached_tokens` nor `cache_read_input_tokens` were populated.

## Testing

- 9 existing `test_usage_pricing.py` tests pass (no regressions)
- Live test on `deepseek-v4-pro`, 7 turns: 549,888 cache hits / 598,661 prompt tokens = **91.9% hit rate** (was 0 before)

## Ref

https://api-docs.deepseek.com/guides/kv_cache
