### PR TITLE
feat(auth): add allow_all_users config key to bypass allowlist checks

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -458,6 +458,11 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Global allow-all override (mirrors GATEWAY_ALLOW_ALL_USERS env var but
+    # settable from config.yaml).  When True, every authenticated message is
+    # accepted regardless of per-user allowlists.
+    allow_all_users: bool = False
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -614,6 +619,8 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        allow_all_users = _coerce_bool(data.get("allow_all_users"), False)
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -629,6 +636,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            allow_all_users=allow_all_users,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -731,6 +739,9 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            if "allow_all_users" in yaml_cfg:
+                gw_data["allow_all_users"] = yaml_cfg["allow_all_users"]
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -670,6 +670,22 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Socket Mode connected (%d workspace(s))",
                 len(self._team_clients),
             )
+            # Warn operators that open-channel auth is active so the risk is visible in logs.
+            _allow_on_ch = self._slack_allow_all_users_on_channel()
+            if _allow_on_ch:
+                if "*" in _allow_on_ch:
+                    logger.warning(
+                        "[Slack] SECURITY: allow_all_users_on_channel is set to ALL channels. "
+                        "Any workspace member in any channel where the bot is present can send commands. "
+                        "Restrict this to specific channel IDs unless you intend open access."
+                    )
+                else:
+                    logger.warning(
+                        "[Slack] SECURITY: allow_all_users_on_channel is active for %d channel(s): %s. "
+                        "Any workspace member in these channels can send commands without being in SLACK_ALLOWED_USERS.",
+                        len(_allow_on_ch),
+                        ", ".join(sorted(_allow_on_ch)),
+                    )
             return True
 
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2981,3 +2997,30 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _slack_allow_all_users_on_channel(self) -> set:
+        """Return channel IDs where any workspace member may interact.
+
+        When a message arrives from a channel in this set the per-user
+        SLACK_ALLOWED_USERS / GATEWAY_ALLOWED_USERS check is bypassed.
+
+        Config key  : platforms.slack.allow_all_users_on_channel
+        Env var     : SLACK_ALLOW_ALL_USERS_ON_CHANNEL
+
+        Accepts a comma-separated list of Slack channel IDs *or* the
+        string ``"true"`` / ``"1"`` / ``"yes"`` to match every channel
+        (equivalent to SLACK_ALLOW_ALL_USERS but scoped to channels only).
+
+        Empty / unset → feature disabled (default, safe).
+        """
+        raw = self.config.extra.get("allow_all_users_on_channel")
+        if raw is None:
+            raw = os.getenv("SLACK_ALLOW_ALL_USERS_ON_CHANNEL", "")
+        if isinstance(raw, bool):
+            return {"*"} if raw else set()
+        s = str(raw).strip()
+        if not s:
+            return set()
+        if s.lower() in ("true", "1", "yes"):
+            return {"*"}
+        return {part.strip() for part in s.split(",") if part.strip()}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5327,10 +5327,10 @@ class GatewayRunner:
         Check if a user is authorized to use the bot.
         
         Checks in order:
