### PR TITLE
fix(web): add Cache-Control: no-store to plugin static file serving

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4160,7 +4160,11 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         ".woff": "font/woff",
     }
     media_type = content_types.get(suffix, "application/octet-stream")
-    return FileResponse(target, media_type=media_type)
+    return FileResponse(
+        target,
+        media_type=media_type,
+        headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+    )
 
 
 def _mount_plugin_api_routes():


### PR DESCRIPTION
## Problem

Dashboard plugin pages (e.g. Kanban) may show rendering errors like `COLUMN_LABEL is not defined` even after the upstream fix has been merged. This happens because the browser caches the old JS file from the plugin static file endpoint.

## Fix

Add `Cache-Control: no-store, no-cache, must-revalidate` header to the `serve_plugin_asset` endpoint so browsers always fetch the latest plugin files.

## Changes

- `hermes_cli/web_server.py`: Added `Cache-Control: no-store` to plugin static file responses