### PR TITLE
fix(cron): resolve null model at fire time, fail fast on missing model

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1295,6 +1295,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
+        # Model resolution precedence: per-job override > HERMES_MODEL env >
+        # config.yaml ``model:`` (string or ``{default: ...}``). The per-job
+        # value is intentionally re-read from storage every tick so a
+        # ``cronjob action=update model=...`` after a failed run takes effect
+        # on the next tick — there is no in-memory cache.
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
@@ -1306,14 +1311,38 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _cfg = _expand_env_vars(_cfg)
-                _model_cfg = _cfg.get("model", {})
+                # ``model:`` may be a non-empty string, a dict like
+                # ``{default: ...}``, missing entirely, or explicitly null
+                # (``model: null`` after a clear). Coerce null/missing to {}
+                # so a falsy default never overwrites an already-resolved
+                # env value with ``None``.
+                _model_cfg = _cfg.get("model") or {}
                 if not job.get("model"):
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
-                        model = _model_cfg.get("default", model)
+                        _default = _model_cfg.get("default")
+                        if _default:
+                            model = _default
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+
+        # If nothing resolved — job has no model, env is empty, and config
+        # has no ``model.default`` — fail fast with an actionable error.
+        # Without this guard the empty string flows through to the provider
+        # which returns an opaque 400 (``model: String should have at least
+        # 1 character``); the operator then has to inspect jobs.json to
+        # realize the job was stored with ``model: null``. See #23979.
+        if not (isinstance(model, str) and model.strip()):
+            raise RuntimeError(
+                f"Cron job '{job_name}' has no model configured "
+                f"(job.model={job.get('model')!r}, "
+                f"HERMES_MODEL={os.getenv('HERMES_MODEL', '')!r}, "
+                "config.yaml model.default missing or empty). "
+                "Set a per-job model via "
+                "`cronjob action=update job_id=<id> model=<name>` or set a "
+                "default with `hermes model <name>`."
+            )
 
         # Apply IPv4 preference if configured.
         try:

