### PR TITLE
 fix(slack): refresh active thread context on explicit mention

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -66,7 +66,8 @@ _slash_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
 @dataclass
 class _ThreadContextCache:
     """Cache entry for fetched thread context."""
-    content: str
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    content: str = ""
     fetched_at: float = field(default_factory=time.monotonic)
     message_count: int = 0
     parent_text: str = ""  # Raw text of the thread parent (for reply_to_text injection)
@@ -1920,6 +1921,14 @@ class SlackAdapter(BasePlatformAdapter):
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
+        has_session = (
+            is_thread_reply
+            and self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+            )
+        )
 
         if not is_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
@@ -1942,14 +1951,6 @@ class SlackAdapter(BasePlatformAdapter):
                     event_thread_ts is not None
                     and event_thread_ts in self._mentioned_threads
                 )
-                has_session = (
-                    is_thread_reply
-                    and self._has_active_session_for_thread(
-                        channel_id=channel_id,
-                        thread_ts=event_thread_ts,
-                        user_id=user_id,
-                    )
-                )
                 if not reply_to_bot_thread and not in_mentioned_thread and not has_session:
                     return
 
@@ -1967,14 +1968,12 @@ class SlackAdapter(BasePlatformAdapter):
                     for t in to_remove:
                         self._mentioned_threads.discard(t)
 
