### PR TITLE
feat(goals): agent-owned /goal checklist + /subgoal user controls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7252,6 +7252,8 @@ class HermesCLI:
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "goal":
             self._handle_goal_command(cmd_original)
+        elif canonical == "subgoal":
+            self._handle_subgoal_command(cmd_original)
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":
@@ -7837,36 +7839,153 @@ class HermesCLI:
 
         _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
         _cprint(
-            f"  {_DIM}After each turn, a judge model will check if the goal is done. "
-            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
-            f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
+            f"  {_DIM}The agent will propose a checklist on the next turn, "
+            f"then mark items completed as it works. The loop continues "
+            f"until every item is in a terminal status, you pause/clear it, "
+            f"or the budget is exhausted. Use /goal status / pause / resume / "
+            f"clear, and /subgoal to view or override the checklist.{_RST}"
         )
-        # Kick the loop off immediately so the user doesn't have to send a
-        # separate message after setting the goal.
+        # Kick the loop off immediately with the decompose prompt so the
+        # agent's first turn proposes a checklist via goal_checklist().
         try:
-            self._pending_input.put(state.goal)
+            kickoff_prompt = mgr.next_continuation_prompt() or state.goal
+            self._pending_input.put(kickoff_prompt)
         except Exception:
             pass
 
+    def _handle_subgoal_command(self, cmd: str) -> None:
+        """Dispatch /subgoal subcommands.
+
+        Forms:
+          /subgoal                              show the checklist
+          /subgoal <text>                       append a user item
+          /subgoal complete <n>                 user marks item n completed
+          /subgoal impossible <n>               user marks item n impossible
+          /subgoal undo <n>                     user reverts n to pending
+          /subgoal challenge <n>                push back on agent's claim
+          /subgoal remove <n>                   delete item n
+          /subgoal clear                        wipe (agent re-decomposes)
+        """
+        parts = (cmd or "").strip().split(None, 2)
+        arg = " ".join(parts[1:]).strip() if len(parts) > 1 else ""
+
+        mgr = self._get_goal_manager()
+        if mgr is None:
+            _cprint(f"  {_DIM}Goals unavailable (no active session).{_RST}")
+            return
+
+        if not mgr.has_goal():
+            _cprint(f"  {_DIM}No active goal. Set one with /goal <text>.{_RST}")
+            return
+
+        if not arg:
+            _cprint(f"  {mgr.status_line()}")
+            _cprint(f"  {mgr.render_checklist()}")
+            return
+
+        tokens = arg.split(None, 1)
+        verb = tokens[0].lower()
+        rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+        action_status_map = {
+            "complete": "completed",
+            "completed": "completed",
+            "done": "completed",
+            "impossible": "impossible",
+            "imp": "impossible",
+            "skip": "impossible",
+            "undo": "pending",
+            "pending": "pending",
+            "reset": "pending",
+        }
+        if verb in action_status_map:
+            if not rest:
+                _cprint(f"  Usage: /subgoal {verb} <n>")
+                return
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                _cprint(f"  /subgoal {verb}: <n> must be an integer (1-based index).")
+                return
+            try:
+                item = mgr.mark_subgoal(idx, action_status_map[verb])
+            except (IndexError, ValueError, RuntimeError) as exc:
+                _cprint(f"  /subgoal {verb}: {exc}")
+                return
+            _cprint(f"  ✓ Item {idx} → {item.status}: {item.text}")
+            return
+
+        if verb == "challenge":
+            if not rest:
+                _cprint("  Usage: /subgoal challenge <n>")
+                return
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                _cprint("  /subgoal challenge: <n> must be an integer (1-based index).")
+                return
+            try:
+                item = mgr.challenge_subgoal(idx)
+            except (IndexError, ValueError, RuntimeError) as exc:
+                _cprint(f"  /subgoal challenge: {exc}")
+                return
+            _cprint(
+                f"  ⚡ Item {idx} challenged → flipped back to pending. "
+                f"Agent will revisit on the next turn: {item.text}"
+            )
+            return
+
+        if verb == "remove":
+            if not rest:
+                _cprint("  Usage: /subgoal remove <n>")
+                return
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                _cprint("  /subgoal remove: <n> must be an integer (1-based index).")
+                return
+            try:
+                removed = mgr.remove_subgoal(idx)
+            except (IndexError, RuntimeError) as exc:
+                _cprint(f"  /subgoal remove: {exc}")
+                return
+            _cprint(f"  ✓ Removed item {idx}: {removed.text}")
+            return
+
+        if verb == "clear":
+            mgr.clear_checklist()
+            _cprint(
+                "  ✓ Checklist cleared. The agent will propose a new one on the next turn."
+            )
+            return
+
+        # Otherwise — append `arg` as a new user-authored checklist item.
+        try:
+            item = mgr.add_subgoal(arg)
+        except (ValueError, RuntimeError) as exc:
+            _cprint(f"  /subgoal: {exc}")
+            return
+        idx = len(mgr.state.checklist) if mgr.state else 0
+        _cprint(f"  ✓ Added subgoal {idx}: {item.text}")
+
     def _maybe_continue_goal_after_turn(self) -> None:
-        """Hook run after every CLI turn. Judges + maybe re-queues.
+        """Hook run after every CLI turn. Decides whether to re-queue.
 
         Safe to call when no goal is set — returns quickly.
 
         Preemption is automatic: if a real user message is already in
