### PR TITLE
feat(web_server): opt-in dashboard session token persistence

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -68,10 +68,49 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).
-# Generated fresh on every server start — dies when the process exits.
-# Injected into the SPA HTML so only the legitimate web UI can use it.
+#
+# Default: generated fresh on every server start — dies when the process
+# exits. Injected into the SPA HTML so only the legitimate web UI can use it.
+#
+# Opt-in persistence: set ``HERMES_DASHBOARD_SESSION_TOKEN_FILE=<path>`` to
+# read/write the token from disk. Useful when a second container (workspace
+# UI, reverse proxy, sidecar) needs a stable token across dashboard
+# restarts — restarting the dashboard otherwise invalidates any token that
+# another process has cached at start-up. The token file is created with
+# mode 0600 when written.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = secrets.token_urlsafe(32)
+def _load_or_create_session_token() -> str:
+    token_file_path = os.getenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", "").strip()
+    if not token_file_path:
+        return secrets.token_urlsafe(32)
+    token_file = Path(token_file_path)
+    try:
+        if token_file.exists():
+            existing = token_file.read_text().strip()
+            if existing:
+                return existing
+            # File present but empty — regenerate and overwrite below.
+        token = secrets.token_urlsafe(32)
+        token_file.parent.mkdir(parents=True, exist_ok=True)
+        token_file.write_text(token)
+        try:
+            token_file.chmod(0o600)
+        except (OSError, NotImplementedError):
+            # chmod isn't supported on every filesystem (e.g. some Windows
+            # setups). The token still works; just not 0600.
+            pass
+        return token
+    except OSError as exc:
+        _log.warning(
+            "HERMES_DASHBOARD_SESSION_TOKEN_FILE=%s could not be read/written "
+            "(%s); falling back to ephemeral random token for this process.",
+            token_file_path,
+            exc,
+        )
+        return secrets.token_urlsafe(32)
+
+
+_SESSION_TOKEN = _load_or_create_session_token()
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2324,3 +2324,95 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+# ---------------------------------------------------------------------------
+# _load_or_create_session_token tests (opt-in token persistence)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrCreateSessionToken:
+    """Tests for `_load_or_create_session_token` — controlled by
+    HERMES_DASHBOARD_SESSION_TOKEN_FILE."""
+
+    def _import_fn(self):
+        # Imported lazily so the env var is read at call time, not import.
+        from hermes_cli.web_server import _load_or_create_session_token
+        return _load_or_create_session_token
+
+    def test_returns_random_when_env_unset(self, monkeypatch):
+        """Default behavior: no env var → fresh random token each call."""
+        monkeypatch.delenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", raising=False)
+        fn = self._import_fn()
+        a = fn()
+        b = fn()
+        assert a and b and len(a) >= 32 and len(b) >= 32
+        assert a != b  # randomness check
+
+    def test_returns_random_when_env_empty_string(self, monkeypatch):
+        """Empty string treated the same as unset."""
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", "   ")
+        fn = self._import_fn()
+        a = fn()
+        b = fn()
+        assert a != b
+
+    def test_creates_file_when_missing(self, tmp_path, monkeypatch):
+        """First call with env var pointing at a missing file: generate +
+        write, then return the same token on subsequent calls."""
+        token_file = tmp_path / "subdir" / "dashboard.token"
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", str(token_file))
+        fn = self._import_fn()
+        a = fn()
+        assert token_file.exists()
+        assert token_file.read_text().strip() == a
+        b = fn()
+        assert a == b  # persistence: same token returned
+
+    def test_reads_existing_file(self, tmp_path, monkeypatch):
+        """Existing non-empty file: read and return its contents (no rewrite)."""
+        token_file = tmp_path / "dashboard.token"
+        token_file.write_text("pre-existing-token-value\n")
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", str(token_file))
+        fn = self._import_fn()
+        assert fn() == "pre-existing-token-value"
+
+    def test_regenerates_when_file_empty(self, tmp_path, monkeypatch):
+        """Empty file: generate fresh token, overwrite."""
+        token_file = tmp_path / "dashboard.token"
+        token_file.write_text("")
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", str(token_file))
+        fn = self._import_fn()
+        token = fn()
+        assert token
+        assert token_file.read_text().strip() == token
+
+    def test_file_mode_is_0600(self, tmp_path, monkeypatch):
+        """Created token file should be owner-only (0600)."""
+        if os.name != "posix":
+            pytest.skip("file mode check only meaningful on POSIX")
+        token_file = tmp_path / "dashboard.token"
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN_FILE", str(token_file))
+        fn = self._import_fn()
+        fn()
+        assert oct(token_file.stat().st_mode & 0o777) == "0o600"
+
+    def test_falls_back_on_unwritable_path(self, tmp_path, monkeypatch):
+        """If the target path is unwritable, fall back to ephemeral token
+        rather than crashing the dashboard."""
+        if os.name != "posix":
+            pytest.skip("permission semantics differ on non-POSIX")
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o500)
+        try:
+            token_file = readonly_dir / "dashboard.token"
+            monkeypatch.setenv(
+                "HERMES_DASHBOARD_SESSION_TOKEN_FILE", str(token_file)
+            )
+            fn = self._import_fn()
+            token = fn()
+            assert token and len(token) >= 32
+            assert not token_file.exists()
+        finally:
+            readonly_dir.chmod(0o700)  # let pytest clean up


