### PR TITLE
fix(media): prevent MEDIA: regex from matching non-path text

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2064,7 +2064,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+[^\s:]+)*\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[`"',;:)\]\}]|$)|(?:~/|/)\S+(?:[^\S\n]+[^\s:]+)*)(?=\s|$)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Problem

The `extract_media()` regex in `gateway/platforms/base.py` had `|\S+` as a catch-all fallback that matched **any** non-whitespace after `MEDIA:`. This caused false positives from:

- Example paths in tool descriptions (`<screenshot_path>`, `/path`, `/tmp/hermes/cache/img_xxx.jpg`)
- Error messages containing paths
- The regex pattern itself from source code comments
- Multiple `MEDIA:` tags being merged into one match

When the agent's response contained `MEDIA:/real/image.png`, the regex would also match all these fake paths, try to send them as files, fail with "file not found", and the real image would get lost.

## Fix

Changed the fallback from `|\S+` to `|(?:~/|/)\S+(?:[^\S\n]+[^\s:]+)*` which:

- Only matches paths starting with `/` or `~`
- Uses `[^\s:]+` instead of `\S+` to prevent matching across `MEDIA:` (contains colon)
- Still supports paths with spaces like `/tmp/Jane Doe/file.flac`
- Properly handles multiple `MEDIA:` tags in the same message

## Testing

- All 14 existing `TestExtractMedia` tests pass
- Manual testing confirmed:
  - `MEDIA:/a.png MEDIA:/b.png` → correctly matches both separately
  - `MEDIA:/tmp/Jane Doe/speech.flac` → correctly matches path with spaces
  - `error: <screenshot_path>` → no longer falsely matches
  - `File not found: /path` → no longer falsely matches