### PR TITLE
fix(dashboard): fallback to stale dist, retry build, add --skip-build flag

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5601,6 +5601,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
+    # First attempt
     r2 = subprocess.run(
         [npm, "run", "build"],
         cwd=web_dir,
@@ -5610,10 +5611,40 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         errors="replace",
     )
     if r2.returncode != 0:
+        # Retry once after a short delay — covers boot-time races on Windows
+        # (antivirus scanning Node.js binaries, npm cache not ready, transient
+        # I/O when launched via Scheduled Task at logon). See issue #23817.
+        _time.sleep(3)
+        r2 = subprocess.run(
+            [npm, "run", "build"],
+            cwd=web_dir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    if r2.returncode != 0:
+        stderr_preview = (r2.stderr or "").strip()
+        stderr_tail = "\n  ".join(stderr_preview.splitlines()[-10:]) if stderr_preview else ""
+        dist_dir = web_dir.parent / "hermes_cli" / "web_dist"
+        dist_index = dist_dir / "index.html"
+
+        # If a stale dist exists, serve it as a fallback instead of failing.
+        # A stale UI is far better than no UI for non-interactive callers
+        # (Windows Scheduled Tasks, CI) — issue #23817.
+        if dist_index.exists():
+            print("  ⚠ Web UI build failed — serving stale dist as fallback")
+            if stderr_tail:
+                print(f"  Build error:\n  {stderr_tail}")
+            return True
+
         print(
             f"  {'✗' if fatal else '⚠'} Web UI build failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
+        if stderr_tail:
+            print(f"  Build error:\n  {stderr_tail}")
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
@@ -9086,7 +9117,7 @@ def cmd_dashboard(args):
         print(f"Import error: {e}")
         sys.exit(1)
 
-    if "HERMES_WEB_DIST" not in os.environ:
+    if "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)
 
@@ -11563,6 +11594,15 @@ Examples:
         help=(
             "Expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket). "
             "Alternatively set HERMES_DASHBOARD_TUI=1."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help=(
+            "Skip the web UI build step and serve the existing dist directly. "
+            "Useful for non-interactive contexts (Windows Scheduled Tasks, CI) "
+            "where npm may not be available. Pre-build with: cd web && npm run build"
         ),
     )
     # Lifecycle flags — mutually exclusive with each other and with the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9120,6 +9120,21 @@ def cmd_dashboard(args):
     if "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)
+    elif getattr(args, "skip_build", False):
+        # --skip-build trusts the caller to have pre-built the web UI.
+        # Verify the dist actually exists; otherwise the server will start
+        # and serve 404s with no obvious cause (issue #23817).
+        _dist_root = (
+            Path(os.environ["HERMES_WEB_DIST"])
+            if "HERMES_WEB_DIST" in os.environ
+            else PROJECT_ROOT / "hermes_cli" / "web_dist"
+        )
+        if not (_dist_root / "index.html").exists():
+            print(f"✗ --skip-build was passed but no web dist found at: {_dist_root}")
+            print("  Pre-build first:  cd web && npm install && npm run build")
+            print("  Or drop --skip-build to build automatically.")
+            sys.exit(1)
+        print(f"→ Skipping web UI build (--skip-build); using dist at {_dist_root}")
 
     from hermes_cli.web_server import start_server
 

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -147,3 +147,64 @@ class TestBuildWebUISkipsWhenFresh:
         assert build_kwargs["text"] is True
         assert build_kwargs["encoding"] == "utf-8"
         assert build_kwargs["errors"] == "replace"
+
+
+class TestBuildWebUIRetryAndStaleFallback:
+    """Coverage for the retry + stale-dist fallback added in #23824 / issue #23817."""
+
+    def test_retries_build_once_on_failure(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        Subprocess = __import__("subprocess")
+        # install: success; build attempt 1: fail; build attempt 2: success
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        build_fail = Subprocess.CompletedProcess([], 1, stdout="", stderr="EPERM")
+        build_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main._time.sleep") as mock_sleep, \
+             patch("hermes_cli.main.subprocess.run",
+                   side_effect=[install_ok, build_fail, build_ok]) as mock_run:
+            result = _build_web_ui(web_dir)
+
+        assert result is True
+        assert mock_run.call_count == 3  # install + build + retry
+        mock_sleep.assert_called_once_with(3)
+
+    def test_falls_back_to_stale_dist_when_retry_also_fails(self, tmp_path, capsys):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        # Stale dist exists but is older than source
+        _touch(dist_dir / "index.html", offset=-100)
+        _touch(web_dir / "src" / "App.tsx")  # newer source -> build_needed=True
+
+        Subprocess = __import__("subprocess")
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        build_fail = Subprocess.CompletedProcess([], 1, stdout="", stderr="vite ENOMEM")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main._time.sleep"), \
+             patch("hermes_cli.main.subprocess.run",
+                   side_effect=[install_ok, build_fail, build_fail]):
+            result = _build_web_ui(web_dir, fatal=True)
+
+        # MUST return True (serve stale) — issue #23817 — even with fatal=True,
+        # because cmd_dashboard passes fatal=True and is the primary caller.
+        assert result is True
+        out = capsys.readouterr().out
+        assert "serving stale dist as fallback" in out
+        assert "vite ENOMEM" in out  # stderr surfaced to user
+
+    def test_hard_fails_when_no_dist_to_fall_back_to(self, tmp_path, capsys):
+        web_dir, _ = _make_web_dir(tmp_path)
+
+        Subprocess = __import__("subprocess")
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        build_fail = Subprocess.CompletedProcess([], 1, stdout="", stderr="vite ENOMEM")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main._time.sleep"), \
+             patch("hermes_cli.main.subprocess.run",
+                   side_effect=[install_ok, build_fail, build_fail]):
+            result = _build_web_ui(web_dir, fatal=True)
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Web UI build failed" in out
+        assert "vite ENOMEM" in out
+        assert "Run manually" in out


