### PR TITLE
fix(teams): make TEAMS_TENANT_ID optional for multi-tenant bots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -467,7 +467,12 @@ IMAGE_TOOLS_DEBUG=false
 #
 # TEAMS_CLIENT_ID=                     # Azure AD App (client) ID
 # TEAMS_CLIENT_SECRET=                 # Azure AD client secret value
-# TEAMS_TENANT_ID=                     # Azure AD tenant ID (or "common" for multi-tenant)
+# TEAMS_TENANT_ID=                     # OPTIONAL. Azure AD tenant ID for single-tenant
+#                                      # bots (signInAudience=AzureADMyOrg). LEAVE EMPTY
+#                                      # for multi-tenant bots — the SDK treats any
+#                                      # non-empty value (including "common") as a
+#                                      # single-tenant constraint and 401s cross-tenant
+#                                      # tokens.
 # TEAMS_ALLOWED_USERS=                 # Comma-separated AAD object IDs or UPNs
 # TEAMS_ALLOW_ALL_USERS=false          # Set true to skip the allowlist
 # TEAMS_HOME_CHANNEL=                  # Default channel/chat ID for cron delivery

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,6 +82,7 @@ body:
         - Discord
         - Slack
         - WhatsApp
+        - Microsoft Teams
 
   - type: textarea
     id: debug-report

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -7,7 +7,8 @@ Proactive messaging (send, typing) uses the SDK's App.send() method.
 
 Requires:
     pip install microsoft-teams-apps aiohttp
-    TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID env vars
+    TEAMS_CLIENT_ID and TEAMS_CLIENT_SECRET env vars
+    TEAMS_TENANT_ID env var (optional — leave unset for multi-tenant bots)
 
 Configuration in config.yaml:
     platforms:
@@ -16,7 +17,12 @@ Configuration in config.yaml:
         extra:
           client_id: "your-client-id"      # or TEAMS_CLIENT_ID env var
           client_secret: "your-secret"      # or TEAMS_CLIENT_SECRET env var
