### PR TITLE
fix(kanban): promote dependents when a parent is archived

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2795,7 +2795,11 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
-        return True
+    # ``archived`` parents no longer block children, same as ``done``.
+    # Promote newly-unblocked dependents immediately instead of waiting
+    # for a later dispatcher tick.
+    recompute_ready(conn)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1247,6 +1247,28 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
             "child should promote to ready immediately after unlink_tasks "
             "removes its last blocking dependency"
         )
+
+
+def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
+    """Archiving a parent must immediately unblock its children.
+
+    ``recompute_ready()`` already treats ``archived`` parents as satisfied
+    dependencies, just like ``done``. Regression: ``archive_task()`` updated
+    the parent row but never ran the ready-promotion pass, so children stayed
+    stuck in ``todo`` until a later dispatcher tick.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="obsolete parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.archive_task(conn, parent) is True
+
+        assert kb.get_task(conn, child).status == "ready", (
+            "child should promote to ready immediately after its last blocking "
+            "parent is archived"
+        )
+
 # ---------------------------------------------------------------------------
 # _add_column_if_missing / _migrate_add_optional_columns idempotency (#21708)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## What does this PR do?
Fixes a Kanban lifecycle inconsistency where archiving a parent task did not immediately unblock dependent children.

`recompute_ready()` already treats `archived` parents the same as `done`, but `archive_task()` was not triggering that promotion pass. As a result, children could remain stuck in `todo` until a later dispatcher tick.

This PR updates `archive_task()` to recompute ready tasks after a successful archive and adds a regression test covering the behavior.

## Related Issue
No linked issue; found via code inspection.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- Added a regression test for archiving a parent with dependent children.
- Updated `archive_task()` to call `recompute_ready(conn)` after a successful archive.
- Kept the change scoped to a single Kanban lifecycle bug.

## How to Test
1. Create a parent task.
2. Create a child task depending on that parent.
3. Confirm the child is in `todo`.
4. Archive the parent task.
5. Confirm the child is immediately promoted to `ready`.

## Test Results
- `pytest tests/hermes_cli/test_kanban_db.py -k "archive_task_triggers_recompute_ready_for_dependents or unlink_tasks_triggers_recompute_ready" -q`
- Result: `2 passed`



