### PR TITLE
fix(tool_result_storage): spill to local fs when no sandbox env (#23767)

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -1,18 +1,22 @@
 """Tests for tools/tool_result_storage.py -- 3-layer tool result persistence."""
 
+import os
+import stat
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
+from hermes_constants import get_hermes_home
 from tools.budget_config import (
     DEFAULT_RESULT_SIZE_CHARS,
     DEFAULT_TURN_BUDGET_CHARS,
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
 )
-from hermes_constants import get_hermes_home
 from tools.tool_result_storage import (
     HEREDOC_MARKER,
-    LOCAL_FS_SUBDIR,
+    LOCAL_FS_SPILL_SUBDIR,
     PERSISTED_OUTPUT_TAG,
     PERSISTED_OUTPUT_CLOSING_TAG,
     STORAGE_DIR,
@@ -163,35 +167,40 @@ class TestWriteToLocalFilesystem:
     def test_writes_under_hermes_home(self):
         path = _write_to_local_filesystem("hello content", "tu_abc")
         assert path is not None
-        target = get_hermes_home() / LOCAL_FS_SUBDIR / "tu_abc.txt"
+        target = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR / "tu_abc.txt"
         assert target.exists()
-        assert target.read_text() == "hello content"
+        assert target.read_text(encoding="utf-8") == "hello content"
         assert path == str(target)
 
     def test_sanitizes_path_traversal(self):
         path = _write_to_local_filesystem("data", "../../etc/passwd")
         assert path is not None
         # No literal ".." or "/" can survive in the spilled filename.
-        from pathlib import Path
         name = Path(path).name
         assert ".." not in name
         assert "/" not in name
         # The file must live under the spill dir, not outside it.
-        spill_root = get_hermes_home() / LOCAL_FS_SUBDIR
+        spill_root = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR
         assert Path(path).parent == spill_root
 
     def test_empty_id_falls_back_to_uuid(self):
         path = _write_to_local_filesystem("data", "")
         assert path is not None
-        from pathlib import Path
         name = Path(path).stem
         assert len(name) >= 8  # uuid4 hex is 32 chars
+
+    def test_sanitize_to_empty_falls_back_to_uuid(self):
+        # Pure-dot inputs survive re.sub then strip to empty -> uuid fallback.
+        path = _write_to_local_filesystem("data", "....")
+        assert path is not None
+        name = Path(path).stem
+        # uuid4().hex is 32 chars; sanitized "...." would be 0 chars.
+        assert len(name) >= 8
 
     def test_unicode_content_round_trip(self):
         content = "日本語テスト " * 100
         path = _write_to_local_filesystem(content, "tu_unicode")
         assert path is not None
-        from pathlib import Path
         assert Path(path).read_text(encoding="utf-8") == content
 
     def test_returns_none_on_unwritable_home(self, tmp_path, monkeypatch):
@@ -201,6 +210,39 @@ class TestWriteToLocalFilesystem:
         blocker.write_text("blocker")
         monkeypatch.setenv("HERMES_HOME", str(blocker))
         assert _write_to_local_filesystem("data", "tu_x") is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX-only file mode semantics")
+    def test_spill_file_is_owner_only_readable(self):
+        path = _write_to_local_filesystem("secret", "tu_perm")
+        assert path is not None
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        # tempfile.NamedTemporaryFile creates files at 0o600 on POSIX; os.replace
+        # preserves source mode, so the visible target is also 0o600.
+        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+    def test_refuses_symlinked_spill_root(self, tmp_path, monkeypatch):
+        # Set up a HERMES_HOME with a pre-planted symlink at tool_results.
+        hermes_home = tmp_path / "fake_home"
+        hermes_home.mkdir()
+        attacker_target = tmp_path / "attacker_dir"
+        attacker_target.mkdir()
+        (hermes_home / LOCAL_FS_SPILL_SUBDIR).symlink_to(attacker_target)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        assert _write_to_local_filesystem("payload", "tu_sym") is None
+        # No write happened anywhere.
+        assert list(attacker_target.iterdir()) == []
+
+    def test_overwrite_is_atomic(self):
+        # Two consecutive writes to the same tool_use_id overwrite cleanly.
+        path1 = _write_to_local_filesystem("first", "tu_overwrite")
+        path2 = _write_to_local_filesystem("second", "tu_overwrite")
+        assert path1 == path2
+        assert Path(path1).read_text(encoding="utf-8") == "second"
+        # No leftover .tmp scratch files.
+        spill_root = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR
+        leftovers = [p for p in spill_root.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
 
 
 class TestResolveStorageDir:
@@ -319,7 +361,7 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
         assert len(result) < len(content)
 
-        spilled_dir = get_hermes_home() / LOCAL_FS_SUBDIR
+        spilled_dir = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR
         spilled_path = spilled_dir / "tc_789.txt"
         assert spilled_path.exists()
         assert spilled_path.read_text() == content
@@ -551,13 +593,39 @@ class TestEnforceTurnBudget:
         )
         assert persisted_count >= 2  # Need to shed at least ~52K
 
-    def test_no_env_falls_back_to_truncation(self):
+    def test_no_env_spills_to_local_fs(self):
+        """Layer 3 with env=None must spill via local fs, not silently truncate.
+
+        Regression for #23767 at the budget layer: previously the only
+        coverage was an or-assertion that accepted either truncation or
+        persisted-output, hiding whether the local-fs path actually fired.
+        """
         msgs = [
-            {"role": "tool", "tool_call_id": "t1", "content": "x" * 250_000},
+            {"role": "tool", "tool_call_id": "tu_layer3", "content": "x" * 250_000},
         ]
         enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
-        # Should be truncated (no sandbox available)
-        assert "Truncated" in msgs[0]["content"] or PERSISTED_OUTPUT_TAG in msgs[0]["content"]
+        assert PERSISTED_OUTPUT_TAG in msgs[0]["content"]
+        assert "Truncated" not in msgs[0]["content"]
+        # The spill file exists under the per-test HERMES_HOME with the full content.
+        spilled = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR / "tu_layer3.txt"
+        assert spilled.exists()
+        assert spilled.read_text(encoding="utf-8") == "x" * 250_000
+        # The absolute path appears inside the persisted-output block.
+        assert str(spilled) in msgs[0]["content"]
+
+    def test_no_env_local_fs_failure_falls_back_to_truncation_at_layer3(
+        self, tmp_path, monkeypatch
+    ):
+        """When local-fs is unavailable at Layer 3, last-resort is inline truncation."""
+        blocker = tmp_path / "blocker_file"
+        blocker.write_text("not a dir")
+        monkeypatch.setenv("HERMES_HOME", str(blocker))
+        msgs = [
+            {"role": "tool", "tool_call_id": "tu_layer3_fail", "content": "x" * 250_000},
+        ]
+        enforce_turn_budget(msgs, env=None, config=BudgetConfig(turn_budget=200_000))
+        assert "Truncated" in msgs[0]["content"]
+        assert PERSISTED_OUTPUT_TAG not in msgs[0]["content"]
 
     def test_returns_same_list(self):
         msgs = [{"role": "tool", "tool_call_id": "t1", "content": "ok"}]

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -9,14 +9,17 @@ from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
 )
+from hermes_constants import get_hermes_home
 from tools.tool_result_storage import (
     HEREDOC_MARKER,
+    LOCAL_FS_SUBDIR,
     PERSISTED_OUTPUT_TAG,
     PERSISTED_OUTPUT_CLOSING_TAG,
     STORAGE_DIR,
     _build_persisted_message,
     _heredoc_marker,
     _resolve_storage_dir,
+    _write_to_local_filesystem,
     _write_to_sandbox,
     enforce_turn_budget,
     generate_preview,
@@ -156,6 +159,50 @@ class TestWriteToSandbox:
         assert "'/tmp/x; rm -rf /; echo .txt'" in cmd
 
 
+class TestWriteToLocalFilesystem:
+    def test_writes_under_hermes_home(self):
+        path = _write_to_local_filesystem("hello content", "tu_abc")
+        assert path is not None
+        target = get_hermes_home() / LOCAL_FS_SUBDIR / "tu_abc.txt"
+        assert target.exists()
+        assert target.read_text() == "hello content"
+        assert path == str(target)
+
+    def test_sanitizes_path_traversal(self):
+        path = _write_to_local_filesystem("data", "../../etc/passwd")
+        assert path is not None
+        # No literal ".." or "/" can survive in the spilled filename.
+        from pathlib import Path
+        name = Path(path).name
+        assert ".." not in name
+        assert "/" not in name
+        # The file must live under the spill dir, not outside it.
+        spill_root = get_hermes_home() / LOCAL_FS_SUBDIR
+        assert Path(path).parent == spill_root
+
+    def test_empty_id_falls_back_to_uuid(self):
+        path = _write_to_local_filesystem("data", "")
+        assert path is not None
+        from pathlib import Path
+        name = Path(path).stem
+        assert len(name) >= 8  # uuid4 hex is 32 chars
+
+    def test_unicode_content_round_trip(self):
+        content = "日本語テスト " * 100
+        path = _write_to_local_filesystem(content, "tu_unicode")
+        assert path is not None
+        from pathlib import Path
+        assert Path(path).read_text(encoding="utf-8") == content
+
+    def test_returns_none_on_unwritable_home(self, tmp_path, monkeypatch):
+        # Point HERMES_HOME at a regular file, so mkdir(parents=True) under it
+        # cannot succeed.
+        blocker = tmp_path / "not_a_directory"
+        blocker.write_text("blocker")
+        monkeypatch.setenv("HERMES_HOME", str(blocker))
+        assert _write_to_local_filesystem("data", "tu_x") is None
+
+
 class TestResolveStorageDir:
     def test_defaults_to_storage_dir_without_env(self):
         assert _resolve_storage_dir(None) == STORAGE_DIR
@@ -254,12 +301,40 @@ class TestMaybePersistToolResult:
         # command string — see test_large_content_via_stdin for why).
         assert env.execute.call_args[1]["stdin_data"] == content
 
-    def test_above_threshold_no_env_truncates_inline(self):
+    def test_above_threshold_no_env_spills_to_local_fs(self):
+        """Bare CLI (env=None) spills oversized results to ``<HERMES_HOME>/tool_results``.
+
+        Regression for #23767: previously env=None fell through to inline
+        truncation, leaving the truncated preview inflating every subsequent
+        prompt and driving a compression-grows-size loop on lower-context models.
+        """
         content = "x" * 60_000
         result = maybe_persist_tool_result(
             content=content,
             tool_name="terminal",
             tool_use_id="tc_789",
+            env=None,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        assert len(result) < len(content)
+
+        spilled_dir = get_hermes_home() / LOCAL_FS_SUBDIR
+        spilled_path = spilled_dir / "tc_789.txt"
+        assert spilled_path.exists()
+        assert spilled_path.read_text() == content
+        assert str(spilled_path) in result
+
+    def test_no_env_local_fs_failure_falls_back_to_truncation(self, tmp_path, monkeypatch):
+        """If both sandbox AND local-fs are unavailable, last-resort is inline truncation."""
+        blocker = tmp_path / "blocker_file"
+        blocker.write_text("not a dir")
+        monkeypatch.setenv("HERMES_HOME", str(blocker))
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_double_fail",
             env=None,
             threshold=30_000,
         )

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -8,11 +8,16 @@ Defense against context-window overflow operates at three levels:
 
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
-   (registry.get_max_result_size), the full output is written INTO THE
-   SANDBOX temp dir (for example /tmp/hermes-results/{tool_use_id}.txt on
-   standard Linux, or $TMPDIR/hermes-results/{tool_use_id}.txt on Termux)
-   via env.execute(). The in-context content is replaced with a preview +
-   file path reference. The model can read_file to access the full output
+   (registry.get_max_result_size), the full output is written to disk and
+   the in-context content is replaced with a preview + file path reference.
+   When a sandbox env is available, the file is written INTO THE SANDBOX
+   temp dir (for example /tmp/hermes-results/{tool_use_id}.txt on standard
+   Linux, or $TMPDIR/hermes-results/{tool_use_id}.txt on Termux) via
+   env.execute(). When no sandbox env is available (bare CLI, local custom
+   providers), the file is written to the local filesystem at
+   $HERMES_HOME/tool_results/{safe_id}.txt with owner-only permissions and
+   an atomic rename. Inline truncation is the last-resort fallback when
+   both write paths fail. The model can read_file to access the full output
    on any backend.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
@@ -26,6 +31,7 @@ import logging
 import os
 import re
 import shlex
+import tempfile
 import uuid
 
 from hermes_constants import get_hermes_home
@@ -39,7 +45,7 @@ logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
-LOCAL_FS_SUBDIR = "tool_results"
+LOCAL_FS_SPILL_SUBDIR = "tool_results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 
@@ -82,18 +88,53 @@ def _write_to_local_filesystem(content: str, tool_use_id: str) -> str | None:
     """Spill content to ``<HERMES_HOME>/tool_results/<safe_id>.txt``.
 
     Used when no sandbox env is available so ``read_file`` can still access
-    the full output. Returns the absolute path on success, ``None`` on any
-    filesystem failure (the caller falls back to inline truncation).
+    the full output. Writes are atomic (tempfile + rename) and owner-only
+    (mode 0o600), and refuse to follow a symlink at the spill root.
+    Returns the absolute path on success, ``None`` on any filesystem
+    failure (the caller falls back to inline truncation).
     """
+    # TODO: consolidate with tools/hook_output_spill.py once #20468 merges --
+    # both share head/tail-preview-plus-disk-spill semantics.
+    storage_dir = get_hermes_home() / LOCAL_FS_SPILL_SUBDIR
+    tmp_path: "Path | None" = None  # noqa: F821 -- forward ref for cleanup
     try:
-        storage_dir = get_hermes_home() / LOCAL_FS_SUBDIR
-        storage_dir.mkdir(parents=True, exist_ok=True)
+        # Refuse to write into a symlinked spill root so a pre-planted symlink
+        # cannot redirect attacker-influenced tool output onto arbitrary files.
+        if storage_dir.is_symlink():
+            logger.warning(
+                "Local-fs persistence refused: spill root is a symlink (%s)", storage_dir,
+            )
+            return None
+        storage_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", tool_use_id).strip("._") or uuid.uuid4().hex
         target = storage_dir / f"{safe_name}.txt"
-        target.write_text(content, encoding="utf-8", errors="replace")
+        # surrogateescape preserves arbitrary bytes from tool output round-trip
+        # (errors='replace' would silently map malformed bytes to U+FFFD).
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            errors="surrogateescape",
+            dir=str(storage_dir),
+            prefix=f".{safe_name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = type(target)(tmp.name)
+            tmp.write(content)
+        # NamedTemporaryFile creates with 0o600 on POSIX; os.replace preserves
+        # the source's permissions, so the visible target also lands at 0o600.
+        os.replace(tmp_path, target)
+        tmp_path = None  # successfully renamed; nothing to clean up
         return str(target)
     except Exception as exc:
-        logger.warning("Local-fs persistence failed for %s: %s", tool_use_id, exc)
+        logger.warning(
+            "Local-fs persistence failed for %s -> %s: %s", tool_use_id, storage_dir, exc,
+        )
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
         return None
 
 
@@ -149,11 +190,21 @@ def maybe_persist_tool_result(
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
 ) -> str:
-    """Layer 2: persist oversized result into the sandbox, return preview + path.
+    """Layer 2: persist oversized result and return preview + path.
 
-    Writes via env.execute() so the file is accessible from any backend
-    (local, Docker, SSH, Modal, Daytona). Falls back to inline truncation
-    if write fails or no env is available.
+    Three-step fallback chain:
+      1. ``env`` is given -> write into the sandbox via ``env.execute()`` so
+         the file is reachable from any backend (local, Docker, SSH, Modal,
+         Daytona) using the agent's own ``read_file``.
+      2. ``env`` is ``None`` -> write to the local filesystem at
+         ``<HERMES_HOME>/tool_results/<safe_id>.txt`` so ``read_file`` can
+         still reach the full output on bare CLI / local-provider setups
+         where the inline-truncation path drives a compression-grows-size
+         loop on lower-context models (see #23767).
+      3. Both writes failed -> fall back to inline truncation. The agent
+         loses access to the full content; the warning log on step 1 or 2
+         and the elevated WARNING-level fallthrough log are the operator's
+         signal that the session is now in degraded mode.
 
     Args:
         content: Raw tool result string.
@@ -174,11 +225,12 @@ def maybe_persist_tool_result(
     if len(content) <= effective_threshold:
         return content
 
-    storage_dir = _resolve_storage_dir(env)
-    remote_path = f"{storage_dir}/{tool_use_id}.txt"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    local_fs_attempted = False
 
     if env is not None:
+        storage_dir = _resolve_storage_dir(env)
+        remote_path = f"{storage_dir}/{tool_use_id}.txt"
         try:
             if _write_to_sandbox(content, remote_path, env):
                 logger.info(
@@ -189,20 +241,20 @@ def maybe_persist_tool_result(
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
     else:
-        # No sandbox env (bare CLI, local custom providers). Spill to local
-        # filesystem so read_file can still reach the full output. Without
-        # this, oversized tool results fall through to inline truncation and
-        # inflate every subsequent prompt, which can drive a compression-grows
-        # -size loop on lower-context models. See issue #23767.
+        local_fs_attempted = True
         local_path = _write_to_local_filesystem(content, tool_use_id)
-        if local_path:
+        if local_path is not None:
             logger.info(
                 "Persisted large tool result to local fs: %s (%s, %d chars -> %s)",
                 tool_name, tool_use_id, len(content), local_path,
             )
             return _build_persisted_message(preview, has_more, len(content), local_path)
 
-    logger.info(
+    # Degraded-mode fallthrough. Use WARNING when the local-fs path was tried
+    # and failed -- monitors should see this; INFO when env != None and the
+    # caller knows their sandbox is the only persistence option.
+    fallthrough_log = logger.warning if local_fs_attempted else logger.info
+    fallthrough_log(
         "Inline-truncating large tool result: %s (%d chars, no sandbox or local-fs write)",
         tool_name, len(content),
     )

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -24,9 +24,11 @@ Defense against context-window overflow operates at three levels:
 
 import logging
 import os
+import re
 import shlex
 import uuid
 
+from hermes_constants import get_hermes_home
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
@@ -37,6 +39,7 @@ logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
+LOCAL_FS_SUBDIR = "tool_results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 
@@ -73,6 +76,25 @@ def _heredoc_marker(content: str) -> str:
     if HEREDOC_MARKER not in content:
         return HEREDOC_MARKER
     return f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
+
+
+def _write_to_local_filesystem(content: str, tool_use_id: str) -> str | None:
+    """Spill content to ``<HERMES_HOME>/tool_results/<safe_id>.txt``.
+
+    Used when no sandbox env is available so ``read_file`` can still access
+    the full output. Returns the absolute path on success, ``None`` on any
+    filesystem failure (the caller falls back to inline truncation).
+    """
+    try:
+        storage_dir = get_hermes_home() / LOCAL_FS_SUBDIR
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", tool_use_id).strip("._") or uuid.uuid4().hex
+        target = storage_dir / f"{safe_name}.txt"
+        target.write_text(content, encoding="utf-8", errors="replace")
+        return str(target)
+    except Exception as exc:
+        logger.warning("Local-fs persistence failed for %s: %s", tool_use_id, exc)
+        return None
 
 
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
@@ -166,15 +188,28 @@ def maybe_persist_tool_result(
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
+    else:
+        # No sandbox env (bare CLI, local custom providers). Spill to local
+        # filesystem so read_file can still reach the full output. Without
+        # this, oversized tool results fall through to inline truncation and
+        # inflate every subsequent prompt, which can drive a compression-grows
+        # -size loop on lower-context models. See issue #23767.
+        local_path = _write_to_local_filesystem(content, tool_use_id)
+        if local_path:
+            logger.info(
+                "Persisted large tool result to local fs: %s (%s, %d chars -> %s)",
+                tool_name, tool_use_id, len(content), local_path,
+            )
+            return _build_persisted_message(preview, has_more, len(content), local_path)
 
     logger.info(
-        "Inline-truncating large tool result: %s (%d chars, no sandbox write)",
+        "Inline-truncating large tool result: %s (%d chars, no sandbox or local-fs write)",
         tool_name, len(content),
     )
     return (
         f"{preview}\n\n"
         f"[Truncated: tool response was {len(content):,} chars. "
-        f"Full output could not be saved to sandbox.]"
+        f"Full output could not be saved.]"
     )
 
 


### PR DESCRIPTION
## Summary

- Addresses #23767: oversized tool results inflate prompts on lower-context models when there is no sandbox env.
- Adds `_write_to_local_filesystem()` that spills to `$HERMES_HOME/tool_results/<safe_id>.txt`.
- Wires it as a fallback path in `maybe_persist_tool_result` when `env is None`.
- Inline truncation remains the last-resort fallback when both sandbox and local-fs writes fail.

## Why

`tool_result_storage.py` already runs a 3-layer defense, but Layer 2 (per-result persistence) requires `env.execute()` to write to the sandbox. When `env is None` (bare CLI sessions, local custom providers like the reporter's setup at `http://127.0.0.1:7993/v1`), the code falls through to inline truncation. The truncated preview still consumes prompt tokens every subsequent turn, and on lower-context models this drives a compression-grows-size loop. From the bug report logs:

> `context compression started: ... tokens=~64,186`
> `context compression done: ... tokens=~71,173`
> `Prompt too long: 78723 tokens exceeds max context window of 65536 tokens`

## What changed

**Core fix** -- `tool_result_storage.py`:
- New `_write_to_local_filesystem(content, tool_use_id)` writes to `$HERMES_HOME/tool_results/<safe_id>.txt`. Path-traversal-safe (sanitized id, empty/sanitize-to-empty falls back to UUID), atomic (tempfile + `os.replace`), owner-only (mode 0o600 file, 0o700 dir), refuses to follow a symlinked spill root, uses `errors='surrogateescape'` to round-trip arbitrary bytes from tool output.
- `maybe_persist_tool_result` now tries local-fs when `env is None`. The agent reads spilled content via `read_file` exactly like sandbox-spilled results, since the `<persisted-output>` block carries the absolute path.
- When `env is not None` but sandbox write fails, behavior is unchanged. Local fs is not safe in that branch because the agent reads via env on Docker/SSH/Modal, and the local path would not be reachable from inside the sandbox.
- The inline-truncation fallthrough log is elevated to WARNING when the local-fs path was attempted and failed, so degraded-mode is visible to monitoring instead of buried at INFO. The warning on `_write_to_local_filesystem` failure includes the resolved spill directory so operators can diagnose path/permission issues directly.
- Module-level and function docstrings updated to describe the three-step fallback (sandbox -> local fs -> inline truncation).
- `LOCAL_FS_SUBDIR` renamed to `LOCAL_FS_SPILL_SUBDIR` to signal that the value is a subdirectory fragment, not a parallel-shape constant to `STORAGE_DIR`.
- Dead assignment of `storage_dir`/`remote_path` on the `env is None` branch moved inside `if env is not None:`.
- TODO marker added pointing at #20468 so the planned consolidation with `hook_output_spill` is signaled at the source.

## Test plan

- [x] `pytest tests/tools/test_tool_result_storage.py` -- 59 passed, 1 skipped (the existing registry skip)
- New tests on top of the originally proposed coverage:
  - `test_spill_file_is_owner_only_readable` -- asserts the spilled file is mode 0o600 (POSIX skip on Windows).
  - `test_refuses_symlinked_spill_root` -- pre-plants a symlink at `<HERMES_HOME>/tool_results` and verifies no write happens at the symlink target.
  - `test_overwrite_is_atomic` -- two writes to the same `tool_use_id` overwrite cleanly with no leftover `.tmp` scratch files.
  - `test_sanitize_to_empty_falls_back_to_uuid` -- pure-dot input (`....`) sanitizes-to-empty then triggers UUID fallback.
  - `test_no_env_spills_to_local_fs` (Layer 3) -- replaces the prior weak `Truncated OR PERSISTED_OUTPUT_TAG` assertion with explicit file-existence and absolute-path-in-message assertions.
  - `test_no_env_local_fs_failure_falls_back_to_truncation_at_layer3` -- last-resort truncation when both sandbox and local-fs are unavailable at Layer 3.
- Existing tests untouched apart from rename of the constant and the strengthened Layer 3 assertion.

## Deferred (residual, not blocking)

- **Unbounded `$HERMES_HOME/tool_results` growth.** No TTL, LRU, or size cap on spilled files. Long sessions on persistent `$HOME` accumulate spill content. Needs a design decision (age-based pruning, total-size cap, or alignment with #20468's session_id grouping) and is reasonably a follow-up PR.
- **`Path.write_text` has no timeout.** NFS/FUSE stalls could block the agent loop. The existing `_write_to_sandbox` path passes `timeout=30` to `env.execute()`; matching that for local-fs needs a threading or signal-based design and is a pre-existing concern affecting the sandbox path equally.

## Relation to #20468

#20468 introduces a similar spill mechanism for hook-injected context. This PR uses a self-contained helper inside `tool_result_storage.py` so it does not depend on #20468 landing first. Note that this PR's helper additionally enforces atomic writes, owner-only mode 0o600, symlink-safety, and `surrogateescape` byte preservation; once both PRs are in, the unification should preserve these properties on the hook side as well.

## Draft

Opened as draft to invite feedback on shape before finalizing. CI in progress.