### PR TITLE
feat(telegram): add ignore_root_dm config to silently drop root DM messages when dm_topics are active

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -370,6 +370,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
+        self._dm_topic_chat_ids: Set[str] = {
+            str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
+        }
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
@@ -3708,16 +3712,23 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
-        if not self._is_group_chat(message):
-            return True
-
         thread_id = getattr(message, "message_thread_id", None)
+
+        # Check ignored_threads first — applies to both groups and DM topics
         if thread_id is not None:
             try:
                 if int(thread_id) in self._telegram_ignored_threads():
                     return False
             except (TypeError, ValueError):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
+
+        if not self._is_group_chat(message):
+            # Root DM (non-topic): ignore if ignore_root_dm is configured
+            if thread_id is None and self.config.extra.get("ignore_root_dm", False):
+                chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+                if not is_command and chat_id in self._dm_topic_chat_ids:
+                    return False
+            return True
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
 
@@ -4307,10 +4318,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 .get("dm_topics", [])
             )
             if not dm_topics:
+                # Clear both config and precomputed set when all topics are removed
+                self._dm_topics_config = []
+                self._dm_topic_chat_ids = set()
                 return
 
             # Update in-memory config and cache any new thread_ids
             self._dm_topics_config = dm_topics
+            # Rebuild the chat_id set for O(1) root-DM ignore lookup
+            self._dm_topic_chat_ids = {
+                str(chat_entry["chat_id"]) for chat_entry in dm_topics if "chat_id" in chat_entry
+            }
             for chat_entry in dm_topics:
                 cid = chat_entry.get("chat_id")
                 if not cid:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -408,6 +408,28 @@ platforms:
 3. Each topic maps to an isolated session key: `agent:main:telegram:dm:{chat_id}:{thread_id}`
 4. Messages in each topic have their own conversation history, memory flush, and context window
 
+### Root DM handling
+
+By default, messages sent to the root DM (outside any topic) are processed
+normally. Set `ignore_root_dm: true` to turn the root DM into a lobby — normal
+messages are silently ignored for users who have DM topics configured, while
+system commands (`/start`, `/help`, `/status`, etc.) still work.
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      ignore_root_dm: true
+      dm_topics:
+        - chat_id: 123456789
+          topics:
+            - name: General
+```
+
+The check is **per-chat**: only users with at least one entry in `dm_topics`
+will have their root DM affected. Users without configured topics are
+unaffected.
+
 ### Skill binding
 
 Topics with a `skill` field automatically load that skill when a new session starts in the topic. This works exactly like typing `/skill-name` at the start of a conversation — the skill content is injected into the first message, and subsequent messages see it in the conversation history.
@@ -442,7 +464,7 @@ Only authorized users (allowlist via `TELEGRAM_ALLOWED_USERS` / platform auth co
 | Who activates it | Operator, in `config.yaml` | End user, by sending `/topic` |
 | Topic list | Fixed set declared in config | User creates/deletes topics freely |
 | Topic names | Chosen by operator | Chosen by user; auto-renamed to match Hermes session title |
-| Root DM behavior | Unchanged — normal chat | Becomes a system lobby (non-command messages are rejected) |
+| Root DM behavior | Normal chat (lobby if `ignore_root_dm: true`) | Becomes a system lobby (non-command messages are rejected) |
 | Primary use case | Permanent workspaces with optional skill binding | Ad-hoc parallel sessions |
 | Persistence | `extra.dm_topics` in config | `telegram_dm_topic_mode` + `telegram_dm_topic_bindings` SQLite tables |
 


### PR DESCRIPTION
### Motivation

When `dm_topics` are configured in Hermes, all conversation is expected to flow through named topic threads (General, Coding, Server, etc.). However, the root DM remains active and processes messages that arrive without a `message_thread_id`, which causes:

- **Split sessions** — replies in root DM create a separate conversation context from topic threads
- **User confusion** — messages sent to root DM get processed but lose topic context

BotFather's **`Disallow users to create a new thread`** option also plays a role: when turned on, users cannot create new threads themselves, so the root DM becomes a **lobby** — the only place new users can send messages. Without this feature, every such lobby message gets processed in the wrong context.

With `ignore_root_dm: true`, the root DM becomes a true quiet lobby — users are naturally guided to select an existing topic from those configured in `dm_topics`.

### Changes

Modified `TelegramAdapter._should_process_message()` in `gateway/platforms/telegram.py`:

1. Moved the `ignored_threads` check to run **before** the group-chat/DM branching — this makes `ignored_threads` work correctly for DM topics
2. Added root DM detection: when `message_thread_id` is `None` (root DM), `ignore_root_dm` is `true`, and `dm_topics` are configured for the chat, the message is silently dropped (`return False`)
3. All DM topics (General, Coding, etc.) continue to be processed normally

### Configuration

```yaml
platforms:
  telegram:
    extra:
      dm_topics:
        - name: General
        - name: Coding
      ignore_root_dm: true   # ← new key
```

### Backward Compatibility

- **Fully backward compatible** — defaults to `false`, existing setups are unaffected
- When `false` (default), behaviour is identical to the current code
- No existing config keys are modified or removed