### PR TITLE
fix: fall through to OPENROUTER_API_KEY env var when credential pool is exhausted (#23452)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1372,14 +1372,15 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
-    if pool_present:
+    if pool_present and entry is not None:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), _OPENROUTER_MODEL
+        # Pool present but no usable key — fall through to env var below
+        # rather than returning (None, None).  See #23452.
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:


### PR DESCRIPTION
## Summary

When using the credential pool for OpenRouter, if the pool exists but contains no usable keys (all previously tried entries failed), `_try_openrouter()` currently exits early with `None, None` without falling through to the `OPENROUTER_API_KEY` environment variable.

This fix ensures that when a credential pool is present but has no usable entry, the code continues to check the `OPENROUTER_API_KEY` env var as a fallback.

## Root cause
The condition `if pool_present:` was true even when no valid entry was found, causing an early return before reaching the env var fallback logic.\n\n## Fix
Changed the early-return guard to check both `pool_present` AND `entry is not None`, allowing the fallthrough when the pool is empty of usable keys.

Fixes #23452