### PR TITLE
feat(agent): trigger-based skill auto-loading from SKILL.md frontmatter

### DIFF
--- a/agent/skill_trigger_loader.py
+++ b/agent/skill_trigger_loader.py
@@ -1,0 +1,184 @@
+"""
+skill_trigger_loader.py — Auto-load skills based on frontmatter trigger patterns.
+
+When `get_triggered_skills(text)` is called at the start of a conversation turn,
+it scans all installed SKILL.md files for a `triggers` frontmatter key, matches
+each regex pattern against the incoming text, and returns the full content of
+every matched skill.
+
+Frontmatter format:
+    triggers:
+      - 'PHP Parse error'
+      - 'syntax error, unexpected'
+      - 'mergeable.*CONFLICTING'
+
+Patterns are matched case-insensitively. If a skill matches, its full SKILL.md
+content is loaded and injected before the agent's reasoning loop begins.
+
+Design decisions:
+- Lazy import: no import-time overhead when the feature is unused.
+- Fail-safe: any exception in this module is caught by the caller — a trigger
+  failure must never crash the agent's main conversation loop.
+- Performance: results are cached for the process lifetime keyed on the skill
+  file's mtime, so repeated turns in the same session don't re-scan disk.
+- Limit: at most MAX_AUTO_LOADED_SKILLS skills are auto-loaded per turn to
+  avoid overwhelming the context with irrelevant content.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+MAX_AUTO_LOADED_SKILLS = 5
+_SKILL_FILENAME = "SKILL.md"
+
+# Module-level cache: skill_path -> (mtime, triggers_list | None, full_content)
+_trigger_cache: dict[str, Tuple[float, Optional[List[str]], Optional[str]]] = {}
+
+
+def _get_skills_home() -> Path:
+    """Return the root skills directory (profile-aware)."""
+    try:
+        from hermes_constants import get_hermes_home
+        return Path(get_hermes_home()) / "skills"
+    except Exception:
+        return Path(os.path.expanduser("~/.hermes/skills"))
+
+
+def _iter_skill_paths(skills_home: Path):
+    """Yield paths to all SKILL.md files under skills_home."""
+    if not skills_home.exists():
+        return
+    for skill_md in skills_home.rglob(_SKILL_FILENAME):
+        # Skip worktrees, hidden dirs, and vendor paths
+        parts = skill_md.parts
+        if any(p.startswith(".") for p in parts):
+            continue
+        yield skill_md
+
+
+def _parse_triggers_and_content(skill_path: Path) -> Tuple[Optional[List[str]], Optional[str]]:
+    """
+    Read a SKILL.md file and return (triggers, full_content).
+    Returns (None, None) if the file has no 'triggers' key or is unreadable.
+    """
+    try:
+        content = skill_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None, None
+
+    # Fast path: skip files without '---' frontmatter delimiter
+    if not content.startswith("---"):
+        return None, None
+
+    # Extract frontmatter block
+    end = content.find("\n---", 3)
+    if end == -1:
+        return None, None
+    frontmatter_text = content[3:end]
+
+    # Only parse YAML if 'triggers' appears in the frontmatter text (cheap check)
+    if "triggers" not in frontmatter_text:
+        return None, None
+
+    try:
+        import yaml
+        fm = yaml.safe_load(frontmatter_text) or {}
+    except Exception:
+        return None, None
+
+    raw_triggers = fm.get("triggers")
+    if not raw_triggers or not isinstance(raw_triggers, list):
+        return None, None
+
+    # Normalise: each trigger must be a non-empty string
+    triggers = [str(t).strip() for t in raw_triggers if t and str(t).strip()]
+    if not triggers:
+        return None, None
+
+    return triggers, content
+
+
+def _get_cached_skill(skill_path: Path) -> Tuple[Optional[List[str]], Optional[str]]:
+    """Return (triggers, content) from cache, refreshing if the file changed."""
+    path_str = str(skill_path)
+    try:
+        mtime = skill_path.stat().st_mtime
+    except OSError:
+        return None, None
+
+    cached = _trigger_cache.get(path_str)
+    if cached and cached[0] == mtime:
+        return cached[1], cached[2]
+
+    triggers, content = _parse_triggers_and_content(skill_path)
+    _trigger_cache[path_str] = (mtime, triggers, content)
+    return triggers, content
+
+
+def get_triggered_skills(text: str) -> List[str]:
+    """
+    Return a list of full SKILL.md contents whose trigger patterns match *text*.
+
+    Args:
+        text: The user message or task description for this turn.
+
+    Returns:
+        List of SKILL.md file contents (strings) for every matched skill,
+        capped at MAX_AUTO_LOADED_SKILLS. Empty list if nothing matches or
+        on any error.
+    """
+    if not text or not text.strip():
+        return []
+
+    try:
+        skills_home = _get_skills_home()
+        matched: List[str] = []
+
+        for skill_path in _iter_skill_paths(skills_home):
+            if len(matched) >= MAX_AUTO_LOADED_SKILLS:
+                break
+            try:
+                triggers, content = _get_cached_skill(skill_path)
+                if not triggers or not content:
+                    continue
+                for pattern in triggers:
+                    try:
+                        if re.search(pattern, text, re.IGNORECASE | re.DOTALL):
+                            matched.append(content)
+                            logger.debug(
+                                "skill_trigger_loader: auto-loaded %s (pattern=%r)",
+                                skill_path.parent.name,
+                                pattern,
+                            )
+                            break  # one match per skill is enough
+                    except re.error:
+                        # Invalid regex in frontmatter — skip silently
+                        continue
+            except Exception as e:
+                logger.debug("skill_trigger_loader: error checking %s: %s", skill_path, e)
+                continue
+
+        return matched
+
+    except Exception as e:
+        logger.debug("skill_trigger_loader: unexpected error: %s", e)
+        return []
+
+
+def format_triggered_skills_block(skill_contents: List[str]) -> str:
+    """
+    Format auto-loaded skill contents into a single context block for injection.
+    """
+    if not skill_contents:
+        return ""
+    parts = ["<!-- Auto-loaded skills (trigger match) -->"]
+    for i, content in enumerate(skill_contents, 1):
+        parts.append(f"\n--- Auto-loaded skill {i} ---\n{content.strip()}")
+    return "\n".join(parts)

--- a/run_agent.py
+++ b/run_agent.py
@@ -11562,6 +11562,31 @@ class AIAgent:
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
 
+        # Auto-load skills whose frontmatter 'triggers' patterns match this message.
+        # Fail-safe: any error here is caught so it never breaks the main loop.
+        # Only runs on the first turn of a session (no history) to avoid redundant
+        # re-injection on every follow-up message.
+        if not conversation_history and user_message:
+            try:
+                from agent.skill_trigger_loader import (
+                    format_triggered_skills_block,
+                    get_triggered_skills,
+                )
+                _triggered = get_triggered_skills(user_message)
+                if _triggered:
+                    _block = format_triggered_skills_block(_triggered)
+                    if _block:
+                        # Inject as a system message prepended before the user turn.
+                        # Using role="system" keeps it out of the visible transcript
+                        # while ensuring the model sees it before any tool calls.
+                        messages.insert(0, {"role": "system", "content": _block})
+                        logger.debug(
+                            "skill_trigger_loader: injected %d skill(s) into context",
+                            len(_triggered),
+                        )
+            except Exception as _e:
+                logger.debug("skill_trigger_loader: injection skipped (%s)", _e)
+
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to
         # recover the todo state from the most recent todo tool response in history)

--- a/tests/agent/test_skill_trigger_loader.py
+++ b/tests/agent/test_skill_trigger_loader.py
@@ -1,0 +1,182 @@
+"""Tests for agent.skill_trigger_loader."""
+from __future__ import annotations
+
+import textwrap
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_skill(tmp_path: Path, name: str, triggers: list[str], body: str = "skill body") -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    frontmatter = "---\nname: {}\ndescription: test skill\ntriggers:\n".format(name)
+    for t in triggers:
+        frontmatter += f"  - '{t}'\n"
+    frontmatter += "---\n"
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(frontmatter + body)
+    return skill_file
+
+
+def _make_skill_no_triggers(tmp_path: Path, name: str) -> Path:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = "---\nname: {}\ndescription: no triggers here\n---\nbody\n".format(name)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(content)
+    return skill_file
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the module-level cache before each test."""
+    from agent import skill_trigger_loader
+    skill_trigger_loader._trigger_cache.clear()
+    yield
+    skill_trigger_loader._trigger_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_triggered_skills
+# ---------------------------------------------------------------------------
+
+def test_returns_empty_for_blank_input(tmp_path):
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        assert skill_trigger_loader.get_triggered_skills("") == []
+        assert skill_trigger_loader.get_triggered_skills("   ") == []
+
+
+def test_matches_simple_string_pattern(tmp_path):
+    _make_skill(tmp_path, "my-skill", ["PHP Parse error"], "## fix it")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("PHP Parse error: syntax error")
+    assert len(result) == 1
+    assert "fix it" in result[0]
+
+
+def test_match_is_case_insensitive(tmp_path):
+    _make_skill(tmp_path, "s", ["php parse error"])
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("PHP PARSE ERROR in controller")
+    assert len(result) == 1
+
+
+def test_no_match_returns_empty(tmp_path):
+    _make_skill(tmp_path, "s", ["PHP Parse error"])
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("everything is fine")
+    assert result == []
+
+
+def test_skill_without_triggers_is_skipped(tmp_path):
+    _make_skill_no_triggers(tmp_path, "no-trigger-skill")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("any text at all")
+    assert result == []
+
+
+def test_multiple_skills_can_match(tmp_path):
+    _make_skill(tmp_path, "skill-a", ["parse error"], "body A")
+    _make_skill(tmp_path, "skill-b", ["syntax error"], "body B")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("parse error and syntax error both")
+    assert len(result) == 2
+
+
+def test_max_skills_cap(tmp_path):
+    from agent import skill_trigger_loader
+    original_max = skill_trigger_loader.MAX_AUTO_LOADED_SKILLS
+    skill_trigger_loader.MAX_AUTO_LOADED_SKILLS = 2
+    try:
+        for i in range(5):
+            _make_skill(tmp_path, f"skill-{i}", ["match me"], f"body {i}")
+        with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+            result = skill_trigger_loader.get_triggered_skills("match me please")
+        assert len(result) <= 2
+    finally:
+        skill_trigger_loader.MAX_AUTO_LOADED_SKILLS = original_max
+
+
+def test_each_skill_loaded_only_once_per_match(tmp_path):
+    """A skill with multiple matching patterns should only be included once."""
+    _make_skill(tmp_path, "s", ["error one", "error two"], "skill body")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        result = skill_trigger_loader.get_triggered_skills("error one and error two")
+    assert len(result) == 1
+
+
+def test_invalid_regex_pattern_is_skipped_gracefully(tmp_path):
+    """An invalid regex in frontmatter must not crash — just skip that pattern."""
+    _make_skill(tmp_path, "bad-regex", ["[invalid(regex"], "body")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        # Should not raise
+        result = skill_trigger_loader.get_triggered_skills("[invalid(regex — matching text")
+    assert isinstance(result, list)
+
+
+def test_nonexistent_skills_home_returns_empty(tmp_path):
+    from agent import skill_trigger_loader
+    missing = tmp_path / "does_not_exist"
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=missing):
+        result = skill_trigger_loader.get_triggered_skills("anything")
+    assert result == []
+
+
+def test_mtime_cache_is_used(tmp_path):
+    """Second call with same mtime should not re-read the file."""
+    skill_file = _make_skill(tmp_path, "cached", ["cached pattern"], "cached body")
+    from agent import skill_trigger_loader
+    with mock.patch.object(skill_trigger_loader, "_get_skills_home", return_value=tmp_path):
+        r1 = skill_trigger_loader.get_triggered_skills("cached pattern")
+        # Overwrite content without changing mtime (force same mtime)
+        mtime = skill_file.stat().st_mtime
+        skill_file.write_text("---\nname: cached\ntriggers:\n  - 'cached pattern'\n---\nnew body\n")
+        import os; os.utime(skill_file, (mtime, mtime))
+        r2 = skill_trigger_loader.get_triggered_skills("cached pattern")
+    # Both results should have the original content (cache hit)
+    assert r1 == r2
+
+
+# ---------------------------------------------------------------------------
+# Tests: format_triggered_skills_block
+# ---------------------------------------------------------------------------
+
+def test_format_empty_list():
+    from agent.skill_trigger_loader import format_triggered_skills_block
+    assert format_triggered_skills_block([]) == ""
+
+
+def test_format_single_skill():
+    from agent.skill_trigger_loader import format_triggered_skills_block
+    result = format_triggered_skills_block(["# My Skill\n\nDo this."])
+    assert "Auto-loaded skill 1" in result
+    assert "My Skill" in result
+    assert "Do this." in result
+
+
+def test_format_multiple_skills():
+    from agent.skill_trigger_loader import format_triggered_skills_block
+    result = format_triggered_skills_block(["skill A content", "skill B content"])
+    assert "Auto-loaded skill 1" in result
+    assert "Auto-loaded skill 2" in result
+    assert "skill A content" in result
+    assert "skill B content" in result


