### PR TITLE
fix(tools): forward thread_id via metadata in _send_via_adapter live path

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -458,7 +458,8 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                result = await adapter.send(chat_id=chat_id, content=chunk)
+                metadata = {"thread_id": thread_id} if thread_id else None
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
             except Exception as e:


### PR DESCRIPTION
## Root cause

`_send_via_adapter` has two delivery paths:

1. **Live adapter** (gateway in-process): calls `adapter.send(chat_id=chat_id, content=chunk)` — **no `thread_id`**
2. **Standalone fallback** (out-of-process): calls `entry.standalone_sender_fn(..., thread_id=thread_id, ...)` — correctly forwarded

For plugin platforms (google_chat, teams, irc, line) when the gateway is running in-process, every call through the live path silently dropped `thread_id`. The reply landed as a new top-level message instead of continuing the thread.

## Fix

Build `metadata = {"thread_id": thread_id} if thread_id else None` and pass it to `adapter.send()`. When `thread_id` is absent, `metadata=None` preserves the existing behaviour exactly.

This matches the pattern already used by `_send_matrix_via_adapter` (line 1529) and `_send_feishu` (line 1720) in the same file.

## Diff

```diff
-                result = await adapter.send(chat_id=chat_id, content=chunk)
+                metadata = {"thread_id": thread_id} if thread_id else None
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
```

## Test plan

- [ ] Send a threaded reply via `send_message` tool targeting a google_chat platform while the gateway is running in-process; confirm the reply lands in the existing thread instead of opening a new one
- [ ] Send without `thread_id`; confirm behaviour is unchanged (new top-level message)
- [ ] Standalone path (gateway out-of-process) continues to pass `thread_id` as before — no regression