### PR TITLE
feat(agent): add host-managed async compression for context engines

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1305,6 +1305,11 @@ def init_agent(
             api_mode=agent.api_mode,
         )
     agent.compression_enabled = compression_enabled
+    agent._async_context_lock = threading.Lock()
+    agent._async_context_thread: threading.Thread | None = None
+    agent._async_context_inflight_digest: str | None = None
+    agent._pending_async_context_candidate = None
+    agent._async_context_generation = 0
 
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -21,12 +21,34 @@ Lifecycle:
   3. update_from_response() called after each API response with usage data
   4. should_compress() checked after each turn
   5. compress() called when should_compress() returns True
-  6. on_session_end() called at real session boundaries (CLI exit, /reset,
+  6. Optional async preparation may run on a host-owned background thread:
+     should_prepare_async_compression() -> prepare_async_compression().
+     The result is only a candidate; the host validates and applies it at a
+     safe point.
+  7. on_session_end() called at real session boundaries (CLI exit, /reset,
      gateway session expiry) — NOT per-turn
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ContextCompressionCandidate:
+    """Prepared context rewrite returned by asynchronous context engines.
+
+    The host owns the commit lifecycle. Engines may prepare a replacement for
+    an immutable snapshot, but the host validates ``base_digest`` against the
+    live transcript before applying it and appends any newer suffix messages.
+    """
+
+    messages: List[Dict[str, Any]]
+    base_message_count: int = 0
+    base_digest: str = ""
+    estimated_tokens_saved: Optional[int] = None
+    description: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class ContextEngine(ABC):
@@ -109,6 +131,53 @@ class ContextEngine(ABC):
         can do a cheap estimate.
         """
         return False
+
+    # -- Optional: asynchronous candidate preparation -------------------------
+
+    def should_prepare_async_compression(
+        self,
+        prompt_tokens: int = None,
+        messages: List[Dict[str, Any]] = None,
+    ) -> bool:
+        """Return True when the host should prepare a background candidate.
+
+        This is intentionally separate from ``should_compress()``. Returning
+        True here must not imply that the live transcript can be rewritten
+        immediately; the host snapshots ``messages``, runs
+        ``prepare_async_compression()`` in the background, then validates the
+        returned candidate at a later safe point.
+        """
+        return False
+
+    def prepare_async_compression(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ) -> Optional[ContextCompressionCandidate | List[Dict[str, Any]]]:
+        """Prepare a compression candidate for an immutable snapshot.
+
+        Implementations must treat ``messages`` as read-only and must not mutate
+        live agent state. They may return either a ``ContextCompressionCandidate``
+        or a replacement OpenAI-format message list; the host fills in snapshot
+        version metadata when omitted.
+        """
+        return None
+
+    def on_async_compression_applied(
+        self,
+        candidate: ContextCompressionCandidate,
+        **kwargs: Any,
+    ) -> None:
+        """Called after the host successfully applies an async candidate."""
+
+    def on_async_compression_discarded(
+        self,
+        candidate: ContextCompressionCandidate,
+        reason: str,
+        **kwargs: Any,
+    ) -> None:
+        """Called when the host discards a prepared candidate."""
 
     # -- Optional: manual /compress preflight ------------------------------
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -28,14 +28,19 @@ these paths see no behavioural change.
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import json
 import logging
 import os
 import tempfile
+import threading
 import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+from agent.context_engine import ContextCompressionCandidate, ContextEngine
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -240,6 +245,402 @@ def replay_compression_warning(agent: Any) -> None:
             pass
 
 
+def get_async_context_lock(agent: Any) -> threading.Lock:
+    lock = getattr(agent, "_async_context_lock", None)
+    if lock is None:
+        lock = threading.Lock()
+        agent._async_context_lock = lock
+    return lock
+
+
+def context_messages_digest(messages: list) -> str:
+    payload = json.dumps(
+        messages,
+        sort_keys=True,
+        ensure_ascii=False,
+        default=str,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def clear_async_context_candidate(agent: Any) -> None:
+    lock = get_async_context_lock(agent)
+    with lock:
+        agent._pending_async_context_candidate = None
+        agent._async_context_inflight_digest = None
+        agent._async_context_generation = (
+            getattr(agent, "_async_context_generation", 0) + 1
+        )
+        thread = getattr(agent, "_async_context_thread", None)
+        if thread is not None and not thread.is_alive():
+            agent._async_context_thread = None
+
+
+def _coerce_async_context_candidate(
+    agent: Any,
+    result: Any,
+    *,
+    snapshot: list,
+) -> ContextCompressionCandidate | None:
+    if result is None:
+        return None
+    if isinstance(result, ContextCompressionCandidate):
+        candidate = result
+    elif isinstance(result, list):
+        candidate = ContextCompressionCandidate(messages=result)
+    else:
+        return None
+    if not isinstance(candidate.messages, list):
+        return None
+    base_message_count = len(snapshot)
+    if candidate.base_message_count <= 0:
+        candidate.base_message_count = base_message_count
+    if candidate.base_message_count > base_message_count:
+        return None
+    if not candidate.base_digest:
+        candidate.base_digest = agent._context_messages_digest(
+            snapshot[: candidate.base_message_count]
+        )
+    return candidate
+
+
+def _notify_async_context_discarded(
+    agent: Any,
+    candidate: ContextCompressionCandidate,
+    reason: str,
+) -> None:
+    try:
+        agent.context_compressor.on_async_compression_discarded(
+            candidate,
+            reason=reason,
+            session_id=agent.session_id or "",
+        )
+    except Exception as exc:
+        logger.debug("context engine async discard hook failed: %s", exc)
+
+
+def maybe_start_async_context_compression(
+    agent: Any,
+    messages: list,
+    *,
+    approx_tokens: Optional[int] = None,
+    focus_topic: Optional[str] = None,
+) -> bool:
+    """Ask the active context engine to prepare a background candidate.
+
+    The host owns snapshotting and commit.  The engine only computes a
+    candidate on a copied message list; the live transcript is never mutated
+    from the background thread.
+    """
+    if not getattr(agent, "compression_enabled", False):
+        return False
+    engine = getattr(agent, "context_compressor", None)
+    if engine is None:
+        return False
+    should_prepare = getattr(engine, "should_prepare_async_compression", None)
+    prepare = getattr(engine, "prepare_async_compression", None)
+    if not callable(should_prepare) or not callable(prepare):
+        return False
+    if (
+        getattr(type(engine), "should_prepare_async_compression", None)
+        is ContextEngine.should_prepare_async_compression
+    ):
+        return False
+
+    lock = agent._get_async_context_lock()
+    with lock:
+        thread = getattr(agent, "_async_context_thread", None)
+        if thread is not None and thread.is_alive():
+            return False
+        if getattr(agent, "_pending_async_context_candidate", None) is not None:
+            return False
+        generation = getattr(agent, "_async_context_generation", 0)
+
+    if approx_tokens is None:
+        try:
+            approx_tokens = estimate_request_tokens_rough(
+                messages,
+                system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
+                tools=agent.tools or None,
+            )
+        except Exception as exc:
+            logger.debug("context engine async token estimate failed: %s", exc)
+            return False
+
+    try:
+        try:
+            should = bool(
+                should_prepare(prompt_tokens=approx_tokens, messages=messages)
+            )
+        except TypeError:
+            should = bool(should_prepare(approx_tokens))
+    except Exception as exc:
+        logger.debug("context engine async prepare check failed: %s", exc)
+        return False
+    if not should:
+        return False
+
+    snapshot = copy.deepcopy(messages)
+    base_digest = agent._context_messages_digest(snapshot)
+    base_message_count = len(snapshot)
+
+    def _run_prepare() -> None:
+        candidate = None
+        try:
+            try:
+                result = prepare(
+                    snapshot,
+                    current_tokens=approx_tokens,
+                    focus_topic=focus_topic,
+                )
+            except TypeError:
+                result = prepare(snapshot, current_tokens=approx_tokens)
+            candidate = _coerce_async_context_candidate(
+                agent,
+                result,
+                snapshot=snapshot,
+            )
+        except Exception as exc:
+            logger.debug("context engine async compression preparation failed: %s", exc)
+        finally:
+            lock = agent._get_async_context_lock()
+            with lock:
+                if getattr(agent, "_async_context_generation", 0) != generation:
+                    return
+                agent._async_context_inflight_digest = None
+                thread = getattr(agent, "_async_context_thread", None)
+                if thread is not None and threading.current_thread() is thread:
+                    agent._async_context_thread = None
+                if candidate is not None:
+                    agent._pending_async_context_candidate = candidate
+
+    thread = threading.Thread(
+        target=_run_prepare,
+        daemon=True,
+        name="context-compression-prepare",
+    )
+    with lock:
+        current_thread = getattr(agent, "_async_context_thread", None)
+        if getattr(agent, "_async_context_generation", 0) != generation:
+            return False
+        if current_thread is not None and current_thread.is_alive():
+            return False
+        if getattr(agent, "_pending_async_context_candidate", None) is not None:
+            return False
+        agent._async_context_thread = thread
+        agent._async_context_inflight_digest = base_digest
+    thread.start()
+    logger.debug(
+        "context async compression preparation started: session=%s messages=%d tokens=~%s",
+        agent.session_id or "none",
+        base_message_count,
+        f"{approx_tokens:,}" if approx_tokens else "unknown",
+    )
+    return True
+
+
+def maybe_apply_async_context_candidate(
+    agent: Any,
+    messages: list,
+    system_message: str,
+    *,
+    approx_tokens: Optional[int] = None,
+    task_id: str = "default",
+) -> tuple[list, str | None, bool]:
+    """Apply a prepared candidate if its snapshot still matches ``messages``."""
+    lock = agent._get_async_context_lock()
+    with lock:
+        candidate = getattr(agent, "_pending_async_context_candidate", None)
+        if candidate is None:
+            return messages, None, False
+        agent._pending_async_context_candidate = None
+
+    base_count = candidate.base_message_count
+    if base_count <= 0 or base_count > len(messages):
+        _notify_async_context_discarded(agent, candidate, "stale_message_count")
+        return messages, None, False
+
+    current_digest = agent._context_messages_digest(messages[:base_count])
+    if current_digest != candidate.base_digest:
+        _notify_async_context_discarded(agent, candidate, "stale_digest")
+        return messages, None, False
+
+    if candidate.messages == messages[:base_count]:
+        _notify_async_context_discarded(agent, candidate, "no_op")
+        return messages, None, False
+
+    rewritten = list(candidate.messages) + list(messages[base_count:])
+    new_messages, new_system_prompt = agent._finalize_context_rewrite(
+        original_messages=messages,
+        rewritten_messages=rewritten,
+        system_message=system_message,
+        approx_tokens=approx_tokens,
+        task_id=task_id,
+        source_label="async context compression",
+        notify_memory_pre_compress=True,
+    )
+    try:
+        agent.context_compressor.on_async_compression_applied(
+            candidate,
+            session_id=agent.session_id or "",
+            new_message_count=len(new_messages),
+        )
+    except Exception as exc:
+        logger.debug("context engine async apply hook failed: %s", exc)
+    return new_messages, new_system_prompt, True
+
+
+def finalize_context_rewrite(
+    agent: Any,
+    *,
+    original_messages: list,
+    rewritten_messages: list,
+    system_message: str,
+    approx_tokens: Optional[int] = None,
+    task_id: str = "default",
+    source_label: str = "context compression",
+    notify_memory_pre_compress: bool = False,
+) -> tuple[list, str]:
+    _pre_msg_count = len(original_messages)
+    compressed = list(rewritten_messages)
+
+    if notify_memory_pre_compress and agent._memory_manager:
+        try:
+            agent._memory_manager.on_pre_compress(original_messages)
+        except Exception:
+            pass
+
+    todo_snapshot = agent._todo_store.format_for_injection()
+    if todo_snapshot:
+        compressed.append({"role": "user", "content": todo_snapshot})
+
+    agent._invalidate_system_prompt()
+    new_system_prompt = agent._build_system_prompt(system_message)
+    agent._cached_system_prompt = new_system_prompt
+
+    old_session_id = None
+    if agent._session_db:
+        try:
+            # Propagate title to the new session with auto-numbering
+            old_title = agent._session_db.get_session_title(agent.session_id)
+            # Trigger memory extraction on the old session before it rotates.
+            agent.commit_memory_session(original_messages)
+            agent._session_db.end_session(agent.session_id, "compression")
+            old_session_id = agent.session_id
+            agent.session_id = (
+                f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_"
+                f"{uuid.uuid4().hex[:6]}"
+            )
+            os.environ["HERMES_SESSION_ID"] = agent.session_id
+            try:
+                from gateway.session_context import _SESSION_ID
+
+                _SESSION_ID.set(agent.session_id)
+            except Exception:
+                pass
+            # Update session_log_file to point to the new session's JSON file
+            agent.session_log_file = agent.logs_dir / f"session_{agent.session_id}.json"
+            agent._session_db_created = False
+            agent._session_db.create_session(
+                session_id=agent.session_id,
+                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=agent.model,
+                model_config=agent._session_init_model_config,
+                parent_session_id=old_session_id,
+            )
+            agent._session_db_created = True
+            # Auto-number the title for the continuation session
+            if old_title:
+                try:
+                    new_title = agent._session_db.get_next_title_in_lineage(old_title)
+                    agent._session_db.set_session_title(agent.session_id, new_title)
+                except (ValueError, Exception) as e:
+                    logger.debug("Could not propagate title on compression: %s", e)
+            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+            # Reset flush cursor — new session starts with no messages written
+            agent._last_flushed_db_idx = 0
+        except Exception as e:
+            logger.warning(
+                "Session DB compression split failed — new session will NOT be indexed: %s",
+                e,
+            )
+
+    # Notify the context engine that the session_id rotated because of
+    # compression (not a fresh /new). Plugin engines (e.g. hermes-lcm) use
+    # boundary_reason="compression" to preserve DAG lineage across the
+    # rollover instead of re-initializing fresh per-session state.
+    # See hermes-lcm#68. Built-in ContextCompressor ignores kwargs.
+    try:
+        if old_session_id and hasattr(agent.context_compressor, "on_session_start"):
+            agent.context_compressor.on_session_start(
+                agent.session_id or "",
+                boundary_reason="compression",
+                old_session_id=old_session_id,
+            )
+    except Exception as _ce_err:
+        logger.debug("context engine on_session_start (compression): %s", _ce_err)
+
+    # Notify memory providers of the compression-driven session_id rotation
+    # so provider-cached per-session state (Hindsight's _document_id,
+    # accumulated turn buffers, counters) refreshes. reset=False because
+    # the logical conversation continues; only the id and DB row rolled
+    # over. See #6672.
+    try:
+        if old_session_id and agent._memory_manager:
+            agent._memory_manager.on_session_switch(
+                agent.session_id or "",
+                parent_session_id=old_session_id,
+                reset=False,
+                reason="compression",
+            )
+    except Exception as _me_err:
+        logger.debug("memory manager on_session_switch (compression): %s", _me_err)
+
+    # Warn on repeated compressions (quality degrades with each pass)
+    _cc = agent.context_compressor.compression_count
+    if _cc >= 2:
+        agent._vprint(
+            f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
+            f"accuracy may degrade. Consider /new to start fresh.",
+            force=True,
+        )
+
+    # Update token estimate after compaction so pressure calculations
+    # use the post-compression count, not the stale pre-compression one.
+    # Use estimate_request_tokens_rough() so tool schemas are included —
+    # with 50+ tools enabled, schemas alone can add 20-30K tokens, and
+    # omitting them delays the next compression cycle far past the
+    # configured threshold (issue #14695).
+    _compressed_est = estimate_request_tokens_rough(
+        compressed,
+        system_prompt=new_system_prompt or "",
+        tools=agent.tools or None,
+    )
+    agent.context_compressor.last_prompt_tokens = _compressed_est
+    agent.context_compressor.last_completion_tokens = 0
+
+    # Clear the file-read dedup cache.  After compression the original
+    # read content is summarised away — if the model re-reads the same
+    # file it needs the full content, not a "file unchanged" stub.
+    try:
+        from tools.file_tools import reset_file_dedup
+
+        reset_file_dedup(task_id)
+    except Exception:
+        pass
+
+    logger.info(
+        "%s done: session=%s messages=%d->%d tokens=~%s",
+        source_label,
+        agent.session_id or "none",
+        _pre_msg_count,
+        len(compressed),
+        f"{_compressed_est:,}",
+    )
+    return compressed, new_system_prompt
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -315,124 +716,14 @@ def compress_context(
                     "check auxiliary.compression.model in config.yaml."
                 )
 
-    todo_snapshot = agent._todo_store.format_for_injection()
-    if todo_snapshot:
-        compressed.append({"role": "user", "content": todo_snapshot})
-
-    agent._invalidate_system_prompt()
-    new_system_prompt = agent._build_system_prompt(system_message)
-    agent._cached_system_prompt = new_system_prompt
-
-    if agent._session_db:
-        try:
-            # Propagate title to the new session with auto-numbering
-            old_title = agent._session_db.get_session_title(agent.session_id)
-            # Trigger memory extraction on the old session before it rotates.
-            agent.commit_memory_session(messages)
-            agent._session_db.end_session(agent.session_id, "compression")
-            old_session_id = agent.session_id
-            agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
-            os.environ["HERMES_SESSION_ID"] = agent.session_id
-            try:
-                from gateway.session_context import _SESSION_ID
-                _SESSION_ID.set(agent.session_id)
-            except Exception:
-                pass
-            # Update session_log_file to point to the new session's JSON file
-            agent.session_log_file = agent.logs_dir / f"session_{agent.session_id}.json"
-            agent._session_db_created = False
-            agent._session_db.create_session(
-                session_id=agent.session_id,
-                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
-                model=agent.model,
-                model_config=agent._session_init_model_config,
-                parent_session_id=old_session_id,
-            )
-            agent._session_db_created = True
-            # Auto-number the title for the continuation session
-            if old_title:
-                try:
-                    new_title = agent._session_db.get_next_title_in_lineage(old_title)
-                    agent._session_db.set_session_title(agent.session_id, new_title)
-                except (ValueError, Exception) as e:
-                    logger.debug("Could not propagate title on compression: %s", e)
-            agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
-            # Reset flush cursor — new session starts with no messages written
-            agent._last_flushed_db_idx = 0
-        except Exception as e:
-            logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
-
-    # Notify the context engine that the session_id rotated because of
-    # compression (not a fresh /new). Plugin engines (e.g. hermes-lcm) use
-    # boundary_reason="compression" to preserve DAG lineage across the
-    # rollover instead of re-initializing fresh per-session state.
-    # See hermes-lcm#68. Built-in ContextCompressor ignores kwargs.
-    try:
-        _old_sid = locals().get("old_session_id")
-        if _old_sid and hasattr(agent.context_compressor, "on_session_start"):
-            agent.context_compressor.on_session_start(
-                agent.session_id or "",
-                boundary_reason="compression",
-                old_session_id=_old_sid,
-            )
-    except Exception as _ce_err:
-        logger.debug("context engine on_session_start (compression): %s", _ce_err)
-
-    # Notify memory providers of the compression-driven session_id rotation
-    # so provider-cached per-session state (Hindsight's _document_id,
-    # accumulated turn buffers, counters) refreshes. reset=False because
-    # the logical conversation continues; only the id and DB row rolled
-    # over. See #6672.
-    try:
-        _old_sid = locals().get("old_session_id")
-        if _old_sid and agent._memory_manager:
-            agent._memory_manager.on_session_switch(
-                agent.session_id or "",
-                parent_session_id=_old_sid,
-                reset=False,
-                reason="compression",
-            )
-    except Exception as _me_err:
-        logger.debug("memory manager on_session_switch (compression): %s", _me_err)
-
-    # Warn on repeated compressions (quality degrades with each pass)
-    _cc = agent.context_compressor.compression_count
-    if _cc >= 2:
-        agent._vprint(
-            f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-            f"accuracy may degrade. Consider /new to start fresh.",
-            force=True,
-        )
-
-    # Update token estimate after compaction so pressure calculations
-    # use the post-compression count, not the stale pre-compression one.
-    # Use estimate_request_tokens_rough() so tool schemas are included —
-    # with 50+ tools enabled, schemas alone can add 20-30K tokens, and
-    # omitting them delays the next compression cycle far past the
-    # configured threshold (issue #14695).
-    _compressed_est = estimate_request_tokens_rough(
-        compressed,
-        system_prompt=new_system_prompt or "",
-        tools=agent.tools or None,
+    return agent._finalize_context_rewrite(
+        original_messages=messages,
+        rewritten_messages=compressed,
+        system_message=system_message,
+        approx_tokens=approx_tokens,
+        task_id=task_id,
+        source_label="context compression",
     )
-    agent.context_compressor.last_prompt_tokens = _compressed_est
-    agent.context_compressor.last_completion_tokens = 0
-
-    # Clear the file-read dedup cache.  After compression the original
-    # read content is summarised away — if the model re-reads the same
-    # file it needs the full content, not a "file unchanged" stub.
-    try:
-        from tools.file_tools import reset_file_dedup
-        reset_file_dedup(task_id)
-    except Exception:
-        pass
-
-    logger.info(
-        "context compression done: session=%s messages=%d->%d tokens=~%s",
-        agent.session_id or "none", _pre_msg_count, len(compressed),
-        f"{_compressed_est:,}",
-    )
-    return compressed, new_system_prompt
 
 
 def try_shrink_image_parts_in_messages(api_messages: list) -> bool:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -259,6 +259,10 @@ def run_conversation(
     if isinstance(persist_user_message, str):
         persist_user_message = _sanitize_surrogates(persist_user_message)
 
+    # Preserve plugin lifecycle semantics even if async compression later
+    # clears conversation_history so persistence rewrites the new session.
+    hook_is_first_turn = not bool(conversation_history)
+
     # Store stream callback for _interruptible_api_call to pick up
     agent._stream_callback = stream_callback
     agent._persist_user_message_idx = None
@@ -357,6 +361,16 @@ def run_conversation(
                 # whose session happened to land just past a multiple of N).
                 agent._turns_since_memory = prior_user_turns % agent._memory_nudge_interval
 
+    if messages:
+        messages, _async_system_prompt, _async_context_applied = (
+            agent._maybe_apply_async_context_candidate(
+                messages,
+                system_message,
+                task_id=effective_task_id,
+            )
+        )
+        if _async_context_applied:
+            conversation_history = None
 
     # Prefill messages (few-shot priming) are injected at API-call time only,
     # never stored in the messages list. This keeps them ephemeral: they won't
@@ -395,6 +409,14 @@ def run_conversation(
 
     # Add user message
     user_msg = {"role": "user", "content": user_message}
+    current_turn_user_msg = user_msg
+    if messages and isinstance(messages[-1], dict) and messages[-1].get("role") == "user":
+        messages.append(
+            {
+                "role": "assistant",
+                "content": agent._ASYNC_CONTEXT_PRIOR_USER_TAIL_SEPARATOR_MESSAGE,
+            }
+        )
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
@@ -507,7 +529,7 @@ def run_conversation(
             session_id=agent.session_id,
             user_message=original_user_message,
             conversation_history=list(messages),
-            is_first_turn=(not bool(conversation_history)),
+            is_first_turn=hook_is_first_turn,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
@@ -738,6 +760,11 @@ def run_conversation(
                 repaired_seq,
                 agent.session_id or "-",
             )
+            for _idx, _msg in enumerate(messages):
+                if _msg is current_turn_user_msg:
+                    current_turn_user_idx = _idx
+                    agent._persist_user_message_idx = _idx
+                    break
 
         api_messages = []
         for idx, msg in enumerate(messages):
@@ -4053,6 +4080,21 @@ def run_conversation(
             )
         except Exception:
             pass  # Background review is best-effort
+
+    if final_response and not interrupted:
+        try:
+            _async_prompt_tokens = (
+                getattr(agent.context_compressor, "last_prompt_tokens", 0) or None
+            )
+            agent._maybe_start_async_context_compression(
+                messages,
+                approx_tokens=_async_prompt_tokens,
+            )
+        except Exception as _async_ctx_err:
+            logger.debug(
+                "async context compression scheduling failed: %s",
+                _async_ctx_err,
+            )
 
     # Note: Memory provider on_session_end() + shutdown_all() are NOT
     # called here — run_conversation() is called once per user message in

--- a/run_agent.py
+++ b/run_agent.py
@@ -335,6 +335,9 @@ class AIAgent:
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"
     )
+    _ASYNC_CONTEXT_PRIOR_USER_TAIL_SEPARATOR_MESSAGE = (
+        "--- END OF PRIOR CONTEXT — respond to the message below, not the context above ---"
+    )
 
     @property
     def base_url(self) -> str:
@@ -562,6 +565,7 @@ class AIAgent:
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
+        self._clear_async_context_candidate()
 
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """
@@ -3709,6 +3713,80 @@ class AIAgent:
             bool: True if sanitization is needed (non-Codex API), False otherwise.
         """
         return self.api_mode != "codex_responses"
+
+    def _get_async_context_lock(self) -> threading.Lock:
+        """Forwarder — see ``agent.conversation_compression.get_async_context_lock``."""
+        from agent.conversation_compression import get_async_context_lock
+        return get_async_context_lock(self)
+
+    @staticmethod
+    def _context_messages_digest(messages: list) -> str:
+        """Forwarder — see ``agent.conversation_compression.context_messages_digest``."""
+        from agent.conversation_compression import context_messages_digest
+        return context_messages_digest(messages)
+
+    def _clear_async_context_candidate(self) -> None:
+        """Forwarder — see ``agent.conversation_compression.clear_async_context_candidate``."""
+        from agent.conversation_compression import clear_async_context_candidate
+        clear_async_context_candidate(self)
+
+    def _maybe_start_async_context_compression(
+        self,
+        messages: list,
+        *,
+        approx_tokens: int = None,
+        focus_topic: str = None,
+    ) -> bool:
+        """Forwarder — see ``agent.conversation_compression.maybe_start_async_context_compression``."""
+        from agent.conversation_compression import maybe_start_async_context_compression
+        return maybe_start_async_context_compression(
+            self,
+            messages,
+            approx_tokens=approx_tokens,
+            focus_topic=focus_topic,
+        )
+
+    def _maybe_apply_async_context_candidate(
+        self,
+        messages: list,
+        system_message: str,
+        *,
+        approx_tokens: int = None,
+        task_id: str = "default",
+    ) -> tuple[list, str | None, bool]:
+        """Forwarder — see ``agent.conversation_compression.maybe_apply_async_context_candidate``."""
+        from agent.conversation_compression import maybe_apply_async_context_candidate
+        return maybe_apply_async_context_candidate(
+            self,
+            messages,
+            system_message,
+            approx_tokens=approx_tokens,
+            task_id=task_id,
+        )
+
+    def _finalize_context_rewrite(
+        self,
+        *,
+        original_messages: list,
+        rewritten_messages: list,
+        system_message: str,
+        approx_tokens: int = None,
+        task_id: str = "default",
+        source_label: str = "context compression",
+        notify_memory_pre_compress: bool = False,
+    ) -> tuple[list, str]:
+        """Forwarder — see ``agent.conversation_compression.finalize_context_rewrite``."""
+        from agent.conversation_compression import finalize_context_rewrite
+        return finalize_context_rewrite(
+            self,
+            original_messages=original_messages,
+            rewritten_messages=rewritten_messages,
+            system_message=system_message,
+            approx_tokens=approx_tokens,
+            task_id=task_id,
+            source_label=source_label,
+            notify_memory_pre_compress=notify_memory_pre_compress,
+        )
 
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``."""

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from typing import Any, Dict, List
 
-from agent.context_engine import ContextEngine
+from agent.context_engine import ContextCompressionCandidate, ContextEngine
 from agent.context_compressor import ContextCompressor
 
 
@@ -123,6 +123,16 @@ class TestDefaults:
     def test_should_compress_preflight_default_false(self):
         engine = StubEngine()
         assert engine.should_compress_preflight([]) is False
+
+    def test_async_compression_defaults_are_noop(self):
+        engine = StubEngine()
+        messages = [{"role": "user", "content": "hello"}]
+        assert engine.should_prepare_async_compression(1000, messages) is False
+        assert engine.prepare_async_compression(messages, current_tokens=1000) is None
+        # Hooks are no-ops by default.
+        candidate = ContextCompressionCandidate(messages=messages)
+        assert engine.on_async_compression_applied(candidate) is None
+        assert engine.on_async_compression_discarded(candidate, "stale") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1207,6 +1207,60 @@ class TestPluginCommands:
             assert engine is not None
             assert engine.name == "stub-engine"
 
+    def test_general_plugin_can_register_context_engine_and_transform_tool_hook(self, tmp_path, monkeypatch):
+        """A general plugin can package a ContextEngine and realtime tool-result hook together."""
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "progressive-context"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.dump({
+                "name": "progressive-context",
+                "version": "0.1.0",
+                "description": "Test progressive context plugin",
+            })
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "from agent.context_engine import ContextEngine\n\n"
+            "class ProgressiveEngine(ContextEngine):\n"
+            "    @property\n"
+            "    def name(self):\n"
+            "        return 'progressive-context'\n\n"
+            "    def update_from_response(self, usage):\n"
+            "        return None\n\n"
+            "    def should_compress(self, prompt_tokens=None):\n"
+            "        return False\n\n"
+            "    def compress(self, messages, current_tokens=None, focus_topic=None):\n"
+            "        return messages\n\n"
+            "def _transform_tool_result(**kw):\n"
+            "    return f'compressed[{kw[\"tool_name\"]}]:' + kw['result']\n\n"
+            "def register(ctx):\n"
+            "    ctx.register_context_engine(ProgressiveEngine())\n"
+            "    ctx.register_hook('transform_tool_result', _transform_tool_result)\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["progressive-context"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.plugins as plugins_mod
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            engine = plugins_mod.get_plugin_context_engine()
+            assert engine is not None
+            assert engine.name == "progressive-context"
+            hook_results = plugins_mod.invoke_hook(
+                "transform_tool_result",
+                tool_name="terminal",
+                args={"command": "cat large.log"},
+                result="raw output",
+                task_id="task",
+                session_id="session",
+                tool_call_id="call",
+                duration_ms=7,
+            )
+            assert hook_results == ["compressed[terminal]:raw output"]
+
     def test_commands_tracked_on_loaded_plugin(self, tmp_path, monkeypatch):
         """Commands registered during discover_and_load() are tracked on LoadedPlugin."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/run_agent/test_async_context_compression.py
+++ b/tests/run_agent/test_async_context_compression.py
@@ -1,0 +1,674 @@
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor
+from agent.context_engine import ContextCompressionCandidate
+from run_agent import AIAgent
+
+
+class _AsyncEngine:
+    def __init__(self, replacement=None):
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.threshold_tokens = 1_000_000
+        self.protect_first_n = 3
+        self.protect_last_n = 6
+        self.compression_count = 0
+        self.replacement = replacement
+        self.applied = []
+        self.discarded = []
+        self.reset_count = 0
+        self.session_start_calls = []
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def should_prepare_async_compression(self, prompt_tokens=None, messages=None):
+        return True
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        return self.replacement or [{"role": "user", "content": "compressed"}]
+
+    def on_async_compression_applied(self, candidate, **kwargs):
+        self.applied.append((candidate, kwargs))
+
+    def on_async_compression_discarded(self, candidate, reason, **kwargs):
+        self.discarded.append((candidate, reason, kwargs))
+
+    def on_session_reset(self):
+        self.reset_count += 1
+
+    def on_session_start(self, session_id, **kwargs):
+        self.session_start_calls.append((session_id, kwargs))
+
+
+class _BlockingAsyncEngine(_AsyncEngine):
+    def __init__(self, replacement=None):
+        super().__init__(replacement=replacement)
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        self.entered.set()
+        assert self.release.wait(timeout=2), "test did not release async prepare"
+        return super().prepare_async_compression(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+        )
+
+
+class _ThresholdAsyncEngine(_AsyncEngine):
+    def __init__(self, *, threshold=10_000, replacement=None):
+        super().__init__(replacement=replacement)
+        self.threshold = threshold
+        self.should_tokens = []
+        self.prepare_tokens = []
+
+    def should_prepare_async_compression(self, prompt_tokens=None, messages=None):
+        self.should_tokens.append(prompt_tokens)
+        return bool(prompt_tokens and prompt_tokens >= self.threshold)
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        self.prepare_tokens.append(current_tokens)
+        return super().prepare_async_compression(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+        )
+
+
+def _minimal_agent(engine):
+    agent = AIAgent.__new__(AIAgent)
+    agent.compression_enabled = True
+    agent.context_compressor = engine
+    agent._async_context_lock = threading.Lock()
+    agent._async_context_thread = None
+    agent._async_context_inflight_digest = None
+    agent._pending_async_context_candidate = None
+    agent._async_context_generation = 0
+    agent._cached_system_prompt = ""
+    agent.tools = []
+    agent.session_id = "sess"
+    return agent
+
+
+def _mock_response(content, usage=None):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        model="test/model",
+        usage=SimpleNamespace(**usage) if usage else None,
+    )
+
+
+def _make_conversation_agent(engine, *, session_db=None, session_id=None):
+    tool_defs = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "web search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    with (
+        patch("run_agent.get_tool_definitions", return_value=tool_defs),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent.context_compressor = engine
+    agent.compression_enabled = True
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    return agent
+
+
+def _wait_for_pending(agent, timeout=2):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if agent._pending_async_context_candidate is not None:
+            return agent._pending_async_context_candidate
+        time.sleep(0.01)
+    return None
+
+
+def test_async_context_prepare_stores_candidate():
+    engine = _AsyncEngine()
+    agent = _minimal_agent(engine)
+    messages = [{"role": "user", "content": "hello"}]
+
+    assert agent._maybe_start_async_context_compression(messages, approx_tokens=25_000)
+
+    candidate = _wait_for_pending(agent)
+    assert isinstance(candidate, ContextCompressionCandidate)
+    assert candidate.messages == [{"role": "user", "content": "compressed"}]
+    assert candidate.base_message_count == len(messages)
+    assert candidate.base_digest == agent._context_messages_digest(messages)
+
+
+def test_async_context_apply_validates_digest_and_appends_new_suffix(monkeypatch):
+    engine = _AsyncEngine()
+    agent = _minimal_agent(engine)
+    base_messages = [
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "done"},
+    ]
+    suffix = [{"role": "user", "content": "new ask"}]
+    candidate_messages = [{"role": "user", "content": "summary"}]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=candidate_messages,
+        base_message_count=len(base_messages),
+        base_digest=agent._context_messages_digest(base_messages),
+    )
+
+    def _fake_finalize(**kwargs):
+        assert kwargs["original_messages"] == base_messages + suffix
+        assert kwargs["rewritten_messages"] == candidate_messages + suffix
+        assert kwargs["source_label"] == "async context compression"
+        assert kwargs["notify_memory_pre_compress"] is True
+        return kwargs["rewritten_messages"], "new system"
+
+    monkeypatch.setattr(agent, "_finalize_context_rewrite", _fake_finalize)
+
+    new_messages, new_prompt, applied = agent._maybe_apply_async_context_candidate(
+        base_messages + suffix,
+        "system",
+        task_id="task",
+    )
+
+    assert applied is True
+    assert new_prompt == "new system"
+    assert new_messages == candidate_messages + suffix
+    assert engine.applied
+    assert not engine.discarded
+
+
+def test_async_context_prepare_fills_missing_digest_for_partial_candidate(monkeypatch):
+    replacement = [
+        {"role": "user", "content": "compressed prefix"},
+        {"role": "assistant", "content": "prefix summarized"},
+    ]
+    engine = _AsyncEngine(
+        replacement=ContextCompressionCandidate(
+            messages=replacement,
+            base_message_count=1,
+            base_digest="",
+        )
+    )
+    agent = _minimal_agent(engine)
+    messages = [
+        {"role": "user", "content": "old prefix"},
+        {"role": "assistant", "content": "suffix answer"},
+    ]
+
+    assert agent._maybe_start_async_context_compression(messages, approx_tokens=25_000)
+    candidate = _wait_for_pending(agent)
+
+    assert isinstance(candidate, ContextCompressionCandidate)
+    assert candidate.base_message_count == 1
+    assert candidate.base_digest == agent._context_messages_digest(messages[:1])
+
+    def _fake_finalize(**kwargs):
+        assert kwargs["rewritten_messages"] == replacement + messages[1:]
+        return kwargs["rewritten_messages"], "new system"
+
+    monkeypatch.setattr(agent, "_finalize_context_rewrite", _fake_finalize)
+
+    new_messages, _new_prompt, applied = agent._maybe_apply_async_context_candidate(
+        messages,
+        "system",
+        task_id="task",
+    )
+
+    assert applied is True
+    assert new_messages == replacement + messages[1:]
+    assert engine.applied
+    assert not engine.discarded
+
+
+def test_async_context_apply_discards_stale_candidate(monkeypatch):
+    engine = _AsyncEngine()
+    agent = _minimal_agent(engine)
+    base_messages = [{"role": "user", "content": "old"}]
+    live_messages = [{"role": "user", "content": "changed"}]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=[{"role": "user", "content": "summary"}],
+        base_message_count=len(base_messages),
+        base_digest=agent._context_messages_digest(base_messages),
+    )
+
+    def _should_not_finalize(**_kwargs):
+        raise AssertionError("stale candidates must not be applied")
+
+    monkeypatch.setattr(agent, "_finalize_context_rewrite", _should_not_finalize)
+
+    new_messages, new_prompt, applied = agent._maybe_apply_async_context_candidate(
+        live_messages,
+        "system",
+        task_id="task",
+    )
+
+    assert applied is False
+    assert new_prompt is None
+    assert new_messages == live_messages
+    assert engine.discarded
+    assert engine.discarded[0][1] == "stale_digest"
+
+
+def test_run_conversation_prepares_then_applies_candidate_on_next_turn():
+    engine = _AsyncEngine(
+        replacement=[
+            {"role": "user", "content": "compressed prior turn"},
+            {"role": "assistant", "content": "prior turn summarized"},
+        ]
+    )
+    agent = _make_conversation_agent(engine)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            "first answer",
+            usage={"prompt_tokens": 25_000, "completion_tokens": 10},
+        ),
+        _mock_response(
+            "second answer",
+            usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+        ),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        first = agent.run_conversation("first ask")
+        assert isinstance(_wait_for_pending(agent), ContextCompressionCandidate)
+
+        second = agent.run_conversation(
+            "second ask",
+            conversation_history=first["messages"],
+        )
+
+    assert first["completed"] is True
+    assert first["final_response"] == "first answer"
+    assert second["completed"] is True
+    assert second["final_response"] == "second answer"
+    assert engine.applied
+    assert second["messages"][0]["content"] == "compressed prior turn"
+    assert second["messages"][1]["content"] == "prior turn summarized"
+    assert second["messages"][-2]["content"] == "second ask"
+    assert second["messages"][-1]["content"] == "second answer"
+    assert not any(msg.get("content") == "first ask" for msg in second["messages"])
+
+
+def test_async_apply_user_tail_keeps_current_turn_bookkeeping(monkeypatch):
+    engine = _AsyncEngine()
+    agent = _make_conversation_agent(engine)
+    base_history = [
+        {"role": "user", "content": "old ask"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    candidate_messages = [{"role": "user", "content": "compressed summary"}]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=candidate_messages,
+        base_message_count=len(base_history),
+        base_digest=agent._context_messages_digest(base_history),
+    )
+    agent.client.chat.completions.create.return_value = _mock_response(
+        "final answer",
+        usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+    )
+
+    def _invoke_hook(name, **_kwargs):
+        if name == "pre_llm_call":
+            return [{"context": "PLUGIN CTX"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke_hook)
+
+    with (
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_save_session_log"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "API ONLY current ask",
+            conversation_history=base_history,
+            persist_user_message="clean current ask",
+        )
+
+    api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    api_roles = [msg.get("role") for msg in api_messages]
+    assert ["user", "user"] not in [
+        api_roles[idx: idx + 2] for idx in range(len(api_roles))
+    ]
+    user_api_messages = [msg for msg in api_messages if msg.get("role") == "user"]
+    assert len(user_api_messages) == 2
+    assert user_api_messages[0]["content"] == "compressed summary"
+    current_api_content = user_api_messages[1]["content"]
+    assert "API ONLY current ask" in current_api_content
+    assert "PLUGIN CTX" in current_api_content
+
+    assert result["messages"][0] == {"role": "user", "content": "compressed summary"}
+    assert result["messages"][1] == {
+        "role": "assistant",
+        "content": AIAgent._ASYNC_CONTEXT_PRIOR_USER_TAIL_SEPARATOR_MESSAGE,
+    }
+    assert result["messages"][2] == {"role": "user", "content": "clean current ask"}
+    assert result["messages"][-1]["content"] == "final answer"
+
+
+def test_async_apply_user_tail_separates_multimodal_current_turn_with_boundary():
+    engine = _AsyncEngine()
+    agent = _make_conversation_agent(engine)
+    base_history = [
+        {"role": "user", "content": "old ask"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=[{"role": "user", "content": "compressed summary"}],
+        base_message_count=len(base_history),
+        base_digest=agent._context_messages_digest(base_history),
+    )
+    agent.client.chat.completions.create.return_value = _mock_response(
+        "vision answer",
+        usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+    )
+    multimodal_user = [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,YWJj"}},
+    ]
+
+    with (
+        patch.object(agent, "_model_supports_vision", return_value=True),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_save_session_log"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            multimodal_user,
+            conversation_history=base_history,
+        )
+
+    api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    api_roles = [msg.get("role") for msg in api_messages]
+    assert ["user", "user"] not in [
+        api_roles[idx: idx + 2] for idx in range(len(api_roles))
+    ]
+
+    user_api_messages = [msg for msg in api_messages if msg.get("role") == "user"]
+    assert len(user_api_messages) == 2
+    assert user_api_messages[0]["content"] == "compressed summary"
+    assert user_api_messages[1]["content"] == multimodal_user
+    assert result["messages"][0] == {"role": "user", "content": "compressed summary"}
+    assert result["messages"][1] == {
+        "role": "assistant",
+        "content": AIAgent._ASYNC_CONTEXT_PRIOR_USER_TAIL_SEPARATOR_MESSAGE,
+    }
+    assert result["messages"][2]["content"] == multimodal_user
+    assert result["messages"][-1]["content"] == "vision answer"
+
+
+def test_supplied_history_user_tail_preserves_persistence_offset():
+    engine = _AsyncEngine()
+    agent = _make_conversation_agent(engine)
+    history_tail = {"role": "user", "content": "interrupted old ask"}
+    history = [history_tail]
+    agent.client.chat.completions.create.return_value = _mock_response(
+        "resumed answer",
+        usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+    )
+    persist_calls = []
+
+    def _capture_persist(messages, conversation_history=None):
+        persist_calls.append((list(messages), conversation_history))
+
+    with (
+        patch.object(agent, "_persist_session", side_effect=_capture_persist),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_save_session_log"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "current ask",
+            conversation_history=history,
+        )
+
+    api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    api_roles = [msg.get("role") for msg in api_messages]
+    assert ["user", "user"] not in [
+        api_roles[idx: idx + 2] for idx in range(len(api_roles))
+    ]
+
+    assert history_tail["content"] == "interrupted old ask"
+    assert persist_calls
+    persisted_messages, persisted_history = persist_calls[-1]
+    assert persisted_history is history
+    assert persisted_messages[len(history)] == {
+        "role": "assistant",
+        "content": AIAgent._ASYNC_CONTEXT_PRIOR_USER_TAIL_SEPARATOR_MESSAGE,
+    }
+    assert persisted_messages[len(history) + 1] == {
+        "role": "user",
+        "content": "current ask",
+    }
+    assert result["messages"][len(history)] == persisted_messages[len(history)]
+    assert result["messages"][len(history) + 1] == persisted_messages[len(history) + 1]
+
+
+def test_async_apply_preserves_pre_llm_continuation_state(monkeypatch):
+    engine = _AsyncEngine()
+    agent = _make_conversation_agent(engine)
+    base_history = [
+        {"role": "user", "content": "old ask"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=[{"role": "user", "content": "compressed summary"}],
+        base_message_count=len(base_history),
+        base_digest=agent._context_messages_digest(base_history),
+    )
+    agent.client.chat.completions.create.return_value = _mock_response(
+        "final answer",
+        usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+    )
+    hook_calls = []
+    persist_calls = []
+
+    def _invoke_hook(name, **kwargs):
+        if name == "pre_llm_call":
+            hook_calls.append(kwargs)
+        return []
+
+    def _capture_persist(messages, conversation_history=None):
+        persist_calls.append((list(messages), conversation_history))
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke_hook)
+
+    with (
+        patch.object(agent, "_persist_session", side_effect=_capture_persist),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_save_session_log"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        agent.run_conversation(
+            "current ask",
+            conversation_history=base_history,
+        )
+
+    assert hook_calls
+    assert hook_calls[-1]["is_first_turn"] is False
+    assert hook_calls[-1]["conversation_history"]
+    assert persist_calls
+    assert persist_calls[-1][1] is None
+
+
+def test_async_apply_runs_session_and_memory_side_effects(tmp_path):
+    from hermes_state import SessionDB
+
+    engine = _AsyncEngine()
+    db = SessionDB(db_path=Path(tmp_path) / "session.db")
+    agent = _make_conversation_agent(
+        engine,
+        session_db=db,
+        session_id="original-session",
+    )
+    agent._memory_manager = MagicMock()
+    agent.commit_memory_session = MagicMock()
+    agent._build_system_prompt = MagicMock(return_value="rebuilt system")
+
+    original_sid = agent.session_id
+    original_messages = [
+        {"role": "user", "content": "old context"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    candidate_messages = [
+        {"role": "user", "content": "compressed context"},
+        {"role": "assistant", "content": "compressed answer"},
+    ]
+    agent._pending_async_context_candidate = ContextCompressionCandidate(
+        messages=candidate_messages,
+        base_message_count=len(original_messages),
+        base_digest=agent._context_messages_digest(original_messages),
+    )
+
+    new_messages, new_prompt, applied = agent._maybe_apply_async_context_candidate(
+        original_messages,
+        "system message",
+        approx_tokens=25_000,
+        task_id="task",
+    )
+
+    assert applied is True
+    assert new_messages == candidate_messages
+    assert new_prompt == "rebuilt system"
+    assert agent.session_id != original_sid
+    agent._build_system_prompt.assert_called_once_with("system message")
+    agent.commit_memory_session.assert_called_once_with(original_messages)
+    agent._memory_manager.on_pre_compress.assert_called_once_with(original_messages)
+    agent._memory_manager.on_session_switch.assert_called_once()
+    switch_call = agent._memory_manager.on_session_switch.call_args
+    assert switch_call.args == (agent.session_id,)
+    assert switch_call.kwargs == {
+        "parent_session_id": original_sid,
+        "reset": False,
+        "reason": "compression",
+    }
+    assert engine.session_start_calls
+    new_sid, kwargs = engine.session_start_calls[-1]
+    assert new_sid == agent.session_id
+    assert kwargs["boundary_reason"] == "compression"
+    assert kwargs["old_session_id"] == original_sid
+    assert engine.applied
+
+
+def test_builtin_compressor_does_not_opt_into_async_preparation():
+    compressor = ContextCompressor.__new__(ContextCompressor)
+    assert compressor.should_prepare_async_compression(10_000, []) is False
+    assert compressor.prepare_async_compression([], current_tokens=10_000) is None
+
+
+def test_default_noop_does_not_estimate_or_snapshot(monkeypatch):
+    compressor = ContextCompressor.__new__(ContextCompressor)
+    agent = _minimal_agent(compressor)
+    messages = [{"role": "user", "content": "hello"}]
+
+    def _fail_estimate(*_args, **_kwargs):
+        raise AssertionError("default no-op path must not estimate tokens")
+
+    def _fail_deepcopy(_value):
+        raise AssertionError("default no-op path must not snapshot messages")
+
+    monkeypatch.setattr(
+        "agent.conversation_compression.estimate_request_tokens_rough",
+        _fail_estimate,
+    )
+    monkeypatch.setattr("agent.conversation_compression.copy.deepcopy", _fail_deepcopy)
+
+    assert agent._maybe_start_async_context_compression(messages) is False
+    assert agent._pending_async_context_candidate is None
+    assert agent._async_context_thread is None
+
+
+def test_async_context_estimates_tokens_before_threshold_gate_when_usage_missing(monkeypatch):
+    engine = _ThresholdAsyncEngine(threshold=10_000)
+    agent = _minimal_agent(engine)
+    agent._cached_system_prompt = "system prompt"
+    agent.tools = [{"type": "function", "function": {"name": "example"}}]
+    messages = [{"role": "user", "content": "large transcript"}]
+    estimate_calls = []
+
+    def _estimate(messages_arg, *, system_prompt="", tools=None):
+        estimate_calls.append((messages_arg, system_prompt, tools))
+        return 25_000
+
+    monkeypatch.setattr(
+        "agent.conversation_compression.estimate_request_tokens_rough",
+        _estimate,
+    )
+
+    assert agent._maybe_start_async_context_compression(messages) is True
+
+    assert _wait_for_pending(agent) is not None
+    assert estimate_calls == [(messages, "system prompt", agent.tools)]
+    assert engine.should_tokens == [25_000]
+    assert engine.prepare_tokens == [25_000]
+
+
+def test_async_context_does_not_start_while_prepare_inflight():
+    engine = _BlockingAsyncEngine()
+    agent = _minimal_agent(engine)
+    messages = [{"role": "user", "content": "hello"}]
+
+    assert agent._maybe_start_async_context_compression(messages, approx_tokens=25_000)
+    assert engine.entered.wait(timeout=2)
+
+    try:
+        assert agent._maybe_start_async_context_compression(messages, approx_tokens=25_000) is False
+    finally:
+        engine.release.set()
+
+    thread = agent._async_context_thread
+    if thread is not None:
+        thread.join(timeout=2)
+    assert isinstance(_wait_for_pending(agent), ContextCompressionCandidate)
+
+
+def test_reset_discards_inflight_async_candidate():
+    engine = _BlockingAsyncEngine()
+    agent = _minimal_agent(engine)
+    messages = [{"role": "user", "content": "hello"}]
+
+    assert agent._maybe_start_async_context_compression(messages, approx_tokens=25_000)
+    assert engine.entered.wait(timeout=2)
+
+    agent.reset_session_state()
+    engine.release.set()
+
+    thread = agent._async_context_thread
+    if thread is not None:
+        thread.join(timeout=2)
+
+    assert engine.reset_count == 1
+    assert agent._pending_async_context_candidate is None
+    assert agent._async_context_inflight_digest is None

--- a/tests/run_agent/test_async_context_compression_plugin_integration.py
+++ b/tests/run_agent/test_async_context_compression_plugin_integration.py
@@ -1,0 +1,566 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+PLUGIN_NAME = "progressive-context-e2e"
+
+
+def _write_progressive_context_plugin(hermes_home):
+    plugin_dir = hermes_home / "plugins" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {PLUGIN_NAME}\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        """
+from agent.context_engine import ContextCompressionCandidate, ContextEngine
+
+
+class ProgressiveContextEngine(ContextEngine):
+    def __init__(self):
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.threshold_tokens = 1_000_000
+        self.context_length = 100_000
+        self.compression_count = 0
+        self.prepare_calls = 0
+        self.applied_calls = 0
+
+    @property
+    def name(self):
+        return "progressive-context-e2e"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+    def should_prepare_async_compression(self, prompt_tokens=None, messages=None):
+        return bool(prompt_tokens and prompt_tokens >= 10_000)
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        self.prepare_calls += 1
+        return ContextCompressionCandidate(
+            messages=[
+                {"role": "user", "content": "plugin compressed context"},
+                {"role": "assistant", "content": "plugin compressed answer"},
+            ],
+        )
+
+    def on_async_compression_applied(self, candidate, **kwargs):
+        self.applied_calls += 1
+
+
+_engine = ProgressiveContextEngine()
+
+
+def _transform_tool_result(**kwargs):
+    return "plugin-transform:" + kwargs["result"]
+
+
+def register(ctx):
+    ctx.register_context_engine(_engine)
+    ctx.register_hook("transform_tool_result", _transform_tool_result)
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_llm_progressive_context_plugin(hermes_home):
+    plugin_dir = hermes_home / "plugins" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {PLUGIN_NAME}\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        """
+from agent.context_engine import ContextCompressionCandidate, ContextEngine
+
+
+LLM_CALLS = []
+
+
+def fake_llm_compress(messages, current_tokens=None, focus_topic=None):
+    LLM_CALLS.append({
+        "messages": list(messages),
+        "current_tokens": current_tokens,
+        "focus_topic": focus_topic,
+    })
+    user_text = next(
+        (m.get("content", "") for m in messages if m.get("role") == "user"),
+        "",
+    )
+    return f"fake llm summary: {user_text}"
+
+
+class LlmProgressiveContextEngine(ContextEngine):
+    def __init__(self):
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.threshold_tokens = 1_000_000
+        self.context_length = 100_000
+        self.compression_count = 0
+        self.applied_calls = 0
+
+    @property
+    def name(self):
+        return "progressive-context-e2e"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+    def should_prepare_async_compression(self, prompt_tokens=None, messages=None):
+        return bool(prompt_tokens and prompt_tokens >= 10_000)
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        summary = fake_llm_compress(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+        )
+        return ContextCompressionCandidate(
+            messages=[
+                {"role": "user", "content": "[llm compressed context]\\n" + summary},
+                {"role": "assistant", "content": "llm summary ready"},
+            ],
+        )
+
+    def on_async_compression_applied(self, candidate, **kwargs):
+        self.applied_calls += 1
+
+
+_engine = LlmProgressiveContextEngine()
+
+
+def register(ctx):
+    ctx.register_context_engine(_engine)
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_slow_llm_progressive_context_plugin(hermes_home):
+    plugin_dir = hermes_home / "plugins" / PLUGIN_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {PLUGIN_NAME}\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        """
+import threading
+
+from agent.context_engine import ContextCompressionCandidate, ContextEngine
+
+
+LLM_CALLS = []
+LLM_STARTED = threading.Event()
+LLM_RELEASE = threading.Event()
+
+
+def fake_llm_compress(messages, current_tokens=None, focus_topic=None):
+    LLM_STARTED.set()
+    if not LLM_RELEASE.wait(timeout=30):
+        raise RuntimeError("test did not release fake llm")
+    LLM_CALLS.append({
+        "messages": list(messages),
+        "current_tokens": current_tokens,
+        "focus_topic": focus_topic,
+    })
+    user_text = next(
+        (m.get("content", "") for m in messages if m.get("role") == "user"),
+        "",
+    )
+    return f"slow fake llm summary: {user_text}"
+
+
+class SlowLlmProgressiveContextEngine(ContextEngine):
+    def __init__(self):
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.threshold_tokens = 1_000_000
+        self.context_length = 100_000
+        self.compression_count = 0
+        self.applied_calls = 0
+
+    @property
+    def name(self):
+        return "progressive-context-e2e"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+    def should_prepare_async_compression(self, prompt_tokens=None, messages=None):
+        return bool(prompt_tokens and prompt_tokens >= 10_000)
+
+    def prepare_async_compression(self, messages, current_tokens=None, focus_topic=None):
+        summary = fake_llm_compress(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+        )
+        return ContextCompressionCandidate(
+            messages=[
+                {"role": "user", "content": "[slow llm compressed context]\\n" + summary},
+                {"role": "assistant", "content": "slow llm summary ready"},
+            ],
+        )
+
+    def on_async_compression_applied(self, candidate, **kwargs):
+        self.applied_calls += 1
+
+
+_engine = SlowLlmProgressiveContextEngine()
+
+
+def register(ctx):
+    ctx.register_context_engine(_engine)
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_config(hermes_home):
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        f"""
+context:
+  engine: {PLUGIN_NAME}
+model:
+  context_length: 100000
+plugins:
+  enabled:
+    - {PLUGIN_NAME}
+""",
+        encoding="utf-8",
+    )
+
+
+def _mock_response(content, usage=None):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        model="test/model",
+        usage=SimpleNamespace(**usage) if usage else None,
+    )
+
+
+def _wait_for_pending(agent, timeout=2):
+    import time
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        candidate = getattr(agent, "_pending_async_context_candidate", None)
+        if candidate is not None:
+            return candidate
+        time.sleep(0.01)
+    return None
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def test_general_plugin_context_engine_async_compression_and_tool_transform_e2e(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes_home"
+    _write_config(hermes_home)
+    _write_progressive_context_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.name == PLUGIN_NAME
+
+    from tools.registry import registry
+    import model_tools
+
+    monkeypatch.setattr(
+        registry,
+        "dispatch",
+        lambda name, args, **kwargs: '{"raw": "tool-output"}',
+    )
+    monkeypatch.setattr(model_tools, "_READ_SEARCH_TOOLS", frozenset())
+
+    transformed = model_tools.handle_function_call(
+        "terminal",
+        {"command": "cat large.log"},
+        task_id="task",
+        session_id="session",
+        tool_call_id="call",
+        skip_pre_tool_call_hook=True,
+    )
+    assert transformed == 'plugin-transform:{"raw": "tool-output"}'
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            "first answer",
+            usage={"prompt_tokens": 25_000, "completion_tokens": 10},
+        ),
+        _mock_response(
+            "second answer",
+            usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+        ),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        first = agent.run_conversation("first ask")
+        assert _wait_for_pending(agent) is not None
+
+        second = agent.run_conversation(
+            "second ask",
+            conversation_history=first["messages"],
+        )
+
+    assert first["completed"] is True
+    assert second["completed"] is True
+    assert second["messages"][0]["content"] == "plugin compressed context"
+    assert second["messages"][1]["content"] == "plugin compressed answer"
+    assert second["messages"][-2]["content"] == "second ask"
+    assert second["messages"][-1]["content"] == "second answer"
+    assert not any(msg.get("content") == "first ask" for msg in second["messages"])
+    assert agent.context_compressor.prepare_calls == 1
+    assert agent.context_compressor.applied_calls == 1
+
+
+def test_general_plugin_async_compression_can_call_fake_llm(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    _write_config(hermes_home)
+    _write_llm_progressive_context_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.name == PLUGIN_NAME
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            "first answer",
+            usage={"prompt_tokens": 25_000, "completion_tokens": 10},
+        ),
+        _mock_response(
+            "second answer",
+            usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+        ),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        first = agent.run_conversation("first ask")
+        assert _wait_for_pending(agent) is not None
+
+        second = agent.run_conversation(
+            "second ask",
+            conversation_history=first["messages"],
+        )
+
+    assert first["completed"] is True
+    assert second["completed"] is True
+    assert agent.context_compressor.applied_calls == 1
+    assert second["messages"][0]["content"].startswith("[llm compressed context]")
+    assert "fake llm summary: first ask" in second["messages"][0]["content"]
+    assert second["messages"][1]["content"] == "llm summary ready"
+    assert second["messages"][-2]["content"] == "second ask"
+    assert second["messages"][-1]["content"] == "second answer"
+
+    plugin_manager = plugins_mod.get_plugin_manager()
+    plugin_module = plugin_manager._plugins[PLUGIN_NAME].module
+    assert len(plugin_module.LLM_CALLS) == 1
+    call = plugin_module.LLM_CALLS[0]
+    assert call["current_tokens"] == 25_000
+    assert call["messages"][0]["content"] == "first ask"
+
+
+def test_general_plugin_async_compression_can_apply_after_intervening_turn(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes_home"
+    _write_config(hermes_home)
+    _write_slow_llm_progressive_context_plugin(hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.name == PLUGIN_NAME
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            "first answer",
+            usage={"prompt_tokens": 25_000, "completion_tokens": 10},
+        ),
+        _mock_response(
+            "second answer",
+            usage={"prompt_tokens": 25_000, "completion_tokens": 10},
+        ),
+        _mock_response(
+            "third answer",
+            usage={"prompt_tokens": 2_000, "completion_tokens": 10},
+        ),
+    ]
+
+    plugin_manager = plugins_mod.get_plugin_manager()
+    plugin_module = plugin_manager._plugins[PLUGIN_NAME].module
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        try:
+            first = agent.run_conversation("first ask")
+            assert plugin_module.LLM_STARTED.wait(timeout=2)
+            assert _wait_for_pending(agent, timeout=0.1) is None
+
+            second = agent.run_conversation(
+                "second ask",
+                conversation_history=first["messages"],
+            )
+            assert _wait_for_pending(agent, timeout=0.1) is None
+
+            plugin_module.LLM_RELEASE.set()
+            assert _wait_for_pending(agent) is not None
+
+            third = agent.run_conversation(
+                "third ask",
+                conversation_history=second["messages"],
+            )
+        finally:
+            plugin_module.LLM_RELEASE.set()
+
+    assert first["completed"] is True
+    assert second["completed"] is True
+    assert third["completed"] is True
+    assert agent.context_compressor.applied_calls == 1
+
+    assert second["messages"][0]["content"] == "first ask"
+    assert second["messages"][1]["content"] == "first answer"
+    assert second["messages"][-2]["content"] == "second ask"
+    assert second["messages"][-1]["content"] == "second answer"
+
+    assert third["messages"][0]["content"].startswith("[slow llm compressed context]")
+    assert "slow fake llm summary: first ask" in third["messages"][0]["content"]
+    assert third["messages"][1]["content"] == "slow llm summary ready"
+    assert any(msg.get("content") == "second ask" for msg in third["messages"])
+    assert any(msg.get("content") == "second answer" for msg in third["messages"])
+    assert third["messages"][-2]["content"] == "third ask"
+    assert third["messages"][-1]["content"] == "third answer"
+    assert not any(msg.get("content") == "first ask" for msg in third["messages"])
+    assert not any(msg.get("content") == "first answer" for msg in third["messages"])
+
+    assert len(plugin_module.LLM_CALLS) == 1
+    call = plugin_module.LLM_CALLS[0]
+    assert call["current_tokens"] == 25_000
+    assert call["messages"][0]["content"] == "first ask"

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -96,7 +96,12 @@ These have sensible defaults in the ABC. Override as needed:
 | `get_tool_schemas()` | Returns `[]` | Your engine provides agent-callable tools (e.g., `lcm_grep`) |
 | `handle_tool_call(name, args, **kwargs)` | Returns error JSON | You implement tool handlers |
 | `should_compress_preflight(messages)` | Returns `False` | You can do a cheap pre-API-call estimate |
