### PR TITLE
feat(feishu): per-chat channel_prompts and AI @-mention syntax

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -138,6 +138,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    resolve_channel_prompt,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -1166,6 +1167,27 @@ def _unique_lines(lines: List[str]) -> List[str]:
         seen.add(line)
         unique.append(line)
     return unique
+
+
+# ---------------------------------------------------------------------------
+# Channel prompt composition
+# ---------------------------------------------------------------------------
+
+
+_FEISHU_AT_TUTORIAL = (
+    'To @-mention someone in this Feishu chat: '
+    '<at user_id="ou_xxx">Name</at> (Name optional)'
+)
+
+
+def _compose_channel_prompt_for_chat(
+    extra: Dict[str, Any],
+    chat_id: str,
+) -> str:
+    configured = resolve_channel_prompt(extra, chat_id) or ""
+    if configured:
+        return f"{configured}\n\n{_FEISHU_AT_TUTORIAL}"
+    return _FEISHU_AT_TUTORIAL
 
 
 # ---------------------------------------------------------------------------
@@ -2980,6 +3002,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
+            channel_prompt=_compose_channel_prompt_for_chat(self.config.extra, chat_id),
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4353,9 +4353,11 @@ class TestFeishuExtractMessageContent(unittest.TestCase):
 
 class TestFeishuProcessInboundMessage(unittest.TestCase):
     def _build_adapter(self):
+        from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = PlatformConfig()
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
@@ -4643,9 +4645,11 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
     """High-level scenarios from the design spec — verify the full pipeline."""
 
     def _build_adapter(self):
+        from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter.__new__(FeishuAdapter)
+        adapter.config = PlatformConfig()
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"

--- a/tests/gateway/test_feishu_channel_prompts.py
+++ b/tests/gateway/test_feishu_channel_prompts.py
@@ -1,0 +1,154 @@
+"""Tests for Feishu per-chat ephemeral channel_prompts.
+
+These tests lock down two contracts:
+
+1. ``gateway.platforms.base.resolve_channel_prompt`` works for
+   Feishu-shaped ``open_chat_id`` keys (``oc_…``) when called with the
+   adapter's ``config.extra`` dict.
+2. ``gateway.platforms.feishu.FeishuAdapter._process_inbound_message``
+   populates ``MessageEvent.channel_prompt`` from the resolved value.
+
+We do not duplicate the resolver's full unit-test surface (already
+covered indirectly by ``test_discord_channel_prompts.py``); we only
+pin down the Feishu key shape and the integration site.
+"""
+
+import asyncio
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.platforms.base import resolve_channel_prompt
+
+
+class TestResolveChannelPromptForFeishu:
+    """The shared resolver works for Feishu's ``oc_…`` chat_id namespace."""
+
+    def test_no_channel_prompts_returns_none(self):
+        assert resolve_channel_prompt({}, "oc_test", None) is None
+
+    def test_match_by_chat_id(self):
+        extra = {"channel_prompts": {"oc_research": "Research mode"}}
+        assert resolve_channel_prompt(extra, "oc_research", None) == "Research mode"
+
+    def test_blank_prompt_treated_as_absent(self):
+        extra = {"channel_prompts": {"oc_research": "   "}}
+        assert resolve_channel_prompt(extra, "oc_research", None) is None
+
+
+class TestComposeChannelPromptWithAtTutorial:
+    """``_compose_channel_prompt_for_chat`` appends the @-syntax tutorial after the configured prompt."""
+
+    def test_no_configured_prompt_returns_tutorial_only(self):
+        from gateway.platforms.feishu import (
+            _FEISHU_AT_TUTORIAL,
+            _compose_channel_prompt_for_chat,
+        )
+
+        assert _compose_channel_prompt_for_chat({}, "oc_test") == _FEISHU_AT_TUTORIAL
+
+    def test_configured_prompt_appears_before_tutorial(self):
+        from gateway.platforms.feishu import (
+            _FEISHU_AT_TUTORIAL,
+            _compose_channel_prompt_for_chat,
+        )
+
+        result = _compose_channel_prompt_for_chat(
+            {"channel_prompts": {"oc_test": "Persona X"}}, "oc_test"
+        )
+        assert result == f"Persona X\n\n{_FEISHU_AT_TUTORIAL}"
+
+    def test_blank_configured_prompt_treated_as_absent(self):
+        from gateway.platforms.feishu import (
+            _FEISHU_AT_TUTORIAL,
+            _compose_channel_prompt_for_chat,
+        )
+
+        result = _compose_channel_prompt_for_chat(
+            {"channel_prompts": {"oc_test": "   "}}, "oc_test"
+        )
+        assert result == _FEISHU_AT_TUTORIAL
+
+
+class TestInboundMessageCarriesChannelPrompt(unittest.TestCase):
+    """``_process_inbound_message`` must populate ``MessageEvent.channel_prompt``
+    from ``self.config.extra['channel_prompts']`` keyed by ``chat_id``.
+    """
+
+    def _make_adapter_with_extra(self, extra: dict):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig()
+        config.extra = extra
+        adapter = FeishuAdapter(config)
+
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_test", "name": "Feishu Test", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "Tester", "user_id_alt": None}
+        )
+        return adapter
+
+    def _make_message(self, chat_id: str = "oc_test"):
+        return SimpleNamespace(
+            chat_id=chat_id,
+            thread_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            root_id=None,
+            message_type="text",
+            content='{"text":"hello"}',
+            message_id="om_msg_1",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_inbound_event_carries_channel_prompt_when_chat_id_matches(self):
+        from gateway.platforms.feishu import _FEISHU_AT_TUTORIAL
+
+        adapter = self._make_adapter_with_extra(
+            {"channel_prompts": {"oc_test": "Persona X"}}
+        )
+        message = self._make_message(chat_id="oc_test")
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_msg_1",
+            )
+        )
+
+        adapter._dispatch_inbound_event.assert_awaited_once()
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.channel_prompt, f"Persona X\n\n{_FEISHU_AT_TUTORIAL}")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_inbound_event_channel_prompt_is_tutorial_only_when_chat_id_unknown(self):
+        from gateway.platforms.feishu import _FEISHU_AT_TUTORIAL
+
+        adapter = self._make_adapter_with_extra(
+            {"channel_prompts": {"oc_other": "Persona X"}}
+        )
+        message = self._make_message(chat_id="oc_test")
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_msg_1",
+            )
+        )
+
+        adapter._dispatch_inbound_event.assert_awaited_once()
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.channel_prompt, _FEISHU_AT_TUTORIAL)

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -431,6 +431,20 @@ platforms:
 | Reconnect interval | `ws_reconnect_interval` | 120s | How long to wait between reconnection attempts |
 | Ping interval | `ws_ping_interval` | _(SDK default)_ | Frequency of WebSocket keepalive pings |
 
