### PR TITLE
fix(local): preserve Git Bash cwd on Windows

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from tools.environments.local import (
     LocalEnvironment,
+    _native_windows_cwd,
     _resolve_safe_cwd,
 )
 
@@ -50,6 +51,34 @@ class TestResolveSafeCwd:
         sep = os.path.sep
         monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
         assert _resolve_safe_cwd("/no/such/deep/dir") == sep
+
+    def test_accepts_git_bash_msys_path_on_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+
+        def fake_isdir(path: str) -> bool:
+            return path == r"C:\Users\alice\repo"
+
+        monkeypatch.setattr(os.path, "isdir", fake_isdir)
+        assert _resolve_safe_cwd("/c/Users/alice/repo") == "/c/Users/alice/repo"
+
+    def test_walks_git_bash_path_up_to_existing_windows_parent(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+
+        def fake_isdir(path: str) -> bool:
+            return path == r"C:\Users\alice"
+
+        monkeypatch.setattr(os.path, "isdir", fake_isdir)
+        assert _resolve_safe_cwd("/c/Users/alice/missing/project") == "/c/Users/alice"
+
+
+class TestNativeWindowsCwd:
+    def test_converts_git_bash_path_on_windows(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _native_windows_cwd("/c/Users/alice/repo") == r"C:\Users\alice\repo"
+
+    def test_leaves_non_windows_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+        assert _native_windows_cwd("/c/Users/alice/repo") == "/c/Users/alice/repo"
 
 
 def _fake_interrupt():

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -18,6 +18,13 @@ _IS_WINDOWS = platform.system() == "Windows"
 logger = logging.getLogger(__name__)
 
 
+def _native_windows_cwd(path: str) -> str:
+    """Convert Git Bash / MSYS ``/c/...`` cwd paths to native Windows form."""
+    if _IS_WINDOWS and path and re.match(r"^/[a-zA-Z]/", path):
+        return path[1].upper() + ":" + path[2:].replace("/", "\\")
+    return path
+
+
 def _resolve_safe_cwd(cwd: str) -> str:
     """Return ``cwd`` if it exists as a directory, else the nearest existing
     ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
@@ -30,11 +37,16 @@ def _resolve_safe_cwd(cwd: str) -> str:
     raises ``FileNotFoundError`` before bash starts, wedging every subsequent
     terminal call until the gateway restarts.
     """
-    if cwd and os.path.isdir(cwd):
+    def _is_existing_dir(candidate: str) -> bool:
+        if not candidate:
+            return False
+        return os.path.isdir(candidate) or os.path.isdir(_native_windows_cwd(candidate))
+
+    if _is_existing_dir(cwd):
         return cwd
     parent = os.path.dirname(cwd) if cwd else ""
     while parent:
-        if os.path.isdir(parent):
+        if _is_existing_dir(parent):
             return parent
         next_parent = os.path.dirname(parent)
         if next_parent == parent:
@@ -456,9 +468,7 @@ class LocalEnvironment(BaseEnvironment):
 
         # On Windows, self.cwd may be a Git Bash-style path (/c/Users/...)
         # from pwd output. subprocess.Popen needs a native Windows path.
-        _popen_cwd = self.cwd
-        if _IS_WINDOWS and _popen_cwd and re.match(r'^/[a-zA-Z]/', _popen_cwd):
-            _popen_cwd = _popen_cwd[1].upper() + ':' + _popen_cwd[2:].replace('/', '\\')
+        _popen_cwd = _native_windows_cwd(self.cwd)
 
         proc = subprocess.Popen(
             args,


### PR DESCRIPTION
## Summary
- accept Git Bash / MSYS cwd paths as valid existing directories on native Windows
- reuse the same cwd normalization when handing off to subprocess.Popen
- add focused regression coverage for MSYS path preservation and parent fallback

## Verification
- uv run --frozen pytest -q -o addopts= tests/tools/test_local_env_cwd_recovery.py\n- uv run --frozen ruff check tools/environments/local.py tests/tools/test_local_env_cwd_recovery.py\n- env -i PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" LANG="C.UTF-8" HOME="$(mktemp -d)" XDG_CONFIG_HOME="$(mktemp -d)/.config" XDG_CACHE_HOME="$(mktemp -d)/.cache" XDG_DATA_HOME="$(mktemp -d)/.local/share" uv run --frozen --extra all python -m pytest tests/ --collect-only -q\n\nCloses #23846