### PR TITLE
fix(browser): add fullPage support to browser_vision for Camofox

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -491,7 +491,7 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
 
 def camofox_vision(question: str, annotate: bool = False,
-                   task_id: Optional[str] = None) -> str:
+                   task_id: Optional[str] = None, fullPage: bool = False) -> str:
     """Take a screenshot and analyze it with vision AI via Camofox."""
     try:
         session = _get_session(task_id)
@@ -499,9 +499,12 @@ def camofox_vision(question: str, annotate: bool = False,
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
         # Get screenshot as binary PNG
+        params = {"userId": session["user_id"]}
+        if fullPage:
+            params["fullPage"] = "true"
         resp = _get_raw(
             f"/tabs/{session['tab_id']}/screenshot",
-            params={"userId": session["user_id"]},
+            params=params,
         )
 
         # Save screenshot to cache

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1473,6 +1473,11 @@ BROWSER_TOOL_SCHEMAS = [
                     "type": "boolean",
                     "default": False,
                     "description": "If true, overlay numbered [N] labels on interactive elements. Each [N] maps to ref @eN for subsequent browser commands. Useful for QA and spatial reasoning about page layout."
+                },
+                "fullPage": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "If true, capture the full scrollable page instead of just the viewport. Useful for capturing entire pages that require scrolling."
                 }
             },
             "required": ["question"]
@@ -2899,7 +2904,7 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None, fullPage: bool = False) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
 
@@ -2915,13 +2920,14 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
         task_id: Task identifier for session isolation
+        fullPage: If True, capture the full scrollable page instead of just the viewport
 
     Returns:
         JSON string with vision analysis results and screenshot_path
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
-        return camofox_vision(question, annotate, task_id)
+        return camofox_vision(question, annotate, task_id, fullPage=fullPage)
 
     import base64
     import uuid as uuid_mod


### PR DESCRIPTION
## Problem

The `camofox_vision()` function in `tools/browser_camofox.py` never passed the `fullPage` query parameter to the Camofox `/screenshot` endpoint. Even when `fullPage=true` was requested, the server always returned a viewport-only screenshot (1280x720).

The Camofox server already supported `fullPage=true` — the bug was only in the Hermes client code.

## Fix

- Added `fullPage` parameter to `camofox_vision()` in `browser_camofox.py`
- Added `fullPage` parameter to `browser_vision()` in `browser_tool.py`
- Added `fullPage` to the `browser_vision` tool schema so LLMs can use it
- When `fullPage=True`, passes `fullPage=true` to the Camofox API

## Testing

- Verified fullPage screenshots now produce 1265x1179 vs 1280x720 viewport
- Tested with Hacker News page — full page captured successfully