### PR TITLE
fix(kanban): treat archived dependencies as satisfied in ready transitions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1526,10 +1526,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             (parent_id, child_id),
         )
         # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
+        if not _parents_satisfied(conn, child_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -1598,6 +1595,21 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
         (task_id,),
     ).fetchall()
     return [r["child_id"] for r in rows]
+
+
+def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return True when every parent is terminally satisfied.
+
+    Both ``done`` and ``archived`` parents count as satisfied dependencies.
+    Keeping the rule in one helper avoids drift between lifecycle paths.
+    """
+    parents = conn.execute(
+        "SELECT t.status FROM tasks t "
+        "JOIN task_links l ON l.parent_id = t.id "
+        "WHERE l.child_id = ?",
+        (task_id,),
+    ).fetchall()
+    return all(p["status"] in {"done", "archived"} for p in parents)
 
 
 def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
@@ -1838,13 +1850,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
-            parents = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if all(p["status"] in {"done", "archived"} for p in parents):
+            if _parents_satisfied(conn, task_id):
                 conn.execute(
                     "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                     (task_id,),
@@ -1882,13 +1888,7 @@ def claim_task(
         # 'todo' here — recompute_ready will re-promote when the parents
         # actually finish. See RCA at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        if undone:
+        if not _parents_satisfied(conn, task_id):
             conn.execute(
                 "UPDATE tasks SET status = 'todo' "
                 "WHERE id = ? AND status = 'ready'",
@@ -2670,13 +2670,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         # if parents are still in progress the task must wait in 'todo'
         # until recompute_ready picks it up. RCA: Bug 2 at
         # kanban/boards/cookai/workspaces/t_a6acd07d/root-cause.md.
-        undone_parents = conn.execute(
-            "SELECT 1 FROM task_links l "
-            "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
-            (task_id,),
-        ).fetchone()
-        new_status = "todo" if undone_parents else "ready"
+        new_status = "ready" if _parents_satisfied(conn, task_id) else "todo"
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL "
             "WHERE id = ? AND status = 'blocked'",

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -712,9 +712,7 @@ def _set_status_direct(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
-            ):
+            if not kanban_db._parents_satisfied(conn, task_id):
                 return False
 
         was_running = prev["status"] == "running"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -103,6 +103,17 @@ def test_link_keeps_ready_child_when_parent_already_done(kanban_home):
         assert kb.get_task(conn, b).status == "ready"
 
 
+def test_link_keeps_ready_child_when_parent_archived(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        kb.complete_task(conn, a)
+        assert kb.archive_task(conn, a)
+        b = kb.create_task(conn, title="b")
+        assert kb.get_task(conn, b).status == "ready"
+        kb.link_tasks(conn, a, b)
+        assert kb.get_task(conn, b).status == "ready"
+
+
 def test_link_rejects_self_loop(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")
@@ -492,6 +503,23 @@ def test_unblock_without_parents_goes_to_ready(kanban_home):
         assert kb.block_task(conn, t, reason="need input")
         assert kb.unblock_task(conn, t)
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_unblock_with_archived_parent_goes_to_ready(kanban_home):
+    """Archived parents count as satisfied when reviving a blocked child."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        kb.complete_task(conn, parent, result="ok")
+        assert kb.archive_task(conn, parent)
+        conn.execute(
+            "UPDATE tasks SET status='blocked' WHERE id=?", (child,),
+        )
+        conn.commit()
+        assert kb.unblock_task(conn, child)
+        assert kb.get_task(conn, child).status == "ready"
 
 
 def test_assign_refuses_while_running(kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -270,6 +270,34 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     assert child_after["status"] == "ready"
 
 
+def test_patch_drag_drop_move_todo_to_ready_with_archived_parent(client):
+    """Archived parents count as satisfied in the dashboard ready path too."""
+    parent = client.post("/api/plugins/kanban/tasks", json={"title": "p"}).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "c", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "todo"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done"},
+    )
+    assert r.status_code == 200
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "archived"},
+    )
+    assert r.status_code == 200
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"status": "ready"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task"]["status"] == "ready"
+
+
 def test_patch_reassign(client):
     t = client.post(
         "/api/plugins/kanban/tasks",


### PR DESCRIPTION
## Summary

This fixes an inconsistency in Kanban dependency handling where archived parent tasks were not treated as satisfied in every ready-transition path.

Hermes already treated `done` and `archived` parents as satisfied in some places, but a few lifecycle paths still checked for `done` only. That caused child tasks to be incorrectly kept in `todo` / `blocked` states or rejected by the dashboard when they should have been allowed to move to `ready`.

## What changed

- Added a shared dependency helper in `hermes_cli/kanban_db.py` so parent satisfaction uses one rule everywhere.
- Updated `link_tasks()` to avoid demoting a ready child when the newly linked parent is already archived.
- Updated `unblock_task()` so a blocked child with archived parents returns to `ready` instead of `todo`.
- Updated the dashboard direct status path to allow `status=ready` when all parents are `done` or `archived`.

## Why this is correct

The board already considers archived dependencies satisfied in other code paths such as ready recomputation and claim gating. This change aligns the remaining transitions with that existing invariant instead of introducing new behavior.

## Tests

Passed targeted regressions:

- `tests/hermes_cli/test_kanban_db.py -k "archived or unblock or link_keeps_ready_child_when_parent_already_done"`
- `tests/plugins/test_kanban_dashboard_plugin.py -k "drag_drop_move_todo_to_ready"`

Added coverage for:

- linking an archived parent to a ready child
- unblocking a child whose parent is archived
- dashboard drag-drop / PATCH to `ready` with an archived parent
