### PR TITLE
fix(kanban): preserve notifier_profile for dashboard home subscriptions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4387,6 +4387,18 @@ def add_notify_sub(
             """,
             (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
         )
+        if notifier_profile:
+            # Self-heal legacy rows that predate notifier ownership by
+            # backfilling only when the existing value is unset.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET notifier_profile = ?
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                   AND (notifier_profile IS NULL OR notifier_profile = '')
+                """,
+                (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+            )
 
 
 def list_notify_subs(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1203,6 +1203,15 @@ def _configured_home_channels() -> list[dict]:
     return result
 
 
+def _active_profile_name() -> str:
+    """Return the current Hermes profile name for notify-sub ownership."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
 def _home_sub_matches(sub: dict, home: dict) -> bool:
     """True if a notify_subs row corresponds to the given home channel."""
     return (
@@ -1274,6 +1283,7 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
             platform=platform,
             chat_id=home["chat_id"],
             thread_id=home["thread_id"] or None,
+            notifier_profile=_active_profile_name(),
         )
         return {"ok": True, "task_id": task_id, "home_channel": home}
     finally:

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1184,6 +1184,7 @@ def test_home_subscribe_creates_notify_sub_row(client, with_home_channels):
     assert subs[0]["platform"] == "telegram"
     assert subs[0]["chat_id"] == "1234567"
     assert subs[0]["thread_id"] == "42"
+    assert subs[0]["notifier_profile"] == "default"
 
 
 def test_home_subscribe_flips_subscribed_flag_in_subsequent_get(client, with_home_channels):
@@ -1209,6 +1210,36 @@ def test_home_subscribe_is_idempotent(client, with_home_channels):
         assert len(kb.list_notify_subs(conn, t["id"])) == 1
     finally:
         conn.close()
+
+
+def test_home_subscribe_backfills_owner_on_legacy_row(client, with_home_channels):
+    """Re-subscribing should backfill notifier ownership on ownerless rows."""
+    from hermes_cli import kanban_db as kb
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+
+    conn = kb.connect()
+    try:
+        kb.add_notify_sub(
+            conn,
+            task_id=t["id"],
+            platform="telegram",
+            chat_id="1234567",
+            thread_id="42",
+        )
+    finally:
+        conn.close()
+
+    r = client.post(f"/api/plugins/kanban/tasks/{t['id']}/home-subscribe/telegram")
+    assert r.status_code == 200
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, t["id"])
+    finally:
+        conn.close()
+
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "default"
 
 
 def test_home_subscribe_unknown_platform_returns_404(client, with_home_channels):


### PR DESCRIPTION
## Summary

Dashboard `home-subscribe` flows were creating Kanban notification subscriptions without a `notifier_profile`, which broke parity with the CLI and gateway `/kanban create` auto-subscribe path.

This patch makes dashboard-created subscriptions preserve notifier ownership and backfills legacy ownerless rows when the same home subscription is re-applied.

## Problem

The gateway notifier watcher uses `kanban_notify_subs.notifier_profile` to decide which profile-owned gateway instance should claim and deliver a subscription.

Two paths already populated that field correctly:

- `hermes kanban notify-subscribe`
- gateway `/kanban create` auto-subscribe

But the dashboard `POST /api/plugins/kanban/tasks/{task_id}/home-subscribe/{platform}` path inserted rows without `notifier_profile`.

That left dashboard-created subscriptions effectively ownerless, so profile-scoped notifier isolation could be bypassed on shared Kanban boards.

## Fix

- Resolve the active Hermes profile name inside the dashboard plugin and pass it into `add_notify_sub(...)` during `home-subscribe`.
- Teach `add_notify_sub(...)` to backfill `notifier_profile` only when an existing matching subscription row is ownerless (`NULL`/empty), preserving idempotency while self-healing legacy rows.

## Why this is safe

- No schema change.
- No behavior change for existing rows that already have an owner.
- Backfill is scoped to the exact `(task_id, platform, chat_id, thread_id)` subscription key.
- Existing CLI and gateway ownership semantics remain unchanged; this only restores parity for dashboard-created subscriptions.

## Tests

Passed:

- `pytest tests/plugins/test_kanban_dashboard_plugin.py -k "home_subscribe"`
- `pytest tests/hermes_cli/test_kanban_notify.py -k "owned_by_other_profile or owned_by_current_profile"`

Added coverage for:

- dashboard `home-subscribe` writes `notifier_profile`
- re-subscribing a legacy ownerless row backfills ownership without duplicating the row
