### PR TITLE
pencil design optional skill

### DIFF
--- a/optional-skills/creative/pencil-design/EXAMPLES.md
+++ b/optional-skills/creative/pencil-design/EXAMPLES.md
@@ -1,0 +1,520 @@
+# Pencil Design Examples
+
+Real-world examples of using Pencil MCP with Hermes Agent.
+
+## Example 1: Create a Mobile App Login Screen
+
+**User Request**: "Create a mobile app login screen with email and password fields, a login button, and a sign-up link."
+
+**Agent Workflow**:
+
+```
+Step 1: Open new design document
+  open_document(filePath="~/designs/login-app.pen")
+
+Step 2: Create the main screen frame
+  container=I("document",{
+    type:"frame",
+    name:"LoginScreen",
+    width:375,           // iPhone width
+    height:812,          // iPhone height
+    fill:"#FFFFFF",
+    layout:"vertical",
+    alignItems:"center",
+    justifyContent:"center",
+    gap:24,
+    padding:24
+  })
+
+Step 3: Add title
+  title=I(container,{
+    type:"text",
+    content:"Welcome Back",
+    fontSize:28,
+    fontWeight:"bold",
+    textAlign:"center"
+  })
+
+Step 4: Add subtitle
+  subtitle=I(container,{
+    type:"text",
+    content:"Sign in to your account",
+    fontSize:14,
+    fill:"#666666"
+  })
+
+Step 5: Create form group (email + password)
+  form=I(container,{
+    type:"frame",
+    layout:"vertical",
+    gap:12,
+    width:"100%"
+  })
+
+Step 6: Email input field
+  email_input=I(form,{
+    type:"frame",
+    width:"100%",
+    height:48,
+    fill:"#F5F5F5",
+    cornerRadius:8,
+    padding:12,
+    layout:"horizontal",
+    alignItems:"center"
+  })
+  email_label=I(email_input,{
+    type:"text",
+    content:"📧",
+    fontSize:16
+  })
+  email_text=I(email_input,{
+    type:"text",
+    content:"Email address",
+    fontSize:14,
+    fill:"#999999"
+  })
+
+Step 7: Password input field (similar structure)
+  password_input=I(form,{
+    type:"frame",
+    width:"100%",
+    height:48,
+    fill:"#F5F5F5",
+    cornerRadius:8,
+    padding:12,
+    layout:"horizontal",
+    alignItems:"center"
+  })
+  password_icon=I(password_input,{
+    type:"text",
+    content:"🔒",
+    fontSize:16
+  })
+  password_text=I(password_input,{
+    type:"text",
+    content:"Password",
+    fontSize:14,
+    fill:"#999999"
+  })
+
+Step 8: Create login button
+  login_btn=I(container,{
+    type:"frame",
+    name:"LoginButton",
+    width:"100%",
+    height:48,
+    fill:"#1E88E5",
+    cornerRadius:8,
+    layout:"horizontal",
+    alignItems:"center",
+    justifyContent:"center"
+  })
+  btn_text=I(login_btn,{
+    type:"text",
+    content:"Sign In",
+    fontSize:16,
+    fontWeight:"bold",
+    fill:"#FFFFFF"
+  })
+
+Step 9: Add sign-up link
+  footer=I(container,{
+    type:"frame",
+    layout:"horizontal",
+    gap:4,
+    justifyContent:"center"
+  })
+  footer_text=I(footer,{
+    type:"text",
+    content:"Don't have an account?",
+    fontSize:12,
+    fill:"#666666"
+  })
+  signup_link=I(footer,{
+    type:"text",
+    content:"Sign Up",
+    fontSize:12,
+    fill:"#1E88E5",
+    textDecoration:"underline"
+  })
+
+Step 10: Verify design with screenshot
+  screenshot=get_screenshot(filePath="~/designs/login-app.pen")
+  → Returns image preview
+
+Result: Beautiful mobile login screen ready for handoff to developers!
+```
+
+---
+
+## Example 2: Update Brand Colors Across Design System
+
+**User Request**: "Our brand color changed from blue (#0066CC) to purple (#7B2BE0). Update all components in the design system."
+
+**Agent Workflow**:
+
+```
+Step 1: Get current design variables
+  vars=get_variables(filePath="~/designs/design-system.pen")
+  → Returns all defined color variables
+
+Step 2: Find all components using the old blue color
+  old_usage=search_all_unique_properties(
+    filePath="~/designs/design-system.pen",
+    property="fill"
+  )
+  → Finds ["#0066CC", "#FF5733", ...]
+
+Step 3: Bulk replace the old color with new color
+  result=replace_all_matching_properties(
+    filePath="~/designs/design-system.pen",
+    property="fill",
+    oldValue="#0066CC",
+    newValue="#7B2BE0"
+  )
+  → Returns {replaced: 47, affectedNodes: ["button-1", "card-1", ...]}
+
+Step 4: Update design variable tokens
+  set_variables(filePath="~/designs/design-system.pen",
+    variables={
+      color: {
+        primary: "#7B2BE0",
+        primaryLight: "#B4A7FF",
+        primaryDark: "#5C1E7B"
+      }
+    }
+  )
+
+Step 5: Verify changes with screenshots
+  screenshot=get_screenshot(filePath="~/designs/design-system.pen")
+  → Shows all components with new purple color
+
+Result: All 47 components updated in seconds, no manual editing needed!
+```
+
+---
+
+## Example 3: Export All Screens as Marketing Assets
+
+**User Request**: "Export all app screens as high-resolution PNG images for our website."
+
+**Agent Workflow**:
+
+```
+Step 1: Fetch all screen nodes
+  screens=batch_get(
+    filePath="~/designs/app.pen",
+    query="*Screen"  // matches HomeScreen, ProfileScreen, etc.
+  )
+  → Returns {
+      HomeScreen: {id: "screen-1", ...},
+      ProfileScreen: {id: "screen-2", ...},
+      SettingsScreen: {id: "screen-3", ...}
+    }
+
+Step 2: Export each screen at 2x resolution
+  exports=export_nodes(
+    filePath="~/designs/app.pen",
+    nodeIds=["screen-1", "screen-2", "screen-3"],
+    format="png",
+    scale=2  // 2x for Retina displays
+  )
+  → Returns {
+      screen-1: "~/exports/HomeScreen@2x.png",
+      screen-2: "~/exports/ProfileScreen@2x.png",
+      screen-3: "~/exports/SettingsScreen@2x.png"
+    }
+
+Step 3: Create a summary
+  User gets:
+    ✅ HomeScreen@2x.png (750x1624px)
+    ✅ ProfileScreen@2x.png (750x1624px)
+    ✅ SettingsScreen@2x.png (750x1624px)
+
+Result: Ready-to-upload marketing assets in minutes!
+```
+
+---
+
+## Example 4: Analyze Design System Consistency
+
+**User Request**: "Check if our design system has consistent spacing and typography."
+
+**Agent Workflow**:
+
+```
+Step 1: Analyze layout and spacing
+  layout=snapshot_layout(filePath="~/designs/design-system.pen")
+  → Returns detailed spacing metrics
+
+Step 2: Get all font sizes in use
+  sizes=search_all_unique_properties(
+    filePath="~/designs/design-system.pen",
+    property="fontSize"
+  )
+  → Returns [12, 14, 14, 16, 16, 16, 18, 20, 24, ...]
+
+Step 3: Get all spacing values
+  spacing=search_all_unique_properties(
+    filePath="~/designs/design-system.pen",
+    property="gap"
+  )
+  → Returns [4, 8, 8, 8, 12, 12, 16, 16, 16, 24, ...]
+
+Step 4: Analyze guidelines
+  guidelines=get_guidelines(filePath="~/designs/design-system.pen")
+  → Returns defined rules and standards
+
+Step 5: Report to user
+  Agent reports:
+    ✅ Typography scale: [12, 14, 16, 18, 20, 24] (well-scaled)
+    ✅ Spacing scale: [4, 8, 12, 16, 24] (good progression)
+    ⚠️  14px used 4 times, consider consolidating
+    ⚠️  Inconsistent padding in cards (12px vs 16px)
+
+  Recommendation: Align padding to single 16px standard
+```
+
+---
+
+## Example 5: Create Light/Dark Theme Variants
+
+**User Request**: "Create a dark theme version of our app design."
+
+**Agent Workflow**:
+
+```
+Step 1: Get current (light) theme variables
+  light_vars=get_variables(filePath="~/designs/app.pen")
+  → Returns:
+    {
+      color: {
+        bg: "#FFFFFF",
+        text: "#000000",
+        border: "#E0E0E0"
+      }
+    }
+
+Step 2: Define dark theme colors
+  set_variables(
+    filePath="~/designs/app.pen",
+    variables={
+      color: {
+        bg: "#121212",
+        text: "#FFFFFF",
+        border: "#333333"
+      }
+    },
+    theme="dark"
+  )
+
+Step 3: Take dark theme screenshot
+  dark_screenshot=get_screenshot(filePath="~/designs/app.pen")
+  → Shows app in dark colors
+
+Step 4: Export both light and dark screens
+  light=export_nodes(filePath="~/designs/app.pen", nodeIds=["HomeScreen"], scale=2)
+  → ~/exports/HomeScreen-light@2x.png
+
+  // Switch to dark theme
+  set_variables(filePath="~/designs/app.pen", theme="dark")
+  dark=export_nodes(filePath="~/designs/app.pen", nodeIds=["HomeScreen"], scale=2)
+  → ~/exports/HomeScreen-dark@2x.png
+
+Step 5: Deliver both variants
+  User gets:
+    ✅ HomeScreen-light@2x.png (light theme)
+    ✅ HomeScreen-dark@2x.png (dark theme)
+
+Result: Dual theme variants ready for development handoff!
+```
+
+---
+
+## Example 6: Programmatic Component Library Setup
+
+**User Request**: "Create a component library with Button, Card, and Input variants."
+
+**Agent Workflow**:
+
+```
+Step 1: Open design system file
+  open_document(filePath="~/designs/components.pen")
+
+Step 2: Create Button component folder
+  button_group=I("document",{
+    type:"frame",
+    name:"Button Components",
+    layout:"horizontal",
+    gap:24
+  })
+
+Step 3: Create Button.Primary variant
+  btn_primary=I(button_group,{
+    type:"frame",
+    name:"Button.Primary",
+    reusable:true,
+    width:120,
+    height:44,
+    fill:"#1E88E5",
+    cornerRadius:8,
+    layout:"horizontal",
+    alignItems:"center",
+    justifyContent:"center",
+    padding:12
+  })
+  btn_text=I(btn_primary,{
+    type:"text",
+    content:"Button",
+    fontSize:14,
+    fill:"#FFFFFF"
+  })
+
+Step 4: Create Button.Secondary variant
+  btn_secondary=I(button_group,{
+    type:"frame",
+    name:"Button.Secondary",
+    reusable:true,
+    width:120,
+    height:44,
+    fill:"#FFFFFF",
+    stroke:"#1E88E5",
+    strokeWidth:2,
+    cornerRadius:8,
+    layout:"horizontal",
+    alignItems:"center",
+    justifyContent:"center",
+    padding:12
+  })
+  btn_text=I(btn_secondary,{
+    type:"text",
+    content:"Button",
+    fontSize:14,
+    fill:"#1E88E5"
+  })
+
+Step 5: Create Card component
+  card_group=I("document",{
+    type:"frame",
+    name:"Card Components",
+    layout:"vertical",
+    gap:24
+  })
+  
+  card_default=I(card_group,{
+    type:"frame",
+    name:"Card.Default",
+    reusable:true,
+    width:300,
+    height:200,
+    fill:"#FFFFFF",
+    stroke:"#E0E0E0",
+    cornerRadius:8,
+    padding:16,
+    layout:"vertical",
+    gap:12
+  })
+
+Step 6: Set up design tokens
+  set_variables(filePath="~/designs/components.pen",
+    variables={
+      spacing: {
+        xs: 4, sm: 8, md: 16, lg: 24, xl: 32
+      },
+      radius: {
+        sm: 4, md: 8, lg: 16
+      },
+      color: {
+        primary: "#1E88E5",
+        secondary: "#43A047",
+        error: "#D32F2F"
+      }
+    }
+  )
+
+Step 7: Export component library showcase
+  export_nodes(filePath="~/designs/components.pen",
+    nodeIds=["Button Components", "Card Components"],
+    format="png"
+  )
+
+Result: Reusable component library set up and documented!
+```
+
+---
+
+## Example 7: Convert Figma-Style Tokens to Hermes Variables
+
+**User Request**: "I have design tokens from Figma. Update our Hermes design system with them."
+
+**Agent Workflow**:
+
+```
+Step 1: Parse/import token data
+  tokens_from_figma={
+    "color.brand.primary": "#FF6B6B",
+    "color.brand.secondary": "#4ECDC4",
+    "typography.heading.large.size": 32,
+    "typography.heading.large.weight": "bold",
+    "spacing.unit": 8,
+  }
+
+Step 2: Map to Hermes variable structure
+  set_variables(filePath="~/designs/system.pen",
+    variables={
+      color: {
+        brand: {
+          primary: "#FF6B6B",
+          secondary: "#4ECDC4"
+        }
+      },
+      typography: {
+        heading: {
+          large: {
+            size: 32,
+            weight: "bold"
+          }
+        }
+      },
+      spacing: {
+        unit: 8,
+        xs: 4,
+        sm: 8,
+        md: 16,
+        lg: 24,
+        xl: 32
+      }
+    }
+  )
+
+Step 3: Verify all components updated
+  layout=snapshot_layout(filePath="~/designs/system.pen")
+  → Confirms all variables applied
+
+Result: Figma tokens integrated into Hermes design system!
+```
+
+---
+
+## Tips for Agent Prompting
+
+When asking Hermes to use Pencil MCP for design tasks:
+
+**Good prompts:**
+- "Create a mobile app login screen with..."
+- "Update all buttons in the design system to use the new blue (#..."
+- "Export all screens as PNG for the marketing team"
+- "Analyze spacing consistency across components"
+- "Create dark/light theme variants"
+
+**Weak prompts:**
+- "Make a nice design" (too vague)
+- "Update the design" (missing details)
+- "Fix it" (unclear what to fix)
+
+**Enable agent success:**
+- Specify file paths (absolute preferred)
+- Mention component/element names
+- Clarify output format (PNG, SVG, etc.)
+- Include color codes or token names
+- Mention screen sizes (mobile=375px width, tablet=600px, etc.)

