### PR TITLE
fix(tui): avoid chmod in npm build on Windows

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build --prefix packages/hermes-ink && tsx --watch src/entry.tsx",
     "start": "tsx src/entry.tsx",
-    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && chmod +x dist/entry.js",
+    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && node scripts/mark-entry-executable.mjs",
     "build:compile": "babel dist --out-dir dist --config-file ./babel.compiler.config.cjs --extensions .js --keep-file-extension",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ packages/",

--- a/ui-tui/scripts/mark-entry-executable.mjs
+++ b/ui-tui/scripts/mark-entry-executable.mjs
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const entry = path.resolve(__dirname, '..', 'dist', 'entry.js')
+
+if (!fs.existsSync(entry)) {
+  throw new Error(`Missing built TUI entry: ${entry}`)
+}
+
+if (process.platform !== 'win32') {
+  fs.chmodSync(entry, 0o755)
+}


### PR DESCRIPTION
## What does this PR do?

Avoids a native Windows npm build failure in the TUI package by replacing the POSIX-only `chmod +x dist/entry.js` tail in `ui-tui/package.json` with a small Node helper.

The helper validates that `dist/entry.js` exists after the build, then applies executable permissions only on non-Windows platforms. Windows keeps the same build artifact without trying to run a shell command that does not exist under `cmd.exe`.

This is adjacent to, but separate from, the web dashboard `sync-assets` Windows fix in #13368.

## Related Issue

Related: #13368

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/package.json`: replace raw `chmod +x dist/entry.js` in the npm `build` script with `node scripts/mark-entry-executable.mjs`.
- `ui-tui/scripts/mark-entry-executable.mjs`: add a cross-platform Node helper that checks for `dist/entry.js` and only calls `fs.chmodSync(..., 0o755)` outside Windows.

## How to Test

1. Run `cd ui-tui && npm run build` and confirm the build succeeds.
2. Confirm `dist/entry.js` exists after the build.
3. On non-Windows platforms, confirm `dist/entry.js` is marked executable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux with `cd ui-tui && npm run build`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

`cd ui-tui && npm run build` passes locally on WSL/Linux.

Full suite run after opening draft PR:

- Command: `scripts/run_tests.sh`
- Worker count: 4, from the project runner
- Result: failed, `62 failed, 22119 passed, 59 skipped, 19 errors in 614.35s`
- Notes: failures/errors are scattered across unrelated Python tests; browser supervisor teardown errors are from `tests/conftest.py` live-system guard blocking `os.kill(...)` during Chrome fixture cleanup. This PR only changes the TUI npm build script and helper.
