### PR TITLE
fix(nix): include locales directory in Nix package to fix raw i18n keys

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -87,9 +87,18 @@ _catalog_lock = threading.Lock()
 def _locales_dir() -> Path:
     """Return the directory containing locale YAML files.
 
-    Lives next to the repo root so both the bundled install and editable
-    checkouts find it without PYTHONPATH gymnastics.
+    Resolution order:
+    1. ``HERMES_BUNDLED_LOCALES`` env var — set by the Nix wrapper (or any
+       sealed-packaging system) to point at the installed locale directory.
+    2. ``<repo-root>/locales/`` — works for editable checkouts and
+       ``pip install -e .`` where the source tree is the working copy.
     """
+    import os
+    bundled = os.environ.get("HERMES_BUNDLED_LOCALES")
+    if bundled:
+        p = Path(bundled)
+        if p.is_dir():
+            return p
     # agent/i18n.py -> agent/ -> repo root
     return Path(__file__).resolve().parent.parent / "locales"
 

--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -61,6 +61,11 @@ let
     filter = path: _type: !(lib.hasInfix "/__pycache__/" path);
   };
 
+  bundledLocales = lib.cleanSourceWith {
+    src = ../locales;
+    filter = path: _type: !(lib.hasInfix "/__pycache__/" path);
+  };
+
   runtimeDeps = [
     nodejs
     ripgrep
@@ -141,6 +146,7 @@ stdenv.mkDerivation {
     mkdir -p $out/share/hermes-agent $out/bin
     cp -r ${bundledSkills} $out/share/hermes-agent/skills
     cp -r ${bundledPlugins} $out/share/hermes-agent/plugins
+    cp -r ${bundledLocales} $out/share/hermes-agent/locales
     cp -r ${hermesWeb} $out/share/hermes-agent/web_dist
 
     mkdir -p $out/ui-tui
@@ -152,6 +158,7 @@ stdenv.mkDerivation {
           --suffix PATH : "${runtimePath}" \
           --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills \
           --set HERMES_BUNDLED_PLUGINS $out/share/hermes-agent/plugins \
+          --set HERMES_BUNDLED_LOCALES $out/share/hermes-agent/locales \
           --set HERMES_WEB_DIST $out/share/hermes-agent/web_dist \
           --set HERMES_TUI_DIR $out/ui-tui \
           --set HERMES_PYTHON ${hermesVenv}/bin/python3 \

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -167,3 +167,30 @@ def test_t_missing_key_in_non_english_falls_back_to_english(tmp_path, monkeypatc
 def test_t_unknown_language_uses_english():
     """Unknown lang codes normalize to English, not to a key-path fallback."""
     assert i18n.t("approval.denied", lang="klingon") == i18n.t("approval.denied", lang="en")
+
+
+def test_bundled_locales_env_var(tmp_path, monkeypatch):
+    """HERMES_BUNDLED_LOCALES overrides the default locales directory.
+
+    This is used by the Nix package (and other sealed-packaging systems)
+    where the repo-root ``locales/`` directory is not available at runtime.
+    """
+    bundled = tmp_path / "bundled-locales"
+    bundled.mkdir()
+    (bundled / "en.yaml").write_text("test.key: Bundled English\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_BUNDLED_LOCALES", str(bundled))
+    try:
+        assert i18n._locales_dir() == bundled
+    finally:
+        monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)
+
+
+def test_bundled_locales_env_var_ignored_when_missing(tmp_path, monkeypatch):
+    """HERMES_BUNDLED_LOCALES is ignored if the directory doesn't exist."""
+    monkeypatch.setenv("HERMES_BUNDLED_LOCALES", str(tmp_path / "nonexistent"))
+    try:
+        # Should fall through to the default repo-root path
+        result = i18n._locales_dir()
+        assert result.name == "locales"
+    finally:
+        monkeypatch.delenv("HERMES_BUNDLED_LOCALES", raising=False)


### PR DESCRIPTION
## What does this PR do?

Fixes raw i18n key paths (e.g. `gateway.reset.header_default`) appearing in gateway command replies when Hermes is installed via Nix.


### Root Cause

The Nix package (built with `uv2nix`) installs `agent/i18n.py` into `site-packages`, but the repo-root `locales/` directory is not copied alongside it. The `_locales_dir()` function resolves catalogs relative to the source file:

```python
return Path(__file__).resolve().parent.parent / "locales"
```

In a Nix sealed environment, this points to a non-existent `site-packages/locales/` directory, so `_load_catalog()` returns `{}` and `t()` falls back to returning the raw key path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A