### PR TITLE
fix(agent): replace fragile tool_call regex with brace-depth scanner for nested JSON

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -53,6 +53,95 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
     return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
+def _find_matching_brace(text: str, start: int) -> int:
+    """Return position of matching ``}`` for ``{`` at *start*, or -1.
+
+    Properly skips string contents (including escaped quotes) so that
+    braces inside JSON string values are never counted as structural
+    delimiters.  This is the root fix for the fragile regex in
+    ``_TOOL_CALL_BLOCK_RE``, which uses ``.*?`` (lazy) and can match a
+    ``}`` embedded inside a string value, producing truncated JSON.
+    """
+    if start >= len(text) or text[start] != "{":
+        return -1
+    depth = 1
+    i = start + 1
+    in_string = False
+    escape = False
+    while i < len(text) and depth > 0:
+        ch = text[i]
+        if escape:
+            escape = False
+        elif ch == "\\" and in_string:
+            escape = True
+        elif ch == '"' and not escape:
+            in_string = not in_string
+        elif not in_string:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+        i += 1
+    return i - 1 if depth == 0 else -1
+
+
+def _extract_tool_call_blocks(text: str) -> list[tuple[int, int, str]]:
+    """Find ``<tool_call>`` blocks using brace-depth scanning.
+
+    Returns a list of ``(start, end, json_str)`` tuples where *start*
+    points at ``<`` of the opening tag and *end* points just past the
+    closing ``>`` of ``</tool_call>``.
+
+    Unlike the regex equivalent (``_TOOL_CALL_BLOCK_RE``), this scanner
+    properly handles:
+    - Nested JSON objects (brace depth tracking)
+    - ``<tool_call>`` or ``</tool_call>`` appearing inside JSON string
+      values (string-aware scanning)
+    - ``}`` characters inside JSON string values (not counted as
+      structural delimiters)
+    - Multiple ``<tool_call>`` blocks in the same text
+    """
+    results: list[tuple[int, int, str]] = []
+    pos = 0
+    while True:
+        start = text.find("<tool_call>", pos)
+        if start == -1:
+            break
+
+        content_start = start + len("<tool_call>")
+
+        # Find the opening JSON brace after the tag.
+        brace_start = -1
+        for i in range(content_start, len(text)):
+            if text[i] == "{":
+                brace_start = i
+                break
+            if text[i] not in " \t\n\r":
+                break  # Non-whitespace before brace → not a valid tool_call block
+        if brace_start == -1:
+            pos = start + 1
+            continue
+
+        brace_end = _find_matching_brace(text, brace_start)
+        if brace_end == -1:
+            pos = start + 1
+            continue
+
+        # Expect whitespace (optional) then </tool_call>.
+        after = brace_end + 1
+        while after < len(text) and text[after] in " \t\n\r":
+            after += 1
+        if text[after : after + len("</tool_call>")] != "</tool_call>":
+            pos = start + 1
+            continue
+
+        block_end = after + len("</tool_call>")
+        results.append((start, block_end, text[brace_start : brace_end + 1]))
+        pos = block_end
+
+    return results
+
+
 def _resolve_command() -> str:
     return (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
@@ -268,10 +357,11 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str
             )
         )
 
-    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
-        raw = m.group(1)
-        _try_add_tool_call(raw)
-        consumed_spans.append((m.start(), m.end()))
+    # Use brace-depth scanner instead of regex -- handles nested JSON and
+    # </tool_call> appearing inside JSON string values (see #22696).
+    for block_start, block_end, json_str in _extract_tool_call_blocks(text):
+        _try_add_tool_call(json_str)
+        consumed_spans.append((block_start, block_end))
 
     # Only try bare-JSON fallback when no XML blocks were found.
     if not extracted:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,145 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+class TestToolCallBlockExtraction:
