### PR TITLE
Add skill change observability and governance proposals

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1797,6 +1797,13 @@ class SkillChangeReviewUpdate(BaseModel):
     note: Optional[str] = None
 
 
+_SKILL_CHANGE_LIMIT_MAX = 100
+
+
+def _clamp_skill_change_limit(limit: int) -> int:
+    return max(0, min(limit, _SKILL_CHANGE_LIMIT_MAX))
+
+
 @app.get("/api/skills/changes")
 async def get_skill_changes(
     skill: Optional[str] = None,
@@ -1805,14 +1812,14 @@ async def get_skill_changes(
 ):
     from tools.skill_change_ledger import list_skill_changes
 
-    return list_skill_changes(skill=skill, limit=limit, unreviewed=unreviewed)
+    return list_skill_changes(skill=skill, limit=_clamp_skill_change_limit(limit), unreviewed=unreviewed)
 
 
 @app.get("/api/skills/{name}/history")
 async def get_skill_history(name: str, limit: int = 50):
     from tools.skill_change_ledger import list_skill_changes
 
-    return list_skill_changes(skill=name, limit=limit)
+    return list_skill_changes(skill=name, limit=_clamp_skill_change_limit(limit))
 
 
 @app.get("/api/skills/changes/{event_id}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1792,6 +1792,52 @@ class SkillToggle(BaseModel):
     enabled: bool
 
 
+class SkillChangeReviewUpdate(BaseModel):
+    status: str = "reviewed"
+    note: Optional[str] = None
+
+
+@app.get("/api/skills/changes")
+async def get_skill_changes(
+    skill: Optional[str] = None,
+    limit: int = 50,
+    unreviewed: Optional[bool] = None,
+):
+    from tools.skill_change_ledger import list_skill_changes
+
+    return list_skill_changes(skill=skill, limit=limit, unreviewed=unreviewed)
+
+
+@app.get("/api/skills/{name}/history")
+async def get_skill_history(name: str, limit: int = 50):
+    from tools.skill_change_ledger import list_skill_changes
+
+    return list_skill_changes(skill=name, limit=limit)
+
+
+@app.get("/api/skills/changes/{event_id}")
+async def get_skill_change_detail(event_id: str):
+    from tools.skill_change_ledger import get_skill_change
+
+    event = get_skill_change(event_id)
+    if event is None:
+        raise HTTPException(status_code=404, detail="Skill change event not found")
+    return event
+
+
+@app.post("/api/skills/changes/{event_id}/review")
+async def review_skill_change(event_id: str, body: SkillChangeReviewUpdate):
+    from tools.skill_change_ledger import mark_skill_change_reviewed
+
+    try:
+        event = mark_skill_change_reviewed(event_id, status=body.status, note=body.note)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if event is None:
+        raise HTTPException(status_code=404, detail="Skill change event not found")
+    return event
+
+
 @app.get("/api/skills")
 async def get_skills():
     from tools.skills_tool import _find_all_skills

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1797,11 +1797,22 @@ class SkillChangeReviewUpdate(BaseModel):
     note: Optional[str] = None
 
 
+class SkillGovernanceDecisionUpdate(BaseModel):
+    status: str
+    note: Optional[str] = None
+    decided_by: Optional[str] = None
+
+
 _SKILL_CHANGE_LIMIT_MAX = 100
+_SKILL_GOVERNANCE_PROPOSAL_LIMIT_MAX = 100
 
 
 def _clamp_skill_change_limit(limit: int) -> int:
     return max(0, min(limit, _SKILL_CHANGE_LIMIT_MAX))
+
+
+def _clamp_skill_governance_proposal_limit(limit: int) -> int:
+    return max(0, min(limit, _SKILL_GOVERNANCE_PROPOSAL_LIMIT_MAX))
 
 
 @app.get("/api/skills/changes")
@@ -1843,6 +1854,50 @@ async def review_skill_change(event_id: str, body: SkillChangeReviewUpdate):
     if event is None:
         raise HTTPException(status_code=404, detail="Skill change event not found")
     return event
+
+
+@app.get("/api/skills/governance/proposals")
+async def get_skill_governance_proposals(
+    decision_status: Optional[str] = None,
+    limit: int = 50,
+):
+    from tools.skill_governance_proposals import list_skill_governance_proposals
+
+    try:
+        return list_skill_governance_proposals(
+            decision_status=decision_status,
+            limit=_clamp_skill_governance_proposal_limit(limit),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.get("/api/skills/governance/proposals/{proposal_id}")
+async def get_skill_governance_proposal_detail(proposal_id: str):
+    from tools.skill_governance_proposals import get_skill_governance_proposal
+
+    proposal = get_skill_governance_proposal(proposal_id, include_artifacts=True)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="Skill Governance proposal not found")
+    return proposal
+
+
+@app.post("/api/skills/governance/proposals/{proposal_id}/decision")
+async def decide_skill_governance_proposal(proposal_id: str, body: SkillGovernanceDecisionUpdate):
+    from tools.skill_governance_proposals import get_skill_governance_proposal, record_skill_governance_decision
+
+    try:
+        proposal = record_skill_governance_decision(
+            proposal_id,
+            body.status,
+            note=body.note,
+            decided_by=body.decided_by or "hermes-user",
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="Skill Governance proposal not found")
+    return get_skill_governance_proposal(proposal_id, include_artifacts=True) or proposal
 
 
 @app.get("/api/skills")
@@ -1982,6 +2037,13 @@ async def get_usage_analytics(days: int = 30):
         return {"daily": daily, "by_model": by_model, "totals": totals, "period_days": days}
     finally:
         db.close()
+
+
+@app.api_route("/api/{full_path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+async def api_not_found(full_path: str):
+    """Keep malformed/unknown API paths from falling through to the SPA shell."""
+    return JSONResponse({"detail": "API endpoint not found"}, status_code=404)
+
 
 
 def mount_spa(application: FastAPI):

--- a/tests/hermes_cli/test_web_server_skill_changes.py
+++ b/tests/hermes_cli/test_web_server_skill_changes.py
@@ -1,0 +1,173 @@
+"""Focused tests for skill change ledger dashboard endpoints."""
+
+from pathlib import Path
+
+import pytest
+
+from tools.skill_change_ledger import record_skill_change
+
+
+def _set_hermes_home(monkeypatch, tmp_path: Path) -> Path:
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    _set_hermes_home(monkeypatch, tmp_path)
+    from hermes_cli.web_server import app
+
+    return TestClient(app)
+
+
+def test_get_skill_changes_returns_empty_list_when_ledger_missing(client):
+    response = client.get("/api/skills/changes")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_skill_changes_filters_by_skill_limit_and_unreviewed(client):
+    first = record_skill_change(
+        skill="github-code-review",
+        category="github",
+        action="patch",
+        actor="hermes-agent",
+        source="skill_manage",
+        reason="Add GitHub review verification step.",
+    )
+    second = record_skill_change(
+        skill="obsidian",
+        category="note-taking",
+        action="edit",
+        actor="hermes-agent",
+        source="skill_manage",
+        reason="Clarify vault source note workflow.",
+    )
+    third = record_skill_change(
+        skill="github-code-review",
+        category="github",
+        action="edit",
+        actor="hermes-agent",
+        source="skill_manage",
+        reason="Add API-rate-limit pitfall.",
+    )
+
+    reviewed = client.post(
+        f"/api/skills/changes/{second['event_id']}/review",
+        json={"status": "reviewed", "note": "Looks fine."},
+    )
+    assert reviewed.status_code == 200
+
+    response = client.get(
+        "/api/skills/changes",
+        params={"skill": "github-code-review", "limit": 1, "unreviewed": "true"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [event["event_id"] for event in data] == [third["event_id"]]
+    assert data[0]["skill"] == "github-code-review"
+    assert data[0]["review_status"] == "unreviewed"
+    assert first["event_id"] != third["event_id"]
+
+
+def test_get_skill_history_returns_events_for_one_skill(client):
+    other = record_skill_change(
+        skill="obsidian",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Other skill.",
+    )
+    target = record_skill_change(
+        skill="github-pr-workflow",
+        category="github",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Add PR checklist.",
+    )
+
+    response = client.get("/api/skills/github-pr-workflow/history")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [event["event_id"] for event in data] == [target["event_id"]]
+    assert other["event_id"] not in {event["event_id"] for event in data}
+
+
+def test_get_skill_change_detail_includes_diff_text(client):
+    event = record_skill_change(
+        skill="github-code-review",
+        category="github",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Add exact diff example.",
+        before_text={"SKILL.md": "old\n"},
+        after_text={"SKILL.md": "new\n"},
+    )
+
+    response = client.get(f"/api/skills/changes/{event['event_id']}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["event_id"] == event["event_id"]
+    assert "-old" in data["diff_text"]
+    assert "+new" in data["diff_text"]
+
+
+def test_get_skill_change_detail_returns_404_for_missing_event(client):
+    response = client.get("/api/skills/changes/not-found")
+
+    assert response.status_code == 404
+
+
+def test_review_skill_change_updates_review_state(client):
+    event = record_skill_change(
+        skill="github-code-review",
+        category="github",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Needs review.",
+    )
+
+    response = client.post(
+        f"/api/skills/changes/{event['event_id']}/review",
+        json={"status": "needs_followup", "note": "Check against upstream docs."},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["event_id"] == event["event_id"]
+    assert data["review_status"] == "needs_followup"
+    assert data["review_note"] == "Check against upstream docs."
+    assert data["reviewed_at"] is not None
+
+    detail = client.get(f"/api/skills/changes/{event['event_id']}").json()
+    assert detail["review_status"] == "needs_followup"
+
+
+def test_review_skill_change_rejects_invalid_status(client):
+    event = record_skill_change(
+        skill="github-code-review",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Needs review.",
+    )
+
+    response = client.post(
+        f"/api/skills/changes/{event['event_id']}/review",
+        json={"status": "accepted"},
+    )
+
+    assert response.status_code == 400

--- a/tests/hermes_cli/test_web_server_skill_changes.py
+++ b/tests/hermes_cli/test_web_server_skill_changes.py
@@ -77,6 +77,21 @@ def test_get_skill_changes_filters_by_skill_limit_and_unreviewed(client):
     assert data[0]["review_status"] == "unreviewed"
     assert first["event_id"] != third["event_id"]
 
+def test_get_skill_changes_caps_excessive_limit(client):
+    for idx in range(105):
+        record_skill_change(
+            skill=f"skill-{idx}",
+            action="patch",
+            actor="hermes-agent",
+            source="unit-test",
+            reason="Populate enough events to test endpoint limit clamping.",
+        )
+
+    response = client.get("/api/skills/changes", params={"limit": 500})
+
+    assert response.status_code == 200
+    assert len(response.json()) == 100
+
 
 def test_get_skill_history_returns_events_for_one_skill(client):
     other = record_skill_change(

--- a/tests/hermes_cli/test_web_server_skill_governance_proposals.py
+++ b/tests/hermes_cli/test_web_server_skill_governance_proposals.py
@@ -1,0 +1,176 @@
+"""Focused tests for Skill Governance proposal dashboard endpoints."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.skill_governance_proposals import create_or_update_skill_governance_proposal
+
+
+def _set_hermes_home(monkeypatch, tmp_path: Path) -> Path:
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    _set_hermes_home(monkeypatch, tmp_path)
+    from hermes_cli.web_server import app
+
+    return TestClient(app)
+
+
+def _create_dashboard_proposal():
+    return create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-dashboard",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Consolidate dashboard/HUDUI skills",
+            "pm_summary": "Create one dashboard umbrella skill.",
+            "impact_summary": "Reduces duplicated dashboard recipes while preserving details as references.",
+            "target_skills": ["hermes-dashboard-cron-operations", "hermes-hudui-frontend-workflow"],
+            "risk_level": "medium",
+            "evidence": ["Curator dry-run identified overlap."],
+        }
+    )
+
+
+def test_get_governance_proposals_returns_empty_list_when_store_missing(client):
+    response = client.get("/api/skills/governance/proposals")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_governance_proposals_filters_by_decision_status_and_limit(client):
+    first = _create_dashboard_proposal()
+    second = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-training",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Consolidate LLM training skills",
+            "pm_summary": "Create one training umbrella skill.",
+            "target_skills": ["grpo-rl-training", "peft-fine-tuning"],
+            "risk_level": "medium",
+            "decision_status": "bad_test_target",
+            "decision_by": "hermes-policy",
+            "decision_note": "Not a good first validation target for this user.",
+        }
+    )
+
+    response = client.get(
+        "/api/skills/governance/proposals",
+        params={"decision_status": "pending", "limit": 1},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [proposal["proposal_id"] for proposal in data] == [first["proposal_id"]]
+    assert second["proposal_id"] not in {proposal["proposal_id"] for proposal in data}
+
+
+def test_get_governance_proposal_detail_and_record_decision(client):
+    proposal = _create_dashboard_proposal()
+
+    detail = client.get(f"/api/skills/governance/proposals/{proposal['proposal_id']}")
+    assert detail.status_code == 200
+    assert detail.json()["title"] == "Consolidate dashboard/HUDUI skills"
+    assert "approved" in detail.json()["allowed_decision_statuses"]
+
+    decided = client.post(
+        f"/api/skills/governance/proposals/{proposal['proposal_id']}/decision",
+        json={"status": "approved", "note": "Good first Curator target.", "decided_by": "test-user"},
+    )
+    assert decided.status_code == 200
+    data = decided.json()
+    assert data["decision_status"] == "approved"
+    assert data["decision_note"] == "Good first Curator target."
+    assert data["decision_by"] == "test-user"
+
+    refreshed = client.get(f"/api/skills/governance/proposals/{proposal['proposal_id']}").json()
+    assert refreshed["decision_status"] == "approved"
+
+
+def test_governance_proposal_detail_exposes_artifacts_but_list_omits_text(client):
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-artifact",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Show proposal artifact",
+            "pm_summary": "Expose a dry-run excerpt without returning large text in the list endpoint.",
+            "target_skills": ["hermes-dashboard-feature-fixture-layer"],
+            "risk_level": "medium",
+            "artifact_texts": {"curator_report_excerpt.md": "dry-run excerpt for PM review"},
+        }
+    )
+
+    listed = client.get("/api/skills/governance/proposals").json()[0]
+    detail = client.get(f"/api/skills/governance/proposals/{proposal['proposal_id']}")
+
+    assert "artifact_texts" not in listed
+    assert detail.status_code == 200
+    assert detail.json()["artifact_texts"] == {"curator_report_excerpt.md": "dry-run excerpt for PM review"}
+    assert detail.json()["diff_text"] is None
+
+
+def test_bad_test_target_transition_returns_specific_error_and_allowed_statuses(client):
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-bad-target",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Bad target",
+            "pm_summary": "Already marked as a poor validation target.",
+            "target_skills": ["grpo-rl-training"],
+            "risk_level": "medium",
+            "decision_status": "bad_test_target",
+            "decision_by": "hermes-policy",
+        }
+    )
+
+    detail = client.get(f"/api/skills/governance/proposals/{proposal['proposal_id']}")
+    assert "approved" not in detail.json()["allowed_decision_statuses"]
+
+    decided = client.post(
+        f"/api/skills/governance/proposals/{proposal['proposal_id']}/decision",
+        json={"status": "approved"},
+    )
+    assert decided.status_code == 400
+    assert "bad_test_target" in decided.json()["detail"]
+    assert "approved" in decided.json()["detail"]
+
+
+def test_governance_proposal_endpoints_return_404_and_400(client):
+    assert client.get("/api/skills/governance/proposals/missing").status_code == 404
+
+    proposal = _create_dashboard_proposal()
+    bad = client.post(
+        f"/api/skills/governance/proposals/{proposal['proposal_id']}/decision",
+        json={"status": "applied"},
+    )
+    assert bad.status_code == 400
+
+
+def test_governance_proposal_endpoints_reject_path_shaped_ids(client):
+    _create_dashboard_proposal()
+
+    for proposal_id in ("..%2Fx", "a%2Fb", "space%20id"):
+        assert client.get(f"/api/skills/governance/proposals/{proposal_id}").status_code == 404
+        assert client.post(
+            f"/api/skills/governance/proposals/{proposal_id}/decision",
+            json={"status": "approved"},
+        ).status_code == 404

--- a/tests/tools/test_skill_change_ledger.py
+++ b/tests/tools/test_skill_change_ledger.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 from tools.skill_change_ledger import (
+    MAX_DIFF_TEXT_CHARS,
     compute_text_diff,
     get_skill_change,
     hash_skill_dir,
@@ -172,6 +173,51 @@ def test_get_skill_change_includes_diff_text_when_artifact_exists(monkeypatch, t
     assert detail["event_id"] == event["event_id"]
     assert detail["reason_kind"] == "explicit"
     assert detail["diff_text"] == raw_diff
+
+
+def test_get_skill_change_ignores_diff_path_outside_artifact_root(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+    secret = tmp_path / "secret.txt"
+    secret.write_text("do not expose\n", encoding="utf-8")
+    event = record_skill_change(
+        skill="demo-skill",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Create event before tampering.",
+        diff_text="--- a/SKILL.md\n+++ b/SKILL.md\n",
+    )
+
+    ledger_path = hermes_home / "skill_changes.jsonl"
+    tampered = json.loads(ledger_path.read_text(encoding="utf-8").splitlines()[0])
+    tampered["diff_path"] = str(secret)
+    ledger_path.write_text(json.dumps(tampered) + "\n", encoding="utf-8")
+
+    detail = get_skill_change(event["event_id"])
+
+    assert detail is not None
+    assert detail["diff_path"] == str(secret)
+    assert "diff_text" not in detail
+
+
+def test_get_skill_change_truncates_large_diff_text(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    raw_diff = "--- a/SKILL.md\n+++ b/SKILL.md\n" + ("+x\n" * (MAX_DIFF_TEXT_CHARS // 2))
+    event = record_skill_change(
+        skill="demo-skill",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Large diff should be bounded for dashboard reads.",
+        diff_text=raw_diff,
+    )
+
+    detail = get_skill_change(event["event_id"])
+
+    assert detail is not None
+    assert len(detail["diff_text"]) < len(raw_diff)
+    assert detail["diff_text"].startswith("--- a/SKILL.md")
+    assert "diff truncated" in detail["diff_text"]
 
 
 def test_list_skill_changes_filters_by_skill_limit_and_review_state(monkeypatch, tmp_path):

--- a/tests/tools/test_skill_change_ledger.py
+++ b/tests/tools/test_skill_change_ledger.py
@@ -1,0 +1,255 @@
+"""Focused tests for the local skill change ledger."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from tools.skill_change_ledger import (
+    compute_text_diff,
+    get_skill_change,
+    hash_skill_dir,
+    list_skill_changes,
+    mark_skill_change_reviewed,
+    record_skill_change,
+)
+
+
+EXPECTED_EVENT_KEYS = {
+    "event_id",
+    "timestamp",
+    "skill",
+    "category",
+    "action",
+    "actor",
+    "source",
+    "session_id",
+    "reason",
+    "reason_kind",
+    "before_hash",
+    "after_hash",
+    "changed_files",
+    "diff_path",
+    "metadata",
+    "review_status",
+    "reviewed_at",
+    "review_note",
+}
+
+
+def _set_hermes_home(monkeypatch, tmp_path: Path) -> Path:
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+def _ledger_lines(hermes_home: Path) -> list[str]:
+    return (hermes_home / "skill_changes.jsonl").read_text(encoding="utf-8").splitlines()
+
+
+def test_empty_ledger_returns_clean_results(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+
+    assert not (hermes_home / "skill_changes.jsonl").exists()
+    assert list_skill_changes() == []
+    assert get_skill_change("missing-event") is None
+    assert mark_skill_change_reviewed("missing-event") is None
+
+
+def test_hash_skill_dir_is_deterministic_and_handles_missing(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    (first / "references").mkdir(parents=True)
+    (second / "references").mkdir(parents=True)
+
+    # Create the same relative files in different orders; only relative paths and
+    # bytes should drive the digest.
+    (first / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (first / "references" / "notes.txt").write_text("notes\n", encoding="utf-8")
+    (second / "references" / "notes.txt").write_text("notes\n", encoding="utf-8")
+    (second / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+
+    digest = hash_skill_dir(first)
+    assert digest is not None
+    assert digest.startswith("sha256:")
+    assert digest == hash_skill_dir(second)
+
+    (second / "SKILL.md").write_text("# Demo v2\n", encoding="utf-8")
+    assert digest != hash_skill_dir(second)
+    assert hash_skill_dir(tmp_path / "does-not-exist") is None
+
+
+def test_compute_text_diff_returns_unified_diff_for_changes_adds_and_deletes():
+    diff = compute_text_diff(
+        before={
+            "SKILL.md": "old line\nsame\n",
+            "deleted.md": "remove me\n",
+        },
+        after={
+            "SKILL.md": "new line\nsame\n",
+            "added.md": "add me\n",
+        },
+    )
+
+    assert "--- a/SKILL.md" in diff
+    assert "+++ b/SKILL.md" in diff
+    assert "-old line" in diff
+    assert "+new line" in diff
+    assert "--- a/added.md" in diff
+    assert "+add me" in diff
+    assert "--- a/deleted.md" in diff
+    assert "-remove me" in diff
+
+
+def test_record_skill_change_writes_default_ledger_and_diff_artifact(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+
+    event = record_skill_change(
+        skill="demo-skill",
+        category="devops",
+        action="patch",
+        actor="hermes-agent",
+        source="skill_manage",
+        session_id="session-123",
+        reason=None,
+        before_hash="sha256:old",
+        after_hash="sha256:new",
+        changed_files=["SKILL.md"],
+        before_text={"SKILL.md": "old\n"},
+        after_text={"SKILL.md": "new\n"},
+        metadata={"tool_call": "skill_manage.patch"},
+    )
+
+    assert set(event) == EXPECTED_EVENT_KEYS
+    assert event["skill"] == "demo-skill"
+    assert event["category"] == "devops"
+    assert event["action"] == "patch"
+    assert event["actor"] == "hermes-agent"
+    assert event["source"] == "skill_manage"
+    assert event["session_id"] == "session-123"
+    assert event["reason"] is None
+    assert event["reason_kind"] == "unattributed"
+    assert event["before_hash"] == "sha256:old"
+    assert event["after_hash"] == "sha256:new"
+    assert event["changed_files"] == ["SKILL.md"]
+    assert event["metadata"] == {"tool_call": "skill_manage.patch"}
+    assert event["review_status"] == "unreviewed"
+    assert event["reviewed_at"] is None
+    assert event["review_note"] is None
+    assert event["event_id"]
+    datetime.fromisoformat(event["timestamp"])
+
+    ledger_path = hermes_home / "skill_changes.jsonl"
+    assert ledger_path.exists()
+    lines = _ledger_lines(hermes_home)
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == event
+
+    diff_path = Path(event["diff_path"])
+    assert diff_path == hermes_home / "skill-history" / "events" / event["event_id"] / "diff.patch"
+    diff_text = diff_path.read_text(encoding="utf-8")
+    assert "-old" in diff_text
+    assert "+new" in diff_text
+
+
+def test_get_skill_change_includes_diff_text_when_artifact_exists(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    raw_diff = "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1 +1 @@\n-old\n+new\n"
+    event = record_skill_change(
+        skill="demo-skill",
+        action="edit",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="User asked for clearer instructions.",
+        before_hash=None,
+        after_hash="sha256:new",
+        changed_files=["SKILL.md"],
+        diff_text=raw_diff,
+    )
+
+    detail = get_skill_change(event["event_id"])
+
+    assert detail is not None
+    assert detail["event_id"] == event["event_id"]
+    assert detail["reason_kind"] == "explicit"
+    assert detail["diff_text"] == raw_diff
+
+
+def test_list_skill_changes_filters_by_skill_limit_and_review_state(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    first = record_skill_change(
+        skill="alpha",
+        action="create",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Create alpha.",
+    )
+    second = record_skill_change(
+        skill="beta",
+        action="patch",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Patch beta.",
+    )
+    third = record_skill_change(
+        skill="alpha",
+        action="edit",
+        actor="hermes-agent",
+        source="unit-test",
+        reason="Edit alpha.",
+    )
+
+    assert [event["event_id"] for event in list_skill_changes(limit=2)] == [
+        third["event_id"],
+        second["event_id"],
+    ]
+    assert [event["event_id"] for event in list_skill_changes(skill="alpha")] == [
+        third["event_id"],
+        first["event_id"],
+    ]
+
+    reviewed = mark_skill_change_reviewed(second["event_id"])
+    assert reviewed is not None
+    assert reviewed["review_status"] == "reviewed"
+
+    assert [event["event_id"] for event in list_skill_changes(unreviewed=True)] == [
+        third["event_id"],
+        first["event_id"],
+    ]
+    assert [event["event_id"] for event in list_skill_changes(unreviewed=False)] == [
+        second["event_id"],
+    ]
+
+
+def test_mark_skill_change_reviewed_appends_review_update(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+    event = record_skill_change(
+        skill="demo-skill",
+        action="edit",
+        actor="hermes-agent",
+        source="unit-test",
+        reason_kind="system",
+        reason="Bundled skill sync detected an update.",
+    )
+
+    updated = mark_skill_change_reviewed(
+        event["event_id"],
+        status="needs_followup",
+        note="Confirm generated diff before accepting.",
+    )
+
+    assert updated is not None
+    assert updated["event_id"] == event["event_id"]
+    assert updated["review_status"] == "needs_followup"
+    assert updated["review_note"] == "Confirm generated diff before accepting."
+    assert updated["reviewed_at"] is not None
+    datetime.fromisoformat(updated["reviewed_at"])
+
+    lines = _ledger_lines(hermes_home)
+    assert len(lines) == 2
+    assert json.loads(lines[0])["review_status"] == "unreviewed"
+    assert json.loads(lines[1])["review_status"] == "needs_followup"
+
+    detail = get_skill_change(event["event_id"])
+    assert detail is not None
+    assert detail["review_status"] == "needs_followup"
+    assert detail["review_note"] == "Confirm generated diff before accepting."

--- a/tests/tools/test_skill_governance_proposals.py
+++ b/tests/tools/test_skill_governance_proposals.py
@@ -1,0 +1,308 @@
+"""Focused tests for Skill Governance proposal storage and Curator dry-run import."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.skill_governance_proposals import (
+    MAX_ARTIFACT_TEXT_CHARS,
+    SCHEMA_VERSION,
+    create_or_update_skill_governance_proposal,
+    get_skill_governance_proposal,
+    import_curator_dry_run,
+    list_skill_governance_proposals,
+    record_skill_governance_decision,
+)
+
+
+def _set_hermes_home(monkeypatch, tmp_path: Path) -> Path:
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+def _sample_report() -> str:
+    return """# Curator run — 2026-05-06T07:17:37.364411+00:00
+
+No mutating actions were taken.
+
+### 1. Create new umbrella: `hermes-dashboard-development`
+
+I would create a broad class-level Hermes dashboard umbrella skill covering dashboard and HUDUI work.
+
+I would:
+- create `hermes-dashboard-development`
+- archive the absorbed narrow skills with `absorbed_into=hermes-dashboard-development`
+
+This would archive 10 skills.
+
+### 2. Create new umbrella: `llm-training-workflows`
+
+I would create a broad class-level LLM training umbrella skill covering PEFT / LoRA / QLoRA fine-tuning.
+
+This would archive 4 skills.
+
+## Structured summary (required)
+```yaml
+consolidations:
+  - from: hermes-dashboard-cron-operations
+    into: hermes-dashboard-development
+    reason: Cron operations is one dashboard feature recipe.
+  - from: hermes-dashboard-feature-fixture-layer
+    into: hermes-dashboard-development
+    reason: Fixture-first backend slices belong under dashboard development.
+  - from: hermes-hudui-frontend-workflow
+    into: hermes-dashboard-development
+    reason: HUDUI frontend work is adjacent dashboard workflow.
+  - from: grpo-rl-training
+    into: llm-training-workflows
+    reason: GRPO/RL post-training is one technique.
+  - from: peft-fine-tuning
+    into: llm-training-workflows
+    reason: PEFT is one training strategy.
+```
+"""
+
+
+def _write_sample_curator_run(tmp_path: Path) -> tuple[Path, Path]:
+    run_dir = tmp_path / "curator" / "20260506-071737"
+    run_dir.mkdir(parents=True)
+    report_path = run_dir / "REPORT.md"
+    run_json_path = run_dir / "run.json"
+    report_path.write_text(_sample_report(), encoding="utf-8")
+    run_json_path.write_text(
+        json.dumps({"started_at": "2026-05-06T07:17:37.364411+00:00", "model": "gpt-5.5"}),
+        encoding="utf-8",
+    )
+    return report_path, run_json_path
+
+
+def test_create_proposal_uses_profile_safe_per_proposal_json_and_artifacts(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-dashboard",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Consolidate dashboard skills",
+            "pm_summary": "Create one dashboard umbrella skill.",
+            "target_skills": ["hermes-dashboard-cron-operations", "hermes-hudui-frontend-workflow"],
+            "risk_level": "medium",
+            "evidence": ["Curator dry-run identified overlap."],
+            "artifact_texts": {"curator_excerpt.md": "raw curator excerpt"},
+        }
+    )
+
+    assert proposal["schema_version"] == SCHEMA_VERSION
+    assert proposal["decision_status"] == "pending"
+    assert proposal["codex_review_status"] == "not_requested"
+    assert proposal["created_at"]
+    assert proposal["updated_at"]
+
+    proposal_dir = hermes_home / "skill-governance" / "proposals" / "curator-20260506-dashboard"
+    assert proposal_dir.is_dir()
+    assert json.loads((proposal_dir / "proposal.json").read_text(encoding="utf-8"))["proposal_id"] == proposal["proposal_id"]
+    artifact_path = Path(proposal["artifact_paths"]["curator_excerpt.md"])
+    assert artifact_path == proposal_dir / "artifacts" / "curator_excerpt.md"
+    assert artifact_path.read_text(encoding="utf-8") == "raw curator excerpt"
+
+
+def test_create_or_update_is_idempotent_and_preserves_existing_decision(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    base = {
+        "proposal_id": "curator-20260506-dashboard",
+        "source": "curator_dry_run",
+        "source_run_id": "20260506-071737",
+        "action": "consolidate",
+        "title": "Consolidate dashboard skills",
+        "pm_summary": "Initial summary.",
+        "target_skills": ["hermes-dashboard-cron-operations"],
+        "risk_level": "medium",
+    }
+    first = create_or_update_skill_governance_proposal(base)
+    decided = record_skill_governance_decision(
+        first["proposal_id"],
+        "deferred",
+        note="Review later.",
+        decided_by="pm-user",
+    )
+    previous_decision_at = decided["decision_at"]
+    previous_history = list(decided["decision_history"])
+
+    second = create_or_update_skill_governance_proposal({**base, "pm_summary": "Updated summary."})
+
+    assert second["proposal_id"] == first["proposal_id"]
+    assert second["created_at"] == first["created_at"]
+    assert second["pm_summary"] == "Updated summary."
+    assert second["decision_status"] == "deferred"
+    assert second["decision_by"] == "pm-user"
+    assert second["decision_at"] == previous_decision_at
+    assert second["decision_note"] == decided["decision_note"]
+    assert second["decision_history"] == previous_history
+    assert [p["proposal_id"] for p in list_skill_governance_proposals()] == [first["proposal_id"]]
+
+
+def test_record_decision_enforces_mvp_state_machine(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "curator-20260506-dashboard",
+            "source": "curator_dry_run",
+            "source_run_id": "20260506-071737",
+            "action": "consolidate",
+            "title": "Consolidate dashboard skills",
+            "pm_summary": "Create one dashboard umbrella skill.",
+            "target_skills": ["hermes-dashboard-cron-operations"],
+            "risk_level": "medium",
+        }
+    )
+
+    updated = record_skill_governance_decision(
+        proposal["proposal_id"],
+        "approved",
+        note="Looks like a good first test.",
+        decided_by="test-user",
+    )
+    assert updated["decision_status"] == "approved"
+    assert updated["decision_by"] == "test-user"
+    assert updated["decision_note"] == "Looks like a good first test."
+    assert updated["decision_at"]
+
+    with pytest.raises(ValueError):
+        record_skill_governance_decision(proposal["proposal_id"], "applied")
+
+    with pytest.raises(ValueError):
+        record_skill_governance_decision(proposal["proposal_id"], "unknown")
+
+
+def test_malformed_stored_proposals_with_illegal_states_are_not_returned(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+    proposal_dir = hermes_home / "skill-governance" / "proposals" / "bad-state"
+    proposal_dir.mkdir(parents=True)
+    (proposal_dir / "proposal.json").write_text(
+        json.dumps({"proposal_id": "bad-state", "decision_status": "applied"}),
+        encoding="utf-8",
+    )
+
+    assert get_skill_governance_proposal("bad-state") is None
+    assert list_skill_governance_proposals() == []
+
+
+def test_manual_proposal_id_is_normalized_for_storage_and_api(monkeypatch, tmp_path):
+    hermes_home = _set_hermes_home(monkeypatch, tmp_path)
+
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "../unsafe proposal/id",
+            "source": "manual",
+            "action": "review",
+            "title": "Unsafe id should be normalized",
+            "pm_summary": "Avoid awkward path-shaped ids.",
+            "risk_level": "low",
+        }
+    )
+
+    assert proposal["proposal_id"] == "unsafe-proposal-id"
+    assert (hermes_home / "skill-governance" / "proposals" / "unsafe-proposal-id" / "proposal.json").exists()
+    assert get_skill_governance_proposal("../unsafe proposal/id") is None
+    assert get_skill_governance_proposal("unsafe-proposal-id") is not None
+
+
+def test_artifact_names_are_sanitized_and_large_artifacts_are_truncated(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    large_text = "x" * (MAX_ARTIFACT_TEXT_CHARS + 100)
+
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "artifact-safety",
+            "source": "manual",
+            "action": "review",
+            "title": "Artifact safety",
+            "pm_summary": "Artifacts should stay inside the proposal directory.",
+            "artifact_texts": {"../unsafe/huge.md": large_text},
+        }
+    )
+
+    artifact_path = Path(proposal["artifact_paths"]["huge.md"])
+    assert artifact_path.name == "huge.md"
+    assert artifact_path.parent.name == "artifacts"
+    stored = artifact_path.read_text(encoding="utf-8")
+    assert stored.startswith("x" * 100)
+    assert len(stored) < len(large_text)
+    assert "artifact truncated" in stored
+
+
+def test_detail_view_reads_safe_artifact_text_and_exposes_allowed_decisions(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "artifact-detail",
+            "source": "curator_dry_run",
+            "action": "consolidate",
+            "title": "Artifact detail",
+            "pm_summary": "Show the dry-run excerpt in the dashboard detail view.",
+            "artifact_texts": {"curator_report_excerpt.md": "dry-run excerpt"},
+        }
+    )
+
+    listed = list_skill_governance_proposals()[0]
+    detail = get_skill_governance_proposal(proposal["proposal_id"], include_artifacts=True)
+
+    assert "artifact_texts" not in listed
+    assert detail["artifact_texts"] == {"curator_report_excerpt.md": "dry-run excerpt"}
+    assert detail["diff_text"] is None
+    assert "approved" in detail["allowed_decision_statuses"]
+
+
+def test_bad_test_target_detail_does_not_offer_approve(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    proposal = create_or_update_skill_governance_proposal(
+        {
+            "proposal_id": "bad-target",
+            "source": "curator_dry_run",
+            "action": "consolidate",
+            "title": "Bad validation target",
+            "pm_summary": "This proposal should not be approved from the bad-test-target state.",
+            "decision_status": "bad_test_target",
+            "decision_by": "hermes-policy",
+            "decision_note": "Not a useful first Curator validation target.",
+        }
+    )
+
+    detail = get_skill_governance_proposal(proposal["proposal_id"])
+
+    assert "approved" not in detail["allowed_decision_statuses"]
+    assert set(detail["allowed_decision_statuses"]) == {"pending", "deferred", "bad_test_target", "rejected"}
+
+
+def test_import_curator_dry_run_creates_idempotent_dashboard_and_bad_test_target_proposals(monkeypatch, tmp_path):
+    _set_hermes_home(monkeypatch, tmp_path)
+    report_path, run_json_path = _write_sample_curator_run(tmp_path)
+
+    imported = import_curator_dry_run(report_path, run_json_path=run_json_path)
+    imported_again = import_curator_dry_run(report_path, run_json_path=run_json_path)
+
+    assert [p["proposal_id"] for p in imported_again] == [p["proposal_id"] for p in imported]
+    assert len(list_skill_governance_proposals()) == 2
+
+    by_id = {proposal["proposal_id"]: proposal for proposal in imported}
+    dashboard = by_id["curator-20260506-071737-hermes-dashboard-development"]
+    training = by_id["curator-20260506-071737-llm-training-workflows"]
+
+    assert dashboard["decision_status"] == "pending"
+    assert dashboard["recommended_decision"] == "review_first"
+    assert "hermes-dashboard-cron-operations" in dashboard["target_skills"]
+    assert "hermes-hudui-frontend-workflow" in dashboard["target_skills"]
+    assert dashboard["artifact_paths"]["curator_report_excerpt.md"]
+
+    assert training["decision_status"] == "bad_test_target"
+    assert training["recommended_decision"] == "defer"
+    assert "llm-training-workflows" in training["title"]
+    assert "user decision" in training["decision_note"].lower()
+
+    detail = get_skill_governance_proposal(dashboard["proposal_id"])
+    assert detail is not None
+    assert detail["proposal_id"] == dashboard["proposal_id"]

--- a/tests/tools/test_skill_manager_change_ledger.py
+++ b/tests/tools/test_skill_manager_change_ledger.py
@@ -1,0 +1,142 @@
+"""Tests for skill_manage integration with the skill change ledger."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.skill_change_ledger import get_skill_change, list_skill_changes
+from tools.skill_manager_tool import skill_manage
+
+
+VALID_SKILL_CONTENT = """\
+---
+name: ledger-skill
+description: A test skill for ledger integration.
+---
+
+# Ledger Skill
+
+Step 1: Do the thing.
+"""
+
+VALID_SKILL_CONTENT_2 = """\
+---
+name: ledger-skill
+description: Updated description.
+---
+
+# Ledger Skill v2
+
+Step 1: Do the new thing.
+"""
+
+
+@contextmanager
+def isolated_skill_environment(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
+        yield skills_dir, hermes_home
+
+
+def test_successful_create_records_skill_change_with_explicit_reason(tmp_path, monkeypatch):
+    with isolated_skill_environment(tmp_path, monkeypatch):
+        raw = skill_manage(
+            action="create",
+            name="ledger-skill",
+            content=VALID_SKILL_CONTENT,
+            reason="User requested a reusable ledger test skill.",
+        )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+    assert result["skill_change_event_id"]
+
+    events = list_skill_changes(skill="ledger-skill")
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_id"] == result["skill_change_event_id"]
+    assert event["action"] == "create"
+    assert event["source"] == "skill_manage"
+    assert event["reason"] == "User requested a reusable ledger test skill."
+    assert event["reason_kind"] == "explicit"
+    assert event["before_hash"] is None
+    assert event["after_hash"].startswith("sha256:")
+    assert "SKILL.md" in event["changed_files"]
+
+    detail = get_skill_change(event["event_id"])
+    assert detail is not None
+    assert "+# Ledger Skill" in detail["diff_text"]
+
+
+def test_successful_patch_records_diff_and_missing_reason_as_unattributed(tmp_path, monkeypatch):
+    with isolated_skill_environment(tmp_path, monkeypatch):
+        json.loads(skill_manage(action="create", name="ledger-skill", content=VALID_SKILL_CONTENT))
+        raw = skill_manage(
+            action="patch",
+            name="ledger-skill",
+            old_string="Do the thing.",
+            new_string="Do the observed thing.",
+        )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+
+    events = list_skill_changes(skill="ledger-skill")
+    patch_event = events[0]
+    assert patch_event["event_id"] == result["skill_change_event_id"]
+    assert patch_event["action"] == "patch"
+    assert patch_event["reason"] is None
+    assert patch_event["reason_kind"] == "unattributed"
+    assert patch_event["before_hash"] != patch_event["after_hash"]
+    assert patch_event["changed_files"] == ["SKILL.md"]
+
+    detail = get_skill_change(patch_event["event_id"])
+    assert detail is not None
+    assert "-Step 1: Do the thing." in detail["diff_text"]
+    assert "+Step 1: Do the observed thing." in detail["diff_text"]
+
+
+def test_failed_patch_does_not_record_skill_change(tmp_path, monkeypatch):
+    with isolated_skill_environment(tmp_path, monkeypatch):
+        json.loads(skill_manage(action="create", name="ledger-skill", content=VALID_SKILL_CONTENT))
+        before = len(list_skill_changes(skill="ledger-skill"))
+        raw = skill_manage(
+            action="patch",
+            name="ledger-skill",
+            old_string="missing text",
+            new_string="replacement",
+            reason="This should not be recorded because the patch fails.",
+        )
+
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert len(list_skill_changes(skill="ledger-skill")) == before
+
+
+def test_delete_records_before_hash_and_delete_diff(tmp_path, monkeypatch):
+    with isolated_skill_environment(tmp_path, monkeypatch):
+        json.loads(skill_manage(action="create", name="ledger-skill", content=VALID_SKILL_CONTENT))
+        raw = skill_manage(
+            action="delete",
+            name="ledger-skill",
+            reason="Remove obsolete skill after review.",
+        )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+
+    event = list_skill_changes(skill="ledger-skill")[0]
+    assert event["event_id"] == result["skill_change_event_id"]
+    assert event["action"] == "delete"
+    assert event["before_hash"].startswith("sha256:")
+    assert event["after_hash"] is None
+    assert event["changed_files"] == ["SKILL.md"]
+
+    detail = get_skill_change(event["event_id"])
+    assert detail is not None
+    assert "-# Ledger Skill" in detail["diff_text"]

--- a/tests/tools/test_skills_sync_change_ledger.py
+++ b/tests/tools/test_skills_sync_change_ledger.py
@@ -1,0 +1,82 @@
+"""Tests for skills_sync integration with the skill change ledger."""
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.skill_change_ledger import get_skill_change, list_skill_changes
+from tools.skills_sync import _dir_hash, sync_skills
+
+
+def _setup_bundled(tmp_path: Path) -> Path:
+    bundled = tmp_path / "bundled_skills"
+    (bundled / "github" / "github-code-review").mkdir(parents=True)
+    (bundled / "github" / "github-code-review" / "SKILL.md").write_text("# GitHub review\n", encoding="utf-8")
+    return bundled
+
+
+def _patch_sync(bundled: Path, skills_dir: Path, manifest_file: Path):
+    stack = ExitStack()
+    stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+    stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+    stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+    return stack
+
+
+def test_fresh_bundled_copy_records_system_change_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    bundled = _setup_bundled(tmp_path)
+    skills_dir = tmp_path / "user_skills"
+    manifest_file = skills_dir / ".bundled_manifest"
+
+    with _patch_sync(bundled, skills_dir, manifest_file):
+        result = sync_skills(quiet=True)
+
+    assert result["copied"] == ["github-code-review"]
+
+    events = list_skill_changes(skill="github-code-review")
+    assert len(events) == 1
+    event = events[0]
+    assert event["action"] == "bundled_copy"
+    assert event["actor"] == "hermes-system"
+    assert event["source"] == "skills_sync"
+    assert event["category"] == "github"
+    assert event["reason_kind"] == "system"
+    assert event["before_hash"] is None
+    assert event["after_hash"].startswith("sha256:")
+    assert event["changed_files"] == ["SKILL.md"]
+
+    detail = get_skill_change(event["event_id"])
+    assert detail is not None
+    assert "+# GitHub review" in detail["diff_text"]
+
+
+def test_bundled_update_records_diff_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    bundled = _setup_bundled(tmp_path)
+    skills_dir = tmp_path / "user_skills"
+    manifest_file = skills_dir / ".bundled_manifest"
+
+    user_skill = skills_dir / "github" / "github-code-review"
+    user_skill.mkdir(parents=True)
+    (user_skill / "SKILL.md").write_text("# GitHub review v1\n", encoding="utf-8")
+    old_origin_hash = _dir_hash(user_skill)
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file.write_text(f"github-code-review:{old_origin_hash}\n", encoding="utf-8")
+
+    with _patch_sync(bundled, skills_dir, manifest_file):
+        result = sync_skills(quiet=True)
+
+    assert result["updated"] == ["github-code-review"]
+
+    event = list_skill_changes(skill="github-code-review")[0]
+    assert event["action"] == "bundled_update"
+    assert event["source"] == "skills_sync"
+    assert event["reason_kind"] == "system"
+    assert event["before_hash"] != event["after_hash"]
+    assert event["changed_files"] == ["SKILL.md"]
+
+    detail = get_skill_change(event["event_id"])
+    assert detail is not None
+    assert "-# GitHub review v1" in detail["diff_text"]
+    assert "+# GitHub review" in detail["diff_text"]

--- a/tools/skill_change_ledger.py
+++ b/tools/skill_change_ledger.py
@@ -1,0 +1,405 @@
+"""Append-only skill change ledger utilities.
+
+This module stores local skill-change events as JSON Lines under
+``get_hermes_home() / "skill_changes.jsonl"`` and optional diff artifacts under
+``get_hermes_home() / "skill-history" / "events"``.  It intentionally has no
+registry side effects so it can be imported safely by tools, API handlers, and
+unit tests.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from hermes_constants import get_hermes_home
+
+REASON_KINDS = {"explicit", "system", "unattributed", "model_summary"}
+REVIEW_STATUSES = {"unreviewed", "reviewed", "needs_followup"}
+EVENT_FIELDS = (
+    "event_id",
+    "timestamp",
+    "skill",
+    "category",
+    "action",
+    "actor",
+    "source",
+    "session_id",
+    "reason",
+    "reason_kind",
+    "before_hash",
+    "after_hash",
+    "changed_files",
+    "diff_path",
+    "metadata",
+    "review_status",
+    "reviewed_at",
+    "review_note",
+)
+
+
+def _default_ledger_path() -> Path:
+    return get_hermes_home() / "skill_changes.jsonl"
+
+
+def _default_artifacts_root() -> Path:
+    return get_hermes_home() / "skill-history" / "events"
+
+
+def _resolve_path(path: str | os.PathLike[str] | None, default: Path) -> Path:
+    if path is None:
+        return default
+    return Path(path)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _safe_component(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip(".-_")
+    return slug or "unknown"
+
+
+def _new_event_id(skill: str, action: str) -> str:
+    stamp = _now().strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{stamp}_{_safe_component(skill)}_{_safe_component(action)}_{uuid.uuid4().hex[:8]}"
+
+
+def _validate_reason_kind(reason: str | None, reason_kind: str | None) -> str:
+    if reason_kind is None:
+        return "explicit" if reason else "unattributed"
+    if reason_kind not in REASON_KINDS:
+        raise ValueError(
+            f"Invalid reason_kind {reason_kind!r}; expected one of {sorted(REASON_KINDS)}"
+        )
+    if not reason and reason_kind != "unattributed":
+        # Caller explicitly supplied provenance even without a text reason; keep it.
+        return reason_kind
+    return reason_kind
+
+
+def _validate_review_status(status: str) -> str:
+    if status not in REVIEW_STATUSES:
+        raise ValueError(
+            f"Invalid review status {status!r}; expected one of {sorted(REVIEW_STATUSES)}"
+        )
+    return status
+
+
+def hash_skill_dir(skill_dir: Path) -> str | None:
+    """Return a deterministic sha256 digest for regular files in a skill dir.
+
+    The digest is based on sorted POSIX relative file paths and raw file bytes.
+    ``None`` is returned when ``skill_dir`` does not exist or is not a directory.
+    """
+
+    root = Path(skill_dir)
+    if not root.is_dir():
+        return None
+
+    files = sorted(
+        (
+            path
+            for path in root.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        ),
+        key=lambda path: path.relative_to(root).as_posix(),
+    )
+
+    digest = hashlib.sha256()
+    for path in files:
+        rel = path.relative_to(root).as_posix().encode("utf-8")
+        data = path.read_bytes()
+        digest.update(b"path\0")
+        digest.update(rel)
+        digest.update(b"\0size\0")
+        digest.update(str(len(data)).encode("ascii"))
+        digest.update(b"\0content\0")
+        digest.update(data)
+        digest.update(b"\0")
+
+    return f"sha256:{digest.hexdigest()}"
+
+
+def compute_text_diff(before: dict[str, str], after: dict[str, str]) -> str:
+    """Return a unified diff for text snapshots keyed by relative file path."""
+
+    chunks: list[str] = []
+    for file_name in sorted(set(before) | set(after)):
+        before_lines = before.get(file_name, "").splitlines()
+        after_lines = after.get(file_name, "").splitlines()
+        diff_lines = list(
+            difflib.unified_diff(
+                before_lines,
+                after_lines,
+                fromfile=f"a/{file_name}",
+                tofile=f"b/{file_name}",
+                lineterm="",
+            )
+        )
+        if diff_lines:
+            chunks.append("\n".join(diff_lines) + "\n")
+    return "".join(chunks)
+
+
+def _append_event(
+    event: Mapping[str, Any],
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> None:
+    path = _resolve_path(ledger_path, _default_ledger_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(event), ensure_ascii=False, sort_keys=True))
+        handle.write("\n")
+        handle.flush()
+
+
+def _read_records(
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    path = _resolve_path(ledger_path, _default_ledger_path())
+    if not path.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict):
+                    records.append(record)
+    except FileNotFoundError:
+        return []
+    return records
+
+
+def _latest_events(
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    by_id: dict[str, dict[str, Any]] = {}
+    creation_order: list[str] = []
+    for record in _read_records(ledger_path=ledger_path):
+        event_id = record.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            continue
+        if event_id not in by_id:
+            creation_order.append(event_id)
+        by_id[event_id] = record
+    return [dict(by_id[event_id]) for event_id in creation_order]
+
+
+def _find_latest_event(
+    event_id: str,
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    for event in _latest_events(ledger_path=ledger_path):
+        if event.get("event_id") == event_id:
+            return event
+    return None
+
+
+def _derive_changed_files(
+    changed_files: Sequence[str] | None,
+    before_text: Mapping[str, str] | None,
+    after_text: Mapping[str, str] | None,
+) -> list[str]:
+    if changed_files is not None:
+        return list(changed_files)
+    if before_text is not None or after_text is not None:
+        return sorted(set(before_text or {}) | set(after_text or {}))
+    return []
+
+
+def _build_diff_text(
+    *,
+    diff_text: str | None,
+    before_text: Mapping[str, str] | None,
+    after_text: Mapping[str, str] | None,
+) -> str | None:
+    if diff_text is not None:
+        return diff_text
+    if before_text is None and after_text is None:
+        return None
+    return compute_text_diff(dict(before_text or {}), dict(after_text or {}))
+
+
+def record_skill_change(
+    skill: str,
+    action: str,
+    actor: str = "hermes-agent",
+    source: str = "unknown",
+    *,
+    category: str | None = None,
+    session_id: str | None = None,
+    reason: str | None = None,
+    reason_kind: str | None = None,
+    before_hash: str | None = None,
+    after_hash: str | None = None,
+    changed_files: Sequence[str] | None = None,
+    before_text: Mapping[str, str] | None = None,
+    after_text: Mapping[str, str] | None = None,
+    diff_text: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    ledger_path: str | os.PathLike[str] | None = None,
+    artifacts_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Append a skill change event and optional diff artifact.
+
+    Missing reasons are accepted and recorded as ``reason_kind='unattributed'``.
+    If ``diff_text`` is supplied, or if ``before_text``/``after_text`` produce a
+    non-empty unified diff, the diff is written under the event artifact root and
+    ``diff_path`` is set on the event.
+    """
+
+    event_id = _new_event_id(skill, action)
+    event_diff = _build_diff_text(
+        diff_text=diff_text,
+        before_text=before_text,
+        after_text=after_text,
+    )
+
+    diff_path: str | None = None
+    if event_diff:
+        root = _resolve_path(artifacts_root, _default_artifacts_root())
+        artifact_path = root / event_id / "diff.patch"
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(event_diff, encoding="utf-8")
+        diff_path = str(artifact_path)
+
+    event = {
+        "event_id": event_id,
+        "timestamp": _now_iso(),
+        "skill": skill,
+        "category": category,
+        "action": action,
+        "actor": actor,
+        "source": source,
+        "session_id": session_id,
+        "reason": reason,
+        "reason_kind": _validate_reason_kind(reason, reason_kind),
+        "before_hash": before_hash,
+        "after_hash": after_hash,
+        "changed_files": _derive_changed_files(changed_files, before_text, after_text),
+        "diff_path": diff_path,
+        "metadata": dict(metadata or {}),
+        "review_status": "unreviewed",
+        "reviewed_at": None,
+        "review_note": None,
+    }
+
+    # Preserve the schema field set/order and avoid accidental extra fields.
+    event = {field: event[field] for field in EVENT_FIELDS}
+    _append_event(event, ledger_path=ledger_path)
+    return event
+
+
+def list_skill_changes(
+    skill: str | None = None,
+    limit: int = 50,
+    unreviewed: bool | None = None,
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return recent skill change events, newest first.
+
+    Review updates are append-only records with the same ``event_id``; listing
+    collapses them to the latest state while preserving original event recency.
+    """
+
+    events = _latest_events(ledger_path=ledger_path)
+    filtered: list[dict[str, Any]] = []
+    for event in events:
+        if skill is not None and event.get("skill") != skill:
+            continue
+        if unreviewed is True and event.get("review_status") != "unreviewed":
+            continue
+        if unreviewed is False and event.get("review_status") == "unreviewed":
+            continue
+        filtered.append(event)
+
+    recent = list(reversed(filtered))
+    if limit is None:  # type: ignore[unreachable]
+        return recent
+    return recent[: max(0, limit)]
+
+
+def get_skill_change(
+    event_id: str,
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    """Return the latest state for one event, including diff text when present."""
+
+    event = _find_latest_event(event_id, ledger_path=ledger_path)
+    if event is None:
+        return None
+
+    detail = dict(event)
+    diff_path = detail.get("diff_path")
+    if isinstance(diff_path, str) and diff_path:
+        path = Path(os.path.expanduser(diff_path))
+        try:
+            if path.exists():
+                detail["diff_text"] = path.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    return detail
+
+
+def mark_skill_change_reviewed(
+    event_id: str,
+    status: str = "reviewed",
+    note: str | None = None,
+    *,
+    ledger_path: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    """Append a review-state update for an existing event.
+
+    The original ledger line is never rewritten; the returned event is the latest
+    state after appending the review update.
+    """
+
+    _validate_review_status(status)
+    event = _find_latest_event(event_id, ledger_path=ledger_path)
+    if event is None:
+        return None
+
+    updated = dict(event)
+    updated["review_status"] = status
+    updated["reviewed_at"] = _now_iso()
+    updated["review_note"] = note
+    updated = {field: updated.get(field) for field in EVENT_FIELDS}
+    _append_event(updated, ledger_path=ledger_path)
+    return updated
+
+
+__all__ = [
+    "hash_skill_dir",
+    "compute_text_diff",
+    "record_skill_change",
+    "list_skill_changes",
+    "get_skill_change",
+    "mark_skill_change_reviewed",
+]

--- a/tools/skill_change_ledger.py
+++ b/tools/skill_change_ledger.py
@@ -23,6 +23,8 @@ from hermes_constants import get_hermes_home
 
 REASON_KINDS = {"explicit", "system", "unattributed", "model_summary"}
 REVIEW_STATUSES = {"unreviewed", "reviewed", "needs_followup"}
+MAX_DIFF_TEXT_CHARS = 50_000
+_DIFF_TRUNCATION_NOTICE = "\n\n[diff truncated to 50,000 characters for dashboard display]"
 EVENT_FIELDS = (
     "event_id",
     "timestamp",
@@ -345,6 +347,25 @@ def list_skill_changes(
     return recent[: max(0, limit)]
 
 
+def _safe_diff_artifact_path(diff_path: str) -> Path | None:
+    """Resolve a diff path only if it stays under the expected artifact root."""
+    try:
+        path = Path(os.path.expanduser(diff_path)).resolve()
+        root = _default_artifacts_root().resolve()
+        if not path.is_relative_to(root):
+            return None
+        return path
+    except OSError:
+        return None
+
+
+def _bounded_diff_text(text: str) -> str:
+    """Bound diff text returned through APIs while preserving the raw artifact."""
+    if len(text) <= MAX_DIFF_TEXT_CHARS:
+        return text
+    return text[:MAX_DIFF_TEXT_CHARS] + _DIFF_TRUNCATION_NOTICE
+
+
 def get_skill_change(
     event_id: str,
     *,
@@ -359,10 +380,10 @@ def get_skill_change(
     detail = dict(event)
     diff_path = detail.get("diff_path")
     if isinstance(diff_path, str) and diff_path:
-        path = Path(os.path.expanduser(diff_path))
+        path = _safe_diff_artifact_path(diff_path)
         try:
-            if path.exists():
-                detail["diff_text"] = path.read_text(encoding="utf-8")
+            if path is not None and path.exists():
+                detail["diff_text"] = _bounded_diff_text(path.read_text(encoding="utf-8"))
         except OSError:
             pass
     return detail

--- a/tools/skill_governance_proposals.py
+++ b/tools/skill_governance_proposals.py
@@ -1,0 +1,689 @@
+"""Read-only Skill Governance proposal storage and Curator dry-run import.
+
+This module is the pre-mutation side of the Skill Governance Loop.  It stores
+PM-reviewable proposal cards under ``get_hermes_home()`` using one directory per
+proposal.  It intentionally does not call ``skill_manage`` or mutate skills.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = 1
+DECISION_STATUSES = {
+    "pending",
+    "approved",
+    "rejected",
+    "deferred",
+    "needs_changes",
+    "bad_test_target",
+}
+DECISION_STATUS_ORDER = (
+    "pending",
+    "approved",
+    "needs_changes",
+    "deferred",
+    "bad_test_target",
+    "rejected",
+)
+CODEX_REVIEW_STATUSES = {
+    "not_requested",
+    "pending",
+    "approved",
+    "changes_requested",
+    "blocked",
+    "failed",
+}
+RISK_LEVELS = {"low", "medium", "high", "unknown"}
+MAX_ARTIFACT_TEXT_CHARS = 200_000
+
+# No ``applied`` state in the MVP.  The dashboard records decisions only; safe
+# apply remains a later CLI/manual wrapper.
+_DECISION_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"pending", "approved", "rejected", "deferred", "needs_changes", "bad_test_target"},
+    "approved": {"approved", "pending", "rejected", "deferred", "needs_changes", "bad_test_target"},
+    "rejected": {"rejected", "pending", "deferred", "needs_changes", "bad_test_target"},
+    "deferred": {"deferred", "pending", "approved", "rejected", "needs_changes", "bad_test_target"},
+    "needs_changes": {"needs_changes", "pending", "approved", "rejected", "deferred", "bad_test_target"},
+    "bad_test_target": {"bad_test_target", "pending", "deferred", "rejected"},
+}
+
+PROPOSAL_FIELDS = (
+    "schema_version",
+    "proposal_id",
+    "created_at",
+    "updated_at",
+    "source",
+    "source_run_id",
+    "source_paths",
+    "action",
+    "title",
+    "pm_summary",
+    "rationale",
+    "risk_level",
+    "impact_summary",
+    "pin_policy_status",
+    "target_skills",
+    "created_skills",
+    "archived_skills",
+    "affected_skills",
+    "pinned_skills",
+    "evidence",
+    "artifact_paths",
+    "diff_path",
+    "backup_path",
+    "rollback_path",
+    "codex_review_status",
+    "codex_review_path",
+    "codex_review_summary",
+    "codex_review_warnings",
+    "codex_review_errors",
+    "recommended_decision",
+    "decision_status",
+    "decision_by",
+    "decision_at",
+    "decision_note",
+    "decision_history",
+    "metadata",
+)
+
+DASHBOARD_HUDUI_SKILLS = [
+    "hermes-dashboard-cron-operations",
+    "hermes-dashboard-feature-fixture-layer",
+    "hermes-dashboard-gateway-channels",
+    "hermes-dashboard-home-overview",
+    "hermes-dashboard-knowledge-overview",
+    "hermes-dashboard-lan-access",
+    "hermes-dashboard-operations",
+    "hermes-dashboard-ui-customization",
+    "hermes-hudui-frontend-workflow",
+    "hermes-hudui-lan-access",
+]
+LLM_TRAINING_SKILLS = [
+    "grpo-rl-training",
+    "peft-fine-tuning",
+    "pytorch-fsdp",
+    "modal-serverless-gpu",
+]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_component(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip(".-_")
+    return slug or "unknown"
+
+
+def _default_proposals_root() -> Path:
+    return get_hermes_home() / "skill-governance" / "proposals"
+
+
+def _resolve_root(root: str | os.PathLike[str] | None = None) -> Path:
+    return Path(root) if root is not None else _default_proposals_root()
+
+
+def _proposal_dir(proposal_id: str, *, proposals_root: str | os.PathLike[str] | None = None) -> Path:
+    return _resolve_root(proposals_root) / _safe_component(proposal_id)
+
+
+def _proposal_json_path(proposal_id: str, *, proposals_root: str | os.PathLike[str] | None = None) -> Path:
+    return _proposal_dir(proposal_id, proposals_root=proposals_root) / "proposal.json"
+
+
+def _read_proposal_file(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _read_safe_detail_text(path_value: Any, *, root: Path) -> str | None:
+    """Read dashboard detail text only when it stays under the proposal root.
+
+    Proposal JSON is mutable local state, so do not trust stored artifact or diff
+    paths blindly. A tampered path must not expose arbitrary local files through
+    the dashboard.
+    """
+
+    if not path_value:
+        return None
+    raw = Path(str(path_value)).expanduser()
+    candidate = raw if raw.is_absolute() else root / raw
+    if not _is_relative_to(candidate, root):
+        return None
+    try:
+        text = candidate.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return None
+    if len(text) > MAX_ARTIFACT_TEXT_CHARS:
+        return text[:MAX_ARTIFACT_TEXT_CHARS] + "\n\n[detail text truncated for dashboard governance view]\n"
+    return text
+
+
+def _is_canonical_proposal_id(proposal_id: str) -> bool:
+    return bool(proposal_id) and proposal_id == _safe_component(proposal_id)
+
+
+def _proposal_view_from_storage(proposal: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Return a dashboard-safe proposal view from stored JSON, or skip stale/tampered data."""
+
+    if not proposal:
+        return None
+    proposal_id = str(proposal.get("proposal_id") or "")
+    if not _is_canonical_proposal_id(proposal_id):
+        return None
+    try:
+        decision_status = _validate_decision_status(str(proposal.get("decision_status") or "pending"))
+        _validate_codex_review_status(str(proposal.get("codex_review_status") or "not_requested"))
+    except ValueError:
+        return None
+    view = {field: proposal.get(field) for field in PROPOSAL_FIELDS}
+    view["allowed_decision_statuses"] = _allowed_decision_statuses(decision_status)
+    return view
+
+
+def _allowed_decision_statuses(current_status: str) -> list[str]:
+    allowed = _DECISION_TRANSITIONS.get(current_status, set())
+    return [status for status in DECISION_STATUS_ORDER if status in allowed]
+
+
+def _proposal_detail_from_storage(
+    proposal: Mapping[str, Any] | None,
+    *,
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    view = _proposal_view_from_storage(proposal)
+    if view is None:
+        return None
+
+    proposal_id = str(view.get("proposal_id") or "")
+    proposal_dir = _proposal_dir(proposal_id, proposals_root=proposals_root)
+    artifacts_dir = proposal_dir / "artifacts"
+
+    artifact_texts: dict[str, str] = {}
+    for raw_name, path_value in (view.get("artifact_paths") or {}).items():
+        artifact_name = _safe_artifact_name(str(raw_name))
+        text = _read_safe_detail_text(path_value, root=artifacts_dir)
+        if text is not None:
+            artifact_texts[artifact_name] = text
+
+    view["artifact_texts"] = artifact_texts
+    view["diff_text"] = _read_safe_detail_text(view.get("diff_path"), root=proposal_dir)
+    return view
+
+
+def _write_proposal_file(path: Path, proposal: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(proposal), ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _as_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [str(item) for item in value if item is not None]
+    return [str(value)]
+
+
+def _as_string_map(value: Any) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): str(val) for key, val in value.items() if val is not None}
+
+
+def _unique_ordered(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _validate_decision_status(status: str) -> str:
+    if status not in DECISION_STATUSES:
+        raise ValueError(
+            f"Invalid Skill Governance decision status {status!r}; expected one of {sorted(DECISION_STATUSES)}"
+        )
+    return status
+
+
+def _validate_decision_transition(current: str, target: str) -> None:
+    allowed = _DECISION_TRANSITIONS.get(current, set())
+    if target not in allowed:
+        raise ValueError(f"Invalid Skill Governance transition {current!r} -> {target!r}")
+
+
+def _validate_codex_review_status(status: str) -> str:
+    if status not in CODEX_REVIEW_STATUSES:
+        raise ValueError(
+            f"Invalid Codex review status {status!r}; expected one of {sorted(CODEX_REVIEW_STATUSES)}"
+        )
+    return status
+
+
+def _validate_risk_level(risk_level: str) -> str:
+    if risk_level not in RISK_LEVELS:
+        return "unknown"
+    return risk_level
+
+
+def _safe_artifact_name(name: str) -> str:
+    return _safe_component(Path(name).name)
+
+
+def _write_artifacts(
+    proposal_id: str,
+    artifact_texts: Mapping[str, str] | None,
+    *,
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> dict[str, str]:
+    if not artifact_texts:
+        return {}
+    artifacts_dir = _proposal_dir(proposal_id, proposals_root=proposals_root) / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, str] = {}
+    for raw_name, raw_text in artifact_texts.items():
+        artifact_name = _safe_artifact_name(str(raw_name))
+        text = str(raw_text)
+        if len(text) > MAX_ARTIFACT_TEXT_CHARS:
+            text = text[:MAX_ARTIFACT_TEXT_CHARS] + "\n\n[artifact truncated for dashboard governance storage]\n"
+        path = artifacts_dir / artifact_name
+        path.write_text(text, encoding="utf-8")
+        written[artifact_name] = str(path)
+    return written
+
+
+def _normalize_proposal(
+    data: Mapping[str, Any],
+    *,
+    existing: Mapping[str, Any] | None = None,
+    artifact_paths: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    now = _now_iso()
+    raw_proposal_id = str(data.get("proposal_id") or "").strip()
+    if raw_proposal_id:
+        proposal_id = _safe_component(raw_proposal_id)
+    else:
+        basis = f"{data.get('source', 'manual')}-{data.get('source_run_id', '')}-{data.get('title', now)}"
+        proposal_id = _safe_component(basis)
+
+    target_skills = _as_string_list(data.get("target_skills"))
+    created_skills = _as_string_list(data.get("created_skills"))
+    archived_skills = _as_string_list(data.get("archived_skills"))
+    affected_skills = _unique_ordered(
+        _as_string_list(data.get("affected_skills")) + target_skills + created_skills + archived_skills
+    )
+
+    existing_decision_status = str(existing.get("decision_status", "pending")) if existing else "pending"
+    incoming_decision_status = data.get("decision_status")
+    if existing and existing_decision_status != "pending":
+        decision_status = _validate_decision_status(existing_decision_status)
+        decision_by = existing.get("decision_by")
+        decision_at = existing.get("decision_at")
+        decision_note = existing.get("decision_note")
+        decision_history = list(existing.get("decision_history") or [])
+    else:
+        decision_status = _validate_decision_status(str(incoming_decision_status or existing_decision_status or "pending"))
+        decision_by = data.get("decision_by", existing.get("decision_by") if existing else None)
+        decision_at = data.get("decision_at", existing.get("decision_at") if existing else None)
+        decision_note = data.get("decision_note", existing.get("decision_note") if existing else None)
+        decision_history = list(data.get("decision_history") or (existing.get("decision_history") if existing else []) or [])
+
+    merged_artifact_paths = dict(existing.get("artifact_paths") or {}) if existing else {}
+    merged_artifact_paths.update(dict(artifact_paths or {}))
+
+    codex_review_status = str(
+        data.get("codex_review_status")
+        or (existing.get("codex_review_status") if existing else None)
+        or "not_requested"
+    )
+
+    proposal: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "proposal_id": proposal_id,
+        "created_at": data.get("created_at") or (existing.get("created_at") if existing else None) or now,
+        "updated_at": now,
+        "source": str(data.get("source") or (existing.get("source") if existing else None) or "manual"),
+        "source_run_id": data.get("source_run_id") or (existing.get("source_run_id") if existing else None),
+        "source_paths": _as_string_map(data.get("source_paths") or (existing.get("source_paths") if existing else None)),
+        "action": str(data.get("action") or (existing.get("action") if existing else None) or "review"),
+        "title": str(data.get("title") or (existing.get("title") if existing else None) or proposal_id),
+        "pm_summary": data.get("pm_summary") or (existing.get("pm_summary") if existing else None) or "",
+        "rationale": data.get("rationale") or (existing.get("rationale") if existing else None) or "",
+        "risk_level": _validate_risk_level(str(data.get("risk_level") or (existing.get("risk_level") if existing else None) or "unknown")),
+        "impact_summary": data.get("impact_summary") or (existing.get("impact_summary") if existing else None) or "",
+        "pin_policy_status": data.get("pin_policy_status") or (existing.get("pin_policy_status") if existing else None) or "not_checked",
+        "target_skills": target_skills,
+        "created_skills": created_skills,
+        "archived_skills": archived_skills,
+        "affected_skills": affected_skills,
+        "pinned_skills": _as_string_list(data.get("pinned_skills") or (existing.get("pinned_skills") if existing else None)),
+        "evidence": _as_string_list(data.get("evidence") or (existing.get("evidence") if existing else None)),
+        "artifact_paths": merged_artifact_paths,
+        "diff_path": data.get("diff_path") or (existing.get("diff_path") if existing else None),
+        "backup_path": data.get("backup_path") or (existing.get("backup_path") if existing else None),
+        "rollback_path": data.get("rollback_path") or (existing.get("rollback_path") if existing else None),
+        "codex_review_status": _validate_codex_review_status(codex_review_status),
+        "codex_review_path": data.get("codex_review_path") or (existing.get("codex_review_path") if existing else None),
+        "codex_review_summary": data.get("codex_review_summary") or (existing.get("codex_review_summary") if existing else None) or "",
+        "codex_review_warnings": _as_string_list(data.get("codex_review_warnings") or (existing.get("codex_review_warnings") if existing else None)),
+        "codex_review_errors": _as_string_list(data.get("codex_review_errors") or (existing.get("codex_review_errors") if existing else None)),
+        "recommended_decision": data.get("recommended_decision") or (existing.get("recommended_decision") if existing else None) or "review_first",
+        "decision_status": decision_status,
+        "decision_by": decision_by,
+        "decision_at": decision_at,
+        "decision_note": decision_note,
+        "decision_history": decision_history,
+        "metadata": dict(data.get("metadata") or (existing.get("metadata") if existing else {}) or {}),
+    }
+    return {field: proposal.get(field) for field in PROPOSAL_FIELDS}
+
+
+def create_or_update_skill_governance_proposal(
+    proposal: Mapping[str, Any],
+    *,
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Create or idempotently update a read-only governance proposal.
+
+    Existing non-pending human/policy decisions are preserved when the same
+    proposal is imported again.  Optional ``artifact_texts`` in ``proposal`` are
+    written under the proposal artifact directory but are not stored inline.
+    """
+
+    raw_id = str(proposal.get("proposal_id") or "").strip()
+    probe_id = raw_id or _safe_component(
+        f"{proposal.get('source', 'manual')}-{proposal.get('source_run_id', '')}-{proposal.get('title', '')}"
+    )
+    path = _proposal_json_path(probe_id, proposals_root=proposals_root)
+    existing = _read_proposal_file(path)
+    artifact_paths = _write_artifacts(
+        probe_id,
+        proposal.get("artifact_texts") if isinstance(proposal.get("artifact_texts"), Mapping) else None,
+        proposals_root=proposals_root,
+    )
+    normalized = _normalize_proposal(proposal, existing=existing, artifact_paths=artifact_paths)
+    final_path = _proposal_json_path(normalized["proposal_id"], proposals_root=proposals_root)
+    _write_proposal_file(final_path, normalized)
+    return normalized
+
+
+def list_skill_governance_proposals(
+    decision_status: str | None = None,
+    limit: int = 50,
+    *,
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return governance proposals, newest first."""
+
+    root = _resolve_root(proposals_root)
+    if not root.exists():
+        return []
+    if decision_status is not None:
+        _validate_decision_status(decision_status)
+
+    proposals: list[dict[str, Any]] = []
+    for path in root.glob("*/proposal.json"):
+        proposal = _proposal_view_from_storage(_read_proposal_file(path))
+        if not proposal:
+            continue
+        if decision_status is not None and proposal.get("decision_status") != decision_status:
+            continue
+        proposals.append(proposal)
+
+    proposals.sort(key=lambda item: str(item.get("updated_at") or item.get("created_at") or ""), reverse=True)
+    status_rank = {
+        "pending": 0,
+        "needs_changes": 1,
+        "approved": 2,
+        "deferred": 3,
+        "bad_test_target": 4,
+        "rejected": 5,
+    }
+    proposals.sort(key=lambda item: status_rank.get(str(item.get("decision_status") or ""), 9))
+    return proposals[: max(0, limit)]
+
+
+def get_skill_governance_proposal(
+    proposal_id: str,
+    *,
+    proposals_root: str | os.PathLike[str] | None = None,
+    include_artifacts: bool = False,
+) -> dict[str, Any] | None:
+    """Return one governance proposal by id."""
+
+    raw_id = str(proposal_id or "").strip()
+    if not _is_canonical_proposal_id(raw_id):
+        return None
+    stored = _read_proposal_file(_proposal_json_path(raw_id, proposals_root=proposals_root))
+    if include_artifacts:
+        return _proposal_detail_from_storage(stored, proposals_root=proposals_root)
+    return _proposal_view_from_storage(stored)
+
+
+def record_skill_governance_decision(
+    proposal_id: str,
+    status: str,
+    *,
+    note: str | None = None,
+    decided_by: str = "hermes-user",
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any] | None:
+    """Record a PM decision on a proposal without applying it."""
+
+    target_status = _validate_decision_status(status)
+    raw_id = str(proposal_id or "").strip()
+    if not _is_canonical_proposal_id(raw_id):
+        return None
+    path = _proposal_json_path(raw_id, proposals_root=proposals_root)
+    proposal = _read_proposal_file(path)
+    if proposal is None:
+        return None
+
+    current_status = _validate_decision_status(str(proposal.get("decision_status") or "pending"))
+    _validate_decision_transition(current_status, target_status)
+
+    now = _now_iso()
+    history = list(proposal.get("decision_history") or [])
+    history.append(
+        {
+            "previous_status": current_status,
+            "status": target_status,
+            "note": note,
+            "decided_by": decided_by,
+            "decided_at": now,
+        }
+    )
+    proposal["updated_at"] = now
+    proposal["decision_status"] = target_status
+    proposal["decision_by"] = decided_by
+    proposal["decision_at"] = now
+    proposal["decision_note"] = note
+    proposal["decision_history"] = history
+    proposal = {field: proposal.get(field) for field in PROPOSAL_FIELDS}
+    _write_proposal_file(path, proposal)
+    return proposal
+
+
+def _load_run_json(run_json_path: str | os.PathLike[str] | None) -> dict[str, Any]:
+    if run_json_path is None:
+        return {}
+    try:
+        data = json.loads(Path(run_json_path).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _parse_consolidations(report_text: str) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {}
+    pattern = re.compile(r"-\s+from:\s+([A-Za-z0-9_.-]+)\s+\n\s+into:\s+([A-Za-z0-9_.-]+)", re.MULTILINE)
+    for match in pattern.finditer(report_text):
+        source, target = match.group(1), match.group(2)
+        grouped.setdefault(target, []).append(source)
+    return {target: _unique_ordered(sources) for target, sources in grouped.items()}
+
+
+def _fallback_skills(report_text: str, umbrella: str, defaults: Sequence[str]) -> list[str]:
+    lower = report_text.lower()
+    found = [skill for skill in defaults if skill.lower() in lower]
+    if found:
+        return found
+    return list(defaults) if umbrella.lower() in lower else []
+
+
+def _extract_section(report_text: str, heading_fragment: str) -> str:
+    lines = report_text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if heading_fragment.lower() in line.lower():
+            start = idx
+            break
+    if start is None:
+        return report_text
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        if lines[idx].startswith("### ") or lines[idx].startswith("## "):
+            end = idx
+            break
+    return "\n".join(lines[start:end]).strip() + "\n"
+
+
+def _run_id_from_paths(report_path: Path, run_json: Mapping[str, Any]) -> str:
+    started_at = run_json.get("started_at")
+    if isinstance(started_at, str) and started_at:
+        return _safe_component(report_path.parent.name or started_at)
+    return _safe_component(report_path.parent.name or "curator-run")
+
+
+def import_curator_dry_run(
+    report_path: str | os.PathLike[str],
+    *,
+    run_json_path: str | os.PathLike[str] | None = None,
+    proposals_root: str | os.PathLike[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Import a Curator dry-run report into reviewable proposals.
+
+    The import is intentionally conservative and idempotent.  It currently
+    recognizes the two umbrella proposals surfaced by the 2026-05-06 dry-run:
+    dashboard/HUDUI consolidation and LLM training consolidation.  Unknown report
+    content yields an empty list rather than a guessed mutation proposal.
+    """
+
+    report = Path(report_path)
+    report_text = report.read_text(encoding="utf-8")
+    run_json = _load_run_json(run_json_path)
+    run_id = _run_id_from_paths(report, run_json)
+    grouped = _parse_consolidations(report_text)
+    source_paths = {"report_path": str(report)}
+    if run_json_path is not None:
+        source_paths["run_json_path"] = str(Path(run_json_path))
+
+    dashboard_sources = grouped.get("hermes-dashboard-development") or _fallback_skills(
+        report_text, "hermes-dashboard-development", DASHBOARD_HUDUI_SKILLS
+    )
+    training_sources = grouped.get("llm-training-workflows") or _fallback_skills(
+        report_text, "llm-training-workflows", LLM_TRAINING_SKILLS
+    )
+
+    imported: list[dict[str, Any]] = []
+    if dashboard_sources:
+        imported.append(
+            create_or_update_skill_governance_proposal(
+                {
+                    "proposal_id": f"curator-{run_id}-hermes-dashboard-development",
+                    "source": "curator_dry_run",
+                    "source_run_id": run_id,
+                    "source_paths": source_paths,
+                    "action": "consolidate",
+                    "title": "Consolidate dashboard/HUDUI skills into hermes-dashboard-development",
+                    "pm_summary": "Curator proposes one dashboard/HUDUI umbrella skill so recurring dashboard recipes become easier to find without losing detailed references.",
+                    "rationale": "The dry-run found repeated dashboard, HUDUI, operations, LAN, and UI-customization recipes that fit one class-level workflow skill.",
+                    "risk_level": "medium",
+                    "impact_summary": "Would create one umbrella and later archive absorbed narrow skills only after backup, diff, review, and explicit approval.",
+                    "pin_policy_status": "not_checked",
+                    "target_skills": dashboard_sources,
+                    "created_skills": ["hermes-dashboard-development"],
+                    "archived_skills": dashboard_sources,
+                    "evidence": [
+                        "Curator dry-run reported no mutating actions.",
+                        "Structured summary proposed consolidation into hermes-dashboard-development.",
+                        "User selected dashboard/HUDUI as the first meaningful validation target.",
+                    ],
+                    "recommended_decision": "review_first",
+                    "metadata": {"curator_model": run_json.get("model"), "curator_provider": run_json.get("provider")},
+                    "artifact_texts": {"curator_report_excerpt.md": _extract_section(report_text, "hermes-dashboard-development")},
+                },
+                proposals_root=proposals_root,
+            )
+        )
+
+    if training_sources:
+        imported.append(
+            create_or_update_skill_governance_proposal(
+                {
+                    "proposal_id": f"curator-{run_id}-llm-training-workflows",
+                    "source": "curator_dry_run",
+                    "source_run_id": run_id,
+                    "source_paths": source_paths,
+                    "action": "consolidate",
+                    "title": "Defer llm-training-workflows consolidation as first Curator test",
+                    "pm_summary": "Curator proposed an LLM training umbrella, but this is a poor first validation target because the user does not actively use that cluster.",
+                    "rationale": "A technically plausible consolidation is not necessarily a good activation test when the maintainer cannot judge source fidelity and retained edges.",
+                    "risk_level": "medium",
+                    "impact_summary": "No skill mutation should be attempted for this proposal during the first governance-console validation pass.",
+                    "pin_policy_status": "not_checked",
+                    "target_skills": training_sources,
+                    "created_skills": ["llm-training-workflows"],
+                    "archived_skills": training_sources,
+                    "evidence": [
+                        "Curator dry-run proposed llm-training-workflows.",
+                        "User decision: do not use this as the first real Curator test.",
+                    ],
+                    "recommended_decision": "defer",
+                    "decision_status": "bad_test_target",
+                    "decision_by": "hermes-policy",
+                    "decision_at": _now_iso(),
+                    "decision_note": "Marked from user decision: llm-training-workflows is a poor first validation target for Curator activation.",
+                    "metadata": {"curator_model": run_json.get("model"), "curator_provider": run_json.get("provider")},
+                    "artifact_texts": {"curator_report_excerpt.md": _extract_section(report_text, "llm-training-workflows")},
+                },
+                proposals_root=proposals_root,
+            )
+        )
+
+    return imported
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "DECISION_STATUSES",
+    "CODEX_REVIEW_STATUSES",
+    "create_or_update_skill_governance_proposal",
+    "list_skill_governance_proposals",
+    "get_skill_governance_proposal",
+    "record_skill_governance_decision",
+    "import_curator_dry_run",
+]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -214,6 +214,99 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _read_skill_text_snapshot(skill_dir: Path) -> Dict[str, str]:
+    """Read text files from a skill directory for local diff evidence."""
+    snapshot: Dict[str, str] = {}
+    if not skill_dir.exists() or not skill_dir.is_dir():
+        return snapshot
+    for path in sorted(skill_dir.rglob("*"), key=lambda p: p.relative_to(skill_dir).as_posix()):
+        if not path.is_file() or path.is_symlink():
+            continue
+        rel = path.relative_to(skill_dir).as_posix()
+        try:
+            snapshot[rel] = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+    return snapshot
+
+
+def _skill_category_from_dir(skill_dir: Path) -> Optional[str]:
+    """Best-effort category from a skill directory relative to SKILLS_DIR."""
+    try:
+        rel = skill_dir.relative_to(SKILLS_DIR)
+    except ValueError:
+        return None
+    if len(rel.parts) <= 1:
+        return None
+    return "/".join(rel.parts[:-1])
+
+
+def _snapshot_for_skill(name: str) -> Optional[Dict[str, Any]]:
+    existing = _find_skill(name)
+    if not existing:
+        return None
+    skill_dir = existing["path"]
+    try:
+        from tools.skill_change_ledger import hash_skill_dir
+        skill_hash = hash_skill_dir(skill_dir)
+    except Exception:
+        skill_hash = None
+    return {
+        "path": skill_dir,
+        "category": _skill_category_from_dir(skill_dir),
+        "hash": skill_hash,
+        "text": _read_skill_text_snapshot(skill_dir),
+    }
+
+
+def _changed_snapshot_files(before: Optional[Dict[str, str]], after: Optional[Dict[str, str]]) -> list[str]:
+    before = before or {}
+    after = after or {}
+    return sorted(path for path in (set(before) | set(after)) if before.get(path) != after.get(path))
+
+
+def _record_skill_manage_change(
+    *,
+    action: str,
+    name: str,
+    reason: Optional[str],
+    session_id: Optional[str],
+    before: Optional[Dict[str, Any]],
+    after: Optional[Dict[str, Any]],
+    file_path: Optional[str],
+    replace_all: bool,
+    result: Dict[str, Any],
+) -> None:
+    """Record a successful skill_manage mutation without making the tool fragile."""
+    try:
+        from tools.skill_change_ledger import record_skill_change
+
+        before_text = before.get("text") if before else {}
+        after_text = after.get("text") if after else {}
+        changed_files = _changed_snapshot_files(before_text, after_text)
+        event = record_skill_change(
+            skill=name,
+            category=(after or before or {}).get("category"),
+            action=action,
+            actor="hermes-agent",
+            source="skill_manage",
+            session_id=session_id,
+            reason=reason,
+            before_hash=before.get("hash") if before else None,
+            after_hash=after.get("hash") if after else None,
+            changed_files=changed_files,
+            before_text=before_text,
+            after_text=after_text,
+            metadata={
+                "file_path": file_path,
+                "replace_all": replace_all,
+            },
+        )
+        result["skill_change_event_id"] = event["event_id"]
+    except Exception as e:
+        logger.warning("Failed to record skill change event for %s/%s: %s", action, name, e, exc_info=True)
+
+
 def _validate_file_path(file_path: str) -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
@@ -595,12 +688,16 @@ def skill_manage(
     old_string: str = None,
     new_string: str = None,
     replace_all: bool = False,
+    reason: str = None,
+    session_id: str = None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
 
     Returns JSON string with results.
     """
+    before_snapshot = _snapshot_for_skill(name)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -637,6 +734,18 @@ def skill_manage(
         result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
 
     if result.get("success"):
+        after_snapshot = None if action == "delete" else _snapshot_for_skill(name)
+        _record_skill_manage_change(
+            action=action,
+            name=name,
+            reason=reason,
+            session_id=session_id,
+            before=before_snapshot,
+            after=after_snapshot,
+            file_path=file_path,
+            replace_all=replace_all,
+            result=result,
+        )
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
             clear_skills_system_prompt_cache(clear_snapshot=True)
@@ -713,6 +822,13 @@ SKILL_MANAGE_SCHEMA = {
                 "type": "boolean",
                 "description": "For 'patch': replace all occurrences instead of requiring a unique match (default: false)."
             },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Optional explicit reason for the skill change. Recorded in the local "
+                    "skill change ledger so dashboard users can see why the skill changed."
+                )
+            },
             "category": {
                 "type": "string",
                 "description": (
@@ -756,6 +872,8 @@ registry.register(
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False)),
+        replace_all=args.get("replace_all", False),
+        reason=args.get("reason"),
+        session_id=kw.get("task_id")),
     emoji="📝",
 )

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -27,7 +27,7 @@ import os
 import shutil
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +173,78 @@ def _dir_hash(directory: Path) -> str:
     return hasher.hexdigest()
 
 
+def _read_text_snapshot(directory: Path) -> Dict[str, str]:
+    """Read text files from a skill directory for diff artifacts."""
+    snapshot: Dict[str, str] = {}
+    if not directory.exists() or not directory.is_dir():
+        return snapshot
+    for fpath in sorted(directory.rglob("*"), key=lambda p: p.relative_to(directory).as_posix()):
+        if not fpath.is_file() or fpath.is_symlink():
+            continue
+        try:
+            snapshot[fpath.relative_to(directory).as_posix()] = fpath.read_text(
+                encoding="utf-8", errors="replace"
+            )
+        except OSError:
+            continue
+    return snapshot
+
+
+def _sha256_skill_hash(directory: Path) -> Optional[str]:
+    try:
+        from tools.skill_change_ledger import hash_skill_dir
+        return hash_skill_dir(directory)
+    except Exception:
+        return None
+
+
+def _skill_category(dest: Path) -> Optional[str]:
+    try:
+        rel = dest.relative_to(SKILLS_DIR)
+    except ValueError:
+        return None
+    if len(rel.parts) <= 1:
+        return None
+    return "/".join(rel.parts[:-1])
+
+
+def _record_sync_change(
+    *,
+    skill_name: str,
+    action: str,
+    dest: Path,
+    before_text: Optional[Dict[str, str]],
+    after_text: Optional[Dict[str, str]],
+    before_hash: Optional[str],
+    after_hash: Optional[str],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Record skills_sync changes without making sync brittle."""
+    try:
+        from tools.skill_change_ledger import record_skill_change
+
+        record_skill_change(
+            skill=skill_name,
+            category=_skill_category(dest),
+            action=action,
+            actor="hermes-system",
+            source="skills_sync",
+            reason=(
+                "Bundled skill copied during skills sync."
+                if action == "bundled_copy"
+                else "Bundled skill updated during skills sync."
+            ),
+            reason_kind="system",
+            before_hash=before_hash,
+            after_hash=after_hash,
+            before_text=before_text or {},
+            after_text=after_text or {},
+            metadata=metadata or {},
+        )
+    except Exception as e:
+        logger.debug("Could not record skills_sync change for %s: %s", skill_name, e, exc_info=True)
+
+
 def sync_skills(quiet: bool = False) -> dict:
     """
     Sync bundled skills into ~/.hermes/skills/ using the manifest.
@@ -214,6 +286,16 @@ def sync_skills(quiet: bool = False) -> dict:
                     shutil.copytree(skill_src, dest)
                     copied.append(skill_name)
                     manifest[skill_name] = bundled_hash
+                    _record_sync_change(
+                        skill_name=skill_name,
+                        action="bundled_copy",
+                        dest=dest,
+                        before_text={},
+                        after_text=_read_text_snapshot(dest),
+                        before_hash=None,
+                        after_hash=_sha256_skill_hash(dest),
+                        metadata={"bundled_hash": bundled_hash},
+                    )
                     if not quiet:
                         print(f"  + {skill_name}")
             except (OSError, IOError) as e:
@@ -247,6 +329,8 @@ def sync_skills(quiet: bool = False) -> dict:
             # User copy matches origin — check if bundled has a newer version
             if bundled_hash != origin_hash:
                 try:
+                    before_text = _read_text_snapshot(dest)
+                    before_sha = _sha256_skill_hash(dest)
                     # Move old copy to a backup so we can restore on failure
                     backup = dest.with_suffix(".bak")
                     shutil.move(str(dest), str(backup))
@@ -254,6 +338,19 @@ def sync_skills(quiet: bool = False) -> dict:
                         shutil.copytree(skill_src, dest)
                         manifest[skill_name] = bundled_hash
                         updated.append(skill_name)
+                        _record_sync_change(
+                            skill_name=skill_name,
+                            action="bundled_update",
+                            dest=dest,
+                            before_text=before_text,
+                            after_text=_read_text_snapshot(dest),
+                            before_hash=before_sha,
+                            after_hash=_sha256_skill_hash(dest),
+                            metadata={
+                                "origin_hash": origin_hash,
+                                "bundled_hash": bundled_hash,
+                            },
+                        )
                         if not quiet:
                             print(f"  ↑ {skill_name} (updated)")
                         # Remove backup after successful copy

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -101,6 +101,22 @@ export const api = {
 
   // Skills & Toolsets
   getSkills: () => fetchJSON<SkillInfo[]>("/api/skills"),
+  getSkillChanges: (params: { skill?: string; limit?: number; unreviewed?: boolean } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.skill) qs.set("skill", params.skill);
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.unreviewed !== undefined) qs.set("unreviewed", String(params.unreviewed));
+    const query = qs.toString();
+    return fetchJSON<SkillChangeEvent[]>(`/api/skills/changes${query ? `?${query}` : ""}`);
+  },
+  getSkillChange: (eventId: string) =>
+    fetchJSON<SkillChangeDetail>(`/api/skills/changes/${encodeURIComponent(eventId)}`),
+  reviewSkillChange: (eventId: string, status = "reviewed", note?: string) =>
+    fetchJSON<SkillChangeEvent>(`/api/skills/changes/${encodeURIComponent(eventId)}/review`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status, note }),
+    }),
   toggleSkill: (name: string, enabled: boolean) =>
     fetchJSON<{ ok: boolean }>("/api/skills/toggle", {
       method: "PUT",
@@ -302,6 +318,31 @@ export interface SkillInfo {
   description: string;
   category: string;
   enabled: boolean;
+}
+
+export interface SkillChangeEvent {
+  event_id: string;
+  timestamp: string;
+  skill: string;
+  category: string | null;
+  action: string;
+  actor: string;
+  source: string;
+  session_id: string | null;
+  reason: string | null;
+  reason_kind: string;
+  before_hash: string | null;
+  after_hash: string | null;
+  changed_files: string[];
+  diff_path: string | null;
+  metadata: Record<string, unknown>;
+  review_status: "unreviewed" | "reviewed" | "needs_followup" | string;
+  reviewed_at: string | null;
+  review_note: string | null;
+}
+
+export interface SkillChangeDetail extends SkillChangeEvent {
+  diff_text?: string;
 }
 
 export interface ToolsetInfo {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -117,6 +117,21 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status, note }),
     }),
+  getSkillGovernanceProposals: (params: { decision_status?: string; limit?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.decision_status) qs.set("decision_status", params.decision_status);
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    const query = qs.toString();
+    return fetchJSON<SkillGovernanceProposal[]>(`/api/skills/governance/proposals${query ? `?${query}` : ""}`);
+  },
+  getSkillGovernanceProposal: (proposalId: string) =>
+    fetchJSON<SkillGovernanceProposal>(`/api/skills/governance/proposals/${encodeURIComponent(proposalId)}`),
+  decideSkillGovernanceProposal: (proposalId: string, status: string, note?: string) =>
+    fetchJSON<SkillGovernanceProposal>(`/api/skills/governance/proposals/${encodeURIComponent(proposalId)}/decision`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status, note }),
+    }),
   toggleSkill: (name: string, enabled: boolean) =>
     fetchJSON<{ ok: boolean }>("/api/skills/toggle", {
       method: "PUT",
@@ -343,6 +358,48 @@ export interface SkillChangeEvent {
 
 export interface SkillChangeDetail extends SkillChangeEvent {
   diff_text?: string;
+}
+
+export interface SkillGovernanceProposal {
+  schema_version: number;
+  proposal_id: string;
+  created_at: string;
+  updated_at: string;
+  source: string;
+  source_run_id: string | null;
+  source_paths: Record<string, string>;
+  action: string;
+  title: string;
+  pm_summary: string;
+  rationale: string;
+  risk_level: "low" | "medium" | "high" | "unknown" | string;
+  impact_summary: string;
+  pin_policy_status: string;
+  target_skills: string[];
+  created_skills: string[];
+  archived_skills: string[];
+  affected_skills: string[];
+  pinned_skills: string[];
+  evidence: string[];
+  artifact_paths: Record<string, string>;
+  diff_path: string | null;
+  backup_path: string | null;
+  rollback_path: string | null;
+  codex_review_status: string;
+  codex_review_path: string | null;
+  codex_review_summary: string;
+  codex_review_warnings: string[];
+  codex_review_errors: string[];
+  recommended_decision: string;
+  decision_status: "pending" | "approved" | "rejected" | "deferred" | "needs_changes" | "bad_test_target" | string;
+  decision_by: string | null;
+  decision_at: string | null;
+  decision_note: string | null;
+  decision_history: Array<Record<string, unknown>>;
+  metadata: Record<string, unknown>;
+  allowed_decision_statuses?: string[];
+  artifact_texts?: Record<string, string>;
+  diff_text?: string | null;
 }
 
 export interface ToolsetInfo {

--- a/web/src/lib/skillChanges.ts
+++ b/web/src/lib/skillChanges.ts
@@ -1,0 +1,47 @@
+import type { SkillChangeEvent } from "@/lib/api";
+
+export function reasonKindLabel(kind: string): string {
+  switch (kind) {
+    case "explicit":
+      return "Explicit reason";
+    case "system":
+      return "System-detected change";
+    case "unattributed":
+      return "No reason captured";
+    case "model_summary":
+      return "Model-generated summary";
+    default:
+      return "Unknown reason source";
+  }
+}
+
+export function reviewStatusLabel(status: string): string {
+  switch (status) {
+    case "unreviewed":
+      return "Unreviewed";
+    case "reviewed":
+      return "Reviewed";
+    case "needs_followup":
+      return "Needs follow-up";
+    default:
+      return status;
+  }
+}
+
+export function latestChangeBySkill<T extends Pick<SkillChangeEvent, "skill" | "event_id">>(
+  changes: readonly T[],
+): Map<string, T> {
+  const bySkill = new Map<string, T>();
+  for (const change of changes) {
+    if (!bySkill.has(change.skill)) {
+      bySkill.set(change.skill, change);
+    }
+  }
+  return bySkill;
+}
+
+export function formatSkillChangeTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return date.toLocaleString();
+}

--- a/web/src/lib/skillChanges.ts
+++ b/web/src/lib/skillChanges.ts
@@ -40,6 +40,18 @@ export function latestChangeBySkill<T extends Pick<SkillChangeEvent, "skill" | "
   return bySkill;
 }
 
+export async function loadSkillChangesBestEffort<T>(
+  loadChanges: () => Promise<T[]>,
+  onError?: (error: unknown) => void,
+): Promise<T[]> {
+  try {
+    return await loadChanges();
+  } catch (error) {
+    onError?.(error);
+    return [];
+  }
+}
+
 export function formatSkillChangeTime(timestamp: string): string {
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return timestamp;

--- a/web/src/lib/skillGovernance.ts
+++ b/web/src/lib/skillGovernance.ts
@@ -1,0 +1,126 @@
+type ProposalLike = {
+  decision_status?: string | null;
+  allowed_decision_statuses?: string[] | null;
+  diff_text?: string | null;
+  artifact_texts?: Record<string, string> | null;
+};
+
+export const PROPOSAL_DECISION_ORDER = [
+  "pending",
+  "approved",
+  "needs_changes",
+  "deferred",
+  "bad_test_target",
+  "rejected",
+] as const;
+
+export function proposalStatusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    pending: "Pending PM decision",
+    approved: "Approved",
+    rejected: "Rejected",
+    deferred: "Deferred",
+    needs_changes: "Needs changes",
+    bad_test_target: "Bad test target",
+  };
+  return labels[status] ?? status.replace(/_/g, " ");
+}
+
+export function proposalDecisionActionLabel(status: string): string {
+  const labels: Record<string, string> = {
+    pending: "Reopen",
+    approved: "Approve record",
+    rejected: "Reject",
+    deferred: "Defer",
+    needs_changes: "Needs changes",
+    bad_test_target: "Bad test target",
+  };
+  return labels[status] ?? proposalStatusLabel(status);
+}
+
+export function proposalDecisionNote(status: string): string {
+  const notes: Record<string, string> = {
+    pending: "Reopened for PM decision; MVP does not apply or mutate skills.",
+    approved: "Approved in dashboard as a PM decision only; MVP does not apply or mutate skills.",
+    rejected: "Rejected in dashboard; no skill mutation should be attempted for this proposal.",
+    deferred: "Deferred in dashboard for later review; no skill mutation should be attempted now.",
+    needs_changes: "Needs changes before approval; keep proposal as review artifact only.",
+    bad_test_target: "Marked as a poor first Curator validation target; no skill mutation should be attempted.",
+  };
+  return notes[status] ?? "Decision recorded in dashboard; MVP does not apply or mutate skills.";
+}
+
+export function allowedProposalDecisionStatuses(proposal: ProposalLike): string[] {
+  const allowed = new Set(proposal.allowed_decision_statuses ?? PROPOSAL_DECISION_ORDER);
+  return PROPOSAL_DECISION_ORDER.filter((status) => allowed.has(status));
+}
+
+export function canRecordProposalDecision(proposal: ProposalLike, status: string): boolean {
+  return allowedProposalDecisionStatuses(proposal).includes(status as (typeof PROPOSAL_DECISION_ORDER)[number]);
+}
+
+export function proposalDecisionActionStatuses(proposal: ProposalLike): string[] {
+  return allowedProposalDecisionStatuses(proposal).filter((status) => status !== proposal.decision_status);
+}
+
+export function unavailableProposalDecisionStatuses(proposal: ProposalLike): string[] {
+  const allowed = new Set(allowedProposalDecisionStatuses(proposal));
+  return PROPOSAL_DECISION_ORDER.filter((status) => !allowed.has(status));
+}
+
+export function proposalDecisionTransitionHint(proposal: ProposalLike): string | null {
+  const unavailable = unavailableProposalDecisionStatuses(proposal);
+  const currentStatus = proposal.decision_status ? proposalStatusLabel(proposal.decision_status) : "this status";
+  if (unavailable.includes("approved") && canRecordProposalDecision(proposal, "pending")) {
+    return `Approved is not available from ${currentStatus}. Reopen to Pending PM decision first if you want to approve it.`;
+  }
+  if (unavailable.length > 0) {
+    return `Unavailable from ${currentStatus}: ${unavailable.map(proposalStatusLabel).join(", ")}.`;
+  }
+  return null;
+}
+
+export function proposalPreviewText(proposal: ProposalLike): {
+  title: string;
+  body: string;
+  kind: "diff" | "artifact" | "empty";
+} {
+  const diff = proposal.diff_text?.trim();
+  if (diff) {
+    return { title: "Unified diff", body: proposal.diff_text ?? "", kind: "diff" };
+  }
+
+  const artifacts = proposal.artifact_texts ?? {};
+  const preferred = artifacts["curator_report_excerpt.md"];
+  if (preferred?.trim()) {
+    return { title: "Dry-run excerpt", body: preferred, kind: "artifact" };
+  }
+
+  const first = Object.entries(artifacts).find(([, value]) => value.trim());
+  if (first) {
+    return { title: `Artifact: ${first[0]}`, body: first[1], kind: "artifact" };
+  }
+
+  return {
+    title: "No diff artifact",
+    body: "No unified diff has been generated for this proposal yet. This MVP is decision-only and does not apply or mutate skills.",
+    kind: "empty",
+  };
+}
+
+export function extractFetchErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return "Unknown error";
+  const message = error.message;
+  const jsonStart = message.indexOf("{");
+  if (jsonStart >= 0) {
+    try {
+      const parsed = JSON.parse(message.slice(jsonStart));
+      if (typeof parsed.detail === "string" && parsed.detail.trim()) {
+        return parsed.detail;
+      }
+    } catch {
+      // Fall through to raw error message.
+    }
+  }
+  return message;
+}

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -7,15 +7,25 @@ import {
   ChevronRight,
   Filter,
   X,
+  History,
+  FileText,
+  CheckCircle2,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { SkillInfo, ToolsetInfo } from "@/lib/api";
+import type { SkillChangeDetail, SkillChangeEvent, SkillInfo, ToolsetInfo } from "@/lib/api";
+import {
+  formatSkillChangeTime,
+  latestChangeBySkill,
+  reasonKindLabel,
+  reviewStatusLabel,
+} from "@/lib/skillChanges";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
 import { useI18n } from "@/i18n";
 
 /* ------------------------------------------------------------------ */
@@ -64,6 +74,10 @@ function prettyCategory(raw: string | null | undefined, generalLabel: string): s
 export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [toolsets, setToolsets] = useState<ToolsetInfo[]>([]);
+  const [skillChanges, setSkillChanges] = useState<SkillChangeEvent[]>([]);
+  const [selectedChange, setSelectedChange] = useState<SkillChangeDetail | null>(null);
+  const [loadingChangeDetail, setLoadingChangeDetail] = useState(false);
+  const [reviewingChange, setReviewingChange] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
@@ -74,10 +88,11 @@ export default function SkillsPage() {
   const { t } = useI18n();
 
   useEffect(() => {
-    Promise.all([api.getSkills(), api.getToolsets()])
-      .then(([s, tsets]) => {
+    Promise.all([api.getSkills(), api.getToolsets(), api.getSkillChanges({ limit: 20 })])
+      .then(([s, tsets, changes]) => {
         setSkills(s);
         setToolsets(tsets);
+        setSkillChanges(changes);
       })
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
@@ -105,6 +120,36 @@ export default function SkillsPage() {
         next.delete(skill.name);
         return next;
       });
+    }
+  };
+
+  const handleSelectChange = async (change: SkillChangeEvent) => {
+    setLoadingChangeDetail(true);
+    try {
+      const detail = await api.getSkillChange(change.event_id);
+      setSelectedChange(detail);
+    } catch {
+      showToast(`Failed to load change for ${change.skill}`, "error");
+    } finally {
+      setLoadingChangeDetail(false);
+    }
+  };
+
+  const handleMarkReviewed = async (eventId: string) => {
+    setReviewingChange(eventId);
+    try {
+      const updated = await api.reviewSkillChange(eventId, "reviewed");
+      setSkillChanges((prev) =>
+        prev.map((event) => (event.event_id === eventId ? { ...event, ...updated } : event))
+      );
+      setSelectedChange((prev) =>
+        prev?.event_id === eventId ? { ...prev, ...updated, diff_text: prev.diff_text } : prev
+      );
+      showToast("Skill change marked reviewed", "success");
+    } catch {
+      showToast("Failed to mark skill change reviewed", "error");
+    } finally {
+      setReviewingChange(null);
     }
   };
 
@@ -162,6 +207,8 @@ export default function SkillsPage() {
   }, [skills]);
 
   const enabledCount = skills.filter((s) => s.enabled).length;
+  const latestChanges = useMemo(() => latestChangeBySkill(skillChanges), [skillChanges]);
+  const unreviewedChangeCount = skillChanges.filter((event) => event.review_status === "unreviewed").length;
 
   const filteredToolsets = useMemo(() => {
     return toolsets.filter(
@@ -274,6 +321,124 @@ export default function SkillsPage() {
         </div>
       )}
 
+      {/* Skill change ledger */}
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <History className="h-4 w-4 text-muted-foreground" />
+              Skill change history
+            </CardTitle>
+            <Badge variant={unreviewedChangeCount > 0 ? "outline" : "secondary"} className="text-[10px]">
+              {unreviewedChangeCount} unreviewed
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="px-4 pb-4 pt-0">
+          {skillChanges.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No skill changes recorded yet. New ledger events will appear here with reasons and diffs.
+            </p>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
+              <div className="grid gap-2">
+                {skillChanges.slice(0, 8).map((change) => (
+                  <button
+                    key={change.event_id}
+                    type="button"
+                    className={`text-left rounded-md border px-3 py-2 transition-colors hover:bg-muted/40 ${
+                      selectedChange?.event_id === change.event_id ? "border-primary/70 bg-primary/5" : "border-border"
+                    }`}
+                    onClick={() => handleSelectChange(change)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono-ui text-xs text-foreground truncate">{change.skill}</span>
+                          <Badge variant="secondary" className="text-[10px] font-normal">
+                            {change.action}
+                          </Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                          {change.reason || reasonKindLabel(change.reason_kind)}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <Badge
+                          variant={change.review_status === "unreviewed" ? "outline" : "secondary"}
+                          className="text-[10px]"
+                        >
+                          {reviewStatusLabel(change.review_status)}
+                        </Badge>
+                        <p className="mt-1 text-[10px] text-muted-foreground">
+                          {formatSkillChangeTime(change.timestamp)}
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="rounded-md border border-border bg-muted/20 p-3 min-h-[160px]">
+                {loadingChangeDetail ? (
+                  <div className="flex items-center justify-center py-10">
+                    <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                  </div>
+                ) : selectedChange ? (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-mono-ui text-sm">{selectedChange.skill}</h3>
+                        <p className="text-xs text-muted-foreground">
+                          {selectedChange.action} · {reasonKindLabel(selectedChange.reason_kind)}
+                        </p>
+                      </div>
+                      {selectedChange.review_status !== "reviewed" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={reviewingChange === selectedChange.event_id}
+                          onClick={() => handleMarkReviewed(selectedChange.event_id)}
+                        >
+                          <CheckCircle2 className="h-3.5 w-3.5" />
+                          Mark reviewed
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="text-xs text-muted-foreground">
+                      <p>{selectedChange.reason || reasonKindLabel(selectedChange.reason_kind)}</p>
+                      <p className="mt-1">
+                        Source: {selectedChange.source} · Actor: {selectedChange.actor}
+                      </p>
+                    </div>
+
+                    {selectedChange.changed_files.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {selectedChange.changed_files.map((file) => (
+                          <Badge key={file} variant="secondary" className="text-[10px] font-mono">
+                            <FileText className="h-3 w-3" />
+                            {file}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    <pre className="max-h-72 overflow-auto rounded bg-background/80 p-3 text-[11px] leading-relaxed text-muted-foreground">
+                      {selectedChange.diff_text || "No diff artifact recorded for this event."}
+                    </pre>
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Select a change to inspect provenance, reason, files, and raw diff.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* ═══════════════ Skills by Category ═══════════════ */}
       <section className="flex flex-col gap-3">
 
@@ -350,6 +515,14 @@ export default function SkillsPage() {
                               >
                                 {skill.name}
                               </span>
+                              {latestChanges.get(skill.name) && (
+                                <Badge
+                                  variant={latestChanges.get(skill.name)?.review_status === "unreviewed" ? "outline" : "secondary"}
+                                  className="text-[10px]"
+                                >
+                                  changed
+                                </Badge>
+                              )}
                             </div>
                             <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
                               {skill.description || t.skills.noDescription}

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -10,9 +10,12 @@ import {
   History,
   FileText,
   CheckCircle2,
+  GitPullRequest,
+  ShieldCheck,
+  AlertTriangle,
 } from "lucide-react";
 import { api } from "@/lib/api";
-import type { SkillChangeDetail, SkillChangeEvent, SkillInfo, ToolsetInfo } from "@/lib/api";
+import type { SkillChangeDetail, SkillChangeEvent, SkillGovernanceProposal, SkillInfo, ToolsetInfo } from "@/lib/api";
 import {
   formatSkillChangeTime,
   latestChangeBySkill,
@@ -20,6 +23,17 @@ import {
   reasonKindLabel,
   reviewStatusLabel,
 } from "@/lib/skillChanges";
+import {
+  allowedProposalDecisionStatuses,
+  extractFetchErrorMessage,
+  proposalDecisionActionLabel,
+  proposalDecisionActionStatuses,
+  proposalDecisionTransitionHint,
+  proposalDecisionNote,
+  proposalPreviewText,
+  proposalStatusLabel,
+  unavailableProposalDecisionStatuses,
+} from "@/lib/skillGovernance";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -66,6 +80,26 @@ function prettyCategory(raw: string | null | undefined, generalLabel: string): s
     .join(" ");
 }
 
+function proposalRiskVariant(risk: string): "default" | "secondary" | "destructive" | "outline" {
+  if (risk === "high") return "destructive";
+  if (risk === "medium") return "outline";
+  if (risk === "low") return "secondary";
+  return "secondary";
+}
+
+function proposalStatusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "approved") return "default";
+  if (status === "rejected") return "destructive";
+  if (status === "pending" || status === "needs_changes") return "outline";
+  return "secondary";
+}
+
+function proposalActionVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "approved") return "default";
+  if (status === "rejected") return "destructive";
+  if (status === "deferred") return "secondary";
+  return "outline";
+}
 
 
 /* ------------------------------------------------------------------ */
@@ -76,6 +110,9 @@ export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [toolsets, setToolsets] = useState<ToolsetInfo[]>([]);
   const [skillChanges, setSkillChanges] = useState<SkillChangeEvent[]>([]);
+  const [governanceProposals, setGovernanceProposals] = useState<SkillGovernanceProposal[]>([]);
+  const [selectedProposal, setSelectedProposal] = useState<SkillGovernanceProposal | null>(null);
+  const [decidingProposal, setDecidingProposal] = useState<string | null>(null);
   const [selectedChange, setSelectedChange] = useState<SkillChangeDetail | null>(null);
   const [loadingChangeDetail, setLoadingChangeDetail] = useState(false);
   const [reviewingChange, setReviewingChange] = useState<string | null>(null);
@@ -96,11 +133,22 @@ export default function SkillsPage() {
         () => api.getSkillChanges({ limit: 20 }),
         () => showToast("Skill change history unavailable", "error"),
       ),
+      api.getSkillGovernanceProposals({ limit: 20 }).catch(() => {
+        showToast("Curator proposals unavailable", "error");
+        return [] as SkillGovernanceProposal[];
+      }),
     ])
-      .then(([s, tsets, changes]) => {
+      .then(([s, tsets, changes, proposals]) => {
         setSkills(s);
         setToolsets(tsets);
         setSkillChanges(changes);
+        setGovernanceProposals(proposals);
+        setSelectedProposal(proposals[0] ?? null);
+        if (proposals[0]) {
+          api.getSkillGovernanceProposal(proposals[0].proposal_id)
+            .then(setSelectedProposal)
+            .catch(() => undefined);
+        }
       })
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
@@ -161,6 +209,37 @@ export default function SkillsPage() {
     }
   };
 
+  const handleSelectProposal = async (proposal: SkillGovernanceProposal) => {
+    try {
+      const detail = await api.getSkillGovernanceProposal(proposal.proposal_id);
+      setSelectedProposal(detail);
+    } catch {
+      showToast(`Failed to load proposal ${proposal.proposal_id}`, "error");
+    }
+  };
+
+  const handleProposalDecision = async (proposalId: string, status: string) => {
+    setDecidingProposal(proposalId);
+    try {
+      const updated = await api.decideSkillGovernanceProposal(
+        proposalId,
+        status,
+        proposalDecisionNote(status),
+      );
+      setGovernanceProposals((prev) =>
+        prev.map((proposal) => (proposal.proposal_id === proposalId ? { ...proposal, ...updated } : proposal))
+      );
+      setSelectedProposal((prev) =>
+        prev?.proposal_id === proposalId ? { ...prev, ...updated } : prev
+      );
+      showToast(`Proposal marked ${proposalStatusLabel(status).toLowerCase()}`, "success");
+    } catch (error) {
+      showToast(extractFetchErrorMessage(error), "error");
+    } finally {
+      setDecidingProposal(null);
+    }
+  };
+
   /* ---- Derived data ---- */
   const lowerSearch = search.toLowerCase();
 
@@ -217,6 +296,12 @@ export default function SkillsPage() {
   const enabledCount = skills.filter((s) => s.enabled).length;
   const latestChanges = useMemo(() => latestChangeBySkill(skillChanges), [skillChanges]);
   const unreviewedChangeCount = skillChanges.filter((event) => event.review_status === "unreviewed").length;
+  const pendingProposalCount = governanceProposals.filter((proposal) => proposal.decision_status === "pending").length;
+  const selectedProposalPreview = selectedProposal ? proposalPreviewText(selectedProposal) : null;
+  const selectedAllowedProposalDecisions = selectedProposal ? allowedProposalDecisionStatuses(selectedProposal) : [];
+  const selectedProposalDecisionActions = selectedProposal ? proposalDecisionActionStatuses(selectedProposal) : [];
+  const selectedUnavailableProposalDecisions = selectedProposal ? unavailableProposalDecisionStatuses(selectedProposal) : [];
+  const selectedProposalTransitionHint = selectedProposal ? proposalDecisionTransitionHint(selectedProposal) : null;
 
   const filteredToolsets = useMemo(() => {
     return toolsets.filter(
@@ -328,6 +413,196 @@ export default function SkillsPage() {
           ))}
         </div>
       )}
+
+      {/* Curator proposal inbox */}
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <GitPullRequest className="h-4 w-4 text-muted-foreground" />
+              Curator proposals
+            </CardTitle>
+            <div className="flex items-center gap-2">
+              <Badge variant={pendingProposalCount > 0 ? "outline" : "secondary"} className="text-[10px]">
+                {pendingProposalCount} pending
+              </Badge>
+              <Badge variant="secondary" className="text-[10px]">
+                decision-only MVP
+              </Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="px-4 pb-4 pt-0">
+          {governanceProposals.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No Curator proposals imported yet. Run a dry-run importer to turn Curator reports into PM-reviewable cards.
+            </p>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(340px,0.95fr)]">
+              <div className="grid gap-2">
+                {governanceProposals.slice(0, 8).map((proposal) => (
+                  <button
+                    key={proposal.proposal_id}
+                    type="button"
+                    className={`text-left rounded-md border px-3 py-2 transition-colors hover:bg-muted/40 ${
+                      selectedProposal?.proposal_id === proposal.proposal_id ? "border-primary/70 bg-primary/5" : "border-border"
+                    }`}
+                    onClick={() => handleSelectProposal(proposal)}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-mono-ui text-xs text-foreground truncate">{proposal.title}</span>
+                          <Badge variant={proposalRiskVariant(proposal.risk_level)} className="text-[10px]">
+                            {proposal.risk_level} risk
+                          </Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                          {proposal.pm_summary || proposal.rationale}
+                        </p>
+                        <p className="mt-1 text-[10px] text-muted-foreground">
+                          {proposal.target_skills.length} affected · {proposal.action} · {proposal.source_run_id || proposal.source}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <Badge variant={proposalStatusVariant(proposal.decision_status)} className="text-[10px]">
+                          {proposalStatusLabel(proposal.decision_status)}
+                        </Badge>
+                        <p className="mt-1 text-[10px] text-muted-foreground">
+                          {formatSkillChangeTime(proposal.updated_at)}
+                        </p>
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+
+              <div className="rounded-md border border-border bg-muted/20 p-3 min-h-[220px]">
+                {selectedProposal ? (
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-mono-ui text-sm">{selectedProposal.title}</h3>
+                        <p className="text-xs text-muted-foreground">
+                          {selectedProposal.action} · {selectedProposal.source} · schema v{selectedProposal.schema_version}
+                        </p>
+                      </div>
+                      <Badge variant={proposalStatusVariant(selectedProposal.decision_status)} className="text-[10px]">
+                        {proposalStatusLabel(selectedProposal.decision_status)}
+                      </Badge>
+                    </div>
+
+                    <div className="grid gap-2 text-xs text-muted-foreground">
+                      <p>{selectedProposal.pm_summary || selectedProposal.rationale}</p>
+                      {selectedProposal.impact_summary && <p>Impact: {selectedProposal.impact_summary}</p>}
+                      <div className="flex flex-wrap gap-2">
+                        <Badge variant={proposalRiskVariant(selectedProposal.risk_level)} className="text-[10px]">
+                          {selectedProposal.risk_level} risk
+                        </Badge>
+                        <Badge variant="secondary" className="text-[10px]">
+                          Codex: {selectedProposal.codex_review_status}
+                        </Badge>
+                        <Badge variant="secondary" className="text-[10px]">
+                          Pins: {selectedProposal.pin_policy_status}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    {selectedProposal.target_skills.length > 0 && (
+                      <div>
+                        <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">Affected skills</p>
+                        <div className="flex flex-wrap gap-1">
+                          {selectedProposal.target_skills.map((skill) => (
+                            <Badge key={skill} variant="secondary" className="text-[10px] font-mono">
+                              {skill}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {selectedProposal.evidence.length > 0 && (
+                      <div>
+                        <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">Evidence</p>
+                        <ul className="list-disc pl-4 text-xs text-muted-foreground">
+                          {selectedProposal.evidence.map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {selectedProposalPreview && (
+                      <div>
+                        <div className="mb-1 flex items-center justify-between gap-2">
+                          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                            {selectedProposalPreview.title}
+                          </p>
+                          {selectedProposalPreview.kind !== "diff" && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              not an apply diff
+                            </Badge>
+                          )}
+                        </div>
+                        <pre className="max-h-72 overflow-auto rounded border border-border bg-background/80 p-3 text-[11px] leading-relaxed text-muted-foreground whitespace-pre-wrap">
+                          {selectedProposalPreview.body}
+                        </pre>
+                      </div>
+                    )}
+
+                    <div className="rounded border border-border bg-background/70 p-2 text-[11px] text-muted-foreground">
+                      <div className="flex items-start gap-2">
+                        <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <p>
+                          MVP records the PM decision only. It does not apply, archive, delete, unpin, repin, or mutate any skill.
+                        </p>
+                      </div>
+                    </div>
+
+                    {selectedProposal.decision_note && (
+                      <div className="rounded border border-border bg-background/70 p-2 text-[11px] text-muted-foreground">
+                        Decision note: {selectedProposal.decision_note}
+                      </div>
+                    )}
+
+                    <div className="flex flex-wrap gap-2">
+                      <p className="basis-full text-[10px] text-muted-foreground">
+                        Allowed now: {selectedAllowedProposalDecisions.map(proposalStatusLabel).join(", ")}
+                      </p>
+                      {selectedProposalTransitionHint && (
+                        <p className="basis-full text-[11px] text-muted-foreground">
+                          {selectedProposalTransitionHint}
+                        </p>
+                      )}
+                      {selectedProposalDecisionActions.map((status) => (
+                        <Button
+                          key={status}
+                          size="sm"
+                          variant={proposalActionVariant(status)}
+                          disabled={decidingProposal === selectedProposal.proposal_id}
+                          onClick={() => handleProposalDecision(selectedProposal.proposal_id, status)}
+                        >
+                          {status === "bad_test_target" && <AlertTriangle className="h-3.5 w-3.5" />}
+                          {proposalDecisionActionLabel(status)}
+                        </Button>
+                      ))}
+                      {selectedUnavailableProposalDecisions.length > 0 && (
+                        <p className="basis-full text-[10px] text-muted-foreground">
+                          Unavailable now: {selectedUnavailableProposalDecisions.map(proposalStatusLabel).join(", ")}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Select a Curator proposal to inspect rationale, risk, evidence, affected skills, and decision state.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* Skill change ledger */}
       <Card>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -16,6 +16,7 @@ import type { SkillChangeDetail, SkillChangeEvent, SkillInfo, ToolsetInfo } from
 import {
   formatSkillChangeTime,
   latestChangeBySkill,
+  loadSkillChangesBestEffort,
   reasonKindLabel,
   reviewStatusLabel,
 } from "@/lib/skillChanges";
@@ -88,7 +89,14 @@ export default function SkillsPage() {
   const { t } = useI18n();
 
   useEffect(() => {
-    Promise.all([api.getSkills(), api.getToolsets(), api.getSkillChanges({ limit: 20 })])
+    Promise.all([
+      api.getSkills(),
+      api.getToolsets(),
+      loadSkillChangesBestEffort(
+        () => api.getSkillChanges({ limit: 20 }),
+        () => showToast("Skill change history unavailable", "error"),
+      ),
+    ])
       .then(([s, tsets, changes]) => {
         setSkills(s);
         setToolsets(tsets);

--- a/web/tests/skillChanges.test.ts
+++ b/web/tests/skillChanges.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  latestChangeBySkill,
+  reasonKindLabel,
+  reviewStatusLabel,
+} from "../src/lib/skillChanges.ts";
+
+test("reasonKindLabel keeps explicit provenance separate from missing reasons", () => {
+  assert.equal(reasonKindLabel("explicit"), "Explicit reason");
+  assert.equal(reasonKindLabel("system"), "System-detected change");
+  assert.equal(reasonKindLabel("unattributed"), "No reason captured");
+  assert.equal(reasonKindLabel("model_summary"), "Model-generated summary");
+  assert.equal(reasonKindLabel("unknown"), "Unknown reason source");
+});
+
+test("reviewStatusLabel maps dashboard review states", () => {
+  assert.equal(reviewStatusLabel("unreviewed"), "Unreviewed");
+  assert.equal(reviewStatusLabel("reviewed"), "Reviewed");
+  assert.equal(reviewStatusLabel("needs_followup"), "Needs follow-up");
+  assert.equal(reviewStatusLabel("other"), "other");
+});
+
+test("latestChangeBySkill keeps the newest event per skill from a newest-first list", () => {
+  const changes = [
+    {
+      event_id: "new-alpha",
+      timestamp: "2026-04-27T08:00:00Z",
+      skill: "alpha",
+      category: null,
+      action: "patch",
+      actor: "hermes-agent",
+      source: "unit-test",
+      session_id: null,
+      reason: "new",
+      reason_kind: "explicit",
+      before_hash: null,
+      after_hash: null,
+      changed_files: [],
+      diff_path: null,
+      metadata: {},
+      review_status: "unreviewed",
+      reviewed_at: null,
+      review_note: null,
+    },
+    {
+      event_id: "beta",
+      timestamp: "2026-04-27T07:00:00Z",
+      skill: "beta",
+      category: null,
+      action: "edit",
+      actor: "hermes-agent",
+      source: "unit-test",
+      session_id: null,
+      reason: "beta",
+      reason_kind: "explicit",
+      before_hash: null,
+      after_hash: null,
+      changed_files: [],
+      diff_path: null,
+      metadata: {},
+      review_status: "reviewed",
+      reviewed_at: "2026-04-27T07:10:00Z",
+      review_note: null,
+    },
+    {
+      event_id: "old-alpha",
+      timestamp: "2026-04-27T06:00:00Z",
+      skill: "alpha",
+      category: null,
+      action: "create",
+      actor: "hermes-agent",
+      source: "unit-test",
+      session_id: null,
+      reason: "old",
+      reason_kind: "explicit",
+      before_hash: null,
+      after_hash: null,
+      changed_files: [],
+      diff_path: null,
+      metadata: {},
+      review_status: "reviewed",
+      reviewed_at: "2026-04-27T06:10:00Z",
+      review_note: null,
+    },
+  ] as const;
+
+  const bySkill = latestChangeBySkill(changes);
+
+  assert.equal(bySkill.get("alpha")?.event_id, "new-alpha");
+  assert.equal(bySkill.get("beta")?.event_id, "beta");
+  assert.equal(bySkill.size, 2);
+});

--- a/web/tests/skillChanges.test.ts
+++ b/web/tests/skillChanges.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   latestChangeBySkill,
+  loadSkillChangesBestEffort,
   reasonKindLabel,
   reviewStatusLabel,
 } from "../src/lib/skillChanges.ts";
@@ -20,6 +21,21 @@ test("reviewStatusLabel maps dashboard review states", () => {
   assert.equal(reviewStatusLabel("reviewed"), "Reviewed");
   assert.equal(reviewStatusLabel("needs_followup"), "Needs follow-up");
   assert.equal(reviewStatusLabel("other"), "other");
+});
+
+test("loadSkillChangesBestEffort degrades to an empty history when the endpoint fails", async () => {
+  let notified = false;
+  const changes = await loadSkillChangesBestEffort(
+    async () => {
+      throw new Error("history unavailable");
+    },
+    () => {
+      notified = true;
+    },
+  );
+
+  assert.deepEqual(changes, []);
+  assert.equal(notified, true);
 });
 
 test("latestChangeBySkill keeps the newest event per skill from a newest-first list", () => {

--- a/web/tests/skillGovernance.test.ts
+++ b/web/tests/skillGovernance.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canRecordProposalDecision,
+  extractFetchErrorMessage,
+  proposalDecisionActionLabel,
+  proposalDecisionActionStatuses,
+  proposalDecisionTransitionHint,
+  proposalPreviewText,
+  unavailableProposalDecisionStatuses,
+} from "../src/lib/skillGovernance.ts";
+
+test("canRecordProposalDecision follows allowed statuses from the backend", () => {
+  const proposal = {
+    allowed_decision_statuses: ["pending", "deferred", "rejected"],
+  };
+
+  assert.equal(canRecordProposalDecision(proposal, "approved"), false);
+  assert.equal(canRecordProposalDecision(proposal, "deferred"), true);
+});
+
+test("proposalPreviewText prefers a unified diff and falls back to the Curator dry-run excerpt", () => {
+  assert.deepEqual(
+    proposalPreviewText({ diff_text: "--- old\n+++ new" }),
+    { title: "Unified diff", body: "--- old\n+++ new", kind: "diff" },
+  );
+
+  assert.deepEqual(
+    proposalPreviewText({ artifact_texts: { "curator_report_excerpt.md": "dry-run excerpt" } }),
+    { title: "Dry-run excerpt", body: "dry-run excerpt", kind: "artifact" },
+  );
+
+  assert.equal(proposalPreviewText({}).kind, "empty");
+});
+
+test("extractFetchErrorMessage surfaces API detail instead of hiding it behind a generic toast", () => {
+  const message = extractFetchErrorMessage(
+    new Error('400: {"detail":"Invalid Skill Governance transition \'bad_test_target\' -> \'approved\'"}'),
+  );
+
+  assert.equal(message, "Invalid Skill Governance transition 'bad_test_target' -> 'approved'");
+});
+
+test("bad-test-target proposals expose a visible reopen route before approval", () => {
+  const proposal = {
+    decision_status: "bad_test_target",
+    allowed_decision_statuses: ["pending", "deferred", "bad_test_target", "rejected"],
+  };
+
+  assert.equal(proposalDecisionActionLabel("pending"), "Reopen");
+  assert.deepEqual(proposalDecisionActionStatuses(proposal), ["pending", "deferred", "rejected"]);
+  assert.deepEqual(unavailableProposalDecisionStatuses(proposal), ["approved", "needs_changes"]);
+  assert.equal(
+    proposalDecisionTransitionHint(proposal),
+    "Approved is not available from Bad test target. Reopen to Pending PM decision first if you want to approve it.",
+  );
+});


### PR DESCRIPTION
## Review-ready packet

This PR publishes the local `feature/skill-change-observability` workstream for independent GitHub review.

> Note: upstream `NousResearch/hermes-agent#5` is an old merged `Update snapshot` PR and is not the target. This PR is the GitHub review vehicle for the local PR-5/Curator governance packet.

### Scope

- Adds a skill change ledger for `skill_manage` and bundled skill sync events.
- Exposes skill change history/review endpoints and dashboard UI.
- Adds Skill Governance proposal listing/detail/decision metadata flow.
- Adds tests for ledger, governance proposal, web API, and frontend dashboard behavior.

### Reviewed base/head

```text
reviewed base: 16f9d0208429a16db983634dd11f62852faf329a
reviewed head: 28d63336cb7a6a802f2baf6c268f0427a9ab3ff3
```

### Verification already run

```text
python -m py_compile hermes_cli/web_server.py tools/skill_change_ledger.py tools/skill_manager_tool.py tools/skills_sync.py tools/skills_hub.py tools/skill_governance_proposals.py
python -m pytest tests/tools/test_skill_change_ledger.py tests/tools/test_skill_manager_change_ledger.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_size_limits.py tests/tools/test_skills_sync.py tests/tools/test_skills_sync_change_ledger.py tests/tools/test_skill_governance_proposals.py tests/hermes_cli/test_web_server_skill_changes.py tests/hermes_cli/test_web_server_skill_governance_proposals.py -q -n0
node --test web/tests/skillChanges.test.ts
node --test web/tests/skillGovernance.test.ts
npm --prefix web run build
git diff --check 16f9d0208..HEAD
```

Results:

```text
backend focused suite: 144 passed
frontend skillChanges tests: 4 passed
frontend skillGovernance tests: 4 passed
frontend build: succeeded
static scan on added diff lines: secrets 0, shell_injection 0, eval_exec 0, pickle 0, sql_format 0
```

### Independent review result

Codex CLI review: **ACCEPT**, no blockers.

Non-blocking follow-up:

- `tools/skill_change_ledger.py:386`
- `tools/skill_governance_proposals.py:173`

Dashboard response text is truncated, but in-root diff/artifact files are read fully before truncation. Consider bounded reads for oversized artifacts.

Claude Code review was not available in the local environment because the CLI is not logged in.

### Safety boundary

- Proposal decision endpoint records proposal decision metadata only.
- No live Curator mutation path is introduced.
- Traversal checks block out-of-root `diff_path` / artifact reads in tested cases.
- Unknown `/api/*` paths return JSON 404 rather than SPA fallback.

### Gate posture

- Observability/governance promotion: **ACCEPT for review/promotion**.
- Import dry-run proposals: **allowed after ledger/proposal UI smoke**.
- Live Curator mutation: **HOLD** — no config edit, run/dry-run, restart, or skill mutation without separate approval.
- Future live apply requires an exact `proposal_id + patch_sha256` approval packet.

### Current caveat

The branch was reviewed against `16f9d0208`; upstream `main` has advanced. Treat this as a review vehicle first; rebase/conflict resolution may be needed before merge readiness.
