### PR TITLE
refactor: extract item validators from _preflight_codex_input_items

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -269,129 +269,9 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                 content_text = str(content) if content is not None else ""
 
             if role == "assistant":
-                # Replay encrypted reasoning items from previous turns
-                # so the API can maintain coherent reasoning chains.
-                codex_reasoning = msg.get("codex_reasoning_items")
-                has_codex_reasoning = False
-                if isinstance(codex_reasoning, list):
-                    for ri in codex_reasoning:
-                        if isinstance(ri, dict) and ri.get("encrypted_content"):
-                            item_id = ri.get("id")
-                            if item_id and item_id in seen_item_ids:
-                                continue
-                            # Strip the "id" field — with store=False the
-                            # Responses API cannot look up items by ID and
-                            # returns 404.  The encrypted_content blob is
-                            # self-contained for reasoning chain continuity.
-                            replay_item = {k: v for k, v in ri.items() if k != "id"}
-                            items.append(replay_item)
-                            if item_id:
-                                seen_item_ids.add(item_id)
-                            has_codex_reasoning = True
-
-                # Replay exact assistant message items (with id/phase) from
-                # previous turns so the API can maintain prefix-cache hits.
-                # OpenAI docs: "preserve and resend phase on all assistant
-                # messages — dropping it can degrade performance."
-                codex_message_items = msg.get("codex_message_items")
-                replayed_message_items = 0
-                if isinstance(codex_message_items, list):
-                    for raw_item in codex_message_items:
-                        if not isinstance(raw_item, dict):
-                            continue
-                        if raw_item.get("type") != "message" or raw_item.get("role") != "assistant":
-                            continue
-                        raw_content_parts = raw_item.get("content")
-                        if not isinstance(raw_content_parts, list):
-                            continue
-
-                        normalized_content_parts = []
-                        for part in raw_content_parts:
-                            if not isinstance(part, dict):
-                                continue
-                            part_type = str(part.get("type") or "").strip()
-                            if part_type not in {"output_text", "text"}:
-                                continue
-                            text = part.get("text", "")
-                            if text is None:
-                                text = ""
-                            if not isinstance(text, str):
-                                text = str(text)
-                            normalized_content_parts.append({"type": "output_text", "text": text})
-
-                        if not normalized_content_parts:
-                            continue
-
-                        replay_item = {
-                            "type": "message",
-                            "role": "assistant",
-                            "status": _normalize_responses_message_status(raw_item.get("status")),
-                            "content": normalized_content_parts,
-                        }
-                        item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
-                        phase = raw_item.get("phase")
-                        if isinstance(phase, str) and phase.strip():
-                            replay_item["phase"] = phase.strip()
-                        items.append(replay_item)
-                        replayed_message_items += 1
-
-                if replayed_message_items > 0:
-                    pass
-                elif content_parts:
-                    items.append({"role": "assistant", "content": content_parts})
-                elif content_text.strip():
-                    items.append({"role": "assistant", "content": content_text})
-                elif has_codex_reasoning:
-                    # The Responses API requires a following item after each
-                    # reasoning item (otherwise: missing_following_item error).
-                    # When the assistant produced only reasoning with no visible
-                    # content, emit an empty assistant message as the required
-                    # following item.
-                    items.append({"role": "assistant", "content": ""})
-
-                tool_calls = msg.get("tool_calls")
-                if isinstance(tool_calls, list):
-                    for tc in tool_calls:
-                        if not isinstance(tc, dict):
-                            continue
-                        fn = tc.get("function", {})
-                        fn_name = fn.get("name")
-                        if not isinstance(fn_name, str) or not fn_name.strip():
-                            continue
-
-                        embedded_call_id, embedded_response_item_id = _split_responses_tool_id(
-                            tc.get("id")
-                        )
-                        call_id = tc.get("call_id")
-                        if not isinstance(call_id, str) or not call_id.strip():
-                            call_id = embedded_call_id
-                        if not isinstance(call_id, str) or not call_id.strip():
-                            if (
-                                isinstance(embedded_response_item_id, str)
-                                and embedded_response_item_id.startswith("fc_")
-                                and len(embedded_response_item_id) > len("fc_")
-                            ):
-                                call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
-                            else:
-                                _raw_args = str(fn.get("arguments", "{}"))
-                                call_id = _deterministic_call_id(fn_name, _raw_args, len(items))
-                        call_id = call_id.strip()
-
-                        arguments = fn.get("arguments", "{}")
-                        if isinstance(arguments, dict):
-                            arguments = json.dumps(arguments, ensure_ascii=False)
-                        elif not isinstance(arguments, str):
-                            arguments = str(arguments)
-                        arguments = arguments.strip() or "{}"
-
-                        items.append({
-                            "type": "function_call",
-                            "call_id": call_id,
-                            "name": fn_name,
-                            "arguments": arguments,
-                        })
+                _convert_assistant_msg_to_responses_items(
+                    msg, items, seen_item_ids, content_parts, content_text,
+                )
                 continue
 
             # Non-assistant (user) role: emit multimodal parts when present,
