### PR TITLE
fix(tui): don't consume Enter for slash autocomplete — let /new and /reset execute (#23919)

### DIFF
--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -360,7 +360,10 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const submit = useCallback(
     (value: string) => {
-      if (composerState.completions.length) {
+      // Enter submits a slash command; Tab applies the completion.
+      // Don't consume Enter when the input is a slash command — /reset
+      // and /new should execute, not select autocomplete text. (#23919)
+      if (composerState.completions.length && !looksLikeSlashCommand(value)) {
         const row = composerState.completions[composerState.compIdx]
 
         if (row?.text) {


### PR DESCRIPTION
## Summary

When a slash completion dropdown is visible (e.g. after typing /reset or /new), pressing Enter was selecting the highlighted completion text instead of executing the command. The completion handler ran before the command dispatch, so the command was never sent.

## Root cause

In `useSubmission.ts`, the `submit` callback checked `composerState.completions.length` first. If completions were present, it applied the completion text via `composerActions.setInput()` and returned early — the slash command never reached `dispatchSubmission()`.

At the time Enter was pressed, the backend had already resolved the alias (/reset → /new) and appended a trailing space to the completion, so the completion text differed from the typed input. This caused the `if (next !== value)` check on line 370 to be true, consuming the Enter key for autocomplete.

## Fix

Added `&& !looksLikeSlashCommand(value)` to the completion guard, so that:
- **Slash commands** (/reset, /new, /help, etc.): Enter executes the command, Tab applies the completion
- **Partial slash input** (/n, /h): Enter no longer completes (Tab still works)
- **File paths** (/etc/passwd, ./src/file.ts): unaffected — `looksLikeSlashCommand` returns false
- **Ordinary text**: completely unaffected

This matches the web TUI behavior where the SlashPopover component explicitly documents Tab-to-apply, Enter-to-submit.

Fixes #23919