-          tenant_id: "your-tenant-id"       # or TEAMS_TENANT_ID env var
+          tenant_id: "your-tenant-id"       # or TEAMS_TENANT_ID env var.
+                                            # Leave unset/blank for multi-tenant bots
+                                            # (signInAudience=AzureADMultipleOrgs).
+                                            # The SDK treats any non-empty value
+                                            # (including "common") as a single-tenant
+                                            # constraint and will 401 cross-tenant tokens.
           port: 3978                        # or TEAMS_PORT env var
 """
 
@@ -406,12 +412,17 @@ def check_requirements() -> bool:
 
 
 def validate_config(config) -> bool:
-    """Return True when the config has the minimum required credentials."""
+    """Return True when the config has the minimum required credentials.
+
+    ``TEAMS_TENANT_ID`` is intentionally optional: an unset/blank value is the
+    correct shape for multi-tenant bots (the SDK falls back to multi-tenant JWT
+    validation when ``tenant_id`` is falsy). Only ``TEAMS_CLIENT_ID`` and
+    ``TEAMS_CLIENT_SECRET`` are strictly required.
+    """
     extra = getattr(config, "extra", {}) or {}
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
     client_secret = os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
-    tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
-    return bool(client_id and client_secret and tenant_id)
+    return bool(client_id and client_secret)
 
 
 def is_connected(config) -> bool:
@@ -433,13 +444,16 @@ def _env_enablement() -> dict | None:
     client_id = os.getenv("TEAMS_CLIENT_ID", "").strip()
     client_secret = os.getenv("TEAMS_CLIENT_SECRET", "").strip()
     tenant_id = os.getenv("TEAMS_TENANT_ID", "").strip()
-    if not (client_id and client_secret and tenant_id):
+    # Mirror validate_config(): tenant_id is optional, so an env-only
+    # multi-tenant bot must still seed extra or it never shows as configured.
+    if not (client_id and client_secret):
         return None
     seed: dict = {
         "client_id": client_id,
         "client_secret": client_secret,
-        "tenant_id": tenant_id,
     }
+    if tenant_id:
+        seed["tenant_id"] = tenant_id
     port = os.getenv("TEAMS_PORT", "").strip()
     if port:
         try:
@@ -463,6 +477,12 @@ def _env_enablement() -> dict | None:
 # ``https://smba.infra.gov.teams.microsoft.us/``) which can be supplied via
 # ``TEAMS_SERVICE_URL`` or ``extra['service_url']``.
 _DEFAULT_TEAMS_SERVICE_URL = "https://smba.trafficmanager.net/teams/"
+
+# Shared token authority for multi-tenant bots. ``botframework.com`` is a fixed
+# literal here, not a tenant id — it is never interpolated from configuration.
+_MULTI_TENANT_TOKEN_URL = (
+    "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
+)
 
 # Allowlist of Bot Framework service hosts that may receive a freshly
 # minted bearer token.  Operator-supplied URLs are matched against this
@@ -503,6 +523,29 @@ def _validate_teams_service_url(raw: str) -> Optional[str]:
     return normalized
 
 
+def _bot_framework_token_url(tenant_id: str) -> str:
+    """Return the client-credentials token endpoint for this bot's app type.
+
+    Bot Framework documents two authorities for the same
+    ``https://api.botframework.com/.default`` scope:
+
+    * single-tenant — ``login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token``
+    * multi-tenant  — ``login.microsoftonline.com/botframework.com/oauth2/v2.0/token``
+
+    A multi-tenant bot has no home tenant to authenticate against, so the
+    tenant-scoped URL cannot be built for it at all. Callers therefore treat a
+    blank tenant id as "multi-tenant" rather than as missing configuration.
+
+    See "Authenticate requests with the Bot Connector API", Step 1 (the
+    Multi-tenant / Single-tenant tabs) and the "Security protocol changes"
+    table:
+    https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication
+    """
+    if tenant_id:
+        return f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    return _MULTI_TENANT_TOKEN_URL
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -519,10 +562,15 @@ async def _standalone_send(
     separate process from ``hermes gateway``).  Without this hook,
     ``deliver=teams`` cron jobs fail with ``No live adapter for platform``.
 
-    Configuration: requires ``TEAMS_CLIENT_ID``, ``TEAMS_CLIENT_SECRET``,
-    ``TEAMS_TENANT_ID``, ``TEAMS_HOME_CHANNEL`` (the conversation ID), and
-    optionally ``TEAMS_SERVICE_URL`` (Bot Framework service host; must be
-    a known Bot Framework endpoint, see ``_ALLOWED_TEAMS_SERVICE_HOSTS``).
+    Configuration: requires ``TEAMS_CLIENT_ID``, ``TEAMS_CLIENT_SECRET`` and
+    ``TEAMS_HOME_CHANNEL`` (the conversation ID), and optionally
+    ``TEAMS_SERVICE_URL`` (Bot Framework service host; must be a known Bot
+    Framework endpoint, see ``_ALLOWED_TEAMS_SERVICE_HOSTS``).
+
+    ``TEAMS_TENANT_ID`` selects the token authority rather than being required:
+    a single-tenant bot authenticates against its own tenant, a multi-tenant
+    bot against the shared ``botframework.com`` authority. See
+    :func:`_bot_framework_token_url`.
 
     Security: ``service_url`` is validated against an allowlist of known
     Bot Framework hosts to block SSRF / token-exfiltration via a tampered
@@ -538,8 +586,8 @@ async def _standalone_send(
     client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
     client_secret = os.getenv("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
     tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
-    if not (client_id and client_secret and tenant_id):
-        return {"error": "Teams standalone send: TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID are all required"}
+    if not (client_id and client_secret):
+        return {"error": "Teams standalone send: TEAMS_CLIENT_ID and TEAMS_CLIENT_SECRET are required"}
 
     raw_service_url = (
         os.getenv("TEAMS_SERVICE_URL")
@@ -561,10 +609,12 @@ async def _standalone_send(
         return {"error": "Teams standalone send: chat_id (conversation ID) is required"}
     if not _TEAMS_CONV_ID_RE.match(chat_id):
         return {"error": "Teams standalone send: chat_id contains characters outside the Bot Framework conversation ID set"}
-    if not _TEAMS_CONV_ID_RE.match(tenant_id):
+    # Only meaningful when a tenant id is supplied; a blank one selects the
+    # fixed multi-tenant authority and is never interpolated into a URL.
+    if tenant_id and not _TEAMS_CONV_ID_RE.match(tenant_id):
         return {"error": "Teams standalone send: TEAMS_TENANT_ID contains characters outside the expected set"}
 
-    token_url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    token_url = _bot_framework_token_url(tenant_id)
     activities_url = f"{service_url}v3/conversations/{chat_id}/activities"
 
     if not AIOHTTP_AVAILABLE:
@@ -741,10 +791,10 @@ class TeamsAdapter(BasePlatformAdapter):
             )
             return False
 
-        if not self._client_id or not self._client_secret or not self._tenant_id:
+        if not self._client_id or not self._client_secret:
             self._set_fatal_error(
                 "MISSING_CREDENTIALS",
-                "TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID are all required",
+                "TEAMS_CLIENT_ID and TEAMS_CLIENT_SECRET are required",
                 retryable=False,
             )
             return False
@@ -758,13 +808,30 @@ class TeamsAdapter(BasePlatformAdapter):
             aiohttp_app = web.Application(client_max_size=_MAX_BODY_BYTES)
             aiohttp_app.router.add_get("/health", lambda _: web.Response(text="ok"))
 
-            self._app = App(
-                client_id=self._client_id,
-                client_secret=self._client_secret,
-                tenant_id=self._tenant_id,
-                http_server_adapter=_AiohttpBridgeAdapter(aiohttp_app),
-                client=ClientOptions(headers={"User-Agent": "Hermes"}),
-            )
+            # Pass tenant_id to the SDK only when it's set. A non-empty value
+            # (including the literal string "common") forces single-tenant JWT
+            # validation in microsoft-teams-apps via TokenValidator.for_entra(tenant_id);
+            # an absent kwarg lets the SDK build a multi-tenant validator.
+            app_kwargs: Dict[str, Any] = {
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+                "http_server_adapter": _AiohttpBridgeAdapter(aiohttp_app),
+                "client": ClientOptions(headers={"User-Agent": "Hermes"}),
+            }
+            if self._tenant_id:
+                app_kwargs["tenant_id"] = self._tenant_id
+                logger.info(
+                    "Teams adapter starting in single-tenant mode "
+                    "(tenant_id=%s)",
+                    self._tenant_id,
+                )
+            else:
+                logger.info(
+                    "Teams adapter starting in multi-tenant mode "
+                    "(TEAMS_TENANT_ID unset; SDK will accept tokens from any tenant)"
+                )
+
+            self._app = App(**app_kwargs)
 
             # Register message handler before initialize()
             @self._app.on_message
@@ -1385,10 +1452,13 @@ def interactive_setup() -> None:
         return
     save_env_value("TEAMS_CLIENT_SECRET", client_secret.strip())
 
-    tenant_id = prompt("Tenant ID", default=get_env_value("TEAMS_TENANT_ID") or "")
-    if not tenant_id:
-        print_warning("Tenant ID is required — skipping Teams setup")
-        return
+    print()
+    print_info("Tenant ID is OPTIONAL.")
+    print_info("  • Single-tenant bot (signInAudience=AzureADMyOrg): enter your tenant GUID.")
+    print_info("  • Multi-tenant bot (signInAudience=AzureADMultipleOrgs): leave blank.")
+    print_info("Do NOT enter \"common\" — the SDK treats it as a single-tenant constraint")
+    print_info("and will 401 every cross-tenant token.")
+    tenant_id = prompt("Tenant ID (leave blank for multi-tenant)", default=get_env_value("TEAMS_TENANT_ID") or "")
     save_env_value("TEAMS_TENANT_ID", tenant_id.strip())
 
     print()
@@ -1424,7 +1494,7 @@ def register(ctx) -> None:
         check_fn=check_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
-        required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
+        required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET"],
         install_hint="pip install microsoft-teams-apps aiohttp",
         setup_fn=interactive_setup,
         # Env-driven auto-configuration — seeds PlatformConfig.extra with

--- a/plugins/platforms/teams/plugin.yaml
+++ b/plugins/platforms/teams/plugin.yaml
@@ -21,11 +21,17 @@ requires_env:
     prompt: "Teams / Azure AD client secret"
     url: "https://portal.azure.com/"
     password: true
-  - name: TEAMS_TENANT_ID
-    description: "Azure AD tenant ID hosting the bot application"
-    prompt: "Teams / Azure AD tenant ID"
-    password: false
 optional_env:
+  - name: TEAMS_TENANT_ID
+    description: >
+      Azure AD tenant ID for single-tenant bots
+      (signInAudience=AzureADMyOrg). Leave unset/blank for multi-tenant bots
+      (signInAudience=AzureADMultipleOrgs); the SDK builds a multi-tenant JWT
+      validator when no tenant ID is supplied. Do not set to "common" — the SDK
+      treats any non-empty value as a single-tenant constraint and will 401
+      cross-tenant tokens.
+    prompt: "Teams / Azure AD tenant ID (blank for multi-tenant)"
+    password: false
   - name: TEAMS_PORT
     description: "Webhook listen port (Bot Framework default: 3978)"
     prompt: "Webhook port"

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -4,7 +4,7 @@ import json
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -231,6 +231,71 @@ class TestTeamsRequirements:
         cfg = _make_config(client_id="id", client_secret="secret", tenant_id="tenant")
         assert validate_config(cfg) is True
 
+    def test_validate_config_missing_tenant_is_valid_for_multi_tenant(self, monkeypatch):
+        # Empty TEAMS_TENANT_ID is the correct shape for multi-tenant bots — the SDK
+        # builds a multi-tenant JWT validator when tenant_id is falsy.
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "test-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "test-secret")
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+        assert validate_config(_make_config()) is True
+
+    def test_validate_config_missing_client_id_is_invalid(self, monkeypatch):
+        monkeypatch.delenv("TEAMS_CLIENT_ID", raising=False)
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "test-secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "test-tenant")
+        assert validate_config(_make_config()) is False
+
+    def test_validate_config_missing_client_secret_is_invalid(self, monkeypatch):
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "test-id")
+        monkeypatch.delenv("TEAMS_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("TEAMS_TENANT_ID", "test-tenant")
+        assert validate_config(_make_config()) is False
+
+class TestTeamsEnvEnablement:
+    """``_env_enablement`` gates env-only bootstrap; it must match validate_config.
+
+    If it demanded a tenant id while validate_config did not, an env-only
+    multi-tenant bot would validate but never seed PlatformConfig.extra, so it
+    would never show up as configured or connected.
+    """
+
+    def _clear(self, monkeypatch):
+        for var in (
+            "TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID",
+            "TEAMS_PORT", "TEAMS_SERVICE_URL", "TEAMS_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_multi_tenant_env_seeds_without_tenant_id(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "bot-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "bot-secret")
+
+        seed = _teams_mod._env_enablement()
+
+        assert seed is not None, (
+            "an env-only multi-tenant bot must still seed PlatformConfig.extra"
+        )
+        assert seed["client_id"] == "bot-id"
+        assert "tenant_id" not in seed
+
+    def test_single_tenant_env_seeds_tenant_id(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "bot-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "bot-secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "my-tenant-guid")
+
+        seed = _teams_mod._env_enablement()
+
+        assert seed is not None
+        assert seed["tenant_id"] == "my-tenant-guid"
+
+    def test_missing_client_secret_returns_none(self, monkeypatch):
+        self._clear(monkeypatch)
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "bot-id")
+
+        assert _teams_mod._env_enablement() is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: Adapter Init
@@ -310,6 +375,20 @@ class TestTeamsInteractiveSetup:
         assert "TEAMS_CLIENT_ID=client-id" in env_text
         assert "TEAMS_TENANT_ID=tenant-id" in env_text
 
+def _stub_aiohttp_web():
+    """Stand in for ``aiohttp.web`` so connect() runs without aiohttp installed.
+
+    The adapter imports ``web`` lazily and leaves it ``None`` when aiohttp is
+    absent, which is the norm in this suite (the Teams SDK is mocked for the
+    same reason). Only the four symbols connect() touches need to behave.
+    """
+    web = MagicMock()
+    web.AppRunner.return_value.setup = AsyncMock()
+    web.AppRunner.return_value.cleanup = AsyncMock()
+    web.TCPSite.return_value.start = AsyncMock()
+    return web
+
+
 class TestTeamsConnect:
     @pytest.mark.anyio
     async def test_connect_fails_without_sdk(self, monkeypatch):
@@ -327,6 +406,127 @@ class TestTeamsConnect:
         result = await adapter.connect()
         assert result is False
 
+    @pytest.mark.anyio
+    async def test_connect_succeeds_without_tenant_id_for_multi_tenant(self, monkeypatch):
+        # Multi-tenant deployments leave TEAMS_TENANT_ID empty; that's the only
+        # input shape the SDK's TokenValidator.for_entra() accepts to issue a
+        # multi-tenant validator. The adapter must NOT fail-fast on empty tenant_id.
+        # TEAMS_TENANT_ID takes precedence over config, so clear it — the
+        # interactive-setup tests seed one earlier in this module.
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret",
+        ))
+        assert adapter._tenant_id == ""
+
+        with patch.object(_teams_mod, "web", _stub_aiohttp_web()):
+            result = await adapter.connect()
+        assert result is True, (
+            "connect() must succeed when tenant_id is empty so the SDK can "
+            "build a multi-tenant JWT validator"
+        )
+
+    @pytest.mark.anyio
+    async def test_connect_omits_tenant_id_kwarg_when_empty(self, monkeypatch, caplog):
+        # The SDK switches between single- and multi-tenant validators based on
+        # the *truthiness* of the tenant_id kwarg passed to App(). The adapter
+        # MUST omit the kwarg entirely (not pass tenant_id="") when running in
+        # multi-tenant mode — otherwise an empty string would still be treated
+        # as a single-tenant constraint.
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+        captured: dict = {}
+
+        class _CapturingApp:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.server = MagicMock()
+                self.server.handle_request = AsyncMock(return_value={"status": 200, "body": None})
+                self.credentials = MagicMock()
+                self.credentials.client_id = kwargs.get("client_id")
+
+            @property
+            def id(self):
+                return captured.get("client_id")
+
+            def on_message(self, fn):
+                return fn
+
+            def on_card_action(self, fn):
+                return fn
+
+            async def initialize(self):
+                pass
+
+            async def start(self, port=3978):
+                pass
+
+            async def stop(self):
+                pass
+
+        monkeypatch.setattr(_teams_mod, "App", _CapturingApp)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="",
+        ))
+        with patch.object(_teams_mod, "web", _stub_aiohttp_web()), \
+                caplog.at_level("INFO", logger=_teams_mod.logger.name):
+            result = await adapter.connect()
+        assert result is True
+        assert "tenant_id" not in captured, (
+            "tenant_id must not be passed to App() when empty; the SDK relies on "
+            "an absent/None tenant_id to build a multi-tenant validator"
+        )
+        assert any("multi-tenant mode" in rec.message for rec in caplog.records), (
+            "expected an INFO log line announcing multi-tenant mode startup"
+        )
+
+    @pytest.mark.anyio
+    async def test_connect_passes_tenant_id_kwarg_when_set(self, monkeypatch, caplog):
+        # Single-tenant deployments must forward the tenant_id to App() so the
+        # SDK builds a single-tenant validator scoped to that tenant.
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+        captured: dict = {}
+
+        class _CapturingApp:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.server = MagicMock()
+                self.server.handle_request = AsyncMock(return_value={"status": 200, "body": None})
+                self.credentials = MagicMock()
+                self.credentials.client_id = kwargs.get("client_id")
+
+            @property
+            def id(self):
+                return captured.get("client_id")
+
+            def on_message(self, fn):
+                return fn
+
+            def on_card_action(self, fn):
+                return fn
+
+            async def initialize(self):
+                pass
+
+            async def start(self, port=3978):
+                pass
+
+            async def stop(self):
+                pass
+
+        monkeypatch.setattr(_teams_mod, "App", _CapturingApp)
+
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="my-tenant-guid",
+        ))
+        with patch.object(_teams_mod, "web", _stub_aiohttp_web()), \
+                caplog.at_level("INFO", logger=_teams_mod.logger.name):
+            result = await adapter.connect()
+        assert result is True
+        assert captured.get("tenant_id") == "my-tenant-guid"
+        assert any("single-tenant mode" in rec.message for rec in caplog.records), (
+            "expected an INFO log line announcing single-tenant mode startup"
+        )
 
 # ---------------------------------------------------------------------------
 # Tests: Send
@@ -653,6 +853,109 @@ class TestTeamsStandaloneSend:
         assert activity_kwargs["json"]["text"] == "hello cron"
         assert activity_kwargs["json"]["type"] == "message"
 
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_multi_tenant_authority_without_tenant_id(
+        self, monkeypatch,
+    ):
+        """A multi-tenant bot has no home tenant; it must use botframework.com.
+
+        Bot Framework documents the shared authority for multi-tenant bots at
+        the same api.botframework.com scope. Building the tenant-scoped URL is
+        impossible without a tenant id, so a blank one selects that authority
+        rather than failing the send.
+        """
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-1"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hello cron",
+        )
+
+        assert result == {"success": True, "message_id": "msg-1"}
+        token_url, token_kwargs = session.calls[0]
+        assert token_url == (
+            "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
+        )
+        # Scope is identical for both app types.
+        assert token_kwargs["data"]["scope"] == "https://api.botframework.com/.default"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_still_uses_tenant_authority_when_set(
+        self, monkeypatch,
+    ):
+        """Single-tenant bots must keep authenticating against their own tenant."""
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "my-tenant-guid")
+        monkeypatch.delenv("TEAMS_SERVICE_URL", raising=False)
+
+        token_resp = _FakeAiohttpResponse(200, {"access_token": "the-token"})
+        activity_resp = _FakeAiohttpResponse(200, {"id": "msg-2"})
+        session = _FakeAiohttpSession([token_resp, activity_resp])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hello cron",
+        )
+
+        assert result == {"success": True, "message_id": "msg-2"}
+        token_url, _ = session.calls[0]
+        assert token_url == (
+            "https://login.microsoftonline.com/my-tenant-guid/oauth2/v2.0/token"
+        )
+        assert "botframework.com/oauth2" not in token_url
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_still_requires_client_credentials(self, monkeypatch):
+        """Relaxing the tenant gate must not relax the credential gate."""
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.delenv("TEAMS_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "TEAMS_CLIENT_SECRET" in result["error"]
+        assert len(session.calls) == 0, "must not reach the token endpoint"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_malformed_tenant_id(self, monkeypatch):
+        """A supplied tenant id is still validated before it reaches a URL."""
+        monkeypatch.setenv("TEAMS_CLIENT_ID", "client-id")
+        monkeypatch.setenv("TEAMS_CLIENT_SECRET", "secret")
+        monkeypatch.setenv("TEAMS_TENANT_ID", "bad/../tenant?x=y")
+
+        session = _FakeAiohttpSession([])
+        _install_fake_aiohttp(monkeypatch, session)
+
+        result = await _teams_mod._standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            "19:abc@thread.skype",
+            "hi",
+        )
+
+        assert "error" in result
+        assert "TEAMS_TENANT_ID" in result["error"]
+        assert len(session.calls) == 0, "must not reach the token endpoint"
 
     @pytest.mark.asyncio
     async def test_standalone_send_propagates_token_failure(self, monkeypatch):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -715,7 +715,7 @@ The Microsoft Teams platform adapter (Bot Framework / Azure AD), distinct from t
 |----------|-------------|
 | `TEAMS_CLIENT_ID` | Azure AD application (Bot Framework) client ID. |
 | `TEAMS_CLIENT_SECRET` | Azure AD application client secret. |
-| `TEAMS_TENANT_ID` | Azure AD tenant ID hosting the bot application. |
+| `TEAMS_TENANT_ID` | Optional. Azure AD tenant ID hosting the bot application, for single-tenant bots (`signInAudience=AzureADMyOrg`). Leave unset for multi-tenant bots — any non-empty value, including `common`, forces single-tenant token validation. |
 | `TEAMS_HOST` | Webhook bind host (default: unset → dual-stack, all interfaces IPv4+IPv6). |
 | `TEAMS_PORT` | Webhook listen port (Bot Framework default: `3978`). |
 | `TEAMS_ALLOWED_USERS` | Comma-separated Teams user IDs / UPNs allowed to talk to the bot. |

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -93,6 +93,10 @@ Add to `~/.hermes/.env`:
 # Required
 TEAMS_CLIENT_ID=<your-client-id>
 TEAMS_CLIENT_SECRET=<your-client-secret>
+
+# Single-tenant bots only (signInAudience=AzureADMyOrg).
+# Leave this OUT for a multi-tenant bot — any non-empty value (including
+# "common") forces single-tenant token validation and 401s cross-tenant users.
 TEAMS_TENANT_ID=<your-tenant-id>
 
 # Restrict access to specific users (recommended)
@@ -140,7 +144,7 @@ Open the printed link in your browser — it opens directly in the Teams client.
 |----------|-------------|
 | `TEAMS_CLIENT_ID` | Azure AD App (client) ID |
 | `TEAMS_CLIENT_SECRET` | Azure AD client secret |
-| `TEAMS_TENANT_ID` | Azure AD tenant ID |
+| `TEAMS_TENANT_ID` | Azure AD tenant ID — optional; omit for multi-tenant bots |
 | `TEAMS_ALLOWED_USERS` | Comma-separated AAD object IDs allowed to use the bot |
 | `TEAMS_ALLOW_ALL_USERS` | Set `true` to skip the allowlist and allow anyone |
 | `TEAMS_HOME_CHANNEL` | Conversation ID for cron/proactive message delivery |
@@ -236,7 +240,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 |---------|----------|
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
-| Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |
+| Bot responds with auth errors | Verify `TEAMS_CLIENT_ID` and `TEAMS_CLIENT_SECRET` are set correctly. For a multi-tenant bot also confirm `TEAMS_TENANT_ID` is **unset** — a stale value (or `common`) forces single-tenant validation and 401s cross-tenant users |
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |
 | Bot receives messages but ignores them | Your AAD object ID may not be in `TEAMS_ALLOWED_USERS`. Run `teams status --verbose` to find it |
 | Tunnel URL changes on restart | devtunnel URLs are persistent if you use a named tunnel (`devtunnel create hermes-bot`). ngrok and cloudflared generate a new URL each run unless you have a paid plan — update the bot endpoint with `teams app update` when it changes |


### PR DESCRIPTION
Closes #23891.

## What

Make `TEAMS_TENANT_ID` truly optional in the Microsoft Teams platform adapter so the bot can run in true multi-tenant mode.

Concrete code changes:

1. **`plugins/platforms/teams/adapter.py`**
   - `validate_config()` no longer requires `tenant_id` — only `client_id` and `client_secret`. Empty `TEAMS_TENANT_ID` is the correct shape for multi-tenant bots.
   - `connect()` no longer fail-fasts on empty `tenant_id`. Required-credentials check now reads "TEAMS_CLIENT_ID and TEAMS_CLIENT_SECRET are required".
   - `_env_enablement()` no longer requires `tenant_id`, and omits the key from the seed when blank. This is the env-only bootstrap path; see *Review feedback addressed* below.
   - `_standalone_send()` selects its token authority by app type instead of demanding a tenant id — see *Out-of-process delivery* below.
   - `App()` is constructed via `**app_kwargs`; `tenant_id` is included **only when non-empty**. The SDK uses kwarg presence + truthiness to switch between `TokenValidator.for_entra(tenant_id)` (single-tenant) and `TokenValidator.for_entra()` (multi-tenant) — passing an empty string would still build a single-tenant validator.
   - Logs the active mode at startup (`single-tenant mode (tenant_id=...)` or `multi-tenant mode (TEAMS_TENANT_ID unset; SDK will accept tokens from any tenant)`) so operators can confirm which validator the SDK selected.
   - `interactive_setup()` tenant prompt is now optional with explicit guidance about why "common" is **not** a multi-tenant value.
   - `register()` drops `TEAMS_TENANT_ID` from the `required_env` hint surfaced by `hermes setup`.

2. **`plugins/platforms/teams/plugin.yaml`** — moves `TEAMS_TENANT_ID` from `requires_env` to `optional_env` with a description that explains the single-tenant vs multi-tenant choice and warns against `"common"`.

3. **`.env.example`** — rewrites the Teams tenant-ID comment to stop suggesting `"common"` works for multi-tenant. New copy explicitly tells the user to leave it blank for multi-tenant.

4. **Docs** — `website/docs/reference/environment-variables.md` and `website/docs/user-guide/messaging/teams.md` both still described `TEAMS_TENANT_ID` as required (the user guide listed it under a literal `# Required` heading). Both now mark it optional and explain the multi-tenant case, and the auth-errors troubleshooting row now tells multi-tenant operators to check the variable is **unset** — a stale value is the actual failure mode.

5. **`.github/ISSUE_TEMPLATE/bug_report.yml`** — adds **Microsoft Teams** to the Messaging Platform dropdown so future Teams-related bug reports land with the right metadata.

## Why

The pre-fix adapter required `TEAMS_TENANT_ID` to be set before connect would proceed, and forwarded whatever value it found verbatim to `microsoft-teams-apps`'s `App(tenant_id=...)`. The SDK's `App.__init__` builds its `TokenValidator` via:

- `TokenValidator.for_entra(tenant_id)` — single-tenant; constrains JWT issuer/audience to the supplied tenant
- `TokenValidator.for_entra()` (no argument) — multi-tenant; permits any tenant

It uses the **truthiness** of `tenant_id` to decide. The string `"common"` is **not** treated specially — it's used as a tenant identifier. Microsoft's identity platform never issues tokens against `"common"`, so all incoming tokens fail validation and the bot silently 401s.

This had two visible consequences:

1. **`.env.example` was actively misleading.** It said `# TEAMS_TENANT_ID= # Azure AD tenant ID (or "common" for multi-tenant)`, but setting it to `"common"` produced silent 401s, not a working multi-tenant bot.
2. **There was no supported way to run the adapter in true multi-tenant mode.** Even if a deployer left the env var unset, the adapter's pre-flight refused to start.

This blocked any deployment shape where the bot's Entra ID App Registration lives in tenant A (e.g. an integrator or dev tenant) and real users live in tenant B (e.g. a customer or corporate tenant). Microsoft Teams' RSC pre-check (`isUserAuthorizedToGrantResourceSpecificPermissions`) returns `404 Workload Unknown` to anyone trying to install the app in that shape, because Teams cannot enumerate RSC permissions for a cross-tenant app whose Application object isn't resolvable in the consenting tenant. The documented Microsoft fix is to make the App Registration multi-tenant — but doing that and then booting Hermes left it still validating tokens single-tenant.

The reproduction is in the linked issue (#23891).

## Review feedback addressed

Rebased onto current `main`, and a self-review pass caught that the original change was only **half applied**:

`_env_enablement()` — the env-driven bootstrap hook that seeds `PlatformConfig.extra` during gateway config load — still required `tenant_id`. So a `.env`-only multi-tenant bot (exactly the configuration this PR documents as supported) passed `validate_config()` but was never seeded, and would not show up as configured or connected. It had **no test coverage at all**, which is why the gap survived the original submission. Now gated on `client_id`/`client_secret` only, with three tests in `TestTeamsEnvEnablement`; the multi-tenant one fails against the previous revision.

## Out-of-process delivery

This was originally flagged as a known gap and deferred; it is now fixed here, because it is the same bug class rather than a separate one — `TEAMS_TENANT_ID` treated as mandatory, across five sibling call paths.

`_standalone_send()` handles delivery when the gateway runner is in another process (`deliver=teams` cron jobs). It built its token URL by interpolating the tenant id into the tenant-scoped authority and refused to run when that value was blank, so out-of-process delivery was unreachable for multi-tenant bots. A multi-tenant bot has no home tenant to authenticate against, so that URL cannot be built for it at all.

Bot Framework documents two authorities for the same `https://api.botframework.com/.default` scope:

| App type | Token endpoint |
|---|---|
| single-tenant | `login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token` |
| multi-tenant | `login.microsoftonline.com/botframework.com/oauth2/v2.0/token` |

`_bot_framework_token_url()` selects between them on the truthiness of the tenant id, mirroring the SDK's own validator switch. Only the authority segment differs — scope, request body and activity POST are unchanged.

Security notes on this path specifically:

- `botframework.com` is a module-level literal, never interpolated from configuration, so the blank-tenant branch introduces no new input into a URL.
- The tenant-id character validation still runs whenever a tenant id is supplied. It is skipped only when the value is blank, where there is nothing to validate.
- The client id / secret gate is untouched. Relaxing the tenant gate must not relax the credential gate, and there is a test asserting exactly that.

Reference: [Authenticate requests with the Bot Connector API](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0) — Step 1 (Multi-tenant / Single-tenant tabs) and the *Security protocol changes* table.

## How to test

```bash
pytest tests/gateway/test_teams.py -v
ruff check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py
```

The PR adds 13 tests covering the contract:

**`validate_config()`**
- `test_validate_config_missing_tenant_is_valid_for_multi_tenant` — empty `TEAMS_TENANT_ID` + valid id/secret → returns True (was previously False).
- `test_validate_config_missing_client_id_is_invalid` and `test_validate_config_missing_client_secret_is_invalid` — id and secret remain strictly required.

**`connect()`**
- `test_connect_succeeds_without_tenant_id_for_multi_tenant` — no longer fails when `tenant_id` is empty.
- `test_connect_omits_tenant_id_kwarg_when_empty` — asserts `App()` is called **without** the `tenant_id` kwarg when unset (passing `tenant_id=""` would still build a single-tenant validator). Also asserts the multi-tenant startup log line.
- `test_connect_passes_tenant_id_kwarg_when_set` — the single-tenant path still forwards `tenant_id` and emits the matching log line.

**`_env_enablement()`** (new coverage — previously untested)
- `test_multi_tenant_env_seeds_without_tenant_id` — env-only multi-tenant bot still seeds `extra`, with no `tenant_id` key.
- `test_single_tenant_env_seeds_tenant_id` — tenant id is carried through when present.
- `test_missing_client_secret_returns_none` — the remaining hard requirement still gates.

**`_standalone_send()`**
- `test_standalone_send_uses_multi_tenant_authority_without_tenant_id` — blank tenant selects the `botframework.com` authority, and the scope is unchanged. Fails against the previous revision.
- `test_standalone_send_still_uses_tenant_authority_when_set` — single-tenant bots keep authenticating against their own tenant.
- `test_standalone_send_rejects_malformed_tenant_id` — a supplied tenant id is still validated, before any token request is made.
- `test_standalone_send_still_requires_client_credentials` — relaxing the tenant gate did not relax the credential gate.

The last two pass against the pre-change adapter as well; they are deliberate regression guards on the security-relevant behaviour rather than tests of new behaviour.

These are purely additive. The `connect()` tests stub `aiohttp.web` rather than patching attributes on it, so they run in environments where aiohttp isn't installed, and they clear `TEAMS_TENANT_ID` explicitly so they don't inherit a value from earlier tests in the module.

## Platforms tested

- Windows 11 (Python 3.13 venv — full `tests/gateway/test_teams.py` suite green, `ruff check` clean)

The adapter changes are platform-independent (no fs / process / signal handling involved).

## Security note

This change does not weaken any auth boundary. In multi-tenant mode the SDK still requires a valid Microsoft-issued JWT — it just doesn't constrain the issuer to a single tenant claim. Operators who want to run single-tenant should continue to set `TEAMS_TENANT_ID` to their tenant GUID; the only behaviour change there is an INFO log line confirming the mode at startup.

## Open questions for reviewers

1. Should the multi-tenant case emit a `WARNING` rather than `INFO` (i.e. nudge operators toward an explicit tenant binding when one is appropriate)? Defaulted to `INFO` because both modes are legitimate and we don't want to noise-up the gateway log for the deployer who deliberately picked multi-tenant.
2. Happy to split the bug template change or the docs updates out into separate PRs if you prefer this kept tighter. The five adapter gates belong together — they are one bug class and fixing a subset leaves multi-tenant broken by a different path each time — but the template and docs changes are separable.
3. CI has never run on this PR (`check-runs: []`) — a maintainer approving workflow runs would let it validate.