+    """Unit tests for _extract_tool_call_blocks, _find_matching_brace,
+    and _extract_tool_calls_from_text."""
+
+    # -- _find_matching_brace ------------------------------------------------
+
+    def test_find_brace_simple(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        assert _find_matching_brace("{a}", 0) == 2
+
+    def test_find_brace_nested_objects(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        assert _find_matching_brace('{"a": {"b": "c"}}', 0) == 16
+
+    def test_find_brace_ignores_braces_in_strings(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        # A } inside a JSON string value should not be treated as structural
+        assert _find_matching_brace('{"a": "}"}', 0) == 9
+
+    def test_find_brace_ignores_tag_in_string(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        assert _find_matching_brace('{"a": "</tool_call>"}', 0) == 20
+
+    def test_find_brace_escaped_quotes(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        import json
+        obj = {"text": 'he said "hello"'}
+        s = json.dumps(obj)
+        assert _find_matching_brace(s, 0) == len(s) - 1
+
+    def test_find_brace_unmatched(self):
+        from agent.copilot_acp_client import _find_matching_brace
+        assert _find_matching_brace("{abc", 0) == -1
+        assert _find_matching_brace("not a brace", 0) == -1
+
+    # -- _extract_tool_call_blocks ------------------------------------------
+
+    def test_extract_simple(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        import json
+        blocks = _extract_tool_call_blocks('<tool_call>{"name": "x"}</tool_call>')
+        assert len(blocks) == 1
+        assert json.loads(blocks[0][2])["name"] == "x"
+
+    def test_extract_tag_inside_string_value(self):
+        """Regression test for the reported bug: </tool_call> and } inside a
+        JSON string value should not confuse the scanner."""
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        import json
+        text = (
+            '<tool_call>{"name": "github_api", "arguments": '
+            '{"query": "repo:owner/name } </tool_call> broken"}}</tool_call>'
+        )
+        blocks = _extract_tool_call_blocks(text)
+        assert len(blocks) == 1
+        assert json.loads(blocks[0][2])["name"] == "github_api"
+
+    def test_extract_nested_json(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        import json
+        text = (
+            '<tool_call>{"name": "read", "args": '
+            '{"path": "/a/b", "opts": {"rec": true}}}</tool_call>'
+        )
+        blocks = _extract_tool_call_blocks(text)
+        assert len(blocks) == 1
+        assert json.loads(blocks[0][2])["args"]["opts"]["rec"] is True
+
+    def test_extract_multiple_blocks(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        text = '<tool_call>{"name": "a"}</tool_call> x <tool_call>{"name": "b"}</tool_call>'
+        blocks = _extract_tool_call_blocks(text)
+        assert len(blocks) == 2
+
+    def test_extract_no_blocks(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        assert _extract_tool_call_blocks("just text") == []
+        assert _extract_tool_call_blocks("use the <tool_call> tag") == []
+
+    def test_extract_whitespace_tolerant(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        blocks = _extract_tool_call_blocks('<tool_call>  {"name": "x"}  </tool_call>')
+        assert len(blocks) == 1
+
+    def test_extract_no_closing_tag(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        assert _extract_tool_call_blocks('<tool_call>{"name": "x"}') == []
+
+    def test_extract_escaped_quotes(self):
+        from agent.copilot_acp_client import _extract_tool_call_blocks
+        import json
+        inner = {"text": 'he said "hello"'}
+        s = json.dumps({"name": "echo", "args": inner})
+        blocks = _extract_tool_call_blocks(f"<tool_call>{s}</tool_call>")
+        assert len(blocks) == 1
+        parsed = json.loads(blocks[0][2])
+        assert parsed["args"]["text"] == 'he said "hello"'
+
+    # -- _extract_tool_calls_from_text (full pipeline) -----------------------
+
+    def test_pipeline_tag_inside_string(self):
+        from agent.copilot_acp_client import _extract_tool_calls_from_text
+        import json
+        tc = {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "arguments": json.dumps({"content": "</tool_call> inside"}),
+            },
+        }
+        text = f'Before <tool_call>{json.dumps(tc)}</tool_call> After'
+        calls, cleaned = _extract_tool_calls_from_text(text)
+        assert len(calls) == 1
+        assert calls[0].function.name == "write_file"
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_pipeline_standard(self):
+        from agent.copilot_acp_client import _extract_tool_calls_from_text
+        import json
+        tc = {"id": "c1", "type": "function", "function": {"name": "search", "arguments": '{"q":"t"}'}}
+        text = f'Pre <tool_call>{json.dumps(tc)}</tool_call> Post'
+        calls, cleaned = _extract_tool_calls_from_text(text)
+        assert len(calls) == 1
+        assert calls[0].function.name == "search"
+        assert "Pre" in cleaned
+        assert "Post" in cleaned
+
+    def test_pipeline_empty_text(self):
+        from agent.copilot_acp_client import _extract_tool_calls_from_text
+        calls, cleaned = _extract_tool_calls_from_text("")
+        assert calls == []
+        assert cleaned == ""
+
+    def test_pipeline_no_calls(self):
+        from agent.copilot_acp_client import _extract_tool_calls_from_text
+        calls, cleaned = _extract_tool_calls_from_text("some regular text")
+        assert calls == []
+        assert cleaned == "some regular text"


### PR DESCRIPTION
## Summary

Replace the fragile `_TOOL_CALL_BLOCK_RE` regex with a proper brace-depth scanner that correctly handles nested JSON objects and `</tool_call>` inside JSON string values.

## The Bug

The regex `r"<tool_call>\s*(\{.*?\})\s*</tool_call>"` uses a lazy `.*?` quantifier that stops at the **first** `}` followed by `</tool_call>`, even when that `}` is inside a string value.

This means any tool call with arguments containing `}` + `</tool_call>` in a string — such as:
- `write_file` with HTML content containing `</tool_call>`
- GitHub API queries containing `}` followed by close-tag patterns

...produces truncated JSON that fails `json.loads()`, causing the entire tool call to be treated as plain text and displayed to the user.

## The Fix

### `_find_matching_brace(text, start)`
Character-level state machine that tracks brace depth while respecting JSON string boundaries (including escaped quotes). Braces inside JSON string values are never counted as structural delimiters.

### `_extract_tool_call_blocks(text)`
Scans for `<tool_call>` tags, finds the first `{` after each tag, uses `_find_matching_brace` to locate the matching `}`, then verifies `</tool_call>` follows. Returns `(start, end, json_str)` tuples matching the interface already consumed by `_extract_tool_calls_from_text`.

## Test Plan

- [x] 18 new unit tests covering brace matching, block extraction, and the full pipeline
- [x] All 25 existing tests in `test_copilot_acp_client.py` pass (7 existing + 18 new)
- [x] Edge cases: nested JSON, escaped quotes, `}` inside strings, `</tool_call>` inside strings, multiple blocks, empty text, malformed input, whitespace tolerance

## Related Issues

Closes #22696

Filed by Jasper (AI agent on behalf of Magnus Hedemark)