--- a/optional-skills/creative/pencil-design/OPERATIONS.md
+++ b/optional-skills/creative/pencil-design/OPERATIONS.md
@@ -1,0 +1,380 @@
+# Pencil Design Operations Reference
+
+Quick reference for all Pencil MCP operations available in Hermes Agent.
+
+## Document Operations
+
+### `open_document`
+
+Open a .pen file for editing.
+
+```
+Arguments:
+  filePath (string, required) — absolute path to .pen file
+
+Returns:
+  editor_state — current document state, selection, viewport
+```
+
+Example workflow:
+```
+User: Open my design file
+Agent: open_document(filePath="/path/to/designs/app.pen")
+```
+
+### `get_editor_state`
+
+Query current editor state without opening a file. Returns viewport, selection, zoom level, active tool.
+
+```
+Arguments:
+  (none)
+
+Returns:
+  {
+    viewport: {x, y, zoom},
+    selection: [node_id, ...],
+    activeDocument: "path/to/file.pen",
+    ...
+  }
+```
+
+## Design Editing (Batch Operations)
+
+### `batch_design`
+
+Insert, update, replace, move, or delete multiple design nodes in a single call.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  operations (array) — list of I/U/R/M/D operations
+
+Supports:
+  I (Insert) — add new nodes
+  U (Update) — modify properties
+  R (Replace) — swap out a node entirely
+  M (Move) — change parent/position
+  D (Delete) — remove nodes
+  G (Generate) — AI-generate or stock images
+```
+
+Example: Insert a button frame with a text label
+
+```javascript
+container=I("parentId",{type:"frame",layout:"horizontal",gap:8,padding:12})
+text=I(container,{type:"text",content:"Click Me",fontSize:14})
+```
+
+Example: Update button colors
+
+```
+U("buttonId",{fill:"#FF0000"})
+```
+
+Example: Move node to different parent
+
+```
+M("nodeId", "newParentId")
+```
+
+### `batch_get`
+
+Fetch multiple nodes by ID, path, or pattern matching.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  query (string or array) — node IDs, paths, or glob patterns
+
+Returns:
+  { nodeId: {type, name, properties, children, ...}, ... }
+```
+
+Example: Get all buttons
+
+```
+batch_get(filePath="app.pen", query="Button*")
+```
+
+## Export & Visualization
+
+### `get_screenshot`
+
+Capture the current viewport as an image (PNG, JPEG, etc.).
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  format (string, default "png") — output format
+  quality (number, 0-100, optional) — compression quality
+  width, height (numbers, optional) — output dimensions
+
+Returns:
+  binary image data (base64 or file path)
+```
+
+Example:
+```
+get_screenshot(filePath="app.pen", format="png")
+→ Returns PNG bytes or file path like "/tmp/screenshot_abc123.png"
+```
+
+### `snapshot_layout`
+
+Analyze layout metrics: spacing, alignment, sizing, hierarchy.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  nodeId (string, optional) — specific node to analyze
+
+Returns:
+  {
+    nodes: [{ id, name, bounds, spacing, alignment, ... }],
+    summary: { totalElements, grouping, spacingPattern, ... }
+  }
+```
+
+Useful for verifying design consistency without full screenshots.
+
+### `export_nodes`
+
+Export selected nodes as image files (PNG, SVG, etc.).
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  nodeIds (array) — node IDs to export
+  format (string, default "png") — "png", "svg", "jpeg", "pdf"
+  scale (number, default 1) — export scale (2 = 2x)
+
+Returns:
+  { nodeId: "file/path/exported.png", ... }
+```
+
+Example: Export all screens as PNG
+
+```
+export_nodes(filePath="app.pen", 
+             nodeIds=["screen-1", "screen-2", "screen-3"],
+             format="png")
+→ Returns paths for each exported image
+```
+
+## Design Variables & Theming
+
+### `get_variables`
+
+Retrieve all defined design variables (colors, typography, spacing, etc.) and current theme values.
+
+```
+Arguments:
+  filePath (string, optional) — scope to specific file
+
+Returns:
+  {
+    variables: {
+      color: {primary: "#FF0000", secondary: "#00FF00", ...},
+      typography: {heading: {...}, body: {...}, ...},
+      spacing: {xs: 4, sm: 8, md: 16, ...}
+    },
+    currentTheme: "light",
+    themes: ["light", "dark", ...]
+  }
+```
+
+### `set_variables`
+
+Update design variables and apply themes.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  variables (object) — new variable values
+  theme (string, optional) — activate a theme
+
+Returns:
+  confirmation + updated variable state
+```
+
+Example: Update brand colors
+
+```
+set_variables(filePath="app.pen",
+              variables={
+                color: {
+                  primary: "#1E88E5",
+                  secondary: "#43A047"
+                }
+              })
+```
+
+Example: Switch to dark theme
+
+```
+set_variables(filePath="app.pen", theme="dark")
+```
+
+## Design Guidelines & Analysis
+
+### `get_guidelines`
+
+Fetch design guidelines, style archetypes, and design system rules.
+
+```
+Arguments:
+  filePath (string, optional) — scope to specific file
+
+Returns:
+  {
+    guidelines: [
+      {name: "Typography", rules: ["Use system fonts", ...]},
+      {name: "Color", rules: ["WCAG AA contrast minimum", ...]},
+      ...
+    ],
+    archetypes: {Button: {...}, Card: {...}, ...}
+  }
+```
+
+### `find_empty_space_on_canvas`
+
+Find available space for new elements on the canvas.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  minWidth, minHeight (numbers, optional) — required dimensions
+
+Returns:
+  {x, y, width, height} — coordinates of largest empty area
+```
+
+Useful for auto-positioning new elements without overlap.
+
+## Property Search & Bulk Updates
+
+### `search_all_unique_properties`
+
+Find all unique values for a specific property across the design.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  property (string) — property name (e.g., "fill", "fontSize")
+
+Returns:
+  ["#FF0000", "#00FF00", "#0000FF", ...]  — unique values found
+```
+
+Example: Find all font sizes in use
+
+```
+search_all_unique_properties(filePath="app.pen", property="fontSize")
+→ Returns [12, 14, 16, 18, 20, 24, ...]
+```
+
+### `replace_all_matching_properties`
+
+Bulk-replace all properties matching a pattern.
+
+```
+Arguments:
+  filePath (string) — .pen file path
+  property (string) — property to match
+  oldValue (any) — value to find
+  newValue (any) — replacement value
+  nodeFilter (optional) — restrict to matching nodes
+
+Returns:
+  { replaced: count, affectedNodes: [id, ...] }
+```
+
+Example: Update all buttons to new padding
+
+```
+replace_all_matching_properties(
+  filePath="app.pen",
+  property="padding",
+  oldValue=8,
+  newValue=12,
+  nodeFilter="Button*")
+→ Returns {replaced: 47, affectedNodes: [...]}
+```
+
+## Component Instances
+
+When working with reusable components (components.reusable=true):
+
+- **Create instance**: `{type: "ref", ref: "ComponentId"}`
+- **Override properties**: Add properties directly to the instance
+- **Customize children**: Use `descendants` map in the I/C operation
+- **Update nested elements**: Use `U` with path like `instanceId/childId`
+
+Example: Create button instance with custom label
+
+```javascript
+button=I("parentId",{type:"ref",ref:"Button.Primary",x:100,y:200})
+U(button+"/label",{content:"Custom Label"})
+```
+
+## Patterns & Common Workflows
+
+### Bulk Create Buttons
+
+```javascript
+buttons=[]
+for i in range(3):
+  btn=I("parentId",{type:"ref",ref:"Button",x:100,y:i*50})
+  buttons.append(btn)
+```
+
+### Find and Update All Text
+
+```javascript
+text_nodes = batch_get("app.pen", "**/*.text")
+for node_id in text_nodes:
+  U(node_id, {fontSize: 16})
+```
+
+### Create Design Variant (Light/Dark)
+
+```javascript
+get_variables("app.pen")  // current state
+set_variables("app.pen", {
+  colors: {bg: "#FFFFFF", text: "#000000"}
+}, theme="light")
+export_nodes("app.pen", nodeIds=["all"], format="png")
+```
+
+### Verify Design Spacing
+
+```javascript
+layout_data = snapshot_layout("app.pen")
+// Analyze layout_data.summary for consistency issues
+```
+
+## Error Handling
+
+Common errors and solutions:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `File not found` | Invalid file path | Use absolute path or check permissions |
+| `Node not found` | ID doesn't exist | Use `batch_get` to list available nodes |
+| `Connection timeout` | Server slow/unreachable | Increase timeout in config |
+| `Invalid operation` | Schema mismatch | Check operation signature in docs |
+| `Permission denied` | Can't modify file | Check file is writable, not locked |
+
+## Performance Tips
+
+- **Batch operations**: Use `batch_design` for multiple edits (not serial calls)
+- **Screenshot caching**: Reuse screenshot paths until you make changes
+- **Lazy loading**: Use `get_editor_state` instead of `get_screenshot` when you just need metadata
+- **Scoped updates**: Use node filters in replace operations to avoid processing the whole document
+
+## See Also
+
+- `SKILL.md` — Full skill documentation and workflows
+- `SETUP.md` — Configuration guide
+- Pencil MCP server docs: https://github.com/pencil-mcp/docs (adjust URL)

