### PR TITLE
fix(kanban): ignore stale HERMES_KANBAN_BOARD for removed boards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -205,7 +205,7 @@ def get_current_board() -> str:
     if env:
         try:
             normed = _normalize_board_slug(env)
-            if normed:
+            if normed and board_exists(normed):
                 return normed
         except ValueError:
             pass

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -176,6 +176,12 @@ class TestCurrentBoard:
         monkeypatch.setenv("HERMES_KANBAN_BOARD", "b")
         assert kb.get_current_board() == "b"
 
+    def test_stale_env_falls_through_to_file_pointer(self, fresh_home, monkeypatch):
+        kb.create_board("persisted")
+        kb.set_current_board("persisted")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "missing-board")
+        assert kb.get_current_board() == "persisted"
+
     def test_invalid_env_falls_through(self, fresh_home, monkeypatch):
         monkeypatch.setenv("HERMES_KANBAN_BOARD", "!!bad!!")
         # Should not crash — falls through to default.
@@ -313,6 +319,22 @@ class TestConnectionIsolation:
             assert [t.title for t in kb.list_tasks(conn)] == ["via-env"]
         with kb.connect(board="persist") as conn:
             assert kb.list_tasks(conn) == []
+
+    def test_connect_stale_env_uses_fallback_board_without_recreating_it(
+        self, fresh_home, monkeypatch,
+    ):
+        kb.create_board("ephemeral")
+        kb.remove_board("ephemeral")
+        kb.create_board("persist")
+        kb.set_current_board("persist")
+        monkeypatch.setenv("HERMES_KANBAN_BOARD", "ephemeral")
+
+        with kb.connect() as conn:
+            kb.create_task(conn, title="via-fallback", assignee="x")
+
+        with kb.connect(board="persist") as conn:
+            assert [t.title for t in kb.list_tasks(conn)] == ["via-fallback"]
+        assert not kb.board_exists("ephemeral")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix Kanban board resolution so a stale `HERMES_KANBAN_BOARD` env override does not resurrect a removed board.

Previously, `get_current_board()` accepted any normalized env slug without checking whether that board still existed. If a session had `HERMES_KANBAN_BOARD` pinned and another session archived or deleted that board, subsequent implicit `connect()` / `init_db()` calls could silently recreate an empty board DB at that slug instead of falling through to the persisted current board or `default`.

## What changed

- Require `HERMES_KANBAN_BOARD` to point at an existing board before treating it as the active board.
- If the env slug is stale, fall through to the normal resolution chain:
  1. current-board file
  2. `default`

## Tests

Added regression coverage for:
- stale env slug falling through to the persisted current-board file
- implicit `connect()` using the fallback board without recreating the removed env-pinned board

## Verification

Targeted board tests were run locally.

Note: in one environment, 5 subprocess CLI tests in `tests/hermes_cli/test_kanban_boards.py` fail because the system Python used by the subprocess is missing `pyyaml` (`ModuleNotFoundError: No module named 'yaml'`). The in-process Kanban tests pass, and the failures are environment-related rather than caused by this change.
