### PR TITLE
fix(gateway): finalize lifecycle-aware stream fallback paths

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -577,7 +577,12 @@ class GatewayStreamConsumer:
             _best_effort_ok = False
             if self._accumulated and self._message_id:
                 try:
-                    _best_effort_ok = bool(await self._send_or_edit(self._accumulated))
+                    _best_effort_ok = bool(
+                        await self._send_or_edit(
+                            self._accumulated,
+                            finalize=self._adapter_requires_finalize,
+                        )
+                    )
                 except Exception:
                     pass
             # Only confirm final delivery if the best-effort send above
@@ -701,6 +706,18 @@ class GatewayStreamConsumer:
             if final_text.strip() and final_text != self._visible_prefix():
                 continuation = final_text
             else:
+                if self._adapter_requires_finalize:
+                    if self._message_id:
+                        self._final_response_sent = await self._send_or_edit(
+                            final_text,
+                            finalize=True,
+                        )
+                        self._fallback_prefix = ""
+                        return
+                    self._already_sent = False
+                    self._final_response_sent = False
+                    self._fallback_prefix = ""
+                    return
                 # Defence-in-depth for #7183: the last edit may still show the
                 # cursor character because fallback mode was entered after an
                 # edit failure left it stuck.  Try one final edit to strip it

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1113,6 +1113,38 @@ class TestCancelledConsumerSetsFlags:
         assert consumer.final_response_sent is True
 
     @pytest.mark.asyncio
+    async def test_cancelled_requires_finalize_sends_terminal_edit(self):
+        """Cancellation cleanup must close lifecycle-aware streams."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+
+        consumer.on_delta("Hello world")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert adapter.edit_message.call_args.kwargs["finalize"] is True
+        assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
     async def test_cancelled_without_any_sends_does_not_mark_final(self):
         """Cancelling before anything was sent should NOT set final_response_sent."""
         adapter = MagicMock()
@@ -1533,6 +1565,54 @@ class TestCursorStrippingOnFallback:
         # _last_sent_text must NOT be updated when the edit failed
         assert consumer._last_sent_text == "Hello ▉"
 
+    @pytest.mark.asyncio
+    async def test_requires_finalize_sends_terminal_edit_when_continuation_empty(self):
+        """Adapters with explicit stream lifecycle need a final edit here."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg-1")
+        )
+
+        consumer = GatewayStreamConsumer(
+            adapter, "chat-1",
+            config=StreamConsumerConfig(cursor=" ▉"),
+        )
+        consumer._message_id = "msg-1"
+        consumer._last_sent_text = "Hello world"
+        consumer._fallback_final_send = False
+
+        await consumer._send_fallback_final("Hello world")
+
+        adapter.edit_message.assert_called_once()
+        call_args = adapter.edit_message.call_args
+        assert call_args.kwargs["content"] == "Hello world"
+        assert call_args.kwargs["finalize"] is True
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_requires_finalize_without_message_id_allows_normal_final_send(self):
+        """Do not claim final delivery when no terminal edit can be sent."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.edit_message = AsyncMock()
+
+        consumer = GatewayStreamConsumer(
+            adapter, "chat-1",
+            config=StreamConsumerConfig(cursor=" ▉"),
+        )
+        consumer._message_id = None
+        consumer._last_sent_text = "Hello world"
+        consumer._fallback_final_send = False
+
+        await consumer._send_fallback_final("Hello world")
+
+        adapter.edit_message.assert_not_called()
+        assert consumer._already_sent is False
+        assert consumer._final_response_sent is False
+
 
 # ── on_new_message callback (tool-progress linearization) ─────────────
 
@@ -1780,4 +1860,3 @@ class TestUtf16OverflowDetection:
         # auto-attr mock. Verified indirectly by all the other tests in
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
-


### PR DESCRIPTION
## Summary

Fix lifecycle-aware gateway stream adapters so fallback and cancellation paths send an explicit terminal edit before claiming the final response was delivered.

Adapters with `REQUIRES_EDIT_FINALIZE = True` need `edit_message(..., finalize=True)` even when the final visible text is unchanged. Without that terminal edit, the gateway can set `final_response_sent=True`, suppress normal final delivery, and leave the remote stream open.

## Changes Made

  - Updated `gateway/stream_consumer.py` so cancellation cleanup passes `finalize=True` for adapters that require explicit finalization.
  - Updated `_send_fallback_final()` so empty-continuation fallback paths send a terminal edit for lifecycle-aware adapters instead of marking the stream final after a non-final cursor cleanup.
  - Added regression tests in `tests/gateway/test_stream_consumer.py` for cancellation cleanup and empty-continuation fallback behavior.

## How to Test

  1. `scripts/run_tests.sh tests/gateway/test_stream_consumer.py -k "CursorStrippingOnFallback or requires_finalize or cancelled_requires_finalize"`
  2. `scripts/run_tests.sh tests/gateway/test_stream_consumer.py`

## Checklist

### Code

  - [x] I've read the Contributing Guide
  - [x] My commit message follows Conventional Commits
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature
  - [x] I've run targeted stream consumer tests and they pass
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS)
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