-        ``_pending_input`` we skip judging (the user's new input takes
-        priority and we'll re-judge after that turn). If judge says done,
-        mark it done and tell the user. If judge says continue and we're
-        under budget, push the continuation prompt onto the queue.
+        ``_pending_input`` we skip the continuation (the user's new
+        input takes priority).
 
         Interrupt handling: if the turn was user-cancelled (Ctrl+C), we
-        AUTO-PAUSE the goal instead of judging + re-queuing. Otherwise
-        Ctrl+C feels like it did nothing — the judge runs on whatever
-        partial output landed, almost always says "continue", and the
-        loop keeps going. Auto-pause keeps the goal recoverable via
-        ``/goal resume`` once the user has sorted out what they want.
-        The empty-response skip mirrors the gateway guard at
-        ``_handle_message`` in ``gateway/run.py``.
+        AUTO-PAUSE the goal so the loop doesn't immediately re-queue
+        another turn the user just cancelled. Pausing keeps the goal
+        recoverable via ``/goal resume``.
+
+        Termination is now agent-owned: the agent flips checklist items
+        via the ``goal_checklist`` model tool. ``evaluate_after_turn``
+        just inspects state — no aux-model judge, no JSON parsing, no
+        snippet extraction.
         """
         mgr = self._get_goal_manager()
         if mgr is None or not mgr.is_active():
@@ -7882,10 +8001,8 @@ class HermesCLI:
             pass
 
         # If the turn was user-interrupted (Ctrl+C), auto-pause the goal
-        # and bail. The judge call would almost always return "continue"
-        # on the partial output and immediately re-queue another turn,
-        # which is exactly what the user cancelled. Pausing (rather than
-        # silently skipping) is the observable, recoverable behavior.
+        # and bail. Pausing (rather than silently skipping) is the
+        # observable, recoverable behavior.
         if getattr(self, "_last_turn_interrupted", False):
             try:
                 mgr.pause(reason="user-interrupted (Ctrl+C)")
@@ -7897,35 +8014,7 @@ class HermesCLI:
             )
             return
 
-        # Extract the agent's final response for this turn.
-        last_response = ""
-        try:
-            hist = self.conversation_history or []
-            for msg in reversed(hist):
-                if msg.get("role") == "assistant":
-                    content = msg.get("content", "")
-                    if isinstance(content, list):
-                        # Multimodal content — flatten text parts.
-                        parts = [
-                            p.get("text", "")
-                            for p in content
-                            if isinstance(p, dict) and p.get("type") in ("text", "output_text")
-                        ]
-                        last_response = "\n".join(t for t in parts if t)
-                    else:
-                        last_response = str(content or "")
-                    break
-        except Exception:
-            last_response = ""
-
-        # Skip judging on empty/whitespace-only responses. These are almost
-        # always transient failures (API error, empty stream) where the
-        # judge would say "continue" and trip the consecutive-parse-failures
-        # backstop unnecessarily. Mirrors the gateway guard.
-        if not last_response.strip():
-            return
-
-        decision = mgr.evaluate_after_turn(last_response, user_initiated=True)
+        decision = mgr.evaluate_after_turn(user_initiated=True)
         msg = decision.get("message") or ""
         if msg:
             _cprint(f"  {msg}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6083,6 +6083,12 @@ class GatewayRunner:
                     return await self._handle_goal_command(event)
                 return "Agent is running — use /goal status / pause / clear mid-run, or /stop before setting a new goal."
 
+            # /subgoal is safe mid-run — it only modifies the active goal's
+            # checklist, which the agent reads from at turn boundaries via
+            # the goal_checklist tool. There is no race with the running turn.
+            if _cmd_def_inner and _cmd_def_inner.name == "subgoal":
+                return await self._handle_subgoal_command(event)
+
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
             # the tool-progress display mode for the ongoing stream.
@@ -6460,6 +6466,9 @@ class GatewayRunner:
 
         if canonical == "goal":
             return await self._handle_goal_command(event)
+
+        if canonical == "subgoal":
+            return await self._handle_subgoal_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -9366,14 +9375,16 @@ class GatewayRunner:
         except ValueError as exc:
             return t("gateway.goal.invalid", error=str(exc))
 
-        # Queue the goal text as an immediate first turn so the agent
-        # starts making progress. The post-turn hook takes over after.
+        # Queue the decompose prompt as an immediate first turn so the
+        # agent's first action is to propose a checklist via the
+        # goal_checklist tool. After that the post-turn hook takes over.
         adapter = self.adapters.get(event.source.platform) if event.source else None
         _quick_key = self._session_key_for_source(event.source) if event.source else None
         if adapter and _quick_key:
             try:
+                kickoff_text = mgr.next_continuation_prompt() or state.goal
                 kickoff_event = MessageEvent(
-                    text=state.goal,
+                    text=kickoff_text,
                     message_type=MessageType.TEXT,
                     source=event.source,
                     message_id=event.message_id,
@@ -9384,6 +9395,80 @@ class GatewayRunner:
                 logger.debug("goal kickoff enqueue failed: %s", exc)
 
         return t("gateway.goal.set", budget=state.max_turns, goal=state.goal)
+
+    async def _handle_subgoal_command(self, event: "MessageEvent") -> str:
+        """Handle /subgoal for gateway platforms (mirror of CLI handler)."""
+        args = (event.get_command_args() or "").strip()
+        mgr, _session_entry = self._get_goal_manager_for_event(event)
+        if mgr is None:
+            return t("gateway.goal.unavailable")
+        if not mgr.has_goal():
+            return "No active goal. Set one with /goal <text>."
+
+        if not args:
+            return f"{mgr.status_line()}\n{mgr.render_checklist()}"
+
+        tokens = args.split(None, 1)
+        verb = tokens[0].lower()
+        rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+        action_status_map = {
+            "complete": "completed", "completed": "completed", "done": "completed",
+            "impossible": "impossible", "imp": "impossible", "skip": "impossible",
+            "undo": "pending", "pending": "pending", "reset": "pending",
+        }
+        if verb in action_status_map:
+            if not rest:
+                return f"Usage: /subgoal {verb} <n>"
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                return f"/subgoal {verb}: <n> must be an integer (1-based index)."
+            try:
+                item = mgr.mark_subgoal(idx, action_status_map[verb])
+            except (IndexError, ValueError, RuntimeError) as exc:
+                return f"/subgoal {verb}: {exc}"
+            return f"✓ Item {idx} → {item.status}: {item.text}"
+
+        if verb == "challenge":
+            if not rest:
+                return "Usage: /subgoal challenge <n>"
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                return "/subgoal challenge: <n> must be an integer (1-based index)."
+            try:
+                item = mgr.challenge_subgoal(idx)
+            except (IndexError, ValueError, RuntimeError) as exc:
+                return f"/subgoal challenge: {exc}"
+            return (
+                f"⚡ Item {idx} challenged → flipped back to pending. "
+                f"Agent will revisit on the next turn: {item.text}"
+            )
+
+        if verb == "remove":
+            if not rest:
+                return "Usage: /subgoal remove <n>"
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                return "/subgoal remove: <n> must be an integer (1-based index)."
+            try:
+                removed = mgr.remove_subgoal(idx)
+            except (IndexError, RuntimeError) as exc:
+                return f"/subgoal remove: {exc}"
+            return f"✓ Removed item {idx}: {removed.text}"
+
+        if verb == "clear":
+            mgr.clear_checklist()
+            return "✓ Checklist cleared. Agent will propose a new one on the next turn."
+
+        try:
+            item = mgr.add_subgoal(args)
+        except (ValueError, RuntimeError) as exc:
+            return f"/subgoal: {exc}"
+        idx = len(mgr.state.checklist) if mgr.state else 0
+        return f"✓ Added subgoal {idx}: {item.text}"
 
     async def _send_goal_status_notice(self, source: Any, message: str) -> None:
         """Send a /goal judge status line back to the originating chat/thread."""
@@ -9480,7 +9565,7 @@ class GatewayRunner:
         if not mgr.is_active():
             return
 
-        decision = mgr.evaluate_after_turn(final_response or "", user_initiated=True)
+        decision = mgr.evaluate_after_turn(user_initiated=True)
         msg = decision.get("message") or ""
 
         # Defer the status line until after the adapter has delivered the

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -104,6 +104,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<prompt>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | pause | resume | clear | status]"),
+    CommandDef("subgoal", "Add or manage checklist items on the active goal", "Session",
+               args_hint="[text | complete N | impossible N | undo N | challenge N | remove N | clear]"),
     CommandDef("status", "Show session info", "Session"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1,28 +1,36 @@
-"""Persistent session goals — the Ralph loop for Hermes.
+"""Persistent session goals — agent-owned checklist.
 
-A goal is a free-form user objective that stays active across turns. After
-each turn completes, a small judge call asks an auxiliary model "is this
-goal satisfied by the assistant's last response?". If not, Hermes feeds a
-continuation prompt back into the same session and keeps working until the
-goal is done, turn budget is exhausted, the user pauses/clears it, or the
-user sends a new message (which takes priority and pauses the goal loop).
+A goal is a free-form user objective that stays active across turns. The
+agent that's actually doing the work owns the progress signal: it
+proposes a checklist of completion criteria when the goal is set, then
+calls the ``goal_checklist`` model tool to mark items completed (or
+impossible) as it works. The continuation loop terminates when every
+item is in a terminal status, the user pauses/clears, or the turn budget
+hits.
+
+There is **no aux-model judge** in the loop. The previous design routed
+each turn through an auxiliary "is the goal done?" call, which suffered
+from snippet-only vision, dump-file size limits, JSON-output drift, and
+evidence misalignment. The agent has full visibility into its own tool
+calls, file writes, and command output — let it self-report and let the
+user audit via ``/subgoal``.
 
 State is persisted in SessionDB's ``state_meta`` table keyed by
 ``goal:<session_id>`` so ``/resume`` picks it up.
 
 Design notes / invariants:
 
-- The continuation prompt is just a normal user message appended to the
-  session via ``run_conversation``. No system-prompt mutation, no toolset
-  swap — prompt caching stays intact.
-- Judge failures are fail-OPEN: ``continue``. A broken judge must not wedge
-  progress; the turn budget is the backstop.
-- When a real user message arrives mid-loop it preempts the continuation
-  prompt and also pauses the goal loop for that turn (we still re-judge
-  after, so if the user's message happens to complete the goal the judge
-  will say ``done``).
-- This module has zero hard dependency on ``cli.HermesCLI`` or the gateway
-  runner — both wire the same ``GoalManager`` in.
+- The continuation prompt is a normal user message appended to the
+  session via ``run_conversation``. No system-prompt mutation, no
+  toolset swap — prompt caching stays intact.
+- The agent is the only authority that flips ``pending → completed |
+  impossible``. The user can override via ``/subgoal complete N`` /
+  ``impossible N`` / ``undo N`` / ``challenge N`` (which flips back to
+  pending AND injects a user-role nudge so the agent revisits).
+- When a real user message arrives mid-loop it preempts the
+  continuation prompt and also pauses the goal loop for that turn.
+- This module has zero hard dependency on ``cli.HermesCLI`` or the
+  gateway runner — both wire the same ``GoalManager`` in.
 
 Nothing in this module touches the agent's system prompt or toolset.
 """
@@ -31,10 +39,9 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import time
-from dataclasses import dataclass, asdict
-from typing import Any, Dict, Optional, Tuple
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -44,70 +51,156 @@ logger = logging.getLogger(__name__)
 # ──────────────────────────────────────────────────────────────────────
 
 DEFAULT_MAX_TURNS = 20
-DEFAULT_JUDGE_TIMEOUT = 30.0
-# Cap how much of the last response + recent messages we send to the judge.
-_JUDGE_RESPONSE_SNIPPET_CHARS = 4000
-# After this many consecutive judge *parse* failures (empty output / non-JSON),
-# the loop auto-pauses and points the user at the goal_judge config. API /
-# transport errors do NOT count toward this — those are transient. This guards
-# against small models (e.g. deepseek-v4-flash) that cannot follow the strict
-# JSON reply contract; without it the loop runs until the turn budget is
-# exhausted with every reply shaped like `judge returned empty response` or
-# `judge reply was not JSON`.
-DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
+
+# Status constants ────────────────────────────────────────────────────
+ITEM_PENDING = "pending"
+ITEM_COMPLETED = "completed"
+ITEM_IMPOSSIBLE = "impossible"
+TERMINAL_ITEM_STATUSES = frozenset({ITEM_COMPLETED, ITEM_IMPOSSIBLE})
+VALID_ITEM_STATUSES = frozenset({ITEM_PENDING, ITEM_COMPLETED, ITEM_IMPOSSIBLE})
+
+ITEM_MARKERS = {
+    ITEM_COMPLETED: "[x]",
+    ITEM_IMPOSSIBLE: "[!]",
+    ITEM_PENDING: "[ ]",
+}
+
+ADDED_BY_AGENT = "agent"
+ADDED_BY_USER = "user"
 
 
-CONTINUATION_PROMPT_TEMPLATE = (
+# ──────────────────────────────────────────────────────────────────────
+# Continuation prompts
+# ──────────────────────────────────────────────────────────────────────
+
+# When no checklist exists yet (decompose hasn't run), kick the agent into
+# proposing one. The model tool ``goal_checklist`` is the entry point.
+DECOMPOSE_PROMPT_TEMPLATE = (
+    "[Standing goal — please propose a checklist before starting]\n"
+    "Goal: {goal}\n\n"
+    "Before doing any other work, decompose this goal into a detailed "
+    "checklist of concrete, verifiable completion criteria. Each item "
+    "should be a specific, checkable thing — not a vague intention. Aim "
+    "for at least 5 items; more is better when warranted. Include "
+    "sub-items, edge cases, quality bars, and verification steps.\n\n"
+    "Submit the checklist by calling the ``goal_checklist`` tool with "
+    "``items`` set to the list of criteria. Then start working on the "
+    "items. Mark each item ``completed`` (with one-line evidence) by "
+    "calling ``goal_checklist`` again with the ``mark`` parameter as "
+    "you finish it. Mark items ``impossible`` (with reason) when they "
+    "cannot be achieved in this environment.\n\n"
+    "When every item is in a terminal status the goal is done."
+)
+
+# Used on subsequent turns when a checklist already exists. The agent
+# sees the current state and continues working.
+CONTINUATION_PROMPT_WITH_CHECKLIST_TEMPLATE = (
+    "[Continuing toward your standing goal]\n"
+    "Goal: {goal}\n\n"
+    "Checklist progress ({done}/{total} done):\n"
+    "{checklist}\n\n"
+    "Take the next concrete step on a pending item. As you complete "
+    "items, call the ``goal_checklist`` tool with the ``mark`` "
+    "parameter to flip them to ``completed`` (with one-line evidence) "
+    "or ``impossible`` (with reason). If you are blocked on a remaining "
+    "item and need user input, say so clearly and stop.\n\n"
+    "Do not over-claim — only mark items completed when they are "
+    "actually done. The user can challenge any item via ``/subgoal "
+    "challenge N`` if they think you over-claimed."
+)
+
+# Fallback for goals that somehow have no checklist (decompose was
+# cleared by the user, or an old back-compat row). Plain Ralph loop.
+CONTINUATION_PROMPT_NO_CHECKLIST_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
     "Goal: {goal}\n\n"
     "Continue working toward this goal. Take the next concrete step. "
-    "If you believe the goal is complete, state so explicitly and stop. "
-    "If you are blocked and need input from the user, say so clearly and stop."
+    "If you believe the goal is complete, call the ``goal_checklist`` "
+    "tool with a single completed item summarizing what you did. If "
+    "you are blocked and need user input, say so clearly and stop."
 )
 
+# Back-compat alias for callers (gateway tests + builtin hooks) that
+# reference the old single-template name. Points at the no-checklist
+# template since it's the closest analogue to the original prompt.
+CONTINUATION_PROMPT_TEMPLATE = CONTINUATION_PROMPT_NO_CHECKLIST_TEMPLATE
 
-JUDGE_SYSTEM_PROMPT = (
-    "You are a strict judge evaluating whether an autonomous agent has "
-    "achieved a user's stated goal. You receive the goal text and the "
-    "agent's most recent response. Your only job is to decide whether "
-    "the goal is fully satisfied based on that response.\n\n"
-    "A goal is DONE only when:\n"
-    "- The response explicitly confirms the goal was completed, OR\n"
-    "- The response clearly shows the final deliverable was produced, OR\n"
-    "- The response explains the goal is unachievable / blocked / needs "
-    "user input (treat this as DONE with reason describing the block).\n\n"
-    "Otherwise the goal is NOT done — CONTINUE.\n\n"
-    "Reply ONLY with a single JSON object on one line:\n"
-    '{\"done\": <true|false>, \"reason\": \"<one-sentence rationale>\"}'
-)
-
-
-JUDGE_USER_PROMPT_TEMPLATE = (
-    "Goal:\n{goal}\n\n"
-    "Agent's most recent response:\n{response}\n\n"
-    "Is the goal satisfied?"
+# When the user uses ``/subgoal challenge N``, this user-role message is
+# injected at the next turn so the agent revisits the item.
+CHALLENGE_PROMPT_TEMPLATE = (
+    "[User challenge on standing-goal checklist]\n"
+    "The user has challenged item {index} ({text!r}). It was previously "
+    "marked {prev_status} but the user disagrees and has flipped it back "
+    "to pending. Address their concern: revisit the work, produce "
+    "additional evidence, or explain why the item is genuinely "
+    "impossible. Do not silently re-mark the item completed without new "
+    "evidence."
 )
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Dataclass
+# Dataclasses
 # ──────────────────────────────────────────────────────────────────────
 
 
 @dataclass
+class ChecklistItem:
+    """One concrete completion criterion attached to a goal."""
+
+    text: str
+    status: str = ITEM_PENDING            # pending | completed | impossible
+    added_by: str = ADDED_BY_AGENT        # agent | user
+    added_at: float = 0.0
+    completed_at: Optional[float] = None
+    evidence: Optional[str] = None        # one-line citation
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChecklistItem":
+        text = str(data.get("text", "")).strip()
+        if not text:
+            text = "(empty item)"
+        status = str(data.get("status", ITEM_PENDING)).strip().lower()
+        if status not in VALID_ITEM_STATUSES:
+            status = ITEM_PENDING
+        added_by = str(data.get("added_by", ADDED_BY_AGENT)).strip().lower()
+        if added_by not in (ADDED_BY_AGENT, ADDED_BY_USER):
+            added_by = ADDED_BY_AGENT
+        return cls(
+            text=text,
+            status=status,
+            added_by=added_by,
+            added_at=float(data.get("added_at", 0.0) or 0.0),
+            completed_at=(
+                float(data["completed_at"])
+                if data.get("completed_at") is not None
+                else None
+            ),
+            evidence=data.get("evidence"),
+        )
+
+
+@dataclass
 class GoalState:
-    """Serializable goal state stored per session."""
+    """Serializable goal state stored per session.
+
+    Backward-compatible with the prior judge-loop schema: missing fields
+    default safely so old ``state_meta`` rows still load.
+    """
 
     goal: str
-    status: str = "active"          # active | paused | done | cleared
+    status: str = "active"            # active | paused | done | cleared
     turns_used: int = 0
     max_turns: int = DEFAULT_MAX_TURNS
     created_at: float = 0.0
     last_turn_at: float = 0.0
-    last_verdict: Optional[str] = None        # "done" | "continue" | "skipped"
-    last_reason: Optional[str] = None
-    paused_reason: Optional[str] = None       # why we auto-paused (budget, etc.)
-    consecutive_parse_failures: int = 0       # judge-output parse failures in a row
+    paused_reason: Optional[str] = None
+    checklist: List[ChecklistItem] = field(default_factory=list)
+    # Pending user-challenge nudges to inject on the next continuation
+    # turn (each is a complete user-role message body).
+    pending_challenges: List[str] = field(default_factory=list)
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False)
@@ -115,18 +208,63 @@ class GoalState:
     @classmethod
     def from_json(cls, raw: str) -> "GoalState":
         data = json.loads(raw)
+        raw_checklist = data.get("checklist") or []
+        checklist: List[ChecklistItem] = []
+        if isinstance(raw_checklist, list):
+            for item in raw_checklist:
+                if isinstance(item, dict):
+                    try:
+                        checklist.append(ChecklistItem.from_dict(item))
+                    except Exception:
+                        continue
+        raw_challenges = data.get("pending_challenges") or []
+        pending_challenges: List[str] = []
+        if isinstance(raw_challenges, list):
+            pending_challenges = [str(c) for c in raw_challenges if c]
         return cls(
             goal=data.get("goal", ""),
             status=data.get("status", "active"),
             turns_used=int(data.get("turns_used", 0) or 0),
-            max_turns=int(data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS),
+            max_turns=int(
+                data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS
+            ),
             created_at=float(data.get("created_at", 0.0) or 0.0),
             last_turn_at=float(data.get("last_turn_at", 0.0) or 0.0),
-            last_verdict=data.get("last_verdict"),
-            last_reason=data.get("last_reason"),
             paused_reason=data.get("paused_reason"),
-            consecutive_parse_failures=int(data.get("consecutive_parse_failures", 0) or 0),
+            checklist=checklist,
+            pending_challenges=pending_challenges,
         )
+
+    # --- checklist helpers ------------------------------------------------
+
+    def checklist_counts(self) -> tuple:
+        """Return (total, completed, impossible, pending)."""
+        total = len(self.checklist)
+        completed = sum(1 for it in self.checklist if it.status == ITEM_COMPLETED)
+        impossible = sum(1 for it in self.checklist if it.status == ITEM_IMPOSSIBLE)
+        pending = total - completed - impossible
+        return total, completed, impossible, pending
+
+    def all_terminal(self) -> bool:
+        """True iff at least one item exists and every item is in a terminal status."""
+        if not self.checklist:
+            return False
+        return all(it.status in TERMINAL_ITEM_STATUSES for it in self.checklist)
+
+    def render_checklist(self, *, numbered: bool = False) -> str:
+        if not self.checklist:
+            return "(empty)"
+        lines = []
+        for i, item in enumerate(self.checklist, start=1):
+            marker = ITEM_MARKERS.get(item.status, "[?]")
+            prefix = f"{i}. {marker}" if numbered else f"  {marker}"
+            line = f"{prefix} {item.text}"
+            if item.status == ITEM_COMPLETED and item.evidence:
+                line += f" — {item.evidence}"
+            elif item.status == ITEM_IMPOSSIBLE and item.evidence:
+                line += f" (impossible: {item.evidence})"
+            lines.append(line)
+        return "\n".join(lines)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -188,7 +326,9 @@ def load_goal(session_id: str) -> Optional[GoalState]:
     try:
         return GoalState.from_json(raw)
     except Exception as exc:
-        logger.warning("GoalManager: could not parse stored goal for %s: %s", session_id, exc)
+        logger.warning(
+            "GoalManager: could not parse stored goal for %s: %s", session_id, exc
+        )
         return None
 
 
@@ -215,144 +355,6 @@ def clear_goal(session_id: str) -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# Judge
-# ──────────────────────────────────────────────────────────────────────
-
-
-def _truncate(text: str, limit: int) -> str:
-    if not text:
-        return ""
-    if len(text) <= limit:
-        return text
-    return text[:limit] + "… [truncated]"
-
-
-_JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
-
-
-def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
-    """Parse the judge's reply. Fail-open to ``(False, "<reason>", parse_failed)``.
-
-    Returns ``(done, reason, parse_failed)``. ``parse_failed`` is True when the
-    judge returned output that couldn't be interpreted as the expected JSON
-    verdict (empty body, prose, malformed JSON). Callers use that flag to
-    auto-pause after N consecutive parse failures so a weak judge model
-    doesn't silently burn the turn budget.
-    """
-    if not raw:
-        return False, "judge returned empty response", True
-
-    text = raw.strip()
-
-    # Strip markdown code fences the model may wrap JSON in.
-    if text.startswith("```"):
-        text = text.strip("`")
-        # Peel off leading json/JSON/etc tag
-        nl = text.find("\n")
-        if nl != -1:
-            text = text[nl + 1:]
-
-    # First try: parse the whole blob.
-    data: Optional[Dict[str, Any]] = None
-    try:
-        data = json.loads(text)
-    except Exception:
-        # Second try: pull the first JSON object out.
-        match = _JSON_OBJECT_RE.search(text)
-        if match:
-            try:
-                data = json.loads(match.group(0))
-            except Exception:
-                data = None
-
-    if not isinstance(data, dict):
-        return False, f"judge reply was not JSON: {_truncate(raw, 200)!r}", True
-
-    done_val = data.get("done")
-    if isinstance(done_val, str):
-        done = done_val.strip().lower() in ("true", "yes", "1", "done")
-    else:
-        done = bool(done_val)
-    reason = str(data.get("reason") or "").strip()
-    if not reason:
-        reason = "no reason provided"
-    return done, reason, False
-
-
-def judge_goal(
-    goal: str,
-    last_response: str,
-    *,
-    timeout: float = DEFAULT_JUDGE_TIMEOUT,
-) -> Tuple[str, str, bool]:
-    """Ask the auxiliary model whether the goal is satisfied.
-
-    Returns ``(verdict, reason, parse_failed)`` where verdict is ``"done"``,
-    ``"continue"``, or ``"skipped"`` (when the judge couldn't be reached).
-
-    ``parse_failed`` is True only when the judge call succeeded but its output
-    was unusable (empty or non-JSON). API/transport errors return False — they
-    are transient and should fail-open silently. Callers use this flag to
-    auto-pause after N consecutive parse failures (see
-    ``DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES``).
-
-    This is deliberately fail-open: any error returns ``("continue", "...", False)``
-    so a broken judge doesn't wedge progress — the turn budget and the
-    consecutive-parse-failures auto-pause are the backstops.
-    """
-    if not goal.strip():
-        return "skipped", "empty goal", False
-    if not last_response.strip():
-        # No substantive reply this turn — almost certainly not done yet.
-        return "continue", "empty response (nothing to evaluate)", False
-
-    try:
-        from agent.auxiliary_client import get_text_auxiliary_client
-    except Exception as exc:
-        logger.debug("goal judge: auxiliary client import failed: %s", exc)
-        return "continue", "auxiliary client unavailable", False
-
-    try:
-        client, model = get_text_auxiliary_client("goal_judge")
-    except Exception as exc:
-        logger.debug("goal judge: get_text_auxiliary_client failed: %s", exc)
-        return "continue", "auxiliary client unavailable", False
-
-    if client is None or not model:
-        return "continue", "no auxiliary client configured", False
-
-    prompt = JUDGE_USER_PROMPT_TEMPLATE.format(
-        goal=_truncate(goal, 2000),
-        response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
-    )
-
-    try:
-        resp = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0,
-            max_tokens=200,
-            timeout=timeout,
-        )
-    except Exception as exc:
-        logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
-        return "continue", f"judge error: {type(exc).__name__}", False
-
-    try:
-        raw = resp.choices[0].message.content or ""
-    except Exception:
-        raw = ""
-
-    done, reason, parse_failed = _parse_judge_response(raw)
-    verdict = "done" if done else "continue"
-    logger.info("goal judge: verdict=%s reason=%s", verdict, _truncate(reason, 120))
-    return verdict, reason, parse_failed
-
-
-# ──────────────────────────────────────────────────────────────────────
 # GoalManager — the orchestration surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
 
