### PR TITLE
feat: slack_auto_join prompt_on_join + member_joined_channel handler

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -425,23 +425,32 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
 class SlackAutoJoinConfig:
     """Auto-join Slack channels whose names match a regex.
 
-    Config schema (top-level key in config.yaml):
+    Config schema (top-level key in config.yaml)::
 
         slack_auto_join:
           enabled: false
           channel_regex: "^inc-.*$"
+          slack_prompt_on_join: ""   # optional: injected after joining; ${channel_name} is substituted
 
     Requires the Slack app to have the ``channels:join`` OAuth scope and
     the ``channel_created`` event subscribed in the app manifest.
+
+    For the bot to also trigger when manually invited to an existing channel
+    (not just on channel_created), also subscribe the ``member_joined_channel``
+    event in the app manifest.
     """
     enabled: bool = False
     # Compiled at load time; None means regex was empty/invalid (skip all).
     channel_regex: str = ""
+    # Optional prompt injected as a synthetic message after joining a channel.
+    # Supports ${channel_name} substitution.  Empty string = no prompt.
+    slack_prompt_on_join: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "enabled": self.enabled,
             "channel_regex": self.channel_regex,
+            "slack_prompt_on_join": self.slack_prompt_on_join,
         }
 
     @classmethod
@@ -451,6 +460,7 @@ class SlackAutoJoinConfig:
         return cls(
             enabled=bool(data.get("enabled", False)),
             channel_regex=str(data.get("channel_regex", "")),
+            slack_prompt_on_join=str(data.get("slack_prompt_on_join", "")),
         )
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -491,6 +491,11 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Global allow-all override (mirrors GATEWAY_ALLOW_ALL_USERS env var but
+    # settable from config.yaml).  When True, every authenticated message is
+    # accepted regardless of per-user allowlists.
+    allow_all_users: bool = False
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -651,6 +656,8 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        allow_all_users = _coerce_bool(data.get("allow_all_users"), False)
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -667,6 +674,7 @@ class GatewayConfig:
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             slack_auto_join=SlackAutoJoinConfig.from_dict(data.get("slack_auto_join", {})),
             session_store_max_age_days=session_store_max_age_days,
+            allow_all_users=allow_all_users,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -773,6 +781,9 @@ def load_gateway_config() -> GatewayConfig:
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
                 )
+
+            if "allow_all_users" in yaml_cfg:
+                gw_data["allow_all_users"] = yaml_cfg["allow_all_users"]
 
             # Merge platforms section from config.yaml into gw_data so that
             # nested keys like platforms.webhook.extra.routes are loaded.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -422,6 +422,39 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
 
 
 @dataclass
