### PR TITLE
fix(agent): protect context compression from session interrupts

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -128,6 +128,42 @@ def _extract_url_query_params(url: str):
 # Module-level flag: only warn once per process about stale OPENAI_BASE_URL.
 _stale_base_url_warned = False
 
+# Thread-local flag set while an auxiliary call must survive a session-level
+# interrupt (e.g. context compression).  Compression is infrastructure that
+# protects conversation continuity: if it aborts mid-stream because a new
+# gateway message arrived, Hermes inserts a fallback marker and the middle
+# of the session is effectively lost from model context.  The next user
+# message is already queued by the gateway (`_pending_messages`) and will be
+# processed once compression returns, so deferring the interrupt is safe.
+# See https://github.com/NousResearch/hermes-agent/issues/23975.
+_aux_interrupt_protection = threading.local()
+
+
+def _is_interrupt_protected() -> bool:
+    return bool(getattr(_aux_interrupt_protection, "active", False))
+
+
+class _AuxInterruptProtection:
+    """Context manager that masks per-thread interrupt checks for the
+    duration of an auxiliary call.  Nests safely: inner ``with`` blocks
+    restore the outer state instead of clearing it unconditionally."""
+
+    def __init__(self, active: bool):
+        self._active = active
+        self._prev: Optional[bool] = None
+
+    def __enter__(self):
+        if self._active:
+            self._prev = bool(getattr(_aux_interrupt_protection, "active", False))
+            _aux_interrupt_protection.active = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._active:
+            _aux_interrupt_protection.active = bool(self._prev)
+        return False
+
+
 _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
@@ -757,6 +793,11 @@ class _CodexCompletionsAdapter:
             if deadline is not None and time.monotonic() >= deadline:
                 timed_out.set()
                 raise TimeoutError(_timeout_message())
+            # Auxiliary tasks marked as interrupt-protected (currently context
+            # compression) must complete atomically even if a new gateway
+            # message arrives mid-stream — see _AuxInterruptProtection.
+            if _is_interrupt_protected():
+                return
             try:
                 from tools.interrupt import is_interrupted
                 if is_interrupted():
