### PR TITLE
fix(gateway): fix Windows status detection failure due to path separators

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -165,6 +165,7 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     patterns = (
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",
+        "hermes_cli\\main.py gateway",
         "hermes gateway",
         "gateway/run.py",
     )

--- a/tests/gateway/test_gateway_status_windows_lock_record.py
+++ b/tests/gateway/test_gateway_status_windows_lock_record.py
@@ -1,0 +1,17 @@
+from gateway import status as gateway_status
+
+
+def test_lock_record_detects_windows_main_py_gateway_argv():
+    record = {
+        "pid": 12496,
+        "kind": "hermes-gateway",
+        "argv": [
+            r"C:\Users\Admin\AppData\Local\hermes\hermes-agent\hermes_cli\main.py",
+            "gateway",
+            "run",
+            "--replace",
+        ],
+        "start_time": None,
+    }
+
+    assert gateway_status._record_looks_like_gateway(record) is True


### PR DESCRIPTION
### Description
This PR resolves an issue where `hermes gateway status` incorrectly reports the process as not running on Windows systems.

The root cause was a mismatch in path separator styles within the lock file's `argv` record (Unix `/` vs Windows `\`). The detection logic in `gateway/status.py` has been updated to handle both path styles correctly.

### Changes
- Updated `gateway/status.py` to support cross-platform path matching for gateway lock records.
- Added a new regression test: `tests/gateway/test_gateway_status_windows_lock_record.py` to ensure ongoing compatibility.

### Verification Results
- Ran `uv run pytest tests/gateway/test_gateway_status_windows_lock_record.py`
- Result: `1 passed`
- Verified the Windows lock-record pattern is now recognized by gateway status detection.