### PR TITLE
Fix/local env msys cwd windows

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from tools.environments.local import (
     LocalEnvironment,
+    _msys_to_windows_path,
     _resolve_safe_cwd,
 )
 
@@ -185,3 +186,62 @@ class TestUpdateCwdRejectsMissingPaths:
         env._update_cwd({"output": "", "returncode": 0})
 
         assert env.cwd == str(new_dir)
+
+
+# ---------------------------------------------------------------------------
+# MSYS / Git Bash path normalizer (#23846) — pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMsysToWindowsPath:
+    """Unit tests for the MSYS2 / Git Bash path normalizer.
+
+    All tests force ``_IS_WINDOWS=True`` so they run on every CI host.  A
+    final section verifies the platform short-circuit (no-op off Windows).
+    """
+
+    def test_converts_lowercase_drive(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("/c/Users/user") == "C:\\Users\\user"
+
+    def test_converts_uppercase_drive(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("/D/Projects/hermes") == "D:\\Projects\\hermes"
+
+    def test_converts_drive_root(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("/c/") == "C:\\"
+
+    def test_converts_nested_path_with_spaces(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert (
+            _msys_to_windows_path("/c/Users/My Name/repo")
+            == "C:\\Users\\My Name\\repo"
+        )
+
+    def test_already_native_windows_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert (
+            _msys_to_windows_path("C:\\Users\\user") == "C:\\Users\\user"
+        )
+
+    def test_posix_path_without_drive_prefix_unchanged(self, monkeypatch):
+        """``/etc/foo`` and ``/usr/bin`` are NOT drive-letter MSYS paths."""
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("/etc/foo") == "/etc/foo"
+        assert _msys_to_windows_path("/usr/bin/python") == "/usr/bin/python"
+
+    def test_multi_letter_pseudo_drive_unchanged(self, monkeypatch):
+        """``/abc/...`` is not a Windows drive — must NOT be rewritten."""
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("/abc/d/file") == "/abc/d/file"
+
+    def test_empty_string_unchanged(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+        assert _msys_to_windows_path("") == ""
+
+    def test_non_windows_host_is_noop(self, monkeypatch):
+        """On Linux/macOS, ``/c/...`` is a legitimate POSIX path — preserve it."""
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+        assert _msys_to_windows_path("/c/Users/user") == "/c/Users/user"
+        assert _msys_to_windows_path("/d/anything") == "/d/anything"

--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -187,6 +187,42 @@ class TestUpdateCwdRejectsMissingPaths:
 
         assert env.cwd == str(new_dir)
 
+    def test_accepts_msys_form_marker_path_on_windows(
+        self, tmp_path, monkeypatch
+    ):
+        """Reproduces the second half of #23846: ``pwd -P`` on Git Bash
+        writes an MSYS-form path (``/c/Users/...``) to the cwd marker file.
+        Without normalization in :meth:`_update_cwd`, ``os.path.isdir``
+        rejects the MSYS form and the cwd silently stays at the previous
+        value — so every ``cd`` inside a Git Bash session is lost.
+        """
+        monkeypatch.setattr("tools.environments.local._IS_WINDOWS", True)
+
+        original = tmp_path / "starting"
+        original.mkdir()
+
+        msys_marker = "/c/Users/user/repo"
+        native_equivalent = "C:\\Users\\user\\repo"
+
+        monkeypatch.setattr(
+            os.path, "isdir", lambda p: p == native_equivalent
+        )
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(original), timeout=10)
+
+        with open(env._cwd_file, "w") as f:
+            f.write(msys_marker)
+
+        env._update_cwd({"output": "", "returncode": 0})
+
+        # cwd is updated AND stored in native form so the next Popen
+        # invocation does not need to re-normalize.
+        assert env.cwd == native_equivalent, (
+            f"Expected ``cd`` in bash to be tracked as {native_equivalent!r}; "
+            f"got {env.cwd!r} (#23846)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # MSYS / Git Bash path normalizer (#23846) — pure-function unit tests


### PR DESCRIPTION
## What does this PR do?

Fixes the spammy `LocalEnvironment cwd '/c/Users/user' is missing on disk; falling back to '/' so terminal commands keep working.` WARNING that fires on **every single terminal command** when Hermes runs under Git Bash / MSYS2 on Windows.

`os.getcwd()` inside a Git Bash-hosted Hermes returns MSYS-form paths like `/c/Users/user`. Python's `os.path.isdir` does not understand the MSYS form — it treats `/c/Users/user` as a missing path even when `C:\Users\user` exists on disk. `_resolve_safe_cwd` then walks the parent chain (`/c` → `/` → none), falls through to `tempfile.gettempdir()`, and `_run_bash` emits the warning. A chat session with 20 terminal calls leaves 20 copies of this line in the log.

The conversion logic already exists in the file (`_run_bash` does it inline before passing `cwd=` to `subprocess.Popen`), it just runs *after* the `_resolve_safe_cwd` check and only on the Popen argument — not on the value `os.path.isdir` sees.

The fix extracts that conversion into a shared `_msys_to_windows_path` helper and applies it everywhere the cwd crosses the boundary between bash output and `os.path.isdir` / `subprocess.Popen`:

1. **`_resolve_safe_cwd`** — normalizes its input first, so the existence check is asked against the *native* form.
2. **`_run_bash`** — normalizes `self.cwd` before the existence check (so the warning doesn't fire purely because of slash direction). The existing inline conversion at the Popen call site is replaced by a call to the shared helper, deduplicating the logic.
3. **`_update_cwd`** — normalizes the value read out of the cwd marker file before the existence check. Without this, `pwd -P` after any `cd` inside bash returns an MSYS path that `os.path.isdir` rejects, and the cwd silently stays at the previous value — so every `cd` was effectively lost.

The helper is a strict no-op on non-Windows hosts: `/c/foo` is a legitimate POSIX path on Linux/macOS and must not be rewritten. `_IS_WINDOWS` is evaluated at import time so the cost on the hot path is a single attribute lookup.

The legitimate "cwd was deleted" warning from #17558 is preserved — when the cwd is genuinely gone *after* MSYS normalization, the warning still fires, and now reports the native form so operators can paste a path their shell can navigate to.

## Related Issue

Fixes #23846

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

Five logically separated commits:

1. **`fix(tools/local-env): add MSYS-to-Windows path normalizer`** — adds `_msys_to_windows_path(path)` and the compiled `_MSYS_DRIVE_RE`. Pure-additive; no call sites changed.
2. **`fix(tools/local-env): normalize MSYS cwd before isdir check (#23846)`** — wires the helper into the two call sites that surface the warning:
   - `_resolve_safe_cwd` normalizes its input first.
   - `_run_bash` normalizes `self.cwd` before the existence check (so the warning doesn't fire purely because of slash direction), and the existing inline conversion at the `subprocess.Popen(cwd=...)` site is replaced by a call to the shared helper.
3. **`test(tools/local-env): cover the MSYS-to-Windows path helper (#23846)`** — nine unit tests for the helper: lowercase/uppercase drives, drive root (`/c/` → `C:\`), nested paths with spaces, already-native paths, POSIX paths without drive prefix, multi-letter pseudo-drives (`/abc/...` — preserved), empty string, and the non-Windows no-op.
4. **`test(tools/local-env): end-to-end regression for MSYS cwd handling (#23846)`** — six integration tests:
   - `_resolve_safe_cwd` on an MSYS path with an existing target returns native form (no temp-dir fallback).
   - `_resolve_safe_cwd` on non-Windows hosts preserves `/c/...` verbatim.
   - `_resolve_safe_cwd` walks up in *native* form — `os.path.isdir` is never called with MSYS slashes.
   - `_run_bash` against an MSYS cwd emits ZERO "missing on disk" warnings and hands `Popen` the native form.
   - **Ten repeated terminal calls** with an MSYS cwd emit ZERO warnings (the original reproducer).
   - The legitimate "cwd was deleted" warning from #17558 still fires when the cwd is genuinely missing, with the message rendering the native form.
5. **`fix(tools/local-env): also normalize MSYS cwd in _update_cwd (#23846)`** — covers the second half of the bug: after any `cd` inside the bash session, `pwd -P` writes an MSYS-form path into the cwd marker file. `_update_cwd` then rejected it via the same `os.path.isdir` mismatch, so every `cd` was silently lost. Normalize the marker value through the same helper so the cwd is correctly tracked in native form. Includes `test_accepts_msys_form_marker_path_on_windows` which fails on the prior commit and passes here.

Files touched:
- `tools/environments/local.py` (+64, −5)
- `tests/tools/test_local_env_cwd_recovery.py` (+324, −1)

## How to Test

1. Check out the branch and ensure `.venv` is set up:

   ```bash
   python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"
   ```

2. Run the new tests in isolation:

   ```bash
   scripts/run_tests.sh \
     tests/tools/test_local_env_cwd_recovery.py::TestMsysToWindowsPath \
     tests/tools/test_local_env_cwd_recovery.py::TestResolveSafeCwdMsys \
     tests/tools/test_local_env_cwd_recovery.py::TestRunBashMsysCwdNoSpurriousWarning \
     "tests/tools/test_local_env_cwd_recovery.py::TestUpdateCwdRejectsMissingPaths::test_accepts_msys_form_marker_path_on_windows" -v
   ```

   Expected: **16 passed**.

3. Run the full `LocalEnvironment` cwd-recovery suite to confirm no regression in the existing tests:

   ```bash
   scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py
   ```

   Expected: **25 passed** (9 pre-existing + 16 new).

4. Reproduce the bug on `main` to confirm the regression test would have caught it:

   ```bash
   git checkout upstream/main -- tools/environments/local.py
   scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py
   ```

   Expected: **collection ImportError** on `_msys_to_windows_path` — the helper doesn't exist on `main`, so the entire test module fails to import. That's the strict version of "tests would fail without the fix".

   Then restore:

   ```bash
   git checkout HEAD -- tools/environments/local.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools/local-env): …`, `test(tools/local-env): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — none open against `tools/environments/local.py` for this issue
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py` and all tests pass (25 passed)
- [x] I've added tests for my changes (16 new test cases across the helper, the resolver, the `_run_bash` integration, and `_update_cwd`)
- [x] I've tested on my platform: macOS 15.6 (Darwin 24.6.0), Python 3.12.7 — tests force `_IS_WINDOWS=True` via `monkeypatch` so the MSYS branch is exercised regardless of the runner platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (operator-visible behavior change is "one warning instead of N per terminal command on Git Bash hosts")
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is platform-gated by `_IS_WINDOWS`, so Linux/macOS behavior is unchanged (`/c/foo` remains a POSIX path)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py
============================== 25 passed in 1.01s ==============================
```

Bug reproduction proof — with the production diff reverted to `upstream/main`, the new tests collection-error because `_msys_to_windows_path` is undefined:

```
$ git checkout upstream/main -- tools/environments/local.py
$ scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py
ERROR tests/tools/test_local_env_cwd_recovery.py - ImportError while importing test module ...
=============================== 1 error in 0.51s ===============================
```