--- a/tests/cron/conftest.py
+++ b/tests/cron/conftest.py
@@ -1,0 +1,21 @@
+"""Cron-test fixtures.
+
+Provides a default ``HERMES_MODEL`` for cron run_job tests so each one
+doesn't have to spell out a model. The global conftest blanks
+HERMES_MODEL hermetically; without this autouse fixture every cron test
+that exercises ``run_job`` would hit the fail-fast guard added in
+``cron/scheduler.py`` (see issue #23979) and have to be rewritten.
+
+Tests that specifically need ``HERMES_MODEL`` unset — model-resolution
+edge cases — call ``monkeypatch.delenv("HERMES_MODEL", raising=False)``
+inside the test, which overrides this fixture's value for that scope.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_cron_test_model(monkeypatch):
+    """Pin a default HERMES_MODEL so cron run_job tests have a resolvable model."""
+    monkeypatch.setenv("HERMES_MODEL", "test-cron-default-model")
+    yield

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1437,6 +1437,7 @@ class TestRunJobConfigEnvVarExpansion:
     def test_fallback_model_env_ref_in_config_yaml_is_expanded(self, tmp_path, monkeypatch):
         """${VAR} in config.yaml fallback_providers model: is expanded."""
         (tmp_path / "config.yaml").write_text(
+            "model: primary-model\n"
             "fallback_providers:\n"
             "  - provider: openrouter\n"
             "    model: ${_HERMES_TEST_CRON_FALLBACK}\n"
@@ -1491,6 +1492,159 @@ class TestRunJobConfigEnvVarExpansion:
         kwargs = mock_agent_cls.call_args.kwargs
         # Unresolved refs are kept verbatim — _expand_env_vars contract
         assert kwargs["model"] == "${_HERMES_TEST_CRON_UNSET_VAR}"
+
+
+class TestRunJobModelResolution:
+    """Verify defensive model resolution for jobs stored with ``model: null``.
+
+    Issue #23979: a cron job created without an explicit model is stored as
+    ``model: null``. At fire time the scheduler must:
+      1. fall back to ``HERMES_MODEL`` env if set,
+      2. else fall back to config.yaml ``model.default`` if set,
+      3. else fail fast with an actionable error — never let an empty string
+         reach the provider where it surfaces as an opaque 400.
+    """
+
+    _RUNTIME = {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+
+    def test_null_job_model_falls_back_to_env(self, tmp_path, monkeypatch):
+        """``model: null`` on the job uses HERMES_MODEL when set."""
+        (tmp_path / "config.yaml").write_text("")
+        monkeypatch.setenv("HERMES_MODEL", "env-model")
+
+        job = {"id": "null-model-job", "name": "null model", "prompt": "hi", "model": None}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.call_args.kwargs["model"] == "env-model"
+
+    def test_null_job_model_falls_back_to_config_default(self, tmp_path, monkeypatch):
+        """``model: null`` on the job uses config.yaml model.default when env is empty."""
+        (tmp_path / "config.yaml").write_text("model:\n  default: config-default-model\n")
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+
+        job = {"id": "cfg-default-job", "name": "cfg default", "prompt": "hi", "model": None}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert mock_agent_cls.call_args.kwargs["model"] == "config-default-model"
+
+    def test_explicit_null_model_block_in_config_does_not_overwrite_env(self, tmp_path, monkeypatch):
+        """``model: null`` in config.yaml must not overwrite a resolved HERMES_MODEL.
+
+        Regression: before #23979 the resolver coerced ``model: null`` to
+        ``{}`` only via the ``.get("model", {})`` default — which does not
+        fire when the key is present with a None value. The resolver then
+        skipped both branches and kept the env value, but a similar
+        ``model: {default: null}`` shape would call ``.get("default", model)``
+        which returns ``None`` and clobbered ``model``.
+        """
+        (tmp_path / "config.yaml").write_text("model:\n  default: null\n")
+        monkeypatch.setenv("HERMES_MODEL", "env-model")
+
+        job = {"id": "null-default-job", "name": "null default", "prompt": "hi", "model": None}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True
+        assert mock_agent_cls.call_args.kwargs["model"] == "env-model"
+
+    def test_no_model_anywhere_fails_with_actionable_error(self, tmp_path, monkeypatch):
+        """All three sources empty → fail fast with a clear message, not an opaque 400."""
+        (tmp_path / "config.yaml").write_text("")
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+
+        job = {"id": "no-model-job", "name": "no model anywhere", "prompt": "hi", "model": None}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, _, _, error = run_job(job)
+
+        assert success is False
+        assert error is not None
+        assert "no model configured" in error
+        # AIAgent must never be constructed with an empty model — that's
+        # precisely the bug we're guarding against.
+        mock_agent_cls.assert_not_called()
+
+    def test_job_model_update_takes_effect_on_next_run(self, tmp_path, monkeypatch):
+        """The per-job model is re-read every tick — no in-memory cache.
+
+        This is the property the original bug report asked for. We verify
+        it by calling run_job twice with the same job dict mutated between
+        calls, simulating the storage update flow.
+        """
+        (tmp_path / "config.yaml").write_text("")
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+
+        job = {"id": "updated-model-job", "name": "updated", "prompt": "hi", "model": "first-model"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            run_job(job)
+            assert mock_agent_cls.call_args.kwargs["model"] == "first-model"
+
+            job["model"] = "second-model"  # simulates jobs.json being rewritten
+            run_job(job)
+            assert mock_agent_cls.call_args.kwargs["model"] == "second-model"
 
 
 class TestRunJobSkillBacked:


### PR DESCRIPTION
Cron jobs created without an explicit `model` are stored as `model: null` and rely on `HERMES_MODEL` or `config.yaml`'s `model.default` at fire time. The runtime resolver had two gaps that let an empty string reach the provider, where it surfaced as an opaque `invalid_request_error: model: String should have at least 1 character`:

1. `model: null` in `config.yaml` was read via `.get("model", {})`, which returns the stored `None` (not the default `{}`) — neither branch fired, so a resolved env value was kept but a `model: {default: null}` shape silently overwrote `model` with `None`.
2. After resolution, an empty string was still passed to `AIAgent` and on to the API.

The original report attributes this to an in-memory cache holding the null model after a `cronjob action=update`. There is no cache: `load_jobs()` re-reads `jobs.json` every tick and `run_job` reads the per-job model from that fresh dict. The bug is resolution robustness, not invalidation — this PR documents that in a comment so the next reader doesn't go chasing the same wrong lead.

## What changed and why
- `cron/scheduler.py`: coerce `model: null` in `config.yaml` to `{}` (`_cfg.get("model") or {}`); skip overwriting a non-empty model with `model.default: null`; raise a clear `RuntimeError` before `AIAgent` is constructed when all three sources (per-job, env, config) are empty.
- The existing `run_job` `except Exception` handler routes the `RuntimeError` through the standard cron failure-delivery path, so the operator sees a `Cron job '<name>' has no model configured. Set ... or set ...` message in their delivery channel instead of the upstream API's opaque 400.
- `tests/cron/conftest.py`: new autouse fixture pins `HERMES_MODEL` for cron tests so each existing `run_job` test doesn't have to spell out a model under the new fail-fast guard. Model-resolution tests that need it unset call `monkeypatch.delenv("HERMES_MODEL")` to override.
- `tests/cron/test_scheduler.py`: new `TestRunJobModelResolution` class covers env-fallback, `model.default` fallback, `model.default: null` not clobbering env, the empty-everywhere fail-fast, and confirms a per-job model update on the second tick takes effect (no cache).

## How to test
- `pytest tests/cron/test_scheduler.py::TestRunJobModelResolution -q` — 5 new tests.
- `pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py -q` — 195 passing, no regressions.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #23979

<!-- autocontrib:worker-id=issue-new-d3e63c5e kind=pr-open -->