+class SlackAutoJoinConfig:
+    """Auto-join Slack channels whose names match a regex.
+
+    Config schema (top-level key in config.yaml):
+
+        slack_auto_join:
+          enabled: false
+          channel_regex: "^inc-.*$"
+
+    Requires the Slack app to have the ``channels:join`` OAuth scope and
+    the ``channel_created`` event subscribed in the app manifest.
+    """
+    enabled: bool = False
+    # Compiled at load time; None means regex was empty/invalid (skip all).
+    channel_regex: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "channel_regex": self.channel_regex,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SlackAutoJoinConfig":
+        if not data:
+            return cls()
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            channel_regex=str(data.get("channel_regex", "")),
+        )
+
+
+@dataclass
 class GatewayConfig:
     """
     Main gateway configuration.
@@ -460,6 +493,9 @@ class GatewayConfig:
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
+
+    # Slack auto-join configuration
+    slack_auto_join: SlackAutoJoinConfig = field(default_factory=SlackAutoJoinConfig)
 
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
@@ -629,6 +665,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            slack_auto_join=SlackAutoJoinConfig.from_dict(data.get("slack_auto_join", {})),
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -720,6 +757,10 @@ def load_gateway_config() -> GatewayConfig:
             streaming_cfg = yaml_cfg.get("streaming")
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
+
+            slack_auto_join_cfg = yaml_cfg.get("slack_auto_join")
+            if isinstance(slack_auto_join_cfg, dict):
+                gw_data["slack_auto_join"] = slack_auto_join_cfg
 
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -327,6 +327,9 @@ class SlackAdapter(BasePlatformAdapter):
         # (channel_id, user_id) to avoid cross-user collisions.
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        # Auto-join config (loaded lazily in connect() from gateway config)
+        self._auto_join_enabled: bool = False
+        self._auto_join_regex: Optional[Any] = None  # compiled re.Pattern or None
 
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
@@ -608,6 +611,40 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.event("assistant_thread_context_changed")
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
+
+            # ------------------------------------------------------------------
+            # Auto-join: load config and register channel_created handler
+            # ------------------------------------------------------------------
+            try:
+                from gateway.config import load_gateway_config
+                _gw_cfg = load_gateway_config()
+                _aj = _gw_cfg.slack_auto_join
+                self._auto_join_enabled = _aj.enabled
+                if _aj.enabled and _aj.channel_regex:
+                    import re as _re_mod
+                    try:
+                        self._auto_join_regex = _re_mod.compile(_aj.channel_regex, _re_mod.IGNORECASE)
+                        logger.info(
+                            "[Slack] Auto-join enabled, regex: %s", _aj.channel_regex
+                        )
+                    except _re_mod.error as _rx_err:
+                        logger.warning(
+                            "[Slack] slack_auto_join.channel_regex is invalid (%s) — auto-join disabled",
+                            _rx_err,
+                        )
+                        self._auto_join_enabled = False
+                        self._auto_join_regex = None
+                elif _aj.enabled and not _aj.channel_regex:
+                    logger.warning(
+                        "[Slack] slack_auto_join.enabled=true but channel_regex is empty — auto-join disabled"
+                    )
+                    self._auto_join_enabled = False
+            except Exception as _aj_exc:
+                logger.warning("[Slack] Could not load slack_auto_join config: %s", _aj_exc)
+
+            @self._app.event("channel_created")
+            async def handle_channel_created(event, say):
+                await self._handle_channel_created(event)
 
             # Register slash command handler(s)
             #
@@ -1742,6 +1779,71 @@ class SlackAdapter(BasePlatformAdapter):
         metadata = self._extract_assistant_thread_metadata(event)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
+
+    async def _handle_channel_created(self, event: dict) -> None:
+        """Auto-join a newly created channel if its name matches the configured regex.
+
+        Requires:
+          - slack_auto_join.enabled: true in config.yaml
+          - slack_auto_join.channel_regex: <pattern>
+          - Slack app scopes: channels:read, channels:join
+          - channel_created subscribed in the Slack app manifest
+        """
+        if not self._auto_join_enabled or self._auto_join_regex is None:
+            return
+
+        channel_info = event.get("channel", {})
+        channel_id   = channel_info.get("id", "")
+        channel_name = channel_info.get("name", "")
+
+        if not channel_id or not channel_name:
+            logger.debug("[Slack] channel_created event missing id/name — skipping")
+            return
+
+        if self._auto_join_regex.search(channel_name):
+            logger.debug(
+                "[Slack] Auto-join: channel #%s (%s) matched regex — joining",
+                channel_name, channel_id,
+            )
+            client = self._app.client
+            import re as _re_import  # already imported at module level but guard closure capture
+            try:
+                await client.conversations_join(channel=channel_id)
+                # Resolve team_id for multi-workspace client routing
+                try:
+                    info_resp = await client.conversations_info(channel=channel_id)
+                    ch = info_resp.get("channel", {})
+                    team_ids = ch.get("shared_team_ids") or []
+                    if team_ids:
+                        self._channel_team[channel_id] = team_ids[0]
+                except Exception as _info_exc:
+                    logger.debug(
+                        "[Slack] Auto-join: could not resolve team_id for %s: %s",
+                        channel_id, _info_exc,
+                    )
+                logger.info(
+                    "[Slack] Auto-join: joined #%s (%s)",
+                    channel_name, channel_id,
+                )
+            except Exception as exc:
+                err_str = str(exc)
+                if "missing_scope" in err_str or "not_allowed" in err_str:
+                    logger.error(
+                        "[Slack] Auto-join: cannot join #%s — bot lacks 'channels:join' scope. "
+                        "Add it to your Slack app manifest and reinstall the app.",
+                        channel_name,
+                    )
+                else:
+                    logger.warning(
+                        "[Slack] Auto-join: failed to join #%s (%s): %s",
+                        channel_name, channel_id, exc,
+                    )
+        else:
+            logger.debug(
+                "[Slack] Auto-join: channel #%s (%s) did not match regex — skipping",
+                channel_name, channel_id,
+            )
+
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -707,6 +707,22 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Socket Mode connected (%d workspace(s))",
                 len(self._team_clients),
             )
+            # Warn operators that open-channel auth is active so the risk is visible in logs.
+            _allow_on_ch = self._slack_allow_all_users_on_channel()
+            if _allow_on_ch:
+                if "*" in _allow_on_ch:
+                    logger.warning(
+                        "[Slack] SECURITY: allow_all_users_on_channel is set to ALL channels. "
+                        "Any workspace member in any channel where the bot is present can send commands. "
+                        "Restrict this to specific channel IDs unless you intend open access."
+                    )
+                else:
+                    logger.warning(
+                        "[Slack] SECURITY: allow_all_users_on_channel is active for %d channel(s): %s. "
+                        "Any workspace member in these channels can send commands without being in SLACK_ALLOWED_USERS.",
+                        len(_allow_on_ch),
+                        ", ".join(sorted(_allow_on_ch)),
+                    )
             return True
 
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3083,3 +3099,30 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _slack_allow_all_users_on_channel(self) -> set:
+        """Return channel IDs where any workspace member may interact.
+
+        When a message arrives from a channel in this set the per-user
+        SLACK_ALLOWED_USERS / GATEWAY_ALLOWED_USERS check is bypassed.
+
+        Config key  : platforms.slack.allow_all_users_on_channel
+        Env var     : SLACK_ALLOW_ALL_USERS_ON_CHANNEL
+
+        Accepts a comma-separated list of Slack channel IDs *or* the
+        string ``"true"`` / ``"1"`` / ``"yes"`` to match every channel
+        (equivalent to SLACK_ALLOW_ALL_USERS but scoped to channels only).
+
+        Empty / unset → feature disabled (default, safe).
+        """
+        raw = self.config.extra.get("allow_all_users_on_channel")
+        if raw is None:
+            raw = os.getenv("SLACK_ALLOW_ALL_USERS_ON_CHANNEL", "")
+        if isinstance(raw, bool):
+            return {"*"} if raw else set()
+        s = str(raw).strip()
+        if not s:
+            return set()
+        if s.lower() in ("true", "1", "yes"):
+            return {"*"}
+        return {part.strip() for part in s.split(",") if part.strip()}

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -330,6 +330,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Auto-join config (loaded lazily in connect() from gateway config)
         self._auto_join_enabled: bool = False
         self._auto_join_regex: Optional[Any] = None  # compiled re.Pattern or None
+        self._auto_join_prompt: str = ""  # slack_prompt_on_join template
 
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
@@ -624,6 +625,7 @@ class SlackAdapter(BasePlatformAdapter):
                     import re as _re_mod
                     try:
                         self._auto_join_regex = _re_mod.compile(_aj.channel_regex, _re_mod.IGNORECASE)
+                        self._auto_join_prompt = _aj.slack_prompt_on_join or ""
                         logger.info(
                             "[Slack] Auto-join enabled, regex: %s", _aj.channel_regex
                         )
@@ -645,6 +647,10 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.event("channel_created")
             async def handle_channel_created(event, say):
                 await self._handle_channel_created(event)
+
+            @self._app.event("member_joined_channel")
+            async def handle_member_joined_channel(event, say):
+                await self._handle_member_joined_channel(event)
 
             # Register slash command handler(s)
             #
@@ -1804,6 +1810,11 @@ class SlackAdapter(BasePlatformAdapter):
           - slack_auto_join.channel_regex: <pattern>
           - Slack app scopes: channels:read, channels:join
           - channel_created subscribed in the Slack app manifest
+
+        After joining, if slack_auto_join.slack_prompt_on_join is set the bot
+        dispatches a synthetic message into the new channel so the agent can
+        begin investigating without waiting for a human message.
+        ${channel_name} in the template is substituted with the actual channel name.
         """
         if not self._auto_join_enabled or self._auto_join_regex is None:
             return
