### PR TITLE
fix(kanban): lower Gridlux disk pressure thresholds to 3/6 GiB

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4251,7 +4251,7 @@ class GatewayRunner:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
-                    if _kb.has_spawnable_ready(conn):
+                    if _kb.has_spawnable_ready(conn, board=slug):
                         return True
                 except Exception:
                     continue
@@ -4270,7 +4270,21 @@ class GatewayRunner:
             try:
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
+                any_disk_pressure_hold = False
                 for slug, res in (results or []):
+                    if (
+                        res is not None
+                        and getattr(res, "disk_pressure_hold", None) is not None
+                        and getattr(res, "skipped_disk_pressure", None)
+                    ):
+                        any_disk_pressure_hold = True
+                        hold = res.disk_pressure_hold
+                        logger.warning(
+                            "kanban dispatcher [%s]: %s skipped_disk_pressure=%d",
+                            slug,
+                            hold.message(),
+                            len(getattr(res, "skipped_disk_pressure", []) or []),
+                        )
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
                         # Quiet by default — only log when something actually
@@ -4288,7 +4302,7 @@ class GatewayRunner:
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                if ready_pending and not any_spawned and not any_disk_pressure_hold:
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1655,12 +1655,14 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
+    board = kb.get_current_board()
     with kb.connect() as conn:
         res = kb.dispatch_once(
             conn,
             dry_run=args.dry_run,
             max_spawn=args.max,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            board=board,
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -1675,6 +1677,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_disk_pressure": res.skipped_disk_pressure,
+            "disk_pressure_hold": (
+                res.disk_pressure_hold.to_dict()
+                if res.disk_pressure_hold is not None else None
+            ),
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -1699,6 +1706,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.disk_pressure_hold is not None:
+        print(res.disk_pressure_hold.message())
+        if res.skipped_disk_pressure:
+            print(f"Skipped (disk pressure): {', '.join(res.skipped_disk_pressure)}")
     return 0
 
 
@@ -1771,7 +1782,16 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
     health_state = {"bad_ticks": 0, "last_warn_at": 0}
 
     def _on_tick(res):
-        ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
+        if res.disk_pressure_hold is not None:
+            print(
+                f"[{_fmt_ts(int(time.time()))}] {res.disk_pressure_hold.message()} "
+                f"skipped={len(res.skipped_disk_pressure)}",
+                file=sys.stderr, flush=True,
+            )
+        ready_pending = (
+            res.disk_pressure_hold is None
+            and (bool(res.skipped_unassigned) or _ready_queue_nonempty())
+        )
         spawned_any = bool(res.spawned)
         if ready_pending and not spawned_any:
             health_state["bad_ticks"] += 1
@@ -1798,7 +1818,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked
+            or res.spawned or res.auto_blocked or res.disk_pressure_hold
         )
         if did_work:
             print(
@@ -1806,7 +1826,8 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
                 f"timed_out={len(res.timed_out)} "
                 f"promoted={res.promoted} spawned={len(res.spawned)} "
-                f"auto_blocked={len(res.auto_blocked)}",
+                f"auto_blocked={len(res.auto_blocked)} "
+                f"skipped_disk_pressure={len(res.skipped_disk_pressure)}",
                 flush=True,
             )
 
