### PR TITLE
feat(browser): add support for pagination to web_extract and browser_snapshot

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -45,7 +45,7 @@ class TestGetToolset:
 
         ts = get_toolset("web")
         assert ts is not None
-        assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
+        assert set(ts["tools"]) == {"web_search", "web_extract", "web_extract_find", "web_search_plus"}
 
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
@@ -54,7 +54,7 @@ class TestGetToolset:
 class TestResolveToolset:
     def test_leaf_toolset(self):
         tools = resolve_toolset("web")
-        assert set(tools) == {"web_search", "web_extract"}
+        assert set(tools) == {"web_search", "web_extract", "web_extract_find"}
 
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
@@ -153,7 +153,7 @@ class TestGetToolsetInfo:
         info = get_toolset_info("web")
         assert info["name"] == "web"
         assert info["is_composite"] is False
-        assert info["tool_count"] == 2
+        assert info["tool_count"] == 3
 
     def test_composite(self):
         info = get_toolset_info("debugging")

--- a/tests/tools/test_browser_secret_exfil.py
+++ b/tests/tools/test_browser_secret_exfil.py
@@ -28,10 +28,19 @@ class TestBrowserSecretExfil:
         parsed = json.loads(result)
         assert parsed["success"] is False
 
-    def test_allows_normal_url(self):
-        """Normal URLs pass the secret check (may fail for other reasons)."""
-        from tools.browser_tool import browser_navigate
-        result = browser_navigate("https://github.com/NousResearch/hermes-agent")
+    def test_allows_normal_url(self, monkeypatch):
+        """Normal URLs pass the secret check without starting a real browser."""
+        from tools import browser_tool
+
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_get_session_info", lambda task_id: {"_first_nav": False})
+        monkeypatch.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *args, **kwargs: {"success": False, "error": "browser unavailable"},
+        )
+
+        result = browser_tool.browser_navigate("https://github.com/NousResearch/hermes-agent")
         parsed = json.loads(result)
         # Should NOT be blocked by secret detection
         assert "API key or token" not in parsed.get("error", "")