+| `should_prepare_async_compression(prompt_tokens, messages)` | Returns `False` | You want the host to prepare a background compression candidate |
+| `prepare_async_compression(messages, current_tokens, focus_topic)` | Returns `None` | You can build a host-validated async compression candidate |
 | `get_status()` | Standard token/threshold dict | You have custom metrics to expose |
+
+Async preparation runs on a host snapshot, so implementations must not mutate live agent state.
+Engines that call external services from `prepare_async_compression()` should enforce their own request timeout and return `None` on timeout; the host treats async preparation as best-effort, keeps at most one in-flight preparation, and does not cancel running plugin code.
 
 ## Engine tools
 
@@ -151,7 +156,11 @@ Only one engine can be registered. A second plugin attempting to register is rej
 3. update_from_response() — after each API call
 4. should_compress() — checked each turn
 5. compress() — called when should_compress() returns True
-6. on_session_end() — session boundary (CLI exit, /reset, gateway expiry)
+6. Optional async preparation — after a completed turn, the host may call
+   should_prepare_async_compression() and run prepare_async_compression() on a
+   snapshot in the background; candidates are validated and applied or
+   discarded at a later safe point
+7. on_session_end() — session boundary (CLI exit, /reset, gateway expiry)
 ```
 
 `on_session_reset()` is called on `/new` or `/reset` to clear per-session state without a full shutdown.


### PR DESCRIPTION
## What does this PR do?

Adds a host-owned asynchronous context compression preparation surface for context-engine plugins.

More precisely, this adds an async context rewrite/apply path: compression is the primary intended use case, but the host surface is candidate-based rather than tied to one specific compression algorithm.

### Background and Motivation

Hermes currently has synchronous context compression paths, including explicit user-triggered compression and automatic compression near the context limit. Once triggered, compression runs inline and interrupts the current flow.

This PR adds infrastructure for **progressive / low-disruption context compression**. The goal is to let future compression strategies begin preparing compressed candidates before the hard compression threshold is reached, without immediately mutating the live transcript. The host can then apply a validated candidate later at a safe point. This makes it possible to build more gradual compression policies: lower-threshold background preparation can run before the existing hard-threshold compression path, and both paths can coexist.

Architecturally, this separates compression policy from the host-owned safety and apply path: producers decide when and how to prepare candidates, while the host owns snapshotting, validation, and transcript rewrite.

Key design points:

- Context engines opt in by overriding `should_prepare_async_compression()`.
- Prepared candidates are validated with `base_message_count` and `base_digest` before apply.
- Partial-prefix candidates are supported; newer suffix messages are preserved.
- Provider usage data is used when available; if usage is missing, opt-in async engines receive a rough token estimate before threshold gating.
- The final context rewrite path is shared by sync and async compression so session splitting, system prompt rebuild, memory hooks, context-engine session hooks, token estimate refresh, and file-read dedup reset stay consistent.
- General plugins can register both a context engine and `transform_tool_result`, allowing future progressive-compression plugins to combine async semantic compression with realtime tool-result transforms.
- If the prior context ends with `role="user"`, the host inserts a synthetic assistant separator before appending the next current-turn user message. This preserves provider role alternation, current-turn bookkeeping, and persisted-history offsets.

## Related Issue

No direct closing issue.

Related to #9561, #14948, and #20717.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_engine.py`
  - Added `ContextCompressionCandidate`.
  - Added optional no-op async context compression hooks:
    - `should_prepare_async_compression()`
    - `prepare_async_compression()`
    - `on_async_compression_applied()`
    - `on_async_compression_discarded()`