@@ -1822,7 +1843,7 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         """
         try:
             with kb.connect() as conn:
-                return kb.has_spawnable_ready(conn)
+                return kb.has_spawnable_ready(conn, board=kb.get_current_board())
         except Exception:
             return False
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,12 +101,14 @@ DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 # dispatcher is allowed to continue bookkeeping (reclaim stale locks,
 # record crashed workers, promote ready tasks), but it must not start new
 # Gridlux workers while the host data volume is critically low.  Hysteresis
-# avoids flap-spawning around the threshold: once held below 10 GiB, dispatch
-# stays held until free space reaches at least 15 GiB.
+# avoids flap-spawning around the threshold: once held below 3 GiB, dispatch
+# stays held until free space reaches at least 6 GiB.  Gridlux janitor
+# watchdogs now react at 8 GiB and alert at 4 GiB, leaving cleanup runway
+# before this last-resort pause threshold.
 GRIDLUX_DISK_PRESSURE_BOARD = "gridlux"
 GRIDLUX_DISK_PRESSURE_PATH = "/System/Volumes/Data"
-GRIDLUX_DISK_PRESSURE_CRITICAL_KIB = 10 * 1024 * 1024
-GRIDLUX_DISK_PRESSURE_RECOVERY_KIB = 15 * 1024 * 1024
+GRIDLUX_DISK_PRESSURE_CRITICAL_KIB = 3 * 1024 * 1024
+GRIDLUX_DISK_PRESSURE_RECOVERY_KIB = 6 * 1024 * 1024
 GRIDLUX_EMERGENCY_PRIORITY = 1000
 _gridlux_disk_pressure_hold_active = False
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -97,6 +97,19 @@ VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 # workloads either finish within 15m or set a longer claim explicitly.
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
+# Gridlux-specific disk pressure guard for Kanban worker fan-out.  The
+# dispatcher is allowed to continue bookkeeping (reclaim stale locks,
+# record crashed workers, promote ready tasks), but it must not start new
+# Gridlux workers while the host data volume is critically low.  Hysteresis
+# avoids flap-spawning around the threshold: once held below 10 GiB, dispatch
+# stays held until free space reaches at least 15 GiB.
+GRIDLUX_DISK_PRESSURE_BOARD = "gridlux"
+GRIDLUX_DISK_PRESSURE_PATH = "/System/Volumes/Data"
+GRIDLUX_DISK_PRESSURE_CRITICAL_KIB = 10 * 1024 * 1024
+GRIDLUX_DISK_PRESSURE_RECOVERY_KIB = 15 * 1024 * 1024
+GRIDLUX_EMERGENCY_PRIORITY = 1000
+_gridlux_disk_pressure_hold_active = False
+
 
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
@@ -2793,6 +2806,54 @@ DEFAULT_LOG_ROTATE_BYTES = 2 * 1024 * 1024   # 2 MiB
 
 
 @dataclass
+class DiskPressureHold:
+    """Dispatcher hold state for Gridlux disk-pressure throttling."""
+
+    active: bool
+    board: str
+    path: str
+    free_kib: Optional[int]
+    critical_kib: int = GRIDLUX_DISK_PRESSURE_CRITICAL_KIB
+    recovery_kib: int = GRIDLUX_DISK_PRESSURE_RECOVERY_KIB
+    reason: Optional[str] = None
+
+    @property
+    def free_gib(self) -> Optional[float]:
+        if self.free_kib is None:
+            return None
+        return self.free_kib / (1024 * 1024)
+
+    def message(self) -> str:
+        if self.free_kib is None:
+            return (
+                f"Gridlux dispatch paused: unable to read free space for {self.path}; "
+                f"holding worker starts until disk check succeeds."
+            )
+        if self.free_kib < self.critical_kib:
+            threshold_detail = "below 10 GiB critical threshold"
+        else:
+            threshold_detail = "below 15 GiB recovery threshold after a critical low-disk hold"
+        return (
+            f"Gridlux dispatch paused: {self.path} free space is "
+            f"{self.free_gib:.2f} GiB; {threshold_detail}. "
+            f"Worker starts resume automatically at >=15 GiB."
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "active": self.active,
+            "board": self.board,
+            "path": self.path,
+            "free_kib": self.free_kib,
+            "free_gib": self.free_gib,
+            "critical_kib": self.critical_kib,
+            "recovery_kib": self.recovery_kib,
+            "reason": self.reason,
+            "message": self.message() if self.active else None,
+        }
+
+
+@dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass."""
 