### PR DESCRIPTION
Salvages #23824 by @ygd58 with two correctness fixes folded in.

Fixes #23817 — Windows Scheduled Task starts the dashboard at logon, npm build fails in the non-interactive environment, and the dashboard exits with no fallback. Port 9119 stays unreachable until the user manually rebuilds.

## Changes

`hermes_cli/main.py`:
- `_build_web_ui`: retry `npm run build` once after 3s (covers boot-time races on Windows — antivirus scanning Node.js, npm cache not ready, transient I/O).
- `_build_web_ui`: if the build still fails AND a stale `web_dist/index.html` exists, serve it as a fallback. A stale UI is far better than no UI for non-interactive callers.
- `_build_web_ui`: surface the npm stderr tail (last 10 lines) in the failure message — previously the user just saw "✗ Web UI build failed" with no clue why.
- `cmd_dashboard`: add `--skip-build` flag for callers that pre-build (e.g. a BAT wrapper around the Scheduled Task). When set, validate that the dist actually exists before starting the server, so a misconfigured pre-build exits 1 with clear guidance instead of silently serving 404s.

`tests/hermes_cli/test_web_ui_build.py`:
- 3 new tests — retry path, stale-dist fallback (with `fatal=True`, which is the issue's primary scenario), and hard-fail when no dist exists.

## Salvage notes

@ygd58's PR had a Python `SyntaxError` (literal newline mid-string in the `\"\\n  \".join(...)`) and gated the stale-dist fallback on `not fatal` — but `cmd_dashboard` always passes `fatal=True`, so the fallback never fired in the exact scenario the issue is about. Both fixed in the cherry-pick. Followup commit adds the `--skip-build` dist-existence sanity check + tests.

## Validation

| | Result |
|---|---|
| `tests/hermes_cli/test_web_ui_build.py` | 16/16 passed (13 pre-existing + 3 new) |
| `tests/hermes_cli/test_dashboard_*` | 24/24 passed |
| E2E: build fails + stale dist (fatal=True) | fallback fires, stderr surfaced |
| E2E: build fails + no dist (fatal=True) | exit 1 with stderr + "Run manually" |
| E2E: `--skip-build` + missing dist | exit 1 with clear "pre-build first" guidance |
| E2E: `--skip-build` + valid dist | "→ Skipping web UI build (--skip-build); using dist at ..." |

Original PR #23824 will be closed with credit pointing here.