### PR TITLE
fix: allow Responses API auto-upgrade for custom providers serving GPT-5.x

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1265,7 +1265,7 @@ class AIAgent:
         # does NOT support the Responses API — skip the upgrade for Azure
         # (openai.azure.com), even though it looks OpenAI-compatible.
         if (
-            api_mode is None
+            (api_mode is None or api_mode == "chat_completions")
             and self.api_mode == "chat_completions"
             and self.provider != "copilot-acp"
             and not str(self.base_url or "").lower().startswith("acp://copilot")


### PR DESCRIPTION
## Summary

Fix the auto-upgrade guard in `AIAgent.__init__` that prevents custom providers from switching to `codex_responses` mode for GPT-5.x models.

## Problem

The condition `api_mode is None` at line ~1268 of `run_agent.py` is always `False` for custom providers, because `runtime_provider.py` always passes `api_mode="chat_completions"` explicitly. This means `_provider_model_requires_responses_api()` (which correctly detects GPT-5.x) never gets a chance to trigger the upgrade.

Users with custom OpenAI-compatible proxies (Codex Manager, one-api, etc.) serving GPT-5.x models get empty responses on every tool call.

## Fix

```diff
-            api_mode is None
+            (api_mode is None or api_mode == "chat_completions")
```

Allows the default `chat_completions` to be auto-upgraded for GPT-5.x, while still respecting explicitly chosen non-default modes.

Fixes #23893