### PR TITLE
fix(google_chat): _standalone_send silently ignores thread_id without messageReplyOption

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -3228,8 +3228,14 @@ async def _standalone_send(
         return {"error": "Google Chat standalone send: refreshed credentials have no token"}
 
     body: Dict[str, Any] = {"text": message}
+    params: Dict[str, str] = {}
     if thread_id:
         body["thread"] = {"name": thread_id}
+        # Without this query param the Chat REST API silently ignores
+        # thread.name and opens a new top-level thread every time.
+        # The live adapter (_create_message / _send_file) already sets
+        # this — the standalone path was the only missing call site.
+        params["messageReplyOption"] = "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
 
     url = f"https://chat.googleapis.com/v1/{chat_id}/messages"
     try:
@@ -3242,6 +3248,7 @@ async def _standalone_send(
             async with session.post(
                 url,
                 json=body,
+                params=params or None,
                 headers={
                     "Authorization": f"Bearer {token}",
                     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- `_standalone_send` (the out-of-process cron/notification path) built the request body with `thread.name` but did **not** include the `messageReplyOption` query parameter
- The Google Chat REST API documents that without this parameter the default behaviour is *"starts a new thread"* and `thread.name` is **silently ignored** — no error, just wrong behaviour
- Every cron or notification delivery that specified a `thread_id` (e.g. `deliver=google_chat` with a target thread) was creating a fresh top-level message instead of replying to the intended thread
- The live adapter already sets `REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` in both `_create_message` (line 2202) and `_send_file` (line 2826); `_standalone_send` was the only call site missing it

## Fix

Pass `params={"messageReplyOption": "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"}` to the `aiohttp` POST when `thread_id` is present. No-op when `thread_id` is absent (`params or None` → `None`, aiohttp adds no query string).

```python
# before
body: Dict[str, Any] = {"text": message}
if thread_id:
    body["thread"] = {"name": thread_id}

# after
body: Dict[str, Any] = {"text": message}
params: Dict[str, str] = {}
if thread_id:
    body["thread"] = {"name": thread_id}
    params["messageReplyOption"] = "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
```

## Test plan

- [ ] Cron job with `deliver=google_chat` and a `thread_id` → message lands in the specified thread instead of opening a new top-level thread
- [ ] Cron job with `deliver=google_chat` and no `thread_id` → behaviour unchanged, no query parameter added
- [ ] Cron job with invalid `thread_id` format → rejected by the existing regex validation at line 3153 before reaching this code path