### PR TITLE
fix(email): preserve Gmail threading metadata

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -265,11 +265,15 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
-            return {
+            target = {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
+            subject = origin.get("chat_topic") or origin.get("subject")
+            if subject:
+                target["subject"] = subject
+            return target
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
@@ -322,11 +326,15 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),
             "thread_id": origin.get("thread_id"),
         }
+        subject = origin.get("chat_topic") or origin.get("subject")
+        if subject:
+            target["subject"] = subject
+        return target
 
     if not _is_known_delivery_platform(platform_name):
         return None
@@ -540,6 +548,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        subject = target.get("subject")
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -578,7 +587,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = None
+            if thread_id or subject:
+                send_metadata = {}
+                if thread_id:
+                    send_metadata["thread_id"] = thread_id
+                if subject:
+                    send_metadata["subject"] = subject
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -624,7 +639,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                email_subject=subject,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -634,7 +657,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            thread_id=thread_id,
+                            media_files=media_files,
+                            email_subject=subject,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -65,6 +65,73 @@ MAX_MESSAGE_LENGTH = 50_000
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
+
+def _split_msg_ids(value: str) -> List[str]:
+    """Extract RFC Message-ID tokens from a References/In-Reply-To header."""
+    if not value:
+        return []
+    # Message-IDs are angle-bracketed.  Fall back to whitespace tokens so tests
+    # and non-compliant clients still get deterministic threading metadata.
+    ids = re.findall(r"<[^>]+>", value)
+    if ids:
+        return ids
+    return [part for part in value.split() if part]
+
+
+def _normalize_email_subject(subject: str) -> str:
+    """Return a Gmail-threading-friendly base subject for Hermes replies.
+
+    Gmail is tolerant of a single ``Re:`` prefix, but large status text such as
+    ``Cronjob Response: ... (job_id: ...)`` in the subject makes replies split
+    into separate conversations.  Keep task/user subject text stable and put
+    operational details in the body instead.
+    """
+    subject = (subject or "Hermes Agent").strip() or "Hermes Agent"
+    # Collapse repeated reply/forward prefixes from common clients.
+    while True:
+        new = re.sub(r"^\s*(?:(?:re|fw|fwd)\s*:\s*)+", "", subject, flags=re.IGNORECASE).strip()
+        if new == subject:
+            break
+        subject = new
+    # Drop Hermes cron/system status suffixes that should live in the body.
+    subject = re.sub(r"\s*[-–—:]\s*Cronjob Response:.*$", "", subject, flags=re.IGNORECASE).strip()
+    subject = re.sub(r"\s*\(job_id:\s*[^)]*\)\s*$", "", subject, flags=re.IGNORECASE).strip()
+    return subject or "Hermes Agent"
+
+
+def _reply_subject(subject: str) -> str:
+    """Return a single Re: subject with the stable base subject."""
+    return f"Re: {_normalize_email_subject(subject)}"
+
+
+def _email_thread_root(message_id: str, in_reply_to: str = "", references: str = "") -> str:
+    """Choose a stable per-email-conversation key.
+
+    Use the first References id when present (root of the RFC thread), else the
+    first In-Reply-To id, else this message's id.  This lets Hermes keep
+    separate email conversations from the same sender isolated, and gives cron
+    origin delivery a reusable reply anchor.
+    """
+    ref_ids = _split_msg_ids(references)
+    if ref_ids:
+        return ref_ids[0]
+    reply_ids = _split_msg_ids(in_reply_to)
+    if reply_ids:
+        return reply_ids[0]
+    return message_id or ""
+
+
+def _append_unique_msg_id_chain(existing: str, *ids: str) -> str:
+    """Build a de-duplicated References header preserving existing order."""
+    out: List[str] = []
+    seen = set()
+    for value in (existing, *ids):
+        for msg_id in _split_msg_ids(value or ""):
+            if msg_id not in seen:
+                out.append(msg_id)
+                seen.add(msg_id)
+    return " ".join(out)
+
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
 
@@ -400,6 +467,7 @@ class EmailAdapter(BasePlatformAdapter):
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
+                    references = msg.get("References", "")
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
@@ -415,6 +483,7 @@ class EmailAdapter(BasePlatformAdapter):
                         "subject": subject,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
+                        "references": references,
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
@@ -473,11 +542,22 @@ class EmailAdapter(BasePlatformAdapter):
             if att["type"] == "image":
                 msg_type = MessageType.PHOTO
 
-        # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
-            "subject": subject,
-            "message_id": msg_data["message_id"],
+        # Store thread context for reply threading.  Key by sender + stable
+        # RFC thread root so two independent email conversations from the same
+        # user do not overwrite each other's subject/message-id.
+        references = msg_data.get("references", "")
+        message_id = msg_data["message_id"]
+        in_reply_to = msg_data.get("in_reply_to", "")
+        thread_id = _email_thread_root(message_id, in_reply_to, references)
+        ctx = {
+            "subject": _normalize_email_subject(subject),
+            "message_id": message_id,
+            "references": _append_unique_msg_id_chain(references, in_reply_to, message_id),
+            "thread_id": thread_id,
         }
