### PR TITLE
RAN-1447: Add Ryan Projects + Ideas dashboard

### DIFF
--- a/plugins/projects-ideas/dashboard/dist/index.js
+++ b/plugins/projects-ideas/dashboard/dist/index.js
@@ -1,0 +1,144 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+  const React = SDK.React;
+  const h = React.createElement;
+  const C = SDK.components || {};
+  const hooks = SDK.hooks || React;
+  const useEffect = hooks.useEffect;
+  const useMemo = hooks.useMemo;
+  const useState = hooks.useState;
+
+  const SECTION_ORDER = ["Active", "Waiting/Blocked", "Paused", "Ideas", "Archived / Parking Lot", "Standing Lanes"];
+  const STATUS_CLASS = {
+    active: "pi-status-active",
+    waiting: "pi-status-waiting",
+    blocked: "pi-status-waiting",
+    paused: "pi-status-paused",
+    idea: "pi-status-idea",
+    parking: "pi-status-archive",
+    archived: "pi-status-archive"
+  };
+
+  function apiFetch(path, options) {
+    const token = window.__HERMES_SESSION_TOKEN__ || "";
+    const headers = Object.assign({}, (options && options.headers) || {});
+    if (token) headers["X-Hermes-Session-Token"] = token;
+    return fetch("/api/plugins/projects-ideas" + path, Object.assign({ credentials: "same-origin", headers: headers }, options || {}))
+      .then(function (res) {
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      });
+  }
+
+  function CardShell(props) {
+    if (C.Card && C.CardContent) {
+      return h(C.Card, { className: props.className }, h(C.CardContent, { className: "pi-card-content" }, props.children));
+    }
+    return h("div", { className: "pi-card " + (props.className || "") }, props.children);
+  }
+
+  function Pill(props) {
+    if (C.Badge) return h(C.Badge, { className: props.className }, props.children);
+    return h("span", { className: "pi-pill " + (props.className || "") }, props.children);
+  }
+
+  function ProjectCard(props) {
+    const card = props.card;
+    const links = card.links || [];
+    return h(CardShell, { className: "pi-card " + (STATUS_CLASS[card.status] || "") },
+      h("div", { className: "pi-card-top" },
+        h("div", null,
+          h("div", { className: "pi-card-kicker" }, (card.kind || "card").replace("_", " ")),
+          h("h3", null, card.name)
+        ),
+        h(Pill, { className: "pi-priority pi-priority-" + card.priority }, card.priority || "normal")
+      ),
+      h("p", { className: "pi-summary" }, card.summary),
+      h("dl", { className: "pi-meta" },
+        h("div", null, h("dt", null, "Owner"), h("dd", null, card.owner || "—")),
+        h("div", null, h("dt", null, "Last activity"), h("dd", null, card.last_activity || "—")),
+        card.stage ? h("div", null, h("dt", null, "Stage"), h("dd", null, card.stage)) : null,
+        card.potential_value ? h("div", null, h("dt", null, "Potential"), h("dd", null, card.potential_value)) : null
+      ),
+      h("div", { className: "pi-next" }, h("strong", null, "Next meaningful action: "), card.next_action),
+      card.evidence ? h("p", { className: "pi-evidence" }, h("strong", null, "Evidence: "), card.evidence) : null,
+      card.signals && card.signals.length ? h("div", { className: "pi-signals" }, card.signals.slice(0, 5).map(function (s) { return h("span", { key: s }, s); })) : null,
+      links.length ? h("div", { className: "pi-links" }, links.map(function (link) {
+        return h("a", { key: link.label + link.url, href: link.url, target: link.url && link.url[0] === "/" ? undefined : "_blank", rel: "noreferrer" }, link.label);
+      })) : null
+    );
+  }
+
+  function ProjectsIdeasPage() {
+    const [data, setData] = useState(null);
+    const [filter, setFilter] = useState("all");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    function load(refresh) {
+      setLoading(true); setError(null);
+      apiFetch(refresh ? "/refresh" : "/snapshot", refresh ? { method: "POST" } : undefined)
+        .then(function (json) { setData(json); })
+        .catch(function (err) { setError(err.message || String(err)); })
+        .finally(function () { setLoading(false); });
+    }
+    useEffect(function () { load(false); }, []);
+
+    const cardsBySection = useMemo(function () {
+      const out = {};
+      SECTION_ORDER.forEach(function (s) { out[s] = []; });
+      ((data && data.cards) || []).forEach(function (card) {
+        if (filter !== "all" && card.kind !== filter && card.status !== filter) return;
+        const lane = card.lane || "Ideas";
+        (out[lane] || (out[lane] = [])).push(card);
+      });
+      return out;
+    }, [data, filter]);
+
+    if (loading && !data) return h("div", { className: "pi-page" }, h("div", { className: "pi-loading" }, "Loading Ryan's project portfolio…"));
+    if (error && !data) return h("div", { className: "pi-page" }, h("div", { className: "pi-error" }, "Could not load Projects + Ideas: " + error));
+
+    return h("div", { className: "pi-page" },
+      h("header", { className: "pi-hero" },
+        h("div", null,
+          h("p", { className: "pi-eyebrow" }, "Private command-center"),
+          h("h1", null, data.title || "Ryan Projects + Ideas"),
+          h("p", null, data.subtitle)
+        ),
+        h("div", { className: "pi-actions" },
+          h("button", { className: "pi-button", onClick: function () { load(true); }, disabled: loading }, loading ? "Refreshing…" : "Refresh from sources"),
+          h("span", { className: "pi-generated" }, data.generated_at ? "Updated " + new Date(data.generated_at * 1000).toLocaleString() : "")
+        )
+      ),
+      h("section", { className: "pi-review-note" },
+        h("strong", null, "What Ryan should notice: "),
+        "this is not another Linear board. Active work, standing workflows, raw ideas, and archived/parking-lot items live in separate scan lanes, each with one next meaningful action."
+      ),
+      h("section", { className: "pi-stats" }, SECTION_ORDER.map(function (section) {
+        return h("button", { key: section, className: "pi-stat", onClick: function () { setFilter("all"); } },
+          h("span", null, section), h("strong", null, ((data.counts || {})[section] || 0))
+        );
+      })),
+      h("div", { className: "pi-filters" }, ["all", "project", "standing_lane", "idea", "waiting", "paused", "parking"].map(function (v) {
+        return h("button", { key: v, className: filter === v ? "active" : "", onClick: function () { setFilter(v); } }, v.replace("_", " "));
+      })),
+      error ? h("div", { className: "pi-warning" }, "Last refresh failed: " + error) : null,
+      h("main", { className: "pi-sections" }, SECTION_ORDER.map(function (section) {
+        const cards = cardsBySection[section] || [];
+        return h("section", { className: "pi-section", key: section },
+          h("div", { className: "pi-section-head" }, h("h2", null, section), h("span", null, cards.length + " cards")),
+          cards.length ? h("div", { className: "pi-grid" }, cards.map(function (card) { return h(ProjectCard, { key: card.id, card: card }); })) :
+            h("div", { className: "pi-empty" }, "No cards in this lane yet.")
+        );
+      })),
+      h("footer", { className: "pi-footer" },
+        h("p", null, data.privacy_note),
+        h("p", null, data.refresh_path)
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("projects-ideas", ProjectsIdeasPage);
+})();

--- a/plugins/projects-ideas/dashboard/dist/style.css
+++ b/plugins/projects-ideas/dashboard/dist/style.css
@@ -1,0 +1,55 @@
+/* Ryan Projects + Ideas dashboard plugin */
+.pi-page { padding: 24px; color: var(--foreground, #f8fafc); }
+.pi-hero { display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; padding: 28px; border: 1px solid rgba(148,163,184,.25); border-radius: 28px; background: radial-gradient(circle at top left, rgba(99,102,241,.32), transparent 36%), linear-gradient(135deg, rgba(15,23,42,.96), rgba(30,41,59,.86)); box-shadow: 0 18px 60px rgba(0,0,0,.28); }
+.pi-eyebrow { margin: 0 0 8px; text-transform: uppercase; letter-spacing: .16em; color: #a5b4fc; font-size: 12px; font-weight: 800; }
+.pi-hero h1 { margin: 0 0 10px; font-size: clamp(32px, 6vw, 62px); line-height: .95; }
+.pi-hero p { max-width: 780px; color: #cbd5e1; font-size: 16px; }
+.pi-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 10px; min-width: 200px; }
+.pi-button, .pi-filters button, .pi-stat { border: 1px solid rgba(148,163,184,.35); background: rgba(15,23,42,.72); color: #f8fafc; border-radius: 999px; padding: 10px 14px; cursor: pointer; font-weight: 700; }
+.pi-button:hover, .pi-filters button:hover, .pi-stat:hover { border-color: #a5b4fc; transform: translateY(-1px); }
+.pi-button:disabled { opacity: .6; cursor: wait; }
+.pi-generated { color: #94a3b8; font-size: 12px; }
+.pi-review-note, .pi-warning, .pi-error, .pi-loading { margin: 18px 0; padding: 16px 18px; border-radius: 18px; background: rgba(99,102,241,.12); border: 1px solid rgba(165,180,252,.25); color: #dbeafe; }
+.pi-warning { background: rgba(245,158,11,.12); border-color: rgba(245,158,11,.35); }
+.pi-error { background: rgba(239,68,68,.14); border-color: rgba(239,68,68,.38); }
+.pi-stats { display: grid; grid-template-columns: repeat(6, minmax(120px, 1fr)); gap: 12px; margin: 18px 0; }
+.pi-stat { border-radius: 18px; text-align: left; display: flex; justify-content: space-between; align-items: center; }
+.pi-stat span { color: #cbd5e1; font-size: 12px; }
+.pi-stat strong { font-size: 22px; }
+.pi-filters { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 18px; }
+.pi-filters button.active { background: #6366f1; border-color: #818cf8; }
+.pi-sections { display: flex; flex-direction: column; gap: 22px; }
+.pi-section { border: 1px solid rgba(148,163,184,.18); border-radius: 24px; padding: 18px; background: rgba(15,23,42,.42); }
+.pi-section-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
+.pi-section-head h2 { margin: 0; font-size: 22px; }
+.pi-section-head span { color: #94a3b8; font-size: 13px; }
+.pi-grid { display: grid; grid-template-columns: repeat(3, minmax(260px, 1fr)); gap: 14px; }
+.pi-card { border: 1px solid rgba(148,163,184,.2); border-radius: 20px; background: rgba(2,6,23,.62); overflow: hidden; min-height: 100%; }
+.pi-card-content { padding: 18px; }
+.pi-status-active { box-shadow: inset 4px 0 0 #22c55e; }
+.pi-status-waiting { box-shadow: inset 4px 0 0 #f59e0b; }
+.pi-status-paused { box-shadow: inset 4px 0 0 #94a3b8; }
+.pi-status-idea { box-shadow: inset 4px 0 0 #a855f7; }
+.pi-status-archive { box-shadow: inset 4px 0 0 #64748b; }
+.pi-card-top { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+.pi-card-kicker { color: #93c5fd; font-size: 11px; font-weight: 900; text-transform: uppercase; letter-spacing: .12em; }
+.pi-card h3 { margin: 4px 0 8px; font-size: 20px; line-height: 1.1; }
+.pi-summary, .pi-evidence { color: #cbd5e1; }
+.pi-pill, .pi-priority { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 9px; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; border: 1px solid rgba(148,163,184,.35); }
+.pi-priority-high { background: rgba(239,68,68,.18); color: #fecaca; border-color: rgba(248,113,113,.35); }
+.pi-priority-medium { background: rgba(245,158,11,.15); color: #fde68a; border-color: rgba(251,191,36,.3); }
+.pi-priority-low { background: rgba(100,116,139,.2); color: #cbd5e1; }
+.pi-meta { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 10px; margin: 14px 0; }
+.pi-meta div { background: rgba(15,23,42,.78); border: 1px solid rgba(148,163,184,.14); border-radius: 12px; padding: 10px; }
+.pi-meta dt { color: #94a3b8; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.pi-meta dd { margin: 4px 0 0; color: #e2e8f0; font-size: 13px; }
+.pi-next { margin: 14px 0; padding: 12px; border-radius: 14px; background: rgba(99,102,241,.12); color: #dbeafe; }
+.pi-signals { display: flex; flex-wrap: wrap; gap: 6px; margin: 12px 0; }
+.pi-signals span { border-radius: 999px; padding: 4px 8px; background: rgba(148,163,184,.13); color: #cbd5e1; font-size: 12px; }
+.pi-links { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+.pi-links a { color: #bfdbfe; border: 1px solid rgba(147,197,253,.28); border-radius: 999px; padding: 7px 10px; text-decoration: none; font-size: 13px; }
+.pi-links a:hover { background: rgba(59,130,246,.16); }
+.pi-empty { color: #94a3b8; border: 1px dashed rgba(148,163,184,.22); border-radius: 16px; padding: 18px; }
+.pi-footer { margin-top: 24px; color: #94a3b8; font-size: 13px; }
+@media (max-width: 1100px) { .pi-grid { grid-template-columns: repeat(2, minmax(240px, 1fr)); } .pi-stats { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 720px) { .pi-page { padding: 12px; } .pi-hero { flex-direction: column; border-radius: 20px; padding: 20px; } .pi-actions { align-items: stretch; width: 100%; } .pi-stats { grid-template-columns: repeat(2, 1fr); } .pi-grid { grid-template-columns: 1fr; } .pi-meta { grid-template-columns: 1fr; } .pi-section { padding: 12px; border-radius: 18px; } }

--- a/plugins/projects-ideas/dashboard/manifest.json
+++ b/plugins/projects-ideas/dashboard/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "projects-ideas",
+  "label": "Projects + Ideas",
+  "description": "Ryan personal command-center for active projects, standing workflows, ideas, and parking-lot items.",
+  "icon": "LayoutDashboard",
+  "version": "0.1.0",
+  "tab": { "path": "/projects-ideas", "position": "after:kanban" },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/projects-ideas/dashboard/plugin_api.py
+++ b/plugins/projects-ideas/dashboard/plugin_api.py
@@ -1,0 +1,335 @@
+"""Projects + Ideas dashboard plugin backend.
+
+Mounted at /api/plugins/projects-ideas/ by the Hermes dashboard.
+Builds a private, local-only portfolio snapshot from curated defaults, local
+Hermes memory artifacts, and (when LINEAR_API_KEY is present) archived/canceled
+Linear work. The response intentionally contains titles, statuses, next actions,
+and links only; it never returns raw note bodies or secrets.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+try:
+    from fastapi import APIRouter
+except Exception:  # pragma: no cover - lets import smoke tests run w/o fastapi
+    APIRouter = None  # type: ignore
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover
+    def get_hermes_home() -> Path:  # type: ignore
+        return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+router = APIRouter() if APIRouter else None
+
+LINEAR_URL = "https://linear.app/ryans-ai-hub/issue"
+SNAPSHOT_VERSION = "0.1.0"
+
+
+@dataclass
+class Link:
+    label: str
+    url: str
+
+
+@dataclass
+class Card:
+    id: str
+    name: str
+    kind: str
+    status: str
+    priority: str
+    owner: str
+    last_activity: str
+    next_action: str
+    summary: str
+    links: List[Link] = field(default_factory=list)
+    signals: List[str] = field(default_factory=list)
+    lane: Optional[str] = None
+    stage: Optional[str] = None
+    evidence: Optional[str] = None
+    potential_value: Optional[str] = None
+    source: str = "curated"
+
+
+CURATED_PROJECTS: List[Card] = [
+    Card(
+        id="life-church-hub", name="Life Church Hub", kind="project", status="active", priority="high",
+        owner="Hermes + Ryan", last_activity="current priority", lane="Active",
+        summary="Primary app workstream; Pulse parity and ChurchPulse data shape remain the main focus.",
+        next_action="Keep active implementation work in Linear; use this card for cross-project scan and links.",
+        links=[Link("Linear Development", "https://linear.app/ryans-ai-hub/team/RAN/all"), Link("Hub repo", "file://~/Desktop/Projects/life-church-hub")],
+        signals=["top priority", "Pulse module parity", "private repo"],
+    ),
+    Card(
+        id="churchpulse-cp2", name="ChurchPulse / CP2", kind="project", status="active", priority="high",
+        owner="Hermes", last_activity="ongoing", lane="Active",
+        summary="Ship and validate ChurchPulse before broader productization.",
+        next_action="Track concrete build/validation tasks in Linear; keep market/ops notes as dashboard links rather than perpetual issues.",
+        links=[Link("ChurchPulse context", "file://~/Desktop/Projects/churchpulse")],
+        signals=["Phase 1", "shipping over tinkering"],
+    ),
+    Card(
+        id="ai-revenue-lab", name="AI Revenue Lab / Aligned Insights", kind="project", status="active", priority="high",
+        owner="Ryan + Hermes", last_activity="strategic direction", lane="Active",
+        summary="Business-development lane for consulting-first revenue and validated offers.",
+        next_action="Promote only validated implementation moves into Linear; keep scans and experiments here as lanes/cards.",
+        links=[Link("Strategic direction", "file://~/.hermes/memory/strategic-direction-2026-04-07.md")],
+        signals=["$10k–$12.5k/mo target", "consulting-first"],
+    ),
+    Card(
+        id="mission-control", name="Mission Control / personal ops", kind="project", status="active", priority="medium",
+        owner="Hermes", last_activity="local dashboard", lane="Active",
+        summary="Ryan's personal ops dashboard and command-center experiments.",
+        next_action="Use this Projects + Ideas tab as the portfolio layer; reserve Mission Control tasks for concrete app changes.",
+        links=[Link("Mission Control", "file://~/Desktop/Projects/mission-control")],
+        signals=["port 4200/4201", "personal ops"],
+    ),
+    Card(
+        id="revenue-streams", name="Revenue streams / opportunity scans", kind="standing_lane", status="active", priority="high",
+        owner="Scout + Hermes", last_activity="recurring scans", lane="Standing Lanes",
+        summary="Recurring discovery and packaging of possible revenue opportunities.",
+        next_action="Summarize outputs here and graduate only Ryan-approved opportunities into implementation issues.",
+        links=[Link("Opportunity scans", "file://~/.hermes/memory/opportunity-scans")],
+        signals=["cadence lane", "not fake In Progress"],
+    ),
+    Card(
+        id="linear-agent-ops", name="Linear cleanup / agent ops", kind="standing_lane", status="active", priority="medium",
+        owner="Hercules + Hermes", last_activity="every few hours", lane="Standing Lanes",
+        summary="Operational hygiene for Linear, kanban dispatch, stale PRs, and agent work queues.",
+        next_action="Keep as a health lane; create Linear issues only for concrete fixes or Ryan decisions.",
+        links=[Link("Kanban dashboard", "/kanban"), Link("Linear", "https://linear.app/ryans-ai-hub/team/RAN/all")],
+        signals=["standing workflow", "source of truth reconciliation"],
+    ),
+]
+
+CURATED_IDEAS: List[Card] = [
+    Card(
+        id="father-son-welding", name="Father/son summer business", kind="idea", status="idea", priority="medium",
+        owner="Ryan", last_activity="memory", lane="Ideas", stage="concept",
+        summary="Explore an AI-assisted summer business with Ryan's 16-year-old son and his welding skills.",
+        next_action="Capture 3 low-risk offer tests before creating any implementation issues.",
+        evidence="Existing skill/assets: welding capability + Ryan's interest.", potential_value="Family project + potential side revenue.",
+        signals=["needs validation", "do not over-task in Linear"],
+    ),
+]
+
+STATUS_TO_SECTION = {
+    "active": "Active",
+    "waiting": "Waiting/Blocked",
+    "blocked": "Waiting/Blocked",
+    "paused": "Paused",
+    "idea": "Ideas",
+    "archived": "Archived / Parking Lot",
+    "parking": "Archived / Parking Lot",
+}
+
+
+def _safe_read(path: Path, limit: int = 120_000) -> str:
+    try:
+        if not path.exists() or not path.is_file():
+            return ""
+        data = path.read_text(encoding="utf-8", errors="ignore")
+        return data[:limit]
+    except Exception:
+        return ""
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:64] or "item"
+
+
+def _first_sentence(text: str, max_len: int = 180) -> str:
+    compact = re.sub(r"\s+", " ", text).strip(" -*#\t")
+    if not compact:
+        return ""
+    sentence = re.split(r"(?<=[.!?])\s+", compact)[0]
+    return sentence[:max_len].rstrip() + ("…" if len(sentence) > max_len else "")
+
+
+def _extract_markdown_items(path: Path, *, kind: str, default_status: str, limit: int = 12, include_lists: bool = True) -> List[Card]:
+    """Extract headings/list items without exposing raw note bodies."""
+    text = _safe_read(path)
+    if not text:
+        return []
+    cards: List[Card] = []
+    seen: set[str] = set()
+    lines = text.splitlines()
+    for idx, raw in enumerate(lines):
+        line = raw.strip()
+        title = ""
+        if line.startswith("##"):
+            title = line.lstrip("#").strip()
+        elif include_lists and re.match(r"^[-*]\s+\S", line):
+            title = re.sub(r"^[-*]\s+", "", line).strip()
+        elif include_lists and re.match(r"^\d+[.)]\s+\S", line):
+            title = re.sub(r"^\d+[.)]\s+", "", line).strip()
+        title = re.sub(r"\[[ xX]\]\s*", "", title).strip()
+        title = re.sub(r"^\*\*(.*?)\*\*.*$", r"\1", title).strip()
+        title = re.split(r"\s+[—-]\s+", title, maxsplit=1)[0].strip()
+        title = re.sub(r"\*\*", "", title).strip()
+        title = re.sub(r"\s+#\w+.*$", "", title).strip()
+        if not title or len(title) < 4 or title.lower() in {"active right now", "ideas", "ideas backlog", "ideas (unresearched)", "ideas (research started)", "graduated to task queue", "backlog", "notes", "todo"}:
+            continue
+        key = _slug(title)
+        if key in seen:
+            continue
+        seen.add(key)
+        context = " ".join(lines[idx + 1: idx + 4])
+        summary = _first_sentence(context) or "Curated from local Hermes notes; open source note for details."
+        status = default_status
+        lowered = (title + " " + context).lower()
+        if any(w in lowered for w in ["park", "archive", "cancel"]):
+            status = "parking"
+        elif any(w in lowered for w in ["blocked", "waiting", "needs ryan"]):
+            status = "waiting"
+        elif any(w in lowered for w in ["paused", "someday"]):
+            status = "paused"
+        cards.append(Card(
+            id=f"{kind}-{key}", name=title[:96], kind=kind, status=status,
+            priority="medium" if kind == "idea" else "low", owner="Ryan + Hermes",
+            last_activity="local notes", lane=STATUS_TO_SECTION.get(status, "Ideas"),
+            summary=summary, next_action="Review and either keep parked, promote to an active card, or create one concrete Linear follow-up.",
+            links=[Link(path.name, f"file://{path}")], source=str(path), stage="noted" if kind == "idea" else None,
+            evidence="Mentioned in local Hermes memory artifacts." if kind == "idea" else None,
+            potential_value="Unknown until Ryan validates." if kind == "idea" else None,
+        ))
+        if len(cards) >= limit:
+            break
+    return cards
+
+
+def _local_note_cards() -> List[Card]:
+    home = Path(get_hermes_home())
+    profile_home = Path.home()
+    user_name = os.environ.get("SUDO_USER") or os.environ.get("USER")
+    user_home = Path("/Users") / user_name if user_name and Path("/Users", user_name).exists() else profile_home
+    candidates = [
+        (home / "memory" / "ideas-backlog.md", "idea", "idea", 14, True),
+        (home / "memory" / "task-queue.md", "standing_lane", "active", 8, True),
+        (home / "vault" / "working-context.md", "project", "active", 8, False),
+        # Ryan's OpenClaw vault is the durable cross-agent note store for
+        # business/projects/ideas context. Read titles and tiny summaries only;
+        # do not leak raw note bodies into the dashboard API.
+        (user_home / "Documents" / "OpenClaw-Vault" / "Agent-Shared" / "ideas-backlog.md", "idea", "idea", 14, True),
+        (user_home / "Documents" / "OpenClaw-Vault" / "Agent-Shared" / "task-queue.md", "standing_lane", "active", 8, True),
+        (user_home / "Documents" / "OpenClaw-Vault" / "Agent-Charles" / "working-context.md", "project", "active", 8, False),
+    ]
+    cards: List[Card] = []
+    for path, kind, status, limit, include_lists in candidates:
+        cards.extend(_extract_markdown_items(path, kind=kind, default_status=status, limit=limit, include_lists=include_lists))
+    return cards
+
+
+def _linear_archived_cards(limit: int = 12) -> List[Card]:
+    """Fetch parked/canceled/archived Linear issues with tiny, title-only cards."""
+    if not os.environ.get("LINEAR_API_KEY"):
+        return []
+    script = Path(__file__).resolve().parents[3] / "skills" / "productivity" / "linear" / "scripts" / "linear_api.py"
+    if not script.exists():
+        # Plugin lives under repo/plugins; skill lives outside repo in profiles on Ryan's machine.
+        script = Path.home() / ".hermes" / "profiles" / "hermes-coder" / "skills" / "productivity" / "linear" / "scripts" / "linear_api.py"
+    if not script.exists():
+        return []
+    query = """
+query($first: Int!) {
+  issues(first: $first, filter: {
+    team: { key: { eq: \"RAN\" } },
+    state: { type: { in: [\"canceled\"] } }
+  }, orderBy: updatedAt) {
+    nodes { identifier title url updatedAt state { name type } labels { nodes { name } } }
+  }
+}
+"""
+    try:
+        proc = subprocess.run(
+            ["python3", str(script), "raw", query, "--vars", json.dumps({"first": limit})],
+            text=True, capture_output=True, timeout=12, check=False,
+        )
+        if proc.returncode != 0:
+            return []
+        payload = json.loads(proc.stdout)
+        root = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+        nodes = (((root.get("issues") if isinstance(root, dict) else {}) or {}).get("nodes") or [])
+    except Exception:
+        return []
+    cards: List[Card] = []
+    for issue in nodes[:limit]:
+        ident = issue.get("identifier") or "Linear"
+        title = issue.get("title") or ident
+        state = (issue.get("state") or {}).get("name") or "Canceled"
+        labels = [n.get("name", "") for n in ((issue.get("labels") or {}).get("nodes") or [])]
+        cards.append(Card(
+            id=f"linear-{ident.lower()}", name=title, kind="idea", status="parking", priority="low",
+            owner="Linear", last_activity=(issue.get("updatedAt") or "")[:10], lane="Archived / Parking Lot",
+            summary=f"Surfaced from Linear {state}; kept out of active task flow until Ryan reactivates it.",
+            next_action="Leave parked unless Ryan explicitly promotes it back into active planning.",
+            links=[Link(ident, issue.get("url") or f"{LINEAR_URL}/{ident.lower()}")],
+            signals=[state] + [l for l in labels if l], source="Linear archived/canceled",
+            stage="parked", evidence="Archived/canceled Linear work.", potential_value="Revisit only if strategic fit improves.",
+        ))
+    return cards
+
+
+def _dedupe(cards: Iterable[Card]) -> List[Card]:
+    out: List[Card] = []
+    seen: set[str] = set()
+    for card in cards:
+        key = card.id or _slug(card.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not card.lane:
+            card.lane = STATUS_TO_SECTION.get(card.status, "Ideas")
+        out.append(card)
+    return out
+
+
+def _section_counts(cards: List[Card]) -> Dict[str, int]:
+    counts = {section: 0 for section in ["Active", "Waiting/Blocked", "Paused", "Ideas", "Archived / Parking Lot", "Standing Lanes"]}
+    for card in cards:
+        lane = card.lane or STATUS_TO_SECTION.get(card.status, "Ideas")
+        counts[lane] = counts.get(lane, 0) + 1
+    return counts
+
+
+def build_snapshot(*, include_linear: bool = True) -> Dict[str, Any]:
+    cards = _dedupe([*CURATED_PROJECTS, *CURATED_IDEAS, *_local_note_cards(), *(_linear_archived_cards() if include_linear else [])])
+    cards.sort(key=lambda c: (
+        ["high", "medium", "low"].index(c.priority) if c.priority in {"high", "medium", "low"} else 3,
+        c.kind != "project",
+        c.name.lower(),
+    ))
+    return {
+        "version": SNAPSHOT_VERSION,
+        "generated_at": int(time.time()),
+        "title": "Ryan Projects + Ideas",
+        "subtitle": "Portfolio scan for active projects, standing lanes, ideas, and parking-lot work — Linear stays reserved for actionable tasks.",
+        "privacy_note": "Served inside the authenticated/local Hermes dashboard. Cards expose curated summaries and links, not raw private note bodies or secrets.",
+        "refresh_path": "Refresh calls this plugin API, which re-reads curated defaults, local Hermes memory artifacts, and archived/canceled Linear items when LINEAR_API_KEY is available.",
+        "sections": ["Active", "Waiting/Blocked", "Paused", "Ideas", "Archived / Parking Lot", "Standing Lanes"],
+        "counts": _section_counts(cards),
+        "cards": [
+            {**asdict(c), "links": [asdict(l) for l in c.links]}
+            for c in cards
+        ],
+    }
+
+
+if router:
+    @router.get("/snapshot")
+    async def snapshot() -> Dict[str, Any]:
+        return build_snapshot(include_linear=True)
+
+    @router.post("/refresh")
+    async def refresh() -> Dict[str, Any]:
+        return build_snapshot(include_linear=True)

--- a/tests/plugins/test_projects_ideas_dashboard_plugin.py
+++ b/tests/plugins/test_projects_ideas_dashboard_plugin.py
@@ -1,0 +1,93 @@
+"""Tests for the Projects + Ideas dashboard plugin backend."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "projects-ideas" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_projects_ideas_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_snapshot_contains_required_portfolio_sections(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    memory = home / "memory"
+    vault = home / "vault"
+    memory.mkdir(parents=True)
+    vault.mkdir(parents=True)
+    (memory / "ideas-backlog.md").write_text("""
+# Ideas backlog
+
+## Kids sports highlight reel service
+Use AI to package clips for families.
+
+- Parking lot: old marketplace flipping variant
+""", encoding="utf-8")
+    (vault / "working-context.md").write_text("""
+# Working context
+
+## Church Portal
+Next action is to decide whether this belongs in Life Church Hub.
+""", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+
+    mod = _load_plugin_module()
+    data = mod.build_snapshot(include_linear=False)
+
+    assert data["title"] == "Ryan Projects + Ideas"
+    for section in ["Active", "Waiting/Blocked", "Paused", "Ideas", "Archived / Parking Lot", "Standing Lanes"]:
+        assert section in data["sections"]
+        assert section in data["counts"]
+
+    names = {card["name"] for card in data["cards"]}
+    assert "Life Church Hub" in names
+    assert "Linear cleanup / agent ops" in names
+    assert "Kids sports highlight reel service" in names
+    assert "Church Portal" in names
+
+    # The plugin should expose concise card summaries, not raw note dumps.
+    idea = next(card for card in data["cards"] if card["name"] == "Kids sports highlight reel service")
+    assert idea["kind"] == "idea"
+    assert idea["next_action"]
+    assert len(idea["summary"]) < 220
+
+
+def test_snapshot_endpoint_and_refresh_endpoint(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "memory").mkdir(parents=True)
+    (home / "memory" / "ideas-backlog.md").write_text("- Community volunteer matching tool\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+
+    mod = _load_plugin_module()
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api/plugins/projects-ideas")
+    client = TestClient(app)
+
+    r = client.get("/api/plugins/projects-ideas/snapshot")
+    assert r.status_code == 200
+    data = r.json()
+    assert any(card["name"] == "Community volunteer matching tool" for card in data["cards"])
+
+    r = client.post("/api/plugins/projects-ideas/refresh")
+    assert r.status_code == 200
+    refreshed = r.json()
+    assert refreshed["version"] == data["version"]
+    assert refreshed["cards"]


### PR DESCRIPTION
## Summary
- Adds a bundled Projects + Ideas dashboard plugin for Ryan's private command-center view.
- Separates Active, Waiting/Blocked, Paused, Ideas, Archived/Parking Lot, and Standing Lanes cards with next meaningful actions and related links.
- Adds a refresh API that re-reads curated defaults, local Hermes/OpenClaw memory artifacts, and canceled Linear issues when available without exposing raw note bodies or secrets.

## Review notes
What Ryan should notice: this is not another Linear task board. Standing workflows and raw ideas are visible as portfolio lanes, while actionable implementation work still links back to Linear/GitHub/docs.

Screenshots captured locally:
- Desktop: /tmp/ran-1447-projects-ideas-desktop.png
- Mobile: /tmp/ran-1447-projects-ideas-mobile.png

## Verification
- /Users/cogginsryan/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/test_projects_ideas_dashboard_plugin.py -q
- node --check plugins/projects-ideas/dashboard/dist/index.js
- /Users/cogginsryan/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/projects-ideas/dashboard/plugin_api.py
- Local dashboard smoke: hermes dashboard --host 127.0.0.1 --port 9127 --no-open --skip-build; opened /projects-ideas and captured desktop/mobile screenshots.

Linear: RAN-1447