@@ -4235,6 +4276,44 @@ def _validate_llm_response(response: Any, task: str = None) -> Any:
 
 
 def call_llm(
+    task: str = None,
+    *,
+    provider: str = None,
+    model: str = None,
+    base_url: str = None,
+    api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    messages: list,
+    temperature: float = None,
+    max_tokens: int = None,
+    tools: list = None,
+    timeout: float = None,
+    extra_body: dict = None,
+) -> Any:
+    """Synchronous LLM call entry point.
+
+    Wraps :func:`_call_llm_impl` with thread-local interrupt protection for
+    tasks that must complete atomically (currently ``compression``).  See
+    :class:`_AuxInterruptProtection` and issue #23975.
+    """
+    with _AuxInterruptProtection(active=(task == "compression")):
+        return _call_llm_impl(
+            task=task,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+            main_runtime=main_runtime,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            timeout=timeout,
+            extra_body=extra_body,
+        )
+
+
+def _call_llm_impl(
     task: str = None,
     *,
     provider: str = None,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2197,6 +2197,208 @@ class TestCodexAuxiliaryAdapterTimeout:
 
 
 # ---------------------------------------------------------------------------
+# Issue #23975 — gateway interrupts must not abort context compression
+# ---------------------------------------------------------------------------
+
+
+class TestCodexAuxiliaryCompressionInterruptProtection:
+    """Context compression must complete atomically even when a new gateway
+    message arrives mid-stream.  Without this, the Codex Responses stream is
+    aborted, Hermes inserts a fallback context marker, and the middle of the
+    conversation is effectively lost from model context."""
+
+    @staticmethod
+    def _make_streaming_client():
+        """Build a fake Codex client whose stream yields a single event."""
+        final = SimpleNamespace(
+            output=[SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="summary")],
+            )],
+            usage=None,
+        )
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.in_progress")
+
+            def get_final_response(self):
+                return final
+
+        return SimpleNamespace(responses=SimpleNamespace(stream=lambda **k: _Stream()))
+
+    def test_interrupt_during_stream_aborts_non_compression_call(self):
+        """Baseline: without protection, a thread-local interrupt aborts the
+        Codex Responses stream with InterruptedError (existing behavior)."""
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+        from tools.interrupt import set_interrupt
+
+        adapter = _CodexCompletionsAdapter(self._make_streaming_client(), "gpt-5.5")
+        set_interrupt(True)
+        try:
+            with pytest.raises(InterruptedError):
+                adapter.create(messages=[{"role": "user", "content": "x"}])
+        finally:
+            set_interrupt(False)
+
+    def test_interrupt_protection_masks_codex_stream_cancel(self):
+        """With protection active on this thread, _check_cancelled must NOT
+        raise InterruptedError even when the per-thread interrupt is set."""
+        from agent.auxiliary_client import (
+            _CodexCompletionsAdapter, _AuxInterruptProtection,
+        )
+        from tools.interrupt import set_interrupt
+
+        adapter = _CodexCompletionsAdapter(self._make_streaming_client(), "gpt-5.5")
+        set_interrupt(True)
+        try:
+            with _AuxInterruptProtection(active=True):
+                response = adapter.create(messages=[{"role": "user", "content": "x"}])
+        finally:
+            set_interrupt(False)
+
+        assert response.choices[0].message.content == "summary"
+
+    def test_protection_does_not_mask_timeout(self):
+        """Protection only suppresses the interrupt check; deadline enforcement
+        is independent and must still fire so a hung Codex stream doesn't sit
+        forever during compression."""
+        from agent.auxiliary_client import (
+            _CodexCompletionsAdapter, _AuxInterruptProtection,
+        )
+
+        class _SlowStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                for _ in range(5):
+                    time.sleep(0.03)
+                    yield SimpleNamespace(type="response.in_progress")
+
+            def get_final_response(self):
+                return SimpleNamespace(output=[], usage=None)
+
+        slow_client = SimpleNamespace(
+            responses=SimpleNamespace(stream=lambda **k: _SlowStream()),
+            close=lambda: None,
+        )
+        adapter = _CodexCompletionsAdapter(slow_client, "gpt-5.5")
+        with _AuxInterruptProtection(active=True), pytest.raises(TimeoutError):
+            adapter.create(
+                messages=[{"role": "user", "content": "x"}],
+                timeout=0.05,
+            )
+
+    def test_protection_is_thread_local_and_nests(self):
+        """The protection flag must not leak to other threads, and nested
+        ``with`` blocks must restore the outer state instead of unconditionally
+        clearing it."""
+        import threading as _threading
+        from agent.auxiliary_client import (
+            _AuxInterruptProtection, _is_interrupt_protected,
+        )
+
+        # Sibling thread sees its own (un-set) state.
+        sibling_saw = []
+        with _AuxInterruptProtection(active=True):
+            assert _is_interrupt_protected() is True
+
+            def _check():
+                sibling_saw.append(_is_interrupt_protected())
+
+            t = _threading.Thread(target=_check)
+            t.start()
+            t.join()
+
+            with _AuxInterruptProtection(active=True):
+                assert _is_interrupt_protected() is True
+            # Inner block exited; outer protection must still be active.
+            assert _is_interrupt_protected() is True
+
+        assert sibling_saw == [False]
+        assert _is_interrupt_protected() is False
+
+    def test_call_llm_enables_protection_for_compression_task(self):
+        """call_llm(task="compression", ...) must run the inner call with the
+        protection flag active so an interrupt landing mid-stream doesn't
+        abort the summary."""
+        from agent.auxiliary_client import call_llm, _is_interrupt_protected
+        from tools.interrupt import set_interrupt
+
+        observed = {}
+
+        def _fake_create(**kwargs):
+            observed["protected_during_call"] = _is_interrupt_protected()
+            return SimpleNamespace(choices=[SimpleNamespace(
+                message=SimpleNamespace(content="summary"),
+            )])
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.side_effect = _fake_create
+        fake_client.base_url = "https://example.test/v1/"
+
+        set_interrupt(True)
+        try:
+            with patch("agent.auxiliary_client._resolve_task_provider_model",
+                       return_value=("openai-codex", "m", None, None, None)), \
+                 patch("agent.auxiliary_client._get_cached_client",
+                       return_value=(fake_client, "m")), \
+                 patch("agent.auxiliary_client._build_call_kwargs",
+                       return_value={"model": "m", "messages": [{"role": "user", "content": "x"}]}):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "x"}],
+                )
+        finally:
+            set_interrupt(False)
+
+        assert observed["protected_during_call"] is True
+        # Flag is cleared once call_llm returns so it doesn't bleed into the
+        # next non-compression auxiliary call on this thread.
+        assert _is_interrupt_protected() is False
+
+    def test_call_llm_does_not_enable_protection_for_other_tasks(self):
+        """Non-compression auxiliary tasks (vision, web_extract, etc.) must
+        still observe interrupts so a user can cancel a long-running call."""
+        from agent.auxiliary_client import call_llm, _is_interrupt_protected
+
+        observed = {}
+
+        def _fake_create(**kwargs):
+            observed["protected_during_call"] = _is_interrupt_protected()
+            return SimpleNamespace(choices=[SimpleNamespace(
+                message=SimpleNamespace(content="ok"),
+            )])
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.side_effect = _fake_create
+        fake_client.base_url = "https://example.test/v1/"
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openrouter", "m", None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(fake_client, "m")), \
+             patch("agent.auxiliary_client._build_call_kwargs",
+                   return_value={"model": "m", "messages": [{"role": "user", "content": "x"}]}):
+            call_llm(
+                task="web_extract",
+                messages=[{"role": "user", "content": "x"}],
+            )
+
+        assert observed["protected_during_call"] is False
+
+
+# ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Context compression should not abort when a new gateway message arrives mid-stream.

