### PR TITLE
fix(bluebubbles): use 127.0.0.1 literal for loopback webhook URL

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -223,8 +223,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
+        # Use 127.0.0.1 literal for loopback so BlueBubbles dials IPv4
+        # directly. The previous "localhost" rewrite caused ECONNREFUSED
+        # on macOS where Node's getaddrinfo returns ::1 first but our
+        # listener binds only to 127.0.0.1.
+        if host in ("0.0.0.0", "localhost", "::", "::1"):
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property


### PR DESCRIPTION
## Summary

When running the BlueBubbles adapter on macOS, the gateway registers a webhook URL with the BlueBubbles server so it can receive `new-message` events. The current code rewrites a `127.0.0.1` host config to `"localhost"` before registering:

```python
# gateway/platforms/bluebubbles.py — _webhook_url
if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
    host = "localhost"
return f"http://{host}:{self.webhook_port}{self.webhook_path}"
```

On macOS, Node's `getaddrinfo` resolves `localhost` to `::1` (IPv6) first, but Hermes's aiohttp webhook listener binds only to `127.0.0.1` (IPv4). Every dispatch fails:

```
[WebhookService] Failed to dispatch "new-message" event to webhook:
  http://localhost:8645/bluebubbles-webhook?password=...
  -> Error: connect ECONNREFUSED ::1:8645
```

No inbound iMessage ever reaches the gateway, with zero log noise on the Hermes side (the listener never gets a connection).

## Fix

Keep `127.0.0.1` literal so BlueBubbles dials IPv4 directly. Also add `::1` and `::` to the rewrite-source set so explicit IPv6 loopback configs are normalized to the same working URL.

## Reproduction (before fix)

1. macOS 26.3 / Apple Silicon, BlueBubbles Server 1.x, Hermes gateway with bluebubbles platform configured (defaults: `BLUEBUBBLES_WEBHOOK_HOST=127.0.0.1`, port 8645).
2. Start the gateway → BlueBubbles log shows `Dispatching event to webhook: http://localhost:8645/...` followed by `connect ECONNREFUSED ::1:8645` for every inbound message.
3. No `inbound message:` line ever appears in `~/.hermes/logs/gateway.log`.

## Verification (after fix)

End-to-end test on the same macOS 26.3 Apple Silicon machine:

```
13:22:22 inbound message: platform=bluebubbles user=+1XXXXXXXXXX msg='ping hermes'
13:22:31 response ready: platform=bluebubbles time=9.2s api_calls=1
13:22:31 [Bluebubbles] Sending response (47 chars) to any;-;+1XXXXXXXXXX
```

Sender received Hermes's reply on the originating Google Voice number. BlueBubbles log no longer shows ECONNREFUSED.

## Risk

- Linux + WSL2: `localhost` already resolves to `127.0.0.1` first via `/etc/hosts`, so behavior is unchanged.
- Windows: same — `localhost` is `127.0.0.1` per the hosts file.
- macOS: behavior changes from broken to working.
- The registered webhook URL is now an IPv4 literal regardless of host config aliasing — slightly more explicit, no functional downside.

## Test Plan
- [x] Manual end-to-end iMessage round-trip on macOS 26.3
- [ ] No automated tests exist for the registered URL string; happy to add one if reviewers want it