+        self._thread_context[sender_addr] = ctx  # legacy fallback
+        if thread_id:
+            self._thread_context[f"{sender_addr}\0{thread_id}"] = ctx
 
         source = self.build_source(
             chat_id=sender_addr,
@@ -485,16 +565,19 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id or None,
+            chat_topic=ctx["subject"],
+            message_id=message_id or None,
         )
 
         event = MessageEvent(
             text=text or "(empty email)",
             message_type=msg_type,
             source=source,
-            message_id=msg_data["message_id"],
+            message_id=message_id,
             media_urls=media_urls,
             media_types=media_types,
-            reply_to_message_id=msg_data["in_reply_to"] or None,
+            reply_to_message_id=in_reply_to or None,
         )
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
@@ -511,7 +594,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, metadata
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -523,24 +606,36 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        # Thread context for reply.  Prefer explicit metadata thread_id (from
+        # the triggering email SessionSource / cron origin), then legacy
+        # per-sender context for backward compatibility.
+        metadata = metadata or {}
+        thread_id = metadata.get("thread_id")
+        ctx = {}
+        if thread_id:
+            ctx = self._thread_context.get(f"{to_addr}\0{thread_id}", {})
+        if not ctx:
+            ctx = self._thread_context.get(to_addr, {})
+        subject = _reply_subject(ctx.get("subject", metadata.get("subject") or "Hermes Agent"))
         msg["Subject"] = subject
 
-        # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        # Threading headers.  Gmail uses Message-ID/In-Reply-To/References plus
+        # stable subject/senders to decide conversation membership.  Keep the
+        # full References chain when we have it instead of replacing it with a
+        # single id.
+        original_msg_id = reply_to_msg_id or ctx.get("message_id") or thread_id
+        references = _append_unique_msg_id_chain(ctx.get("references", ""), original_msg_id or "")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            if references:
+                msg["References"] = references
 
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -433,11 +433,50 @@ class TestRoutingIntents:
 
         monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-111")
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "-222")
+        for env_name in (
+            "SLACK_HOME_CHANNEL",
+            "EMAIL_HOME_ADDRESS",
+            "SMS_HOME_NUMBER",
+            "MATRIX_HOME_ROOM",
+            "MATTERMOST_HOME_CHANNEL",
+            "HOMEASSISTANT_HOME_TARGET",
+            "DINGTALK_HOME_TARGET",
+            "WECOM_HOME_TARGET",
+            "WHATSAPP_HOME_NUMBER",
+            "SIGNAL_HOME_NUMBER",
+            "FEISHU_HOME_TARGET",
+            "WEIXIN_HOME_CHANNEL",
+            "QQBOT_HOME_CHANNEL",
+            "BLUEBUBBLES_HOME_TARGET",
+            "YUANBAO_HOME_TARGET",
+        ):
+            monkeypatch.delenv(env_name, raising=False)
 
         for token in ("ALL", "All", "all"):
             targets = _resolve_delivery_targets({"deliver": token, "origin": None})
             platforms = sorted(t["platform"].lower() for t in targets)
             assert platforms == ["discord", "telegram"], f"token={token!r} -> {platforms}"
+
+    def test_origin_email_target_preserves_thread_id_and_subject(self):
+        """Email-origin cron jobs carry RFC reply anchor and stable subject forward."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        targets = _resolve_delivery_targets({
+            "deliver": "origin",
+            "origin": {
+                "platform": "email",
+                "chat_id": "user@test.com",
+                "thread_id": "<root@test.com>",
+                "chat_topic": "处理邮箱问题",
+            },
+        })
+
+        assert targets == [{
+            "platform": "email",
+            "chat_id": "user@test.com",
+            "thread_id": "<root@test.com>",
+            "subject": "处理邮箱问题",
+        }]
 
 
 class TestDeliverResultWrapping:
@@ -490,6 +529,34 @@ class TestDeliverResultWrapping:
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
+
+    def test_email_origin_delivery_passes_subject_to_standalone_sender(self):
+        """Standalone email cron delivery should receive the origin subject for Gmail threading."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.EMAIL: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "email-job",
+                "name": "watchdog",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "email",
+                    "chat_id": "user@test.com",
+                    "thread_id": "<root@test.com>",
+                    "chat_topic": "处理邮箱问题",
+                },
+            }
+            _deliver_result(job, "Done.")
+
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs["thread_id"] == "<root@test.com>"
+        assert send_mock.call_args.kwargs["email_subject"] == "处理邮箱问题"
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -593,6 +593,56 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["Subject"], "Re: Project question")
             self.assertFalse(send_call["Subject"].startswith("Re: Re:"))
 