@@ -403,39 +283,185 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
             continue
 
         if role == "tool":
-            raw_tool_call_id = msg.get("tool_call_id")
-            call_id, _ = _split_responses_tool_id(raw_tool_call_id)
-            if not isinstance(call_id, str) or not call_id.strip():
-                if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
-                    call_id = raw_tool_call_id.strip()
-            if not isinstance(call_id, str) or not call_id.strip():
-                continue
-
-            # Multimodal tool result: convert OpenAI-style content list into
-            # Responses ``function_call_output.output`` array. The Responses
-            # API accepts ``output`` as either a string or an array of
-            # ``input_text``/``input_image`` items. See
-            # https://developers.openai.com/api/reference/python/resources/responses/.
-            tool_content = msg.get("content")
-            output_value: Any
-            if isinstance(tool_content, list):
-                converted = _chat_content_to_responses_parts(
-                    tool_content, role="user",
-                )
-                if converted:
-                    output_value = converted
-                else:
-                    output_value = ""
-            else:
-                output_value = str(tool_content or "")
-
-            items.append({
-                "type": "function_call_output",
-                "call_id": call_id,
-                "output": output_value,
-            })
+            tool_item = _convert_tool_msg_to_responses_item(msg)
+            if tool_item is not None:
+                items.append(tool_item)
 
     return items