-        # When entering a thread for the first time (no existing session),
-        # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
-        ):
-            thread_context = await self._fetch_thread_context(
+        # Thread context rules:
+        # - First message in a thread session: hydrate full context.
+        # - Active thread + explicit @mention: refresh with only the delta
+        #   since the last hydrate/refresh, bypassing the TTL cache.
+        if is_thread_reply and not has_session:
+            thread_context, last_seen_ts = await self._fetch_thread_context(
                 channel_id=channel_id,
                 thread_ts=event_thread_ts,
                 current_ts=ts,
@@ -1982,6 +1981,34 @@ class SlackAdapter(BasePlatformAdapter):
             )
             if thread_context:
                 text = thread_context + text
+            self._set_thread_watermark(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+                watermark_ts=last_seen_ts,
+            )
+        elif is_thread_reply and has_session and is_mentioned:
+            watermark_ts = self._get_thread_watermark(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+            )
+            thread_context, last_seen_ts = await self._fetch_thread_context(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                current_ts=ts,
+                team_id=team_id,
+                after_ts=watermark_ts,
+                bypass_cache=True,
+            )
+            if thread_context:
+                text = thread_context + text
+            self._set_thread_watermark(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+                watermark_ts=last_seen_ts,
+            )
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -2535,30 +2562,111 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Thread context fetching -----
 
+    def _build_thread_session_key(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        user_id: str,
+    ) -> Optional[str]:
+        """Build the backing session key for a Slack thread."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return None
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            source = SessionSource(
+                platform=Platform.SLACK,
+                chat_id=channel_id,
+                chat_type="group",
+                user_id=user_id,
+                thread_id=thread_ts,
+            )
+            store_cfg = getattr(session_store, "config", None)
+            gspu = getattr(store_cfg, "group_sessions_per_user", True) if store_cfg else True
+            tspu = getattr(store_cfg, "thread_sessions_per_user", False) if store_cfg else False
+            return build_session_key(
+                source,
+                group_sessions_per_user=gspu,
+                thread_sessions_per_user=tspu,
+            )
+        except Exception:
+            return None
+
+    def _thread_watermark_key(self, channel_id: str, thread_ts: str) -> str:
+        return f"slack_thread_watermark:{channel_id}:{thread_ts}"
+
+    def _get_thread_watermark(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        user_id: str,
+    ) -> str:
+        """Return the last hydrated Slack thread timestamp for this session."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return ""
+        session_key = self._build_thread_session_key(channel_id, thread_ts, user_id)
+        if not session_key or not hasattr(session_store, "get_session_metadata"):
+            return ""
+        try:
+            value = session_store.get_session_metadata(
+                session_key,
+                self._thread_watermark_key(channel_id, thread_ts),
+                "",
+            )
+            return str(value or "")
+        except Exception:
+            return ""
+
+    def _set_thread_watermark(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        user_id: str,
+        watermark_ts: str,
+    ) -> None:
+        """Persist the latest Slack thread timestamp seen by this session."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store or not watermark_ts:
+            return
+        session_key = self._build_thread_session_key(channel_id, thread_ts, user_id)
+        if not session_key or not hasattr(session_store, "set_session_metadata"):
+            return
+        try:
+            session_store.set_session_metadata(
+                session_key,
+                self._thread_watermark_key(channel_id, thread_ts),
+                watermark_ts,
+            )
+        except Exception:
+            logger.debug("[Slack] Failed to persist thread watermark", exc_info=True)
+
     async def _fetch_thread_context(
         self, channel_id: str, thread_ts: str, current_ts: str,
         team_id: str = "", limit: int = 30,
-    ) -> str:
+        after_ts: str = "", bypass_cache: bool = False,
+    ) -> Tuple[str, str]:
         """Fetch recent thread messages to provide context when the bot is
-        mentioned mid-thread for the first time.
-
-        This method is only called when there is NO active session for the
-        thread (guarded at the call site by _has_active_session_for_thread).
-        That guard ensures thread messages are prepended only on the very
-        first turn — after that the session history already holds them, so
-        there is no duplication across subsequent turns.
+        mentioned mid-thread or explicitly refreshed on an active session.
 
         Results are cached for _THREAD_CACHE_TTL seconds per thread to avoid
         hammering conversations.replies (Tier 3, ~50 req/min).
 
-        Returns a formatted string with prior thread history, or empty string
-        on failure or if the thread has no prior messages.
+        Returns a formatted string plus the latest thread timestamp observed.
         """
         cache_key = f"{channel_id}:{thread_ts}:{team_id}"
         now = time.monotonic()
-        cached = self._thread_context_cache.get(cache_key)
+        cached = None if bypass_cache else self._thread_context_cache.get(cache_key)
         if cached and (now - cached.fetched_at) < self._THREAD_CACHE_TTL:
-            return cached.content
+            return await self._format_thread_context(
+                messages=cached.messages,
+                thread_ts=thread_ts,
+                current_ts=current_ts,
+                team_id=team_id,
+                channel_id=channel_id,
+                after_ts=after_ts,
+            )
 
         try:
             client = self._get_client(channel_id)
@@ -2593,84 +2701,105 @@ class SlackAdapter(BasePlatformAdapter):
                     raise
 
             if result is None:
-                return ""
+                return "", ""
 
             messages = result.get("messages", [])
             if not messages:
-                return ""
+                return "", ""
 
-            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-            context_parts = []
             parent_text = ""
             for msg in messages:
-                msg_ts = msg.get("ts", "")
-                # Exclude the current triggering message — it will be delivered
-                # as the user message itself, so including it here would duplicate it.
-                if msg_ts == current_ts:
-                    continue
+                if msg.get("ts", "") == thread_ts:
+                    parent_text = (msg.get("text") or "").strip()
+                    break
 
-                is_parent = msg_ts == thread_ts
-                is_bot = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
-                msg_user = msg.get("user", "")
-
-                # Identify "our own" bot for this workspace (multi-workspace safe).
-                msg_team = msg.get("team") or team_id
-                self_bot_uid = (
-                    self._team_bot_user_ids.get(msg_team)
-                    if msg_team
-                    else None
-                ) or self._bot_user_id
-
-                # Exclude only our own prior bot replies (circular context).
-                # Keep:
-                #   - the thread parent even if it was posted by a bot
-                #     (e.g. a cron job summary we are now replying to);
-                #   - other bots' child messages (useful third-party context).
-                if (
-                    is_bot
-                    and not is_parent
-                    and self_bot_uid
-                    and msg_user == self_bot_uid
-                ):
-                    continue
-
-                msg_text = msg.get("text", "").strip()
-                if not msg_text:
-                    continue
-
-                # Strip bot mentions from context messages
-                if bot_uid:
-                    msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
-
-                prefix = "[thread parent] " if is_parent else ""
-                display_user = msg_user or "unknown"
-                # Prefer the bot's own name when the message is a bot post.
-                if is_bot and not display_user:
-                    display_user = msg.get("username") or "bot"
-                name = await self._resolve_user_name(display_user, chat_id=channel_id)
-                context_parts.append(f"{prefix}{name}: {msg_text}")
-                if is_parent:
-                    parent_text = msg_text
-
-            content = ""
-            if context_parts:
-                content = (
-                    "[Thread context — prior messages in this thread (not yet in conversation history):]\n"
-                    + "\n".join(context_parts)
-                    + "\n[End of thread context]\n\n"
-                )
-
+            content, last_seen_ts = await self._format_thread_context(
+                messages=messages,
+                thread_ts=thread_ts,
+                current_ts=current_ts,
+                team_id=team_id,
+                channel_id=channel_id,
+                after_ts=after_ts,
+            )
             self._thread_context_cache[cache_key] = _ThreadContextCache(
+                messages=list(messages),
                 content=content,
                 fetched_at=now,
-                message_count=len(context_parts),
+                message_count=len(messages),
                 parent_text=parent_text,
             )
-            return content
+            return content, last_seen_ts
 
         except Exception as e:
             logger.warning("[Slack] Failed to fetch thread context: %s", e)
-            return ""
+            return "", ""
+
+    async def _format_thread_context(
+        self,
+        messages: List[Dict[str, Any]],
+        thread_ts: str,
+        current_ts: str,
+        team_id: str,
+        channel_id: str,
+        after_ts: str = "",
+    ) -> Tuple[str, str]:
+        """Format cached/fetched Slack replies into injected thread context."""
+        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        context_parts = []
+        last_seen_ts = ""
+        for msg in messages:
+            msg_ts = msg.get("ts", "")
+            if msg_ts and msg_ts > last_seen_ts:
+                last_seen_ts = msg_ts
+            # Exclude the current triggering message — it will be delivered
+            # as the user message itself, so including it here would duplicate it.
+            if msg_ts == current_ts:
+                continue
+            if after_ts and msg_ts and msg_ts <= after_ts:
+                continue
+
+            is_parent = msg_ts == thread_ts
+            is_bot = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
+            msg_user = msg.get("user", "")
+
+            # Identify "our own" bot for this workspace (multi-workspace safe).
+            msg_team = msg.get("team") or team_id
+            self_bot_uid = (
+                self._team_bot_user_ids.get(msg_team)
+                if msg_team
+                else None
+            ) or self._bot_user_id
+
+            if (
+                is_bot
+                and not is_parent
+                and self_bot_uid
+                and msg_user == self_bot_uid
+            ):
+                continue
+
+            msg_text = msg.get("text", "").strip()
+            if not msg_text:
+                continue
+
+            if bot_uid:
+                msg_text = msg_text.replace(f"<@{bot_uid}>", "").strip()
+
+            prefix = "[thread parent] " if is_parent else ""
+            display_user = msg_user or "unknown"
+            if is_bot and not msg_user:
+                display_user = msg.get("username") or "bot"
+            name = await self._resolve_user_name(display_user, chat_id=channel_id)
+            context_parts.append(f"{prefix}{name}: {msg_text}")
+
+        content = ""
+        if context_parts:
+            content = (
+                "[Thread context — prior messages in this thread (not yet in conversation history):]\n"
+                + "\n".join(context_parts)
+                + "\n[End of thread context]\n\n"
+            )
+        return content, last_seen_ts
 
     async def _fetch_thread_parent_text(
         self, channel_id: str, thread_ts: str, team_id: str = "",
@@ -2817,27 +2946,9 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
         try:
-            from gateway.session import SessionSource, build_session_key
-
-            source = SessionSource(
-                platform=Platform.SLACK,
-                chat_id=channel_id,
-                chat_type="group",
-                user_id=user_id,
-                thread_id=thread_ts,
-            )
-
-            # Read session isolation settings from the store's config
-            store_cfg = getattr(session_store, "config", None)
-            gspu = getattr(store_cfg, "group_sessions_per_user", True) if store_cfg else True
-            tspu = getattr(store_cfg, "thread_sessions_per_user", False) if store_cfg else False
-
-            session_key = build_session_key(
-                source,
-                group_sessions_per_user=gspu,
-                thread_sessions_per_user=tspu,
-            )
-
+            session_key = self._build_thread_session_key(channel_id, thread_ts, user_id)
+            if not session_key:
+                return False
             session_store._ensure_loaded()
             return session_key in session_store._entries
         except Exception:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -440,6 +440,7 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+    metadata: Dict[str, Any] = field(default_factory=dict)
     
     # Token tracking
     input_tokens: int = 0
@@ -500,6 +501,7 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "metadata": self.metadata,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -553,6 +555,7 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            metadata=dict(data.get("metadata") or {}),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -963,6 +966,37 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_session_metadata(
+        self,
+        session_key: str,
+        key: str,
+        default: Any = None,
+    ) -> Any:
+        """Return a metadata value stored on a live session entry."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return default
+            return entry.metadata.get(key, default)
+
+    def set_session_metadata(
+        self,
+        session_key: str,
+        key: str,
+        value: Any,
+    ) -> bool:
+        """Persist a metadata value on a live session entry."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            entry.metadata[key] = value
+            entry.updated_at = _now()
+            self._save()
+            return True
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1198,6 +1198,52 @@ class TestLastPromptTokens:
         store.update_session("k1", last_prompt_tokens=0)
         assert entry.last_prompt_tokens == 0
 
+
+class TestSessionMetadata:
+    """SessionEntry metadata should persist arbitrary lightweight state."""
+
+    def test_session_entry_metadata_roundtrip(self):
+        from gateway.session import SessionEntry
+        from datetime import datetime
+
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            metadata={"slack_thread_watermark:C123:123.000": "123.456"},
+        )
+
+        restored = SessionEntry.from_dict(entry.to_dict())
+        assert restored.metadata == {"slack_thread_watermark:C123:123.000": "123.456"}
+
+    def test_store_session_metadata_persists_to_sessions_json(self, tmp_path):
+        config = GatewayConfig()
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="group",
+            user_id="U123",
+            thread_id="123.000",
+        )
+
+        entry = store.get_or_create_session(source)
+        assert store.set_session_metadata(
+            entry.session_key,
+            "slack_thread_watermark:C123:123.000",
+            "123.456",
+        )
+
+        reloaded = SessionStore(sessions_dir=tmp_path, config=config)
+        assert (
+            reloaded.get_session_metadata(
+                entry.session_key,
+                "slack_thread_watermark:C123:123.000",
+            )
+            == "123.456"
+        )
+
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -11,6 +11,7 @@ We mock the slack modules at import time to avoid collection errors.
 import asyncio
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
@@ -1900,6 +1901,25 @@ class TestThreadReplyHandling:
         store._ensure_loaded = MagicMock()
         store.config = MagicMock()
         store.config.group_sessions_per_user = True
+        store.config.thread_sessions_per_user = True
+
+        def _get_session_metadata(session_key, key, default=None):
+            entry = store._entries.get(session_key)
+            if entry is None:
+                return default
+            return getattr(entry, "metadata", {}).get(key, default)
+
+        def _set_session_metadata(session_key, key, value):
+            entry = store._entries.get(session_key)
+            if entry is None:
+                return False
+            metadata = dict(getattr(entry, "metadata", {}))
+            metadata[key] = value
+            entry.metadata = metadata
+            return True
+
+        store.get_session_metadata = MagicMock(side_effect=_get_session_metadata)
+        store.set_session_metadata = MagicMock(side_effect=_set_session_metadata)
         return store
 
     @pytest.fixture()
@@ -1984,6 +2004,195 @@ class TestThreadReplyHandling:
         msg_event = adapter_with_session_store.handle_message.call_args[0][0]
         assert "<@U_BOT>" not in msg_event.text
         assert msg_event.text == "thanks for the help"
+
+    @pytest.mark.asyncio
+    async def test_active_thread_explicit_mention_refreshes_context_delta(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Explicit @mentions on active threads should bypass the stale-session shortcut."""
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {
+            session_key: SimpleNamespace(metadata={
+                "slack_thread_watermark:C123:123.000": "123.100",
+            })
+        }
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "123.000", "user": "U_PARENT", "text": "Original question"},
+                {"ts": "123.100", "user": "U_USER", "text": "Old context"},
+                {"ts": "123.200", "user": "U_OTHER", "text": "Fresh update"},
+                {"ts": "123.456", "user": "U_USER", "text": "<@U_BOT> what changed?"},
+            ]
+        })
+
+        with patch.object(
+            adapter_with_session_store,
+            "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda user_id, chat_id=None: user_id),
+        ):
+            await adapter_with_session_store._handle_slack_message({
+                "text": "<@U_BOT> what changed?",
+                "user": "U_USER",
+                "channel": "C123",
+                "ts": "123.456",
+                "thread_ts": "123.000",
+                "channel_type": "channel",
+                "team": "T_TEAM",
+            })
+
+        adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert "Fresh update" in msg_event.text
+        assert "Old context" not in msg_event.text
+        assert msg_event.text.endswith("what changed?")
+        assert (
+            mock_session_store._entries[session_key].metadata["slack_thread_watermark:C123:123.000"]
+            == "123.456"
+        )
+
+    @pytest.mark.asyncio
+    async def test_active_thread_unmentioned_reply_keeps_existing_behavior(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Unmentioned replies in active threads should still avoid thread re-fetch."""
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {
+            session_key: SimpleNamespace(metadata={
+                "slack_thread_watermark:C123:123.000": "123.100",
+            })
+        }
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock()
+        adapter_with_session_store._fetch_thread_parent_text = AsyncMock(return_value="")
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "Follow-up without mention",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        adapter_with_session_store.handle_message.assert_called_once()
+        adapter_with_session_store._app.client.conversations_replies.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_mention_bypasses_stale_thread_cache(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Explicit refresh should ignore cached thread content and replace it with fresh replies."""
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {
+            session_key: SimpleNamespace(metadata={
+                "slack_thread_watermark:C123:123.000": "123.100",
+            })
+        }
+        cache_key = "C123:123.000:T_TEAM"
+        adapter_with_session_store._thread_context_cache[cache_key] = _slack_mod._ThreadContextCache(
+            messages=[
+                {"ts": "123.000", "user": "U_PARENT", "text": "Original question"},
+                {"ts": "123.200", "user": "U_OTHER", "text": "Stale cached update"},
+                {"ts": "123.456", "user": "U_USER", "text": "<@U_BOT> refresh"},
+            ],
+            content="stale",
+        )
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "123.000", "user": "U_PARENT", "text": "Original question"},
+                {"ts": "123.300", "user": "U_OTHER", "text": "Fresh API update"},
+                {"ts": "123.456", "user": "U_USER", "text": "<@U_BOT> refresh"},
+            ]
+        })
+
+        with patch.object(
+            adapter_with_session_store,
+            "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda user_id, chat_id=None: user_id),
+        ):
+            await adapter_with_session_store._handle_slack_message({
+                "text": "<@U_BOT> refresh",
+                "user": "U_USER",
+                "channel": "C123",
+                "ts": "123.456",
+                "thread_ts": "123.000",
+                "channel_type": "channel",
+                "team": "T_TEAM",
+            })
+
+        adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert "Fresh API update" in msg_event.text
+        assert "Stale cached update" not in msg_event.text
+        assert adapter_with_session_store._thread_context_cache[cache_key].messages[1]["text"] == "Fresh API update"
+
+    @pytest.mark.asyncio
+    async def test_explicit_mention_refresh_advances_watermark_across_turns(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """Two explicit refreshes should only inject messages newer than the prior watermark."""
+        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        mock_session_store._entries = {
+            session_key: SimpleNamespace(metadata={
+                "slack_thread_watermark:C123:123.000": "123.100",
+            })
+        }
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(side_effect=[
+            {
+                "messages": [
+                    {"ts": "123.000", "user": "U_PARENT", "text": "Original question"},
+                    {"ts": "123.100", "user": "U_USER", "text": "Old context"},
+                    {"ts": "123.200", "user": "U_OTHER", "text": "First delta"},
+                    {"ts": "123.300", "user": "U_USER", "text": "<@U_BOT> first refresh"},
+                ]
+            },
+            {
+                "messages": [
+                    {"ts": "123.000", "user": "U_PARENT", "text": "Original question"},
+                    {"ts": "123.100", "user": "U_USER", "text": "Old context"},
+                    {"ts": "123.200", "user": "U_OTHER", "text": "First delta"},
+                    {"ts": "123.300", "user": "U_USER", "text": "<@U_BOT> first refresh"},
+                    {"ts": "123.400", "user": "U_OTHER", "text": "Second delta"},
+                    {"ts": "123.500", "user": "U_USER", "text": "<@U_BOT> second refresh"},
+                ]
+            },
+        ])
+        captured_events = []
+        adapter_with_session_store.handle_message = AsyncMock(side_effect=lambda e: captured_events.append(e))
+
+        with patch.object(
+            adapter_with_session_store,
+            "_resolve_user_name",
+            new=AsyncMock(side_effect=lambda user_id, chat_id=None: user_id),
+        ):
+            await adapter_with_session_store._handle_slack_message({
+                "text": "<@U_BOT> first refresh",
+                "user": "U_USER",
+                "channel": "C123",
+                "ts": "123.300",
+                "thread_ts": "123.000",
+                "channel_type": "channel",
+                "team": "T_TEAM",
+            })
+            await adapter_with_session_store._handle_slack_message({
+                "text": "<@U_BOT> second refresh",
+                "user": "U_USER",
+                "channel": "C123",
+                "ts": "123.500",
+                "thread_ts": "123.000",
+                "channel_type": "channel",
+                "team": "T_TEAM",
+            })
+
+        assert len(captured_events) == 2
+        assert "First delta" in captured_events[0].text
+        assert "Second delta" not in captured_events[0].text
+        assert "Second delta" in captured_events[1].text
+        assert "First delta" not in captured_events[1].text
+        assert (
+            mock_session_store._entries[session_key].metadata["slack_thread_watermark:C123:123.000"]
+            == "123.500"
+        )
 
     @pytest.mark.asyncio
     async def test_top_level_message_requires_mention_even_with_session(


### PR DESCRIPTION
 ## Summary

  This fixes a Slack thread-context bug where an explicit `@Hermes` reply in an already-active thread could continue without re-fetching the latest Slack thread state.

  Before this change, thread context hydration only happened on the first thread entry when no active session existed. That meant a later explicit mention inside the same thread could miss newer replies posted after the original hydrate.

  This change adds a persistent per-session Slack thread watermark and uses it to refresh thread context only when a user explicitly mentions Hermes in an active thread.

  ## What changed

  - persist Slack thread watermarks in session metadata
  - refresh active Slack thread context on explicit `@Hermes` replies
  - bypass the 60s thread-context cache for the explicit-refresh path
  - inject only the delta since the last hydrate/refresh instead of replaying the whole thread
  - keep unmentioned active-thread replies unchanged
  - keep `strict_mention` and `allow_bots` semantics unchanged

  ## Why

  Explicit mention in an active Slack thread is a fresh user intent signal. Hermes should re-read the current thread state in that case, especially in multi-agent threads where another bot or integration may have posted new context since the original hydrate.

  ## Testing

  - `uv run pytest tests/gateway/test_session.py::TestSessionMetadata -q -o addopts= -n 0`
  - `uv run pytest tests/gateway/test_slack.py -q -o addopts= -n 0`

  ## Related issue

  - Fixes #23918

  ## Related work

  - #15421
  - #23141
  - #16200
  - #6809
  - #16193
  - #8019
