### PR TITLE
feat(tts): support OpenAI-compatible TTS endpoints (OpenRouter et al.)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -977,6 +977,12 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+            # Optional: point at any OpenAI-compatible /audio/speech endpoint
+            # (OpenRouter, Vercel AI Gateway, …) by setting base_url+api_key.
+            # When unset, the SDK uses https://api.openai.com/v1 with the
+            # VOICE_TOOLS_OPENAI_KEY / OPENAI_API_KEY env var.
+            "base_url": "",
+            "api_key": "",
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
@@ -1464,7 +1470,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -461,9 +461,18 @@ def _print_setup_summary(config: dict, hermes_home):
     elif tts_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Text-to-Speech (ElevenLabs)", True, None))
     elif tts_provider == "openai" and (
-        get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
+        get_env_value("VOICE_TOOLS_OPENAI_KEY")
+        or get_env_value("OPENAI_API_KEY")
+        or cfg_get(config, "tts", "openai", "api_key", default="")
     ):
-        tool_status.append(("Text-to-Speech (OpenAI)", True, None))
+        # Detect a custom OpenAI-compatible endpoint (OpenRouter, Vercel AI
+        # Gateway, …) so the status line matches what was configured.
+        tts_base_url = cfg_get(config, "tts", "openai", "base_url", default="") or ""
+        if tts_base_url and "openai.com" not in tts_base_url:
+            label = f"Text-to-Speech (OpenAI-compatible — {base_url_hostname(tts_base_url)})"
+        else:
+            label = "Text-to-Speech (OpenAI)"
+        tool_status.append((label, True, None))
     elif tts_provider == "minimax" and get_env_value("MINIMAX_API_KEY"):
         tool_status.append(("Text-to-Speech (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):
@@ -1089,6 +1098,7 @@ def _setup_tts_provider(config: dict):
         "edge": "Edge TTS",
         "elevenlabs": "ElevenLabs",
         "openai": "OpenAI TTS",
+        "openai-compatible": "OpenAI-compatible (OpenRouter, Vercel AI Gateway, …)",
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
@@ -1113,6 +1123,7 @@ def _setup_tts_provider(config: dict):
             "Edge TTS (free, cloud-based, no setup needed)",
             "ElevenLabs (premium quality, needs API key)",
             "OpenAI TTS (good quality, needs API key)",
+            "OpenAI-compatible endpoint (OpenRouter, Vercel AI Gateway, custom — Gemini TTS et al.)",
             "xAI TTS (Grok voices, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
@@ -1121,7 +1132,20 @@ def _setup_tts_provider(config: dict):
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(
+        [
+            "edge",
+            "elevenlabs",
+            "openai",
+            "openai-compatible",
+            "xai",
+            "minimax",
+            "mistral",
+            "gemini",
+            "neutts",
+            "kittentts",
+        ]
+    )
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1246,6 +1270,83 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "openai-compatible":
+        # OpenAI-compatible endpoint (OpenRouter, Vercel AI Gateway, custom).
+        # Stores config in tts.openai.{base_url, model, voice, api_key} and
+        # sets provider=openai (the same OpenAI SDK code path drives them all).
+        endpoint_presets = {
+            "1": (
+                "OpenRouter",
+                "https://openrouter.ai/api/v1",
+                "google/gemini-3.1-flash-tts-preview",
+                "Kore",
+            ),
+            "2": (
+                "Vercel AI Gateway",
+                "https://ai-gateway.vercel.sh/v1",
+                "openai/tts-1",
+                "alloy",
+            ),
+            "3": ("Custom", "", "", ""),
+        }
+        print()
+        print_info("Choose an OpenAI-compatible TTS endpoint:")
+        for k, (name, url, _, _) in endpoint_presets.items():
+            print(f"  {k}. {name}" + (f"  ({url})" if url else ""))
+        choice = prompt("Endpoint [1]", default="1") or "1"
+        choice = choice.strip()
+        if choice not in endpoint_presets:
+            choice = "1"
+        preset_name, preset_url, preset_model, preset_voice = endpoint_presets[choice]
+
+        if preset_url:
+            base_url = preset_url
+            print_success(f"Base URL: {base_url}")
+        else:
+            base_url = prompt("Base URL (e.g. https://example.com/v1)").strip()
+            if not base_url:
+                print_warning("No base URL provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+        if selected != "edge":
+            model_prompt = (
+                f"Model [{preset_model}]" if preset_model else "Model (e.g. google/gemini-3.1-flash-tts-preview)"
+            )
+            model = prompt(model_prompt, default=preset_model).strip() or preset_model
+            if not model:
+                print_warning("No model provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+        if selected != "edge":
+            voice_prompt = f"Voice [{preset_voice}]" if preset_voice else "Voice (e.g. Kore, alloy)"
+            voice = prompt(voice_prompt, default=preset_voice).strip() or preset_voice or "alloy"
+
+        if selected != "edge":
+            print()
+            print_info(
+                f"Provide the API key for {preset_name}. It will be stored in "
+                "config.yaml under tts.openai.api_key (so it does not collide "
+                "with your main LLM credentials)."
+            )
+            api_key = prompt(f"{preset_name} API key", password=True)
+            if not api_key:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+        if selected != "edge":
+            tts_section = config.setdefault("tts", {})
+            openai_section = tts_section.setdefault("openai", {})
+            openai_section["base_url"] = base_url
+            openai_section["model"] = model
+            openai_section["voice"] = voice
+            openai_section["api_key"] = api_key
+            # Persist as provider=openai — the same code path drives any
+            # OpenAI-compatible endpoint via the SDK's base_url override.
+            selected = "openai"
+            print_success(
+                f"OpenAI-compatible TTS configured (endpoint={preset_name}, model={model}, voice={voice})"
+            )
 
     elif selected == "kittentts":
         # Check if already installed

--- a/tests/hermes_cli/test_setup_tts_openai_compatible.py
+++ b/tests/hermes_cli/test_setup_tts_openai_compatible.py
@@ -1,0 +1,259 @@
+"""Tests for the OpenAI-compatible TTS branch of `hermes setup tts`.
+
+Covers `_setup_tts_provider()` when the user picks the
+"OpenAI-compatible (OpenRouter, Vercel AI Gateway, …)" option, which writes
+``tts.openai.{base_url, model, voice, api_key}`` and persists ``provider=openai``
+(the same OpenAI SDK code path drives any compatible /audio/speech endpoint).
+
+Approach: mock ``prompt_choice``, ``prompt``, and ``save_config`` so the
+wizard branch runs deterministically end-to-end without any I/O.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.setup import _setup_tts_provider
+
+
+# Index of "OpenAI-compatible" in the provider list when the Nous-managed
+# entry is NOT prepended (i.e. user has no paid subscription).
+# Order: edge(0), elevenlabs(1), openai(2), openai-compatible(3), xai(4), …
+OPENAI_COMPAT_IDX = 3
+
+
+@pytest.fixture
+def no_nous_subscription(monkeypatch):
+    """Disable the Nous-managed TTS option so the index above stays stable."""
+    from types import SimpleNamespace
+
+    # Minimal duck-typed object: only the .nous_auth_present attribute is read
+    # by `_setup_tts_provider` (gating the optional menu prefix).
+    fake_features = SimpleNamespace(nous_auth_present=False)
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_nous_subscription_features",
+        lambda config: fake_features,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.managed_nous_tools_enabled",
+        lambda: False,
+    )
+    return fake_features
+
+
+def _patch_io(prompt_choice_idx: int, prompt_responses: list[str]):
+    """Build patchers for prompt_choice + prompt + save_config + print_*.
+
+    prompt_choice_idx: index returned by prompt_choice.
+    prompt_responses: list of strings returned in order by sequential prompt() calls.
+    """
+    prompt_iter = iter(prompt_responses)
+
+    def _fake_prompt(question, default=None, password=False):  # noqa: ARG001
+        try:
+            return next(prompt_iter)
+        except StopIteration:
+            return default or ""
+
+    return [
+        patch("hermes_cli.setup.prompt_choice", return_value=prompt_choice_idx),
+        patch("hermes_cli.setup.prompt", side_effect=_fake_prompt),
+        patch("hermes_cli.setup.save_config"),
+    ]
+
+
+class TestOpenAICompatibleTTS:
+    """Verify the new wizard branch for OpenRouter / Vercel AI Gateway / custom."""
+
+    def test_openrouter_preset_writes_openai_section(self, no_nous_subscription):
+        """OpenRouter preset (choice 1) pre-fills base_url + Gemini TTS model."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        # User flow:
+        #   prompt_choice → "OpenAI-compatible" (index 3)
+        #   prompt 1: endpoint preset → "1" (OpenRouter)
+        #   prompt 2: model → "" (accept preset default)
+        #   prompt 3: voice → "" (accept preset default)
+        #   prompt 4: API key → "sk-or-v1-test"
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            ["1", "", "", "sk-or-v1-test"],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        # Provider is normalized to "openai" (same code path drives all compatible endpoints).
+        assert config["tts"]["provider"] == "openai"
+        oai = config["tts"]["openai"]
+        assert oai["base_url"] == "https://openrouter.ai/api/v1"
+        assert oai["model"] == "google/gemini-3.1-flash-tts-preview"
+        assert oai["voice"] == "Kore"
+        assert oai["api_key"] == "sk-or-v1-test"
+
+    def test_openrouter_preset_with_overridden_model_and_voice(self, no_nous_subscription):
+        """User can override the preset model and voice."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        # endpoint=1 (OpenRouter), model=custom, voice=custom, key=custom
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            [
+                "1",
+                "google/gemini-3-pro-tts",
+                "Charon",
+                "sk-or-v1-override",
+            ],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        oai = config["tts"]["openai"]
+        assert oai["base_url"] == "https://openrouter.ai/api/v1"
+        assert oai["model"] == "google/gemini-3-pro-tts"
+        assert oai["voice"] == "Charon"
+        assert oai["api_key"] == "sk-or-v1-override"
+
+    def test_vercel_ai_gateway_preset(self, no_nous_subscription):
+        """Vercel AI Gateway preset (choice 2)."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            ["2", "", "", "vai-gateway-key"],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        oai = config["tts"]["openai"]
+        assert oai["base_url"] == "https://ai-gateway.vercel.sh/v1"
+        assert oai["model"] == "openai/tts-1"
+        assert oai["voice"] == "alloy"
+        assert oai["api_key"] == "vai-gateway-key"
+
+    def test_custom_endpoint_requires_all_fields(self, no_nous_subscription):
+        """Custom endpoint (choice 3): user must supply base_url, model, voice, key."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            [
+                "3",
+                "https://my-proxy.example.com/v1",
+                "custom/tts-model",
+                "MyVoice",
+                "custom-key-123",
+            ],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        oai = config["tts"]["openai"]
+        assert oai["base_url"] == "https://my-proxy.example.com/v1"
+        assert oai["model"] == "custom/tts-model"
+        assert oai["voice"] == "MyVoice"
+        assert oai["api_key"] == "custom-key-123"
+
+    def test_missing_api_key_falls_back_to_edge(self, no_nous_subscription):
+        """If the user does not supply an API key, fall back to Edge TTS."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        # endpoint=1 (OpenRouter), defaults for model/voice, EMPTY api_key
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            ["1", "", "", ""],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        # No openai.api_key written, provider falls back to edge.
+        assert config["tts"]["provider"] == "edge"
+
+    def test_custom_endpoint_missing_base_url_falls_back(self, no_nous_subscription):
+        """Custom endpoint with no base_url provided → fallback to Edge."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        # endpoint=3 (Custom), EMPTY base_url
+        patchers = _patch_io(OPENAI_COMPAT_IDX, ["3", ""])
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        assert config["tts"]["provider"] == "edge"
+
+    def test_invalid_endpoint_choice_defaults_to_openrouter(self, no_nous_subscription):
+        """Out-of-range choice silently maps to "1" (OpenRouter preset)."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            ["99", "", "", "key"],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        oai = config["tts"]["openai"]
+        assert oai["base_url"] == "https://openrouter.ai/api/v1"
+        assert oai["model"] == "google/gemini-3.1-flash-tts-preview"
+
+    def test_does_not_pollute_global_env_vars(self, no_nous_subscription, monkeypatch):
+        """The branch must not write to OPENAI_API_KEY / VOICE_TOOLS_OPENAI_KEY."""
+        config: dict = {"tts": {"provider": "edge"}}
+
+        save_env_calls: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            "hermes_cli.setup.save_env_value",
+            lambda k, v: save_env_calls.append((k, v)),
+        )
+
+        patchers = _patch_io(
+            OPENAI_COMPAT_IDX,
+            ["1", "", "", "sk-or-v1-key"],
+        )
+        for p in patchers:
+            p.start()
+        try:
+            _setup_tts_provider(config)
+        finally:
+            for p in patchers:
+                p.stop()
+
+        # Critical: the openai-compatible branch never touches env vars —
+        # the key is always stored in config.yaml under tts.openai.api_key.
+        assert save_env_calls == []
+        assert config["tts"]["openai"]["api_key"] == "sk-or-v1-key"

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -308,7 +308,7 @@ class TestResolveModalBackendState:
 # resolve_openai_audio_api_key
 # ---------------------------------------------------------------------------
 class TestResolveOpenaiAudioApiKey:
-    """Priority: VOICE_TOOLS_OPENAI_KEY > OPENAI_API_KEY."""
+    """Priority: VOICE_TOOLS_OPENAI_KEY > OPENAI_API_KEY > tts.openai.api_key."""
 
     def test_voice_key_preferred(self, monkeypatch):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "voice-key")
@@ -328,9 +328,92 @@ class TestResolveOpenaiAudioApiKey:
     def test_no_keys_returns_empty(self, monkeypatch):
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Also clear config-based fallback
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {},
+        )
         assert resolve_openai_audio_api_key() == ""
 
     def test_strips_whitespace(self, monkeypatch):
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "  voice-key  ")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         assert resolve_openai_audio_api_key() == "voice-key"
+
+    # --- config.yaml fallback (tts.openai.api_key) ---
+
+    def test_falls_back_to_config_api_key(self, monkeypatch):
+        """When no env var is set, use tts.openai.api_key from config.yaml."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tts": {"openai": {"api_key": "sk-or-v1-config"}}},
+        )
+        assert resolve_openai_audio_api_key() == "sk-or-v1-config"
+
+    def test_env_var_wins_over_config_api_key(self, monkeypatch):
+        """Env vars take precedence over config-based fallback."""
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "env-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tts": {"openai": {"api_key": "config-key"}}},
+        )
+        assert resolve_openai_audio_api_key() == "env-key"
+
+    def test_openai_key_wins_over_config_api_key(self, monkeypatch):
+        """OPENAI_API_KEY env var also beats the config fallback."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "general-key")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tts": {"openai": {"api_key": "config-key"}}},
+        )
+        assert resolve_openai_audio_api_key() == "general-key"
+
+    def test_empty_config_api_key_returns_empty(self, monkeypatch):
+        """Empty/whitespace api_key in config is treated as unset."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tts": {"openai": {"api_key": "   "}}},
+        )
+        assert resolve_openai_audio_api_key() == ""
+
+    def test_strips_config_api_key_whitespace(self, monkeypatch):
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"tts": {"openai": {"api_key": "  config-key  "}}},
+        )
+        assert resolve_openai_audio_api_key() == "config-key"
+
+    def test_missing_tts_section_safe(self, monkeypatch):
+        """Missing or non-dict tts/openai sections must not raise."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"unrelated": "data"},
+        )
+        assert resolve_openai_audio_api_key() == ""
+
+    def test_load_config_exception_returns_empty(self, monkeypatch):
+        """When load_config() raises, resolver returns "" — never propagates."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        def _boom():
+            raise RuntimeError("simulated config read failure")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+        assert resolve_openai_audio_api_key() == ""
+
+    def test_load_config_returns_none_safe(self, monkeypatch):
+        """load_config() returning None must not crash the resolver."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: None)
+        assert resolve_openai_audio_api_key() == ""

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -101,11 +101,37 @@ def resolve_modal_backend_state(
 
 
 def resolve_openai_audio_api_key() -> str:
-    """Prefer the voice-tools key, but fall back to the normal OpenAI key."""
-    return (
+    """Resolve the API key for OpenAI-compatible audio endpoints.
+
+    Priority order:
+      1. ``VOICE_TOOLS_OPENAI_KEY`` env var (dedicated key, recommended)
+      2. ``OPENAI_API_KEY`` env var (general OpenAI key)
+      3. ``tts.openai.api_key`` from config.yaml (works with any
+         OpenAI-compatible endpoint like OpenRouter or Vercel AI Gateway)
+
+    The config-based fallback lets users point ``tts.openai.base_url`` at a
+    third-party endpoint (e.g. ``https://openrouter.ai/api/v1``) and supply a
+    matching key in config.yaml, without polluting the global env namespace
+    with a non-OpenAI key.
+    """
+    env_key = (
         os.getenv("VOICE_TOOLS_OPENAI_KEY", "")
         or os.getenv("OPENAI_API_KEY", "")
     ).strip()
+    if env_key:
+        return env_key
+
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        tts_section = cfg.get("tts") or {}
+        openai_section = tts_section.get("openai") or {}
+        config_key = (openai_section.get("api_key") or "").strip()
+        if config_key:
+            return config_key
+    except Exception:
+        pass
+    return ""
 
 
 def prefers_gateway(config_section: str) -> bool:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1871,7 +1871,12 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
-        message = "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set"
+        message = (
+            "No OpenAI-compatible TTS credentials found. Set "
+            "VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY in the environment, "
+            "or configure tts.openai.api_key (with tts.openai.base_url for "
+            "third-party endpoints like OpenRouter)"
+        )
         if managed_nous_tools_enabled():
             message += ", and the managed OpenAI audio gateway is unavailable"
         raise ValueError(message)


### PR DESCRIPTION
# feat(tts): support OpenAI-compatible TTS endpoints (OpenRouter et al.)

## Summary

Lets users route TTS through any `/audio/speech` endpoint that speaks the
OpenAI SDK protocol — OpenRouter, Vercel AI Gateway, custom proxies, etc.

The OpenAI TTS code path *already* honors a `tts.openai.base_url` override.
This PR hooks up the missing pieces so it's actually configurable end-to-end:

- the resolver can pick up an API key from `tts.openai.api_key` in
  `config.yaml` (no env var needed);
- the setup wizard surfaces the option as a first-class menu entry with
  presets for OpenRouter and Vercel AI Gateway, plus a "Custom" mode.

## Why

OpenRouter exposes `/audio/speech` with the same shape as OpenAI, *including*
Google's Gemini TTS models (e.g. `google/gemini-3.1-flash-tts-preview`) that
are otherwise only reachable via Google's native, non-OpenAI-shaped
`generateContent` API.

Today, `hermes setup tts` → "Gemini TTS" hardcodes `GEMINI_API_KEY` + Google's
native endpoint. OpenRouter users who want to reuse a single key for both
chat and TTS — without going to Google AI Studio for a second key just for
voice — currently have no path through the wizard. This PR fixes that
without rewriting the TTS provider abstraction.

## What's new — user-facing

```
$ hermes setup tts
…
1. Edge TTS (free, cloud-based, no setup needed)
2. ElevenLabs (premium quality, needs API key)
3. OpenAI TTS (good quality, needs API key)
4. OpenAI-compatible endpoint (OpenRouter, Vercel AI Gateway, custom — Gemini TTS et al.)   ← NEW
5. xAI TTS (Grok voices, needs API key)
…

Choose an OpenAI-compatible TTS endpoint:
  1. OpenRouter         (https://openrouter.ai/api/v1)
  2. Vercel AI Gateway  (https://ai-gateway.vercel.sh/v1)
  3. Custom

Endpoint [1]: 1
Model [google/gemini-3.1-flash-tts-preview]:
Voice [Kore]:
OpenRouter API key: ********
✓ OpenAI-compatible TTS configured (endpoint=OpenRouter, model=google/gemini-3.1-flash-tts-preview, voice=Kore)
```

The wizard writes:
```yaml
tts:
  provider: openai      # same SDK code path drives every compatible endpoint
  openai:
    base_url: https://openrouter.ai/api/v1
    model: google/gemini-3.1-flash-tts-preview
    voice: Kore
    api_key: sk-or-v1-…
```

## Changes

- `tools/tool_backend_helpers.py::resolve_openai_audio_api_key` —
  Falls back to `tts.openai.api_key` from `config.yaml` when neither
  `VOICE_TOOLS_OPENAI_KEY` nor `OPENAI_API_KEY` is set.
  Lets users keep their (non-OpenAI) key in config rather than polluting
  the global env namespace. Defensive: any `load_config()` exception is
  swallowed and treated as "no key in config".

- `tools/tts_tool.py` —
  Improves the "no credentials" `ValueError` to mention the new config-based
  path so the error message points users at the right knob.

- `hermes_cli/setup.py` —
  New `"openai-compatible"` provider option in the TTS menu. Ships presets
  for OpenRouter + Vercel AI Gateway, plus a "Custom" mode that asks for
  base_url / model / voice. Stores everything under
  `tts.openai.{base_url, model, voice, api_key}` and persists
  `provider=openai` (same OpenAI SDK code path drives every compatible
  endpoint via its built-in `base_url` override). Status panel learns to
  show the endpoint hostname when a non-`openai.com` base_url is configured.

- `hermes_cli/config.py` —
  Declares `tts.openai.{base_url, api_key}` (empty defaults) so
  `hermes config migrate` preserves them. Bumps `_config_version` 23 → 24.

## Tests

- **`tests/tools/test_tool_backend_helpers.py`** — 9 new cases on
  `resolve_openai_audio_api_key`:
  - config fallback when no env vars set
  - precedence (env > config) for both env keys
  - whitespace stripping in config values
  - empty / missing `tts` or `openai` sections handled safely
  - exception in `load_config()` returns `""` instead of propagating
  - `load_config()` returning `None` doesn't crash

- **`tests/hermes_cli/test_setup_tts_openai_compatible.py`** — 8 new cases
  on the wizard branch:
  - OpenRouter preset writes the correct base_url + Gemini TTS model
  - Override model/voice on top of a preset
  - Vercel AI Gateway preset
  - Custom endpoint requires base_url + model + voice + key
  - Missing API key → falls back to Edge TTS
  - Missing base_url on Custom → falls back to Edge TTS
  - Out-of-range endpoint choice clamps to OpenRouter (preset 1)
  - **Invariant**: the new branch never writes to env vars — the key
    always lives in `config.yaml`

All existing TTS-adjacent tests still pass:
`tests/tools/test_tts_*.py`, `test_tool_backend_helpers.py`,
`test_voice_*.py`, `test_managed_media_gateways.py`,
`test_nous_subscription.py` — 266 cases green.

## Backward compatibility

- Default config keeps `provider: edge`. Users on `provider: openai`
  without a custom `base_url` get the same behavior they had before
  (resolver still prefers env vars).
- Migration from `_config_version: 23` adds two empty fields and is a
  no-op behaviorally.
- The new wizard option is additive — every existing TTS provider entry
  is unchanged.

## Out of scope

- Other TTS-specific OpenAI-compatible providers (Groq, Together, etc.)
  that don't currently ship a TTS-capable model. They'll work the moment
  they expose `/audio/speech`; "Custom" already handles them.
- Per-platform credential pools for TTS — config.yaml is the single
  source of truth here.