@@ -2810,12 +2871,17 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_disk_pressure: list[str] = field(default_factory=list)
+    """Gridlux task ids left ready because disk pressure is holding
+    non-emergency worker starts."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
     """Task ids whose workers exceeded ``max_runtime_seconds``."""
+    disk_pressure_hold: Optional[DiskPressureHold] = None
+    """Gridlux-only hold that prevented new worker starts this tick."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -3530,9 +3596,104 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
-def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
+def _disk_free_kib(path: str) -> Optional[int]:
+    """Return free KiB for ``path`` using the same unit as ``df -k``.
+
+    ``None`` means the path could not be checked; callers fail open so a
+    non-macOS development checkout does not accidentally disable Gridlux.
+    The production Gridlux host has ``/System/Volumes/Data``.
+    """
+    try:
+        st = os.statvfs(path)
+    except OSError:
+        return None
+    return int((st.f_bavail * st.f_frsize) // 1024)
+
+
+def _connection_board_slug(conn: sqlite3.Connection) -> Optional[str]:
+    """Best-effort board slug for an open kanban DB connection."""
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        db_path = Path(row["file"] if isinstance(row, sqlite3.Row) else row[2]).resolve()
+    except Exception:
+        return None
+    try:
+        # Do not call kanban_db_path() here: tests and worker handoffs may set
+        # HERMES_KANBAN_DB, which intentionally aliases every board arg to the
+        # same override path. Compare canonical on-disk board locations instead.
+        root = kanban_home()
+        if db_path == (root / "kanban" / "boards" / GRIDLUX_DISK_PRESSURE_BOARD / "kanban.db").resolve():
+            return GRIDLUX_DISK_PRESSURE_BOARD
+        if db_path == (root / "kanban.db").resolve():
+            return DEFAULT_BOARD
+    except Exception:
+        return None
+    return None
+
+
+def _gridlux_disk_pressure_hold(
+    board: Optional[str],
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Optional[DiskPressureHold]:
+    """Return an active Gridlux disk-pressure hold, if worker starts must pause."""
+    global _gridlux_disk_pressure_hold_active
+
+    slug = _normalize_board_slug(board)
+    if slug is None and conn is not None:
+        slug = _connection_board_slug(conn)
+    if slug is None:
+        # If the caller did not explicitly identify Gridlux and the connection
+        # path cannot prove it is the Gridlux board, fail open. This preserves
+        # legacy dispatch_once(conn) behavior for tests and ad-hoc callers.
+        return None
+    if slug != GRIDLUX_DISK_PRESSURE_BOARD:
+        return None
+
+    path = os.environ.get(
+        "HERMES_KANBAN_GRIDLUX_DISK_PRESSURE_PATH",
+        GRIDLUX_DISK_PRESSURE_PATH,
+    )
+    free_kib = _disk_free_kib(path)
+    if free_kib is None:
+        # Fail open on hosts without the macOS data volume path.  The task
+        # specifically targets the Gridlux VM; tests and non-macOS dev boxes
+        # should not be held forever because the reference path is absent.
+        _gridlux_disk_pressure_hold_active = False
+        return None
+
+    if free_kib < GRIDLUX_DISK_PRESSURE_CRITICAL_KIB:
+        _gridlux_disk_pressure_hold_active = True
+    elif free_kib >= GRIDLUX_DISK_PRESSURE_RECOVERY_KIB:
+        _gridlux_disk_pressure_hold_active = False
+
+    if not _gridlux_disk_pressure_hold_active:
+        return None
+    return DiskPressureHold(
+        active=True,
+        board=slug,
+        path=path,
+        free_kib=free_kib,
+        reason="free_space_below_recovery_threshold",
+    )
+
+
+def _is_emergency_task(task: Task) -> bool:
+    """Best-effort operator escape hatch for starts during Gridlux holds.
+
+    Kanban has no dedicated emergency flag, so support two explicit markers:
+    a very high priority (>=1000) or an ``[emergency]`` / ``emergency: true``
+    marker in the title/body. Normal tasks stay paused.
+    """
+    if int(task.priority or 0) >= GRIDLUX_EMERGENCY_PRIORITY:
+        return True
+    text = f"{task.title or ''}\n{task.body or ''}".lower()
+    return "[emergency]" in text or "emergency: true" in text
+
+
+def has_spawnable_ready(conn: sqlite3.Connection, *, board: Optional[str] = None) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
-    whose assignee maps to a real Hermes profile.
+    whose assignee maps to a real Hermes profile and is not policy-held.
 
     Used by the gateway- and CLI-embedded dispatchers' health telemetry to
     decide whether ``0 spawned`` is a "stuck" condition (real spawnable
@@ -3545,20 +3706,27 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     the warning still fires in degraded environments.
     """
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT * FROM tasks "
         "WHERE status = 'ready' AND assignee IS NOT NULL "
         "    AND claim_lock IS NULL"
     ).fetchall()
     if not rows:
         return False
+    hold = _gridlux_disk_pressure_hold(board, conn=conn)
     try:
         from hermes_cli.profiles import profile_exists  # local import: avoids cycle
     except Exception:
-        # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
-    for row in rows:
-        if profile_exists(row["assignee"]):
+        # Can't introspect — assume spawnable unless disk pressure policy holds
+        # every non-emergency Gridlux task in the ready queue.
+        if hold is None:
             return True
+        return any(_is_emergency_task(Task.from_row(row)) for row in rows)
+    for row in rows:
+        if not profile_exists(row["assignee"]):
+            continue
+        if hold is not None and not _is_emergency_task(Task.from_row(row)):
+            continue
+        return True
     return False
 
 
@@ -3625,6 +3793,7 @@ def dispatch_once(
             pass
 
     result = DispatchResult()
+    result.disk_pressure_hold = _gridlux_disk_pressure_hold(board, conn=conn)
     result.reclaimed = release_stale_claims(conn)
     result.crashed = detect_crashed_workers(conn)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
@@ -3673,6 +3842,13 @@ def dispatch_once(
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
             continue
+        if result.disk_pressure_hold is not None:
+            task_for_policy = get_task(conn, row["id"])
+            if task_for_policy is not None and not _is_emergency_task(task_for_policy):
+                # Leave the task ready/unclaimed. This gates only new starts;
+                # already-running workers remain untouched by design.
+                result.skipped_disk_pressure.append(row["id"])
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
@@ -3935,6 +4111,7 @@ def run_daemon(
                 except (ValueError, OSError):
                     pass
 
+    board = get_current_board()
     while not stop_event.is_set():
         try:
             with contextlib.closing(connect()) as conn:
@@ -3942,6 +4119,7 @@ def run_daemon(
                     conn,
                     max_spawn=max_spawn,
                     failure_limit=failure_limit,
+                    board=board,
                 )
             if on_tick is not None:
                 try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2831,14 +2831,18 @@ class DiskPressureHold:
                 f"Gridlux dispatch paused: unable to read free space for {self.path}; "
                 f"holding worker starts until disk check succeeds."
             )
+        critical_gib = f"{self.critical_kib / (1024 * 1024):g}"
+        recovery_gib = f"{self.recovery_kib / (1024 * 1024):g}"
         if self.free_kib < self.critical_kib:
-            threshold_detail = "below 10 GiB critical threshold"
+            threshold_detail = f"below {critical_gib} GiB critical threshold"
         else:
-            threshold_detail = "below 15 GiB recovery threshold after a critical low-disk hold"
+            threshold_detail = (
+                f"below {recovery_gib} GiB recovery threshold after a critical low-disk hold"
+            )
         return (
             f"Gridlux dispatch paused: {self.path} free space is "
             f"{self.free_gib:.2f} GiB; {threshold_detail}. "
-            f"Worker starts resume automatically at >=15 GiB."
+            f"Worker starts resume automatically at >={recovery_gib} GiB."
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -34,10 +34,28 @@ from hermes_cli.kanban import run_slash
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _isolate_kanban_test_home(home, tmp_path, monkeypatch)
     kb.init_db()
     return home
+
+
+def _isolate_kanban_test_home(home: Path, path_home: Path, monkeypatch) -> None:
+    """Pin Kanban tests to a temp home and discard inherited board pins."""
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: path_home)
+
+
+def test_kanban_home_ignores_external_board_pins(kanban_home):
+    """Tests must not inherit real Kanban board pins from the developer shell."""
+    assert os.environ.get("HERMES_KANBAN_BOARD") is None
+    assert os.environ.get("HERMES_KANBAN_DB") is None
+    assert os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT") is None
+    assert kb.kanban_home() == kanban_home
+    assert kb.kanban_db_path(board="gridlux").is_relative_to(kanban_home)
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +123,166 @@ def test_spawn_failure_auto_blocks_after_limit(kanban_home, all_assignees_spawna
         assert task.status == "blocked"
         assert task.consecutive_failures >= 2
         assert task.last_failure_error and "no PATH" in task.last_failure_error
+    finally:
+        conn.close()
+
+
+def test_gridlux_dispatch_pauses_non_emergency_workers_under_disk_pressure(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    """Gridlux ready tasks stay unclaimed below the 10 GiB data-volume floor."""
+    kb.create_board("gridlux")
+    monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
+    monkeypatch.setattr(
+        kb,
+        "_disk_free_kib",
+        lambda _path: kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1,
+    )
+    spawned = []
+
+    conn = kb.connect(board="gridlux")
+    try:
+        tid = kb.create_task(conn, title="normal work", assignee="worker", priority=999)
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _ws: spawned.append(task.id),
+            board="gridlux",
+        )
+
+        assert spawned == []
+        assert res.disk_pressure_hold is not None
+        assert tid in res.skipped_disk_pressure
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.claim_lock is None
+    finally:
+        conn.close()
+
+
+def test_gridlux_dispatch_resumes_only_after_recovery_threshold(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    """The Gridlux disk hold has hysteresis: hold at 12 GiB, resume at 15 GiB."""
+    kb.create_board("gridlux")
+    free = {"kib": kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1}
+    monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
+    monkeypatch.setattr(kb, "_disk_free_kib", lambda _path: free["kib"])
+
+    conn = kb.connect(board="gridlux")
+    try:
+        tid = kb.create_task(conn, title="normal work", assignee="worker", priority=999)
+        first = kb.dispatch_once(conn, spawn_fn=lambda *_: 111, board="gridlux", max_spawn=1)
+        assert first.disk_pressure_hold is not None
+        assert kb.get_task(conn, tid).status == "ready"
+
+        free["kib"] = kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB + (2 * 1024 * 1024)
+        mid = kb.dispatch_once(conn, spawn_fn=lambda *_: 222, board="gridlux", max_spawn=1)
+        assert mid.disk_pressure_hold is not None
+        assert kb.get_task(conn, tid).status == "ready"
+
+        spawned = []
+        free["kib"] = kb.GRIDLUX_DISK_PRESSURE_RECOVERY_KIB
+        resumed = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _ws: spawned.append(task.id) or 333,
+            board="gridlux",
+            max_spawn=1,
+        )
+        assert resumed.disk_pressure_hold is None
+        assert len(spawned) == 1
+        assert kb.get_task(conn, spawned[0]).status == "running"
+    finally:
+        conn.close()
+
+
+def test_gridlux_disk_pressure_does_not_affect_other_boards(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
+    monkeypatch.setattr(
+        kb,
+        "_disk_free_kib",
+        lambda _path: kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1,
+    )
+    spawned = []
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="other work", assignee="worker", priority=999)
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _ws: spawned.append(task.id) or 444,
+            board="default",
+            max_spawn=1,
+        )
+        assert res.disk_pressure_hold is None
+        assert res.skipped_disk_pressure == []
+        assert len(spawned) == 1
+    finally:
+        conn.close()
+
+
+def test_gridlux_disk_pressure_allows_explicit_emergency_work(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    """Critical disk pressure pauses normal Gridlux fan-out, not emergency starts."""
+    kb.create_board("gridlux")
+    monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
+    monkeypatch.setattr(
+        kb,
+        "_disk_free_kib",
+        lambda _path: kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1,
+    )
+    spawned = []
+
+    conn = kb.connect(board="gridlux")
+    try:
+        normal = kb.create_task(conn, title="normal work", assignee="worker", priority=999)
+        emergency = kb.create_task(
+            conn,
+            title="[emergency] free disk space",
+            assignee="worker",
+            priority=kb.GRIDLUX_EMERGENCY_PRIORITY,
+        )
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _ws: spawned.append(task.id) or 555,
+            board="gridlux",
+            max_spawn=2,
+        )
+
+        assert res.disk_pressure_hold is not None
+        assert normal in res.skipped_disk_pressure
+        assert emergency not in res.skipped_disk_pressure
+        assert spawned == [emergency]
+        assert kb.get_task(conn, normal).status == "ready"
+        assert kb.get_task(conn, emergency).status == "running"
+    finally:
+        conn.close()
+
+
+def test_gridlux_has_spawnable_ready_respects_disk_pressure_hold(
+    kanban_home, monkeypatch, all_assignees_spawnable
+):
+    kb.create_board("gridlux")
+    monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
+    monkeypatch.setattr(
+        kb,
+        "_disk_free_kib",
+        lambda _path: kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1,
+    )
+
+    conn = kb.connect(board="gridlux")
+    try:
+        kb.create_task(conn, title="normal work", assignee="worker", priority=999)
+        assert kb.has_spawnable_ready(conn, board="gridlux") is False
+        kb.create_task(
+            conn,
+            title="[emergency] free disk space",
+            assignee="worker",
+            priority=kb.GRIDLUX_EMERGENCY_PRIORITY,
+        )
+        assert kb.has_spawnable_ready(conn, board="gridlux") is True
     finally:
         conn.close()
 
@@ -1113,8 +1291,7 @@ def test_migration_renames_legacy_event_kinds(tmp_path, monkeypatch):
     in place on init_db()."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _isolate_kanban_test_home(home, tmp_path, monkeypatch)
     # Init fresh.
     kb.init_db()
     conn = kb.connect()
@@ -1185,10 +1362,9 @@ def test_list_profiles_on_disk_custom_root(tmp_path, monkeypatch):
 def test_known_assignees_merges_disk_and_board(tmp_path, monkeypatch):
     """known_assignees unions profiles on disk with currently-assigned
     names, and reports per-status counts."""
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     profiles = tmp_path / ".hermes" / "profiles"
     profiles.mkdir(parents=True)
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    _isolate_kanban_test_home(tmp_path / ".hermes", tmp_path, monkeypatch)
 
     for name in ("researcher", "writer"):
         d = profiles / name
@@ -2075,13 +2251,13 @@ def test_cli_create_on_fresh_home_auto_inits(tmp_path, monkeypatch):
     'no such table: tasks' — init_db auto-runs now."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _isolate_kanban_test_home(home, tmp_path, monkeypatch)
     # Sanity: kanban.db does NOT exist yet.
     import subprocess as _sp
     import sys as _sys
     worktree_root = Path(__file__).resolve().parents[2]
     env = {**os.environ, "HERMES_HOME": str(home),
+           "HERMES_KANBAN_HOME": str(home),
            "PYTHONPATH": str(worktree_root)}
     r = _sp.run(
         [_sys.executable, "-m", "hermes_cli.main", "kanban",
@@ -2101,8 +2277,7 @@ def test_connect_auto_inits_fresh_db(tmp_path, monkeypatch):
     schema. Previously callers had to remember kb.init_db() first."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _isolate_kanban_test_home(home, tmp_path, monkeypatch)
     # Flush the module-level cache so this path looks fresh.
     kb._INITIALIZED_PATHS.clear()
 
@@ -2211,8 +2386,7 @@ def test_migration_backfill_idempotent_under_re_run(tmp_path, monkeypatch):
     dispatcher is simultaneously claiming."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _isolate_kanban_test_home(home, tmp_path, monkeypatch)
 
     # Fresh DB, one task left in 'running' with a claim but no run row.
     # Simulates a pre-runs-era DB.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -130,7 +130,8 @@ def test_spawn_failure_auto_blocks_after_limit(kanban_home, all_assignees_spawna
 def test_gridlux_dispatch_pauses_non_emergency_workers_under_disk_pressure(
     kanban_home, monkeypatch, all_assignees_spawnable
 ):
-    """Gridlux ready tasks stay unclaimed below the 10 GiB data-volume floor."""
+    """Gridlux ready tasks stay unclaimed below the 3 GiB data-volume floor."""
+    assert kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB == 3 * 1024 * 1024
     kb.create_board("gridlux")
     monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)
     monkeypatch.setattr(
@@ -162,7 +163,9 @@ def test_gridlux_dispatch_pauses_non_emergency_workers_under_disk_pressure(
 def test_gridlux_dispatch_resumes_only_after_recovery_threshold(
     kanban_home, monkeypatch, all_assignees_spawnable
 ):
-    """The Gridlux disk hold has hysteresis: hold at 12 GiB, resume at 15 GiB."""
+    """The Gridlux disk hold has hysteresis: hold below 3 GiB, resume at 6 GiB."""
+    assert kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB == 3 * 1024 * 1024
+    assert kb.GRIDLUX_DISK_PRESSURE_RECOVERY_KIB == 6 * 1024 * 1024
     kb.create_board("gridlux")
     free = {"kib": kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB - 1}
     monkeypatch.setattr(kb, "_gridlux_disk_pressure_hold_active", False)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -152,6 +152,8 @@ def test_gridlux_dispatch_pauses_non_emergency_workers_under_disk_pressure(
 
         assert spawned == []
         assert res.disk_pressure_hold is not None
+        assert "below 3 GiB critical threshold" in res.disk_pressure_hold.message()
+        assert "Worker starts resume automatically at >=6 GiB" in res.disk_pressure_hold.message()
         assert tid in res.skipped_disk_pressure
         task = kb.get_task(conn, tid)
         assert task.status == "ready"
@@ -181,6 +183,8 @@ def test_gridlux_dispatch_resumes_only_after_recovery_threshold(
         free["kib"] = kb.GRIDLUX_DISK_PRESSURE_CRITICAL_KIB + (2 * 1024 * 1024)
         mid = kb.dispatch_once(conn, spawn_fn=lambda *_: 222, board="gridlux", max_spawn=1)
         assert mid.disk_pressure_hold is not None
+        assert "below 6 GiB recovery threshold" in mid.disk_pressure_hold.message()
+        assert "Worker starts resume automatically at >=6 GiB" in mid.disk_pressure_hold.message()
         assert kb.get_task(conn, tid).status == "ready"
 
         spawned = []


### PR DESCRIPTION
## Summary
- lowers Gridlux Kanban disk-pressure pause/recovery thresholds to 3/6 GiB
- keeps the existing hysteresis path unchanged and scoped to the gridlux board
- documents alignment with the janitor/watchdog 8 GiB trigger and 4 GiB alert so Bedřich sees fewer pauses while still keeping a last-resort reserve before macOS/VM instability
- pins disk-pressure tests to the new constants while preserving isolated Kanban test home setup

## Test Plan
- .venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k 'gridlux_disk_pressure or gridlux_dispatch'
- .venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py

Task: t_d449bb45