### PR TITLE
fix(cli): preserve LF as newline in Warp terminal (Shift+Enter regression #22908)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1874,6 +1874,11 @@ def _preserve_ctrl_enter_newline() -> bool:
     some thin PTYs without SSH) still need c-j bound to submit, so we keep
     that binding for those.
 
+    Warp terminal also sends Shift+Enter as bare LF (c-j) — detected via the
+    TERM_PROGRAM=WarpTerminal env var set by Warp for all its shell sessions.
+    Binding c-j to submit in Warp makes Shift+Enter submit instead of inserting
+    a newline. See issue #22908.
+
     See issue #22379.
     """
     if sys.platform == "win32":
@@ -1892,6 +1897,10 @@ def _preserve_ctrl_enter_newline() -> bool:
                     return True
         except OSError:
             continue
+    # Warp terminal sends Shift+Enter as bare LF (c-j), same as Ctrl+Enter on
+    # Windows Terminal. Preserve c-j as newline so Shift+Enter works.
+    if os.environ.get("TERM_PROGRAM") == "WarpTerminal":
+        return True
     return False
 
 

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -51,6 +51,27 @@ def test_windows_terminal_session_preserves_newline():
             assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_warp_terminal_preserves_newline():
+    """Warp sends Shift+Enter as bare LF (c-j). Detect via TERM_PROGRAM=WarpTerminal.
+
+    Regression test for issue #22908.
+    """
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "WarpTerminal"}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc")):
+                assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_non_warp_macos_does_not_preserve():
+    """Non-Warp macOS terminals (e.g. Terminal.app, iTerm2) keep c-j → submit."""
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "Apple_Terminal"}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc")):
+                assert cli_mod._preserve_ctrl_enter_newline() is False
+
+
 def test_pure_local_linux_does_not_preserve():
     """A bare local Linux TTY (no SSH/WSL/WT) keeps c-j → submit so docker exec
     style Enter-as-LF stays usable."""


### PR DESCRIPTION
## Problem

Warp terminal sends **Shift+Enter as bare LF** (`c-j`), exactly the same byte that Windows Terminal sends for Ctrl+Enter. On macOS, `_preserve_ctrl_enter_newline()` returns `False`, so `_bind_prompt_submit_keys()` binds `c-j` to **submit** — meaning Shift+Enter submits the message instead of inserting a newline.

This is a regression from commit `5044e1cbf` (`fix(cli): submit LF enter in thin PTYs`), which was correct for docker-exec / thin PTY environments, but inadvertently broke Warp users.

Fixes #22908.

## Root Cause

```
_preserve_ctrl_enter_newline()
  → False  (macOS, no SSH/WSL/WT_SESSION detected)

_bind_prompt_submit_keys(kb, handle_enter)
  → kb.add('enter')(handler)
  → kb.add('c-j')(handler)   ← LF now submits
```

Warp sets `TERM_PROGRAM=WarpTerminal` for every shell session. Checking this env var is the same pattern already used for `WT_SESSION` (Windows Terminal).

## Fix

Add a Warp detection branch to `_preserve_ctrl_enter_newline()`:

```python
# Warp terminal sends Shift+Enter as bare LF (c-j), same as Ctrl+Enter on
# Windows Terminal. Preserve c-j as newline so Shift+Enter works.
if os.environ.get("TERM_PROGRAM") == "WarpTerminal":
    return True
```

When this returns `True`, `_bind_prompt_submit_keys()` skips the `c-j → submit` binding, and the separately registered `@kb.add('c-j')` newline handler fires for Shift+Enter instead.

## Testing

- Added `test_warp_terminal_preserves_newline` — asserts the fix triggers for `TERM_PROGRAM=WarpTerminal`
- Added `test_non_warp_macos_does_not_preserve` — asserts other macOS terminals (Terminal.app, iTerm2) are unaffected
- All 11 tests in `tests/cli/test_ctrl_enter_newline.py` pass

## Affected Terminals

| Terminal | Before | After |
|---|---|---|
| Warp (macOS) | Shift+Enter submits ❌ | Shift+Enter inserts newline ✅ |
| Terminal.app / iTerm2 | unchanged (Alt+Enter works) | unchanged |
| Windows Terminal | unchanged ✅ | unchanged ✅ |
| SSH / WSL | unchanged ✅ | unchanged ✅ |
| docker exec / thin PTY | unchanged ✅ | unchanged ✅ |