### PR TITLE
fix(gateway): honour tool_preview_length=0 as unlimited in all/new progress modes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14309,14 +14309,15 @@ class GatewayRunner:
                 return
             
             # "all" / "new" modes: short preview, respects tool_preview_length
-            # config (defaults to 40 chars when unset to keep gateway messages
-            # compact — unlike CLI spinners, these persist as permanent messages).
+            # config (0 = unlimited, positive = cap at that many chars).
+            # When the user explicitly sets 0 (no limit), honour it — do not
+            # fall back to 40.  This matches build_tool_preview() and the
+            # verbose-mode branch above.
             if preview:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
-                _cap = _pl if _pl > 0 else 40
-                if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
+                if _pl > 0 and len(preview) > _pl:
+                    preview = preview[:_pl - 3] + "..."
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -402,20 +402,17 @@ def _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0):
     return adapter, result
 
 
-def test_all_mode_default_truncation_40_chars(monkeypatch, tmp_path):
-    """When tool_preview_length is 0 (default), all/new mode truncates to 40 chars."""
+def test_all_mode_zero_means_unlimited(monkeypatch, tmp_path):
+    """When tool_preview_length is 0 (default), all/new mode does NOT truncate.
+
+    0 means unlimited — matching build_tool_preview() and verbose-mode semantics.
+    """
     adapter, result = _run_long_preview_helper(monkeypatch, tmp_path, preview_length=0)
     assert result["final_response"] == "done"
     assert adapter.sent
     content = adapter.sent[0]["content"]
-    # The long command should be truncated — total preview <= 40 chars
-    assert "..." in content
-    # Extract the preview part between quotes
-    import re
-    match = re.search(r'"(.+)"', content)
-    assert match, f"No quoted preview found in: {content}"
-    preview_text = match.group(1)
-    assert len(preview_text) <= 40, f"Preview too long ({len(preview_text)}): {preview_text}"
+    # The long command should NOT be truncated — 0 = no limit
+    assert "..." not in content, f"Preview was truncated when tool_preview_length=0: {content}"
 
 
 def test_all_mode_respects_custom_preview_length(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`gateway/run.py` treated `tool_preview_length=0` (meaning unlimited) as "unset" and
fell back to a hardcoded 40-char cap, while `build_tool_preview()` and the
verbose-mode branch correctly treat `0` as no limit.

Line 14317 (`_cap = _pl if _pl > 0 else 40`) is the only offender. This PR
aligns all/new mode to match the established semantics.

## Same bug class as #21217

PR #21217 fixed the identical issue in CLI `get_cute_tool_message` — the same
Boolean-vs-integer confusion where `0` was treated as falsy/default instead of
"no limit". This PR covers the gateway side that was missed.

## Changes

**gateway/run.py** — replace the `_cap` fallback with a direct guard:
```python
# Before (0 → fallback to 40)
_cap = _pl if _pl > 0 else 40
if len(preview) > _cap:
    preview = preview[:_cap - 3] + "..."

# After (0 → no limit)
if _pl > 0 and len(preview) > _pl:
    preview = preview[:_pl - 3] + "..."
```

**tests/gateway/test_run_progress_topics.py** — rename and invert
`test_all_mode_default_truncation_40_chars` → `test_all_mode_zero_means_unlimited`:
assert NO truncation when `tool_preview_length=0`.

## Validation

```
scripts/run_tests.sh tests/gateway/test_run_progress_topics.py → all relevant tests pass
```

3 tests verified:
- `test_all_mode_zero_means_unlimited` — 0 = no truncation ✅
- `test_all_mode_respects_custom_preview_length` — positive cap works ✅
- `test_all_mode_no_truncation_when_preview_fits` — short preview untouched ✅