### PR TITLE
fix(cli): make kanban specify max_tokens configurable

### DIFF
--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -40,6 +40,11 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 
+HERMES_KANBAN_SPECIFY_MAX_TOKENS = max(
+    1500,
+    int(os.getenv("HERMES_KANBAN_SPECIFY_MAX_TOKENS", "6000")),
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -185,7 +190,7 @@ def specify_task(
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
-            max_tokens=1500,
+            max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
             timeout=timeout or 120,
         )
     except Exception as exc:
@@ -198,7 +203,7 @@ def specify_task(
         )
 
     try:
-        raw = resp.choices[0].message.content or ""
+        raw = (resp.choices[0].message.content or "").strip()
     except Exception:
         raw = ""
 


### PR DESCRIPTION
## What

Make Kanban Specify use a configurable token budget instead of a hardcoded 1500.

### Changes
- add HERMES_KANBAN_SPECIFY_MAX_TOKENS
- replace hardcoded max_tokens=1500 with the configurable value
- the default token budget increases from 1500 to 6000
- trim assistant content before parsing

## Why

When using reasoning/thinking models behind an OpenAI-compatible backend, 1500 tokens may be too low for Specify. Reasoning-capable Hermes-family models and similar backends can spend a large part of the completion budget on internal reasoning before producing the final assistant content.

In my reproduction with LM Studio:
- Specify sent a completion request with max_tokens=1500
- the response ended with inish_reason: ""length""
- nearly the entire completion budget was consumed by reasoning tokens
- choices[0].message.content ended up empty or unusable on the Hermes side

Raising the available token budget resolved the failure in my local deployment, so making this value configurable seemed like the smallest useful upstream fix.

## Default behavior

This change increases the default Specify completion budget from 1500 to 6000.

HERMES_KANBAN_SPECIFY_MAX_TOKENS can be used to override the value, but anything below 1500 is clamped to 1500.

## Related

- Related to #9344
- Similar reasoning-model compatibility precedent: #13211
- Similar empty-content bug family: #2128
- Similar assistant-empty-content transport issue: #11906

## Testing

Tested manually with:
- Hermes Agent in Docker on WSL2
- LM Studio OpenAI-compatible endpoint
- a reasoning/thinking model (qwen3.6-35b-a3b)
- Kanban dashboard Specify flow
- I also verified in the running hermes-dashboard container that the kanban_specify.py token-budget constant was applied in the live file during debugging of this issue.

How to test:
1. Configure Hermes to use an OpenAI-compatible reasoning model backend.
2. Create or open a Kanban task in the Triage column.
3. Trigger Specify for the task.
4. Verify that Specify succeeds with the default token budget, or with a custom HERMES_KANBAN_SPECIFY_MAX_TOKENS override.
5. Optionally set HERMES_KANBAN_SPECIFY_MAX_TOKENS=1500 and confirm the previous failure mode is easier to reproduce with long reasoning responses.

### Before

Specify could fail after the model exhausted the completion budget in reasoning and returned empty assistant content.

### After

- Specify can use a larger token budget via HERMES_KANBAN_SPECIFY_MAX_TOKENS
- the default token budget increases from 1500 to 6000
- configured values below 1500 are clamped to 1500
- reasoning-model users can increase the budget without patching source code

manual testing only; pytest not run