### PR TITLE
fix(tui): submit exact slash commands on Enter

### DIFF
--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { completionSubmitReplacement } from '../app/useSubmission.js'
+
+describe('completionSubmitReplacement', () => {
+  it('does not apply slash completion when the only difference is trailing whitespace', () => {
+    expect(
+      completionSubmitReplacement('/reset', { display: '/reset', text: 'reset ' }, 1)
+    ).toBeNull()
+
+    expect(
+      completionSubmitReplacement('/new', { display: '/new', text: 'new ' }, 1)
+    ).toBeNull()
+  })
+
+  it('still applies slash completion for partial command input', () => {
+    expect(
+      completionSubmitReplacement('/re', { display: '/reset', text: 'reset' }, 1)
+    ).toBe('/reset')
+  })
+
+  it('still applies @-style completion on Enter', () => {
+    expect(
+      completionSubmitReplacement('@rea', { display: '@README.md', text: '@README.md' }, 0)
+    ).toBe('@README.md')
+  })
+
+  it('still applies path completion on Enter', () => {
+    expect(
+      completionSubmitReplacement('./sr', { display: './src/', text: './src/' }, 0)
+    ).toBe('./src/')
+  })
+})

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -15,7 +15,7 @@ import { hasInterpolation, INTERPOLATION_RE } from '../protocol/interpolation.js
 import { PASTE_SNIPPET_RE } from '../protocol/paste.js'
 import type { Msg } from '../types.js'
 
-import type { ComposerActions, ComposerRefs, ComposerState, PasteSnippet } from './interfaces.js'
+import type { CompletionItem, ComposerActions, ComposerRefs, ComposerState, PasteSnippet } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
@@ -37,6 +37,27 @@ const expandSnips = (snips: PasteSnippet[]) => {
 
 const spliceMatches = (text: string, matches: RegExpMatchArray[], results: string[]) =>
   matches.reduceRight((acc, m, i) => acc.slice(0, m.index!) + results[i] + acc.slice(m.index! + m[0].length), text)
+
+export function completionSubmitReplacement(
+  value: string,
+  row: CompletionItem | null | undefined,
+  replaceFrom: number
+): null | string {
+  if (!row?.text) {
+    return null
+  }
+
+  const candidate = value.startsWith('/') && row.text.startsWith('/') ? row.text.slice(1) : row.text
+  const next = value.slice(0, replaceFrom) + candidate
+
+  // Exact slash commands keep a completion row open by appending a trailing
+  // space. Treat that as already-complete input so Enter can submit.
+  if (next.trimEnd() === value.trimEnd()) {
+    return null
+  }
+
+  return next !== value ? next : null
+}
 
 export function useSubmission(opts: UseSubmissionOptions) {
   const {
@@ -361,15 +382,14 @@ export function useSubmission(opts: UseSubmissionOptions) {
   const submit = useCallback(
     (value: string) => {
       if (composerState.completions.length) {
-        const row = composerState.completions[composerState.compIdx]
+        const next = completionSubmitReplacement(
+          value,
+          composerState.completions[composerState.compIdx],
+          composerState.compReplace
+        )
 
-        if (row?.text) {
-          const text = value.startsWith('/') && row.text.startsWith('/') ? row.text.slice(1) : row.text
-          const next = value.slice(0, composerState.compReplace) + text
-
-          if (next !== value) {
-            return composerActions.setInput(next)
-          }
+        if (next !== null) {
+          return composerActions.setInput(next)
         }
       }
 


### PR DESCRIPTION
 ## Summary

  This fixes a TUI regression where exact slash commands like `/reset` and `/new` were swallowed by Enter-driven autocomplete instead of executing.

 After the Enter-to-apply completion change in 4b0686f63d1 (fix(tui): apply path/@ completion on Enter), pressing Enter started applying any active completion before dispatch. That behavior was correct for @file and path completion, but it broke exact slash commands because the slash completer intentionally keeps those rows alive by appending trailing whitespace.

  As a result, `/reset` became `/reset ` on Enter and never reached the slash command handler.

  ## What changed

  - treat exact slash-command completions that differ only by trailing whitespace as already complete
  - let Enter fall through to normal slash-command submission in that case
  - keep Enter-to-apply behavior for partial slash commands
  - keep Enter-to-apply behavior for `@file`, `./path`, `~/path`, and other non-slash completions unchanged

  ## Why

  The slash completer intentionally appends trailing spaces for exact command matches so completion menus stay useful. The fix should therefore live in TUI submit behavior, not by changing completer output.

  ## Testing

  - `npm test -- --run src/__tests__/useSubmission.test.ts src/__tests__/useCompletion.test.ts`

  ## Related issue

  - Fixes #23919

  ## Related work

  - Regressing commit: `4b0686f63d1d50b1b603af05235f0c21be63ad77`

