### PR TITLE
fix(kanban): COLUMN_LABEL → FALLBACK_COLUMN_LABEL typo in aria-label

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${FALLBACK_COLUMN_LABEL[props.column.name] || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## Summary

The i18n merge (b8bf2f817) introduced `FALLBACK_COLUMN_LABEL` but one aria-label template literal still referenced the undefined `COLUMN_LABEL`, causing a rendering crash in the Kanban dashboard tab.

## Root Cause

`plugins/kanban/dashboard/dist/index.js` line 1901 used `COLUMN_LABEL` instead of `FALLBACK_COLUMN_LABEL` (which is the actual constant defined on line 59).

## Fix

One-line change: `COLUMN_LABEL` → `FALLBACK_COLUMN_LABEL` in the checkbox aria-label.