- `run_agent.py`
  - Added host-owned async compression state and lifecycle helpers.
  - Added background candidate preparation with snapshotting and digest validation.
  - Added safe candidate application before later user turns.
  - Added support for partial-prefix async candidates while preserving newer suffix messages.
  - Added rough token estimation before async threshold gating when provider usage data is missing, but only for explicit async opt-in engines.
  - Extracted shared context rewrite finalization into `_finalize_context_rewrite()` so sync and async compression use the same session/memory/finalization path.
  - Added a prior-user-tail separator before appending the current user turn, so rewritten or resumed histories that end in `user` do not merge with or mutate the current turn.
  - Preserved `pre_llm_call.is_first_turn` from the original turn state when context rewrites clear `conversation_history` for full persistence flushes.

- `tests/agent/test_context_engine.py`
  - Added coverage for default async hook no-op behavior.

- `tests/hermes_cli/test_plugins.py`
  - Added coverage that a general plugin can register a context engine and `transform_tool_result`.

- `tests/run_agent/test_async_context_compression.py`
  - Added host-level async compression tests for candidate preparation, digest validation, suffix preservation, stale candidate discard, reset behavior, inflight suppression, rough-token fallback, prior-user-tail separation, resumed-history persistence offsets, `pre_llm_call` continuation state, and sync/async finalizer side effects.

