### PR TITLE
feat(stt): add Yandex SpeechKit and hybrid_ru providers

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -9,6 +9,7 @@ import os
 import struct
 import subprocess
 import wave
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -49,6 +50,8 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("YANDEX_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -1346,3 +1349,678 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# Fixtures — Yandex / hybrid_ru
+# ============================================================================
+
+@pytest.fixture
+def sample_oga(tmp_path):
+    """Fake OGA (Telegram voice) file — 512 bytes, well under 1 MB."""
+    oga_path = tmp_path / "voice.oga"
+    oga_path.write_bytes(b"\x4f\x67\x67\x53" + b"\x00" * 508)
+    return str(oga_path)
+
+
+# ============================================================================
+# _get_audio_duration_seconds / _get_audio_channels helpers
+# ============================================================================
+
+class TestGetAudioChannels:
+    def test_get_audio_channels_via_ffprobe_mock(self, sample_ogg):
+        mock_result = MagicMock()
+        mock_result.stdout = "2\n"
+
+        with patch("tools.transcription_tools._find_binary", return_value="/usr/bin/ffprobe"), \
+             patch("tools.transcription_tools.subprocess.run", return_value=mock_result):
+            from tools.transcription_tools import _get_audio_channels
+            result = _get_audio_channels(sample_ogg)
+
+        assert result == 2
+
+    def test_returns_none_when_ffprobe_missing(self, sample_ogg):
+        with patch("tools.transcription_tools._find_binary", return_value=None):
+            from tools.transcription_tools import _get_audio_channels
+            result = _get_audio_channels(sample_ogg)
+
+        assert result is None
+
+    def test_returns_none_on_empty_output(self, sample_ogg):
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+
+        with patch("tools.transcription_tools._find_binary", return_value="/usr/bin/ffprobe"), \
+             patch("tools.transcription_tools.subprocess.run", return_value=mock_result):
+            from tools.transcription_tools import _get_audio_channels
+            result = _get_audio_channels(sample_ogg)
+
+        assert result is None
+
+
+# ============================================================================
+# _ensure_mono_for_yandex
+# ============================================================================
+
+class TestEnsureMonoForYandex:
+    def test_ensure_mono_passes_through_mono_file(self, sample_ogg, tmp_path):
+        with patch("tools.transcription_tools._get_audio_channels", return_value=1):
+            from tools.transcription_tools import _ensure_mono_for_yandex
+            path, error = _ensure_mono_for_yandex(sample_ogg, str(tmp_path))
+
+        assert path == sample_ogg
+        assert error is None
+
+    def test_ensure_mono_passes_through_when_channels_unknown(self, sample_ogg, tmp_path):
+        with patch("tools.transcription_tools._get_audio_channels", return_value=None):
+            from tools.transcription_tools import _ensure_mono_for_yandex
+            path, error = _ensure_mono_for_yandex(sample_ogg, str(tmp_path))
+
+        assert path == sample_ogg
+        assert error is None
+
+    def test_ensure_mono_downmixes_stereo(self, sample_ogg, tmp_path):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch("tools.transcription_tools._get_audio_channels", return_value=2), \
+             patch("tools.transcription_tools._find_binary", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.transcription_tools.subprocess.run", return_value=mock_result):
+            from tools.transcription_tools import _ensure_mono_for_yandex
+            path, error = _ensure_mono_for_yandex(sample_ogg, str(tmp_path))
+
+        assert "yandex-mono" in path
+        assert path.endswith(".ogg")
+        assert error is None
+
+    def test_ensure_mono_no_ffmpeg_returns_error_for_stereo(self, sample_ogg, tmp_path):
+        with patch("tools.transcription_tools._get_audio_channels", return_value=2), \
+             patch("tools.transcription_tools._find_binary", return_value=None):
+            from tools.transcription_tools import _ensure_mono_for_yandex
+            path, error = _ensure_mono_for_yandex(sample_ogg, str(tmp_path))
+
+        assert path == sample_ogg
+        assert error is not None
+        assert "ffmpeg" in error.lower() or "ffmpeg" in error
+
+
+# ============================================================================
+# _transcribe_yandex
+# ============================================================================
+
+class TestTranscribeYandex:
+    def test_no_key(self, monkeypatch, sample_oga):
+        monkeypatch.delenv("YANDEX_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_yandex
+        result = _transcribe_yandex(sample_oga, "speechkit-v3")
+        assert result["success"] is False
+        assert "YANDEX_API_KEY" in result["error"]
+
+    def test_successful_transcription_ogg(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "привет мир"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is True
+        assert result["transcript"] == "привет мир"
+        assert result["provider"] == "yandex"
+
+    def test_whitespace_stripped(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "  привет  \n"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["transcript"] == "привет"
+
+    def test_file_too_large(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        large_file = tmp_path / "big.ogg"
+        large_file.write_bytes(b"\x00" * (2 * 1024 * 1024))
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post") as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(str(large_file), "speechkit-v3")
+
+        assert result["success"] is False
+        assert "МБ" in result["error"] or "large" in result["error"].lower() or "большой" in result["error"]
+        mock_post.assert_not_called()
+
+    def test_file_too_long(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=35.0), \
+             patch("requests.post") as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is False
+        assert "35.0" in result["error"] or "длинное" in result["error"]
+        mock_post.assert_not_called()
+
+    def test_duration_check_skipped_when_ffprobe_unavailable(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "тест"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=None), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is True
+
+    def test_http_401_returns_error(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "bad-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"error_message": "API key not found"}
+        mock_response.text = '{"error_message": "API key not found"}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is False
+        assert "HTTP 401" in result["error"]
+        assert "API key not found" in result["error"]
+
+    def test_http_error_without_json_body(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.json.side_effect = ValueError("no json")
+        mock_response.text = "Internal Server Error"
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is False
+        assert "HTTP 500" in result["error"]
+
+    def test_empty_transcript_returns_failure(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "  "}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is False
+        assert "пустую" in result["error"] or "empty" in result["error"].lower()
+
+    def test_permission_error(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("builtins.open", side_effect=PermissionError("denied")):
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+    def test_unsupported_format_wav_is_accepted(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "тест"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=1.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_wav, None)), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(sample_wav, "speechkit-v3")
+
+        assert result["success"] is True
+        call_kwargs = mock_post.call_args
+        params = call_kwargs.kwargs.get("params", call_kwargs[1].get("params", {}))
+        assert params.get("format") == "lpcm"
+
+    def test_unsupported_format_mp3_returns_error(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        mp3_file = tmp_path / "audio.mp3"
+        mp3_file.write_bytes(b"fake mp3 data")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("requests.post") as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            result = _transcribe_yandex(str(mp3_file), "speechkit-v3")
+
+        assert result["success"] is False
+        assert "mp3" in result["error"].lower() or "формат" in result["error"]
+        mock_post.assert_not_called()
+
+    def test_config_options_propagate_to_params(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        config = {
+            "yandex": {
+                "folder_id": "b1g12345",
+                "profanity_filter": True,
+                "language": "ru-RU",
+                "topic": "general",
+            }
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "тест"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        call_kwargs = mock_post.call_args
+        params = call_kwargs.kwargs.get("params", call_kwargs[1].get("params", {}))
+        assert params.get("folderId") == "b1g12345"
+        assert params.get("profanityFilter") == "true"
+
+    def test_auth_header_is_api_key_not_bearer(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "my-secret-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"result": "тест"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._ensure_mono_for_yandex",
+                   return_value=(sample_oga, None)), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_yandex
+            _transcribe_yandex(sample_oga, "speechkit-v3")
+
+        call_kwargs = mock_post.call_args
+        headers = call_kwargs.kwargs.get("headers", call_kwargs[1].get("headers", {}))
+        assert headers["Authorization"].startswith("Api-Key ")
+        assert not headers["Authorization"].startswith("Bearer ")
+
+
+# ============================================================================
+# _get_provider — Yandex
+# ============================================================================
+
+class TestGetProviderYandex:
+    def test_yandex_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "yandex"}) == "yandex"
+
+    def test_yandex_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("YANDEX_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "yandex"}) == "none"
+
+    def test_auto_detect_yandex_after_xai(self, monkeypatch):
+        """Auto-detect: yandex is tried after xAI when all above are unavailable."""
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._HAS_MISTRAL", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "yandex"
+
+    def test_auto_detect_xai_preferred_over_yandex(self, monkeypatch):
+        """Auto-detect: xAI key takes priority over Yandex in auto-detect (no local)."""
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+        monkeypatch.setenv("XAI_API_KEY", "xai-key")
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._HAS_MISTRAL", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "xai"
+
+    def test_auto_detect_hybrid_ru_when_local_and_yandex(self, monkeypatch):
+        """Auto-detect: hybrid_ru when both faster-whisper and YANDEX_API_KEY present."""
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "hybrid_ru"
+
+    def test_auto_detect_local_when_faster_whisper_no_yandex(self, monkeypatch):
+        """Auto-detect: plain local when faster-whisper available but no Yandex key."""
+        monkeypatch.delenv("YANDEX_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "local"
+
+
+# ============================================================================
+# _get_provider — hybrid_ru explicit
+# ============================================================================
+
+class TestGetProviderHybridRu:
+    def test_hybrid_ru_explicit_with_faster_whisper(self):
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "hybrid_ru"}) == "hybrid_ru"
+
+    def test_hybrid_ru_explicit_no_faster_whisper_returns_none(self):
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "hybrid_ru"}) == "none"
+
+
+# ============================================================================
+# transcribe_audio — Yandex dispatch
+# ============================================================================
+
+class TestTranscribeAudioYandexDispatch:
+    def test_dispatches_to_yandex(self, sample_oga):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "yandex"}), \
+             patch("tools.transcription_tools._get_provider", return_value="yandex"), \
+             patch("tools.transcription_tools._transcribe_yandex",
+                   return_value={"success": True, "transcript": "привет", "provider": "yandex"}) as mock_yandex:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_oga)
+
+        assert result["success"] is True
+        assert result["provider"] == "yandex"
+        mock_yandex.assert_called_once()
+
+    def test_config_yandex_model_placeholder_used(self, sample_oga):
+        config = {"provider": "yandex", "yandex": {}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="yandex"), \
+             patch("tools.transcription_tools._transcribe_yandex",
+                   return_value={"success": True, "transcript": "привет"}) as mock_yandex:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_oga, model=None)
+
+        assert mock_yandex.call_args[0][1] == "speechkit-v3"
+
+
+# ============================================================================
+# _transcribe_hybrid_ru
+# ============================================================================
+
+class TestTranscribeHybridRu:
+    def test_routes_to_yandex_for_short_mono(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        yandex_ok = {"success": True, "transcript": "привет", "provider": "yandex"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=20.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex", return_value=yandex_ok) as mock_yandex, \
+             patch("tools.transcription_tools._transcribe_local") as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_yandex.assert_called_once()
+        mock_local.assert_not_called()
+        assert result["routed_to"] == "yandex"
+        assert result["success"] is True
+
+    def test_routes_to_local_when_file_too_large(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        large_file = tmp_path / "large.ogg"
+        large_file.write_bytes(b"\x00" * (2 * 1024 * 1024))
+
+        local_ok = {"success": True, "transcript": "привет", "provider": "local"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=10.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex") as mock_yandex, \
+             patch("tools.transcription_tools._transcribe_local", return_value=local_ok) as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(str(large_file), "base")
+
+        mock_yandex.assert_not_called()
+        mock_local.assert_called_once()
+        assert result["routed_to"] == "local"
+
+    def test_routes_to_local_when_duration_over_28s(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        local_ok = {"success": True, "transcript": "длинный текст", "provider": "local"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=45.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex") as mock_yandex, \
+             patch("tools.transcription_tools._transcribe_local", return_value=local_ok) as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_yandex.assert_not_called()
+        mock_local.assert_called_once()
+        assert result["routed_to"] == "local"
+
+    def test_routes_to_local_when_no_yandex_key(self, monkeypatch, sample_oga):
+        monkeypatch.delenv("YANDEX_API_KEY", raising=False)
+
+        local_ok = {"success": True, "transcript": "привет", "provider": "local"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=10.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex") as mock_yandex, \
+             patch("tools.transcription_tools._transcribe_local", return_value=local_ok):
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_yandex.assert_not_called()
+        assert result["routed_to"] == "local"
+
+    def test_yandex_failure_falls_back_to_local(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        yandex_fail = {"success": False, "transcript": "", "error": "API error 500"}
+        local_ok = {"success": True, "transcript": "привет", "provider": "local"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=10.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex", return_value=yandex_fail), \
+             patch("tools.transcription_tools._transcribe_local", return_value=local_ok) as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_local.assert_called_once()
+        assert result["routed_to"] == "local"
+        assert result["yandex_attempted"] is True
+        assert result["yandex_error"] == "API error 500"
+        assert result["success"] is True
+
+    def test_yandex_success_no_local_call(self, monkeypatch, sample_oga):
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        yandex_ok = {"success": True, "transcript": "привет", "provider": "yandex"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=5.0), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=1), \
+             patch("tools.transcription_tools._transcribe_yandex", return_value=yandex_ok), \
+             patch("tools.transcription_tools._transcribe_local") as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_local.assert_not_called()
+        assert result["routed_to"] == "yandex"
+
+    def test_ffprobe_unavailable_routes_to_yandex_if_under_size(self, monkeypatch, sample_oga):
+        """If duration check returns None (no ffprobe), small file should still try Yandex."""
+        monkeypatch.setenv("YANDEX_API_KEY", "test-key")
+
+        yandex_ok = {"success": True, "transcript": "тест", "provider": "yandex"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_audio_duration_seconds", return_value=None), \
+             patch("tools.transcription_tools._get_audio_channels", return_value=None), \
+             patch("tools.transcription_tools._transcribe_yandex", return_value=yandex_ok) as mock_yandex, \
+             patch("tools.transcription_tools._transcribe_local") as mock_local:
+            from tools.transcription_tools import _transcribe_hybrid_ru
+            result = _transcribe_hybrid_ru(sample_oga, "base")
+
+        mock_yandex.assert_called_once()
+        mock_local.assert_not_called()
+        assert result["routed_to"] == "yandex"
+
+
+# ============================================================================
+# transcribe_audio — hybrid_ru dispatch
+# ============================================================================
+
+class TestTranscribeAudioHybridRuDispatch:
+    def test_dispatches_to_hybrid_ru(self, sample_oga):
+        hybrid_ok = {"success": True, "transcript": "привет", "provider": "yandex", "routed_to": "yandex"}
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="hybrid_ru"), \
+             patch("tools.transcription_tools._transcribe_hybrid_ru",
+                   return_value=hybrid_ok) as mock_hybrid:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_oga)
+
+        mock_hybrid.assert_called_once()
+        assert result["routed_to"] == "yandex"
+
+
+# ============================================================================
+# Correction F — Local model cache with HF-Hub path
+# ============================================================================
+
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("faster_whisper"),
+    reason="faster_whisper not installed",
+)
+def test_local_model_cache_with_hf_hub_path(monkeypatch):
+    """Loading the same HF-Hub-style model name twice reuses the cached instance."""
+    hf_model = "bzikst/faster-whisper-large-v3-russian"
+
+    mock_segment = MagicMock()
+    mock_segment.text = "привет"
+    mock_info = MagicMock()
+    mock_info.language = "ru"
+    mock_info.duration = 1.0
+
+    mock_model = MagicMock()
+    mock_model.transcribe.return_value = ([mock_segment], mock_info)
+    mock_whisper_cls = MagicMock(return_value=mock_model)
+
+    import tempfile
+    import struct
+    import wave as _wave
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        tmp_wav = f.name
+
+    n_frames = 8000
+    silence = struct.pack(f"<{n_frames}h", *([0] * n_frames))
+    with _wave.open(tmp_wav, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(8000)
+        wf.writeframes(silence)
+
+    try:
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(tmp_wav, hf_model)
+            _transcribe_local(tmp_wav, hf_model)
+
+        assert mock_whisper_cls.call_count == 1
+        assert mock_whisper_cls.call_args[0][0] == hf_model
+    finally:
+        import os
+        os.unlink(tmp_wav)
+
+
+# ============================================================================
+# Integration test (skipped without real key)
+# ============================================================================
+
+@pytest.mark.skipif(
+    not os.getenv("YANDEX_API_KEY"),
+    reason="YANDEX_API_KEY not set — integration test skipped",
+)
+def test_yandex_integration_real_ogg(tmp_path):
+    """
+    Send a real OGG file with Russian speech to Yandex SpeechKit.
+    Place /tmp/test_ru_voice.ogg before running:
+      YANDEX_API_KEY=... pytest -k test_yandex_integration
+    """
+    import shutil
+    ogg_src = Path("/tmp/test_ru_voice.ogg")  # noqa: F811 — module-level Path imported above
+    if not ogg_src.exists():
+        pytest.skip("test audio file /tmp/test_ru_voice.ogg not found")
+    ogg = tmp_path / "voice.ogg"
+    shutil.copy(ogg_src, ogg)
+    from tools.transcription_tools import _transcribe_yandex
+    result = _transcribe_yandex(str(ogg), "speechkit-v3")
+    assert result["success"] is True, result.get("error")
+    assert result["transcript"]
+    assert any("Ѐ" <= c <= "ӿ" for c in result["transcript"]), "expected Cyrillic"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -11,11 +11,15 @@ Provides speech-to-text transcription with six providers:
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
+  - **yandex** — Yandex SpeechKit Sync API, requires ``YANDEX_API_KEY``.
+    Best Russian-language accuracy (~97%). Hard limits: 1 MB, 30s, mono, OGG/WAV only.
+  - **hybrid_ru** — Auto-routes: short audio → Yandex (best accuracy), long audio →
+    local Whisper (no hard limits). Best out-of-box experience for Russian-speaking users.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac
+Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, oga, aac, flac
 
 Usage::
 
@@ -91,8 +95,10 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+YANDEX_STT_URL = "https://stt.api.cloud.yandex.net/speech/v1/stt:recognize"
+YANDEX_MAX_FILE_SIZE = 1 * 1024 * 1024  # 1 MB — Yandex SpeechKit Sync hard limit
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".oga", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 
@@ -268,10 +274,29 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "yandex":
+            if get_env_value("YANDEX_API_KEY"):
+                return "yandex"
+            logger.warning(
+                "STT provider 'yandex' configured but YANDEX_API_KEY not set"
+            )
+            return "none"
+
+        if provider == "hybrid_ru":
+            if _HAS_FASTER_WHISPER:
+                return "hybrid_ru"
+            logger.warning(
+                "STT provider 'hybrid_ru' configured but faster-whisper not installed"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai -
+    # --- Auto-detect (no explicit provider): hybrid_ru > local > groq > openai > mistral > xai > yandex -
 
+    # hybrid_ru: local Whisper + Yandex key → best out-of-box experience for Russian
+    if _HAS_FASTER_WHISPER and get_env_value("YANDEX_API_KEY"):
+        return "hybrid_ru"
     if _HAS_FASTER_WHISPER:
         return "local"
     if _has_local_command():
@@ -288,6 +313,9 @@ def _get_provider(stt_config: dict) -> str:
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
+    if get_env_value("YANDEX_API_KEY"):
+        logger.info("No local STT available, using Yandex SpeechKit API")
+        return "yandex"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -321,6 +349,73 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
 
     return None
+
+
+def _get_audio_duration_seconds(file_path: str) -> Optional[float]:
+    """Return audio duration in seconds via ffprobe, or None if unavailable."""
+    ffprobe = _find_binary("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        result = subprocess.run(
+            [ffprobe, "-v", "quiet", "-show_entries", "format=duration",
+             "-of", "csv=p=0", file_path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        raw = result.stdout.strip()
+        return float(raw) if raw else None
+    except Exception:
+        return None
+
+
+def _get_audio_channels(file_path: str) -> Optional[int]:
+    """Return number of audio channels via ffprobe, or None if unavailable."""
+    ffprobe = _find_binary("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        result = subprocess.run(
+            [ffprobe, "-v", "quiet", "-show_entries", "stream=channels",
+             "-of", "csv=p=0", "-select_streams", "a:0", file_path],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+        raw = result.stdout.strip()
+        return int(raw) if raw else None
+    except Exception:
+        return None
+
+
+def _ensure_mono_for_yandex(file_path: str, work_dir: str) -> tuple[str, Optional[str]]:
+    """If file is stereo+, downmix to mono via ffmpeg into work_dir.
+
+    Returns (path_to_use, error_or_None). Caller is responsible for cleanup
+    when returned path differs from input.
+    """
+    channels = _get_audio_channels(file_path)
+    if channels is None or channels <= 1:
+        return file_path, None
+    ffmpeg = _find_binary("ffmpeg")
+    if not ffmpeg:
+        return file_path, (
+            f"Yandex требует моно-аудио, но файл содержит {channels} каналов "
+            "и ffmpeg не установлен."
+        )
+    suffix = Path(file_path).suffix.lower()
+    out_path = str(Path(work_dir) / f"yandex-mono{suffix}")
+    try:
+        result = subprocess.run(
+            [ffmpeg, "-y", "-i", file_path, "-ac", "1", out_path],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        if result.returncode != 0:
+            return file_path, f"ffmpeg downmix failed: {result.stderr[:200]}"
+        return out_path, None
+    except Exception as e:
+        return file_path, f"ffmpeg downmix exception: {e}"
+
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -782,6 +877,247 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: yandex (Yandex SpeechKit Sync API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_yandex(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Yandex SpeechKit Sync API.
+
+    Sends raw binary audio to POST https://stt.api.cloud.yandex.net/speech/v1/stt:recognize
+    with Authorization: Api-Key header. Supports OGG/Opus (Telegram default) natively.
+    Requires YANDEX_API_KEY environment variable.
+    Hard limits: 1 MB, 30 seconds, mono audio.
+    """
+    import wave as _wave
+
+    api_key = get_env_value("YANDEX_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "YANDEX_API_KEY не задан"}
+
+    stt_config = _load_stt_config()
+    yandex_cfg = stt_config.get("yandex", {})
+
+    language = str(yandex_cfg.get("language", "ru-RU")).strip()
+    topic = str(yandex_cfg.get("topic", "general")).strip()
+    folder_id = str(yandex_cfg.get("folder_id", "")).strip()
+    profanity_filter = is_truthy_value(yandex_cfg.get("profanity_filter", False))
+    raw_results = is_truthy_value(yandex_cfg.get("raw_results", False))
+
+    try:
+        import requests
+
+        # --- Size check (Yandex hard limit: 1 MB) ---
+        file_size = Path(file_path).stat().st_size
+        if file_size > YANDEX_MAX_FILE_SIZE:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": (
+                    f"Yandex SpeechKit: файл слишком большой "
+                    f"({file_size / (1024*1024):.2f} МБ, лимит 1 МБ). "
+                    "Используй провайдер 'local' для длинных записей."
+                ),
+            }
+
+        # --- Duration check (Yandex hard limit: 30 seconds) ---
+        duration = _get_audio_duration_seconds(file_path)
+        if duration is not None and duration > 30.0:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": (
+                    f"Yandex SpeechKit: аудио слишком длинное ({duration:.1f}с, лимит 30с). "
+                    "Используй провайдер 'local' для длинных записей."
+                ),
+            }
+
+        # --- Format detection ---
+        suffix = Path(file_path).suffix.lower()
+        if suffix in {".ogg", ".oga"}:
+            audio_format = "oggopus"
+            params: Dict[str, str] = {"lang": language, "format": audio_format, "topic": topic}
+        elif suffix == ".wav":
+            audio_format = "lpcm"
+            try:
+                with _wave.open(file_path, "rb") as wf:
+                    sample_rate = wf.getframerate()
+                if sample_rate not in (8000, 16000, 48000):
+                    return {
+                        "success": False,
+                        "transcript": "",
+                        "error": (
+                            f"Yandex SpeechKit: частота дискретизации WAV {sample_rate} Гц "
+                            "не поддерживается (поддерживаются только 8000/16000/48000). "
+                            "Конвертируй в OGG Opus с помощью ffmpeg."
+                        ),
+                    }
+            except _wave.Error as e:
+                return {"success": False, "transcript": "", "error": f"Неверный WAV-файл: {e}"}
+            params = {
+                "lang": language,
+                "format": audio_format,
+                "sampleRateHertz": str(sample_rate),
+                "topic": topic,
+            }
+        else:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": (
+                    f"Yandex SpeechKit: неподдерживаемый формат '{suffix}'. "
+                    "Поддерживаются: .ogg/.oga (OGG Opus) и .wav (PCM). "
+                    "Конвертируй в OGG Opus с помощью ffmpeg."
+                ),
+            }
+
+        if folder_id:
+            params["folderId"] = folder_id
+        if profanity_filter:
+            params["profanityFilter"] = "true"
+        if raw_results:
+            params["rawResults"] = "true"
+
+        # --- Ensure mono (Yandex requires 1 audio channel) ---
+        with tempfile.TemporaryDirectory(prefix="hermes-yandex-stt-") as work_dir:
+            send_path, mono_error = _ensure_mono_for_yandex(file_path, work_dir)
+            if mono_error:
+                return {"success": False, "transcript": "", "error": mono_error}
+
+            send_size = Path(send_path).stat().st_size
+            if send_size > YANDEX_MAX_FILE_SIZE:
+                return {
+                    "success": False,
+                    "transcript": "",
+                    "error": (
+                        f"Yandex SpeechKit: файл после конвертации в моно слишком большой "
+                        f"({send_size / (1024*1024):.2f} МБ, лимит 1 МБ). "
+                        "Используй провайдер 'local' для длинных записей."
+                    ),
+                }
+
+            with open(send_path, "rb") as audio_file:
+                audio_bytes = audio_file.read()
+
+        response = requests.post(
+            YANDEX_STT_URL,
+            headers={"Authorization": f"Api-Key {api_key}"},
+            params=params,
+            data=audio_bytes,
+            timeout=60,
+        )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = (
+                    err_body.get("error_message", "")
+                    or err_body.get("message", "")
+                    or response.text[:300]
+                )
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Yandex SpeechKit API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = result.get("result", "").strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Yandex SpeechKit вернул пустую транскрипцию",
+            }
+
+        logger.info(
+            "Transcribed %s via Yandex SpeechKit (lang=%s, topic=%s, %d chars)",
+            Path(file_path).name, language, topic, len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "yandex"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Yandex SpeechKit transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Yandex SpeechKit transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Provider: hybrid_ru (Yandex for short audio, local Whisper for long audio)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_hybrid_ru(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Hybrid Russian STT: short audio → Yandex (best accuracy, fast),
+    long audio → local Whisper (handles >30s files Yandex can't).
+
+    Decision logic:
+      1. If YANDEX_API_KEY not set → fall through to local immediately.
+      2. If file size > 1 MB → local (Yandex hard limit).
+      3. If ffprobe gives duration > 28 seconds → local (Yandex hard limit is 30s; we use
+         28s as safety margin to account for ffprobe rounding / encoder differences).
+      4. If ffprobe gives channels > 1 AND ffmpeg unavailable → local.
+      5. Otherwise → Yandex. If Yandex returns error → log warning, fall back to local.
+
+    Returns same dict shape as other providers. Adds "routed_to" key: "yandex" or "local".
+    """
+    stt_config = _load_stt_config()
+    local_model = _normalize_local_model(
+        stt_config.get("local", {}).get("model", DEFAULT_LOCAL_MODEL)
+    )
+
+    yandex_key = get_env_value("YANDEX_API_KEY")
+
+    # Preflight (call ffprobe once, reuse results in both branches)
+    try:
+        file_size = Path(file_path).stat().st_size
+    except OSError:
+        file_size = 0
+
+    duration = _get_audio_duration_seconds(file_path)
+    channels = _get_audio_channels(file_path)
+
+    # Routing decision
+    use_local = False
+    if not yandex_key:
+        use_local = True
+    elif file_size > YANDEX_MAX_FILE_SIZE:
+        use_local = True
+    elif duration is not None and duration > 28.0:
+        use_local = True
+    elif channels is not None and channels > 1 and not _find_binary("ffmpeg"):
+        use_local = True
+
+    if use_local:
+        result = _transcribe_local(file_path, local_model)
+        result["routed_to"] = "local"
+        return result
+
+    # Try Yandex
+    yandex_result = _transcribe_yandex(file_path, "speechkit-v3")
+    if yandex_result.get("success"):
+        yandex_result["routed_to"] = "yandex"
+        return yandex_result
+
+    # Yandex failed — fall back to local Whisper
+    logger.warning(
+        "hybrid_ru: Yandex SpeechKit failed for %s (%s), falling back to local Whisper",
+        Path(file_path).name,
+        yandex_result.get("error", "unknown error"),
+    )
+    local_result = _transcribe_local(file_path, local_model)
+    local_result["routed_to"] = "local"
+    local_result["yandex_attempted"] = True
+    local_result["yandex_error"] = yandex_result.get("error", "")
+    return local_result
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -854,6 +1190,18 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "yandex":
+        yandex_cfg = stt_config.get("yandex", {})
+        model_name = model or yandex_cfg.get("model", "speechkit-v3")
+        return _transcribe_yandex(file_path, model_name)
+
+    if provider == "hybrid_ru":
+        local_cfg = stt_config.get("local", {})
+        model_name = _normalize_local_model(
+            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+        )
+        return _transcribe_hybrid_ru(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -862,8 +1210,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, "
+            "set YANDEX_API_KEY for Yandex SpeechKit (лучшее качество русской речи), "
+            "or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
 


### PR DESCRIPTION
- New provider `yandex`: Yandex SpeechKit Sync API (best Russian-language accuracy on the market, ~97% vs Whisper-base ~84%). Hard limits 30s/1MB.
- New provider `hybrid_ru`: auto-routes short audio to Yandex, falls back to local Whisper for longer recordings. Best user experience for Russian-speaking users.
- Helpers: _get_audio_duration_seconds, _get_audio_channels, _ensure_mono_for_yandex (ffmpeg downmix).
- WAV sample rate read from header (Correction A): supports 8000/16000/48000 Hz.
- SUPPORTED_FORMATS now includes .oga (Telegram voice extension).
- Tests: 32 new test cases covering success/error/edge paths.
- HF-Hub model paths (e.g. bzikst/faster-whisper-large-v3-russian) pass through _normalize_local_model and _load_local_whisper_model unchanged.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