+## Per-Chat Channel Prompts
+
+Configure per-chat ephemeral system prompts via `channel_prompts`, keyed by `open_chat_id` (`oc_xxx`):
+
+```yaml
+platforms:
+  feishu:
+    channel_prompts:
+      "oc_research_chat_id": "Research mode — cite sources, be concise."
+      "oc_casual_chat_id": "Relaxed tone, short replies."
+```
+
+Hermes also auto-appends an @-mention syntax hint so the agent can write `<at user_id="ou_xxx">Name</at>` correctly. No extra configuration needed.
+
 ## Per-Group Access Control
 
 Beyond the global `FEISHU_GROUP_POLICY`, you can set fine-grained rules per group chat using `group_rules` in config.yaml:


### PR DESCRIPTION
## What does this PR do?

Wires Feishu into the cross-platform `channel_prompts` pipeline already used by Discord/Slack/Telegram/Mattermost, and teaches the agent the right Feishu @-mention syntax so its replies actually ping users.

Two pieces:
1. **Per-`open_chat_id` channel prompts** — operators can configure ephemeral system prompts keyed by Feishu `oc_xxx` chat IDs in gateway yaml, exactly like other platforms.
2. **`<at user_id="ou_xxx">` syntax hint** — every composed channel_prompt is appended with a short rule teaching the model to emit Feishu's mention XML instead of plain `@Name` (which doesn't notify in Feishu). Inbound `open_id`s already reach the model via the existing `[Mentioned: ...]` hint from `_build_mention_hint` — this PR only supplies the output syntax rule.

Server-side `@Name` resolution and `<at>` tag validation are intentionally deferred to follow-up work.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — resolve `channel_prompts` by `open_chat_id`; append the Feishu `<at user_id="ou_xxx">Name</at>` syntax hint to the composed prompt; surface it through `MessageEvent.channel_prompt`
- `tests/gateway/test_feishu_channel_prompts.py` — 8 new tests covering resolver contracts for `oc_xxx` keys, channel_prompt composition (tutorial appended after configured prompt), and inbound `MessageEvent.channel_prompt` integration
- `tests/gateway/test_feishu.py` — minor additions to keep existing assertions consistent with the new prompt path
- `website/docs/user-guide/messaging/feishu.md` — user-facing docs for per-chat prompts and the mention syntax behavior

## How to Test

1. `pytest tests/gateway/test_feishu_channel_prompts.py -q` — all 8 tests pass
2. `pytest tests/gateway/ -q -k feishu` — adjacent Feishu suites still green
3. Manual: configure `channel_prompts` for an `oc_xxx` chat in gateway yaml, run the gateway, ask the bot in that Feishu group to ping a member — verify the reply contains `<at user_id="ou_…">` and Feishu fires the mention notification

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- pre-existing failures on `main` (Windows footgun in `tools/process_registry.py`, `/new` reset_session in e2e, vision/provider tests) are unrelated to this PR — they reproduce on `main` HEAD -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/messaging/feishu.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (reuses existing `channel_prompts` schema)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string/dict logic, no OS-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_feishu_channel_prompts.py -q
........                                                                  [100%]
8 passed
```