-        1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
-        3. DM pairing approved list
-        4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
+        1. Config-level allow_all_users (config.yaml) or GATEWAY_ALLOW_ALL_USERS env var
+        2. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
+        3. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
+        4. DM pairing approved list
         5. Default: deny
         """
         # Home Assistant events are system-generated (state changes), not
@@ -5344,6 +5344,17 @@ class GatewayRunner:
         user_id = source.user_id
         if not user_id:
             return False
+
+        # Config-level allow-all: config.yaml allow_all_users: true (or
+        # GATEWAY_ALLOW_ALL_USERS env var) — skip all allowlist checks.
+        try:
+            _gw_cfg = self.config
+            if getattr(_gw_cfg, "allow_all_users", False):
+                return True
+        except Exception:
+            pass
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes"):
+            return True
 
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
@@ -5413,6 +5424,20 @@ class GatewayRunner:
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
             return True
+
+        # Slack channel-level allow-all: if SLACK_ALLOW_ALL_USERS_ON_CHANNEL lists
+        # the channel (or is set to "*"), bypass per-user checks for this message.
+        # Guard: only applies when the bot is in a proper channel (chat_id starts
+        # with "C") — DMs (chat_id starts with "D") are never affected.
+        if source.platform == Platform.SLACK and source.chat_id and source.chat_id.startswith("C"):
+            try:
+                slack_adapter = self.adapters.get(Platform.SLACK)
+                if slack_adapter is not None:
+                    allow_on_channel = slack_adapter._slack_allow_all_users_on_channel()
+                    if allow_on_channel and ("*" in allow_on_channel or source.chat_id in allow_on_channel):
+                        return True
+            except Exception:
+                pass  # defensive — fall through to normal allowlist check
 
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1202,12 +1202,28 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Allow all users to interact with the bot (true/false).
+    # When true, the per-user GATEWAY_ALLOWED_USERS / SLACK_ALLOWED_USERS
+    # allowlist checks are bypassed and every message is accepted.
+    # When false (default), the standard allowlist logic applies.
+    # WARNING: setting this to true on a publicly visible channel grants
+    # unrestricted access to anyone who can reach the bot.
+    "allow_all_users": False,
+
     # Slack platform settings (gateway mode)
     "slack": {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        # Comma-separated Slack channel IDs (or "true" for all channels).
+        # When a message arrives from a listed channel, the per-user
+        # SLACK_ALLOWED_USERS check is bypassed — any workspace member
+        # already in that channel can interact with the bot.
+        # WARNING: enabling this on large public channels grants broad access;
+        # use with care if Hermes can execute sensitive operations.
+        # Env-var equivalent: SLACK_ALLOW_ALL_USERS_ON_CHANNEL
+        "allow_all_users_on_channel": "",
     },
 
     # Discord platform settings (gateway mode)


### PR DESCRIPTION
## Summary

Adds a top-level `allow_all_users` boolean to `~/.hermes/config.yaml` (default: `false`) that grants open access to all users regardless of per-platform allowlists. Also adds `slack.allow_all_users_on_channel` for a channel-scoped Slack bypass.

## Changes

### `hermes_cli/config.py`
- Added `allow_all_users: false` top-level key to `DEFAULT_CONFIG` with warning comment

### `gateway/config.py`
- Added `allow_all_users: bool = False` field to `GatewayConfig`
- Parsed in `from_dict()` via `_coerce_bool` (accepts `true/false/1/0/yes/no`)
- Mapped from `config.yaml` in `load_gateway_config()`

### `gateway/run.py`
- `_is_user_authorized()` checks `config.allow_all_users` as first real auth step, before all allowlist logic
- `GATEWAY_ALLOW_ALL_USERS` env var consolidated at the same point (backwards compat preserved)
- Updated docstring to reflect new check order

### `gateway/platforms/slack.py`
- Added `_slack_allow_all_users_on_channel()` helper — parses comma-separated channel IDs, `"true"` (all channels), or `bool`
- Startup warning log when the feature is enabled
- Channel-level bypass guards with `chat_id.startswith("C")` — DMs (`D`-prefix) are never affected

## Usage

```yaml
# ~/.hermes/config.yaml

# Global: bypass all per-user allowlists on every platform
allow_all_users: false   # set to true to enable

# Slack-only: bypass per-user check for specific channels only
slack:
  allow_all_users_on_channel: "C0ATFHY907L,C0B0GV4FKK7"  # or "true" for all channels
```

## Safety

- Default `false` — zero behavior change for existing deployments
- Warning log at gateway startup when `allow_all_users_on_channel` is active
- DMs are unconditionally protected for the channel-scoped flag (Slack channel IDs start with `C`, DMs start with `D`)

## Tests

1555 passed; 1 pre-existing failure in `TestStreamingConfig` — fails on base branch too, unrelated to this change.