+
+
+def _convert_assistant_msg_to_responses_items(
+    msg: Dict[str, Any],
+    items: List[Dict[str, Any]],
+    seen_item_ids: set,
+    content_parts: List[Dict[str, Any]],
+    content_text: str,
+) -> None:
+    """Convert an assistant message to one or more Responses input items.
+
+    Handles reasoning item replay, message item replay, content emission,
+    and tool call conversion.  Appends directly to *items*.
+    """
+    # Replay encrypted reasoning items from previous turns
+    # so the API can maintain coherent reasoning chains.
+    codex_reasoning = msg.get("codex_reasoning_items")
+    has_codex_reasoning = False
+    if isinstance(codex_reasoning, list):
+        for ri in codex_reasoning:
+            if isinstance(ri, dict) and ri.get("encrypted_content"):
+                item_id = ri.get("id")
+                if item_id and item_id in seen_item_ids:
+                    continue
+                # Strip the "id" field — with store=False the
+                # Responses API cannot look up items by ID and
+                # returns 404.  The encrypted_content blob is
+                # self-contained for reasoning chain continuity.
+                replay_item = {k: v for k, v in ri.items() if k != "id"}
+                items.append(replay_item)
+                if item_id:
+                    seen_item_ids.add(item_id)
+                has_codex_reasoning = True
+
+    # Replay exact assistant message items (with id/phase) from
+    # previous turns so the API can maintain prefix-cache hits.
+    # OpenAI docs: "preserve and resend phase on all assistant
+    # messages — dropping it can degrade performance."
+    codex_message_items = msg.get("codex_message_items")
+    replayed_message_items = 0
+    if isinstance(codex_message_items, list):
+        for raw_item in codex_message_items:
+            if not isinstance(raw_item, dict):
+                continue
+            if raw_item.get("type") != "message" or raw_item.get("role") != "assistant":
+                continue
+            raw_content_parts = raw_item.get("content")
+            if not isinstance(raw_content_parts, list):
+                continue
+
+            normalized_content_parts = []
+            for part in raw_content_parts:
+                if not isinstance(part, dict):
+                    continue
+                part_type = str(part.get("type") or "").strip()
+                if part_type not in {"output_text", "text"}:
+                    continue
+                text = part.get("text", "")
+                if text is None:
+                    text = ""
+                if not isinstance(text, str):
+                    text = str(text)
+                normalized_content_parts.append({"type": "output_text", "text": text})
+
+            if not normalized_content_parts:
+                continue
+
+            replay_item = {
+                "type": "message",
+                "role": "assistant",
+                "status": _normalize_responses_message_status(raw_item.get("status")),
+                "content": normalized_content_parts,
+            }
+            item_id = raw_item.get("id")
+            if isinstance(item_id, str) and item_id.strip():
+                replay_item["id"] = item_id.strip()
+            phase = raw_item.get("phase")
+            if isinstance(phase, str) and phase.strip():
+                replay_item["phase"] = phase.strip()
+            items.append(replay_item)
+            replayed_message_items += 1
+
+    if replayed_message_items > 0:
+        pass
+    elif content_parts:
+        items.append({"role": "assistant", "content": content_parts})
+    elif content_text.strip():
+        items.append({"role": "assistant", "content": content_text})
+    elif has_codex_reasoning:
+        # The Responses API requires a following item after each
+        # reasoning item (otherwise: missing_following_item error).
+        # When the assistant produced only reasoning with no visible
+        # content, emit an empty assistant message as the required
+        # following item.
+        items.append({"role": "assistant", "content": ""})
+
+    tool_calls = msg.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function", {})
+            fn_name = fn.get("name")
+            if not isinstance(fn_name, str) or not fn_name.strip():
+                continue
+
+            embedded_call_id, embedded_response_item_id = _split_responses_tool_id(
+                tc.get("id")
+            )
+            call_id = tc.get("call_id")
+            if not isinstance(call_id, str) or not call_id.strip():
+                call_id = embedded_call_id
+            if not isinstance(call_id, str) or not call_id.strip():
+                if (
+                    isinstance(embedded_response_item_id, str)
+                    and embedded_response_item_id.startswith("fc_")
+                    and len(embedded_response_item_id) > len("fc_")
+                ):
+                    call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
+                else:
+                    _raw_args = str(fn.get("arguments", "{}"))
+                    call_id = _deterministic_call_id(fn_name, _raw_args, len(items))
+            call_id = call_id.strip()
+
+            arguments = fn.get("arguments", "{}")
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            elif not isinstance(arguments, str):
+                arguments = str(arguments)
+            arguments = arguments.strip() or "{}"
+
+            items.append({
+                "type": "function_call",
+                "call_id": call_id,
+                "name": fn_name,
+                "arguments": arguments,
+            })
+
+
+def _convert_tool_msg_to_responses_item(
+    msg: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Convert a tool message to a ``function_call_output`` input item.
+
+    Returns *None* when the tool_call_id is missing or invalid.
+    """
+    raw_tool_call_id = msg.get("tool_call_id")
+    call_id, _ = _split_responses_tool_id(raw_tool_call_id)
+    if not isinstance(call_id, str) or not call_id.strip():
+        if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
+            call_id = raw_tool_call_id.strip()
+    if not isinstance(call_id, str) or not call_id.strip():
+        return None
+
+    # Multimodal tool result: convert OpenAI-style content list into
+    # Responses ``function_call_output.output`` array. The Responses
+    # API accepts ``output`` as either a string or an array of
+    # ``input_text``/``input_image`` items. See
+    # https://developers.openai.com/api/reference/python/resources/responses/.
+    tool_content = msg.get("content")
+    output_value: Any
+    if isinstance(tool_content, list):
+        converted = _chat_content_to_responses_parts(
+            tool_content, role="user",
+        )
+        output_value = converted if converted else ""
+    else:
+        output_value = str(tool_content or "")
+
+    return {
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": output_value,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -468,6 +468,217 @@ def _convert_tool_msg_to_responses_item(
 # Input preflight / validation
 # ---------------------------------------------------------------------------
 
+def _validate_function_call_item(
+    item: Dict[str, Any], idx: int, normalized: List[Dict[str, Any]],
+) -> None:
+    """Validate and append a ``function_call`` input item."""
+    call_id = item.get("call_id")
+    name = item.get("name")
+    if not isinstance(call_id, str) or not call_id.strip():
+        raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
+
+    arguments = item.get("arguments", "{}")
+    if isinstance(arguments, dict):
+        arguments = json.dumps(arguments, ensure_ascii=False)
+    elif not isinstance(arguments, str):
+        arguments = str(arguments)
+    arguments = arguments.strip() or "{}"
+
+    normalized.append(
+        {
+            "type": "function_call",
+            "call_id": call_id.strip(),
+            "name": name.strip(),
+            "arguments": arguments,
+        }
+    )
+
+
+def _validate_function_call_output_item(
+    item: Dict[str, Any], idx: int, normalized: List[Dict[str, Any]],
+) -> None:
+    """Validate and append a ``function_call_output`` input item."""
+    call_id = item.get("call_id")
+    if not isinstance(call_id, str) or not call_id.strip():
+        raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
+    output = item.get("output", "")
+    if output is None:
+        output = ""
+    # Output may be a string OR an array of structured content
+    # items (input_text / input_image) for multimodal tool results.
+    # Both shapes are accepted by the Responses API. We preserve
+    # the array form when present.
+    if isinstance(output, list):
+        # Validate each item is a recognised content shape; drop
+        # anything else to avoid 4xx from the API.
+        cleaned: List[Dict[str, Any]] = []
+        for part in output:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "input_text":
+                text = part.get("text")
+                if isinstance(text, str) and text:
+                    cleaned.append({"type": "input_text", "text": text})
+            elif ptype == "input_image":
+                url = part.get("image_url")
+                if isinstance(url, str) and url:
+                    entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                    detail = part.get("detail")
+                    if isinstance(detail, str) and detail.strip():
+                        entry["detail"] = detail.strip()
+                    cleaned.append(entry)
+        normalized.append(
+            {
+                "type": "function_call_output",
+                "call_id": call_id.strip(),
+                "output": cleaned if cleaned else "",
+            }
+        )
+        return
+    if not isinstance(output, str):
+        output = str(output)
+
+    normalized.append(
+        {
+            "type": "function_call_output",
+            "call_id": call_id.strip(),
+            "output": output,
+        }
+    )
+
+
+def _validate_reasoning_item(
+    item: Dict[str, Any],
+    idx: int,
+    normalized: List[Dict[str, Any]],
+    seen_ids: set,
+) -> None:
+    """Validate and append a ``reasoning`` input item (with dedup)."""
+    encrypted = item.get("encrypted_content")
+    if not (isinstance(encrypted, str) and encrypted):
+        return
+    item_id = item.get("id")
+    if isinstance(item_id, str) and item_id:
+        if item_id in seen_ids:
+            return
+        seen_ids.add(item_id)
+    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+    # Do NOT include the "id" in the outgoing item — with
+    # store=False (our default) the API tries to resolve the
+    # id server-side and returns 404.  The id is still used
+    # above for local deduplication via seen_ids.
+    summary = item.get("summary")
+    if isinstance(summary, list):
+        reasoning_item["summary"] = summary
+    else:
+        reasoning_item["summary"] = []
+    normalized.append(reasoning_item)
+
+
+def _validate_message_item(
+    item: Dict[str, Any], idx: int, normalized: List[Dict[str, Any]],
+) -> None:
+    """Validate and append a ``message`` input item."""
+    role = item.get("role")
+    if role != "assistant":
+        raise ValueError(f"Codex Responses input[{idx}] message items must have role='assistant'.")
+    content = item.get("content")
+    if not isinstance(content, list):
+        raise ValueError(f"Codex Responses input[{idx}] message item must have content list.")
+    normalized_content = []
+    for part_idx, part in enumerate(content):
+        if not isinstance(part, dict):
+            raise ValueError(
+                f"Codex Responses input[{idx}] message content[{part_idx}] must be an object."
+            )
+        part_type = part.get("type")
+        if part_type not in {"output_text", "text"}:
+            raise ValueError(
+                f"Codex Responses input[{idx}] message content[{part_idx}] has unsupported type {part_type!r}."
+            )
+        text = part.get("text", "")
+        if text is None:
+            text = ""
+        if not isinstance(text, str):
+            text = str(text)
+        normalized_content.append({"type": "output_text", "text": text})
+    if not normalized_content:
+        raise ValueError(f"Codex Responses input[{idx}] message item must contain at least one text part.")
+    normalized_item: Dict[str, Any] = {
+        "type": "message",
+        "role": "assistant",
+        "status": _normalize_responses_message_status(item.get("status")),
+        "content": normalized_content,
+    }
+    item_id = item.get("id")
+    if isinstance(item_id, str) and item_id.strip():
+        normalized_item["id"] = item_id.strip()
+    phase = item.get("phase")
+    if isinstance(phase, str) and phase.strip():
+        normalized_item["phase"] = phase.strip()
+    normalized.append(normalized_item)
+
+
+def _validate_role_content_item(
+    item: Dict[str, Any], idx: int, normalized: List[Dict[str, Any]],
+) -> None:
+    """Validate and append a bare ``role``+``content`` input item."""
+    role = item.get("role")
+    content = item.get("content", "")
+    if content is None:
+        content = ""
+    if isinstance(content, list):
+        # Multimodal content from ``_chat_messages_to_responses_input``
+        # is already in Responses format (``input_text`` / ``output_text``
+        # / ``input_image``).  Validate each part and pass through.
+        # Use the correct text type for the role — ``output_text`` for
+        # assistant messages, ``input_text`` for user messages.
+        text_type = "output_text" if role == "assistant" else "input_text"
+        validated: List[Dict[str, Any]] = []
+        for part_idx, part in enumerate(content):
+            if isinstance(part, str):
+                if part:
+                    validated.append({"type": text_type, "text": part})
+                continue
+            if not isinstance(part, dict):
+                raise ValueError(
+                    f"Codex Responses input[{idx}].content[{part_idx}] must be an object or string."
+                )
+            ptype = str(part.get("type") or "").strip().lower()
+            if ptype in {"input_text", "text", "output_text"}:
+                text = part.get("text", "")
+                if not isinstance(text, str):
+                    text = str(text or "")
+                validated.append({"type": text_type, "text": text})
+            elif ptype in {"input_image", "image_url"}:
+                image_ref = part.get("image_url", "")
+                detail = part.get("detail")
+                if isinstance(image_ref, dict):
+                    url = image_ref.get("url", "")
+                    detail = image_ref.get("detail", detail)
+                else:
+                    url = image_ref
+                if not isinstance(url, str):
+                    url = str(url or "")
+                image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                if isinstance(detail, str) and detail.strip():
+                    image_part["detail"] = detail.strip()
+                validated.append(image_part)
+            else:
+                raise ValueError(
+                    f"Codex Responses input[{idx}].content[{part_idx}] has unsupported type {part.get('type')!r}."
+                )
+        normalized.append({"role": role, "content": validated})
+        return
+    if not isinstance(content, str):
+        content = str(content)
+
+    normalized.append({"role": role, "content": content})
+
+
 def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
@@ -480,195 +691,24 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
 
         item_type = item.get("type")
         if item_type == "function_call":
-            call_id = item.get("call_id")
-            name = item.get("name")
-            if not isinstance(call_id, str) or not call_id.strip():
-                raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
-            if not isinstance(name, str) or not name.strip():
-                raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
-
-            arguments = item.get("arguments", "{}")
-            if isinstance(arguments, dict):
-                arguments = json.dumps(arguments, ensure_ascii=False)
-            elif not isinstance(arguments, str):
-                arguments = str(arguments)
-            arguments = arguments.strip() or "{}"
-
-            normalized.append(
-                {
-                    "type": "function_call",
-                    "call_id": call_id.strip(),
-                    "name": name.strip(),
-                    "arguments": arguments,
-                }
-            )
+            _validate_function_call_item(item, idx, normalized)
             continue
 
         if item_type == "function_call_output":
-            call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not call_id.strip():
-                raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
-            output = item.get("output", "")
-            if output is None:
-                output = ""
-            # Output may be a string OR an array of structured content
-            # items (input_text / input_image) for multimodal tool results.
-            # Both shapes are accepted by the Responses API. We preserve
-            # the array form when present.
-            if isinstance(output, list):
-                # Validate each item is a recognised content shape; drop
-                # anything else to avoid 4xx from the API.
-                cleaned: List[Dict[str, Any]] = []
-                for part in output:
-                    if not isinstance(part, dict):
-                        continue
-                    ptype = part.get("type")
-                    if ptype == "input_text":
-                        text = part.get("text")
-                        if isinstance(text, str) and text:
-                            cleaned.append({"type": "input_text", "text": text})
-                    elif ptype == "input_image":
-                        url = part.get("image_url")
-                        if isinstance(url, str) and url:
-                            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
-                            detail = part.get("detail")
-                            if isinstance(detail, str) and detail.strip():
-                                entry["detail"] = detail.strip()
-                            cleaned.append(entry)
-                normalized.append(
-                    {
-                        "type": "function_call_output",
-                        "call_id": call_id.strip(),
-                        "output": cleaned if cleaned else "",
-                    }
-                )
-                continue
-            if not isinstance(output, str):
-                output = str(output)
-
-            normalized.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": call_id.strip(),
-                    "output": output,
-                }
-            )
+            _validate_function_call_output_item(item, idx, normalized)
             continue
 
         if item_type == "reasoning":
-            encrypted = item.get("encrypted_content")
-            if isinstance(encrypted, str) and encrypted:
-                item_id = item.get("id")
-                if isinstance(item_id, str) and item_id:
-                    if item_id in seen_ids:
-                        continue
-                    seen_ids.add(item_id)
-                reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
-                # Do NOT include the "id" in the outgoing item — with
-                # store=False (our default) the API tries to resolve the
-                # id server-side and returns 404.  The id is still used
-                # above for local deduplication via seen_ids.
-                summary = item.get("summary")
-                if isinstance(summary, list):
-                    reasoning_item["summary"] = summary
-                else:
-                    reasoning_item["summary"] = []
-                normalized.append(reasoning_item)
+            _validate_reasoning_item(item, idx, normalized, seen_ids)
             continue
 
         if item_type == "message":
-            role = item.get("role")
-            if role != "assistant":
-                raise ValueError(f"Codex Responses input[{idx}] message items must have role='assistant'.")
-            content = item.get("content")
-            if not isinstance(content, list):
-                raise ValueError(f"Codex Responses input[{idx}] message item must have content list.")
-            normalized_content = []
-            for part_idx, part in enumerate(content):
-                if not isinstance(part, dict):
-                    raise ValueError(
-                        f"Codex Responses input[{idx}] message content[{part_idx}] must be an object."
-                    )
-                part_type = part.get("type")
-                if part_type not in {"output_text", "text"}:
-                    raise ValueError(
-                        f"Codex Responses input[{idx}] message content[{part_idx}] has unsupported type {part_type!r}."
-                    )
-                text = part.get("text", "")
-                if text is None:
-                    text = ""
-                if not isinstance(text, str):
-                    text = str(text)
-                normalized_content.append({"type": "output_text", "text": text})
-            if not normalized_content:
-                raise ValueError(f"Codex Responses input[{idx}] message item must contain at least one text part.")
-            normalized_item: Dict[str, Any] = {
-                "type": "message",
-                "role": "assistant",
-                "status": _normalize_responses_message_status(item.get("status")),
-                "content": normalized_content,
-            }
-            item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
-            phase = item.get("phase")
-            if isinstance(phase, str) and phase.strip():
-                normalized_item["phase"] = phase.strip()
-            normalized.append(normalized_item)
+            _validate_message_item(item, idx, normalized)
             continue
 
         role = item.get("role")
         if role in {"user", "assistant"}:
-            content = item.get("content", "")
-            if content is None:
-                content = ""
-            if isinstance(content, list):
-                # Multimodal content from ``_chat_messages_to_responses_input``
-                # is already in Responses format (``input_text`` / ``output_text``
-                # / ``input_image``).  Validate each part and pass through.
-                # Use the correct text type for the role — ``output_text`` for
-                # assistant messages, ``input_text`` for user messages.
-                text_type = "output_text" if role == "assistant" else "input_text"
-                validated: List[Dict[str, Any]] = []
-                for part_idx, part in enumerate(content):
-                    if isinstance(part, str):
-                        if part:
-                            validated.append({"type": text_type, "text": part})
-                        continue
-                    if not isinstance(part, dict):
-                        raise ValueError(
-                            f"Codex Responses input[{idx}].content[{part_idx}] must be an object or string."
-                        )
-                    ptype = str(part.get("type") or "").strip().lower()
-                    if ptype in {"input_text", "text", "output_text"}:
-                        text = part.get("text", "")
-                        if not isinstance(text, str):
-                            text = str(text or "")
-                        validated.append({"type": text_type, "text": text})
-                    elif ptype in {"input_image", "image_url"}:
-                        image_ref = part.get("image_url", "")
-                        detail = part.get("detail")
-                        if isinstance(image_ref, dict):
-                            url = image_ref.get("url", "")
-                            detail = image_ref.get("detail", detail)
-                        else:
-                            url = image_ref
-                        if not isinstance(url, str):
-                            url = str(url or "")
-                        image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
-                        if isinstance(detail, str) and detail.strip():
-                            image_part["detail"] = detail.strip()
-                        validated.append(image_part)
-                    else:
-                        raise ValueError(
-                            f"Codex Responses input[{idx}].content[{part_idx}] has unsupported type {part.get('type')!r}."
-                        )
-                normalized.append({"role": role, "content": validated})
-                continue
-            if not isinstance(content, str):
-                content = str(content)
-
-            normalized.append({"role": role, "content": content})
+            _validate_role_content_item(item, idx, normalized)
             continue
 
         raise ValueError(


### PR DESCRIPTION
## Summary

Split the 210-line `_preflight_codex_input_items` (C901 complexity 51) into five focused validators:

| Function | Item type | Complexity |
|---|---|---|
| `_preflight_codex_input_items` | Type dispatcher | **51 → <10** ✅ |
| `_validate_function_call_item` | function_call | <10 |
| `_validate_function_call_output_item` | function_call_output | 12 |
| `_validate_reasoning_item` | reasoning | <10 |
| `_validate_message_item` | message | 11 |
| `_validate_role_content_item` | user/assistant content | 14 |

Zero logic changes — pure extraction. Each validator handles one item type's validation + normalization + append.

Part 2 of 4 for `codex_responses_adapter.py`.

**Depends on: #23951** (refactor/codex-chat-to-responses) — same file.