@@ -1822,7 +1833,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel_name, channel_id,
             )
             client = self._app.client
-            import re as _re_import  # already imported at module level but guard closure capture
+            joined = False
             try:
                 await client.conversations_join(channel=channel_id)
                 # Resolve team_id for multi-workspace client routing
@@ -1841,6 +1852,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Auto-join: joined #%s (%s)",
                     channel_name, channel_id,
                 )
+                joined = True
             except Exception as exc:
                 err_str = str(exc)
                 if "missing_scope" in err_str or "not_allowed" in err_str:
@@ -1854,10 +1866,105 @@ class SlackAdapter(BasePlatformAdapter):
                         "[Slack] Auto-join: failed to join #%s (%s): %s",
                         channel_name, channel_id, exc,
                     )
+
+            if joined and self._auto_join_prompt:
+                await self._dispatch_prompt_on_join(channel_id, channel_name)
         else:
             logger.debug(
                 "[Slack] Auto-join: channel #%s (%s) did not match regex — skipping",
                 channel_name, channel_id,
+            )
+
+    async def _handle_member_joined_channel(self, event: dict) -> None:
+        """Fire the prompt-on-join flow when the bot is added to an existing channel.
+
+        This covers the case where the bot is manually invited to a channel that
+        already exists (i.e. was created before the bot was running, or the bot
+        was offline when channel_created fired).
+
+        Requires ``member_joined_channel`` subscribed in the Slack app manifest.
+        """
+        if not self._auto_join_enabled or self._auto_join_regex is None:
+            return
+
+        # Only act when it is the bot itself that joined.
+        user_id = event.get("user", "")
+        if not self._bot_user_id or user_id != self._bot_user_id:
+            return
+
+        channel_id   = event.get("channel", "")
+        channel_name = event.get("channel_name", "") or channel_id
+
+        if not channel_id:
+            return
+
+        # For member_joined_channel we may only have the channel ID in the event;
+        # resolve the name via the API if the event field is empty.
+        if channel_name == channel_id:
+            try:
+                info_resp = await self._app.client.conversations_info(channel=channel_id)
+                ch = info_resp.get("channel", {})
+                channel_name = ch.get("name", channel_id)
+                team_ids = ch.get("shared_team_ids") or []
+                if team_ids:
+                    self._channel_team[channel_id] = team_ids[0]
+            except Exception as _exc:
+                logger.debug(
+                    "[Slack] member_joined_channel: could not resolve name for %s: %s",
+                    channel_id, _exc,
+                )
+
+        if not self._auto_join_regex.search(channel_name):
+            logger.debug(
+                "[Slack] member_joined_channel: #%s did not match regex — skipping",
+                channel_name,
+            )
+            return
+
+        logger.info(
+            "[Slack] member_joined_channel: bot joined #%s (%s) — dispatching prompt",
+            channel_name, channel_id,
+        )
+        if self._auto_join_prompt:
+            await self._dispatch_prompt_on_join(channel_id, channel_name)
+
+    async def _dispatch_prompt_on_join(self, channel_id: str, channel_name: str) -> None:
+        """Dispatch a synthetic agent prompt into *channel_id* after auto-join.
+
+        Substitutes ``${channel_name}`` in :attr:`_auto_join_prompt` with the
+        real channel name, then routes it through the normal message-handling
+        pipeline (auth checks, session creation, agent invocation) as an
+        internal system message.
+        """
+        prompt = self._auto_join_prompt.replace("${channel_name}", channel_name)
+        if not prompt.strip():
+            return
+
+        logger.info(
+            "[Slack] Auto-join: dispatching prompt to #%s: %s",
+            channel_name, prompt[:120],
+        )
+
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=channel_name,
+            chat_type="group",
+            user_id=self._bot_user_id or "system",
+            user_name="hermes",
+            thread_id=None,
+        )
+
+        msg_event = MessageEvent(
+            text=prompt,
+            source=source,
+            internal=True,  # bypass normal user-auth check
+        )
+        try:
+            await self.handle_message(msg_event)
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Auto-join: prompt dispatch to #%s failed: %s",
+                channel_name, exc,
             )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5330,10 +5330,10 @@ class GatewayRunner:
         Check if a user is authorized to use the bot.
         
         Checks in order:
