### PR TITLE
fix(gateway): make WhatsApp npm install timeout configurable

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -494,12 +494,15 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 # plain executable path.
                 _npm_bin = shutil.which("npm") or "npm"
                 try:
+                    # Read timeout from environment variable, default to 300 seconds (5 minutes)
+                    # to accommodate slower systems like Unraid NAS
+                    npm_install_timeout = int(os.environ.get("WHATSAPP_NPM_INSTALL_TIMEOUT", "300"))
                     install_result = subprocess.run(
                         [_npm_bin, "install", "--silent"],
                         cwd=str(bridge_dir),
                         capture_output=True,
                         text=True,
-                        timeout=60,
+                        timeout=npm_install_timeout,
                     )
                     if install_result.returncode != 0:
                         print(f"[{self.name}] npm install failed: {install_result.stderr}")


### PR DESCRIPTION
## Summary

Raise the WhatsApp bridge `npm install` timeout from 60s to a configurable value (default 300s) via the `WHATSAPP_NPM_INSTALL_TIMEOUT` environment variable.

## Root Cause

The hardcoded 60-second timeout for `npm install` in the WhatsApp bridge adapter is too short for slower systems (e.g., Unraid NAS, ARM devices, or constrained CI environments). The install silently fails with a timeout exception, leaving the bridge in a broken state.

## Fix

- Default timeout raised from 60s → 300s (5 minutes)
- Configurable via `WHATSAPP_NPM_INSTALL_TIMEOUT` environment variable
- Backward compatible: existing setups that are fast enough are unaffected

## Testing

Change is isolated to a single `subprocess.run` call. No existing tests cover the WhatsApp bridge `connect()` method (platform adapter). Verified the env var parsing logic is correct.

## Scope

Single file, single parameter change. No unrelated changes.