### PR TITLE
fix(discord): open DMs for user targets

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -20,6 +20,7 @@ def _reset_signal_scheduler():
     yield
     _reset_scheduler()
 
+import tools.send_message_tool as send_message_module
 from gateway.config import Platform
 from tools.send_message_tool import (
     _derive_forum_thread_name,
@@ -31,6 +32,15 @@ from tools.send_message_tool import (
     _send_to_platform,
     send_message_tool,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_send_message_caches():
+    send_message_module._DISCORD_CHANNEL_TYPE_PROBE_CACHE.clear()
+    send_message_module._DISCORD_DM_CHANNEL_CACHE.clear()
+    yield
+    send_message_module._DISCORD_CHANNEL_TYPE_PROBE_CACHE.clear()
+    send_message_module._DISCORD_DM_CHANNEL_CACHE.clear()
 
 
 def _run_async_immediately(coro):
@@ -1014,6 +1024,84 @@ class TestSendDiscordThreadId:
             result = self._run("tok", "111", "hi")
         assert "error" in result
         assert "403" in result["error"]
+
+    def test_discord_dm_target_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("discord", "dm:1173534822736597085")
+        assert chat_id == "dm:1173534822736597085"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_user_id_fallback_opens_dm_channel(self):
+        open_dm_resp = MagicMock()
+        open_dm_resp.status = 200
+        open_dm_resp.json = AsyncMock(return_value={"id": "dm-channel-1"})
+        open_dm_resp.text = AsyncMock(return_value='{"id":"dm-channel-1"}')
+        open_dm_resp.__aenter__ = AsyncMock(return_value=open_dm_resp)
+        open_dm_resp.__aexit__ = AsyncMock(return_value=None)
+
+        first_send_resp = MagicMock()
+        first_send_resp.status = 404
+        first_send_resp.json = AsyncMock(return_value={"message": "Unknown Channel", "code": 10003})
+        first_send_resp.text = AsyncMock(return_value='{"message":"Unknown Channel","code": 10003}')
+        first_send_resp.__aenter__ = AsyncMock(return_value=first_send_resp)
+        first_send_resp.__aexit__ = AsyncMock(return_value=None)
+
+        retry_send_resp = MagicMock()
+        retry_send_resp.status = 200
+        retry_send_resp.json = AsyncMock(return_value={"id": "msg-after-dm"})
+        retry_send_resp.text = AsyncMock(return_value='{"id":"msg-after-dm"}')
+        retry_send_resp.__aenter__ = AsyncMock(return_value=retry_send_resp)
+        retry_send_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(side_effect=[first_send_resp, open_dm_resp, retry_send_resp])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = self._run("tok", "1173534822736597085", "hello world")
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-after-dm"
+        assert result["chat_id"] == "dm-channel-1"
+        post_urls = [call.args[0] for call in mock_session.post.call_args_list]
+        assert post_urls == [
+            "https://discord.com/api/v10/channels/1173534822736597085/messages",
+            "https://discord.com/api/v10/users/@me/channels",
+            "https://discord.com/api/v10/channels/dm-channel-1/messages",
+        ]
+
+    def test_explicit_discord_dm_target_opens_dm_before_send(self):
+        open_dm_resp = MagicMock()
+        open_dm_resp.status = 200
+        open_dm_resp.json = AsyncMock(return_value={"id": "dm-channel-2"})
+        open_dm_resp.text = AsyncMock(return_value='{"id":"dm-channel-2"}')
+        open_dm_resp.__aenter__ = AsyncMock(return_value=open_dm_resp)
+        open_dm_resp.__aexit__ = AsyncMock(return_value=None)
+
+        send_resp = MagicMock()
+        send_resp.status = 200
+        send_resp.json = AsyncMock(return_value={"id": "msg-explicit-dm"})
+        send_resp.text = AsyncMock(return_value='{"id":"msg-explicit-dm"}')
+        send_resp.__aenter__ = AsyncMock(return_value=send_resp)
+        send_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.post = MagicMock(side_effect=[open_dm_resp, send_resp])
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = self._run("tok", "dm:1173534822736597085", "hello dm")
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-explicit-dm"
+        assert result["chat_id"] == "dm-channel-2"
+        post_urls = [call.args[0] for call in mock_session.post.call_args_list]
+        assert post_urls == [
+            "https://discord.com/api/v10/users/@me/channels",
+            "https://discord.com/api/v10/channels/dm-channel-2/messages",
+        ]
 
 
 class TestSendToPlatformDiscordThread:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -30,6 +30,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+_DISCORD_DM_TARGET_RE = re.compile(r"^\s*dm:(\d+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -133,7 +134,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Discord DMs also accept 'discord:dm:USER_ID'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:dm:1173534822736597085', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -326,6 +327,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "discord":
+        dm_match = _DISCORD_DM_TARGET_RE.fullmatch(target_ref)
+        if dm_match:
+            return f"dm:{dm_match.group(1)}", None, True
         match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
@@ -913,6 +917,7 @@ def _derive_forum_thread_name(message: str) -> str:
 # same channel on every send when the directory cache has no entry (e.g. fresh
 # install, or channel created after the last directory build).
 _DISCORD_CHANNEL_TYPE_PROBE_CACHE: Dict[str, bool] = {}
+_DISCORD_DM_CHANNEL_CACHE: Dict[str, str] = {}
 
 
 def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
@@ -921,6 +926,36 @@ def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
 
 def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
     return _DISCORD_CHANNEL_TYPE_PROBE_CACHE.get(str(chat_id))
+
+
+def _remember_discord_dm_channel(user_id: str, channel_id: str) -> None:
+    _DISCORD_DM_CHANNEL_CACHE[str(user_id)] = str(channel_id)
+
+
+def _cached_discord_dm_channel(user_id: str) -> Optional[str]:
+    return _DISCORD_DM_CHANNEL_CACHE.get(str(user_id))
+
+
+async def _open_discord_dm_channel(session, auth_headers, req_kw, user_id: str) -> str:
+    cached = _cached_discord_dm_channel(user_id)
+    if cached:
+        return cached
+    dm_url = "https://discord.com/api/v10/users/@me/channels"
+    async with session.post(
+        dm_url,
+        headers={**auth_headers, "Content-Type": "application/json"},
+        json={"recipient_id": str(user_id)},
+        **req_kw,
+    ) as resp:
+        if resp.status not in (200, 201):
+            body = await resp.text()
+            raise RuntimeError(f"Discord DM open error ({resp.status}): {body}")
+        data = await resp.json()
+    channel_id = str(data.get("id") or "").strip()
+    if not channel_id:
+        raise RuntimeError("Discord DM open returned no channel id")
+    _remember_discord_dm_channel(user_id, channel_id)
+    return channel_id
 
 
 async def _send_discord(token, chat_id, message, thread_id=None, media_files=None):
@@ -955,6 +990,8 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         media_files = media_files or []
         last_data = None
         warnings = []
+        original_chat_id = str(chat_id)
+        dm_user_id = original_chat_id.split(":", 1)[1] if original_chat_id.startswith("dm:") else None
 
         # Thread endpoint: Discord threads are channels; send directly to the thread ID.
         if thread_id:
@@ -1070,6 +1107,10 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
                     result["warnings"] = warnings
                 return result
 
+            if dm_user_id:
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
+                    resolved_channel_id = await _open_discord_dm_channel(session, auth_headers, _req_kw, dm_user_id)
+                chat_id = resolved_channel_id
             url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
@@ -1078,8 +1119,28 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
                 async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
                     if resp.status not in (200, 201):
                         body = await resp.text()
-                        return _error(f"Discord API error ({resp.status}): {body}")
-                    last_data = await resp.json()
+                        should_try_dm = (
+                            not thread_id
+                            and not dm_user_id
+                            and original_chat_id.isdigit()
+                            and resp.status == 404
+                            and '"code": 10003' in body
+                        )
+                        if should_try_dm:
+                            try:
+                                chat_id = await _open_discord_dm_channel(session, auth_headers, _req_kw, original_chat_id)
+                                url = f"https://discord.com/api/v10/channels/{chat_id}/messages"
+                                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as retry_resp:
+                                    if retry_resp.status not in (200, 201):
+                                        retry_body = await retry_resp.text()
+                                        return _error(f"Discord API error ({retry_resp.status}): {retry_body}")
+                                    last_data = await retry_resp.json()
+                            except Exception as e:
+                                return _error(f"Discord API error ({resp.status}): {body}; DM fallback failed: {e}")
+                        else:
+                            return _error(f"Discord API error ({resp.status}): {body}")
+                    if last_data is None:
+                        last_data = await resp.json()
 
             # Send each media file as a separate multipart upload
             for media_path, _is_voice in media_files:


### PR DESCRIPTION
## What does this PR do?

Fix Discord DM delivery in `send_message` when the target is a user ID.

This change adds explicit `discord:dm:USER_ID` support and also makes the existing bare numeric `discord:USER_ID` flow recover automatically when Discord returns `Unknown Channel (10003)`. In that case Hermes now opens the DM channel via `POST /users/@me/channels`, caches the resulting channel ID, and retries the send.

## Related Issue

Fixes #22882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added explicit Discord DM target parsing for `discord:dm:USER_ID` in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22882-discord-dm-user-id/tools/send_message_tool.py`
- Added a small process-local DM channel cache and helper to open DM channels via Discord REST before sending
- Added fallback retry logic so an `Unknown Channel (10003)` error on a numeric Discord target can recover by opening a DM channel and retrying
- Updated the `send_message` schema description to document Discord DM targets
- Added regression tests in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22882-discord-dm-user-id/tests/tools/test_send_message_tool.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k 'DiscordThreadId or discord_dm_target_is_explicit or user_id_fallback_opens_dm_channel or explicit_discord_dm_target_opens_dm_before_send'`
2. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k 'discord'`
3. Confirm both `discord:dm:USER_ID` and bare numeric `discord:USER_ID` use the DM-open flow in the added tests

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k 'discord'` -> `33 passed, 81 deselected`
- `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py` -> `All checks passed!`
- Clean collect-only smoke still hits pre-existing repo import/packaging errors outside this diff; proof recorded in `.paperclip_artifacts/quality-gate/`