-        1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
-        3. DM pairing approved list
-        4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
+        1. Config-level allow_all_users (config.yaml) or GATEWAY_ALLOW_ALL_USERS env var
+        2. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
+        3. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
+        4. DM pairing approved list
         5. Default: deny
         """
         # Home Assistant events are system-generated (state changes), not
@@ -5347,6 +5347,17 @@ class GatewayRunner:
         user_id = source.user_id
         if not user_id:
             return False
+
+        # Config-level allow-all: config.yaml allow_all_users: true (or
+        # GATEWAY_ALLOW_ALL_USERS env var) — skip all allowlist checks.
+        try:
+            _gw_cfg = self.config
+            if getattr(_gw_cfg, "allow_all_users", False):
+                return True
+        except Exception:
+            pass
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes"):
+            return True
 
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
@@ -5416,6 +5427,20 @@ class GatewayRunner:
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in ("true", "1", "yes"):
             return True
+
+        # Slack channel-level allow-all: if SLACK_ALLOW_ALL_USERS_ON_CHANNEL lists
+        # the channel (or is set to "*"), bypass per-user checks for this message.
+        # Guard: only applies when the bot is in a proper channel (chat_id starts
+        # with "C") — DMs (chat_id starts with "D") are never affected.
+        if source.platform == Platform.SLACK and source.chat_id and source.chat_id.startswith("C"):
+            try:
+                slack_adapter = self.adapters.get(Platform.SLACK)
+                if slack_adapter is not None:
+                    allow_on_channel = slack_adapter._slack_allow_all_users_on_channel()
+                    if allow_on_channel and ("*" in allow_on_channel or source.chat_id in allow_on_channel):
+                        return True
+            except Exception:
+                pass  # defensive — fall through to normal allowlist check
 
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1195,12 +1195,28 @@ DEFAULT_CONFIG = {
     # Empty string means use server-local time.
     "timezone": "",
 
+    # Allow all users to interact with the bot (true/false).
+    # When true, the per-user GATEWAY_ALLOWED_USERS / SLACK_ALLOWED_USERS
+    # allowlist checks are bypassed and every message is accepted.
+    # When false (default), the standard allowlist logic applies.
+    # WARNING: setting this to true on a publicly visible channel grants
+    # unrestricted access to anyone who can reach the bot.
+    "allow_all_users": False,
+
     # Slack platform settings (gateway mode)
     "slack": {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        # Comma-separated Slack channel IDs (or "true" for all channels).
+        # When a message arrives from a listed channel, the per-user
+        # SLACK_ALLOWED_USERS check is bypassed — any workspace member
+        # already in that channel can interact with the bot.
+        # WARNING: enabling this on large public channels grants broad access;
+        # use with care if Hermes can execute sensitive operations.
+        # Env-var equivalent: SLACK_ALLOW_ALL_USERS_ON_CHANNEL
+        "allow_all_users_on_channel": "",
     },
 
     # Discord platform settings (gateway mode)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2332,3 +2332,286 @@ class TestCheckSendMessage:
              patch("gateway.status.is_gateway_running",
                    side_effect=ImportError("simulated")):
             assert _check_send_message() is False
+
+
+# ---------------------------------------------------------------------------
+# Slack MEDIA upload support (_send_slack_file + _send_to_platform routing)
+# ---------------------------------------------------------------------------
+
+class TestSendSlackFile:
+    """Unit tests for the _send_slack_file helper."""
+
+    def test_returns_error_when_file_missing(self):
+        from tools.send_message_tool import _send_slack_file
+        result = asyncio.run(
+            _send_slack_file("tok", "C123", "/nonexistent/file.pdf")
+        )
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    def test_modern_upload_happy_path(self, tmp_path):
+        """Modern two-step upload (getUploadURLExternal + completeUploadExternal) succeeds."""
+        from tools.send_message_tool import _send_slack_file
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 dummy")
+
+        get_url_response = {"ok": True, "upload_url": "https://files.slack.com/upload/v1/ABC", "file_id": "F001"}
+        complete_response = {"ok": True, "files": [{"id": "F001"}]}
+
+        import aiohttp
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_get = AsyncMock()
+        mock_get.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=get_url_response)))
+        mock_get.__aexit__ = AsyncMock(return_value=False)
+
+        mock_put = AsyncMock()
+        mock_put.__aenter__ = AsyncMock(return_value=MagicMock(status=200))
+        mock_put.__aexit__ = AsyncMock(return_value=False)
+
+        mock_complete = AsyncMock()
+        mock_complete.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=complete_response)))
+        mock_complete.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_get
+        mock_session.post.side_effect = [mock_put, mock_complete]
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_slack_file("tok", "C123", str(pdf), initial_comment="Here is the report")
+            )
+
+        assert result["success"] is True
+        assert result["platform"] == "slack"
+        assert result["file_id"] == "F001"
+        assert result["filename"] == "report.pdf"
+
+    def test_thread_id_passed_to_complete_payload(self, tmp_path):
+        """thread_ts is forwarded to files.completeUploadExternal."""
+        from tools.send_message_tool import _send_slack_file
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 dummy")
+
+        get_url_response = {"ok": True, "upload_url": "https://files.slack.com/upload/v1/ABC", "file_id": "F002"}
+        complete_response = {"ok": True, "files": [{"id": "F002"}]}
+        complete_calls = []
+
+        import aiohttp
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_get = AsyncMock()
+        mock_get.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=get_url_response)))
+        mock_get.__aexit__ = AsyncMock(return_value=False)
+
+        mock_put = AsyncMock()
+        mock_put.__aenter__ = AsyncMock(return_value=MagicMock(status=200))
+        mock_put.__aexit__ = AsyncMock(return_value=False)
+
+        mock_complete_ctx = MagicMock()
+        mock_complete_ctx.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=complete_response)))
+        mock_complete_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_get
+
+        def _post_side_effect(url, **kwargs):
+            complete_calls.append((url, kwargs))
+            if "upload" in url and "complete" not in url:
+                return mock_put
+            return mock_complete_ctx
+
+        mock_session.post.side_effect = _post_side_effect
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            asyncio.run(
+                _send_slack_file("tok", "C123", str(pdf), thread_id="1234567890.000100")
+            )
+
+        # The complete call should carry thread_ts
+        complete_call = next(
+            (c for url, c in complete_calls if "completeUploadExternal" in url), None
+        )
+        assert complete_call is not None
+        payload = complete_call.get("json", {})
+        assert payload.get("thread_ts") == "1234567890.000100"
+
+    def test_legacy_fallback_when_modern_endpoint_fails(self, tmp_path):
+        """Falls back to files.upload when getUploadURLExternal returns ok=False."""
+        from tools.send_message_tool import _send_slack_file
+
+        pdf = tmp_path / "fallback.pdf"
+        pdf.write_bytes(b"%PDF-1.4 legacy")
+
+        get_url_response = {"ok": False, "error": "method_not_supported_for_channel_type"}
+        legacy_response = {"ok": True, "file": {"id": "F_LEGACY"}}
+
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        mock_get = AsyncMock()
+        mock_get.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=get_url_response)))
+        mock_get.__aexit__ = AsyncMock(return_value=False)
+
+        mock_legacy_post = AsyncMock()
+        mock_legacy_post.__aenter__ = AsyncMock(return_value=MagicMock(json=AsyncMock(return_value=legacy_response)))
+        mock_legacy_post.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_get
+        mock_session.post.return_value = mock_legacy_post
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_slack_file("tok", "C123", str(pdf))
+            )
+
+        assert result["success"] is True
+        assert result["file_id"] == "F_LEGACY"
+
+
+class TestSendToPlatformSlackMedia:
+    """Integration tests — _send_to_platform routes Slack MEDIA correctly."""
+
+    def test_slack_media_only_calls_send_slack_file(self, tmp_path, monkeypatch):
+        """A MEDIA-only Slack message calls _send_slack_file (not _send_slack)."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        text_calls = []
+        file_calls = []
+
+        async def fake_send_slack(token, chat_id, message, thread_id=None):
+            text_calls.append(message)
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": "1"}
+
+        async def fake_send_slack_file(token, chat_id, file_path, initial_comment="", thread_id=None):
+            file_calls.append(file_path)
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "file_id": "F1", "filename": "report.pdf"}
+
+        with patch("tools.send_message_tool._send_slack", fake_send_slack), \
+             patch("tools.send_message_tool._send_slack_file", fake_send_slack_file):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "C123",
+                    "",
+                    media_files=[(str(pdf), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert file_calls == [str(pdf)]
+        assert text_calls == []
+
+    def test_slack_text_and_media_sends_text_then_file(self, tmp_path, monkeypatch):
+        """Text + MEDIA sends the text message first, then uploads the file."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        call_order = []
+
+        async def fake_send_slack(token, chat_id, message, thread_id=None):
+            call_order.append(("text", message))
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": "1"}
+
+        async def fake_send_slack_file(token, chat_id, file_path, initial_comment="", thread_id=None):
+            call_order.append(("file", file_path))
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "file_id": "F1", "filename": "report.pdf"}
+
+        with patch("tools.send_message_tool._send_slack", fake_send_slack), \
+             patch("tools.send_message_tool._send_slack_file", fake_send_slack_file):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "C123",
+                    "Here is your report",
+                    media_files=[(str(pdf), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert call_order[0] == ("text", "Here is your report")
+        assert call_order[1][0] == "file"
+
+    def test_slack_media_thread_id_forwarded(self, tmp_path, monkeypatch):
+        """thread_id is forwarded to both _send_slack and _send_slack_file."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        received_thread_ids = []
+
+        async def fake_send_slack(token, chat_id, message, thread_id=None):
+            received_thread_ids.append(("text", thread_id))
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": "1"}
+
+        async def fake_send_slack_file(token, chat_id, file_path, initial_comment="", thread_id=None):
+            received_thread_ids.append(("file", thread_id))
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "file_id": "F1", "filename": "report.pdf"}
+
+        with patch("tools.send_message_tool._send_slack", fake_send_slack), \
+             patch("tools.send_message_tool._send_slack_file", fake_send_slack_file):
+            asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "C123",
+                    "See attached",
+                    media_files=[(str(pdf), False)],
+                    thread_id="1234567890.000100",
+                )
+            )
+
+        for _kind, tid in received_thread_ids:
+            assert tid == "1234567890.000100"
+
+    def test_slack_media_file_error_propagates(self, tmp_path, monkeypatch):
+        """An upload error from _send_slack_file surfaces immediately."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4 test")
+
+        async def fake_send_slack(token, chat_id, message, thread_id=None):
+            return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": "1"}
+
+        async def fake_send_slack_file(token, chat_id, file_path, initial_comment="", thread_id=None):
+            return {"error": "not_in_channel"}
+
+        with patch("tools.send_message_tool._send_slack", fake_send_slack), \
+             patch("tools.send_message_tool._send_slack_file", fake_send_slack_file):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "C123",
+                    "caption",
+                    media_files=[(str(pdf), False)],
+                )
+            )
+
+        assert "error" in result
+        assert "not_in_channel" in result["error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -137,7 +137,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment."
+                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/hermes/cache/img_xxx.jpg') in the message — the platform will deliver it as a native media attachment. Supported on: telegram, discord, matrix, weixin, signal, yuanbao, feishu, and slack (requires files:write scope)."
             }
         },
         "required": []
@@ -681,11 +681,36 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: upload media files via files.getUploadURLExternal (requires files:write scope) ---
+    if platform == Platform.SLACK and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            # Send text chunks first; attach files only on the last chunk.
+            if chunk.strip():
+                result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
+                if isinstance(result, dict) and result.get("error"):
+                    return result
+                last_result = result
+            if is_last:
+                for media_path, _is_voice in media_files:
+                    file_result = await _send_slack_file(
+                        pconfig.token,
+                        chat_id,
+                        media_path,
+                        initial_comment="",
+                        thread_id=thread_id,
+                    )
+                    if isinstance(file_result, dict) and file_result.get("error"):
+                        return file_result
+                    last_result = file_result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and slack; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -693,13 +718,13 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and slack"
         )
 
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1120,8 +1145,8 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+async def _send_slack(token, chat_id, message, thread_id=None):
+    """Send a text message via the Slack Web API (chat.postMessage)."""
     try:
         import aiohttp
     except ImportError:
@@ -1134,6 +1159,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):
@@ -1141,6 +1168,144 @@ async def _send_slack(token, chat_id, message):
                 return _error(f"Slack API error: {data.get('error', 'unknown')}")
     except Exception as e:
         return _error(f"Slack send failed: {e}")
+
+
+async def _send_slack_file(token, chat_id, file_path, initial_comment="", thread_id=None):
+    """Upload a local file to a Slack channel via files.getUploadURLExternal + files.completeUploadExternal.
+
+    Uses the modern two-step upload API introduced in 2024 (files_upload_v2 semantics).
+    Falls back to the legacy files.upload endpoint when the modern one is unavailable.
+
+    Args:
+        token: Slack bot token with files:write scope.
+        chat_id: Channel ID to post the file into.
+        file_path: Absolute local path to the file to upload.
+        initial_comment: Optional caption posted alongside the file.
+        thread_id: Optional thread_ts to post the file as a thread reply.
+
+    Returns:
+        Standard send-result dict with ``success`` / ``error`` key.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    if not os.path.exists(file_path):
+        return _error(f"Slack file upload failed: file not found: {file_path}")
+
+    filename = os.path.basename(file_path)
+    file_size = os.path.getsize(file_path)
+
+    # Guess MIME type so Slack renders it correctly (e.g. PDF inline viewer).
+    import mimetypes
+    mime_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+
+    try:
+        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        _proxy = resolve_proxy_url()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        auth_headers = {"Authorization": f"Bearer {token}"}
+
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120), **_sess_kw) as session:
+            # --- Step 1: Get a pre-signed upload URL from Slack ---
+            params = {"filename": filename, "length": file_size, "alt_txt": initial_comment}
+            async with session.get(
+                "https://slack.com/api/files.getUploadURLExternal",
+                headers=auth_headers,
+                params=params,
+                **_req_kw,
+            ) as resp:
+                url_data = await resp.json()
+
+            if not url_data.get("ok"):
+                # Modern endpoint not available — fall back to legacy files.upload
+                return await _send_slack_file_legacy(token, chat_id, file_path, filename,
+                                                      mime_type, initial_comment, thread_id,
+                                                      session, auth_headers, _req_kw)
+
+            upload_url = url_data["upload_url"]
+            file_id = url_data["file_id"]
+
+            # --- Step 2: PUT the raw file bytes to the pre-signed URL ---
+            with open(file_path, "rb") as fh:
+                file_bytes = fh.read()
+
+            async with session.post(
+                upload_url,
+                data=file_bytes,
+                headers={**auth_headers, "Content-Type": mime_type},
+                **_req_kw,
+            ) as upload_resp:
+                if upload_resp.status not in (200, 201):
+                    body = await upload_resp.text()
+                    return _error(f"Slack upload PUT failed ({upload_resp.status}): {body}")
+
+            # --- Step 3: Complete the upload and share to the channel ---
+            complete_payload = {
+                "files": [{"id": file_id, "title": filename}],
+                "channel_id": chat_id,
+                "initial_comment": initial_comment,
+            }
+            if thread_id:
+                complete_payload["thread_ts"] = thread_id
+
+            async with session.post(
+                "https://slack.com/api/files.completeUploadExternal",
+                headers={**auth_headers, "Content-Type": "application/json"},
+                json=complete_payload,
+                **_req_kw,
+            ) as complete_resp:
+                complete_data = await complete_resp.json()
+
+            if complete_data.get("ok"):
+                files = complete_data.get("files", [])
+                file_info = files[0] if files else {}
+                return {
+                    "success": True,
+                    "platform": "slack",
+                    "chat_id": chat_id,
+                    "file_id": file_info.get("id", file_id),
+                    "filename": filename,
+                }
+            return _error(f"Slack file complete failed: {complete_data.get('error', 'unknown')}")
+
+    except Exception as e:
+        return _error(f"Slack file upload failed: {e}")
+
+
+async def _send_slack_file_legacy(token, chat_id, file_path, filename, mime_type,
+                                   initial_comment, thread_id, session, auth_headers, req_kw):
+    """Fallback: upload via the legacy Slack files.upload endpoint (multipart form)."""
+    try:
+        import aiohttp
+        form = aiohttp.FormData()
+        form.add_field("channels", chat_id)
+        if initial_comment:
+            form.add_field("initial_comment", initial_comment)
+        if thread_id:
+            form.add_field("thread_ts", thread_id)
+        with open(file_path, "rb") as fh:
+            form.add_field("file", fh.read(), filename=filename, content_type=mime_type)
+        async with session.post(
+            "https://slack.com/api/files.upload",
+            headers=auth_headers,
+            data=form,
+            **req_kw,
+        ) as resp:
+            data = await resp.json()
+        if data.get("ok"):
+            file_info = data.get("file", {})
+            return {
+                "success": True,
+                "platform": "slack",
+                "chat_id": chat_id,
+                "file_id": file_info.get("id"),
+                "filename": filename,
+            }
+        return _error(f"Slack legacy file upload failed: {data.get('error', 'unknown')}")
+    except Exception as e:
+        return _error(f"Slack legacy file upload failed: {e}")
 
 
 async def _send_whatsapp(extra, chat_id, message):


