### PR TITLE
fix(skills_tool): Use Path.parts for platform-agnostic file categorization in skill_view

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -438,6 +438,38 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is False
 
+    def test_view_nonexistent_file_categorizes_available_files(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "my-skill")
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "guide.md").write_text("ref content")
+            (skill_dir / "templates").mkdir()
+            (skill_dir / "templates" / "output.yaml").write_text("template content")
+            (skill_dir / "assets").mkdir()
+            (skill_dir / "assets" / "icon.png").write_bytes(b"\x89PNG")
+            (skill_dir / "scripts").mkdir()
+            (skill_dir / "scripts" / "build.sh").write_text("#!/bin/bash")
+
+            raw = skill_view("my-skill", file_path="references/nonexistent.md")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        available = result["available_files"]
+        # Use Path parts for platform-agnostic comparison (Windows uses backslashes)
+        assert [Path(p).parts for p in available["references"]] == [
+            ("references", "guide.md")
+        ]
+        assert [Path(p).parts for p in available["templates"]] == [
+            ("templates", "output.yaml")
+        ]
+        assert [Path(p).parts for p in available["assets"]] == [
+            ("assets", "icon.png")
+        ]
+        assert [Path(p).parts for p in available["scripts"]] == [
+            ("scripts", "build.sh")
+        ]
+        assert "other" not in available
+
     def test_view_shows_linked_files(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "my-skill")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1124,15 +1124,15 @@ def skill_view(
                 # Scan for all readable files
                 for f in skill_dir.rglob("*"):
                     if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
-                        if rel.startswith("references/"):
-                            available_files["references"].append(rel)
-                        elif rel.startswith("templates/"):
-                            available_files["templates"].append(rel)
-                        elif rel.startswith("assets/"):
-                            available_files["assets"].append(rel)
-                        elif rel.startswith("scripts/"):
-                            available_files["scripts"].append(rel)
+                        rel_path = f.relative_to(skill_dir)
+                        if rel_path.parts[0] == "references":
+                            available_files["references"].append(str(rel_path))
+                        elif rel_path.parts[0] == "templates":
+                            available_files["templates"].append(str(rel_path))
+                        elif rel_path.parts[0] == "assets":
+                            available_files["assets"].append(str(rel_path))
+                        elif rel_path.parts[0] == "scripts":
+                            available_files["scripts"].append(str(rel_path))
                         elif f.suffix in {
                             ".md",
                             ".py",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1142,7 +1142,7 @@ def skill_view(
                             ".tex",
                             ".sh",
                         }:
-                            available_files["other"].append(rel)
+                            available_files["other"].append(str(rel_path))
 
                 # Remove empty categories
                 available_files = {k: v for k, v in available_files.items() if v}


### PR DESCRIPTION
## Problem
The `skill_view()` function in `tools/skills_tool.py` used hardcoded forward slash `/` 
separators when categorizing files by directory (references/, templates/, assets/, scripts/).
On Windows, `str(Path.relative_to())` returns backslash-separated paths, causing all 
categorization checks to fail and files to be dumped into the "other" category.

## Fix
Replaced `str.startswith("dir/")` pattern with `Path.parts[0] == "dir"` comparison,
which is platform-agnostic and handles both Windows backslashes and POSIX forward slashes.

## Testing
- Existing test suite: `tests/tools/test_skill_view_path_check.py`
- Verified file categorization works correctly on Windows with backslash paths
- No behavior change on POSIX systems