### PR DESCRIPTION
## Problem

Skills are only loaded when the agent *recognises* the match from a one-line description. If a skill description does not surface for a given trigger condition, the knowledge is never applied — even if the exact fix is documented.

Real example: a `PHP ParseError: syntax error, unexpected token "if"` in CI was debugged from scratch even though `laravel-pitfalls` had the exact fix documented. The one-line description did not match the error pattern.

## Solution

Add a `triggers:` key to SKILL.md frontmatter. When regex patterns match the incoming user message, the skill is automatically injected into context **before the agent reasons** — no recognition gap.

```yaml
triggers:
  - 'PHP Parse error.*syntax error'
  - 'mergeable.*CONFLICTING'
  - 'inStore\(null\)'
```

Patterns are matched case-insensitively. Invalid regex is skipped without error. At most 5 skills are auto-loaded per turn (configurable via `MAX_AUTO_LOADED_SKILLS`). Results are mtime-cached to avoid repeated disk reads in long gateway sessions.

## Changes

### `agent/skill_trigger_loader.py` (new, ~170 LOC)
- `get_triggered_skills(text)` — scan all SKILL.md files, match triggers, return full contents
- `format_triggered_skills_block(skills)` — format for context injection
- mtime-based cache, profile-aware skills home, fail-safe throughout

### `run_agent.py` (+25 LOC)
- Hook at start of `run_conversation()`, first turn only
- Injects matched skills as a `system` message before the user turn
- Wrapped in `try/except` — any failure is logged at DEBUG, never raised

### `tests/agent/test_skill_trigger_loader.py` (new, 14 tests)
- Blank input, case-insensitive match, no-match, skip-no-triggers
- Multiple matches, per-skill cap, single-load-per-skill
- Invalid regex graceful skip, nonexistent skills home
- mtime cache correctness, format functions

All 14 tests pass.

## Fail-safe design

The hook in `run_agent.py` is wrapped in a broad `except Exception` — a bug in the trigger loader can never crash or slow the agent loop. Failures are logged at `DEBUG` level only.

## Backwards compatibility

Fully additive. Skills without a `triggers:` key behave exactly as before. No config changes required.