@@ -367,11 +369,21 @@ class GoalManager:
     - ``set(goal)`` — start a new standing goal.
     - ``clear()`` — remove the active goal.
     - ``pause()`` / ``resume()`` — explicit user controls.
-    - ``status()`` — printable one-liner.
-    - ``evaluate_after_turn(last_response)`` — call the judge, update state,
-      and return a decision dict the caller uses to drive the next turn.
-    - ``next_continuation_prompt()`` — the canonical user-role message to
-      feed back into ``run_conversation``.
+    - ``status_line()`` — printable one-liner.
+    - ``add_subgoal(text)`` — user appends a checklist item.
+    - ``mark_subgoal(index, status)`` — user override.
+    - ``challenge_subgoal(index)`` — flip terminal → pending and queue
+      a user-role nudge for the next turn.
+    - ``remove_subgoal(index)`` — delete an item.
+    - ``clear_checklist()`` — wipe the checklist; agent re-decomposes
+      on the next turn.
+    - ``apply_agent_update(items=, mark=)`` — invoked by the
+      ``goal_checklist`` model tool handler. Replaces or extends the
+      checklist (``items``) and/or flips item statuses (``mark``).
+    - ``evaluate_after_turn(...)`` — check termination, return a
+      decision dict the caller uses to drive the next turn.
+    - ``next_continuation_prompt()`` — the canonical user-role message
+      to feed back into ``run_conversation``.
     """
 
     def __init__(self, session_id: str, *, default_max_turns: int = DEFAULT_MAX_TURNS):
@@ -393,17 +405,31 @@ class GoalManager:
 
     def status_line(self) -> str:
         s = self._state
-        if s is None or s.status in ("cleared",):
+        if s is None or s.status == "cleared":
             return "No active goal. Set one with /goal <text>."
         turns = f"{s.turns_used}/{s.max_turns} turns"
+        cl_total, cl_done, cl_imp, _ = s.checklist_counts()
+        cl_text = ""
+        if cl_total:
+            cl_text = f", {cl_done + cl_imp}/{cl_total} done"
         if s.status == "active":
-            return f"⊙ Goal (active, {turns}): {s.goal}"
+            return f"⊙ Goal (active, {turns}{cl_text}): {s.goal}"
         if s.status == "paused":
             extra = f" — {s.paused_reason}" if s.paused_reason else ""
-            return f"⏸ Goal (paused, {turns}{extra}): {s.goal}"
+            return f"⏸ Goal (paused, {turns}{cl_text}{extra}): {s.goal}"
         if s.status == "done":
-            return f"✓ Goal done ({turns}): {s.goal}"
-        return f"Goal ({s.status}, {turns}): {s.goal}"
+            return f"✓ Goal done ({turns}{cl_text}): {s.goal}"
+        return f"Goal ({s.status}, {turns}{cl_text}): {s.goal}"
+
+    def render_checklist(self) -> str:
+        """Public helper for the /subgoal slash command."""
+        if self._state is None:
+            return "(no active goal)"
+        if not self._state.checklist:
+            return (
+                "(checklist empty — agent will propose one on the next turn)"
+            )
+        return self._state.render_checklist(numbered=True)
 
     # --- mutation -----------------------------------------------------
 
@@ -418,6 +444,8 @@ class GoalManager:
             max_turns=int(max_turns) if max_turns else self.default_max_turns,
             created_at=time.time(),
             last_turn_at=0.0,
+            checklist=[],
+            pending_challenges=[],
         )
         self._state = state
         save_goal(self.session_id, state)
@@ -448,44 +476,268 @@ class GoalManager:
         save_goal(self.session_id, self._state)
         self._state = None
 
-    def mark_done(self, reason: str) -> None:
-        if not self._state:
-            return
-        self._state.status = "done"
-        self._state.last_verdict = "done"
-        self._state.last_reason = reason
+    # --- /subgoal user controls ---------------------------------------
+
+    def add_subgoal(self, text: str) -> ChecklistItem:
+        """User appends a new checklist item. Requires an active or paused goal."""
+        if self._state is None:
+            raise RuntimeError("no active goal")
+        text = (text or "").strip()
+        if not text:
+            raise ValueError("subgoal text is empty")
+        item = ChecklistItem(
+            text=text,
+            status=ITEM_PENDING,
+            added_by=ADDED_BY_USER,
+            added_at=time.time(),
+        )
+        self._state.checklist.append(item)
         save_goal(self.session_id, self._state)
+        return item
+
+    def mark_subgoal(self, index_1based: int, status: str) -> ChecklistItem:
+        """User overrides an item's status.
+
+        ``status`` may be ``completed``, ``impossible``, or ``pending``
+        (the last as an undo flow). User actions bypass any stickiness —
+        the user is the final authority on what's done.
+        """
+        if self._state is None:
+            raise RuntimeError("no active goal")
+        status = (status or "").strip().lower()
+        if status not in VALID_ITEM_STATUSES:
+            raise ValueError(
+                f"status must be one of {sorted(VALID_ITEM_STATUSES)}; got {status!r}"
+            )
+        idx = int(index_1based) - 1
+        if idx < 0 or idx >= len(self._state.checklist):
+            raise IndexError(
+                f"index out of range (1..{len(self._state.checklist)})"
+            )
+        item = self._state.checklist[idx]
+        item.status = status
+        if status in TERMINAL_ITEM_STATUSES:
+            item.completed_at = time.time()
+            if not item.evidence:
+                item.evidence = "marked by user"
+        else:
+            item.completed_at = None
+            # Don't wipe agent-supplied evidence on undo — useful audit trail.
+        save_goal(self.session_id, self._state)
+        return item
+
+    def challenge_subgoal(self, index_1based: int) -> ChecklistItem:
+        """Flip an item back to pending AND queue a user-role nudge so
+        the agent revisits it on the next turn.
+
+        Only valid on items in a terminal status — there's nothing to
+        challenge on a pending item.
+        """
+        if self._state is None:
+            raise RuntimeError("no active goal")
+        idx = int(index_1based) - 1
+        if idx < 0 or idx >= len(self._state.checklist):
+            raise IndexError(
+                f"index out of range (1..{len(self._state.checklist)})"
+            )
+        item = self._state.checklist[idx]
+        if item.status not in TERMINAL_ITEM_STATUSES:
+            raise ValueError(
+                f"item {index_1based} is {item.status} — nothing to challenge"
+            )
+        prev_status = item.status
+        item.status = ITEM_PENDING
+        item.completed_at = None
+        # Keep the agent's prior evidence on the item as audit trail —
+        # the next-turn nudge calls it out.
+        nudge = CHALLENGE_PROMPT_TEMPLATE.format(
+            index=index_1based,
+            text=item.text,
+            prev_status=prev_status,
+        )
+        self._state.pending_challenges.append(nudge)
+        save_goal(self.session_id, self._state)
+        return item
+
+    def remove_subgoal(self, index_1based: int) -> ChecklistItem:
+        if self._state is None:
+            raise RuntimeError("no active goal")
+        idx = int(index_1based) - 1
+        if idx < 0 or idx >= len(self._state.checklist):
+            raise IndexError(
+                f"index out of range (1..{len(self._state.checklist)})"
+            )
+        removed = self._state.checklist.pop(idx)
+        save_goal(self.session_id, self._state)
+        return removed
+
+    def clear_checklist(self) -> None:
+        """Wipe the checklist. Agent will re-propose one on the next turn."""
+        if self._state is None:
+            return
+        self._state.checklist = []
+        self._state.pending_challenges = []
+        save_goal(self.session_id, self._state)
+
+    # --- agent updates (called from the goal_checklist model tool) ----
+
+    def apply_agent_update(
+        self,
+        *,
+        items: Optional[List[Dict[str, Any]]] = None,
+        mark: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Apply agent updates and persist. Returns a summary dict the
+        tool handler can return verbatim to the model.
+
+        ``items`` (initial decompose or replacement set):
+            Replaces the checklist when present. Each item is
+            ``{text: str, status?: pending|completed|impossible,
+            evidence?: str}``. User-added items survive at their
+            current positions if they aren't already present.
+
+        ``mark`` (per-item flips):
+            ``[{index: int (1-based), status: str, evidence?: str}, ...]``.
+            Stickiness rules: the agent can flip pending → terminal but
+            cannot regress its own terminal items; only the user can.
+        """
+        if self._state is None:
+            raise RuntimeError("no active goal")
+
+        updates_applied: List[str] = []
+
+        # ── items: replace / extend ────────────────────────────────
+        if items is not None:
+            # If the agent submits a fresh items list AND the existing
+            # checklist is empty, this is the initial decompose: store
+            # everything.
+            #
+            # If items are submitted on top of an existing checklist
+            # (rare), append the new ones to the end and skip duplicates
+            # by exact text match.
+            now = time.time()
+            new_items: List[ChecklistItem] = []
+            for entry in items:
+                if not isinstance(entry, dict):
+                    if isinstance(entry, str):
+                        entry = {"text": entry}
+                    else:
+                        continue
+                text = str(entry.get("text", "")).strip()
+                if not text:
+                    continue
+                status = str(entry.get("status", ITEM_PENDING)).strip().lower()
+                if status not in VALID_ITEM_STATUSES:
+                    status = ITEM_PENDING
+                evidence = str(entry.get("evidence") or "").strip() or None
+                ci = ChecklistItem(
+                    text=text,
+                    status=status,
+                    added_by=ADDED_BY_AGENT,
+                    added_at=now,
+                    completed_at=now if status in TERMINAL_ITEM_STATUSES else None,
+                    evidence=evidence,
+                )
+                new_items.append(ci)
+
+            if not self._state.checklist:
+                # Initial decompose
+                self._state.checklist = new_items
+                updates_applied.append(f"submitted {len(new_items)} items")
+            else:
+                existing_texts = {it.text.lower() for it in self._state.checklist}
+                appended = 0
+                for ci in new_items:
+                    if ci.text.lower() in existing_texts:
+                        continue
+                    self._state.checklist.append(ci)
+                    existing_texts.add(ci.text.lower())
+                    appended += 1
+                if appended:
+                    updates_applied.append(f"appended {appended} new items")
+
+        # ── mark: per-item flips ──────────────────────────────────
+        if mark:
+            for upd in mark:
+                if not isinstance(upd, dict):
+                    continue
+                try:
+                    idx_1based = int(upd.get("index"))
+                except (TypeError, ValueError):
+                    continue
+                idx = idx_1based - 1
+                if idx < 0 or idx >= len(self._state.checklist):
+                    continue
+                item = self._state.checklist[idx]
+                new_status = str(upd.get("status", "")).strip().lower()
+                if new_status not in TERMINAL_ITEM_STATUSES:
+                    # Agent can only flip to terminal statuses; skip non-terminal.
+                    continue
+                if item.status in TERMINAL_ITEM_STATUSES:
+                    # Stickiness: agent cannot regress its own terminal items.
+                    # Only user can via /subgoal undo or /subgoal challenge.
+                    continue
+                item.status = new_status
+                item.completed_at = time.time()
+                evidence = str(upd.get("evidence") or "").strip() or None
+                if evidence:
+                    item.evidence = evidence
+                updates_applied.append(f"item {idx_1based} → {new_status}")
+
+        save_goal(self.session_id, self._state)
+
+        cl_total, cl_done, cl_imp, cl_pending = self._state.checklist_counts()
+        return {
+            "ok": True,
+            "applied": updates_applied,
+            "checklist": [it.to_dict() for it in self._state.checklist],
+            "summary": {
+                "total": cl_total,
+                "completed": cl_done,
+                "impossible": cl_imp,
+                "pending": cl_pending,
+                "all_terminal": self._state.all_terminal(),
+            },
+        }
 
     # --- the main entry point called after every turn -----------------
 
     def evaluate_after_turn(
         self,
-        last_response: str,
+        last_response: str = "",
         *,
         user_initiated: bool = True,
     ) -> Dict[str, Any]:
