### PR TITLE
fix: prepare messages for non-vision model in provider profile code path (#23733)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9356,9 +9356,14 @@ class AIAgent:
             if _ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None
 
+            # Strip image parts for non-vision models (no-op when vision-capable).
+            # Mirrors the legacy branch below — the profile path was shipping
+            # raw image_url to text-only providers.  See #23733.
+            _msgs_for_profile = self._prepare_messages_for_non_vision_model(api_messages)
+
             return _ct.build_kwargs(
                 model=self.model,
-                messages=api_messages,
+                messages=_msgs_for_profile,
                 tools=self.tools,
                 base_url=self.base_url,
                 timeout=self._resolved_api_call_timeout(),


### PR DESCRIPTION
## Summary

When routing through a provider profile (non-legacy path), the code skips the `_prepare_messages_for_non_vision_model` transformation that the legacy path applies. This causes image-containing messages to be passed unmodified to models that do not support vision, leading to crashes or incorrect behavior.

## Root cause
The provider profile branch of the routing logic was missing the `_prepare_messages_for_non_vision_model(api_messages)` call that the legacy branch already performed.

## Fix
Added `_msgs_for_profile = self._prepare_messages_for_non_vision_model(api_messages)` in the profile path and used `messages=_msgs_for_profile` instead of `messages=api_messages` when calling the model.

Fixes #23733