--- a/optional-skills/creative/pencil-design/README.md
+++ b/optional-skills/creative/pencil-design/README.md
@@ -1,0 +1,174 @@
+# Pencil Design Skill
+
+Programmatic design editing via Pencil MCP for Hermes Agent.
+
+## Files in This Skill
+
+| File | Purpose |
+|------|---------|
+| **SKILL.md** | Main skill documentation, setup, workflows, best practices |
+| **SETUP.md** | Step-by-step configuration guide for Pencil MCP connection |
+| **OPERATIONS.md** | Complete reference for all available Pencil MCP operations |
+| **EXAMPLES.md** | Real-world examples with full agent workflows |
+| **README.md** | This file — quick overview |
+
+## What This Skill Does
+
+Provides programmatic access to Pencil's design editing capabilities via the Pencil MCP protocol. Agent can:
+
+✅ Create/edit .pen design files  
+✅ Batch insert/update/delete design nodes  
+✅ Export designs as images (PNG, SVG, JPEG)  
+✅ Manage design systems and variables  
+✅ Analyze design consistency  
+✅ Apply themes and design tokens  
+✅ Find and replace design properties  
+
+## Quick Start (5 minutes)
+
+### 1. Configure Pencil MCP
+
+Edit `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "http://localhost:5000/mcp"  # or your Pencil server URL
+    timeout: 120
+    connect_timeout: 60
+```
+
+See **SETUP.md** for alternative transports (stdio, SSH).
+
+### 2. Verify Tools Are Available
+
+```bash
+hermes tools
+# Filter for "pencil" or "design"
+# Should list operations like:
+#   - open_document
+#   - batch_design
+#   - export_nodes
+#   - get_screenshot
+#   - set_variables
+#   etc.
+```
+
+### 3. Try It
+
+```bash
+hermes
+# Type: Create a mobile app login screen in ~/designs/login.pen
+# Agent will use Pencil MCP to build the design programmatically
+```
+
+## Common Tasks
+
+### Create a design from scratch
+
+```
+User: Create a landing page design in ~/designs/landing.pen
+Agent: Uses batch_design to insert frames, text, buttons, images
+```
+
+### Update design colors
+
+```
+User: Change all blue buttons to purple
+Agent: Uses replace_all_matching_properties to bulk-update colors
+```
+
+### Export assets
+
+```
+User: Export all screens as PNG for the website
+Agent: Uses export_nodes to generate image files
+```
+
+### Manage design system
+
+```
+User: Set up our design tokens (colors, fonts, spacing)
+Agent: Uses set_variables to define reusable tokens
+```
+
+## Documentation Files
+
+- **SKILL.md** — Full reference, workflows, design patterns, integration with other skills
+- **SETUP.md** — Configuration options, troubleshooting, advanced setup
+- **OPERATIONS.md** — API reference for all Pencil MCP operations
+- **EXAMPLES.md** — Seven real-world examples with complete workflows
+
+## When to Use This Skill
+
+✅ **Use this skill when:**
+- Agent needs to programmatically edit design files
+- Bulk design operations (color updates, spacing fixes)
+- Exporting designs as marketing assets
+- Building design systems with reusable components
+- Analyzing design consistency
+
+❌ **Don't use when:**
+- Creating HTML/CSS prototypes (use `claude-design`)
+- Authoring design token specs (use `design-md`)
+- Looking up brand design systems (use `popular-web-designs`)
+
+## MCP Server Requirements
+
+You must have a Pencil MCP server running and accessible. The server can be:
+
+- **Local command** (stdio): `npx @pencil-mcp/server`
+- **HTTP service**: Running on localhost or remote host
+- **SSH tunnel**: Remote server over SSH
+
+Configure the connection in `~/.hermes/config.yaml` under `mcp_servers.pencil`.
+
+## Integration with Other Skills
+
+| Skill | How they work together |
+|-------|----------------------|
+| `claude-design` | pencil-design does programmatic edits; claude-design does design process/taste |
+| `design-md` | Export Pencil variables to DESIGN.md token specs |
+| `popular-web-designs` | Reference brand design systems; implement in Pencil |
+
+## Troubleshooting
+
+**"Pencil tools not showing in `hermes tools`?"**
+- Check `mcp_servers.pencil` is configured in config.yaml
+- Verify Pencil server is running and reachable
+- Try `hermes /reload-mcp` to reconnect
+- Check logs: `hermes logs --level DEBUG | grep pencil`
+
+**"Connection timeout errors?"**
+- Increase `timeout` in config.yaml (default 120s)
+- Verify network connectivity to Pencil server
+- For HTTP: `curl http://localhost:5000/mcp` to test
+
+**"Design edits not saving?"**
+- Pencil MCP handles persistence automatically
+- Check file permissions on .pen files
+- Verify Pencil server has write access
+
+See **SETUP.md** for more detailed troubleshooting.
+
+## References
+
+- **Full Skill Guide**: SKILL.md (150+ lines of documentation)
+- **Configuration**: SETUP.md (environment vars, multiple servers, advanced setup)
+- **API Reference**: OPERATIONS.md (complete operation signatures)
+- **Examples**: EXAMPLES.md (7 real-world workflows)
+- **Pencil MCP Docs**: https://github.com/pencil-mcp/docs (adjust URL)
+- **MCP Spec**: https://modelcontextprotocol.io/
+
+## Contributing
+
+To improve this skill:
+
+1. Test Pencil MCP operations thoroughly
+2. Add new examples to EXAMPLES.md if you discover useful workflows
+3. Update troubleshooting section if you hit and resolve new issues
+4. Keep OPERATIONS.md in sync with actual Pencil MCP schema
+
+## License
+
+MIT (same as Hermes Agent)