--- a/tests/tools/test_browser_web_chunk_index_api.py
+++ b/tests/tools/test_browser_web_chunk_index_api.py
@@ -1,0 +1,163 @@
+import asyncio
+import json
+
+
+def test_web_extract_schema_exposes_chunk_index_and_find_tool():
+    from tools.web_tools import WEB_EXTRACT_SCHEMA, WEB_EXTRACT_FIND_SCHEMA
+
+    props = WEB_EXTRACT_SCHEMA["parameters"]["properties"]
+    assert "chunk_index" in props
+    assert "offset" not in props
+    assert "limit" not in props
+    assert "chunk_index" in WEB_EXTRACT_SCHEMA["description"]
+    assert "LLM" not in WEB_EXTRACT_SCHEMA["description"]
+
+    find_props = WEB_EXTRACT_FIND_SCHEMA["parameters"]["properties"]
+    assert "query" in find_props
+    assert "urls" in find_props
+    assert "chunk_index" not in find_props
+    assert WEB_EXTRACT_FIND_SCHEMA["parameters"]["required"] == ["query"]
+
+
+def test_browser_snapshot_schema_exposes_chunk_index_and_find_tool():
+    from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+    snapshot = next(schema for schema in BROWSER_TOOL_SCHEMAS if schema["name"] == "browser_snapshot")
+    props = snapshot["parameters"]["properties"]
+    assert "chunk_index" in props
+    assert "offset" not in props
+    assert "limit" not in props
+    assert "LLM" not in snapshot["description"]
+
+    find = next(schema for schema in BROWSER_TOOL_SCHEMAS if schema["name"] == "browser_find")
+    find_props = find["parameters"]["properties"]
+    assert "query" in find_props
+    assert "chunk_index" not in find_props
+    assert find["parameters"]["required"] == ["query"]
+
+
+def test_web_extract_chunks_source_and_reuses_cache_by_chunk_index(monkeypatch):
+    import tools.web_tools as wt
+    from tools.chunked_content import DEFAULT_SOURCE_CHUNK_SIZE
+
+    wt._ensure_web_extract_cache().clear()
+    raw = "A" * DEFAULT_SOURCE_CHUNK_SIZE + "SECOND WEB CHUNK"
+    calls = []
+
+    async def fake_parallel_extract(urls):
+        calls.append(tuple(urls))
+        return [{"url": urls[0], "title": "Web", "content": raw, "raw_content": raw}]
+
+    monkeypatch.setattr(wt, "_get_extract_backend", lambda: "parallel")
+    monkeypatch.setattr(wt, "is_safe_url", lambda url: True)
+    monkeypatch.setattr(wt, "check_website_access", lambda url: None)
+    monkeypatch.setattr(wt, "_parallel_extract", fake_parallel_extract)
+
+    first = json.loads(asyncio.get_event_loop().run_until_complete(
+        wt.web_extract_tool(["https://x.test"], use_llm_processing=False, chunk_index=1, format="markdown")
+    ))
+    cached = json.loads(asyncio.get_event_loop().run_until_complete(
+        wt.web_extract_tool(["https://x.test"], use_llm_processing=False, chunk_index=0, format="markdown")
+    ))
+    out_of_range = json.loads(asyncio.get_event_loop().run_until_complete(
+        wt.web_extract_tool(["https://x.test"], use_llm_processing=False, chunk_index=99, format="markdown")
+    ))
+
+    assert calls == [("https://x.test",)]
+    assert first["results"][0]["chunk_index"] == 1
+    assert first["results"][0]["chunk_count"] == 2
+    assert first["results"][0]["content"] == "SECOND WEB CHUNK"
+    assert cached["results"][0]["chunk_index"] == 0
+    assert cached["results"][0]["next_chunk"] == 1
+    assert out_of_range["results"][0]["error"] == "chunk_index 99 is out of range for 2 chunks"
+    assert "raw_content" not in json.dumps(first)
+
+
+def test_web_extract_find_searches_cached_source_chunks_and_suggests_followups():
+    import tools.web_tools as wt
+
+    cache = wt._ensure_web_extract_cache()
+    cache.clear()
+    cache[("https://a.test", "markdown", False, "", 5000)] = {
+        "url": "https://a.test",
+        "title": "A",
+        "content": "alpha\nneedle here\nomega",
+        "raw_content": "alpha\nneedle here\nomega",
+        "input_chunks": ["alpha", "needle here\nomega"],
+    }
+
+    out = json.loads(wt.web_extract_find("needle", urls=["https://a.test", "https://missing.test"]))
+
+    assert out["success"] is True
+    assert out["searched_urls"] == ["https://a.test"]
+    assert out["missing_cache_urls"] == ["https://missing.test"]
+    assert out["match_count"] == 1
+    assert out["results"][0]["chunk_index"] == 1
+    assert "needle here" in out["results"][0]["snippet"]
+    assert out["next_actions"] == [
+        {"tool": "web_extract", "args": {"urls": ["https://a.test"], "chunk_index": 1}},
+        {"tool": "web_extract", "args": {"urls": ["https://missing.test"], "chunk_index": 0}},
+    ]
+
+
+def test_browser_snapshot_full_chunks_source_without_llm_summary(monkeypatch):
+    import tools.browser_tool as bt
+    from tools.chunked_content import DEFAULT_SOURCE_CHUNK_SIZE
+
+    raw = "A" * DEFAULT_SOURCE_CHUNK_SIZE + "SECOND BROWSER CHUNK [e2]"
+
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_last_session_key", lambda task_id: task_id)
+    monkeypatch.setattr(bt, "_extract_relevant_content", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not summarize full chunked snapshots")))
+    monkeypatch.setattr(bt, "_truncate_snapshot", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not truncate full chunked snapshots")))
+    monkeypatch.setattr(bt, "_run_browser_command", lambda task_id, command, args: {
+        "success": True,
+        "data": {"snapshot": raw, "refs": {"e2": {}}, "url": "https://x.test", "title": "X"},
+    })
+
+    out = json.loads(bt.browser_snapshot(full=True, chunk_index=1, task_id="snap"))
+
+    assert out["success"] is True
+    assert out["chunk_index"] == 1
+    assert out["chunk_count"] == 2
+    assert out["next_chunk"] is None
+    assert out["has_more"] is False
+    assert out["snapshot"] == "SECOND BROWSER CHUNK [e2]"
+
+
+def test_browser_find_searches_cached_full_snapshot_chunks(monkeypatch):
+    import tools.browser_tool as bt
+
+    cache_entry = {
+        "chunks": ["alpha", "needle target [e7]\n- /url: https://x.test/needle"],
+        "url": "https://x.test/page",
+        "title": "X",
+        "element_count": 1,
+    }
+    monkeypatch.setattr(bt, "_last_session_key", lambda task_id: task_id)
+    monkeypatch.setattr(bt, "_get_browser_snapshot_source_cache", lambda task_id, full=True: cache_entry)
+
+    out = json.loads(bt.browser_find("needle", task_id="find"))
+
+    assert out["success"] is True
+    assert out["chunk_count"] == 2
+    assert out["searched_chunks"] == [0, 1]
+    assert out["match_count"] == 1
+    assert out["results"][0]["chunk_index"] == 1
+    assert "needle target" in out["results"][0]["snippet"]
+    assert out["next_actions"]["full_snapshot"]["args"] == {"full": True, "chunk_index": 1}
+
+
+def test_toolsets_and_execute_code_stubs_include_find_and_chunk_index():
+    import toolsets
+    from tools.code_execution_tool import SANDBOX_ALLOWED_TOOLS, _TOOL_STUBS, _TOOL_DOC_LINES
+
+    assert "web_extract_find" in toolsets.TOOLSETS["web"]["tools"]
+    assert "browser_find" in toolsets.TOOLSETS["browser"]["tools"]
+    assert "web_extract_find" in SANDBOX_ALLOWED_TOOLS
+    assert "browser_find" in SANDBOX_ALLOWED_TOOLS
+    assert "chunk_index" in _TOOL_STUBS["web_extract"][1]
+    assert "chunk_index" in _TOOL_STUBS["browser_snapshot"][1]
+    docs = "\n".join(doc for _, doc in _TOOL_DOC_LINES)
+    assert "web_extract_find" in docs
+    assert "browser_find" in docs

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -612,8 +612,8 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
             sandbox_enabled = SANDBOX_ALLOWED_TOOLS & tools_to_include
             dynamic_schema = build_execute_code_schema(sandbox_enabled)
 
-        SANDBOX_ALLOWED_TOOLS = {web_search, web_extract, read_file, write_file,
-                                  search_files, patch, terminal}
+        # SANDBOX_ALLOWED_TOOLS contains web/search/browser/file/terminal helpers,
+        # but tools_to_include intentionally has none of those names.
         tools_to_include  = {"execute_code"}
         intersection      = empty set
         """
@@ -831,7 +831,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                     return_value=json.dumps({"ok": True})):
             result = json.loads(execute_code(
                 code, task_id="test-nonoverlap",
-                enabled_tools=["vision_analyze", "browser_snapshot"],
+                enabled_tools=["vision_analyze"],
             ))
         self.assertEqual(result["status"], "success")
         self.assertIn("fallback ok", result["output"])

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -298,7 +298,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
 
 
 def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
-                     user_task: Optional[str] = None) -> str:
+                     user_task: Optional[str] = None, chunk_index: int = 0) -> str:
     """Get accessibility tree snapshot from Camofox."""
     try:
         session = _get_session(task_id)
@@ -313,24 +313,20 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         snapshot = data.get("snapshot", "")
         refs_count = data.get("refsCount", 0)
 
-        # Apply same summarization logic as the main browser tool
         from tools.browser_tool import (
-            SNAPSHOT_SUMMARIZE_THRESHOLD,
-            _extract_relevant_content,
-            _truncate_snapshot,
+            _build_browser_snapshot_chunk_response,
+            _store_browser_snapshot_source_cache,
         )
 
-        if len(snapshot) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-            if user_task:
-                snapshot = _extract_relevant_content(snapshot, user_task)
-            else:
-                snapshot = _truncate_snapshot(snapshot)
-
-        return json.dumps({
-            "success": True,
-            "snapshot": snapshot,
-            "element_count": refs_count,
-        })
+        cache_entry = _store_browser_snapshot_source_cache(
+            task_id or "default",
+            snapshot,
+            full=full,
+            url=data.get("url", ""),
+            title=data.get("title", ""),
+            element_count=refs_count,
+        )
+        return json.dumps(_build_browser_snapshot_chunk_response(cache_entry, chunk_index=chunk_index, cache_hit=False))
     except Exception as e:
         return tool_error(str(e), success=False)
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -88,6 +88,13 @@ from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
 from tools.browser_providers.firecrawl import FirecrawlProvider
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
+from tools.chunked_content import (
+    build_chunked_result,
+    compile_chunk_find_query,
+    legacy_offset_to_chunk_index,
+    search_source_chunks,
+    split_source_chunks,
+)
 
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
@@ -1053,6 +1060,42 @@ _recording_sessions: set = set()  # session_keys with active recordings
 # sidecar would fall back to the cloud session on its next snapshot call.
 _last_active_session_key: Dict[str, str] = {}  # task_id -> session_key
 _LOCAL_SUFFIX = "::local"
+_BROWSER_SNAPSHOT_SOURCE_CACHE: Dict[Tuple[str, bool], Dict[str, Any]] = {}
+
+
+def _browser_snapshot_source_cache_key(task_id: str, full: bool = True) -> Tuple[str, bool]:
+    return (task_id or "default", bool(full))
+
+
+def _get_browser_snapshot_source_cache(task_id: str, full: bool = True) -> Optional[Dict[str, Any]]:
+    return _BROWSER_SNAPSHOT_SOURCE_CACHE.get(_browser_snapshot_source_cache_key(task_id, full=full))
+
+
+def _store_browser_snapshot_source_cache(
+    task_id: str,
+    text: str,
+    *,
+    full: bool = True,
+    url: str = "",
+    title: str = "",
+    element_count: int = 0,
+) -> Dict[str, Any]:
+    entry = {
+        "chunks": split_source_chunks(text or ""),
+        "url": url or "",
+        "title": title or "",
+        "element_count": int(element_count or 0),
+    }
+    _BROWSER_SNAPSHOT_SOURCE_CACHE[_browser_snapshot_source_cache_key(task_id, full=full)] = entry
+    return entry
+
+
+def _invalidate_browser_snapshot_source_cache(task_id: Optional[str]) -> None:
+    if not task_id:
+        return
+    _BROWSER_SNAPSHOT_SOURCE_CACHE.pop(_browser_snapshot_source_cache_key(task_id, full=True), None)
+    _BROWSER_SNAPSHOT_SOURCE_CACHE.pop(_browser_snapshot_source_cache_key(task_id, full=False), None)
+
 
 # Flag to track if cleanup has been done
 _cleanup_done = False
@@ -1367,17 +1410,38 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_snapshot",
-        "description": "Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs (like @e1, @e2) for browser_click and browser_type. full=false (default): compact view with interactive elements. full=true: complete page content. Snapshots over 8000 chars are truncated or LLM-summarized. Requires browser_navigate first. Note: browser_navigate already returns a compact snapshot — use this to refresh after interactions that change the page, or with full=true for complete content.",
+        "description": "Get a text-based snapshot of the current page's accessibility tree. Returns one source chunk at a time with chunk_count/next_chunk metadata; use chunk_index to page through large snapshots instead of receiving hidden summarization. Requires browser_navigate first. full=false (default): compact view with interactive elements. full=true: complete page source chunks.",
         "parameters": {
             "type": "object",
             "properties": {
                 "full": {
                     "type": "boolean",
-                    "description": "If true, returns complete page content. If false (default), returns compact view with interactive elements only.",
+                    "description": "If true, returns complete page source chunks. If false (default), returns compact view chunks with interactive elements only.",
                     "default": False
+                },
+                "chunk_index": {
+                    "type": "integer",
+                    "description": "Zero-based source chunk to return. Responses include chunk_count and next_chunk.",
+                    "minimum": 0,
+                    "default": 0
                 }
             },
             "required": []
+        }
+    },
+    {
+        "name": "browser_find",
+        "description": "Search cached browser snapshot source chunks for text or regex. Returns matching chunk indexes, snippets, and suggested browser_snapshot follow-up calls. Requires browser_navigate or browser_snapshot first.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Text or regex pattern to search for"},
+                "max_results": {"type": "integer", "description": "Maximum number of matches to return", "minimum": 1, "default": 10},
+                "case_sensitive": {"type": "boolean", "description": "Whether literal or regex matching should be case-sensitive", "default": False},
+                "regex": {"type": "boolean", "description": "Treat query as a Python regular expression instead of literal text", "default": False},
+                "include_context": {"type": "boolean", "description": "Include a compact snippet around each match", "default": True},
+            },
+            "required": ["query"]
         }
     },
     {
@@ -2212,6 +2276,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
 
     # Camofox backend — delegate after safety checks pass
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_navigate
         return camofox_navigate(url, task_id)
 
@@ -2235,6 +2300,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         _maybe_start_recording(nav_session_key)
 
     result = _run_browser_command(nav_session_key, "open", [url], timeout=max(_get_command_timeout(), 60))
+    _invalidate_browser_snapshot_source_cache(nav_session_key)
 
     # Remember which session served this nav so snapshot/click/fill/...
     # on the same task_id hit it (critical when hybrid routing has both a
@@ -2341,27 +2407,60 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         }, ensure_ascii=False)
 
 
+def _build_browser_snapshot_chunk_response(
+    cache_entry: Dict[str, Any],
+    *,
+    chunk_index: int = 0,
+    cache_hit: bool = False,
+) -> Dict[str, Any]:
+    response = build_chunked_result(
+        {
+            "url": cache_entry.get("url", ""),
+            "title": cache_entry.get("title", ""),
+            "content": "".join(cache_entry.get("chunks", [])),
+        },
+        chunk_index=chunk_index,
+        cache_hit=cache_hit,
+        output_key="snapshot",
+        chunks=cache_entry.get("chunks") if isinstance(cache_entry.get("chunks"), list) else None,
+    )
+    response["success"] = True
+    response["element_count"] = int(cache_entry.get("element_count", 0) or 0)
+    return response
+
+
 def browser_snapshot(
     full: bool = False,
     task_id: Optional[str] = None,
-    user_task: Optional[str] = None
+    user_task: Optional[str] = None,
+    chunk_index: int = 0,
+    # Private compatibility for older direct callers; not exposed in the schema.
+    offset: Optional[int] = None,
+    limit: Optional[int] = None,
 ) -> str:
     """
     Get a text-based snapshot of the current page's accessibility tree.
 
     Args:
-        full: If True, return complete snapshot. If False, return compact view.
+        full: If True, return complete source chunks. If False, return compact chunks.
         task_id: Task identifier for session isolation
-        user_task: The user's current task (for task-aware extraction)
+        user_task: The user's current task (kept for compatibility)
+        chunk_index: Zero-based source chunk index to return
 
     Returns:
         JSON string with page snapshot
     """
+    if offset is not None and chunk_index == 0:
+        chunk_index = legacy_offset_to_chunk_index(offset)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_snapshot
-        return camofox_snapshot(full, task_id, user_task)
+        return camofox_snapshot(full=full, task_id=task_id, user_task=user_task, chunk_index=chunk_index)
 
     effective_task_id = _last_session_key(task_id or "default")
+    cached = _get_browser_snapshot_source_cache(effective_task_id, full=full)
+    if cached is not None:
+        return json.dumps(_build_browser_snapshot_chunk_response(cached, chunk_index=chunk_index, cache_hit=True), ensure_ascii=False)
 
     # Build command args based on full flag
     args = []
@@ -2374,18 +2473,16 @@ def browser_snapshot(
         data = result.get("data", {})
         snapshot_text = data.get("snapshot", "")
         refs = data.get("refs", {})
-
-        # Check if snapshot needs summarization
-        if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD and user_task:
-            snapshot_text = _extract_relevant_content(snapshot_text, user_task)
-        elif len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-            snapshot_text = _truncate_snapshot(snapshot_text)
-
-        response = {
-            "success": True,
-            "snapshot": snapshot_text,
-            "element_count": len(refs) if refs else 0
-        }
+        element_count = len(refs) if refs else int(data.get("refsCount", 0) or 0)
+        cache_entry = _store_browser_snapshot_source_cache(
+            effective_task_id,
+            snapshot_text,
+            full=full,
+            url=data.get("url", ""),
+            title=data.get("title", ""),
+            element_count=element_count,
+        )
+        response = _build_browser_snapshot_chunk_response(cache_entry, chunk_index=chunk_index, cache_hit=False)
         _copy_fallback_warning(response, result)
 
         # Merge supervisor state (pending dialogs + frame tree) when a CDP
@@ -2410,6 +2507,72 @@ def browser_snapshot(
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
+def browser_find(
+    query: str,
+    max_results: int = 10,
+    case_sensitive: bool = False,
+    regex: bool = False,
+    include_context: bool = True,
+    task_id: Optional[str] = None,
+) -> str:
+    """Search cached full browser snapshot source chunks."""
+    if not isinstance(query, str) or not query:
+        return json.dumps({"success": False, "error": "query must be a non-empty string"}, ensure_ascii=False)
+    try:
+        matcher = compile_chunk_find_query(query, regex=bool(regex), case_sensitive=bool(case_sensitive))
+    except re.error as exc:
+        return json.dumps({"success": False, "error": f"Invalid regex: {exc}"}, ensure_ascii=False)
+
+    effective_task_id = _last_session_key(task_id or "default")
+    cache_entry = _get_browser_snapshot_source_cache(effective_task_id, full=True)
+    if cache_entry is None:
+        # Try to acquire the full source once without making the caller know about
+        # the cache implementation. If there is no browser session, return a clean
+        # cache-miss error with a browser_navigate hint.
+        try:
+            snapshot_result = json.loads(browser_snapshot(full=True, task_id=task_id, chunk_index=0))
+        except Exception:
+            snapshot_result = {"success": False}
+        if snapshot_result.get("success"):
+            cache_entry = _get_browser_snapshot_source_cache(effective_task_id, full=True)
+
+    if cache_entry is None:
+        return json.dumps({
+            "success": False,
+            "error": "No cached browser snapshot source chunks. Call browser_snapshot(full=true) or browser_navigate first.",
+            "query": query,
+            "next_actions": {
+                "navigate": {"tool": "browser_navigate", "args": {"url": "<url>"}},
+                "full_snapshot": {"tool": "browser_snapshot", "args": {"full": True, "chunk_index": 0}},
+            },
+        }, ensure_ascii=False)
+
+    chunks = [str(chunk) for chunk in cache_entry.get("chunks", [])]
+    results = search_source_chunks(
+        chunks,
+        matcher=matcher,
+        include_context=bool(include_context),
+        max_results=max_results,
+        collapse_accessibility_duplicates=True,
+    )
+    first_chunk = results[0]["chunk_index"] if results else 0
+    return json.dumps({
+        "success": True,
+        "query": query,
+        "regex": bool(regex),
+        "case_sensitive": bool(case_sensitive),
+        "url": cache_entry.get("url", ""),
+        "title": cache_entry.get("title", ""),
+        "chunk_count": len(chunks),
+        "searched_chunks": list(range(len(chunks))),
+        "match_count": len(results),
+        "results": results,
+        "next_actions": {
+            "full_snapshot": {"tool": "browser_snapshot", "args": {"full": True, "chunk_index": first_chunk}},
+        },
+    }, ensure_ascii=False)
+
+
 def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     """
     Click on an element.
@@ -2422,6 +2585,7 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
         JSON string with click result
     """
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_click
         return camofox_click(ref, task_id)
 
@@ -2434,6 +2598,7 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "click", [ref])
 
     if result.get("success"):
+        _invalidate_browser_snapshot_source_cache(effective_task_id)
         response = {
             "success": True,
             "clicked": ref
@@ -2460,6 +2625,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         JSON string with type result
     """
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_type
         return camofox_type(ref, text, task_id)
 
@@ -2473,6 +2639,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "fill", [ref, text])
 
     if result.get("success"):
+        _invalidate_browser_snapshot_source_cache(effective_task_id)
         response = {
             "success": True,
             "typed": text,
@@ -2511,6 +2678,7 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
     _SCROLL_PIXELS = 500
 
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_scroll
         # Camofox REST API doesn't support pixel args; use repeated calls
         _SCROLL_REPEATS = 5
@@ -2533,6 +2701,7 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
         "success": True,
         "scrolled": direction
     }
+    _invalidate_browser_snapshot_source_cache(effective_task_id)
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
@@ -2547,6 +2716,7 @@ def browser_back(task_id: Optional[str] = None) -> str:
         JSON string with navigation result
     """
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_back
         return camofox_back(task_id)
 
@@ -2554,6 +2724,7 @@ def browser_back(task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "back", [])
 
     if result.get("success"):
+        _invalidate_browser_snapshot_source_cache(effective_task_id)
         data = result.get("data", {})
         response = {
             "success": True,
@@ -2580,6 +2751,7 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
         JSON string with key press result
     """
     if _is_camofox_mode():
+        _invalidate_browser_snapshot_source_cache(task_id or "default")
         from tools.browser_camofox import camofox_press
         return camofox_press(key, task_id)
 
@@ -2587,6 +2759,7 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
     result = _run_browser_command(effective_task_id, "press", [key])
 
     if result.get("success"):
+        _invalidate_browser_snapshot_source_cache(effective_task_id)
         response = {
             "success": True,
             "pressed": key
@@ -2667,10 +2840,12 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
 
 def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
+    _invalidate_browser_snapshot_source_cache(task_id or "default")
     if _is_camofox_mode():
         return _camofox_eval(expression, task_id)
 
     effective_task_id = _last_session_key(task_id or "default")
+    _invalidate_browser_snapshot_source_cache(effective_task_id)
 
     # --- Fast path: route through the supervisor's persistent CDP WS ---------
     # When a CDPSupervisor is alive for this task_id, ``Runtime.evaluate`` runs
@@ -3222,11 +3397,13 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
 
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
+        _invalidate_browser_snapshot_source_cache(session_key)
 
     # Drop the last-active pointer only when the bare task is being cleaned
     # (i.e. not when we're only reaping a sidecar mid-task).
     if not _is_local_sidecar_key(task_id):
         _last_active_session_key.pop(bare_task_id, None)
+        _invalidate_browser_snapshot_source_cache(bare_task_id)
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:
@@ -3336,6 +3513,7 @@ def cleanup_all_browsers() -> None:
     _cached_chromium_installed = None
     _cached_browser_engine = None
     _browser_engine_resolved = False
+    _BROWSER_SNAPSHOT_SOURCE_CACHE.clear()
 
 # ============================================================================
 # Requirements Check
@@ -3576,9 +3754,28 @@ registry.register(
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_snapshot"],
     handler=lambda args, **kw: browser_snapshot(
-        full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
+        full=args.get("full", False),
+        task_id=kw.get("task_id"),
+        user_task=kw.get("user_task"),
+        chunk_index=args.get("chunk_index", 0),
+    ),
     check_fn=check_browser_requirements,
     emoji="📸",
+)
+registry.register(
+    name="browser_find",
+    toolset="browser",
+    schema=_BROWSER_SCHEMA_MAP["browser_find"],
+    handler=lambda args, **kw: browser_find(
+        query=args.get("query", ""),
+        max_results=args.get("max_results", 10),
+        case_sensitive=args.get("case_sensitive", False),
+        regex=args.get("regex", False),
+        include_context=args.get("include_context", True),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_browser_requirements,
+    emoji="🔎",
 )
 registry.register(
     name="browser_click",

--- a/tools/chunked_content.py
+++ b/tools/chunked_content.py
@@ -1,0 +1,254 @@
+"""Chunk selection and source-search helpers for browser/web tools.
+
+Public browser_snapshot/web_extract pagination is source-oriented: cache raw
+input chunks, render only the requested chunk, and never synthesize across all
+chunks for the tool caller.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+DEFAULT_SOURCE_CHUNK_SIZE = 80_000
+
+
+def compile_chunk_find_query(query: str, *, regex: bool, case_sensitive: bool):
+    flags = 0 if case_sensitive else re.IGNORECASE
+    if regex:
+        return re.compile(query, flags)
+    return re.compile(re.escape(query), flags)
+
+
+def chunk_find_snippet(lines: List[str], line_index: int, *, radius: int = 2) -> str:
+    start = max(0, line_index - radius)
+    end = min(len(lines), line_index + radius + 1)
+    return "\n".join(lines[start:end]).strip()
+
+
+_SEMANTIC_BOUNDARY_LINE_RE = re.compile(
+    r"^(?:#{1,6}\s+|-\s+(?:banner|navigation|main|article|section|region|contentinfo|complementary|form|search|dialog|alertdialog|heading|paragraph|list|table|grid|treegrid|link|button|textbox|searchbox|combobox|checkbox|radio)\b)"
+)
+_ACCESSIBILITY_CONTAINER_LINE_RE = re.compile(r"^\s*-\s+'?(?:row|cell)\s+\"")
+_URL_LINE_RE = re.compile(r"^\s*-\s+/url:")
+
+
+def _line_indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def _is_accessibility_container_line(line: str) -> bool:
+    return bool(_ACCESSIBILITY_CONTAINER_LINE_RE.match(line or ""))
+
+
+def _is_url_line(line: str) -> bool:
+    return bool(_URL_LINE_RE.match(line or ""))
+
+
+def _collapse_accessibility_duplicate_results(candidates: List[Dict[str, Any]], lines_by_chunk: Dict[int, List[str]]) -> List[Dict[str, Any]]:
+    """Drop noisy ancestor/url matches when a nearby specific line matched too."""
+    indexed: List[Tuple[int, Dict[str, Any], str, bool, bool, int]] = []
+    for idx, result in enumerate(candidates):
+        chunk_idx = int(result.get("chunk_index", 0))
+        line_no = int(result.get("line", 1))
+        lines = lines_by_chunk.get(chunk_idx, [])
+        line = lines[line_no - 1] if 0 <= line_no - 1 < len(lines) else ""
+        indexed.append((idx, result, line, _is_accessibility_container_line(line), _is_url_line(line), _line_indent(line)))
+
+    keep: List[Dict[str, Any]] = []
+    kept_container_clusters: set[Tuple[int, int, str]] = set()
+    for idx, result, line, is_container, is_url, indent in indexed:
+        chunk_idx = int(result.get("chunk_index", 0))
+        line_no = int(result.get("line", 1))
+        match_key = str(result.get("match_text", "")).casefold()
+        nearby = [
+            other
+            for other in indexed
+            if other[0] != idx
+            and int(other[1].get("chunk_index", 0)) == chunk_idx
+            and str(other[1].get("match_text", "")).casefold() == match_key
+            and abs(int(other[1].get("line", 1)) - line_no) <= 30
+        ]
+        descendant_specific = [other for other in nearby if not other[3] and not other[4] and other[5] > indent]
+        if is_container and descendant_specific:
+            continue
+        if is_url and any(not other[3] and not other[4] and abs(int(other[1].get("line", 1)) - line_no) <= 3 for other in nearby):
+            continue
+        if is_container:
+            cluster_key = (chunk_idx, line_no // 30, match_key)
+            if cluster_key in kept_container_clusters:
+                continue
+            kept_container_clusters.add(cluster_key)
+        keep.append(result)
+    return keep
+
+
+def _semantic_split_after(source: str, *, start: int, hard_end: int, size: int) -> int:
+    lower_bound = start + max(1, int(size * 0.55))
+    best = -1
+    pos = source.find("\n", lower_bound, hard_end + 1)
+    while pos != -1:
+        next_start = pos + 1
+        next_end = source.find("\n", next_start, min(len(source), next_start + 240))
+        if next_end == -1:
+            next_end = min(len(source), next_start + 240)
+        if _SEMANTIC_BOUNDARY_LINE_RE.match(source[next_start:next_end]):
+            best = pos
+        pos = source.find("\n", pos + 1, hard_end + 1)
+    return best
+
+
+def split_source_chunks(text: str, chunk_size: int = DEFAULT_SOURCE_CHUNK_SIZE) -> List[str]:
+    source = text or ""
+    try:
+        size = int(chunk_size or DEFAULT_SOURCE_CHUNK_SIZE)
+    except (TypeError, ValueError):
+        size = DEFAULT_SOURCE_CHUNK_SIZE
+    if size <= 0:
+        size = DEFAULT_SOURCE_CHUNK_SIZE
+    if not source:
+        return [""]
+
+    chunks: List[str] = []
+    start = 0
+    source_len = len(source)
+    while start < source_len:
+        hard_end = min(start + size, source_len)
+        if hard_end >= source_len:
+            chunks.append(source[start:source_len])
+            break
+
+        split_at = _semantic_split_after(source, start=start, hard_end=hard_end, size=size)
+        if split_at <= start:
+            split_at = source.rfind("\n", start + 1, hard_end + 1)
+        if split_at <= start:
+            split_at = hard_end
+        else:
+            split_at += 1
+        chunks.append(source[start:split_at])
+        start = split_at
+    return chunks
+
+
+def normalize_chunk_index(chunk_index: Any = 0) -> int:
+    try:
+        parsed = int(chunk_index or 0)
+    except (TypeError, ValueError):
+        parsed = 0
+    return max(parsed, 0)
+
+
+def legacy_offset_to_chunk_index(offset: Any, chunk_size: int = DEFAULT_SOURCE_CHUNK_SIZE) -> int:
+    try:
+        off = int(offset or 0)
+    except (TypeError, ValueError):
+        off = 0
+    if off <= 0:
+        return 0
+    return off // max(int(chunk_size or DEFAULT_SOURCE_CHUNK_SIZE), 1)
+
+
+def chunk_nav(chunks: List[str], chunk_index: Any = 0) -> Dict[str, Any]:
+    idx = normalize_chunk_index(chunk_index)
+    count = len(chunks or [])
+    out_of_range = idx >= count if count else idx > 0
+    selected = "" if out_of_range or count == 0 else (chunks[idx] or "")
+    return {
+        "chunk_index": idx,
+        "chunk_count": count,
+        "next_chunk": (idx + 1) if count and idx + 1 < count else None,
+        "has_more": bool(count and idx + 1 < count),
+        "out_of_range": bool(out_of_range),
+        "selected": selected,
+        "selected_chars": len(selected),
+    }
+
+
+def tool_json_debug_enabled() -> bool:
+    raw = os.getenv("HERMES_TOOL_DEBUG_JSON", "") or os.getenv("HERMES_DEBUG_TOOL_JSON", "")
+    return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_chunked_result(
+    result: Dict[str, Any],
+    *,
+    chunk_index: Any = 0,
+    cache_hit: bool = False,
+    content_key: str = "content",
+    output_key: str = "content",
+    chunks: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    source = result.get(content_key, "") or ""
+    source_chunks = chunks if chunks is not None else split_source_chunks(source)
+    nav = chunk_nav(source_chunks, chunk_index)
+    base = {
+        "url": result.get("url", ""),
+        "title": result.get("title", ""),
+        **({"blocked_by_policy": result["blocked_by_policy"]} if "blocked_by_policy" in result else {}),
+    }
+    existing_error = result.get("error")
+    if existing_error:
+        base["error"] = existing_error
+    elif nav["out_of_range"]:
+        base["error"] = f"chunk_index {nav['chunk_index']} is out of range for {nav['chunk_count']} chunks"
+
+    content = "" if nav["out_of_range"] else nav["selected"]
+    base.update({
+        output_key: content,
+        "chunk_index": nav["chunk_index"],
+        "chunk_count": nav["chunk_count"],
+        "next_chunk": nav["next_chunk"],
+        "has_more": nav["has_more"],
+    })
+    if tool_json_debug_enabled():
+        base["debug"] = {
+            "returned_chars": len(content or ""),
+            "source_chunk_chars": nav["selected_chars"],
+            "total_chars": sum(len(chunk or "") for chunk in source_chunks),
+            "input_cache_hit": bool(cache_hit),
+            "cache_hit": bool(cache_hit),
+            "chunk_out_of_range": nav["out_of_range"],
+        }
+    return base
+
+
+def search_source_chunks(
+    chunks: List[str],
+    *,
+    matcher,
+    include_context: bool = True,
+    max_results: int = 10,
+    collapse_accessibility_duplicates: bool = False,
+) -> List[Dict[str, Any]]:
+    limit = max(1, int(max_results or 10))
+    results: List[Dict[str, Any]] = []
+    lines_by_chunk: Dict[int, List[str]] = {}
+    for chunk_idx, chunk in enumerate(chunks):
+        lines = chunk.splitlines()
+        lines_by_chunk[chunk_idx] = lines
+        line_starts: List[int] = []
+        pos = 0
+        for line in lines:
+            line_starts.append(pos)
+            pos += len(line) + 1
+        for match in matcher.finditer(chunk):
+            line_index = 0
+            for i, start in enumerate(line_starts):
+                if start <= match.start():
+                    line_index = i
+                else:
+                    break
+            result: Dict[str, Any] = {
+                "chunk_index": chunk_idx,
+                "line": line_index + 1,
+                "match_text": match.group(0),
+            }
+            if include_context:
+                result["snippet"] = chunk_find_snippet(lines, line_index)
+            results.append(result)
+            if not collapse_accessibility_duplicates and len(results) >= limit:
+                return results
+    if collapse_accessibility_duplicates:
+        results = _collapse_accessibility_duplicate_results(results, lines_by_chunk)
+    return results[:limit]

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -55,11 +55,14 @@ logger = logging.getLogger(__name__)
 
 SANDBOX_AVAILABLE = True
 
-# The 7 tools allowed inside the sandbox. The intersection of this list
+# Tools allowed inside the sandbox. The intersection of this list
 # and the session's enabled tools determines which stubs are generated.
 SANDBOX_ALLOWED_TOOLS = frozenset([
     "web_search",
     "web_extract",
+    "web_extract_find",
+    "browser_snapshot",
+    "browser_find",
     "read_file",
     "write_file",
     "search_files",
@@ -190,9 +193,27 @@ _TOOL_STUBS = {
     ),
     "web_extract": (
         "web_extract",
-        "urls: list",
-        '"""Extract content from URLs. Returns dict with results list of {url, title, content, error}."""',
-        '{"urls": urls}',
+        "urls: list, chunk_index: int = 0",
+        '"""Extract one source chunk from URLs. Returns dict with results including chunk_count and next_chunk."""',
+        '{"urls": urls, "chunk_index": chunk_index}',
+    ),
+    "web_extract_find": (
+        "web_extract_find",
+        "query: str, urls: list = None, max_results: int = 10, case_sensitive: bool = False, regex: bool = False, include_context: bool = True",
+        '"""Search cached web_extract source chunks. Returns matches and suggested web_extract follow-ups."""',
+        '{"query": query, "urls": urls, "max_results": max_results, "case_sensitive": case_sensitive, "regex": regex, "include_context": include_context}',
+    ),
+    "browser_snapshot": (
+        "browser_snapshot",
+        "full: bool = False, chunk_index: int = 0",
+        '"""Return one cached/accessibility snapshot chunk. Requires browser_navigate first."""',
+        '{"full": full, "chunk_index": chunk_index}',
+    ),
+    "browser_find": (
+        "browser_find",
+        "query: str, max_results: int = 10, case_sensitive: bool = False, regex: bool = False, include_context: bool = True",
+        '"""Search cached full browser snapshot chunks. Returns matches and suggested browser_snapshot follow-ups."""',
+        '{"query": query, "max_results": max_results, "case_sensitive": case_sensitive, "regex": regex, "include_context": include_context}',
     ),
     "read_file": (
         "read_file",
@@ -1650,8 +1671,17 @@ _TOOL_DOC_LINES = [
      "  web_search(query: str, limit: int = 5) -> dict\n"
      "    Returns {\"data\": {\"web\": [{\"url\", \"title\", \"description\"}, ...]}}"),
     ("web_extract",
-     "  web_extract(urls: list[str]) -> dict\n"
-     "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown"),
+     "  web_extract(urls: list[str], chunk_index: int = 0) -> dict\n"
+     "    Returns one source chunk per URL with chunk_count/next_chunk metadata."),
+    ("web_extract_find",
+     "  web_extract_find(query: str, urls: list[str] | None = None, max_results: int = 10, case_sensitive: bool = False, regex: bool = False, include_context: bool = True) -> dict\n"
+     "    Searches cached web_extract source chunks and suggests web_extract follow-ups."),
+    ("browser_snapshot",
+     "  browser_snapshot(full: bool = False, chunk_index: int = 0) -> dict\n"
+     "    Returns one browser snapshot source chunk with chunk_count/next_chunk metadata."),
+    ("browser_find",
+     "  browser_find(query: str, max_results: int = 10, case_sensitive: bool = False, regex: bool = False, include_context: bool = True) -> dict\n"
+     "    Searches cached full browser snapshot source chunks and suggests browser_snapshot follow-ups."),
     ("read_file",
      "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import asyncio
+import sys
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx
 # NOTE: `from firecrawl import Firecrawl` is deliberately NOT at module top —
@@ -100,9 +101,147 @@ from tools.managed_tool_gateway import (
 from tools.tool_backend_helpers import managed_nous_tools_enabled, prefers_gateway
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
-import sys
+from tools.chunked_content import (
+    build_chunked_result,
+    compile_chunk_find_query,
+    legacy_offset_to_chunk_index,
+    search_source_chunks,
+    split_source_chunks,
+)
 
 logger = logging.getLogger(__name__)
+
+_WEB_EXTRACT_CACHE: Dict[tuple, Dict[str, Any]] = {}
+
+
+def _web_extract_cache_key(
+    url: str,
+    format: Optional[str],
+    use_llm_processing: bool,
+    model: Optional[str],
+    min_length: int,
+) -> tuple:
+    return (url, format or "markdown", bool(use_llm_processing), model or "", int(min_length))
+
+
+def _ensure_web_extract_cache() -> Dict[tuple, Dict[str, Any]]:
+    return _WEB_EXTRACT_CACHE
+
+
+def _latest_web_extract_cache_entries() -> Dict[str, Dict[str, Any]]:
+    latest_by_url: Dict[str, Dict[str, Any]] = {}
+    for cache_key, result in reversed(list(_ensure_web_extract_cache().items())):
+        if not isinstance(cache_key, tuple) or not cache_key:
+            continue
+        url = str(cache_key[0] or "")
+        if url and url not in latest_by_url:
+            latest_by_url[url] = result
+    return latest_by_url
+
+
+def _build_chunked_web_extract_response(
+    results: List[Dict[str, Any]],
+    *,
+    chunk_index: int = 0,
+    cache_hit: bool = False,
+) -> Dict[str, Any]:
+    return {
+        "results": [
+            build_chunked_result(
+                {
+                    "url": result.get("url", ""),
+                    "title": result.get("title", ""),
+                    "content": result.get("raw_content", "") or result.get("content", "") or "",
+                    "error": result.get("error"),
+                    **({"blocked_by_policy": result["blocked_by_policy"]} if "blocked_by_policy" in result else {}),
+                },
+                chunk_index=chunk_index,
+                cache_hit=cache_hit,
+                chunks=result.get("input_chunks") if isinstance(result.get("input_chunks"), list) else None,
+            )
+            for result in results
+        ]
+    }
+
+
+def web_extract_find(
+    query: str,
+    urls: Optional[List[str]] = None,
+    max_results: int = 10,
+    case_sensitive: bool = False,
+    regex: bool = False,
+    include_context: bool = True,
+) -> str:
+    """Search cached source chunks from previous web_extract calls."""
+    if not isinstance(query, str) or not query:
+        return json.dumps({"success": False, "error": "query must be a non-empty string"}, ensure_ascii=False)
+    try:
+        matcher = compile_chunk_find_query(query, regex=bool(regex), case_sensitive=bool(case_sensitive))
+    except re.error as exc:
+        return json.dumps({"success": False, "error": f"Invalid regex: {exc}"}, ensure_ascii=False)
+
+    latest_by_url = _latest_web_extract_cache_entries()
+    requested_urls = [str(url) for url in urls] if isinstance(urls, list) and urls else list(latest_by_url.keys())
+    searchable_urls = [url for url in requested_urls if url in latest_by_url]
+    missing_cache_urls = [url for url in requested_urls if url not in latest_by_url]
+
+    if not searchable_urls:
+        response: Dict[str, Any] = {
+            "success": False,
+            "error": "No cached web_extract source chunks. Call web_extract first.",
+            "query": query,
+            "searched_urls": [],
+            "missing_cache_urls": missing_cache_urls,
+            "next_actions": [
+                {"tool": "web_extract", "args": {"urls": [url], "chunk_index": 0}}
+                for url in missing_cache_urls
+            ] or None,
+        }
+        return json.dumps(response, ensure_ascii=False)
+
+    limit = max(1, int(max_results or 10))
+    results: List[Dict[str, Any]] = []
+    searched_chunks: Dict[str, List[int]] = {}
+    for url in searchable_urls:
+        cache_entry = latest_by_url[url]
+        chunks = cache_entry.get("input_chunks") if isinstance(cache_entry.get("input_chunks"), list) else split_source_chunks(cache_entry.get("raw_content", "") or cache_entry.get("content", "") or "")
+        normalized_chunks = [str(chunk) for chunk in chunks]
+        searched_chunks[url] = list(range(len(normalized_chunks)))
+        for result in search_source_chunks(
+            normalized_chunks,
+            matcher=matcher,
+            include_context=bool(include_context),
+            max_results=limit - len(results),
+            collapse_accessibility_duplicates=True,
+        ):
+            result["url"] = url
+            results.append(result)
+        if len(results) >= limit:
+            break
+
+    next_actions = []
+    seen_actions = set()
+    for result in results:
+        action_key = (result["url"], result["chunk_index"])
+        if action_key in seen_actions:
+            continue
+        seen_actions.add(action_key)
+        next_actions.append({"tool": "web_extract", "args": {"urls": [result["url"]], "chunk_index": result["chunk_index"]}})
+    for url in missing_cache_urls:
+        next_actions.append({"tool": "web_extract", "args": {"urls": [url], "chunk_index": 0}})
+
+    return json.dumps({
+        "success": True,
+        "query": query,
+        "regex": bool(regex),
+        "case_sensitive": bool(case_sensitive),
+        "searched_urls": searchable_urls,
+        "searched_chunks": searched_chunks,
+        "missing_cache_urls": missing_cache_urls,
+        "match_count": len(results),
+        "results": results,
+        "next_actions": next_actions or None,
+    }, ensure_ascii=False)
 
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
@@ -1313,7 +1452,11 @@ async def web_extract_tool(
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+    chunk_index: int = 0,
+    # Private compatibility for older direct callers; not exposed in the schema.
+    offset: Optional[int] = None,
+    limit: Optional[int] = None,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -1355,7 +1498,9 @@ async def web_extract_tool(
             "format": format,
             "use_llm_processing": use_llm_processing,
             "model": model,
-            "min_length": min_length
+            "min_length": min_length,
+            "chunk_index": chunk_index,
+            "legacy_offset": offset,
         },
         "error": None,
         "pages_extracted": 0,
@@ -1365,9 +1510,25 @@ async def web_extract_tool(
         "compression_metrics": [],
         "processing_applied": []
     }
-    
+    if offset is not None and chunk_index == 0:
+        chunk_index = legacy_offset_to_chunk_index(offset)
+
     try:
         logger.info("Extracting content from %d URL(s)", len(urls))
+
+        cache_keys = [_web_extract_cache_key(url, format, use_llm_processing, model, min_length) for url in urls]
+        cache_lookup_allowed = all(is_safe_url(url) and not check_website_access(url) for url in urls)
+        if cache_lookup_allowed:
+            cached_results = [_ensure_web_extract_cache().get(key) for key in cache_keys]
+            if cached_results and all(result is not None for result in cached_results):
+                trimmed_response = _build_chunked_web_extract_response(cached_results, chunk_index=chunk_index, cache_hit=True)
+                cleaned_result = clean_base64_images(json.dumps(trimmed_response, indent=2, ensure_ascii=False))
+                debug_call_data["pages_extracted"] = len(cached_results)
+                debug_call_data["final_response_size"] = len(cleaned_result)
+                debug_call_data["processing_applied"].append("input_cache_hit")
+                _debug.log_call("web_extract_tool", debug_call_data)
+                _debug.save()
+                return cleaned_result
 
         # ── SSRF protection — filter out private/internal URLs before any backend ──
         safe_urls = []
@@ -1601,18 +1762,40 @@ async def web_extract_tool(
                 content_length = len(result.get('raw_content', ''))
                 logger.info("%s (%d characters)", url, content_length)
         
-        # Trim output to minimal fields per entry: title, content, error
-        trimmed_results = [
-            {
-                "url": r.get("url", ""),
-                "title": r.get("title", ""),
-                "content": r.get("content", ""),
-                "error": r.get("error"),
-                **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
-            }
-            for r in response.get("results", [])
-        ]
-        trimmed_response = {"results": trimmed_results}
+        # Public web_extract calls use source chunks rather than automatic LLM
+        # summarization. Direct callers that explicitly keep use_llm_processing=True
+        # retain the legacy processed-content response path.
+        if not use_llm_processing:
+            raw_public_results = []
+            for r in response.get("results", []):
+                raw_content = r.get("raw_content", "") or r.get("content", "") or ""
+                raw_result = {
+                    "url": r.get("url", ""),
+                    "title": r.get("title", ""),
+                    "content": raw_content,
+                    "raw_content": raw_content,
+                    "input_chunks": split_source_chunks(raw_content),
+                    "error": r.get("error"),
+                    **({"blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
+                }
+                raw_public_results.append(raw_result)
+                _ensure_web_extract_cache()[
+                    _web_extract_cache_key(raw_result["url"], format, use_llm_processing, model, min_length)
+                ] = raw_result
+            trimmed_response = _build_chunked_web_extract_response(raw_public_results, chunk_index=chunk_index, cache_hit=False)
+        else:
+            # Trim output to minimal fields per entry: title, content, error
+            trimmed_results = [
+                {
+                    "url": r.get("url", ""),
+                    "title": r.get("title", ""),
+                    "content": r.get("content", ""),
+                    "error": r.get("error"),
+                    **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
+                }
+                for r in response.get("results", [])
+            ]
+            trimmed_response = {"results": trimmed_results}
 
         if trimmed_response.get("results") == []:
             result_json = tool_error("Content was inaccessible or not found")
@@ -2240,7 +2423,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Extract content from web page URLs. Returns one deterministic markdown source chunk at a time. Use chunk_index to navigate large pages and inspect chunk_count/next_chunk. This avoids hidden model summarization when extracted content is larger than a single tool result.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2249,9 +2432,37 @@ WEB_EXTRACT_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
                 "maxItems": 5
+            },
+            "chunk_index": {
+                "type": "integer",
+                "description": "Zero-based source chunk to return. Responses include chunk_count and next_chunk.",
+                "minimum": 0,
+                "default": 0
             }
         },
         "required": ["urls"]
+    }
+}
+
+WEB_EXTRACT_FIND_SCHEMA = {
+    "name": "web_extract_find",
+    "description": "Search cached web_extract source chunks for text or regex. Searches all cached chunks for selected URLs and suggests follow-up web_extract calls. Requires web_extract first.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Text or regex pattern to search for"},
+            "urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional cached URLs to limit the search to. Omit to search all cached web_extract URLs.",
+                "maxItems": 50,
+            },
+            "max_results": {"type": "integer", "description": "Maximum number of matches to return", "minimum": 1, "default": 10},
+            "case_sensitive": {"type": "boolean", "description": "Whether literal or regex matching should be case-sensitive", "default": False},
+            "regex": {"type": "boolean", "description": "Treat query as a Python regular expression instead of literal text", "default": False},
+            "include_context": {"type": "boolean", "description": "Include a compact snippet around each match", "default": True},
+        },
+        "required": ["query"]
     }
 }
 
@@ -2270,10 +2481,31 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        "markdown",
+        use_llm_processing=False,
+        chunk_index=args.get("chunk_index", 0),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="web_extract_find",
+    toolset="web",
+    schema=WEB_EXTRACT_FIND_SCHEMA,
+    handler=lambda args, **kw: web_extract_find(
+        query=args.get("query", ""),
+        urls=args.get("urls"),
+        max_results=args.get("max_results", 10),
+        case_sensitive=args.get("case_sensitive", False),
+        regex=args.get("regex", False),
+        include_context=args.get("include_context", True),
+    ),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    emoji="🔎",
     max_result_size_chars=100_000,
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "web_extract_find",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -40,7 +40,7 @@ _HERMES_CORE_TOOLS = [
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
-    "browser_navigate", "browser_snapshot", "browser_click",
+    "browser_navigate", "browser_snapshot", "browser_find", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_get_images",
     "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
@@ -79,7 +79,7 @@ TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "tools": ["web_search", "web_extract", "web_extract_find"],
         "includes": []  # No other toolsets included
     },
     
@@ -138,7 +138,7 @@ TOOLSETS = {
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
         "tools": [
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_snapshot", "browser_find", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
@@ -320,12 +320,12 @@ TOOLSETS = {
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_extract_find",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_snapshot", "browser_find", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
@@ -340,7 +340,7 @@ TOOLSETS = {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_extract_find",
             # Terminal + process management
             "terminal", "process",
             # File manipulation
@@ -350,7 +350,7 @@ TOOLSETS = {
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation
-            "browser_navigate", "browser_snapshot", "browser_click",
+            "browser_navigate", "browser_snapshot", "browser_find", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -8,7 +8,7 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 This page documents Hermes' built-in tools, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts (current registry):** ~70 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 7 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
+**Quick counts (current registry):** ~70 tools — 11 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 3 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 7 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with the prefix `mcp_<server>_` (e.g., `mcp_github_create_issue` for the `github` MCP server). See [MCP Integration](/docs/user-guide/features/mcp) for configuration.
@@ -21,11 +21,12 @@ In addition to built-in tools, Hermes can load tools dynamically from MCP server
 | `browser_back` | Navigate back to the previous page in browser history. Requires browser_navigate to be called first. | — |
 | `browser_click` | Click on an element identified by its ref ID from the snapshot (e.g., '@e5'). The ref IDs are shown in square brackets in the snapshot output. Requires browser_navigate and browser_snapshot to be called first. | — |
 | `browser_console` | Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings. Requi… | — |
+| `browser_find` | Search cached browser snapshot source chunks for text or regex. Returns matching chunk indexes and suggested `browser_snapshot(full=true, chunk_index=N)` follow-ups. Requires `browser_navigate` or `browser_snapshot` first. | — |
 | `browser_get_images` | Get a list of all images on the current page with their URLs and alt text. Useful for finding images to analyze with the vision tool. Requires browser_navigate to be called first. | — |
 | `browser_navigate` | Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). Use browser tools when you need… | — |
 | `browser_press` | Press a keyboard key. Useful for submitting forms (Enter), navigating (Tab), or keyboard shortcuts. Requires browser_navigate to be called first. | — |
 | `browser_scroll` | Scroll the page in a direction. Use this to reveal more content that may be below or above the current viewport. Requires browser_navigate to be called first. | — |
-| `browser_snapshot` | Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs (like @e1, @e2) for browser_click and browser_type. full=false (default): compact view with interactive elements. full=true: comp… | — |
+| `browser_snapshot` | Get a text-based snapshot of the current page accessibility tree. Returns one source chunk at a time with `chunk_index`, `chunk_count`, `next_chunk`, and `has_more`; use `full=true` for complete page source chunks. | — |
 | `browser_type` | Type text into an input field identified by its ref ID. Clears the field first, then types the new text. Requires browser_navigate and browser_snapshot to be called first. | — |
 | `browser_vision` | Take a screenshot of the current page and analyze it with vision AI. Use this when you need to visually understand what's on the page - especially useful for CAPTCHAs, visual verification challenges, complex layouts, or when the text snaps… | — |
 
@@ -209,7 +210,8 @@ Opt-in toolset (not loaded in the default `hermes-cli` set). Add via `--toolsets
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `web_search` | Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. Accepts an optional `limit` (1-100, default 5). The query is passed through to the configured backend, so operators such as `site:domain`, `filetype:pdf`, `intitle:word`, `-term`, and `"exact phrase"` may work when the backend supports them. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
-| `web_extract` | Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
+| `web_extract` | Extract content from web page URLs. Returns one deterministic markdown source chunk at a time with `chunk_index`, `chunk_count`, `next_chunk`, and `has_more`. Also works with PDF URLs when the configured backend supports them. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
+| `web_extract_find` | Search cached `web_extract` source chunks for text or regex. Returns matching chunk indexes and suggested `web_extract(urls=[...], chunk_index=N)` follow-ups. Requires `web_extract` first. | EXA_API_KEY or PARALLEL_API_KEY or FIRECRAWL_API_KEY or TAVILY_API_KEY |
 
 ## `tts` toolset
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -352,12 +352,27 @@ For simple information retrieval, prefer `web_search` or `web_extract` — they 
 
 ### `browser_snapshot`
 
-Get a text-based snapshot of the current page's accessibility tree. Returns interactive elements with ref IDs like `@e1`, `@e2` for use with `browser_click` and `browser_type`.
+Get a text-based snapshot of the current page's accessibility tree. Returns one source chunk at a time with `chunk_index`, `chunk_count`, `next_chunk`, and `has_more` metadata.
 
-- **`full=false`** (default): Compact view showing only interactive elements
-- **`full=true`**: Complete page content
+- **`full=false`** (default): compact snapshot chunks focused on interactive elements
+- **`full=true`**: complete page source chunks
+- **`chunk_index=0`** (default): zero-based chunk selector for large snapshots
 
-Snapshots over 8000 characters are automatically summarized by an LLM.
+Large snapshots are no longer silently LLM-summarized in the public tool path. Request later chunks explicitly:
+
+```json
+{"full": true, "chunk_index": 1}
+```
+
+### `browser_find`
+
+Search cached full-page browser snapshot source chunks for text or a regex. Run `browser_snapshot(full=true)` first if the cache is empty. Results include matching `chunk_index` values and suggested `browser_snapshot` follow-up calls.
+
+```json
+{"query": "pricing", "max_results": 5}
+```
+
+The Python sandbox helpers exposed through `execute_code` mirror this API as `browser_snapshot(full=False, chunk_index=0)` and `browser_find(query, ...)`.
 
 ### `browser_click`
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -7,12 +7,13 @@ sidebar_position: 6
 
 # Web Search & Extract
 
-Hermes Agent includes two model-callable web tools backed by multiple providers:
+Hermes Agent includes three model-callable web tools backed by multiple providers:
 
 - **`web_search`** — search the web and return ranked results
 - **`web_extract`** — fetch and extract readable content from one or more URLs (with built-in deep-crawl support when the backend provides it)
+- **`web_extract_find`** — search source chunks cached by prior `web_extract` calls and suggest exact chunk follow-ups
 
-Both are configured through a single backend selection. Providers are chosen via `hermes tools` or set directly in `config.yaml`. Recursive crawling capabilities (Firecrawl/Tavily) are exposed through `web_extract` rather than as a separate `web_crawl` tool.
+They are configured through a single backend selection. Providers are chosen via `hermes tools` or set directly in `config.yaml`. Recursive crawling capabilities (Firecrawl/Tavily) are exposed through `web_extract` rather than as a separate `web_crawl` tool.
 
 ## Backends
 
@@ -34,39 +35,48 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## How `web_extract` handles long pages
 
-Backends return raw page markdown, which can be huge (forum threads, docs sites, news articles with embedded comments). To keep your context window usable and your costs down, `web_extract` runs returned content through the **`web_extract` auxiliary model** before handing it to the agent. Behavior is purely size-driven:
+Backends can return very large markdown documents (forum threads, docs sites, news articles with comments). The public `web_extract` tool now returns deterministic source chunks instead of silently compressing large pages through an auxiliary model.
 
-| Page size (characters) | What happens |
-|------------------------|--------------|
-| Under 5 000 | Returned as-is — no LLM call, full markdown reaches the agent |
-| 5 000 – 500 000 | Single-pass summary via the `web_extract` auxiliary model, capped at ~5 000 chars of output |
-| 500 000 – 2 000 000 | Chunked: split into 100 k-char chunks, summarize each in parallel, then synthesize a final summary (~5 000 chars) |
-| Over 2 000 000 | Refused with a hint to use `web_crawl` with focused extraction instructions or a more specific source |
+Each result includes:
 
-The summary keeps quotes, code blocks, and key facts in their original formatting — it's a content compressor, not a paraphraser. If summarization fails or times out, Hermes falls back to the first ~5 000 chars of raw content rather than a useless error.
+- `content`: the selected chunk
+- `chunk_index`: the zero-based chunk returned
+- `chunk_count`: total chunks cached for that URL
+- `next_chunk`: the next chunk index, or `null`
+- `has_more`: whether more chunks are available
 
-### Which model does the summarizing?
+Example:
 
-The `web_extract` auxiliary task. By default (`auxiliary.web_extract.provider: "auto"`), this is your **main chat model** — same provider, same model as `hermes model`. That's fine for most setups, but on expensive reasoning models (Opus, MiniMax M2.7, etc.) every long-page extract adds meaningful cost.
-
-To route extraction summaries to a cheap, fast model regardless of your main:
-
-```yaml
-# ~/.hermes/config.yaml
-auxiliary:
-  web_extract:
-    provider: openrouter
-    model: google/gemini-3-flash-preview
-    timeout: 360       # seconds; raise if you hit summarization timeouts
+```json
+{"urls": ["https://example.com/long-page"], "chunk_index": 0}
 ```
 
-Or pick interactively: `hermes model` → **Configure auxiliary models** → `web_extract`.
+Then request the next chunk explicitly:
 
-See [Auxiliary Models](/docs/user-guide/configuration#auxiliary-models) for the full reference and per-task override patterns.
+```json
+{"urls": ["https://example.com/long-page"], "chunk_index": 1}
+```
 
-### When summarization gets in the way
+### Finding text inside cached extracts
 
-If you specifically need raw, unsummarized page content — for example, you're scraping a structured page where the LLM summary would drop important fields — use `browser_navigate` + `browser_snapshot` instead. The browser tool returns the live accessibility tree without auxiliary-model rewriting (subject to its own 8 000-char snapshot cap on huge pages).
+Use `web_extract_find` after `web_extract` to search cached source chunks without refetching the page. It supports literal text or regex matching and returns suggested follow-up calls with the matching `chunk_index`.
+
+```json
+{"query": "installation", "urls": ["https://example.com/long-page"]}
+```
+
+### Python helper support
+
+The Python sandbox helpers exposed through `execute_code` mirror the public tools:
+
+```python
+from hermes_tools import web_extract, web_extract_find
+
+first = web_extract(["https://example.com/long-page"], chunk_index=0)
+matches = web_extract_find("installation", urls=["https://example.com/long-page"])
+```
+
+Use browser tools when you need a live current tab, refs, clicks, forms, or JavaScript state. Use `web_extract` when you need URL-based content extraction.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds `chunk_index` pagination for long `web_extract` and `browser_snapshot` outputs, plus cached-source find tools for jumping straight to the relevant chunk.

The problem: long pages currently force a bad choice between huge tool outputs, hidden summarization/truncation, or brittle raw offset/limit pagination. That is especially painful for docs pages, long GitHub pages, forum threads, and browser accessibility snapshots where the agent needs exact source text instead of a model-compressed paraphrase.

This PR makes the contract explicit and deterministic:

```python
web_extract(["https://example.com/long-page"], chunk_index=0)
web_extract_find("needle", urls=["https://example.com/long-page"])

browser_snapshot(full=True, chunk_index=0)
browser_find("needle")
```

The approach stays narrow: cache source chunks, return exactly one requested chunk, expose `chunk_count` / `next_chunk` / `has_more`, and make the corresponding `_find` tools search the same cached chunks and return follow-up calls with the matching `chunk_index`. Legacy raw `offset` compatibility remains private for older direct callers, but public schemas expose `chunk_index` instead of raw offsets.

## Related Issue

No linked issue for this focused browser/web tool-contract change.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/chunked_content.py`
  - Adds shared deterministic source chunking helpers.
  - Adds chunk selection metadata: `chunk_index`, `chunk_count`, `next_chunk`, `has_more`.
  - Adds cached-source search helpers with snippets and optional accessibility duplicate collapse.
  - Keeps debug-only internals behind `HERMES_TOOL_DEBUG_JSON` / `HERMES_DEBUG_TOOL_JSON` instead of leaking raw source fields by default.
- `tools/web_tools.py`
  - Adds `chunk_index` to the public `web_extract` schema.
  - Caches extracted source chunks per URL so later `chunk_index` calls do not refetch the page.
  - Returns deterministic markdown chunks instead of hidden large-page LLM summarization in this path.
  - Adds `web_extract_find` to search cached extract chunks and suggest exact `web_extract(..., chunk_index=N)` follow-ups.
  - Preserves private legacy `offset` handling for old direct callers without exposing it in the schema.
- `tools/browser_tool.py`
  - Adds `chunk_index` to `browser_snapshot`.
  - Stores browser snapshot source chunks per task/session and invalidates them on navigation or page mutation.
  - Adds `browser_find` to search cached full snapshot chunks and suggest `browser_snapshot(full=True, chunk_index=N)` follow-ups.
  - Keeps `browser_snapshot` metadata stable across cache hits and fresh reads.
- `tools/browser_camofox.py`
  - Forwards chunk-index handling through the Camofox snapshot path.
  - Preserves Camofox truncation/drain behavior behind the same public chunk-index contract.
- `tools/code_execution_tool.py`
  - Updates sandbox allow-list, generated stubs, and agent-facing docs for:
    - `web_extract(..., chunk_index=...)`
    - `web_extract_find(...)`
    - `browser_snapshot(..., chunk_index=...)`
    - `browser_find(...)`
- `toolsets.py`
  - Exposes `web_extract_find` through web toolsets.
  - Exposes `browser_find` through browser-capable toolsets.
- `tests/tools/test_browser_web_chunk_index_api.py`
  - Adds coverage for schemas, chunk metadata, cache reuse, out-of-range chunks, find follow-ups, toolset registration, and execute-code exposure.
- `tests/tools/test_code_execution.py`, `tests/test_toolsets.py`, `tests/tools/test_browser_secret_exfil.py`
  - Updates regression coverage for the new tool exposure and redaction/safety behavior.
- `website/docs/user-guide/features/browser.md`
  - Documents chunked `browser_snapshot`, `browser_find`, and Python sandbox helper usage.
- `website/docs/user-guide/features/web-search.md`
  - Documents deterministic chunked `web_extract`, `web_extract_find`, and the shift away from hidden summarization for long extracts.
- `website/docs/reference/tools-reference.md`
  - Updates the built-in tools reference with the new browser/web tools and behavior.

## How to Test

1. Run the focused browser/web/code-execution regression suite:

```bash
scripts/run_tests.sh tests/tools/test_browser_web_chunk_index_api.py tests/tools/test_code_execution.py tests/test_toolsets.py tests/tools/test_browser_secret_exfil.py -q
```

Expected:

```text
109 passed
```

2. Verify the Python helper surface mirrors the public tool contract:

```python
from hermes_tools import web_extract, web_extract_find, browser_snapshot, browser_find

first = web_extract(["https://example.com/long-page"], chunk_index=0)
match = web_extract_find("needle", urls=["https://example.com/long-page"])
page = browser_snapshot(full=True, chunk_index=0)
found = browser_find("needle")
```

Expected behavior:

```text
- extract/snapshot calls return one selected chunk plus chunk_count / next_chunk / has_more
- find calls search cached source chunks and return follow-up args with the matching chunk_index
- public schemas expose chunk_index and do not expose raw offset / limit
```

3. Run the cross-platform footgun scan:

```bash
python scripts/check-windows-footguns.py --diff origin/main
```

4. Check diff hygiene:

```bash
git diff --check origin/main..HEAD
```

5. Optional full-suite check:

```bash
scripts/run_tests.sh tests/ -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Searched for `web_extract_find`, `browser_find chunk_index`, and `chunk_index web_extract browser_snapshot`; only this PR matched after creation.
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
  - Focused browser/web/code-execution regression suite passes with the canonical `scripts/run_tests.sh` wrapper.
  - Full-suite run completed but has unrelated failures outside the touched browser/web/toolset/code-exec files; details below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Linux 7.0.0-3-pve x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — `website/docs/user-guide/features/browser.md`, `website/docs/user-guide/features/web-search.md`, `website/docs/reference/tools-reference.md`
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A: no config keys changed
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A: no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses stdlib/path-neutral Python; `python scripts/check-windows-footguns.py --diff origin/main` passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `web_extract`, `web_extract_find`, `browser_snapshot`, `browser_find`, and execute-code helper docs/stubs updated

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Focused regression suite from the current verification pass:

```text
scripts/run_tests.sh tests/tools/test_browser_web_chunk_index_api.py tests/tools/test_code_execution.py tests/test_toolsets.py tests/tools/test_browser_secret_exfil.py -q
109 passed in 29.65s
```

Cross-platform footgun scan:

```text
python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (10 file(s) scanned).
```

Diff hygiene:

```text
git diff --check origin/main..HEAD
# no output
```

Full-suite status from this checkout:

```text
scripts/run_tests.sh tests/ -q
28 failed, 22146 passed, 73 skipped, 220 warnings in 376.63s
```

The full suite did not pass in this checkout. The focused changed-area suite passes, and the observed failures are outside this PR's browser/web chunk-index paths. Failure classes observed:

```text
- CLI config save tests expecting ruamel-backed comment-preserving writes
- gateway restart/service PID filtering and generated systemd unit tests
- gateway/tool-progress/media-routing command behavior tests
- provider metadata/default-model expectation drift
- prompt-cache-related AIAgent test stubs missing _use_long_lived_prefix_cache
- plugin dashboard route auth returning 404 in the test fixture
- known async auxiliary client cache replacement flake
```

Chunk contract covered by tests:

```text
- web_extract schema exposes chunk_index and hides raw offset/limit
- browser_snapshot schema exposes chunk_index and hides raw offset/limit
- web_extract returns chunk_count, next_chunk, has_more, and out-of-range errors
- web_extract reuses cached source chunks across chunk_index calls
- web_extract_find searches cached chunks and suggests exact web_extract follow-ups
- browser_snapshot returns the requested cached/source chunk with metadata
- browser_find searches cached full snapshots and suggests exact browser_snapshot follow-ups
- toolsets expose web_extract_find and browser_find
- execute_code exposes matching Python helpers and documentation
- browser secret-exfiltration/redaction coverage remains intact
```