-        """Run the judge and update state. Return a decision dict.
+        """Decide whether the loop should continue. NO judge call.
 
-        ``user_initiated`` distinguishes a real user prompt (True) from a
-        continuation prompt we fed ourselves (False). Both increment
-        ``turns_used`` because both consume model budget.
+        We just check the agent-owned checklist:
+        - all items terminal → status=done
+        - turn budget hit → paused
+        - else → continue and emit the next continuation prompt
+
+        ``last_response`` and ``user_initiated`` are accepted for API
+        parity with the old judge-loop signature; we don't need them.
 
         Decision keys:
           - ``status``: current goal status after update
           - ``should_continue``: bool — caller should fire another turn
           - ``continuation_prompt``: str or None
-          - ``verdict``: "done" | "continue" | "skipped" | "inactive"
-          - ``reason``: str
           - ``message``: user-visible one-liner to print/send
         """
+        # Reload state from SessionDB before evaluating. The agent may have
+        # written checklist updates via the goal_checklist tool during the
+        # turn that just finished; those writes go through a separate
+        # GoalManager instance, so our cached ``self._state`` is stale.
+        # Without this reload, ``all_terminal()`` returns False on a fully-
+        # completed checklist and the loop spins.
+        self._state = load_goal(self.session_id)
+
         state = self._state
         if state is None or state.status != "active":
             return {
                 "status": state.status if state else None,
                 "should_continue": False,
                 "continuation_prompt": None,
-                "verdict": "inactive",
-                "reason": "no active goal",
                 "message": "",
             }
 
@@ -493,101 +745,105 @@ class GoalManager:
         state.turns_used += 1
         state.last_turn_at = time.time()
 
-        verdict, reason, parse_failed = judge_goal(state.goal, last_response)
-        state.last_verdict = verdict
-        state.last_reason = reason
-
-        # Track consecutive judge parse failures. Reset on any usable reply,
-        # including API / transport errors (parse_failed=False) so a flaky
-        # network doesn't trip the auto-pause meant for bad judge models.
-        if parse_failed:
-            state.consecutive_parse_failures += 1
-        else:
-            state.consecutive_parse_failures = 0
-
-        if verdict == "done":
+        # 1) Did the agent complete the goal?
+        if state.all_terminal():
             state.status = "done"
             save_goal(self.session_id, state)
+            cl_total, cl_done, cl_imp, _ = state.checklist_counts()
             return {
                 "status": "done",
                 "should_continue": False,
                 "continuation_prompt": None,
-                "verdict": "done",
-                "reason": reason,
-                "message": f"✓ Goal achieved: {reason}",
+                "message": f"✓ Goal achieved ({cl_done}/{cl_total} done, {cl_imp} impossible).",
             }
 
-        # Auto-pause when the judge model can't produce the expected JSON
-        # verdict N turns in a row. Points the user at the goal_judge config
-        # so they can route this side task to a model that follows the
-        # contract (e.g. google/gemini-3-flash-preview). Without this guard,
-        # weak judge models burn the entire turn budget returning prose or
-        # empty strings.
-        if state.consecutive_parse_failures >= DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES:
+        # 2) Out of turns?
+        if state.turns_used >= state.max_turns:
             state.status = "paused"
             state.paused_reason = (
-                f"judge model returned unparseable output {state.consecutive_parse_failures} turns in a row"
+                f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
             )
             save_goal(self.session_id, state)
             return {
                 "status": "paused",
                 "should_continue": False,
                 "continuation_prompt": None,
-                "verdict": "continue",
-                "reason": reason,
                 "message": (
-                    f"⏸ Goal paused — the judge model ({state.consecutive_parse_failures} turns) "
-                    "isn't returning the required JSON verdict. Route the judge to a stricter "
-                    "model in ~/.hermes/config.yaml:\n"
-                    "  auxiliary:\n"
-                    "    goal_judge:\n"
-                    "      provider: openrouter\n"
-                    "      model: google/gemini-3-flash-preview\n"
-                    "Then /goal resume to continue."
+                    f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns "
+                    "used. Use /goal resume to keep going, or /goal clear to stop."
                 ),
             }
 
-        if state.turns_used >= state.max_turns:
-            state.status = "paused"
-            state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
-            save_goal(self.session_id, state)
-            return {
-                "status": "paused",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "continue",
-                "reason": reason,
-                "message": (
-                    f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns used. "
-                    "Use /goal resume to keep going, or /goal clear to stop."
-                ),
-            }
-
+        # 3) Continue. Build the continuation prompt (which will pick up
+        # any pending user challenges).
         save_goal(self.session_id, state)
+        cl_total, cl_done, cl_imp, _ = state.checklist_counts()
+        progress = ""
+        if cl_total:
+            progress = f" — {cl_done + cl_imp}/{cl_total} done"
         return {
             "status": "active",
             "should_continue": True,
             "continuation_prompt": self.next_continuation_prompt(),
-            "verdict": "continue",
-            "reason": reason,
             "message": (
-                f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
+                f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}{progress})."
             ),
         }
 
+    # --- continuation prompt ------------------------------------------
+
     def next_continuation_prompt(self) -> Optional[str]:
+        """Build the user-role message to feed into the next turn.
+
+        Three flavors:
+        1. No checklist yet → prompt the agent to decompose.
+        2. Checklist exists → standard continuation with progress.
+        3. Pending user challenges → prepend to the continuation (and
+           drain the queue so each challenge is delivered exactly once).
+        """
         if not self._state or self._state.status != "active":
             return None
-        return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
+
+        if not self._state.checklist:
+            base = DECOMPOSE_PROMPT_TEMPLATE.format(goal=self._state.goal)
+        else:
+            base = CONTINUATION_PROMPT_WITH_CHECKLIST_TEMPLATE.format(
+                goal=self._state.goal,
+                done=sum(
+                    1 for it in self._state.checklist
+                    if it.status in TERMINAL_ITEM_STATUSES
+                ),
+                total=len(self._state.checklist),
+                checklist=self._state.render_checklist(numbered=False),
+            )
+
+        if self._state.pending_challenges:
+            challenges = "\n\n".join(self._state.pending_challenges)
+            self._state.pending_challenges = []
+            save_goal(self.session_id, self._state)
+            return f"{challenges}\n\n{base}"
+        return base
 
 
 __all__ = [
+    "ChecklistItem",
     "GoalState",
     "GoalManager",
-    "CONTINUATION_PROMPT_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "ITEM_PENDING",
+    "ITEM_COMPLETED",
+    "ITEM_IMPOSSIBLE",
+    "ITEM_MARKERS",
+    "TERMINAL_ITEM_STATUSES",
+    "VALID_ITEM_STATUSES",
+    "ADDED_BY_AGENT",
+    "ADDED_BY_USER",
+    "DECOMPOSE_PROMPT_TEMPLATE",
+    "CONTINUATION_PROMPT_TEMPLATE",
+    "CONTINUATION_PROMPT_WITH_CHECKLIST_TEMPLATE",
+    "CONTINUATION_PROMPT_NO_CHECKLIST_TEMPLATE",
+    "CHALLENGE_PROMPT_TEMPLATE",
     "load_goal",
     "save_goal",
     "clear_goal",
-    "judge_goal",
 ]

--- a/run_agent.py
+++ b/run_agent.py
@@ -10089,6 +10089,24 @@ class AIAgent:
                     parent_session_id=old_session_id,
                 )
                 self._session_db_created = True
+                # Forward any standing /goal state from the parent session
+                # to the continuation session so the goal loop survives
+                # auto-compression. Without this, _get_goal_manager()
+                # rebinds for the new session_id, load_goal() returns None,
+                # is_active() flips to False, and the loop silently dies.
+                # State is stored under "goal:<sid>" in state_meta.
+                try:
+                    _goal_blob = self._session_db.get_meta(f"goal:{old_session_id}")
+                    if _goal_blob:
+                        self._session_db.set_meta(
+                            f"goal:{self.session_id}", _goal_blob
+                        )
+                        logger.info(
+                            "goal: forwarded standing goal from %s → %s on compression",
+                            old_session_id, self.session_id,
+                        )
+                except Exception as exc:
+                    logger.debug("goal forward on compression failed: %s", exc)
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
@@ -10282,6 +10300,23 @@ class AIAgent:
                 todos=function_args.get("todos"),
                 merge=function_args.get("merge", False),
                 store=self._todo_store,
+            )
+        elif function_name == "goal_checklist":
+            from tools.goal_checklist_tool import goal_checklist_tool as _gc_tool
+            # Pull max_turns from config if available so a fresh
+            # GoalManager respects user budget settings.
+            try:
+                from hermes_cli.config import load_config
+                _cfg = load_config() or {}
+                _goals_cfg = _cfg.get("goals") or {}
+                _gc_max_turns = int(_goals_cfg.get("max_turns", 20) or 20)
+            except Exception:
+                _gc_max_turns = 20
+            return _gc_tool(
+                items=function_args.get("items"),
+                mark=function_args.get("mark"),
+                session_id=self.session_id,
+                default_max_turns=_gc_max_turns,
             )
         elif function_name == "session_search":
             session_db = self._get_session_db_for_recall()
@@ -10908,6 +10943,24 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
+            elif function_name == "goal_checklist":
+                from tools.goal_checklist_tool import goal_checklist_tool as _gc_tool
+                try:
+                    from hermes_cli.config import load_config
+                    _cfg = load_config() or {}
+                    _goals_cfg = _cfg.get("goals") or {}
+                    _gc_max_turns = int(_goals_cfg.get("max_turns", 20) or 20)
+                except Exception:
+                    _gc_max_turns = 20
+                function_result = _gc_tool(
+                    items=function_args.get("items"),
+                    mark=function_args.get("mark"),
+                    session_id=self.session_id,
+                    default_max_turns=_gc_max_turns,
+                )
+                tool_duration = time.time() - tool_start_time
+                if self._should_emit_quiet_tool_messages():
+                    self._vprint(f"  {_get_cute_tool_message_impl('goal_checklist', function_args, tool_duration, result=function_result)}")
             elif function_name == "session_search":
                 session_db = self._get_session_db_for_recall()
                 if not session_db:

--- a/tests/cli/test_cli_goal_interrupt.py
+++ b/tests/cli/test_cli_goal_interrupt.py
@@ -1,21 +1,23 @@
-"""Tests for CLI goal-continuation interrupt handling.
+"""Tests for CLI goal-continuation hook behavior.
 
 Covers:
 - Ctrl+C during a /goal turn auto-pauses the goal (no more continuations).
-- Empty/whitespace-only responses skip the judge (no phantom continuations).
-- Clean response without interrupt still drives the judge + enqueues.
+- Clean turn with empty checklist re-queues a continuation (decompose path).
+- Checklist all-terminal marks the goal done.
+- Budget exhaustion pauses the loop.
 
 These tests exercise ``_maybe_continue_goal_after_turn`` directly on a
-minimal ``HermesCLI`` stub (pattern used elsewhere in tests/cli).
+minimal ``HermesCLI`` stub. There is no aux-model judge in the new
+design — the agent owns the checklist via the ``goal_checklist`` model
+tool, and the hook just inspects state.
 """
 
 from __future__ import annotations
 
 import queue
-import sys
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -33,7 +35,6 @@ def hermes_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    # Bust the goal module's DB cache so it re-resolves HERMES_HOME each test.
     from hermes_cli import goals
     goals._DB_CACHE.clear()
     yield home
@@ -46,12 +47,9 @@ def _make_cli_with_goal(session_id: str, goal_text: str = "build a thing"):
     from hermes_cli.goals import GoalManager
 
     cli = HermesCLI.__new__(HermesCLI)
-    # State the hook + helpers touch directly.
     cli._pending_input = queue.Queue()
     cli._last_turn_interrupted = False
     cli.conversation_history = []
-    # `_get_goal_manager()` reads `self.session_id` directly, not
-    # `self.agent.session_id`. Match the production lookup.
     cli.session_id = session_id
     cli.agent = MagicMock()
     cli.agent.session_id = session_id
@@ -72,31 +70,19 @@ class TestInterruptAutoPause:
         """Ctrl+C mid-turn must auto-pause the goal, not queue another round."""
         sid = f"sid-interrupt-{uuid.uuid4().hex}"
         cli, mgr = _make_cli_with_goal(sid)
-        # Simulate an interrupted turn with a partial assistant reply.
         cli._last_turn_interrupted = True
         cli.conversation_history = [
             {"role": "user", "content": "kickoff"},
             {"role": "assistant", "content": "starting work..."},
         ]
 
-        # Judge MUST NOT run on an interrupted turn. If it does, we've
-        # regressed — fail loudly instead of silently querying a mock.
-        with patch("hermes_cli.goals.judge_goal") as judge_mock:
-            judge_mock.side_effect = AssertionError(
-                "judge_goal called on an interrupted turn"
-            )
-            cli._maybe_continue_goal_after_turn()
+        cli._maybe_continue_goal_after_turn()
 
-        # Pending input must NOT contain a continuation prompt.
         assert cli._pending_input.empty(), (
             "Interrupted turn should not enqueue a continuation prompt"
         )
-
-        # Goal should be paused, not active.
-        state = mgr.state
-        assert state is not None
-        assert state.status == "paused"
-        assert "interrupt" in (state.paused_reason or "").lower()
+        assert mgr.state.status == "paused"
+        assert "interrupt" in (mgr.state.paused_reason or "").lower()
 
     def test_interrupted_turn_is_resumable(self, hermes_home):
         """After auto-pause from Ctrl+C, /goal resume puts it back to active."""
@@ -106,93 +92,85 @@ class TestInterruptAutoPause:
         cli.conversation_history = [
             {"role": "assistant", "content": "partial"},
         ]
-        with patch("hermes_cli.goals.judge_goal"):
-            cli._maybe_continue_goal_after_turn()
+        cli._maybe_continue_goal_after_turn()
         assert mgr.state.status == "paused"
 
         mgr.resume()
         assert mgr.state.status == "active"
 
 
