### PR TITLE
fix(gateway): ignore stale macOS token locks from reused PIDs

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -129,11 +129,27 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     try:
         raw = cmdline_path.read_bytes()
     except (FileNotFoundError, PermissionError, OSError):
-        return None
+        raw = b""
 
-    if not raw:
+    if raw:
+        return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+
+    # macOS and some BSD-like systems do not expose /proc/<pid>/cmdline.
+    # Fall back to ps so stale scoped-lock detection can distinguish a real
+    # Hermes gateway from an unrelated process that reused the same PID.
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
         return None
-    return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+    if result.returncode != 0:
+        return None
+    cmdline = result.stdout.strip()
+    return cmdline or None
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
@@ -585,6 +601,12 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         stale = existing_pid is None
         if not stale:
             if not _pid_exists(existing_pid):
+                stale = True
+            elif not _looks_like_gateway_process(existing_pid):
+                # macOS has no /proc start_time, so token locks written there
+                # commonly carry start_time=None. After a crash or reboot the
+                # PID can be reused by an unrelated process; without checking
+                # the live command line, that stale lock blocks gateway startup.
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -438,6 +438,7 @@ class TestScopedLocks:
         # ``gateway.status._pid_exists`` (psutil-first, safe on Windows).
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "python -m hermes_cli.main gateway run")
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
@@ -456,6 +457,34 @@ class TestScopedLocks:
 
         # Post-#21561: simulate "PID gone" via _pid_exists returning False.
         monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_replaces_reused_non_gateway_pid_without_start_time(self, tmp_path, monkeypatch):
+        """macOS has no /proc start_time; PID reuse must not preserve stale locks.
+
+        Regression: a crash/reboot left token lock files with start_time=None.
+        If macOS later reused that PID for an unrelated app, the next gateway
+        startup treated the lock as live and refused to connect Discord.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/System/Applications/Stocks.app/StocksWidget")
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 


### PR DESCRIPTION
## Summary
- fall back to `ps -p <pid> -o command=` when `/proc/<pid>/cmdline` is unavailable on macOS/BSD-like systems
- treat scoped token locks as stale when their PID is alive but the process command line is not a Hermes gateway
- add regression coverage for macOS stale lock records with `start_time: null` and PID reuse by a non-gateway process

## Test Plan
- `python -m pytest tests/gateway/test_status.py -q`

## Context
On macOS, scoped gateway token locks can have `start_time: null`. If a gateway exits uncleanly and the PID is later reused by an unrelated process, the next gateway startup can falsely report that a Discord/Telegram/Weixin bot token is already in use. This change verifies the live PID actually looks like a Hermes gateway before honoring the lock.
