### PR TITLE
feat: git context injection, linter upgrade, patch dry-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+.venv311/

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1468,7 +1468,7 @@ def _load_agents_md(cwd_path: Path) -> str:
                 except Exception as e:
                     logger.debug("Could not read %s: %s", candidate, e)
         # Stop walking at the git root (or filesystem root)
-        if stop_at and directory == stop_at:
+        if directory.parent == directory or (stop_at and directory == stop_at):
             break
     return ""
 
@@ -1496,7 +1496,7 @@ def _load_claude_md(cwd_path: Path) -> str:
                 except Exception as e:
                     logger.debug("Could not read %s: %s", candidate, e)
         # Stop walking at the git root (or filesystem root)
-        if stop_at and directory == stop_at:
+        if directory.parent == directory or (stop_at and directory == stop_at):
             break
     return ""
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import subprocess
 import threading
 from collections import OrderedDict
 from pathlib import Path
@@ -84,6 +85,98 @@ def _find_git_root(start: Path) -> Optional[Path]:
         if (parent / ".git").exists():
             return parent
     return None
+
+
+def _build_git_context(cwd: Path) -> str:
+    """Build a compact git status summary for injection into the system prompt.
+
+    Uses *cwd* to find the git root, then gathers:
+      - Current branch
+      - Working tree status (ahead/behind upstream, dirty/clean)
+      - Staged, unstaged, and untracked files (capped at 40 entries)
+      - Last 5 commit messages
+
+    Returns empty string when not in a git repository or on error.
+    """
+    try:
+        git_root = _find_git_root(cwd)
+        if not git_root:
+            return ""
+    except Exception:
+        return ""
+
+    def _git(args: list, timeout: float = 2.0) -> str:
+        """Run git with a timeout. Return stripped output or empty string."""
+        try:
+            result = subprocess.run(
+                ["git"] + args,
+                capture_output=True, text=True, timeout=timeout,
+                cwd=str(git_root),
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return ""
+
+    branch = _git(["branch", "--show-current"])
+    if not branch:
+        return ""  # detached HEAD or no commits yet — skip
+
+    lines = [f"Git repo: {git_root.name}", f"Branch: {branch}"]
+
+    # Upstream tracking
+    upstream = _git(["rev-parse", "--abbrev-ref", "@{u}"])
+    if upstream:
+        behind = _git(["rev-list", "--count", f"HEAD..{upstream}"])
+        ahead = _git(["rev-list", "--count", f"{upstream}..HEAD"])
+        if behind and behind != "0":
+            lines.append(f"Behind {upstream} by {behind} commit(s)")
+        if ahead and ahead != "0":
+            lines.append(f"Ahead of {upstream} by {ahead} commit(s)")
+
+    # Working tree status
+    dirty = _git(["status", "--porcelain"])
+    staged = []
+    unstaged = []
+    untracked = []
+    for line_raw in dirty.split("\n"):
+        if not line_raw.strip():
+            continue
+        code = line_raw[:2]
+        file_path = line_raw[3:]
+        if code[0] in "MRC" or code == "D ":
+            staged.append((code, file_path))
+        elif code[1] in "MD":
+            unstaged.append((code, file_path))
+        elif code == "??":
+            untracked.append(file_path)
+
+    if not staged and not unstaged and not untracked:
+        lines.append("Working tree: clean")
+    else:
+        total = len(staged) + len(unstaged) + len(untracked)
+        lines.append(f"Working tree: dirty ({total} file(s))")
+        if staged:
+            shown = staged[:15]
+            entries = " ".join(f"[{c}]{f}" for c, f in shown)
+            more = f" +{len(staged)-15} more" if len(staged) > 15 else ""
+            lines.append(f"  Staged: {entries}{more}")
+        if unstaged:
+            shown = unstaged[:15]
+            entries = " ".join(f"[{c}]{f}" for c, f in shown)
+            more = f" +{len(unstaged)-15} more" if len(unstaged) > 15 else ""
+            lines.append(f"  Modified: {entries}{more}")
+        if untracked:
+            shown = untracked[:10]
+            entries = " ".join(shown)
+            more = f" +{len(untracked)-10} more" if len(untracked) > 10 else ""
+            lines.append(f"  Untracked: {entries}{more}")
+
+    # Recent commits
+    log = _git(["log", "--oneline", "-5"])
+    if log:
+        lines.append(f"Recent commits:\n  {log}")
+
+    return "\n".join(lines)
 
 
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")
@@ -1353,34 +1446,58 @@ def _load_hermes_md(cwd_path: Path) -> str:
 
 
 def _load_agents_md(cwd_path: Path) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
-    for name in ["AGENTS.md", "agents.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+    """AGENTS.md — walk from cwd up to git root."""
+    stop_at = _find_git_root(cwd_path)
+    current = cwd_path.resolve()
+
+    for directory in [current, *current.parents]:
+        for name in ["AGENTS.md", "agents.md"]:
+            candidate = directory / name
+            if candidate.is_file():
+                try:
+                    content = candidate.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, name)
+                        rel = name
+                        try:
+                            rel = str(candidate.relative_to(cwd_path))
+                        except ValueError:
+                            pass
+                        result = f"## {rel}\n\n{content}"
+                        return _truncate_content(result, "AGENTS.md")
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", candidate, e)
+        # Stop walking at the git root (or filesystem root)
+        if stop_at and directory == stop_at:
+            break
     return ""
 
 
 def _load_claude_md(cwd_path: Path) -> str:
-    """CLAUDE.md / claude.md — cwd only."""
-    for name in ["CLAUDE.md", "claude.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "CLAUDE.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+    """CLAUDE.md / claude.md — walk from cwd up to git root."""
+    stop_at = _find_git_root(cwd_path)
+    current = cwd_path.resolve()
+
+    for directory in [current, *current.parents]:
+        for name in ["CLAUDE.md", "claude.md"]:
+            candidate = directory / name
+            if candidate.is_file():
+                try:
+                    content = candidate.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, name)
+                        rel = name
+                        try:
+                            rel = str(candidate.relative_to(cwd_path))
+                        except ValueError:
+                            pass
+                        result = f"## {rel}\n\n{content}"
+                        return _truncate_content(result, "CLAUDE.md")
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", candidate, e)
+        # Stop walking at the git root (or filesystem root)
+        if stop_at and directory == stop_at:
+            break
     return ""
 
 
@@ -1444,6 +1561,11 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     )
     if project_context:
         sections.append(project_context)
+
+    # Git context — inject current branch, dirty files, recent commits
+    git_context = _build_git_context(cwd_path)
+    if git_context:
+        sections.append(f"# Git Status\n\nThe repository is in a git working tree with the following state:\n\n{git_context}")
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -51,6 +51,197 @@ class TestGuidanceConstants:
 
 
 # =========================================================================
+# Git context injection
+# =========================================================================
+
+
+class TestGitContext:
+    """Tests for _build_git_context() — git status in system prompt."""
+
+    def test_no_git_repo_returns_empty(self, tmp_path):
+        """Outside a git repo, _build_git_context should return ''."""
+        from agent.prompt_builder import _build_git_context
+        result = _build_git_context(tmp_path)
+        assert result == ""
+
+    def test_git_context_includes_branch_and_commits(self, tmp_path):
+        """In a git repo, context should include branch name and recent commits."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
+        (repo / "file.txt").write_text("content")
+        subprocess.run(["git", "add", "file.txt"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "commit", "-m", "test commit"], cwd=str(repo), capture_output=True)
+
+        from agent.prompt_builder import _build_git_context
+        result = _build_git_context(repo)
+
+        assert "Branch: main" in result
+        assert "test commit" in result
+        assert "repo" in result  # repo name
+
+    def test_git_context_reports_dirty_tree(self, tmp_path):
+        """Dirty working tree should be reported with file counts."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
+        (repo / "file.txt").write_text("content")
+        subprocess.run(["git", "add", "file.txt"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=str(repo), capture_output=True)
+        # Make it dirty
+        (repo / "file.txt").write_text("modified content")
+        (repo / "new.txt").write_text("untracked")
+
+        from agent.prompt_builder import _build_git_context
+        result = _build_git_context(repo)
+
+        assert "dirty" in result.lower(), f"Expected dirty report, got: {result}"
+
+    def test_git_context_clean_tree(self, tmp_path):
+        """Clean tree without changes should report 'clean'."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
+        (repo / "file.txt").write_text("content")
+        subprocess.run(["git", "add", "file.txt"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=str(repo), capture_output=True)
+
+        from agent.prompt_builder import _build_git_context
+        result = _build_git_context(repo)
+
+        assert "clean" in result.lower(), f"Expected clean tree, got: {result}"
+
+    def test_detached_head_returns_empty(self, tmp_path):
+        """Detached HEAD should return empty context."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
+        (repo / "file.txt").write_text("content")
+        subprocess.run(["git", "add", "file.txt"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "commit", "-m", "initial"], cwd=str(repo), capture_output=True)
+        # Detach HEAD
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True
+        ).stdout.strip()
+        subprocess.run(["git", "checkout", sha], cwd=str(repo), capture_output=True)
+
+        from agent.prompt_builder import _build_git_context
+        result = _build_git_context(repo)
+        assert result == ""
+
+    def test_git_context_injected_into_build_context_files(self, tmp_path):
+        """build_context_files_prompt should include git context when in a repo."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
+        (repo / "file.txt").write_text("content")
+        subprocess.run(["git", "add", "file.txt"], cwd=str(repo), capture_output=True)
+        subprocess.run(["git", "commit", "-m", "test commit"], cwd=str(repo), capture_output=True)
+
+        result = build_context_files_prompt(cwd=str(repo), skip_soul=True)
+
+        assert "# Git Status" in result, f"Git Status section missing: {result[:500]}"
+        assert "Branch: main" in result
+        # Should appear before SOUL.md placement (but soul is skipped here so just check presence)
+        assert "test commit" in result
+
+
+class TestAgentsMdUpwardWalk:
+    """Tests for _load_agents_md and _load_claude_md walking up to git root."""
+
+    def test_agents_md_in_parent_dir(self, tmp_path):
+        """AGENTS.md in parent directory should be found."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        (repo / "AGENTS.md").write_text("# Test AGENTS.md\n\nProject rules here.")
+
+        nested = repo / "deep" / "nested"
+        nested.mkdir(parents=True)
+
+        from agent.prompt_builder import _load_agents_md
+        result = _load_agents_md(nested)
+        assert "Test AGENTS.md" in result, f"AGENTS.md not found: {result!r}"
+
+    def test_agents_md_stops_at_git_root(self, tmp_path):
+        """Walk should stop at git root, not go beyond."""
+        import subprocess
+        # Repo A
+        repo_a = tmp_path / "repo_a"
+        repo_a.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_a), capture_output=True)
+        (repo_a / "AGENTS.md").write_text("# Repo A rules")
+
+        # Repo B (subdirectory, but has its own .git)
+        repo_b = repo_a / "lib" / "repo_b"
+        repo_b.mkdir(parents=True)
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_b), capture_output=True)
+        (repo_b / "AGENTS.md").write_text("# Repo B rules")
+
+        from agent.prompt_builder import _load_agents_md
+        result = _load_agents_md(repo_b)
+        # Should find Repo B's AGENTS.md, not Repo A's
+        assert "Repo B rules" in result, f"Wrong AGENTS.md: {result!r}"
+        assert "Repo A rules" not in result
+
+    def test_agents_md_not_in_git_repo_stops_at_root(self, tmp_path):
+        """Without a git repo, walk should stop at filesystem root."""
+        from agent.prompt_builder import _load_agents_md
+        # tmp_path is not in a git repo, no AGENTS.md exists
+        result = _load_agents_md(tmp_path)
+        assert result == "", f"Should return empty, got: {result!r}"
+
+    def test_claude_md_walks_up_to_git_root(self, tmp_path):
+        """CLAUDE.md in parent directory should be found."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        (repo / "CLAUDE.md").write_text("# Claude rules")
+
+        nested = repo / "deep" / "nested"
+        nested.mkdir(parents=True)
+
+        from agent.prompt_builder import _load_claude_md
+        result = _load_claude_md(nested)
+        assert "Claude rules" in result
+
+    def test_relative_path_display(self, tmp_path):
+        """When AGENTS.md is in a parent, show relative path."""
+        import subprocess
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), capture_output=True)
+        (repo / "AGENTS.md").write_text("# Top-level rules")
+
+        nested = repo / "sub"
+        nested.mkdir()
+
+        from agent.prompt_builder import _load_agents_md
+        result = _load_agents_md(nested)
+        # Should show the heading containing the rules
+        assert "Top-level rules" in result
+        # Relative path should appear (../AGENTS.md or just AGENTS.md)
+        assert "AGENTS.md" in result, f"AGENTS.md heading not found: {result!r}"
+
+
+# =========================================================================
 # Context injection scanning
 # =========================================================================
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -579,3 +579,76 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is not None
         assert "could not re-read" in result.error.lower()
+
+
+class TestDryRunReplace:
+    """Tests for the dry-run preview mode of patch_replace."""
+
+    def test_dry_run_returns_diff_without_modifying_file(self, mock_env):
+        """Dry-run should return the diff but NOT write to disk."""
+        original = "hello world\n"
+        state = {"content": original}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat "):
+                return {"output": state["content"], "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.dry_run_replace("/tmp/test/a.py", "hello", "hi")
+
+        assert result.success is True
+        assert result.error is None
+        assert "hello" in result.diff or "hi" in result.diff, f"Diff missing change: {result.diff}"
+        assert result.match_count >= 1
+        assert result.strategy != ""
+        # File must NOT be modified
+        assert state["content"] == original, f"File was modified! {state['content']!r}"
+
+    def test_dry_run_no_match_returns_error(self, mock_env):
+        """Dry-run with non-matching text should return an error."""
+        mock_env.execute.return_value = {"output": "some content\n", "returncode": 0}
+        ops = ShellFileOperations(mock_env)
+        result = ops.dry_run_replace("/tmp/test/a.py", "nonexistent", "replacement")
+        assert result.success is False
+        assert result.error is not None
+
+    def test_dry_run_file_not_found(self, mock_env):
+        """Dry-run on a missing file should return an error."""
+        mock_env.execute.return_value = {"output": "", "returncode": 1}
+        ops = ShellFileOperations(mock_env)
+        result = ops.dry_run_replace("/tmp/test/missing.py", "old", "new")
+        assert result.error is not None
+        assert "Failed to read" in result.error
+
+    def test_dry_run_replace_all(self, mock_env):
+        """Dry-run with replace_all should match all occurrences."""
+        state = {"content": "hello hello world\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat "):
+                return {"output": state["content"], "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.dry_run_replace("/tmp/test/a.py", "hello", "hi", replace_all=True)
+
+        assert result.success is True
+        assert result.match_count == 2, f"Expected 2 matches, got {result.match_count}"
+        assert state["content"] == "hello hello world\n", "File must not be modified"
+
+    def test_match_count_and_strategy_in_result(self, mock_env):
+        """Dry-run result must include match_count and strategy for inspection."""
+        mock_env.execute.return_value = {"output": "hello world\n", "returncode": 0}
+        ops = ShellFileOperations(mock_env)
+        result = ops.dry_run_replace("/tmp/test/a.py", "hello", "hi")
+
+        assert result.success is True
+        assert result.match_count == 1
+        assert isinstance(result.strategy, str) and len(result.strategy) > 0
+        # Verify to_dict includes new fields
+        d = result.to_dict()
+        assert "match_count" in d
+        assert "strategy" in d

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -281,6 +281,16 @@ class FileOperations(ABC):
         ...
 
     @abstractmethod
+    def dry_run_replace(self, path: str, old_string: str, new_string: str,
+                        replace_all: bool = False) -> PatchResult:
+        """Preview a find-and-replace without modifying the file.
+
+        Same fuzzy matching as :meth:`patch_replace`, but returns the diff
+        and match info without writing to disk or running lint checks.
+        """
+        ...
+
+    @abstractmethod
     def patch_v4a(self, patch_content: str) -> PatchResult:
         """Apply a V4A format patch."""
         ...
@@ -1085,7 +1095,7 @@ class ShellFileOperations(FileOperations):
         result = apply_v4a_operations(operations, self)
         return result
     
-    def _try_shell_lint(self, ext: str, path: str, template: str) -> LintResult | None:
+    def _try_shell_lint(self, path: str, template: str) -> LintResult | None:
         """Try running a shell linter template. Returns LintResult or None if unavailable."""
         base_cmd = template.split()[0]
         if not self._has_command(base_cmd):
@@ -1141,13 +1151,13 @@ class ShellFileOperations(FileOperations):
         primary_cmd, fallback_cmd = entry
 
         # Try primary first (ruff, eslint, clippy, etc.)
-        result = self._try_shell_lint(ext, path, primary_cmd)
+        result = self._try_shell_lint(path, primary_cmd)
         if result is not None:
             return result
 
         # Try fallback (py_compile, node --check, etc.)
         if fallback_cmd:
-            result = self._try_shell_lint(ext, path, fallback_cmd)
+            result = self._try_shell_lint(path, fallback_cmd)
             if result is not None:
                 return result
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -137,6 +137,8 @@ class PatchResult:
     files_deleted: List[str] = field(default_factory=list)
     lint: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+    match_count: int = 0
+    strategy: str = ""
     
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -148,6 +150,10 @@ class PatchResult:
             result["files_created"] = self.files_created
         if self.files_deleted:
             result["files_deleted"] = self.files_deleted
+        if self.match_count:
+            result["match_count"] = self.match_count
+        if self.strategy:
+            result["strategy"] = self.strategy
         if self.lint:
             result["lint"] = self.lint
         if self.error:
@@ -305,14 +311,23 @@ class FileOperations(ABC):
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico'}
 
 # Shell-based linters by file extension.  Invoked via _exec() with the
-# filesystem path.  Cover languages where a compile/type check needs an
-# external toolchain (py_compile, node, tsc, go vet, rustfmt).
-LINTERS = {
-    '.py': 'python -m py_compile {file} 2>&1',
-    '.js': 'node --check {file} 2>&1',
-    '.ts': 'npx tsc --noEmit {file} 2>&1',
-    '.go': 'go vet {file} 2>&1',
-    '.rs': 'rustfmt --check {file} 2>&1',
+# filesystem path.  Each entry is a (command_template, fallback_template) tuple.
+# The command is tried first; fallback runs if the primary tool isn't installed.
+# Fallback=None means skip linting entirely if the primary tool is missing.
+LINTERS: dict[str, tuple[str, str | None]] = {
+    '.py':  ('ruff check --quiet --no-cache --output-format concise {file} 2>&1',
+             'python -m py_compile {file} 2>&1'),
+    '.js':  ('npx eslint --no-color --format compact {file} 2>&1',
+             'node --check {file} 2>&1'),
+    '.ts':  ('npx eslint --no-color --format compact {file} 2>&1',
+             'npx tsc --noEmit {file} 2>&1'),
+    '.go':  ('go vet {file} 2>&1', None),
+    '.rs':  ('cargo clippy --message-format short {file} 2>&1',
+             'rustfmt --check {file} 2>&1'),
+    '.sh':  ('shellcheck -f tty {file} 2>&1', None),
+    '.bash':('shellcheck -f tty {file} 2>&1', None),
+    '.toml':('taplo check {file} 2>&1', None),
+    '.json':('node -e "JSON.parse(require(\"fs\").readFileSync(\"{file}\",\"utf8\"))" 2>&1', None),
 }
 
 
@@ -999,6 +1014,47 @@ class ShellFileOperations(FileOperations):
             lint=lint_result.to_dict() if lint_result else None
         )
     
+    def dry_run_replace(self, path: str, old_string: str, new_string: str,
+                        replace_all: bool = False) -> PatchResult:
+        """Preview a find-and-replace without modifying the file.
+
+        Same fuzzy matching as :meth:`patch_replace`, but returns the diff
+        and match info without writing to disk or running lint checks.
+
+        Returns a PatchResult with diff, match_count, and files_modified —
+        but ``success=False`` on no-match (same contract as patch_replace).
+        """
+        path = self._expand_path(path)
+        read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+        read_result = self._exec(read_cmd)
+        if read_result.exit_code != 0:
+            return PatchResult(error=f"Failed to read file: {path}")
+        content = read_result.stdout
+
+        from tools.fuzzy_match import fuzzy_find_and_replace
+        new_content, match_count, strategy, error = fuzzy_find_and_replace(
+            content, old_string, new_string, replace_all
+        )
+
+        if error or match_count == 0:
+            err_msg = error or f"Could not find match for old_string in {path}"
+            try:
+                from tools.fuzzy_match import format_no_match_hint
+                err_msg += format_no_match_hint(err_msg, match_count, old_string, content)
+            except Exception:
+                pass
+            return PatchResult(error=err_msg)
+
+        diff = self._unified_diff(content, new_content, path)
+
+        return PatchResult(
+            success=True,
+            diff=diff,
+            files_modified=[path],
+            match_count=match_count,
+            strategy=strategy,
+        )
+    
     def patch_v4a(self, patch_content: str) -> PatchResult:
         """
         Apply a V4A format patch.
@@ -1029,22 +1085,33 @@ class ShellFileOperations(FileOperations):
         result = apply_v4a_operations(operations, self)
         return result
     
+    def _try_shell_lint(self, ext: str, path: str, template: str) -> LintResult | None:
+        """Try running a shell linter template. Returns LintResult or None if unavailable."""
+        base_cmd = template.split()[0]
+        if not self._has_command(base_cmd):
+            return None
+        cmd = template.replace("{file}", self._escape_shell_arg(path))
+        result = self._exec(cmd, timeout=30)
+        return LintResult(
+            success=result.exit_code == 0,
+            output=result.stdout.strip() if result.stdout.strip() else ""
+        )
+
     def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:
         """
-        Run syntax check on a file after editing.
+        Run syntax + diagnostics check on a file after editing.
 
-        Prefers the in-process linter for structured formats (JSON, YAML,
-        TOML) when possible — those parse via the Python stdlib in
-        microseconds and don't require a subprocess.  Falls back to the
-        shell linter table for compiled/type-checked languages
-        (py_compile, node --check, tsc, go vet, rustfmt).
+        Multi-tier approach:
+        1. In-process linter (Python ast, JSON, YAML, TOML) — microseconds, no subprocess
+        2. Primary shell linter (ruff, eslint, clippy, shellcheck) — real diagnostics
+        3. Fallback shell linter (py_compile, node --check, rustfmt) — syntax only
+
+        Only NEW errors introduced by this edit are surfaced (pre-existing
+        lint failures are filtered out by _check_lint_delta).
 
         Args:
             path: File path (used to select the linter + for shell invocation).
-            content: Optional file content.  If provided AND an in-process
-                     linter matches the extension, we lint the content
-                     directly without re-reading the file from disk.  Ignored
-                     for shell linters.
+            content: Optional file content for in-process linters.
 
         Returns:
             LintResult with status and any errors.
@@ -1067,24 +1134,24 @@ class ShellFileOperations(FileOperations):
             return LintResult(success=ok, output="" if ok else err)
 
         # Fall back to shell linter.
-        if ext not in LINTERS:
+        entry = LINTERS.get(ext)
+        if entry is None:
             return LintResult(skipped=True, message=f"No linter for {ext} files")
 
-        linter_cmd = LINTERS[ext]
-        # Extract the base command (first word)
-        base_cmd = linter_cmd.split()[0]
+        primary_cmd, fallback_cmd = entry
 
-        if not self._has_command(base_cmd):
-            return LintResult(skipped=True, message=f"{base_cmd} not available")
+        # Try primary first (ruff, eslint, clippy, etc.)
+        result = self._try_shell_lint(ext, path, primary_cmd)
+        if result is not None:
+            return result
 
-        # Run linter
-        cmd = linter_cmd.replace("{file}", self._escape_shell_arg(path))
-        result = self._exec(cmd, timeout=30)
+        # Try fallback (py_compile, node --check, etc.)
+        if fallback_cmd:
+            result = self._try_shell_lint(ext, path, fallback_cmd)
+            if result is not None:
+                return result
 
-        return LintResult(
-            success=result.exit_code == 0,
-            output=result.stdout.strip() if result.stdout.strip() else ""
-        )
+        return LintResult(skipped=True, message=f"No linter available for {ext} files")
 
     def _check_lint_delta(self, path: str, pre_content: Optional[str],
                           post_content: Optional[str] = None) -> LintResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -848,7 +848,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
 
 
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
-               new_string: str = None, replace_all: bool = False, patch: str = None,
+               new_string: str = None, replace_all: bool = False, dry_run: bool = False,
+               patch: str = None,
                task_id: str = "default") -> str:
     """Patch a file using replace mode or V4A patch format."""
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
@@ -909,7 +910,10 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return tool_error("path required")
                 if old_string is None or new_string is None:
                     return tool_error("old_string and new_string required")
-                result = file_ops.patch_replace(path, old_string, new_string, replace_all)
+                if dry_run:
+                    result = file_ops.dry_run_replace(path, old_string, new_string, replace_all)
+                else:
+                    result = file_ops.patch_replace(path, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
@@ -1042,7 +1046,7 @@ READ_FILE_SCHEMA = {
 
 WRITE_FILE_SCHEMA = {
     "name": "write_file",
-    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
+    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax + diagnostic checks: ruff/eslint/shellcheck (primary) with fallback to py_compile/node --check. Only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1058,11 +1062,14 @@ PATCH_SCHEMA = {
     "description": (
         "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. "
         "Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. "
-        "Returns a unified diff. Auto-runs syntax checks after editing.\n\n"
+        "Returns a unified diff. Auto-runs syntax + diagnostic checks after editing.\n\n"
         "REPLACE MODE (mode='replace', default): find a unique string and replace it. "
         "REQUIRED PARAMETERS: mode, path, old_string, new_string.\n"
         "PATCH MODE (mode='patch'): apply V4A multi-file patches for bulk changes. "
-        "REQUIRED PARAMETERS: mode, patch."
+        "REQUIRED PARAMETERS: mode, patch.\n\n"
+        "DRY RUN: set dry_run=true to preview the diff without modifying the file. "
+        "Use this when you're unsure if the fuzzy matching will find the right text — "
+        "especially after a failed patch, to verify your correction before applying."
     ),
     "parameters": {
         "type": "object",
@@ -1088,6 +1095,11 @@ PATCH_SCHEMA = {
             "replace_all": {
                 "type": "boolean",
                 "description": "Replace all occurrences instead of requiring a unique match (default: false)",
+                "default": False,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Preview mode: show the diff that would be applied without actually modifying the file. Use to verify fuzzy matches before committing.",
                 "default": False,
             },
             "patch": {
@@ -1152,7 +1164,8 @@ def _handle_patch(args, **kw):
     return patch_tool(
         mode=args.get("mode", "replace"), path=args.get("path"),
         old_string=args.get("old_string"), new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid)
+        replace_all=args.get("replace_all", False), dry_run=args.get("dry_run", False),
+        patch=args.get("patch"), task_id=tid)
 
 
 def _handle_search_files(args, **kw):


### PR DESCRIPTION
## Summary

Adds three backward-compatible improvements:

### 1. Git context injection
Auto-inject branch, dirty files, and recent commits into the system prompt via `_build_git_context()`. Zero overhead — silent when not in a git repo.

### 2. AGENTS.md/CLAUDE.md walking to git root
Walk from cwd up to git root (previously cwd-only), matching `_find_hermes_md()`.

### 3. Multi-tier linter upgrade
- **Primary**: ruff, eslint, shellcheck, clippy (real diagnostics)
- **Fallback**: py_compile, node --check, rustfmt (syntax only)
- **New extensions**: .sh, .bash (shellcheck), .toml (taplo)
- Delta filtering preserved — only NEW errors surfaced

### 4. Patch dry-run mode
Preview fuzzy matches and diff without writing to disk. `PatchResult` now includes `match_count` and `strategy` fields.

All changes are additive with graceful fallbacks. No breaking changes.