-class TestEmptyResponseSkip:
-    def test_empty_response_does_not_invoke_judge(self, hermes_home):
-        """Whitespace-only replies skip judging (transient failure guard)."""
-        sid = f"sid-empty-{uuid.uuid4().hex}"
+class TestPendingUserInputPreemption:
+    def test_pending_user_input_skips_continuation(self, hermes_home):
+        """If a real user message is already queued, the goal hook
+        defers — the user's turn takes priority."""
+        sid = f"sid-preempt-{uuid.uuid4().hex}"
         cli, mgr = _make_cli_with_goal(sid)
-        cli._last_turn_interrupted = False
-        cli.conversation_history = [
-            {"role": "user", "content": "go"},
-            {"role": "assistant", "content": "   \n\n   "},
-        ]
-
-        with patch("hermes_cli.goals.judge_goal") as judge_mock:
-            judge_mock.side_effect = AssertionError(
-                "judge_goal called on an empty response"
-            )
-            cli._maybe_continue_goal_after_turn()
-
-        # No continuation queued; goal still active (neither paused nor done).
-        assert cli._pending_input.empty()
-        assert mgr.state.status == "active"
-
-    def test_no_assistant_message_skipped(self, hermes_home):
-        """Conversation with zero assistant replies must not trip the judge."""
-        sid = f"sid-noassistant-{uuid.uuid4().hex}"
-        cli, mgr = _make_cli_with_goal(sid)
-        cli._last_turn_interrupted = False
-        cli.conversation_history = [
-            {"role": "user", "content": "go"},
-        ]
-
-        with patch("hermes_cli.goals.judge_goal") as judge_mock:
-            judge_mock.side_effect = AssertionError(
-                "judge_goal called without an assistant response"
-            )
-            cli._maybe_continue_goal_after_turn()
-
-        assert cli._pending_input.empty()
-        assert mgr.state.status == "active"
+        cli._pending_input.put("a real user message")
+        cli._maybe_continue_goal_after_turn()
+        # Hook should be a no-op; the user message stays in front and no
+        # continuation is appended.
+        assert cli._pending_input.qsize() == 1
+        # turn budget not consumed
+        assert mgr.state.turns_used == 0
 
 
-class TestHealthyTurnStillRuns:
-    def test_clean_response_enqueues_continuation_when_judge_says_continue(
-        self, hermes_home,
-    ):
-        """Sanity check: the hook still works in the happy path."""
+class TestHealthyTurn:
+    def test_empty_checklist_enqueues_decompose_prompt(self, hermes_home):
+        """First turn after /goal: checklist empty → continuation prompt is
+        the decompose prompt asking the agent to call goal_checklist."""
         sid = f"sid-healthy-{uuid.uuid4().hex}"
         cli, mgr = _make_cli_with_goal(sid)
-        cli._last_turn_interrupted = False
         cli.conversation_history = [
-            {"role": "user", "content": "go"},
-            {"role": "assistant", "content": "did some work, more to do"},
+            {"role": "user", "content": "kickoff"},
+            {"role": "assistant", "content": "starting"},
         ]
 
-        # Force the judge to say "continue" without touching the network.
-        with patch(
-            "hermes_cli.goals.judge_goal",
-            return_value=("continue", "needs more steps", False),
-        ):
-            cli._maybe_continue_goal_after_turn()
+        cli._maybe_continue_goal_after_turn()
 
-        # Continuation prompt must be queued.
         assert not cli._pending_input.empty()
         queued = cli._pending_input.get_nowait()
-        assert "Continuing toward your standing goal" in queued
+        assert "propose a checklist" in queued
+        assert "goal_checklist" in queued
         assert mgr.state.status == "active"
+        assert mgr.state.turns_used == 1
 
-    def test_clean_response_marks_done_when_judge_says_done(self, hermes_home):
+    def test_partial_checklist_enqueues_continuation(self, hermes_home):
+        """Some items pending → continuation prompt has the progress block."""
+        from hermes_cli.goals import (
+            ChecklistItem, ITEM_PENDING, ITEM_COMPLETED, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals as _g
+        sid = f"sid-partial-{uuid.uuid4().hex}"
+        cli, mgr = _make_cli_with_goal(sid)
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="b", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+        ]
+        _g.save_goal(sid, mgr.state)
+
+        cli._maybe_continue_goal_after_turn()
+
+        assert not cli._pending_input.empty()
+        queued = cli._pending_input.get_nowait()
+        assert "Checklist progress (1/2 done)" in queued
+        assert "[x] a" in queued
+        assert "[ ] b" in queued
+
+    def test_all_terminal_marks_done(self, hermes_home):
+        """All items terminal → status=done, no continuation."""
+        from hermes_cli.goals import (
+            ChecklistItem, ITEM_COMPLETED, ITEM_IMPOSSIBLE, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals as _g
         sid = f"sid-done-{uuid.uuid4().hex}"
         cli, mgr = _make_cli_with_goal(sid)
-        cli._last_turn_interrupted = False
-        cli.conversation_history = [
-            {"role": "assistant", "content": "all finished, here's the result"},
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="b", status=ITEM_IMPOSSIBLE, added_by=ADDED_BY_AGENT),
         ]
+        _g.save_goal(sid, mgr.state)
 
-        with patch(
-            "hermes_cli.goals.judge_goal",
-            return_value=("done", "goal satisfied", False),
-        ):
-            cli._maybe_continue_goal_after_turn()
+        cli._maybe_continue_goal_after_turn()
 
         assert cli._pending_input.empty()
         assert mgr.state.status == "done"
@@ -205,14 +183,10 @@ class TestInterruptFlagLifecycle:
         This guards against stale flag state: if turn N was interrupted and
         turn N+1 runs clean, the hook must not see True from N.
         """
-        # We can't run chat() end-to-end here, but we can assert the reset
-        # is the first thing after the secret-capture registration by
-        # inspecting the source shape.
         from cli import HermesCLI
         import inspect
 
         src = inspect.getsource(HermesCLI.chat)
-        # Look for an explicit reset near the top of chat().
         head = src.split("if not self._ensure_runtime_credentials", 1)[0]
         assert "self._last_turn_interrupted = False" in head, (
             "chat() must reset _last_turn_interrupted before run_conversation "

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -1,18 +1,23 @@
 """Tests for gateway /goal verdict-message delivery.
 
-The judge verdict message ("✓ Goal achieved", "⏸ budget exhausted", etc.)
-must reach the user after each turn. Before this fix the code checked
-``hasattr(adapter, "send_message")`` — but adapters expose ``send()``,
-never ``send_message``, so the check always evaluated False and users
-never saw verdicts. This test locks in the fix.
+The status messages ("✓ Goal achieved", "⏸ budget exhausted",
+"↻ Continuing toward goal") must reach the user after each turn.
+Before this fix the code checked ``hasattr(adapter, "send_message")``
+— but adapters expose ``send()``, never ``send_message``, so the check
+always evaluated False and users never saw verdicts. This test locks
+in the fix.
+
+Updated for the agent-owned checklist design: there is no aux-model
+judge to mock. State is driven directly via GoalManager.
 """
 
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -63,7 +68,6 @@ class _RecordingAdapter:
 
 def _make_runner_with_adapter(session_id: str = None):
     from gateway.run import GatewayRunner
-    import uuid
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
@@ -75,9 +79,6 @@ def _make_runner_with_adapter(session_id: str = None):
     runner._queued_events = {}
 
     src = _make_source()
-    # Default to a unique session_id so xdist parallel runs on the same worker
-    # don't see each other's GoalManager state (DEFAULT_DB_PATH gets frozen at
-    # module-import time, defeating per-test HERMES_HOME monkeypatches).
     session_entry = SessionEntry(
         session_key=build_session_key(src),
         session_id=session_id or f"goal-sess-{uuid.uuid4().hex[:8]}",
@@ -98,56 +99,57 @@ def _make_runner_with_adapter(session_id: str = None):
 
 @pytest.mark.asyncio
 async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
-    """When the judge says done, the '✓ Goal achieved' message must reach
-    the user through the adapter's ``send()`` method."""
+    """When all checklist items terminal, '✓ Goal achieved' must reach the
+    user through the adapter's ``send()`` method."""
     runner, adapter, session_entry, src = _make_runner_with_adapter()
 
-    from hermes_cli.goals import GoalManager
+    from hermes_cli.goals import (
+        GoalManager, ChecklistItem, ITEM_COMPLETED, ADDED_BY_AGENT, save_goal,
+    )
 
     mgr = GoalManager(session_entry.session_id)
     mgr.set("ship the feature")
+    # Drive the state directly: agent marked all items terminal.
+    mgr.state.checklist = [
+        ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+    ]
+    save_goal(session_entry.session_id, mgr.state)
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False)):
-        await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=src,
-            final_response="I shipped the feature.",
-        )
-        # fire-and-forget create_task — give the loop a tick
-        await asyncio.sleep(0.05)
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="I shipped the feature.",
+    )
+    await asyncio.sleep(0.05)
 
     assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
     msg = adapter.sends[0]
     assert msg["chat_id"] == "c1"
     assert "Goal achieved" in msg["content"]
-    assert "the feature shipped" in msg["content"]
 
 
 @pytest.mark.asyncio
 async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
-    """When the judge says continue, both the 'continuing' status and the
-    continuation-prompt event must be delivered. The continuation prompt is
-    routed through the adapter's pending-messages FIFO so the goal loop
-    proceeds on the next turn."""
+    """Active goal with pending items → 'Continuing toward goal' status sent
+    AND continuation prompt enqueued for the next turn."""
     runner, adapter, session_entry, src = _make_runner_with_adapter()
 
     from hermes_cli.goals import GoalManager
 
     mgr = GoalManager(session_entry.session_id)
     mgr.set("polish the docs")
+    # Empty checklist — first turn after /goal, continuation prompt is the
+    # decompose prompt asking the agent to call goal_checklist.
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "still needs work", False)):
-        await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=src,
-            final_response="here's a partial edit",
-        )
-        await asyncio.sleep(0.05)
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="here's a partial edit",
+    )
+    await asyncio.sleep(0.05)
 
-    # Status line sent back
     assert len(adapter.sends) == 1
     assert "Continuing toward goal" in adapter.sends[0]["content"]
-    # Continuation prompt enqueued for next turn
     assert adapter._pending_messages, "continuation prompt must be enqueued in pending_messages"
 
 
@@ -161,22 +163,20 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
 
     mgr = GoalManager(session_entry.session_id, default_max_turns=2)
     state = mgr.set("tiny goal", max_turns=2)
-    state.turns_used = 2
+    state.turns_used = 1  # next call increments to 2 == max_turns → paused
     save_goal(session_entry.session_id, state)
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("continue", "keep going", False)):
-        await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=src,
-            final_response="still partial",
-        )
-        await asyncio.sleep(0.05)
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="still partial",
+    )
+    await asyncio.sleep(0.05)
 
     assert len(adapter.sends) == 1
     content = adapter.sends[0]["content"]
     assert "paused" in content.lower()
     assert "turns used" in content.lower()
-    # No continuation enqueued when budget is exhausted
     assert not adapter._pending_messages
 
 
@@ -198,12 +198,19 @@ async def test_goal_verdict_skipped_when_no_active_goal(hermes_home):
 
 @pytest.mark.asyncio
 async def test_goal_verdict_survives_adapter_without_send(hermes_home):
-    """Bad adapter (no ``send`` attribute) must not crash the judge hook."""
+    """Bad adapter (no ``send`` attribute) must not crash the goal hook."""
     runner, _adapter, session_entry, src = _make_runner_with_adapter()
 
-    from hermes_cli.goals import GoalManager
+    from hermes_cli.goals import (
+        GoalManager, ChecklistItem, ITEM_COMPLETED, ADDED_BY_AGENT, save_goal,
+    )
 
-    GoalManager(session_entry.session_id).set("survive missing send")
+    mgr = GoalManager(session_entry.session_id)
+    mgr.set("survive missing send")
+    mgr.state.checklist = [
+        ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+    ]
+    save_goal(session_entry.session_id, mgr.state)
 
     class _NoSendAdapter:
         def __init__(self):
@@ -211,11 +218,10 @@ async def test_goal_verdict_survives_adapter_without_send(hermes_home):
 
     runner.adapters[Platform.TELEGRAM] = _NoSendAdapter()
 
-    with patch("hermes_cli.goals.judge_goal", return_value=("done", "ok", False)):
-        # must not raise
-        await runner._post_turn_goal_continuation(
-            session_entry=session_entry,
-            source=src,
-            final_response="whatever",
-        )
-        await asyncio.sleep(0.05)
+    # must not raise
+    await runner._post_turn_goal_continuation(
+        session_entry=session_entry,
+        source=src,
+        final_response="whatever",
+    )
+    await asyncio.sleep(0.05)

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -1,9 +1,9 @@
-"""Tests for hermes_cli/goals.py — persistent cross-turn goals."""
+"""Tests for hermes_cli/goals.py — agent-owned standing-goal checklist."""
 
 from __future__ import annotations
 
 import json
-from unittest.mock import patch, MagicMock
+from pathlib import Path
 
 import pytest
 
@@ -16,14 +16,11 @@ import pytest
 @pytest.fixture
 def hermes_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME so SessionDB.state_meta writes don't clobber the real one."""
-    from pathlib import Path
-
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    # Bust the goal-module's DB cache for each test so it re-resolves HERMES_HOME.
     from hermes_cli import goals
 
     goals._DB_CACHE.clear()
@@ -32,485 +29,511 @@ def hermes_home(tmp_path, monkeypatch):
 
 
 # ──────────────────────────────────────────────────────────────────────
-# _parse_judge_response
+# GoalState + ChecklistItem round-trip / backcompat
 # ──────────────────────────────────────────────────────────────────────
 
 
-class TestParseJudgeResponse:
-    def test_clean_json_done(self):
-        from hermes_cli.goals import _parse_judge_response
+class TestGoalStateRoundTrip:
+    def test_old_state_meta_row_loads_without_checklist_fields(self):
+        """A goal serialized BEFORE the checklist fields existed must
+        round-trip through GoalState.from_json with empty defaults."""
+        from hermes_cli.goals import GoalState
 
-        done, reason, _ = _parse_judge_response('{"done": true, "reason": "all good"}')
-        assert done is True
-        assert reason == "all good"
+        legacy_json = json.dumps({
+            "goal": "do the thing",
+            "status": "active",
+            "turns_used": 3,
+            "max_turns": 20,
+            "created_at": 1.0,
+            "last_turn_at": 2.0,
+            "paused_reason": None,
+        })
+        state = GoalState.from_json(legacy_json)
+        assert state.goal == "do the thing"
+        assert state.checklist == []
+        assert state.pending_challenges == []
 
