### PR TITLE
feat(environments): + AgentRun (Alibaba Cloud) backend · #8 sandbox vendor

### DIFF
--- a/tests/tools/test_agentrun_environment.py
+++ b/tests/tools/test_agentrun_environment.py
@@ -1,0 +1,436 @@
+"""Unit tests for the Alibaba Cloud AgentRun cloud sandbox backend.
+
+The real ``agentrun-sdk`` package is intentionally not imported here. We
+patch ``sys.modules['agentrun.sandbox']`` with a stand-in module so
+``AgentRunEnvironment`` can be constructed and exercised without any
+network or credentials. Every test in this file is expected to pass on
+CI without the SDK installed and without ``AGENTRUN_*`` env vars.
+"""
+
+from __future__ import annotations
+
+import types as _types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a stand-in agentrun.sandbox module
+# ---------------------------------------------------------------------------
+
+
+class _FakeTemplateType:
+    """Minimal stand-in for ``agentrun.sandbox.model.TemplateType``."""
+
+    CODE_INTERPRETER = "code-interpreter"
+    BROWSER = "browser"
+    AIO = "aio"
+    CUSTOM = "custom"
+
+
+def _make_fake_sandbox(sandbox_id: str = "sb-fake-123") -> MagicMock:
+    """Build a ``MagicMock`` shaped like a Code Interpreter sandbox."""
+    sb = MagicMock()
+    sb.sandbox_id = sandbox_id
+    sb.check_health.return_value = {"status": "ok"}
+    # Default cmd response matches the documented Code Interpreter shape.
+    sb.process.cmd.return_value = {
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 0,
+    }
+    return sb
+
+
+def _patch_agentrun_imports(monkeypatch, sandbox: MagicMock):
+    """Install a stand-in ``agentrun.sandbox`` module that the adapter imports.
+
+    Returns the fake ``Sandbox`` class so individual tests can assert on
+    its calls (``Sandbox.create`` / ``Sandbox.connect`` / ``Sandbox.get_template``
+    / ``Sandbox.create_template``).
+    """
+    fake_sandbox_cls = MagicMock(name="FakeSandboxClass")
+    # By default the template already exists (get_template succeeds) so we
+    # exercise the happy path. Individual tests override the side effects
+    # as needed.
+    fake_sandbox_cls.get_template.return_value = MagicMock(
+        template_type=_FakeTemplateType.CODE_INTERPRETER,
+    )
+    fake_sandbox_cls.create_template.return_value = MagicMock()
+    fake_sandbox_cls.create.return_value = sandbox
+    fake_sandbox_cls.connect.return_value = sandbox
+
+    fake_template_input = MagicMock(name="FakeTemplateInput")
+
+    sandbox_mod = _types.ModuleType("agentrun.sandbox")
+    sandbox_mod.Sandbox = fake_sandbox_cls
+    sandbox_mod.TemplateType = _FakeTemplateType
+    sandbox_mod.TemplateInput = fake_template_input
+
+    # We also expose top-level ``agentrun`` and ``agentrun.utils.log`` in
+    # case importlib walks the package; the adapter currently only
+    # touches ``agentrun.sandbox`` so these are defensive.
+    parent_mod = _types.ModuleType("agentrun")
+    parent_mod.sandbox = sandbox_mod
+
+    monkeypatch.setitem(__import__("sys").modules, "agentrun", parent_mod)
+    monkeypatch.setitem(__import__("sys").modules, "agentrun.sandbox", sandbox_mod)
+    return fake_sandbox_cls
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_sandbox():
+    return _make_fake_sandbox()
+
+
+@pytest.fixture()
+def agentrun_sdk(monkeypatch, fake_sandbox):
+    """Install the stand-in SDK and return the fake ``Sandbox`` class."""
+    # Quiet down hermes-side noise: skip is_interrupted checks and
+    # credential file enumeration so the test only sees calls we drove.
+    monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts", lambda: []
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.iter_skills_files", lambda **kw: []
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.iter_cache_files", lambda **kw: []
+    )
+    return _patch_agentrun_imports(monkeypatch, fake_sandbox)
+
+
+@pytest.fixture()
+def isolated_store(monkeypatch, tmp_path):
+    """Redirect the ``agentrun_sandboxes.json`` store at the module level.
+
+    The adapter binds ``_SANDBOX_STORE`` at import time, so we have to
+    patch the attribute directly rather than mutating ``HERMES_HOME``.
+    """
+    import tools.environments.agentrun as agentrun_mod
+
+    monkeypatch.setattr(
+        agentrun_mod, "_SANDBOX_STORE", tmp_path / "agentrun_sandboxes.json"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def make_env(agentrun_sdk, fake_sandbox, isolated_store):
+    """Factory that constructs an ``AgentRunEnvironment`` with sane defaults."""
+
+    def _factory(*, persistent: bool = True, task_id: str = "test-task", **kwargs):
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        env = AgentRunEnvironment(
+            cwd="/root",
+            timeout=60,
+            task_id=task_id,
+            persistent_filesystem=persistent,
+            **kwargs,
+        )
+        env._mock_sandbox_cls = agentrun_sdk
+        env._mock_sandbox = fake_sandbox
+        return env
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — create_sandbox: template name + create call wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSandbox:
+    def test_create_uses_task_scoped_template_and_idle_timeout(self, make_env):
+        env = make_env(task_id="alpha")
+        # template_name defaults to ``hermes-{task_id}``
+        env._mock_sandbox_cls.create.assert_called_once()
+        kwargs = env._mock_sandbox_cls.create.call_args.kwargs
+        assert kwargs["template_name"] == "hermes-alpha"
+        # template_type forwarded as CODE_INTERPRETER
+        assert kwargs["template_type"] == _FakeTemplateType.CODE_INTERPRETER
+        # idle timeout defaults to 5 minutes
+        assert kwargs["sandbox_idle_timeout_seconds"] == 300
+
+    def test_explicit_template_name_wins(self, make_env):
+        env = make_env(template_name="custom-tpl")
+        kwargs = env._mock_sandbox_cls.create.call_args.kwargs
+        assert kwargs["template_name"] == "custom-tpl"
+
+    def test_template_created_when_get_returns_not_found(
+        self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox
+    ):
+        """When the named template does not exist we create it once."""
+        # Suppress hermes-internal noise (the agentrun_sdk fixture would
+        # have done this, but we need a clean setup here so we replicate
+        # the few critical patches).
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+
+        agentrun_sdk.get_template.side_effect = RuntimeError("not found")
+
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        AgentRunEnvironment(
+            cwd="/root",
+            timeout=60,
+            task_id="beta",
+            persistent_filesystem=False,
+        )
+
+        agentrun_sdk.create_template.assert_called_once()
+        # template_name must propagate into the TemplateInput payload.
+        called_input = agentrun_sdk.create_template.call_args.kwargs.get("input")
+        # We constructed TemplateInput via a MagicMock — assert the mock
+        # was invoked with the right template_name keyword.
+        # MagicMock records call args; the adapter calls TemplateInput(...)
+        # imported from the patched module, so check that mock.
+        import agentrun.sandbox as patched_sandbox_mod  # type: ignore[import-not-found]
+
+        patched_sandbox_mod.TemplateInput.assert_called_once()
+        ti_kwargs = patched_sandbox_mod.TemplateInput.call_args.kwargs
+        assert ti_kwargs["template_name"] == "hermes-beta"
+        assert ti_kwargs["template_type"] == _FakeTemplateType.CODE_INTERPRETER
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — run_bash: cmd is invoked with the right args + timeout clamping
+# ---------------------------------------------------------------------------
+
+
+class TestRunBash:
+    def test_basic_command_forwards_to_sandbox_process_cmd(self, make_env):
+        env = make_env()
+        # init_session and bulk-sync may have invoked cmd() already.
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "hello\n",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+        result = env.execute("echo hello")
+        assert "hello" in result["output"]
+        assert result["returncode"] == 0
+        # The last cmd() call should have included our payload (wrapped
+        # by the base class' session-snapshot machinery; we only assert
+        # that ``cmd`` was reached at all and accepted a non-empty
+        # command string with the cwd we configured).
+        last_call = env._mock_sandbox.process.cmd.call_args
+        assert last_call is not None
+        assert "command" in last_call.kwargs
+        assert last_call.kwargs["command"]  # non-empty
+        assert last_call.kwargs["cwd"] == "/root"
+
+    def test_timeout_clamped_to_vendor_limit(self, make_env, caplog):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "ok",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+        with caplog.at_level("WARNING", logger="tools.environments.agentrun"):
+            env.execute("sleep 1", timeout=120)
+
+        # Vendor-side max is 30s; the adapter must not forward a larger
+        # value silently.
+        forwarded_timeouts = [
+            call.kwargs.get("timeout")
+            for call in env._mock_sandbox.process.cmd.call_args_list
+        ]
+        assert all(t is None or t <= 30 for t in forwarded_timeouts)
+        assert any("clamping" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — file sync: upload + delete + bulk download all reach the SDK
+# ---------------------------------------------------------------------------
+
+
+class TestFileSync:
+    def test_upload_calls_mkdir_then_upload(self, make_env):
+        env = make_env()
+        env._mock_sandbox.file_system.mkdir.reset_mock()
+        env._mock_sandbox.file_system.upload.reset_mock()
+
+        env._agentrun_upload("/tmp/host-file.txt", "/root/.hermes/foo/bar.txt")
+
+        env._mock_sandbox.file_system.mkdir.assert_called_once_with(
+            path="/root/.hermes/foo", parents=True,
+        )
+        env._mock_sandbox.file_system.upload.assert_called_once_with(
+            local_file_path="/tmp/host-file.txt",
+            target_file_path="/root/.hermes/foo/bar.txt",
+        )
+
+    def test_delete_invokes_rm_via_process_cmd(self, make_env):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "", "stderr": "", "exit_code": 0,
+        }
+
+        env._agentrun_delete([
+            "/root/.hermes/a.txt",
+            "/root/.hermes/b.txt",
+        ])
+
+        env._mock_sandbox.process.cmd.assert_called_once()
+        kwargs = env._mock_sandbox.process.cmd.call_args.kwargs
+        assert kwargs["command"].startswith("rm -f ")
+        assert "/root/.hermes/a.txt" in kwargs["command"]
+        assert "/root/.hermes/b.txt" in kwargs["command"]
+
+    def test_bulk_download_tars_then_downloads(self, make_env, tmp_path):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "", "stderr": "", "exit_code": 0,
+        }
+        env._mock_sandbox.file_system.download.reset_mock()
+
+        dest = tmp_path / "out.tar"
+        env._agentrun_bulk_download(dest)
+
+        # First we should have invoked ``tar cf`` inside the sandbox.
+        cmd_calls = env._mock_sandbox.process.cmd.call_args_list
+        assert any("tar cf" in c.kwargs.get("command", "") for c in cmd_calls)
+        # Then we pull the archive down.
+        env._mock_sandbox.file_system.download.assert_called_once()
+        download_kwargs = env._mock_sandbox.file_system.download.call_args.kwargs
+        assert download_kwargs["save_path"] == str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — cleanup: sync_back, then stop (persistent) or delete (ephemeral),
+#                   and both branches swallow underlying SDK errors.
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_persistent_cleanup_calls_sync_back_then_stop(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()
+
+        env._sync_manager.sync_back.assert_called_once()
+        sb.stop.assert_called_once()
+        sb.delete.assert_not_called()
+        assert env._sandbox is None
+
+    def test_non_persistent_cleanup_deletes_sandbox(self, make_env):
+        env = make_env(persistent=False)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()
+
+        sb.delete.assert_called_once()
+        sb.stop.assert_not_called()
+
+    def test_cleanup_swallows_sync_back_failure(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(
+            name="sync_back", side_effect=RuntimeError("sync failed")
+        )
+
+        # The exception must be swallowed and stop() must still run, so
+        # that an unhealthy sync_back never leaks a dangling sandbox.
+        env.cleanup()
+        sb.stop.assert_called_once()
+
+    def test_cleanup_swallows_stop_failure(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        sb.stop.side_effect = RuntimeError("stop boom")
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()  # must not raise
+        assert env._sandbox is None
+
+
+# ---------------------------------------------------------------------------
+# Bonus — response normalisation: payload shape variants from the data API
+# ---------------------------------------------------------------------------
+
+
+class TestResponseNormalisation:
+    def test_handles_stdout_stderr_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(
+            {"stdout": "hi", "stderr": "warn", "exit_code": 0}
+        )
+        assert "hi" in out and "warn" in out
+        assert code == 0
+
+    def test_handles_output_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response({"output": "hi", "exit_code": 1})
+        assert out == "hi"
+        assert code == 1
+
+    def test_handles_nested_data_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(
+            {"data": {"stdout": "x", "exit_code": 2}}
+        )
+        assert "x" in out
+        assert code == 2
+
+    def test_handles_none(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(None)
+        assert out == ""
+        assert code == 1
+
+
+# ---------------------------------------------------------------------------
+# Persistence — task_id ↔ sandbox_id store survives across constructions
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_second_construction_reconnects(self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox):
+        # First construction should hit ``create`` and persist the id.
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        env1 = AgentRunEnvironment(
+            cwd="/root", timeout=60,
+            task_id="resume-me", persistent_filesystem=True,
+        )
+        first_create_calls = agentrun_sdk.create.call_count
+        first_connect_calls = agentrun_sdk.connect.call_count
+        env1.cleanup()
+
+        # Second construction with same task_id should reconnect, not
+        # re-create.
+        agentrun_sdk.create.reset_mock()
+        agentrun_sdk.connect.reset_mock()
+        agentrun_sdk.connect.return_value = fake_sandbox
+
+        env2 = AgentRunEnvironment(
+            cwd="/root", timeout=60,
+            task_id="resume-me", persistent_filesystem=True,
+        )
+
+        assert agentrun_sdk.connect.call_count == 1
+        assert agentrun_sdk.create.call_count == 0
+        env2.cleanup()

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -2,8 +2,9 @@
 
 Each backend provides the same interface (BaseEnvironment ABC) for running
 shell commands in a specific execution context: local, Docker, SSH,
-Singularity, Modal, Daytona, or Vercel Sandbox. (Modal additionally has
-direct and Nous-managed modes, selected via terminal.modal_mode.)
+Singularity, Modal, Daytona, Vercel Sandbox, or Alibaba Cloud AgentRun.
+(Modal additionally has direct and Nous-managed modes, selected via
+terminal.modal_mode.)
 
 The terminal_tool.py factory (_create_environment) selects the backend
 based on the TERMINAL_ENV configuration.

--- a/tools/environments/agentrun.py
+++ b/tools/environments/agentrun.py
@@ -1,0 +1,527 @@
+"""Alibaba Cloud AgentRun execution environment.
+
+Uses the ``agentrun-sdk`` Python package
+(`pip install agentrun-sdk`, ``import agentrun``) to run shell commands in
+managed Code Interpreter sandboxes on Alibaba Cloud Function Compute v3 /
+AgentRun. Supports persistent sandboxes across sessions: when enabled, the
+sandbox id is stored locally and the sandbox is reconnected on the next
+construction with the same ``task_id`` (vendor-side session affinity:
+sandboxes survive idle periods up to ``sandbox_idle_timeout_seconds``,
+and once their idle timeout fires the AgentRun control plane reaps them).
+
+Compared to ``modal.py``:
+
+* AgentRun does not expose a snapshot API. Filesystem persistence is
+  provided by reconnecting to the same long-lived sandbox via
+  ``Sandbox.connect(sandbox_id)``; the sandbox stays alive across calls
+  as long as it is reused within ``sandbox_idle_timeout_seconds``.
+* Templates are first-class server-side resources. We materialise a
+  template named ``hermes-{task_id}`` once via ``Sandbox.create_template``;
+  re-creates of the same template name are tolerated (idempotent on the
+  client side: we catch the conflict and re-use the existing one).
+* AgentRun caps single-command execution at ~30s server-side. The SDK's
+  ``sandbox.process.cmd(command, cwd, timeout=...)`` is invoked once per
+  ``_run_bash()`` call. We forward the caller's timeout but clamp to the
+  vendor maximum to avoid silent truncation surprises.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import shlex
+import tarfile
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from tools.environments.base import (
+    BaseEnvironment,
+    _ThreadedProcessHandle,
+    _load_json_store,
+    _save_json_store,
+)
+from tools.environments.file_sync import (
+    FileSyncManager,
+    iter_sync_files,
+    quoted_mkdir_command,
+    quoted_rm_command,
+    unique_parent_dirs,
+)
+
+logger = logging.getLogger(__name__)
+
+# Hard upper bound on a single command's timeout as enforced by the AgentRun
+# Code Interpreter sandbox HTTP API (per the published Sandbox docs). Callers
+# may request more; the SDK will silently truncate. We clamp explicitly so
+# users see a warning rather than a surprise timeout.
+_AGENTRUN_CMD_MAX_TIMEOUT = 30
+
+# Default idle ttl for the sandbox itself: 5 minutes of inactivity before the
+# control plane reaps it. Long enough to cover a normal multi-tool-call
+# conversation; short enough to keep the dormant-instance bill negligible.
+_DEFAULT_IDLE_TIMEOUT = 300
+
+# Remote home/working directory inside the Code Interpreter sandbox.
+_REMOTE_HOME = "/root"
+
+# Local store mapping ``task_id -> sandbox_id`` so we can resume across
+# process restarts (parallel to modal_snapshots.json).
+_SANDBOX_STORE = get_hermes_home() / "agentrun_sandboxes.json"
+
+
+def _load_sandbox_map() -> dict:
+    return _load_json_store(_SANDBOX_STORE)
+
+
+def _save_sandbox_map(data: dict) -> None:
+    _save_json_store(_SANDBOX_STORE, data)
+
+
+def _get_stored_sandbox_id(task_id: str) -> str | None:
+    value = _load_sandbox_map().get(task_id)
+    return value if isinstance(value, str) and value else None
+
+
+def _store_sandbox_id(task_id: str, sandbox_id: str) -> None:
+    data = _load_sandbox_map()
+    data[task_id] = sandbox_id
+    _save_sandbox_map(data)
+
+
+def _delete_stored_sandbox(task_id: str, sandbox_id: str | None = None) -> None:
+    data = _load_sandbox_map()
+    current = data.get(task_id)
+    if current is None:
+        return
+    if sandbox_id is None or current == sandbox_id:
+        data.pop(task_id, None)
+        _save_sandbox_map(data)
+
+
+def _ensure_template(template_name: str) -> None:
+    """Create the named template if it does not already exist.
+
+    AgentRun templates are durable server-side resources. The first time
+    a backend instance is materialised for a given task_id we create the
+    template; subsequent instances re-use it. We swallow
+    ``already exists``-shaped errors because the SDK does not expose a
+    typed ``AlreadyExists`` exception (it raises ``ServerError`` /
+    ``APIError`` with the upstream HTTP message).
+    """
+    from agentrun.sandbox import Sandbox, TemplateInput, TemplateType
+
+    try:
+        Sandbox.get_template(template_name)
+        return  # already exists
+    except Exception as exc:
+        # Treat any "get" failure as "not found" — the create call below
+        # will raise distinctly if something else is wrong.
+        logger.debug(
+            "AgentRun: get_template(%s) failed (treating as not-found): %s",
+            template_name, exc,
+        )
+
+    try:
+        Sandbox.create_template(
+            input=TemplateInput(
+                template_name=template_name,
+                template_type=TemplateType.CODE_INTERPRETER,
+            )
+        )
+        logger.info("AgentRun: created template %s", template_name)
+    except Exception as exc:
+        # Tolerate race with concurrent creators (e.g. parallel callers
+        # with the same task_id). If get_template now succeeds, we are
+        # fine. Otherwise re-raise.
+        try:
+            Sandbox.get_template(template_name)
+            logger.info(
+                "AgentRun: template %s already existed (raced create)",
+                template_name,
+            )
+        except Exception:
+            raise exc
+
+
+class AgentRunEnvironment(BaseEnvironment):
+    """Alibaba Cloud AgentRun Code Interpreter sandbox execution backend.
+
+    Spawn-per-call via ``_ThreadedProcessHandle`` wrapping blocking SDK
+    calls. ``cancel_fn`` is wired to ``sandbox.stop()`` so an interrupt
+    tears the sandbox down cleanly. Persistence is by reconnecting to a
+    stored ``sandbox_id`` keyed on ``task_id``.
+    """
+
+    _stdin_mode = "heredoc"
+    _snapshot_timeout = 60
+
+    def __init__(
+        self,
+        cwd: str = _REMOTE_HOME,
+        timeout: int = 60,
+        task_id: str = "default",
+        template_name: Optional[str] = None,
+        idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT,
+        persistent_filesystem: bool = True,
+    ):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+        self._persistent = persistent_filesystem
+        self._task_id = task_id
+        self._template_name = template_name or f"hermes-{task_id}"
+        self._idle_timeout = idle_timeout_seconds
+        self._sandbox = None
+        self._lock = threading.Lock()
+
+        # Late import: SDK is only required when this backend is selected.
+        from agentrun.sandbox import Sandbox, TemplateType
+
+        self._TemplateType = TemplateType
+
+        _ensure_template(self._template_name)
+
+        # Persistence path: try to resume an existing sandbox first. We
+        # only attempt resume when persistent_filesystem=True; otherwise
+        # we always create a fresh sandbox to enforce isolation between
+        # ephemeral runs.
+        stored_sandbox_id = (
+            _get_stored_sandbox_id(self._task_id) if self._persistent else None
+        )
+
+        if stored_sandbox_id:
+            try:
+                self._sandbox = Sandbox.connect(
+                    stored_sandbox_id,
+                    template_type=TemplateType.CODE_INTERPRETER,
+                )
+                logger.info(
+                    "AgentRun: resumed sandbox %s for task %s",
+                    stored_sandbox_id, self._task_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "AgentRun: failed to resume sandbox %s for task %s "
+                    "(%s); creating a fresh one",
+                    stored_sandbox_id, self._task_id, exc,
+                )
+                _delete_stored_sandbox(self._task_id, stored_sandbox_id)
+                self._sandbox = None
+
+        if self._sandbox is None:
+            self._sandbox = Sandbox.create(
+                template_type=TemplateType.CODE_INTERPRETER,
+                template_name=self._template_name,
+                sandbox_idle_timeout_seconds=self._idle_timeout,
+            )
+            logger.info(
+                "AgentRun: created sandbox %s for task %s "
+                "(template=%s, idle_ttl=%ds)",
+                self._sandbox.sandbox_id, self._task_id,
+                self._template_name, self._idle_timeout,
+            )
+
+        # Wait until the sandbox is actually ready to serve requests.
+        # ``check_health`` polls the data-plane endpoint inside the
+        # sandbox; ``Sandbox.create`` returns as soon as the control
+        # plane accepts the request, which is *before* the workload is
+        # actually accepting commands.
+        self._wait_for_health()
+
+        if self._persistent and self._sandbox.sandbox_id:
+            _store_sandbox_id(self._task_id, self._sandbox.sandbox_id)
+
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sync_files(f"{_REMOTE_HOME}/.hermes"),
+            upload_fn=self._agentrun_upload,
+            delete_fn=self._agentrun_delete,
+            bulk_upload_fn=self._agentrun_bulk_upload,
+            bulk_download_fn=self._agentrun_bulk_download,
+        )
+        self._sync_manager.sync(force=True)
+        self.init_session()
+
+    # ------------------------------------------------------------------
+    # Sandbox lifecycle helpers
+    # ------------------------------------------------------------------
+
+    def _wait_for_health(self, retries: int = 60) -> None:
+        """Poll ``check_health`` until the sandbox is ready or we give up.
+
+        The SDK's built-in context-manager (``with sandbox as sb:``) does
+        the same poll, but we are not using the context manager so we
+        replicate the wait explicitly.
+        """
+        import time
+
+        for attempt in range(1, retries + 1):
+            try:
+                health = self._sandbox.check_health()
+                if isinstance(health, dict) and health.get("status") == "ok":
+                    logger.debug(
+                        "AgentRun: sandbox %s ready after %ds",
+                        self._sandbox.sandbox_id, attempt,
+                    )
+                    return
+            except Exception as exc:
+                logger.debug(
+                    "AgentRun: health check %d/%d failed: %s",
+                    attempt, retries, exc,
+                )
+            time.sleep(1)
+
+        raise RuntimeError(
+            f"AgentRun: sandbox {self._sandbox.sandbox_id} did not become "
+            f"healthy within {retries}s"
+        )
+
+    # ------------------------------------------------------------------
+    # File sync callbacks
+    # ------------------------------------------------------------------
+
+    def _agentrun_upload(self, host_path: str, remote_path: str) -> None:
+        """Upload a single file via the SDK's multipart endpoint."""
+        parent = str(Path(remote_path).parent)
+        try:
+            self._sandbox.file_system.mkdir(path=parent, parents=True)
+        except Exception as exc:
+            # mkdir is idempotent in practice; log and proceed so the
+            # upload itself surfaces the real failure if any.
+            logger.debug(
+                "AgentRun: mkdir %s failed (continuing): %s", parent, exc,
+            )
+        self._sandbox.file_system.upload(
+            local_file_path=host_path,
+            target_file_path=remote_path,
+        )
+
+    def _agentrun_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload a batch of files.
+
+        The SDK does not expose a multi-file multipart endpoint, so we
+        ship each file individually via ``file_system.upload``. We still
+        batch-create parent directories with a single shell command to
+        keep the round-trip count down. For larger payloads (~hundreds of
+        files) callers should prefer this to ``upload_fn`` so the parent
+        ``mkdir -p`` only fires once.
+        """
+        if not files:
+            return
+
+        parents = unique_parent_dirs(files)
+        if parents:
+            try:
+                self._sandbox.process.cmd(
+                    command=quoted_mkdir_command(parents),
+                    cwd="/",
+                    timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "AgentRun: bulk mkdir failed (continuing): %s", exc,
+                )
+
+        for host_path, remote_path in files:
+            self._sandbox.file_system.upload(
+                local_file_path=host_path,
+                target_file_path=remote_path,
+            )
+
+    def _agentrun_bulk_download(self, dest: Path) -> None:
+        """Download remote ``.hermes/`` as a tar archive to *dest*.
+
+        We tar inside the sandbox, then pull the tar with
+        ``file_system.download``. The remote tar path is suffixed with
+        the host PID to avoid collisions when multiple processes share
+        the same sandbox by accident.
+        """
+        rel_base = f"{_REMOTE_HOME}/.hermes".lstrip("/")
+        remote_tar = f"/tmp/.hermes_sync.{os.getpid()}.tar"
+
+        self._sandbox.process.cmd(
+            command=f"tar cf {shlex.quote(remote_tar)} -C / {shlex.quote(rel_base)}",
+            cwd="/",
+            timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+        )
+        self._sandbox.file_system.download(
+            path=remote_tar,
+            save_path=str(dest),
+        )
+        try:
+            self._sandbox.process.cmd(
+                command=f"rm -f {shlex.quote(remote_tar)}",
+                cwd="/",
+                timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+            )
+        except Exception as exc:
+            # Best-effort cleanup; not fatal.
+            logger.debug("AgentRun: remote tar cleanup failed: %s", exc)
+
+    def _agentrun_delete(self, remote_paths: list[str]) -> None:
+        """Batch-delete remote files via a single shell ``rm -f``."""
+        if not remote_paths:
+            return
+        self._sandbox.process.cmd(
+            command=quoted_rm_command(remote_paths),
+            cwd="/",
+            timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Hooks
+    # ------------------------------------------------------------------
+
+    def _before_execute(self) -> None:
+        """Sync files to sandbox via FileSyncManager (rate-limited internally)."""
+        self._sync_manager.sync()
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ):
+        """Run a bash command in the AgentRun sandbox.
+
+        Returns a ``_ThreadedProcessHandle`` whose worker performs a
+        single blocking ``sandbox.process.cmd`` call. ``cancel_fn`` is
+        wired to ``sandbox.stop`` so a ``kill`` from the base class
+        tears the instance down (subsequent commands will resume into a
+        fresh sandbox under the same task_id).
+        """
+        sandbox = self._sandbox
+        lock = self._lock
+
+        # Clamp timeout to the vendor limit, log once if we had to.
+        effective_timeout = timeout
+        if timeout > _AGENTRUN_CMD_MAX_TIMEOUT:
+            logger.warning(
+                "AgentRun: requested cmd timeout %ds exceeds vendor "
+                "maximum %ds; clamping",
+                timeout, _AGENTRUN_CMD_MAX_TIMEOUT,
+            )
+            effective_timeout = _AGENTRUN_CMD_MAX_TIMEOUT
+
+        if login:
+            shell_cmd = f"bash -l -c {shlex.quote(cmd_string)}"
+        else:
+            shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
+
+        def cancel():
+            with lock:
+                try:
+                    sandbox.stop()
+                except Exception as exc:
+                    logger.debug("AgentRun: sandbox.stop on cancel failed: %s", exc)
+
+        def exec_fn() -> tuple[str, int]:
+            response = sandbox.process.cmd(
+                command=shell_cmd,
+                cwd=self.cwd,
+                timeout=effective_timeout,
+            )
+            # SDK returns a raw HTTP body dict. Code Interpreter shapes
+            # it as ``{"stdout": ..., "stderr": ..., "exit_code": ...,
+            # "result": ...}``; older versions used ``output`` for the
+            # combined stream. Accept all variants and fall back to the
+            # full payload as a string.
+            output, exit_code = _normalise_cmd_response(response)
+            return output, exit_code
+
+        return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        """Sync changes back to the host, then stop or delete the sandbox.
+
+        When ``persistent_filesystem=True`` we call ``sandbox.stop()`` so
+        the filesystem is preserved server-side and the next constructor
+        call with the same ``task_id`` will reconnect. Otherwise we
+        ``delete()`` the sandbox outright.
+        """
+        with self._lock:
+            if self._sandbox is None:
+                return
+
+            if self._sync_manager:
+                logger.info("AgentRun: syncing files from sandbox...")
+                try:
+                    self._sync_manager.sync_back()
+                except Exception as exc:
+                    logger.warning("AgentRun: sync_back failed: %s", exc)
+
+            sandbox_id = self._sandbox.sandbox_id
+            try:
+                if self._persistent:
+                    self._sandbox.stop()
+                    logger.info(
+                        "AgentRun: stopped sandbox %s "
+                        "(filesystem preserved for resume)",
+                        sandbox_id,
+                    )
+                else:
+                    self._sandbox.delete()
+                    _delete_stored_sandbox(self._task_id, sandbox_id)
+                    logger.info("AgentRun: deleted sandbox %s", sandbox_id)
+            except Exception as exc:
+                logger.warning(
+                    "AgentRun: cleanup of sandbox %s failed: %s",
+                    sandbox_id, exc,
+                )
+            self._sandbox = None
+
+
+def _normalise_cmd_response(response: Any) -> tuple[str, int]:
+    """Coerce the SDK's cmd-response payload into ``(output, exit_code)``.
+
+    The SDK forwards the data-plane HTTP body unchanged. Across versions
+    we have seen these shapes:
+
+    * ``{"stdout": "...", "stderr": "...", "exit_code": 0}``
+    * ``{"output": "...", "exit_code": 0}``
+    * ``{"data": {"stdout": ..., "exit_code": ...}}``
+
+    We normalise to ``(combined_output, exit_code)``. Unknown shapes are
+    repr()d so the caller still sees *something* instead of an empty
+    string.
+    """
+    if response is None:
+        return "", 1
+    body = response
+    if isinstance(body, dict) and "data" in body and isinstance(body["data"], dict):
+        body = body["data"]
+
+    if isinstance(body, dict):
+        stdout = body.get("stdout") or body.get("output") or ""
+        stderr = body.get("stderr") or ""
+        exit_code = body.get("exit_code")
+        if exit_code is None:
+            exit_code = body.get("exitCode")
+        if exit_code is None:
+            exit_code = body.get("returncode", 0)
+        try:
+            exit_code = int(exit_code)
+        except (TypeError, ValueError):
+            exit_code = 0
+
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+
+        if stderr and stdout:
+            return f"{stdout}\n{stderr}", exit_code
+        return stdout or stderr or "", exit_code
+
+    return str(body), 0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3,18 +3,19 @@
 Terminal Tool Module
 
 A terminal tool that executes commands in local, Docker, Modal, SSH,
-Singularity, Daytona, and Vercel Sandbox environments. Supports local
-execution, containerized backends, and cloud sandboxes, including managed
-Modal mode.
+Singularity, Daytona, Vercel Sandbox, and Alibaba Cloud AgentRun
+environments. Supports local execution, containerized backends, and
+cloud sandboxes, including managed Modal mode.
 
 Environment Selection (via TERMINAL_ENV environment variable):
 - "local": Execute directly on the host machine (default, fastest)
 - "docker": Execute in Docker containers (isolated, requires Docker)
 - "modal": Execute in Modal cloud sandboxes (direct Modal or managed gateway)
 - "vercel_sandbox": Execute in Vercel Sandbox cloud sandboxes
+- "agentrun": Execute in Alibaba Cloud AgentRun Code Interpreter sandboxes
 
 Features:
-- Multiple execution backends (local, docker, modal, vercel_sandbox)
+- Multiple execution backends (local, docker, modal, vercel_sandbox, agentrun)
 - Background task support
 - VM/container lifecycle management
 - Automatic cleanup after inactivity
@@ -1041,7 +1042,7 @@ def _get_env_config() -> Dict[str, Any]:
         ):
             host_cwd = candidate
             cwd = "/workspace"
-    elif env_type in ("modal", "docker", "singularity", "daytona", "vercel_sandbox") and cwd:
+    elif env_type in ("modal", "docker", "singularity", "daytona", "vercel_sandbox", "agentrun") and cwd:
         # Host paths and relative paths that won't work inside containers
         is_host_path = any(cwd.startswith(p) for p in host_prefixes)
         is_relative = not os.path.isabs(cwd)  # e.g. "." or "src/"
@@ -1110,7 +1111,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
-            "daytona", "vercel_sandbox", "ssh"
+            "daytona", "vercel_sandbox", "agentrun", "ssh"
         image: Docker/Singularity/Modal image name (ignored for local/ssh/vercel)
         cwd: Working directory
         timeout: Default command timeout
@@ -1244,10 +1245,24 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             timeout=timeout,
         )
 
+    elif env_type == "agentrun":
+        # Lazy import so agentrun-sdk is only required when this backend
+        # is selected.
+        from tools.environments.agentrun import AgentRunEnvironment as _AgentRunEnvironment
+        return _AgentRunEnvironment(
+            cwd=cwd,
+            timeout=timeout,
+            task_id=task_id,
+            template_name=cc.get("agentrun_template_name"),
+            idle_timeout_seconds=int(cc.get("agentrun_idle_timeout_seconds", 300)),
+            persistent_filesystem=persistent,
+        )
+
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', "
+            f"'agentrun', or 'ssh'"
         )
 
 
@@ -2215,10 +2230,40 @@ def check_terminal_requirements() -> bool:
             from daytona import Daytona  # noqa: F401 — SDK presence check
             return os.getenv("DAYTONA_API_KEY") is not None
 
+        elif env_type == "agentrun":
+            # SDK is published as ``agentrun-sdk`` on PyPI but imports as
+            # ``agentrun``. Credentials are taken from environment
+            # variables (AGENTRUN_ACCESS_KEY_ID / AGENTRUN_ACCESS_KEY_SECRET
+            # / AGENTRUN_ACCOUNT_ID / AGENTRUN_REGION), matching the SDK
+            # default config loader.
+            if importlib.util.find_spec("agentrun") is None:
+                logger.error(
+                    "agentrun-sdk is required for the agentrun terminal "
+                    "backend: pip install agentrun-sdk"
+                )
+                return False
+            missing = [
+                name for name in (
+                    "AGENTRUN_ACCESS_KEY_ID",
+                    "AGENTRUN_ACCESS_KEY_SECRET",
+                    "AGENTRUN_ACCOUNT_ID",
+                )
+                if not os.getenv(name)
+            ]
+            if missing:
+                logger.error(
+                    "AgentRun backend selected but the following environment "
+                    "variables are not set: %s. Configure them or switch "
+                    "TERMINAL_ENV to a different value.",
+                    ", ".join(missing),
+                )
+                return False
+            return True
+
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, vercel_sandbox, agentrun, ssh.",
                 env_type,
             )
             return False
@@ -2261,7 +2306,7 @@ if __name__ == "__main__":
     print(
         "  TERMINAL_ENV: "
         f"{os.getenv('TERMINAL_ENV', 'local')} "
-        "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
+        "(local/docker/singularity/modal/daytona/vercel_sandbox/agentrun/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
     print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -87,7 +87,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | agentrun | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
@@ -108,6 +108,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
 | **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
 | **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
+| **agentrun** | Alibaba Cloud AgentRun Code Interpreter sandbox | Full (cloud microVM) | China-region cloud execution with idle-billed sandboxes |
 | **singularity** | Singularity/Apptainer container | Namespaces (--containall) | HPC clusters, shared machines |
 
 ### Local Backend
@@ -270,6 +271,45 @@ OIDC tokens are short-lived and should not be used as the documented deployment 
 
 **Disk sizing:** Vercel Sandbox does not currently support Hermes' `container_disk` resource knob. Leave `container_disk` unset or at the shared default `51200`; non-default values fail diagnostics and backend creation instead of being silently ignored.
 
+### AgentRun Backend
+
+Runs commands in an [Alibaba Cloud AgentRun](https://help.aliyun.com/zh/functioncompute/fc/what-is-agentrun) Code Interpreter sandbox — a managed microVM on Function Compute v3 with idle-billed sandboxes (vCPU is billed only while a command is actually executing; the rest is memory-only).
+
+```yaml
+terminal:
+  backend: agentrun
+  agentrun_template_name: "hermes-default"   # Optional; defaults to "hermes-{task_id}"
+  agentrun_idle_timeout_seconds: 300         # Sandbox idle TTL (server-side reaps after this)
+  container_persistent: true                 # Reconnect to the same sandbox across calls
+```
+
+**Required install:** Install the SDK:
+
+```bash
+pip install agentrun-sdk
+```
+
+**Required authentication:** Set the SDK's documented environment variables before launching Hermes. These are picked up automatically by the `agentrun` Python package:
+
+```bash
+export AGENTRUN_ACCESS_KEY_ID="<RAM AccessKey ID>"
+export AGENTRUN_ACCESS_KEY_SECRET="<RAM AccessKey secret>"
+export AGENTRUN_ACCOUNT_ID="<Aliyun account ID>"
+export AGENTRUN_REGION="cn-hangzhou"            # Any AgentRun-enabled region
+```
+
+Create a dedicated RAM sub-account (rather than the root key) with the `AliyunAgentRunFullAccess` managed policy, or a tighter custom policy if you do not need template/sandbox management at runtime.
+
+**Persistence model:** AgentRun does not expose a snapshot API. With `container_persistent: true` Hermes stores the live `sandbox_id` in `~/.hermes/agentrun_sandboxes.json`, keyed by `task_id`, and reconnects to that sandbox via `Sandbox.connect(sandbox_id)` on the next call. The sandbox stays alive across calls as long as it is reused within `agentrun_idle_timeout_seconds` (default 5 minutes); after that the control plane reaps it and the next construction transparently allocates a new one. With `container_persistent: false` Hermes deletes the sandbox at the end of every session.
+
+**Templates:** AgentRun sandboxes are launched from server-side *templates*. Hermes materialises one named `hermes-{task_id}` on first use (idempotent — concurrent constructions resolve to the existing template). Override `agentrun_template_name` to share a single curated template across tasks (useful if you customise the runtime image in the AgentRun console).
+
+**Command timeout:** AgentRun caps a single Code Interpreter command at 30 s server-side. Hermes clamps caller-supplied timeouts to that ceiling and emits a warning when it does. Longer-running shell workflows should be split into multiple commands (the sandbox itself stays alive across them).
+
+**Background commands:** `terminal(background=true)` uses Hermes' generic non-local background flow on top of the SDK's `process.cmd` endpoint. The 30-second command ceiling applies; for genuinely long-running work prefer detaching to `nohup ... &` and polling status via subsequent commands.
+
+**Region note:** AgentRun is currently an Alibaba Cloud product and runs in China + Singapore regions only. Outbound network from the sandbox follows the chosen region's egress.
+
 ### Singularity/Apptainer Backend
 
 Runs commands in a [Singularity/Apptainer](https://apptainer.org) container. Designed for HPC clusters and shared machines where Docker isn't available.
@@ -300,6 +340,7 @@ If terminal commands fail immediately or the terminal tool is reported as disabl
 - **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
 - **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.
 - **Daytona** — Needs `DAYTONA_API_KEY`. The Daytona SDK handles server URL configuration.
+- **AgentRun** — Needs `AGENTRUN_ACCESS_KEY_ID`, `AGENTRUN_ACCESS_KEY_SECRET`, and `AGENTRUN_ACCOUNT_ID`; `AGENTRUN_REGION` defaults to `cn-hangzhou`. Install `agentrun-sdk`. See the AgentRun Backend section above.
 - **Singularity** — Needs `apptainer` or `singularity` in `$PATH`. Common on HPC clusters.
 
 When in doubt, set `terminal.backend` back to `local` and verify that commands run there first.


### PR DESCRIPTION
## Summary

Adds a new ``agentrun`` execution backend backed by Alibaba Cloud's AgentRun service — the agent-focused successor to FC v3, offering microVM sandboxes with idle-billed compute (vCPU is billed only while a command actually runs) and server-side session affinity via ``Sandbox.connect(sandbox_id)``. This is the 8th terminal backend, parallel to ``modal`` / ``daytona`` / ``vercel_sandbox`` / ``singularity`` / ``ssh`` / ``docker`` / ``local``.

Why submit this upstream: AgentRun is the only major China-region cloud sandbox with first-class agent semantics (session affinity, idle billing, 6 h sandbox lifetime). Several China-based Hermes users have asked for a backend that does not require egress to US-based microVM providers. The adapter follows the same shape as ``daytona.py`` and ``modal.py``; it is opt-in (lazy import) and does not touch any existing backend's behaviour.

## What is in the change

* **New backend** ``tools/environments/agentrun.py`` (~430 LOC):
  * ``AgentRunEnvironment(BaseEnvironment)`` with the standard ``_run_bash`` / ``cleanup`` / ``_before_execute`` surface.
  * Spawn-per-call via ``_ThreadedProcessHandle`` wrapping ``sandbox.process.cmd``; ``cancel_fn`` is wired to ``sandbox.stop()`` so interrupts tear the instance down.
  * Persistence: ``~/.hermes/agentrun_sandboxes.json`` stores ``task_id -> sandbox_id``; next construction with the same ``task_id`` reconnects via ``Sandbox.connect(...)`` rather than allocating a fresh sandbox.
  * Templates: ``Sandbox.create_template(...)`` lazily materialises ``hermes-{task_id}`` on first use; races with concurrent constructions are tolerated by re-querying ``get_template``.
  * ``FileSyncManager`` plumbed through ``sandbox.file_system.upload/download`` for single files and ``sandbox.process.cmd`` for batched ``mkdir -p`` / ``rm -f`` / ``tar`` operations.
  * Single-command timeout clamped to AgentRun's 30 s server-side ceiling with a one-shot warning, so callers do not silently lose work to truncation.
  * Cleanup runs ``sync_back`` first and swallows underlying SDK exceptions in both branches (``stop()`` for persistent, ``delete()`` for ephemeral) so that an unhealthy sandbox never leaks.

* **Factory wiring** in ``tools/terminal_tool.py``:
  * New ``elif env_type == \"agentrun\"`` branch in ``_create_environment``.
  * ``check_terminal_requirements`` reports missing ``AGENTRUN_ACCESS_KEY_ID`` / ``AGENTRUN_ACCESS_KEY_SECRET`` / ``AGENTRUN_ACCOUNT_ID`` with a clear remediation message and a hint to ``pip install agentrun-sdk`` if the package is missing.
  * Backend list updated in the module docstring and the cwd-sanitisation branch (``_get_env_config``).
  * ``"agentrun"`` added to the unknown-backend error message and the diagnostic banner.

* **17 unit tests** in ``tests/tools/test_agentrun_environment.py`` (mocks ``agentrun.sandbox`` via ``sys.modules`` so the suite runs without ``agentrun-sdk`` installed and without credentials):
  * Constructor — template scoping by ``task_id``, explicit override wins, template auto-creation when ``get_template`` reports not-found.
  * ``_run_bash`` — forwards command + cwd correctly, clamps vendor-max timeout, emits warning when clamping.
  * File sync — upload calls ``mkdir`` then ``upload``; delete batches into a single ``rm -f``; bulk download tars then downloads.
  * Cleanup — persistent path runs ``sync_back`` → ``stop``; ephemeral path runs ``delete``; both swallow underlying SDK errors so the sandbox handle is always cleared.
  * Response normalisation — handles the documented ``{stdout, stderr, exit_code}`` shape, the legacy ``{output, exit_code}`` shape, the nested ``{data: {...}}`` shape, and ``None``.
  * Persistence — second construction with the same ``task_id`` reconnects to the stored ``sandbox_id`` rather than creating a fresh one.

* **Docs** in ``website/docs/user-guide/configuration.md``:
  * New row in the *Backend Overview* table.
  * New *AgentRun Backend* section covering install, env vars, persistence model (snapshot-free, sandbox-id-based reconnect), templates, the 30 s command ceiling, background commands, and region notes.
  * New bullet in *Common Terminal Backend Issues*.

## Test plan

- [x] ``uv run pytest tests/tools/test_agentrun_environment.py -v`` — 17/17 pass on Python 3.14.
- [x] ``uv run pytest tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_requirements.py tests/tools/test_daytona_environment.py`` — 46/46 pass, no regressions in adjacent backends.
- [x] ``uv run ruff check tools/environments/agentrun.py tools/environments/__init__.py tools/terminal_tool.py tests/tools/test_agentrun_environment.py`` — clean.
- [ ] Manual end-to-end against a live AgentRun workspace (Alibaba Cloud account + ``AGENTRUN_*`` env vars) — pending vendor credentials on the contributor side; happy to demo once those are available.

## Notes for reviewers

* AgentRun is **opt-in**: the SDK is only imported when ``TERMINAL_ENV=agentrun`` is selected. No changes to default install or existing backends.
* The adapter intentionally clamps the per-command timeout instead of failing the call, mirroring the pragmatic behaviour of the Daytona backend (which similarly does not raise on SDK-level timeouts).
* AgentRun does not expose a snapshot API; persistence is by reconnect. The behaviour is described upfront in the new docs section so users do not silently expect Modal/Vercel-style snapshot semantics.
* Region availability: AgentRun is currently China + Singapore only. Users outside those regions should prefer Modal / Daytona / Vercel Sandbox.

Happy to iterate on naming or split into smaller commits if preferred.