### PR TITLE
fix(tui): reset overlays on new session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8577,8 +8577,32 @@ class HermesCLI:
         if not confirm_required:
             return "once"
 
-        # Render warning + prompt — single-line composer prompt, mirrors
-        # ``_confirm_and_reload_mcp``.
+        # In the TUI, slash commands are processed by the background
+        # ``process_loop`` thread while prompt_toolkit owns stdin on the main
+        # thread. Calling ``input()`` here races prompt_toolkit and leaves the
+        # visible confirmation prompt unable to receive keyboard input. Reuse
+        # the prompt_toolkit approval modal for thread-safe selection.
+        if getattr(self, "_app", None) and threading.current_thread() is not threading.main_thread():
+            verdict = self._approval_callback(
+                command=f"/{command}",
+                description=f"Destroys conversation state. {detail.replace(chr(10), ' ')}",
+                allow_permanent=True,
+            )
+            if verdict == "deny":
+                print(f"🟡 /{command} cancelled. Conversation unchanged.")
+                return None
+            if verdict == "session":
+                verdict = "once"
+            if verdict == "always":
+                if save_config_value("approvals.destructive_slash_confirm", False):
+                    print("🔒 Future /clear, /new, /reset, and /undo will run without confirmation.")
+                    print("   Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.")
+                else:
+                    print("⚠️  Couldn't persist opt-out — proceeding once.")
+            return verdict if verdict in ("once", "always") else None
+
+        # Non-TUI path: render warning + prompt — single-line composer prompt,
+        # mirrors ``_confirm_and_reload_mcp``.
         print()
         print(f"⚠️  /{command} — destroys conversation state")
         print()

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import patch
+import threading
 
 
 def _bound(fn, instance):
@@ -20,6 +21,17 @@ def _make_self(prompt_response):
     return SimpleNamespace(
         _app=None,
         _prompt_text_input=lambda _prompt: prompt_response,
+    )
+
+
+def _make_tui_self(approval_response):
+    """Build a minimal TUI stand-in that must not read stdin directly."""
+    return SimpleNamespace(
+        _app=object(),
+        _prompt_text_input=lambda _prompt: (_ for _ in ()).throw(
+            AssertionError("TUI path must not call input/prompt_text_input")
+        ),
+        _approval_callback=lambda **_kwargs: approval_response,
     )
 
 
@@ -132,6 +144,34 @@ def test_gate_on_choice_always_persists_and_returns_always():
 
     assert result == "always"
     assert ("approvals.destructive_slash_confirm", False) in saves
+
+
+def test_tui_background_thread_uses_approval_modal_not_stdin():
+    """In the TUI process_loop thread, use prompt_toolkit modal approval.
+
+    Calling _prompt_text_input/input() from this background thread races the
+    prompt_toolkit main loop and leaves /new unable to receive keyboard input.
+    """
+    from cli import HermesCLI
+
+    self_ = _make_tui_self(approval_response="once")
+    result_holder = []
+
+    def _run():
+        with patch(
+            "cli.load_cli_config",
+            return_value={"approvals": {"destructive_slash_confirm": True}},
+        ):
+            result_holder.append(
+                _bound(HermesCLI._confirm_destructive_slash, self_)("new", "detail")
+            )
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    assert result_holder == ["once"]
 
 
 def test_gate_default_true_when_config_missing():

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -19,7 +19,7 @@ import { asRpcResult } from '../lib/rpc.js'
 import type { Msg, PanelSection, SessionInfo, Usage } from '../types.js'
 
 import type { ComposerActions, GatewayRpc, StateSetter } from './interfaces.js'
-import { patchOverlayState } from './overlayStore.js'
+import { patchOverlayState, resetOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -92,6 +92,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   )
 
   const resetSession = useCallback(() => {
+    resetOverlayState()
     turnController.fullReset()
     setVoiceRecording(false)
     setVoiceProcessing(false)


### PR DESCRIPTION
## Summary
- reset TUI overlay state when starting a fresh session
- prevents stale confirmation/tool overlays from blocking composer input after `/new`

## Testing
- `npm run type-check` (ui-tui)
- `npm test` (ui-tui)
- `npm run build` (ui-tui)