-    def test_clean_json_continue(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        done, reason, _ = _parse_judge_response('{"done": false, "reason": "more work needed"}')
-        assert done is False
-        assert reason == "more work needed"
-
-    def test_json_in_markdown_fence(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        raw = '```json\n{"done": true, "reason": "done"}\n```'
-        done, reason, _ = _parse_judge_response(raw)
-        assert done is True
-        assert "done" in reason
-
-    def test_json_embedded_in_prose(self):
-        """Some models prefix reasoning before emitting JSON — we extract it."""
-        from hermes_cli.goals import _parse_judge_response
-
-        raw = 'Looking at this... the agent says X. Verdict: {"done": false, "reason": "partial"}'
-        done, reason, _ = _parse_judge_response(raw)
-        assert done is False
-        assert reason == "partial"
-
-    def test_string_done_values(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        for s in ("true", "yes", "done", "1"):
-            done, _, _ = _parse_judge_response(f'{{"done": "{s}", "reason": "r"}}')
-            assert done is True
-        for s in ("false", "no", "not yet"):
-            done, _, _ = _parse_judge_response(f'{{"done": "{s}", "reason": "r"}}')
-            assert done is False
-
-    def test_malformed_json_fails_open(self):
-        """Non-JSON → not done, with error-ish reason (so judge_goal can map to continue)."""
-        from hermes_cli.goals import _parse_judge_response
-
-        done, reason, _ = _parse_judge_response("this is not json at all")
-        assert done is False
-        assert reason  # non-empty
-
-    def test_empty_response(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        done, reason, _ = _parse_judge_response("")
-        assert done is False
-        assert reason
-
-
-# ──────────────────────────────────────────────────────────────────────
-# judge_goal — fail-open semantics
-# ──────────────────────────────────────────────────────────────────────
-
-
-class TestJudgeGoal:
-    def test_empty_goal_skipped(self):
-        from hermes_cli.goals import judge_goal
-
-        verdict, _, _ = judge_goal("", "some response")
-        assert verdict == "skipped"
-
-    def test_empty_response_continues(self):
-        from hermes_cli.goals import judge_goal
-
-        verdict, _, _ = judge_goal("ship the thing", "")
-        assert verdict == "continue"
-
-    def test_no_aux_client_continues(self):
-        """Fail-open: if no aux client, we must return continue, not skipped/done."""
-        from hermes_cli import goals
-
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(None, None),
-        ):
-            verdict, _, _ = goals.judge_goal("my goal", "my response")
-        assert verdict == "continue"
-
-    def test_api_error_continues(self):
-        """Judge exception → fail-open continue (don't wedge progress on judge bugs)."""
-        from hermes_cli import goals
-
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.side_effect = RuntimeError("boom")
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
-        ):
-            verdict, reason, _ = goals.judge_goal("goal", "response")
-        assert verdict == "continue"
-        assert "judge error" in reason.lower()
-
-    def test_judge_says_done(self):
-        from hermes_cli import goals
-
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.return_value = MagicMock(
-            choices=[
-                MagicMock(
-                    message=MagicMock(content='{"done": true, "reason": "achieved"}')
-                )
-            ]
+    def test_new_state_round_trip(self):
+        from hermes_cli.goals import (
+            ChecklistItem, GoalState,
+            ITEM_COMPLETED, ITEM_PENDING, ADDED_BY_AGENT, ADDED_BY_USER,
         )
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
-        ):
-            verdict, reason, _ = goals.judge_goal("goal", "agent response")
-        assert verdict == "done"
-        assert reason == "achieved"
-
-    def test_judge_says_continue(self):
-        from hermes_cli import goals
-
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.return_value = MagicMock(
-            choices=[
-                MagicMock(
-                    message=MagicMock(content='{"done": false, "reason": "not yet"}')
-                )
-            ]
+        state = GoalState(
+            goal="g",
+            checklist=[
+                ChecklistItem(text="a", status=ITEM_COMPLETED,
+                              added_by=ADDED_BY_AGENT, evidence="done"),
+                ChecklistItem(text="b", status=ITEM_PENDING,
+                              added_by=ADDED_BY_USER),
+            ],
+            pending_challenges=["challenge nudge text"],
         )
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
-        ):
-            verdict, reason, _ = goals.judge_goal("goal", "agent response")
-        assert verdict == "continue"
-        assert reason == "not yet"
+        rt = GoalState.from_json(state.to_json())
+        assert len(rt.checklist) == 2
+        assert rt.checklist[0].evidence == "done"
+        assert rt.checklist[1].added_by == ADDED_BY_USER
+        assert rt.pending_challenges == ["challenge nudge text"]
+
+    def test_checklist_counts_and_all_terminal(self):
+        from hermes_cli.goals import (
+            ChecklistItem, GoalState,
+            ITEM_COMPLETED, ITEM_IMPOSSIBLE, ITEM_PENDING,
+        )
+        state = GoalState(
+            goal="g",
+            checklist=[
+                ChecklistItem(text="a", status=ITEM_COMPLETED),
+                ChecklistItem(text="b", status=ITEM_IMPOSSIBLE),
+                ChecklistItem(text="c", status=ITEM_PENDING),
+            ],
+        )
+        total, done, imp, pending = state.checklist_counts()
+        assert (total, done, imp, pending) == (3, 1, 1, 1)
+        assert state.all_terminal() is False
+
+        state.checklist[2].status = ITEM_IMPOSSIBLE
+        assert state.all_terminal() is True
+
+    def test_empty_checklist_is_not_all_terminal(self):
+        from hermes_cli.goals import GoalState
+        assert GoalState(goal="g").all_terminal() is False
 
 
 # ──────────────────────────────────────────────────────────────────────
-# GoalManager lifecycle + persistence
+# GoalManager basic lifecycle
 # ──────────────────────────────────────────────────────────────────────
 
 
-class TestGoalManager:
-    def test_no_goal_initial(self, hermes_home):
+class TestGoalManagerLifecycle:
+    def test_set_and_status(self, hermes_home):
         from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="test-sid-1")
-        assert mgr.state is None
+        mgr = GoalManager(session_id="s1")
         assert not mgr.is_active()
-        assert not mgr.has_goal()
-        assert "No active goal" in mgr.status_line()
-
-    def test_set_then_status(self, hermes_home):
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="test-sid-2", default_max_turns=5)
-        state = mgr.set("port the thing")
-        assert state.goal == "port the thing"
-        assert state.status == "active"
-        assert state.max_turns == 5
-        assert state.turns_used == 0
+        mgr.set("ship the feature")
         assert mgr.is_active()
-        assert "active" in mgr.status_line().lower()
-        assert "port the thing" in mgr.status_line()
+        assert "ship the feature" in mgr.status_line()
 
-    def test_set_rejects_empty(self, hermes_home):
+    def test_pause_resume_clear(self, hermes_home):
         from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="test-sid-3")
-        with pytest.raises(ValueError):
-            mgr.set("")
-        with pytest.raises(ValueError):
-            mgr.set("   ")
-
-    def test_pause_and_resume(self, hermes_home):
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="test-sid-4")
-        mgr.set("goal text")
+        mgr = GoalManager(session_id="s2")
+        mgr.set("g")
         mgr.pause(reason="user-paused")
-        assert mgr.state.status == "paused"
         assert not mgr.is_active()
         assert mgr.has_goal()
+        assert "paused" in mgr.status_line().lower()
 
         mgr.resume()
-        assert mgr.state.status == "active"
         assert mgr.is_active()
+        assert mgr.state.turns_used == 0  # resume resets budget
 
-    def test_clear(self, hermes_home):
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="test-sid-5")
-        mgr.set("goal")
         mgr.clear()
+        assert not mgr.has_goal()
         assert mgr.state is None
-        assert not mgr.is_active()
 
     def test_persistence_across_managers(self, hermes_home):
-        """Key invariant: a second manager on the same session sees the goal.
-
-        This is what makes /resume work — each session rebinds its
-        GoalManager and picks up the saved state.
-        """
         from hermes_cli.goals import GoalManager
+        m1 = GoalManager(session_id="persist-sid")
+        m1.set("a goal")
+        m2 = GoalManager(session_id="persist-sid")
+        assert m2.is_active()
+        assert m2.state.goal == "a goal"
 
-        mgr1 = GoalManager(session_id="persist-sid")
-        mgr1.set("do the thing")
 
-        mgr2 = GoalManager(session_id="persist-sid")
-        assert mgr2.state is not None
-        assert mgr2.state.goal == "do the thing"
-        assert mgr2.is_active()
+# ──────────────────────────────────────────────────────────────────────
+# evaluate_after_turn (no judge call!)
+# ──────────────────────────────────────────────────────────────────────
 
-    def test_evaluate_after_turn_done(self, hermes_home):
-        """Judge says done → status=done, no continuation."""
-        from hermes_cli import goals
+
+class TestEvaluateAfterTurn:
+    def test_inactive_goal_is_noop(self, hermes_home):
         from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="eval-sid-1")
-        mgr.set("ship it")
-
-        with patch.object(goals, "judge_goal", return_value=("done", "shipped", False)):
-            decision = mgr.evaluate_after_turn("I shipped the feature.")
-
-        assert decision["verdict"] == "done"
-        assert decision["should_continue"] is False
-        assert decision["continuation_prompt"] is None
-        assert mgr.state.status == "done"
-        assert mgr.state.turns_used == 1
-
-    def test_evaluate_after_turn_continue_under_budget(self, hermes_home):
-        from hermes_cli import goals
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="eval-sid-2", default_max_turns=5)
-        mgr.set("a long goal")
-
-        with patch.object(goals, "judge_goal", return_value=("continue", "more work", False)):
-            decision = mgr.evaluate_after_turn("made some progress")
-
-        assert decision["verdict"] == "continue"
-        assert decision["should_continue"] is True
-        assert decision["continuation_prompt"] is not None
-        assert "a long goal" in decision["continuation_prompt"]
-        assert mgr.state.status == "active"
-        assert mgr.state.turns_used == 1
-
-    def test_evaluate_after_turn_budget_exhausted(self, hermes_home):
-        """When turn budget hits ceiling, auto-pause instead of continuing."""
-        from hermes_cli import goals
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="eval-sid-3", default_max_turns=2)
-        mgr.set("hard goal")
-
-        with patch.object(goals, "judge_goal", return_value=("continue", "not yet", False)):
-            d1 = mgr.evaluate_after_turn("step 1")
-            assert d1["should_continue"] is True
-            assert mgr.state.turns_used == 1
-            assert mgr.state.status == "active"
-
-            d2 = mgr.evaluate_after_turn("step 2")
-            # turns_used is now 2 which equals max_turns → paused
-            assert d2["should_continue"] is False
-            assert mgr.state.status == "paused"
-            assert mgr.state.turns_used == 2
-            assert "budget" in (mgr.state.paused_reason or "").lower()
-
-    def test_evaluate_after_turn_inactive(self, hermes_home):
-        """evaluate_after_turn is a no-op when goal isn't active."""
-        from hermes_cli.goals import GoalManager
-
-        mgr = GoalManager(session_id="eval-sid-4")
-        d = mgr.evaluate_after_turn("anything")
-        assert d["verdict"] == "inactive"
+        mgr = GoalManager(session_id="eval-1")
+        d = mgr.evaluate_after_turn()
         assert d["should_continue"] is False
-
-        mgr.set("a goal")
+        mgr.set("g")
         mgr.pause()
-        d2 = mgr.evaluate_after_turn("anything")
-        assert d2["verdict"] == "inactive"
+        d2 = mgr.evaluate_after_turn()
         assert d2["should_continue"] is False
 
-    def test_continuation_prompt_shape(self, hermes_home):
-        """The continuation prompt must include the goal text verbatim —
-        and must be safe to inject as a user-role message (prompt-cache
-        invariants: no system-prompt mutation)."""
+    def test_empty_checklist_continues(self, hermes_home):
+        """No checklist yet → loop continues so the agent can decompose."""
         from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="eval-2", default_max_turns=5)
+        mgr.set("g")
+        d = mgr.evaluate_after_turn()
+        assert d["should_continue"] is True
+        # Continuation prompt is the decompose prompt for the empty case.
+        assert "propose a checklist" in d["continuation_prompt"]
+        assert mgr.state.turns_used == 1
 