- `tests/run_agent/test_async_context_compression_plugin_integration.py`
  - Added end-to-end temp-plugin tests for:
    - context-engine plugin registration,
    - async candidate prepare/apply across turns,
    - tool-result transform hook coexistence,
    - fake LLM-based async compression,
    - delayed multi-turn async compression application.

- `website/docs/developer-guide/context-engine-plugin.md`
  - Documented the optional async compression hooks and lifecycle behavior.

## How to Test

Run focused and impact coverage:

```bash
python3 -m py_compile run_agent.py agent/context_engine.py tests/run_agent/test_async_context_compression.py
git diff --check
scripts/run_tests.sh \
  tests/run_agent/test_async_context_compression.py \
  tests/run_agent/test_async_context_compression_plugin_integration.py \
  tests/agent/test_context_engine.py \
  tests/hermes_cli/test_plugins.py \
  tests/run_agent/test_memory_nudge_counter_hydration.py \
  tests/run_agent/test_commit_memory_session_context_engine.py \
  tests/run_agent/test_plugin_context_engine_init.py \
  tests/run_agent/test_compression_boundary.py \
  tests/run_agent/test_compression_boundary_hook.py \
  tests/run_agent/test_compression_persistence.py \
  -q
```

Result:

```text
134 passed
```

Full-suite validation was also run:

```bash
scripts/run_tests.sh tests/ -q
```

Result:

```text
82 failed, 22036 passed, 90 skipped
```

The failures were rerun, and the remaining 80 failures were reproduced on `origin/main` (`88a2ce4ae`) in a detached baseline worktree.

```text
PR-only failures: 0
```

Additional review:

```bash
codex review --base upstream/main
```

Result:

```text
codex: No actionable correctness issues were identified in the diff. The async context compression lifecycle validates candidates before applying them and preserves existing compression/session behavior.
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass **— no PR-only failure**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