+    def test_reply_strips_cron_status_from_subject(self):
+        """Cron/job metadata belongs in the body, not the Gmail thread subject."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "处理邮箱问题 - Cronjob Response: MailArchive import milestone watchdog (job_id: abc)",
+            "message_id": "<original@test.com>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Progress update.", None)
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: 处理邮箱问题")
+            self.assertNotIn("Cronjob Response", send_call["Subject"])
+            self.assertNotIn("job_id", send_call["Subject"])
+
+    def test_thread_context_is_keyed_by_email_thread_root(self):
+        """Independent email threads from the same sender keep separate reply anchors."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com\0<root-a@test.com>"] = {
+            "subject": "Topic A",
+            "message_id": "<latest-a@test.com>",
+            "references": "<root-a@test.com> <latest-a@test.com>",
+        }
+        adapter._thread_context["user@test.com\0<root-b@test.com>"] = {
+            "subject": "Topic B",
+            "message_id": "<latest-b@test.com>",
+            "references": "<root-b@test.com> <latest-b@test.com>",
+        }
+        adapter._thread_context["user@test.com"] = adapter._thread_context["user@test.com\0<root-b@test.com>"]
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email(
+                "user@test.com",
+                "Reply to A.",
+                None,
+                metadata={"thread_id": "<root-a@test.com>"},
+            )
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Topic A")
+            self.assertEqual(send_call["In-Reply-To"], "<latest-a@test.com>")
+            self.assertEqual(send_call["References"], "<root-a@test.com> <latest-a@test.com>")
+
     def test_no_thread_context_uses_default_subject(self):
         """Without thread context, subject should be 'Re: Hermes Agent'."""
         adapter = self._make_adapter()
@@ -981,6 +1031,37 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertIn("Date", send_call)
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_send_email_tool_threads_with_stable_origin_subject(self):
+        """Standalone cron email delivery should keep RFC headers and subject stable."""
+        import asyncio
+        from tools.send_message_tool import _send_email
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "user@test.com",
+                    "Cronjob Response: watchdog\n(job_id: abc)\n\nDone",
+                    thread_id="<root@test.com>",
+                    subject="处理邮箱问题 - Cronjob Response: noisy (job_id: abc)",
+                )
+            )
+
+            self.assertTrue(result["success"])
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: 处理邮箱问题")
+            self.assertEqual(send_call["In-Reply-To"], "<root@test.com>")
+            self.assertEqual(send_call["References"], "<root@test.com>")
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -511,7 +511,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    email_subject=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -705,7 +714,13 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
-            result = await _send_email(pconfig.extra, chat_id, chunk)
+            result = await _send_email(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                subject=email_subject,
+            )
         elif platform == Platform.SMS:
             result = await _send_sms(pconfig.api_key, chat_id, chunk)
         elif platform == Platform.MATTERMOST:
@@ -1352,8 +1367,13 @@ async def _send_signal(extra, chat_id, message, media_files=None):
         return _error(f"Signal send failed: {e}")
 
 
-async def _send_email(extra, chat_id, message):
-    """Send via SMTP (one-shot, no persistent connection needed)."""
+async def _send_email(extra, chat_id, message, thread_id=None, subject=None):
+    """Send via SMTP (one-shot, no persistent connection needed).
+
+    When ``thread_id`` is an RFC Message-ID from an email-origin cron job, use
+    it as the reply anchor so Gmail can keep the delivery in the original
+    conversation instead of creating a new standalone "Hermes Agent" thread.
+    """
     import smtplib
     from email.mime.text import MIMEText
     from email.utils import formatdate
@@ -1373,7 +1393,17 @@ async def _send_email(extra, chat_id, message):
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        if subject:
+            try:
+                from gateway.platforms.email import _reply_subject
+                msg["Subject"] = _reply_subject(subject) if thread_id else str(subject)
+            except Exception:
+                msg["Subject"] = f"Re: {subject}" if thread_id else str(subject)
+        else:
+            msg["Subject"] = "Re: Hermes Agent" if thread_id else "Hermes Agent"
+        if thread_id:
+            msg["In-Reply-To"] = str(thread_id)
+            msg["References"] = str(thread_id)
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)


### PR DESCRIPTION
## Summary
- Preserve Gmail threading metadata (`Message-ID`, `In-Reply-To`, `References`) across email gateway messages.
- Propagate email thread metadata through gateway/cron delivery so Gmail replies stay in the intended conversation.
- Add regression coverage for email threading/session metadata behavior.

## Related work
- Related to #11185 / #11418, which address email thread-context clobbering when multiple messages from the same sender are in flight.
- Related to #11422, which proposes Gmail `X-GM-THRID`-based session keying.
- This PR is a narrower fix for preserving the inbound email threading headers through normal gateway replies, `send_message`, and cron-originated email delivery so replies land in the intended Gmail conversation.

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_email.py tests/cron/test_scheduler.py -q -o 'addopts='`
- Result: `186 passed`
