### PR TITLE
fix(cli): avoid blocking reload-mcp confirmation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
 
 import logging
 import os
+import shlex
 import shutil
 import sys
 import json
@@ -8630,6 +8631,27 @@ class HermesCLI:
         without this prompt), Cancel.  Gated by
         ``approvals.mcp_reload_confirm`` — default on.
         """
+        args = []
+        if cmd_original:
+            try:
+                args = shlex.split(cmd_original)[1:]
+            except ValueError:
+                args = cmd_original.split()[1:]
+        explicit_choice = args[0].strip().lower() if args else ""
+        if explicit_choice in {"now", "once"}:
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._reload_mcp()
+            return
+        if explicit_choice == "always":
+            if save_config_value("approvals.mcp_reload_confirm", False):
+                print("🔒 Future /reload-mcp calls will run without confirmation.")
+                print("   Re-enable via `approvals.mcp_reload_confirm: true` in config.yaml.")
+            else:
+                print("⚠️  Couldn't persist opt-out — reloading once.")
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._reload_mcp()
+            return
+
         # Gate check — respects prior "Always Approve" clicks.
         try:
             cfg = load_cli_config()
@@ -8643,6 +8665,14 @@ class HermesCLI:
         if not confirm_required:
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_mcp()
+            return
+
+        interactive_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
+        in_main_thread = threading.current_thread() is threading.main_thread()
+        if not interactive_tty or not in_main_thread:
+            print("🟡 /reload-mcp needs confirmation, but this context is non-interactive.")
+            print("   Re-run `/reload-mcp now` to proceed once, or `/reload-mcp always`")
+            print("   to proceed and silence this prompt permanently.")
             return
 
         # Render warning + prompt.  Use a single-line prompt so the user

--- a/tests/cli/test_reload_mcp_confirmation.py
+++ b/tests/cli/test_reload_mcp_confirmation.py
@@ -1,0 +1,88 @@
+"""Tests for ``HermesCLI._confirm_and_reload_mcp`` non-interactive safety."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _bound(fn, instance):
+    return fn.__get__(instance, type(instance))
+
+
+def _make_self(prompt_response="1"):
+    calls = {"reload": 0, "prompt": 0, "busy": 0}
+
+    def _reload():
+        calls["reload"] += 1
+
+    def _prompt(_text):
+        calls["prompt"] += 1
+        return prompt_response
+
+    def _busy(_status):
+        calls["busy"] += 1
+        return nullcontext()
+
+    self_ = SimpleNamespace(
+        _app=None,
+        _reload_mcp=_reload,
+        _prompt_text_input=_prompt,
+        _busy_command=_busy,
+        _slow_command_status=lambda cmd: f"status:{cmd}",
+    )
+    return self_, calls
+
+
+def test_reload_mcp_now_bypasses_confirmation():
+    from cli import HermesCLI
+
+    self_, calls = _make_self(prompt_response="3")
+
+    with patch(
+        "cli.load_cli_config",
+        return_value={"approvals": {"mcp_reload_confirm": True}},
+    ):
+        _bound(HermesCLI._confirm_and_reload_mcp, self_)("/reload-mcp now")
+
+    assert calls == {"reload": 1, "prompt": 0, "busy": 1}
+
+
+def test_reload_mcp_always_persists_opt_out_and_reloads():
+    from cli import HermesCLI
+
+    self_, calls = _make_self(prompt_response="3")
+    saves = []
+
+    def _fake_save(key, value):
+        saves.append((key, value))
+        return True
+
+    with patch(
+        "cli.load_cli_config",
+        return_value={"approvals": {"mcp_reload_confirm": True}},
+    ), patch("cli.save_config_value", side_effect=_fake_save):
+        _bound(HermesCLI._confirm_and_reload_mcp, self_)("/reload-mcp always")
+
+    assert ("approvals.mcp_reload_confirm", False) in saves
+    assert calls == {"reload": 1, "prompt": 0, "busy": 1}
+
+
+def test_reload_mcp_noninteractive_context_warns_instead_of_blocking(capsys):
+    from cli import HermesCLI
+
+    self_, calls = _make_self(prompt_response="1")
+
+    fake_stdin = SimpleNamespace(isatty=lambda: False)
+
+    with patch(
+        "cli.load_cli_config",
+        return_value={"approvals": {"mcp_reload_confirm": True}},
+    ), patch("sys.stdin", fake_stdin):
+        _bound(HermesCLI._confirm_and_reload_mcp, self_)("/reload-mcp")
+
+    output = capsys.readouterr().out
+    assert "non-interactive" in output
+    assert "/reload-mcp now" in output
+    assert calls == {"reload": 0, "prompt": 0, "busy": 0}


### PR DESCRIPTION
## Summary
- support `/reload-mcp now` and `/reload-mcp always` in classic CLI to match the TUI flow
- refuse to open a blocking confirmation prompt from non-main-thread or non-TTY contexts
- add focused regressions for explicit overrides and non-interactive safety

## Testing
- uv run --frozen pytest -q -o addopts='' tests/cli/test_reload_mcp_confirmation.py tests/cli/test_prompt_text_input_thread_safety.py
- uv run --frozen pytest -q -o addopts='' tests/cli/test_cli_loading_indicator.py
- uv run --frozen ruff check cli.py tests/cli/test_reload_mcp_confirmation.py
