### PR TITLE
fix(kanban): ignore `--board` override for `boards` subcommands

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -646,6 +646,14 @@ def kanban_command(args: argparse.Namespace) -> int:
             )
         return 0
 
+    # Board-management commands operate on board metadata and the persisted
+    # current-board pointer itself. They must ignore the shared `--board`
+    # task-routing override; otherwise `/kanban --board beta boards show`
+    # reports beta as the current board even when the on-disk pointer is
+    # alpha.
+    if action == "boards":
+        return _dispatch_boards(args)
+
     # `--board <slug>` applies to every subcommand below by way of an
     # env-var pin for the duration of this call. Using HERMES_KANBAN_BOARD
     # (rather than threading `board=` through 50+ kb.connect() sites)
@@ -682,15 +690,6 @@ def kanban_command(args: argparse.Namespace) -> int:
             return 1
         os.environ["HERMES_KANBAN_BOARD"] = normed
         restore_board_env = True
-
-    # Boards management doesn't touch the DB at all — dispatch early so
-    # fresh installs that haven't initialized any DB can still use
-    # `hermes kanban boards create …`.
-    if action == "boards":
-        try:
-            return _dispatch_boards(args)
-        finally:
-            _restore_board_env()
 
     # Auto-initialize the DB before dispatching any subcommand. init_db
     # is idempotent, so running it every invocation is cheap (one

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -402,3 +402,13 @@ def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
     kc.run_slash("--board alpha list")
 
     assert os.environ.get("HERMES_KANBAN_BOARD") == "beta"
+
+
+def test_run_slash_board_override_does_not_change_boards_show_current(kanban_home):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    kb.set_current_board("alpha")
+
+    out = kc.run_slash("--board beta boards show")
+
+    assert "Current board: alpha" in out


### PR DESCRIPTION

### What does this PR do?
Fixes a Kanban board-state bug where `--board <slug>` affected `boards` subcommands like `boards show`, causing them to report the override board instead of the persisted current board.

### Related Issue
No linked issue; found via code inspection.

### Type of Change
- [x] 🐛 Bug fix

### Changes Made
- Dispatch `boards` subcommands before applying the `HERMES_KANBAN_BOARD` override
- Added a regression test for `/kanban --board beta boards show`

### How to Test
1. Create `alpha` and `beta` boards.
2. Switch the current board to `alpha`.
3. Run `/kanban --board beta boards show`.
4. Verify it still reports `Current board: alpha`.

Automated:
1. `uv run pytest tests/hermes_cli/test_kanban_cli.py -k "board_override" -q`
2. `uv run --extra dev pytest tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_cli.py -k "board" -q -n0`

### Checklist
- [x] Tests added/updated
- [x] Relevant tests pass
- [x] Cross-platform impact considered
- [x] No unrelated changes