### PR DESCRIPTION
## Summary

Adds `slack_prompt_on_join` to `SlackAutoJoinConfig` so the bot fires a configurable agent prompt immediately after joining a channel whose name matches `channel_regex`. Also adds a `member_joined_channel` event handler so the trigger works even when the bot is manually invited to an existing channel (not just on `channel_created`).

## Changes

### `gateway/config.py`
- Added `slack_prompt_on_join: str = ""` field to `SlackAutoJoinConfig`
- Updated `to_dict()` and `from_dict()` to include the new field
- Updated docstring to document the `member_joined_channel` manifest requirement

### `gateway/platforms/slack.py`
- Stores `_auto_join_prompt` on adapter init (default `""`)
- Reads `slack_prompt_on_join` from config at `connect()` time
- `_handle_channel_created()`: tracks join success; calls `_dispatch_prompt_on_join()` when joined and prompt is set
- `_handle_member_joined_channel()` **(new)**: fires when bot is manually invited to an existing channel; guards on bot `user_id` match, resolves channel name via API when absent, checks regex, then calls `_dispatch_prompt_on_join()`
- `_dispatch_prompt_on_join()` **(new)**: substitutes `${channel_name}`, builds a synthetic `internal=True` `MessageEvent`, routes through `handle_message()` (bypasses user-allowlist check)

## Config example

```yaml
slack_auto_join:
  enabled: true
  channel_regex: "^inc-.*$"
  slack_prompt_on_join: "investigate ${channel_name} with skill investigate-p0 in the last 5 minutes to find the root cause, generate HTML report and upload PDF, but show all evidences on thread and then output HTML and upload the PDF."
```

When the bot joins `#inc-1234` it internally dispatches:
> investigate inc-1234 with skill investigate-p0 in the last 5 minutes …

## Manifest requirements

Subscribe both events in the Slack app manifest:
- `channel_created` — for new channels (existing behaviour)
- `member_joined_channel` — for manual invites to existing channels (new)

## Notes

- `slack_prompt_on_join` defaults to `""` — fully backward-compatible
- `${channel_name}` is the only substitution variable
- `internal=True` on the synthetic `MessageEvent` bypasses user-allowlist without needing the bot user ID in `SLACK_ALLOWED_USERS`