-        mgr = GoalManager(session_id="cont-sid")
-        mgr.set("port goal command to hermes")
+    def test_partial_checklist_continues(self, hermes_home):
+        """Some items pending → loop continues with checklist progress."""
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_PENDING, ITEM_COMPLETED, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="eval-3", default_max_turns=5)
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="b", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+        ]
+        goals.save_goal("eval-3", mgr.state)
+        d = mgr.evaluate_after_turn()
+        assert d["should_continue"] is True
+        assert "Checklist progress (1/2 done)" in d["continuation_prompt"]
+
+    def test_all_terminal_marks_done(self, hermes_home):
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_COMPLETED, ITEM_IMPOSSIBLE, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="eval-4")
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_COMPLETED, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="b", status=ITEM_IMPOSSIBLE, added_by=ADDED_BY_AGENT),
+        ]
+        goals.save_goal("eval-4", mgr.state)
+        d = mgr.evaluate_after_turn()
+        assert d["should_continue"] is False
+        assert d["status"] == "done"
+        assert "Goal achieved" in d["message"]
+
+    def test_budget_exhausted_pauses(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="eval-5", default_max_turns=2)
+        mgr.set("g")
+        d1 = mgr.evaluate_after_turn()
+        assert d1["should_continue"] is True
+        d2 = mgr.evaluate_after_turn()
+        assert d2["should_continue"] is False
+        assert d2["status"] == "paused"
+        assert "budget" in (mgr.state.paused_reason or "").lower()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# apply_agent_update (called by the goal_checklist tool handler)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestApplyAgentUpdate:
+    def test_initial_decompose_via_items(self, hermes_home):
+        from hermes_cli.goals import GoalManager, ITEM_PENDING, ADDED_BY_AGENT
+        mgr = GoalManager(session_id="upd-1")
+        mgr.set("build a website")
+        result = mgr.apply_agent_update(items=[
+            {"text": "homepage exists"},
+            {"text": "navigation works"},
+            {"text": "deployed"},
+        ])
+        assert result["ok"] is True
+        assert result["summary"]["total"] == 3
+        assert result["summary"]["pending"] == 3
+        assert all(it.added_by == ADDED_BY_AGENT for it in mgr.state.checklist)
+        assert all(it.status == ITEM_PENDING for it in mgr.state.checklist)
+
+    def test_mark_flips_pending_to_terminal(self, hermes_home):
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_PENDING, ITEM_COMPLETED, ITEM_IMPOSSIBLE, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="upd-2")
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="b", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+            ChecklistItem(text="c", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+        ]
+        goals.save_goal("upd-2", mgr.state)
+
+        mgr.apply_agent_update(mark=[
+            {"index": 1, "status": "completed", "evidence": "ran a"},
+            {"index": 3, "status": "impossible", "evidence": "blocked"},
+        ])
+        assert mgr.state.checklist[0].status == ITEM_COMPLETED
+        assert mgr.state.checklist[0].evidence == "ran a"
+        assert mgr.state.checklist[1].status == ITEM_PENDING
+        assert mgr.state.checklist[2].status == ITEM_IMPOSSIBLE
+
+    def test_stickiness_agent_cannot_regress_terminal(self, hermes_home):
+        """Once an item is in a terminal status, the agent cannot flip it
+        via apply_agent_update. Only the user can (via /subgoal)."""
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_COMPLETED, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="upd-stick")
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(
+                text="a", status=ITEM_COMPLETED,
+                added_by=ADDED_BY_AGENT, evidence="original",
+            ),
+        ]
+        goals.save_goal("upd-stick", mgr.state)
+
+        mgr.apply_agent_update(mark=[
+            {"index": 1, "status": "impossible", "evidence": "regression"},
+        ])
+        assert mgr.state.checklist[0].status == ITEM_COMPLETED
+        assert mgr.state.checklist[0].evidence == "original"
+
+    def test_non_terminal_status_in_mark_is_filtered(self, hermes_home):
+        """The agent can only mark terminal statuses via the tool; pending
+        is filtered (the agent doesn't get to un-finish work)."""
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_PENDING, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="upd-filter")
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(text="a", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+        ]
+        goals.save_goal("upd-filter", mgr.state)
+
+        mgr.apply_agent_update(mark=[
+            {"index": 1, "status": "pending", "evidence": "no-op"},
+        ])
+        assert mgr.state.checklist[0].status == ITEM_PENDING
+        assert mgr.state.checklist[0].evidence is None
+
+    def test_items_appended_when_checklist_already_populated(self, hermes_home):
+        from hermes_cli.goals import (
+            GoalManager, ChecklistItem,
+            ITEM_PENDING, ADDED_BY_AGENT,
+        )
+        from hermes_cli import goals
+        mgr = GoalManager(session_id="upd-append")
+        mgr.set("g")
+        mgr.state.checklist = [
+            ChecklistItem(text="existing", status=ITEM_PENDING, added_by=ADDED_BY_AGENT),
+        ]
+        goals.save_goal("upd-append", mgr.state)
+
+        mgr.apply_agent_update(items=[
+            {"text": "existing"},  # duplicate, dropped
+            {"text": "newly discovered"},
+        ])
+        assert [it.text for it in mgr.state.checklist] == ["existing", "newly discovered"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# /subgoal user controls
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestSubgoalUserControls:
+    def test_add_subgoal(self, hermes_home):
+        from hermes_cli.goals import GoalManager, ITEM_PENDING, ADDED_BY_USER
+        mgr = GoalManager(session_id="sub-1")
+        mgr.set("g")
+        item = mgr.add_subgoal("user added")
+        assert item.text == "user added"
+        assert item.status == ITEM_PENDING
+        assert item.added_by == ADDED_BY_USER
+
+    def test_add_subgoal_requires_active_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="sub-2")
+        with pytest.raises(RuntimeError):
+            mgr.add_subgoal("x")
+
+    def test_mark_subgoal_user_can_revert_terminal(self, hermes_home):
+        """User mark_subgoal bypasses stickiness — only path to revert."""
+        from hermes_cli.goals import GoalManager, ITEM_COMPLETED, ITEM_PENDING
+        mgr = GoalManager(session_id="sub-3")
+        mgr.set("g")
+        mgr.add_subgoal("a")
+        mgr.mark_subgoal(1, "completed")
+        assert mgr.state.checklist[0].status == ITEM_COMPLETED
+        mgr.mark_subgoal(1, "pending")
+        assert mgr.state.checklist[0].status == ITEM_PENDING
+
+    def test_challenge_flips_terminal_to_pending_and_queues_nudge(self, hermes_home):
+        from hermes_cli.goals import GoalManager, ITEM_PENDING
+        mgr = GoalManager(session_id="sub-4")
+        mgr.set("g")
+        mgr.add_subgoal("did the thing")
+        mgr.mark_subgoal(1, "completed")
+        assert mgr.state.checklist[0].status != ITEM_PENDING
+        assert mgr.state.pending_challenges == []
+
+        mgr.challenge_subgoal(1)
+        assert mgr.state.checklist[0].status == ITEM_PENDING
+        assert len(mgr.state.pending_challenges) == 1
+        assert "challenged item 1" in mgr.state.pending_challenges[0]
+
+    def test_challenge_rejects_non_terminal(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="sub-5")
+        mgr.set("g")
+        mgr.add_subgoal("a")  # still pending
+        with pytest.raises(ValueError):
+            mgr.challenge_subgoal(1)
+
+    def test_remove_subgoal(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="sub-6")
+        mgr.set("g")
+        mgr.add_subgoal("a")
+        mgr.add_subgoal("b")
+        removed = mgr.remove_subgoal(1)
+        assert removed.text == "a"
+        assert [it.text for it in mgr.state.checklist] == ["b"]
+
+    def test_clear_checklist(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="sub-7")
+        mgr.set("g")
+        mgr.add_subgoal("a")
+        mgr.clear_checklist()
+        assert mgr.state.checklist == []
+        assert mgr.state.pending_challenges == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Continuation prompt — three flavors + challenge prepending
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestContinuationPrompt:
+    def test_decompose_prompt_when_checklist_empty(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="cp-1")
+        mgr.set("g")
         prompt = mgr.next_continuation_prompt()
-        assert prompt is not None
-        assert "port goal command to hermes" in prompt
-        assert prompt.strip()  # non-empty
+        assert "propose a checklist" in prompt
+        assert "goal_checklist" in prompt
 
-
-# ──────────────────────────────────────────────────────────────────────
-# Smoke: CommandDef is wired
-# ──────────────────────────────────────────────────────────────────────
-
-
-def test_goal_command_in_registry():
-    from hermes_cli.commands import resolve_command
-
-    cmd = resolve_command("goal")
-    assert cmd is not None
-    assert cmd.name == "goal"
-
-
-def test_goal_command_dispatches_in_cli_registry_helpers():
-    """goal shows up in autocomplete / help categories alongside other Session cmds."""
-    from hermes_cli.commands import COMMANDS, COMMANDS_BY_CATEGORY
-
-    assert "/goal" in COMMANDS
-    session_cmds = COMMANDS_BY_CATEGORY.get("Session", {})
-    assert "/goal" in session_cmds
-
-
-# ──────────────────────────────────────────────────────────────────────
-# Auto-pause on consecutive judge parse failures
-# ──────────────────────────────────────────────────────────────────────
-
-
-class TestJudgeParseFailureAutoPause:
-    """Regression: weak judge models (e.g. deepseek-v4-flash) that return
-    empty strings or non-JSON prose must auto-pause the loop after N turns
-    instead of burning the whole turn budget."""
-
-    def test_parse_response_flags_empty_as_parse_failure(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        done, reason, parse_failed = _parse_judge_response("")
-        assert done is False
-        assert parse_failed is True
-        assert "empty" in reason.lower()
-
-    def test_parse_response_flags_non_json_as_parse_failure(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        done, reason, parse_failed = _parse_judge_response(
-            "Let me analyze whether the goal is fully satisfied based on the agent's response..."
-        )
-        assert done is False
-        assert parse_failed is True
-        assert "not json" in reason.lower()
-
-    def test_parse_response_clean_json_is_not_parse_failure(self):
-        from hermes_cli.goals import _parse_judge_response
-
-        done, _, parse_failed = _parse_judge_response(
-            '{"done": false, "reason": "more work"}'
-        )
-        assert done is False
-        assert parse_failed is False
-
-    def test_api_error_does_not_count_as_parse_failure(self):
-        """Transient network/API errors must not trip the auto-pause guard."""
-        from hermes_cli import goals
-
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.side_effect = RuntimeError("connection reset")
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
-        ):
-            verdict, _, parse_failed = goals.judge_goal("goal", "response")
-        assert verdict == "continue"
-        assert parse_failed is False
-
-    def test_empty_judge_reply_flagged_as_parse_failure(self):
-        """End-to-end: judge returns empty content → parse_failed=True."""
-        from hermes_cli import goals
-
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=""))]
-        )
-        with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
-        ):
-            verdict, _, parse_failed = goals.judge_goal("goal", "response")
-        assert verdict == "continue"
-        assert parse_failed is True
-
-    def test_auto_pause_after_three_consecutive_parse_failures(self, hermes_home):
-        """N=3 consecutive parse failures → auto-pause with config pointer."""
-        from hermes_cli import goals
-        from hermes_cli.goals import GoalManager, DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES
-
-        assert DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES == 3
-        mgr = GoalManager(session_id="parse-fail-sid-1", default_max_turns=20)
-        mgr.set("do a thing")
-
-        with patch.object(
-            goals, "judge_goal", return_value=("continue", "judge returned empty response", True)
-        ):
-            d1 = mgr.evaluate_after_turn("step 1")
-            assert d1["should_continue"] is True
-            assert mgr.state.consecutive_parse_failures == 1
-
-            d2 = mgr.evaluate_after_turn("step 2")
-            assert d2["should_continue"] is True
-            assert mgr.state.consecutive_parse_failures == 2
-
-            d3 = mgr.evaluate_after_turn("step 3")
-            assert d3["should_continue"] is False
-            assert d3["status"] == "paused"
-            assert mgr.state.consecutive_parse_failures == 3
-            # Message points at the config surface so the user can fix it.
-            assert "auxiliary" in d3["message"]
-            assert "goal_judge" in d3["message"]
-            assert "config.yaml" in d3["message"]
-
-    def test_parse_failure_counter_resets_on_good_reply(self, hermes_home):
-        """A single good judge reply resets the counter — transient flakes don't pause."""
-        from hermes_cli import goals
+    def test_continuation_prompt_with_checklist(self, hermes_home):
         from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="cp-2")
+        mgr.set("g")
+        mgr.apply_agent_update(items=[
+            {"text": "a"}, {"text": "b"}, {"text": "c"},
+        ])
+        mgr.apply_agent_update(mark=[{"index": 1, "status": "completed", "evidence": "did a"}])
+        prompt = mgr.next_continuation_prompt()
+        assert "Checklist progress (1/3 done)" in prompt
+        assert "[x] a" in prompt
+        assert "[ ] b" in prompt
 
-        mgr = GoalManager(session_id="parse-fail-sid-2", default_max_turns=20)
-        mgr.set("another goal")
-
-        # Two parse failures…
-        with patch.object(
-            goals, "judge_goal", return_value=("continue", "not json", True)
-        ):
-            mgr.evaluate_after_turn("step 1")
-            mgr.evaluate_after_turn("step 2")
-            assert mgr.state.consecutive_parse_failures == 2
-
-        # …then one clean reply resets the counter.
-        with patch.object(
-            goals, "judge_goal", return_value=("continue", "making progress", False)
-        ):
-            d = mgr.evaluate_after_turn("step 3")
-            assert d["should_continue"] is True
-            assert mgr.state.consecutive_parse_failures == 0
-
-    def test_parse_failure_counter_not_incremented_by_api_errors(self, hermes_home):
-        """API/transport errors must NOT count toward the auto-pause threshold."""
-        from hermes_cli import goals
+    def test_pending_challenges_prepend_and_drain(self, hermes_home):
         from hermes_cli.goals import GoalManager
+        mgr = GoalManager(session_id="cp-3")
+        mgr.set("g")
+        mgr.apply_agent_update(items=[{"text": "a"}])
+        mgr.apply_agent_update(mark=[{"index": 1, "status": "completed", "evidence": "x"}])
+        mgr.challenge_subgoal(1)
 
-        mgr = GoalManager(session_id="parse-fail-sid-3", default_max_turns=20)
-        mgr.set("goal")
+        prompt = mgr.next_continuation_prompt()
+        assert "challenged item 1" in prompt
+        assert "Continuing toward your standing goal" in prompt
+        # Drained — second call doesn't re-include the challenge
+        assert mgr.state.pending_challenges == []
+        prompt2 = mgr.next_continuation_prompt()
+        assert "challenged item 1" not in prompt2
 
-        with patch.object(
-            goals, "judge_goal", return_value=("continue", "judge error: RuntimeError", False)
-        ):
-            for _ in range(5):
-                d = mgr.evaluate_after_turn("still going")
-                assert d["should_continue"] is True
-            assert mgr.state.consecutive_parse_failures == 0
-            assert mgr.state.status == "active"
 
-    def test_consecutive_parse_failures_persists_across_goalmanager_reloads(
-        self, hermes_home
-    ):
-        """The counter must be durable so cross-session resumes see it."""
-        from hermes_cli import goals
-        from hermes_cli.goals import GoalManager, load_goal
+# ──────────────────────────────────────────────────────────────────────
+# goal_checklist model tool
+# ──────────────────────────────────────────────────────────────────────
 
-        mgr = GoalManager(session_id="parse-fail-sid-4", default_max_turns=20)
-        mgr.set("persistent goal")
 
-        with patch.object(
-            goals, "judge_goal", return_value=("continue", "empty", True)
-        ):
-            mgr.evaluate_after_turn("r")
-            mgr.evaluate_after_turn("r")
+class TestGoalChecklistTool:
+    def test_tool_no_active_goal(self, hermes_home):
+        from tools.goal_checklist_tool import goal_checklist_tool
+        out = goal_checklist_tool(items=[{"text": "x"}], session_id="no-goal-sid")
+        data = json.loads(out)
+        assert data["ok"] is False
+        assert "no active" in data["error"].lower()
 