--- a/optional-skills/creative/pencil-design/SETUP.md
+++ b/optional-skills/creative/pencil-design/SETUP.md
@@ -1,0 +1,197 @@
+# Pencil MCP Configuration Guide
+
+This guide helps you set up Pencil MCP for use with Hermes Agent.
+
+## Quick Start (3 steps)
+
+### 1. Identify Your Pencil Server Transport
+
+- **Command-line (stdio)**: Pencil MCP runs as a CLI command
+- **HTTP/REST**: Pencil MCP runs as a web service
+- **SSH**: Pencil MCP runs on a remote machine
+
+### 2. Add to `~/.hermes/config.yaml`
+
+**Stdio example:**
+```yaml
+mcp_servers:
+  pencil:
+    command: "npx"
+    args: ["@pencil-mcp/server"]
+    timeout: 120
+    connect_timeout: 60
+    env: {}  # Add env vars here if needed
+```
+
+**HTTP example:**
+```yaml
+mcp_servers:
+  pencil:
+    url: "http://localhost:5000/mcp"
+    timeout: 120
+    connect_timeout: 60
+    headers:
+      Authorization: "Bearer your-token-here"  # if needed
+```
+
+**SSH example:**
+```yaml
+mcp_servers:
+  pencil:
+    command: "ssh"
+    args: ["user@example.com", "pencil-mcp-server"]
+    timeout: 120
+    connect_timeout: 60
+    env:
+      SSH_KEY: "/path/to/key"  # optional
+```
+
+### 3. Verify It Works
+
+```bash
+hermes tools
+# Filter for "pencil" or "design"
+# Should list Pencil operations like:
+#   - open_document
+#   - batch_design
+#   - get_screenshot
+#   - export_nodes
+#   etc.
+```
+
+## Environment Variable Substitution
+
+Config values support `${VAR}` placeholder substitution:
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "${PENCIL_SERVER_URL}"  # reads from env or ~/.hermes/.env
+    headers:
+      Authorization: "Bearer ${PENCIL_API_KEY}"
+```
+
+Environment variables are loaded from:
+1. Process environment (`export VAR=value`)
+2. `~/.hermes/.env` (one `KEY=value` per line)
+3. System environment
+
+## Troubleshooting
+
+### Issue: "mcp_servers not found" or config not loading
+
+**Solution**: Ensure `mcp_servers:` is at the **top level** of config.yaml, not nested under `auxiliary:` or `model:`.
+
+```yaml
+# ✅ CORRECT
+mcp_servers:
+  pencil:
+    url: "..."
+
+model: "gpt-4"
+agent: {}
+
+# ❌ WRONG (mcp_servers is nested)
+agent:
+  mcp_servers:
+    pencil:
+      url: "..."
+```
+
+### Issue: Pencil tools don't appear after adding config
+
+1. **Check logs**:
+   ```bash
+   hermes logs --level DEBUG | grep -i pencil
+   ```
+
+2. **Reload MCP manually**:
+   ```bash
+   hermes /reload-mcp
+   ```
+
+3. **Test server connectivity**:
+   - **HTTP**: `curl -I http://localhost:5000/mcp`
+   - **Stdio**: Run the command directly: `npx @pencil-mcp/server`
+
+### Issue: "Connection timeout" errors
+
+- Increase `timeout` value: `timeout: 180` (default 120)
+- Increase `connect_timeout`: `connect_timeout: 90` (default 60)
+- Check server is actually running and accessible
+- For HTTP, verify firewall/network rules allow connections
+
+### Issue: Authentication/Headers not working
+
+Ensure headers are under the `headers:` key:
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "http://..."
+    headers:
+      Authorization: "Bearer token-here"
+      X-Custom-Header: "value"
+```
+
+## Advanced Configuration
+
+### Per-Server Timeouts
+
+Each MCP server can have its own timeout:
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "http://localhost:5000/mcp"
+    timeout: 120        # per-tool-call timeout
+    connect_timeout: 60  # initial connection timeout
+```
+
+### Multiple Pencil Servers
+
+You can connect to multiple Pencil instances with different names:
+
+```yaml
+mcp_servers:
+  pencil-primary:
+    url: "http://server1.example.com/mcp"
+  pencil-staging:
+    url: "http://server2.example.com/mcp"
+```
+
+All operations become available, prefixed with their server name if disambiguation is needed.
+
+### Environment Variables in Config
+
+Pencil server URLs, ports, and credentials can reference env vars:
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "${PENCIL_BASE_URL}/mcp"  # reads PENCIL_BASE_URL from env
+    headers:
+      X-API-Key: "${PENCIL_API_KEY}"  # reads PENCIL_API_KEY
+```
+
+Set these in `~/.hermes/.env`:
+
+```
+PENCIL_BASE_URL=http://localhost:5000
+PENCIL_API_KEY=sk-pencil-xxxx
+```
+
+## Next Steps
+
+Once configured:
+
+1. **Load the skill**: `hermes skills install official/creative/pencil-design`
+2. **Test it**: `hermes` → ask to create a design
+3. **Check logs**: `hermes logs --follow` while running a design task
+
+## Related Documentation
+
+- **Hermes MCP Integration**: `tools/mcp_tool.py` (source code)
+- **MCP Specification**: https://modelcontextprotocol.io/
+- **Pencil MCP Docs**: https://github.com/pencil-mcp/docs (adjust URL as needed)
+- **Pencil Skills**: See `pencil-design` SKILL.md in this directory

--- a/optional-skills/creative/pencil-design/SKILL.md
+++ b/optional-skills/creative/pencil-design/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: pencil-design
+description: Design and manipulate .pen files using Pencil MCP. Create/edit web and mobile app designs, manage design systems, export assets, and generate design previews. Requires Pencil MCP server connection.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [pencil, design, MCP, UI/UX, design-systems, web-design, mobile-design]
+    homepage: https://pencil.com
+    related_skills: [claude-design, popular-web-designs, design-md]
+    category: creative
+    config:
+      mcp.pencil:
+        description: "Pencil MCP server configuration (command, url, or transport settings)"
+        prompt: "Pencil MCP server details"
+prerequisites:
+  services: ["Pencil MCP server"]
+  notes: "See Setup section for MCP connection configuration"
+---
+
+# Pencil Design via MCP
+
+Programmatically edit Pencil design files (.pen format) using the Pencil MCP protocol. Create, modify, export, and inspect designs for web and mobile applications with full system prompt awareness.
+
+## When To Use This Skill
+
+Use this skill when:
+
+- **Creating/editing app designs** — wireframes, prototypes, high-fidelity UI mockups
+- **Designing design systems** — component libraries, token definitions, reusable patterns
+- **Batch design operations** — programmatically update multiple elements, swap properties
+- **Extracting design artifacts** — export nodes as images, generate screenshots, extract variables
+- **Inspecting designs** — query design structure, find components, analyze layouts
+- **Automating design tasks** — bulk updates, design variable management, theme switching
+
+Do NOT use this skill for:
+- One-off HTML/CSS prototypes (use `claude-design` instead)
+- Design token specs (use `design-md` for DESIGN.md format)
+- Brand design lookups (use `popular-web-designs`)
+
+## Setup: Configure Pencil MCP Connection
+
+### Option 1: Stdio (if Pencil MCP is a command-line server)
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  pencil:
+    command: "npx"
+    args: ["@pencil-mcp/server"]  # adjust package name as needed
+    timeout: 120
+    connect_timeout: 60
+```
+
+### Option 2: HTTP (if Pencil MCP is running as a service)
+
+```yaml
+mcp_servers:
+  pencil:
+    url: "http://localhost:5000/mcp"  # adjust URL/port as needed
+    timeout: 120
+    connect_timeout: 60
+    headers: {}  # add auth headers if needed
+```
+
+### Option 3: SSH (if Pencil MCP is on a remote host)
+
+```yaml
+mcp_servers:
+  pencil:
+    command: "ssh"
+    args: ["user@host", "pencil-mcp-server"]
+    timeout: 120
+    connect_timeout: 60
+```
+
+### Verify Connection
+
+After configuring, verify the connection:
+
+```bash
+hermes tools                    # open curses UI
+                                # filter "pencil" or "design"
+                                # should list all Pencil operations
+```
+
+If tools don't appear:
+- Check `~/.hermes/logs/agent.log` for MCP connection errors
+- Verify the Pencil server is running and reachable
+- Try `hermes /reload-mcp` to reconnect
+
+## Available Operations
+
+Once connected, all Pencil MCP tools are available. Common operations:
+
+| Operation | Purpose |
+|-----------|---------|
+| `open_document` | Open a .pen file for editing |
+| `get_editor_state` | Query current editor state (selection, zoom, viewport) |
+| `batch_design` | Insert/update/delete/move design nodes in bulk |
+| `batch_get` | Fetch multiple nodes by ID or pattern |
+| `get_screenshot` | Capture current viewport as image |
+| `snapshot_layout` | Get layout analysis (spacing, alignment, structure) |
+| `export_nodes` | Export selected nodes as images (PNG, SVG, etc.) |
+| `get_variables` | Retrieve design variables and theme definitions |
+| `set_variables` | Update design variables and apply themes |
+| `get_guidelines` | Fetch design guidelines and style archetypes |
+| `find_empty_space_on_canvas` | Find available space for new elements |
+| `search_all_unique_properties` | Find all unique property values in design |
+| `replace_all_matching_properties` | Bulk-replace properties matching patterns |
+
+Full operation docs are available in the Pencil MCP server reference.
+
+## Workflow Examples
+
+### 1. Create a New Design from Scratch
+
+```
+Agent: I'll create a mobile app login screen design for you.
+
+Action: open_document → create new design document
+
+Then:
+- Use batch_design to insert frame containers, text fields, buttons
+- Use set_variables to define colors, typography, spacing
+- Use get_screenshot to verify the design looks right
+- Use export_nodes to save mockups as PNG
+```
+
+### 2. Modify an Existing Design
+
+```
+User: Update the button colors to our new brand colors.
+
+Agent: I'll open your design, find all buttons, and update their fill colors.
+
+Action: open_document → batch_get all button components
+→ replace_all_matching_properties to update fill colors
+→ set_variables to sync the design tokens
+→ get_screenshot to verify changes
+```
+
+### 3. Bulk Design Operations
+
+```
+User: Add a 16px padding to all containers.
+
+Agent: I'll find all container frames and update their padding property.
+
+Action: batch_get containers
+→ batch_design with padding updates
+→ snapshot_layout to verify spacing
+```
+
+### 4. Design System Management
+
+```
+User: Create a design system with color tokens and typography.
+
+Agent: I'll set up design variables for colors, fonts, and spacing.
+
+Action: get_guidelines → set_variables with theme definitions
+→ Create reusable component instances
+→ get_variables to confirm token setup
+```
+
+### 5. Export Assets for Development
+
+```
+User: Export all component screens as PNG for the dev team.
+
+Agent: I'll extract each component and export as individual images.
+
+Action: batch_get component nodes
+→ export_nodes to PNG
+→ Return file paths to uploaded assets
+```
+
+## Design Patterns & Best Practices
+
+### Naming Conventions
+
+Use clear, semantic names for components and variables:
+
+- **Colors**: `color.primary`, `color.secondary`, `color.success`, `color.error`
+- **Typography**: `typography.heading-1`, `typography.body`, `typography.caption`
+- **Spacing**: `spacing.xs`, `spacing.sm`, `spacing.md`, `spacing.lg`, `spacing.xl`
+- **Components**: `Button.Primary`, `Button.Secondary`, `Card.Default`, `Card.Featured`
+
+### Batch Operations Best Practices
+
+When using `batch_design` for bulk updates:
+
+1. **Plan the operations** — list all nodes to update before calling batch_design
+2. **Use bindings** — give temporary names to inserted nodes for follow-up operations
+3. **Test incrementally** — use `get_screenshot` after each major batch to verify
+4. **Keep descendants organized** — use the `descendants` map when copying components to customize sub-elements
+
+Example batch operation:
+
+```javascript
+// Insert frame
+container=I("parentId",{type:"frame",layout:"vertical",gap:16,padding:16})
+
+// Insert children into that frame
+title=I(container,{type:"text",content:"Title",fontSize:24})
+body=I(container,{type:"text",content:"Body",fontSize:14})
+
+// Update a nested element inside a component instance
+card=I("parentId",{type:"ref",ref:"CardComponent"})
+U(card+"/cardTitle",{content:"New Title"})
+```
+
+### Component Instance Customization
+
+When working with component instances (reusable=true):
+
+- Use `ref` nodes to create instances of components
+- Override properties with the instance's properties object
+- Use `descendants` to customize child elements within instances
+- Use subsequent `U` (update) operations for nested property changes
+
+## Troubleshooting
+
+### "Tool not found" / MCP operations not available
+
+1. **Check config.yaml**:
+   ```bash
+   cat ~/.hermes/config.yaml | grep -A 10 "mcp_servers:"
+   ```
+
+2. **Check server is running**:
+   - Verify Pencil MCP server is accessible
+   - Check logs at `~/.hermes/logs/agent.log` for connection errors
+
+3. **Reconnect**:
+   ```bash
+   hermes /reload-mcp
+   ```
+
+### "Connection timeout" / Slow responses
+
+- Increase `timeout` in config.yaml (default 120s)
+- Check network latency if using HTTP/SSH transport
+- Verify Pencil server isn't overloaded
+
+### "File not found" when opening .pen files
+
+- Ensure file paths are absolute or relative to current working directory
+- Use `terminal(cwd=...)` to change working directory before opening
+- Verify you have read/write permissions on the file
+
+### Design edits not persisting
+
+- Confirm that Pencil MCP is saving changes to disk (should be automatic)
+- Check file system permissions on the .pen file
+- Look for any "read-only" or "locked" status in editor state
+
+## Integration with Other Skills
+
+### With `claude-design`
+
+Combine `pencil-design` (programmatic .pen editing) with `claude-design` (design process/taste) when building complex interfaces:
+
+- Use `pencil-design` for automated batch updates, exports, and system management
+- Use `claude-design` for one-off artistry, visual polish, and human-facing mockups
+
+### With `design-md`
+
+Use `design-md` alongside `pencil-design` when exporting design tokens:
+
+- Define variables in Pencil design system
+- Export to DESIGN.md format with `design-md` skill
+- Author design-token specs for downstream consumption
+
+### With `popular-web-designs`
+
+Reference existing design systems (Stripe, Linear, Vercel, etc.) to inform Pencil design decisions:
+
+- Pull visual vocabulary from `popular-web-designs`
+- Implement color, typography, and spacing in Pencil
+- Export tokens to DESIGN.md or code
+
+## References
+
+- **Pencil MCP docs**: https://github.com/pencil-mcp/docs (adjust as needed)
+- **MCP specification**: https://modelcontextprotocol.io/
+- **Related skills**: `design-md`, `claude-design`, `popular-web-designs`
+- **Hermes MCP integration**: See `/reload-mcp` command and `mcp_servers:` config section
+
+## Notes
+
+- Pencil MCP is accessed through Hermes' generic MCP client in `tools/mcp_tool.py`
+- All .pen file operations are mediated by the Pencil server — no direct file parsing
+- Design changes are persisted to disk by the Pencil MCP server automatically
+- Screenshots and exports are served by the Pencil server (may require additional file handling)


### PR DESCRIPTION
## What does this PR do?

Adds a new optional creative skill for Pencil MCP integration.

This PR introduces pencil-design with a full skill definition and supporting documentation. It enables Hermes users to connect to a Pencil MCP server and perform design workflows such as opening `.pen` documents, batch editing design nodes, exporting assets, managing variables/themes, and analyzing layouts.

## Related Issue

Fixes # (none)

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Added SKILL.md
- Added README.md
- Added SETUP.md
- Added OPERATIONS.md
- Added EXAMPLES.md

## How to Test

1. Verify the skill files exist in pencil-design.
2. Confirm the skill metadata is valid YAML and includes the required SKILL.md frontmatter.
3. Optionally, run `hermes skills install official/creative/pencil-design` in a Hermes environment to ensure the skill can be discovered and loaded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow Conventional Commits
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [ ] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [ ] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — yes, skill docs were added
- [ ] I've updated cli-config.yaml.example if I added/changed config keys
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows
- [ ] I've considered cross-platform impact — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

N/A