### PR DESCRIPTION
## Summary

Adds a new `HERMES_DASHBOARD_SESSION_TOKEN_FILE` environment variable that lets the dashboard's session token be read from / written to a file on disk instead of being regenerated on every process start. Opt-in — default behavior is unchanged.

## Motivation

Today, `_SESSION_TOKEN` in `hermes_cli/web_server.py` is generated by `secrets.token_urlsafe(32)` at module load. Any process that consumes the dashboard's API has to read the token at its own start (typically from the injected `window.__HERMES_SESSION_TOKEN__` or from a shared env var), and that cached value silently goes stale on every dashboard restart.

This is fine for the standard single-process / solo-dev case. It surfaces as a real outage in multi-container deployments where the dashboard can restart independently of its consumers — for example:

- Dashboard runs in its own container alongside a separate workspace UI / reverse proxy / sidecar
- Dashboard container is killed by OOM, recycled by an orchestrator, or rebuilt during an upgrade
- All consumer processes that cached the previous token now get **401 Unauthorized** on every subsequent call until they too are restarted

The failure mode is silent (just a flashing auth banner / 401 logs) and recovery requires manually restarting every dependent container even though only the dashboard moved. Persisting the token through a file on a shared volume eliminates the cascade.

## Design

Single new env var: `HERMES_DASHBOARD_SESSION_TOKEN_FILE`

- **Unset (default)** — exactly today's behavior: fresh random token on every start.
- **Set to a path** — read the file on start; if it doesn't exist (or is empty), generate a fresh random token, create the file with mode `0600`, and write the token. Subsequent dashboard restarts read the same token from disk.
- **Path unwritable / unreadable** — log a warning and fall back to ephemeral random token, so a misconfigured path can't bring the dashboard down.

A new helper `_load_or_create_session_token()` encapsulates the logic; `_SESSION_TOKEN` simply calls it. No other module changes.

## Backward compatibility

Fully backward-compatible. Users who don't set the env var see no change. The new env var name is unambiguous and consistent with the existing `HERMES_*` prefix (also matches the `_DASHBOARD_*` naming convention already used on the dashboard surface).

## Tests

7 new tests in `tests/hermes_cli/test_web_server.py::TestLoadOrCreateSessionToken`:

- `test_returns_random_when_env_unset` — confirms default behavior unchanged
- `test_returns_random_when_env_empty_string` — empty/whitespace treated as unset
- `test_creates_file_when_missing` — first call creates parent dirs and persists
- `test_reads_existing_file` — second call returns the persisted token
- `test_regenerates_when_file_empty` — defensive: empty file → regenerate + overwrite
- `test_file_mode_is_0600` — POSIX-only assertion on file mode
- `test_falls_back_on_unwritable_path` — graceful degradation, no crash

All 7 pass locally (`uv run pytest tests/hermes_cli/test_web_server.py::TestLoadOrCreateSessionToken`).

## Out of scope

- No change to how the token is consumed (HTML injection / `X-Hermes-Session-Token` header / Authorization Bearer fallback all unchanged).
- No change to ephemeral default — this is purely additive opt-in.
- Docs PR will follow separately if this design is accepted.