-        reloaded = load_goal("parse-fail-sid-4")
-        assert reloaded is not None
-        assert reloaded.consecutive_parse_failures == 2
+    def test_tool_no_session_id(self, hermes_home):
+        from tools.goal_checklist_tool import goal_checklist_tool
+        out = goal_checklist_tool(items=[{"text": "x"}], session_id="")
+        data = json.loads(out)
+        assert data["ok"] is False
+        assert "session_id" in data["error"]
+
+    def test_tool_seeds_initial_checklist(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_checklist_tool import goal_checklist_tool
+        mgr = GoalManager(session_id="tool-1")
+        mgr.set("build it")
+
+        out = goal_checklist_tool(
+            items=[{"text": "step a"}, {"text": "step b"}],
+            session_id="tool-1",
+        )
+        data = json.loads(out)
+        assert data["ok"] is True
+        assert data["summary"]["total"] == 2
+        assert data["summary"]["pending"] == 2
+
+        # Verify state actually persisted via a fresh manager
+        mgr2 = GoalManager(session_id="tool-1")
+        assert len(mgr2.state.checklist) == 2
+
+    def test_tool_marks_items(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_checklist_tool import goal_checklist_tool
+        mgr = GoalManager(session_id="tool-2")
+        mgr.set("g")
+        goal_checklist_tool(items=[{"text": "a"}, {"text": "b"}], session_id="tool-2")
+        out = goal_checklist_tool(
+            mark=[{"index": 1, "status": "completed", "evidence": "did a"}],
+            session_id="tool-2",
+        )
+        data = json.loads(out)
+        assert data["ok"] is True
+        assert data["summary"]["completed"] == 1
+        assert data["summary"]["pending"] == 1
+
+    def test_tool_read_only_call(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_checklist_tool import goal_checklist_tool
+        mgr = GoalManager(session_id="tool-3")
+        mgr.set("g")
+        goal_checklist_tool(items=[{"text": "a"}], session_id="tool-3")
+        out = goal_checklist_tool(session_id="tool-3")  # no items, no mark
+        data = json.loads(out)
+        assert data["ok"] is True
+        assert len(data["checklist"]) == 1
+        assert data["applied"] == []
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Compression session-rotation: goal must survive the new session_id
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGoalSurvivesCompressionRotation:
+    def test_load_goal_after_session_id_rotates(self, hermes_home):
+        """When auto-compression rotates the session_id, the goal must be
+        readable from the new session_id (forwarded by run_agent's
+        _compress_context block).
+        """
+        from hermes_cli.goals import GoalManager
+        from hermes_state import SessionDB
+
+        parent_sid = "parent-rotate-001"
+        mgr = GoalManager(session_id=parent_sid)
+        mgr.set("survive compression")
+
+        db = SessionDB()
+        new_sid = "child-rotate-001"
+        blob = db.get_meta(f"goal:{parent_sid}")
+        assert blob, "goal must be in state_meta"
+        db.set_meta(f"goal:{new_sid}", blob)
+
+        mgr2 = GoalManager(session_id=new_sid)
+        assert mgr2.is_active()
+        assert mgr2.state.goal == "survive compression"
+        assert mgr2.state.checklist == mgr.state.checklist

--- a/tools/goal_checklist_tool.py
+++ b/tools/goal_checklist_tool.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""goal_checklist tool — agent-owned standing-goal checklist.
+
+The agent calls this tool to:
+  1. Submit the initial checklist when a /goal is set (Phase A).
+  2. Mark items completed/impossible as it works (Phase B).
+  3. Append items it discovers along the way.
+
+There is no aux-model judge in the loop. The agent that's actually
+doing the work owns the progress signal. The user audits via
+``/subgoal`` slash commands.
+
+Behavior
+--------
+- ``items``: write a fresh checklist (initial decompose, or replacement
+  when the user has cleared the existing one). Each item is
+  ``{text: str, status?: pending|completed|impossible, evidence?: str}``.
+- ``mark``: per-item flips ``[{index: int (1-based), status: str,
+  evidence?: str}, ...]``. Stickiness in code: agent can flip pending →
+  terminal but cannot regress its own terminal items. Only the user can
+  via ``/subgoal undo`` or ``/subgoal challenge``.
+
+Both params are optional — call with ``items`` to seed, ``mark`` to
+update, both for a one-shot bulk update. Returns the full current
+checklist + summary counters.
+
+Wiring
+------
+The tool is dispatched via ``run_agent.handle_function_call`` (see the
+``goal_checklist`` branch in run_agent.py). It needs the live agent's
+``session_id`` to load/save state via ``hermes_cli.goals.GoalManager``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+GOAL_CHECKLIST_SCHEMA = {
+    "name": "goal_checklist",
+    "description": (
+        "Manage the checklist for the user's standing /goal. The user has "
+        "asked you to work toward a goal across multiple turns; this tool "
+        "is how you communicate progress.\n\n"
+        "When a goal is set, the system asks you to propose a detailed "
+        "checklist of completion criteria. Submit it by calling this tool "
+        "with the ``items`` parameter — each item should be a concrete, "
+        "verifiable thing (not a vague intention).\n\n"
+        "On subsequent turns, mark items completed (or impossible) as you "
+        "finish them by passing ``mark``. Always include one-line evidence "
+        "citing the specific tool call, file, or output that satisfies the "
+        "item. Once an item is in a terminal status (completed or "
+        "impossible), it is sticky — only the user can flip it back via "
+        "/subgoal commands.\n\n"
+        "When every item is in a terminal status, the goal completes and "
+        "the loop ends.\n\n"
+        "Do NOT mark items completed without doing the work. The user can "
+        "challenge any over-claim via /subgoal challenge N, which flips the "
+        "item back to pending and forces you to revisit it.\n\n"
+        "You may pass both ``items`` and ``mark`` in the same call. With no "
+        "params, the tool reads the current checklist."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "description": (
+                    "Submit or replace the checklist. Use this once at the "
+                    "start of a new goal to seed the criteria, or when the "
+                    "user has cleared the checklist and asked you to "
+                    "re-propose. To append a single item to an existing "
+                    "checklist, include it here — duplicates by exact text "
+                    "are skipped."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": (
+                                "Concrete, verifiable completion criterion."
+                            ),
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["pending", "completed", "impossible"],
+                            "description": (
+                                "Initial status. Defaults to pending; only "
+                                "set this when an item is already done or "
+                                "impossible at decompose time."
+                            ),
+                        },
+                        "evidence": {
+                            "type": "string",
+                            "description": (
+                                "One-line citation of why this item is in "
+                                "its initial status, when not pending."
+                            ),
+                        },
+                    },
+                    "required": ["text"],
+                },
+            },
+            "mark": {
+                "type": "array",
+                "description": (
+                    "Per-item status flips. Each entry has a 1-based "
+                    "``index`` into the current checklist, a ``status`` "
+                    "(must be 'completed' or 'impossible'), and a one-line "
+                    "``evidence`` citing the specific work that satisfies "
+                    "or blocks the item."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "description": "1-based checklist index.",
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["completed", "impossible"],
+                        },
+                        "evidence": {
+                            "type": "string",
+                            "description": (
+                                "One-line citation of why this item is "
+                                "done or impossible. Reference your actual "
+                                "tool calls or output."
+                            ),
+                        },
+                    },
+                    "required": ["index", "status", "evidence"],
+                },
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def goal_checklist_tool(
+    items: Optional[List[Dict[str, Any]]] = None,
+    mark: Optional[List[Dict[str, Any]]] = None,
+    session_id: Optional[str] = None,
+    default_max_turns: int = 20,
+) -> str:
+    """Single entry point for the goal_checklist tool.
+
+    Args:
+        items: optional initial / append list of checklist items.
+        mark: optional per-item terminal-status flips.
+        session_id: the live agent's session_id (used to load/save the
+            GoalState row).
+        default_max_turns: budget passed through to GoalManager when it
+            instantiates a new manager. Pulled from config by the
+            run_agent dispatch site.
+
+    Returns:
+        JSON string with the full current checklist + summary counters,
+        or an error message if no active goal exists.
+    """
+    if not session_id:
+        return json.dumps(
+            {"ok": False, "error": "no session_id — cannot resolve goal state"},
+            ensure_ascii=False,
+        )
+
+    try:
+        from hermes_cli.goals import GoalManager
+    except Exception as exc:
+        logger.debug("goal_checklist: GoalManager import failed: %s", exc)
+        return json.dumps(
+            {"ok": False, "error": f"goal manager unavailable: {exc}"},
+            ensure_ascii=False,
+        )
+
+    mgr = GoalManager(session_id=session_id, default_max_turns=default_max_turns)
+
+    if not mgr.has_goal():
+        return json.dumps(
+            {
+                "ok": False,
+                "error": (
+                    "No active /goal for this session. The user has not set "
+                    "a standing goal — this tool is only useful when /goal "
+                    "is active."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    # Read-only call: just return the current state.
+    if items is None and not mark:
+        state = mgr.state
+        if state is None:
+            return json.dumps(
+                {"ok": False, "error": "goal state missing"}, ensure_ascii=False
+            )
+        cl_total, cl_done, cl_imp, cl_pending = state.checklist_counts()
+        return json.dumps(
+            {
+                "ok": True,
+                "applied": [],
+                "checklist": [it.to_dict() for it in state.checklist],
+                "summary": {
+                    "total": cl_total,
+                    "completed": cl_done,
+                    "impossible": cl_imp,
+                    "pending": cl_pending,
+                    "all_terminal": state.all_terminal(),
+                },
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        result = mgr.apply_agent_update(items=items, mark=mark)
+    except RuntimeError as exc:
+        return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+
+    return json.dumps(result, ensure_ascii=False)
+
+
+def check_goal_checklist_requirements() -> bool:
+    """Always available — no external dependencies."""
+    return True
+
+
+# --- Registry ---
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="goal_checklist",
+    toolset="todo",
+    schema=GOAL_CHECKLIST_SCHEMA,
+    # The dispatch site in run_agent.py injects ``session_id`` and
+    # ``default_max_turns`` from the AIAgent instance — this lambda is
+    # kept as a fallback that returns an error when called without that
+    # context (e.g., unit tests that bypass the dispatch).
+    handler=lambda args, **kw: goal_checklist_tool(
+        items=args.get("items"),
+        mark=args.get("mark"),
+        session_id=kw.get("session_id"),
+        default_max_turns=kw.get("default_max_turns", 20),
+    ),
+    check_fn=check_goal_checklist_requirements,
+    emoji="⊙",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -47,7 +47,7 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "memory", "goal_checklist",
     # Session history search
     "session_search",
     # Clarifying questions
@@ -188,7 +188,7 @@ TOOLSETS = {
         "tools": ["todo"],
         "includes": []
     },
-    
+
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
         "tools": ["memory"],
@@ -329,7 +329,7 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
-            "todo", "memory",
+            "todo", "memory", "goal_checklist",
             "session_search",
             "execute_code", "delegate_task",
         ],
@@ -355,7 +355,7 @@ TOOLSETS = {
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             # Planning & memory
-            "todo", "memory",
+            "todo", "memory", "goal_checklist",
             # Session history search
             "session_search",
             # Code execution + delegation

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3249,7 +3249,6 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         )
                         if goal_mgr.is_active():
                             decision = goal_mgr.evaluate_after_turn(
-                                raw,
                                 user_initiated=True,
                             )
                             verdict_msg = decision.get("message") or ""


### PR DESCRIPTION
# Summary

Replaces the aux-model judge loop with a model tool the agent calls itself. The agent that's actually doing the work owns the progress signal; the user audits via `/subgoal` slash commands.

This addresses the three structural failure modes that killed v3-v5:
1. **Judge has worse vision than the agent.** Snippet-only access, 1MB+ dump files unreadable in 5 reads.
2. **Even opus 4.7 drifts out of strict JSON.** Tool-call enforcement only helps if the loop can credit the work — on long checklists the judge keeps emitting empty `updates=0` calls because it can't verify items it can't see.
3. **The agent gives up.** A loop that never credits evidence becomes pure punishment; the agent rationally refuses to keep paying for it. (Real failure in your modpack run — agent went `Idle.` after 8 turns of stuck-at-0/25.)

# How it works

- `/goal X` queues the decompose prompt asking the agent to call `goal_checklist` with proposed criteria.
- On every subsequent turn the agent calls `goal_checklist` again with `mark={index, status, evidence}` to flip items completed or impossible as it finishes them.
- The continuation prompt shows the live checklist progress so the agent always sees what's still pending.
- `evaluate_after_turn` just inspects state — no aux call, no JSON parsing, no parse-failure auto-pause. `all_terminal()` → done; turn budget hit → paused; else → continue.

# /subgoal user controls

- `/subgoal` — show the checklist
- `/subgoal <text>` — append a user item
- `/subgoal complete N` — user marks N completed
- `/subgoal impossible N` — user marks N impossible
- `/subgoal undo N` — user reverts N to pending
- `/subgoal challenge N` — flip terminal → pending AND queue a user-role nudge for the next turn so the agent revisits with the user's concern
- `/subgoal remove N` — delete N
- `/subgoal clear` — wipe (agent re-decomposes next turn)

`/subgoal challenge` is the new feedback channel that the broken judge tried to be — coming from the user with full context, async, and the agent gets a clear "address this concern" prompt next turn.

# Stickiness

- Agent CAN flip pending → completed | impossible.
- Agent CANNOT regress its own terminal items (filtered in `apply_agent_update`). Only the user can revert via `/subgoal undo` or `/subgoal challenge`.
- Schema description tells the agent not to over-claim; user has `/subgoal challenge` to push back.

# Validation

| | Before (v5 judge) | After (v6 agent-owned) |
|---|---|---|
| Live fizzbuzz on opus 4.7 | Got stuck or auto-paused | Done in **1 turn**, 9 items marked with item-specific evidence |
| Live modpack-style goal | 0/25 forever, agent gave up after 8 turns | Structural failure mode gone (agent owns the signal) |
| Tests | n/a | **60 passing** across goals.py / interrupt / verdict-send / max-turns / status-notice / tui-gateway |

Live agent.log on opus 4.7 fizzbuzz:

```
goal_checklist completed (0.00s, 2006 chars)   ← decompose: 9 items submitted
goal_checklist completed (0.00s, 2822 chars)   ← mark: all 9 completed in same turn
```

# What's gone

- All aux-model judge code (`judge_goal`, `evaluate_checklist`, `decompose_goal`)
- `auxiliary.goal_judge` config plumbing
- `<HERMES_HOME>/goals/<sid>.json` conversation dumps
- `consecutive_parse_failures` auto-pause
- `submit_checklist` / `update_checklist` aux tools
- Snippet extraction in `evaluate_after_turn`
- Aux `read_file` tool for the judge

# What's new

- Single model tool: `goal_checklist({items?, mark?})`
- `/subgoal` slash command with 7 verbs including `challenge`
- Decompose prompt that primes the agent to call the tool

# Files

- `tools/goal_checklist_tool.py` — new model tool
- `hermes_cli/goals.py` — rewritten without the judge
- `hermes_cli/commands.py` — `/subgoal` registry entry
- `cli.py` — `_handle_subgoal_command()`, simplified post-turn hook
- `gateway/run.py` — `_handle_subgoal_command()`, mid-run guard, simplified post-turn hook
- `tui_gateway/server.py` — drop `raw` arg from `evaluate_after_turn`
- `run_agent.py` — two dispatch sites for `goal_checklist`, plus state_meta forwarding on compression rotation (re-application of #23530)
- `toolsets.py` — `goal_checklist` added to core + hermes-acp + hermes-api-server tool lists
- Tests rewritten to match state-driven design (no judge mocks)

# Compression survival

State_meta forwarding from PR #23530 is re-applied here: when `_compress_context` rotates the session_id, `state_meta[goal:<old>]` is copied to `state_meta[goal:<new>]` so the checklist survives the rotation.
