### PR TITLE
fix(tirith): cache OSError spawn failure to suppress repeated WARNING spam

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -646,7 +646,14 @@ def check_command_security(command: str) -> dict:
             timeout=timeout,
         )
     except OSError as exc:
-        # Covers FileNotFoundError, PermissionError, exec format error
+        # Covers FileNotFoundError, PermissionError, exec format error.
+        # On Windows with MSYS/Git Bash in PATH, shutil.which("tirith") may
+        # return a MSYS-style path (/mingw64/bin/tirith) that exists on disk
+        # but cannot be executed by Windows subprocess.  Cache this failure
+        # so we don't retry and re-log on every subsequent command.
+        global _resolved_path, _install_failure_reason
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "spawn_failed"
         logger.warning("tirith spawn failed: %s", exc)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith unavailable: {exc}"}


### PR DESCRIPTION
Closes #23845

## Summary

When tirith is not installed on Windows but 'tirith' appears in PATH (e.g. from MSYS/Git Bash),  returns a MSYS-style path () that exists on disk but cannot be executed by Windows subprocess. The  was raised on every command without caching the failure, causing the same  to fire 20+ times per session.

## Fix

In  OSError handler, set  so subsequent calls short-circuit to 'path unavailable' (fires once) instead of retrying the same broken path and re-logging the same WARNING.



## Testing

-  passes
- The fix is purely defensive — no behavioral change when tirith is available or when the failure is transient