### PR TITLE
fix: strip VIRTUAL_ENV from subprocess environment to avoid venv contamination (#23473)

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -137,6 +137,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "VERCEL_TOKEN",
         "VERCEL_PROJECT_ID",
         "VERCEL_TEAM_ID",
+        "VIRTUAL_ENV",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## Summary

When Hermes Agent spawns subprocesses (e.g., for code execution in the `local.py` environment), the `VIRTUAL_ENV` environment variable leaks from the parent process into the child. If the child process uses a different Python virtual environment, this causes import errors and unexpected behavior.

## Root cause
The `_build_provider_env_blocklist()` function in `tools/environments/local.py` blocked several environment variables from leaking into subprocesses, but `VIRTUAL_ENV` was not included.

## Fix
Added `"VIRTUAL_ENV"` to the blocked environment variables set, ensuring subprocesses get a clean environment without parent venv contamination.

Fixes #23473