## What changed and why
- Add a thread-local protection flag (`_AuxInterruptProtection`) in `agent/auxiliary_client.py` that masks `_CodexCompletionsAdapter._check_cancelled`'s `is_interrupted()` poll while it is active.
- `call_llm(task="compression", ...)` now wraps the inner implementation with that protection, so a new Telegram message or watch-pattern notification arriving while the summary is streaming no longer raises `InterruptedError` and forces Hermes to insert a fallback context marker.
- Timeouts and the existing close-on-timeout closer are unchanged: a genuinely hung Codex stream still cancels via the configured `auxiliary.compression.timeout`. The protection is scoped to the auxiliary call site only; other auxiliary tasks (`vision`, `web_extract`, etc.) continue to honor interrupts so users can still cancel long-running web extractions or vision lookups.
- The pending gateway message stays queued by the platform adapter in `_pending_messages` and is served as soon as compression returns, so the user-facing UX is unchanged except that the next turn now sees a real summary instead of the fallback marker.

## How to test
- `pytest tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryCompressionInterruptProtection -q` covers: baseline interrupt aborts the non-compression call, protection masks the interrupt during streaming, timeouts still fire under protection, the flag is thread-local and nests correctly, and `call_llm` enables protection only for `task="compression"`.
- `pytest tests/agent/test_context_compressor.py tests/agent/test_compress_focus.py tests/agent/test_context_compressor_summary_continuity.py tests/agent/test_auxiliary_main_first.py -q` to confirm no regressions in the compression flow.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #23975

<!-- autocontrib:worker-id=issue-new-590604eb kind=pr-open -->