### PR TITLE
fix(model): refresh cached model catalogs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1724,6 +1724,8 @@ def cmd_setup(args):
 def cmd_model(args):
     """Select default model — starts with provider selection, then model picker."""
     _require_tty("model")
+    if bool(getattr(args, "refresh", False)):
+        _clear_model_catalog_cache()
     select_provider_and_model(args=args)
 
 
@@ -1763,6 +1765,7 @@ def select_provider_and_model(args=None):
     from hermes_cli.providers import resolve_provider_full
 
     config = load_config()
+    force_model_catalog_refresh = bool(getattr(args, "refresh", False))
     current_model = config.get("model")
     if isinstance(current_model, dict):
         current_model = current_model.get("default", "")
@@ -1973,7 +1976,12 @@ def select_provider_and_model(args=None):
     elif selected_provider == "ai-gateway":
         _model_flow_ai_gateway(config, current_model)
     elif selected_provider == "nous":
-        _model_flow_nous(config, current_model, args=args)
+        _model_flow_nous(
+            config,
+            current_model,
+            args=args,
+            force_catalog_refresh=force_model_catalog_refresh,
+        )
     elif selected_provider == "openai-codex":
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "qwen-oauth":
@@ -2584,7 +2592,13 @@ def _model_flow_ai_gateway(config, current_model=""):
         print("No change.")
 
 
-def _model_flow_nous(config, current_model="", args=None):
+def _model_flow_nous(
+    config,
+    current_model="",
+    args=None,
+    *,
+    force_catalog_refresh: bool = False,
+):
     """Nous Portal provider: ensure logged in, then pick model."""
     from hermes_cli.auth import (
         get_provider_auth_state,
@@ -2646,7 +2660,7 @@ def _model_flow_nous(config, current_model="", args=None):
         partition_nous_models_by_tier,
     )
 
-    model_ids = get_curated_nous_model_ids()
+    model_ids = get_curated_nous_model_ids(force_refresh=force_catalog_refresh)
     if not model_ids:
         print("No curated models available for Nous Portal.")
         return
@@ -6109,6 +6123,8 @@ def _update_via_zip(args):
     except Exception:
         pass
 
+    _invalidate_update_cache()
+
     print()
     print("✓ Update complete!")
     try:
@@ -6547,13 +6563,26 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         print("    Your local repo is updated, but your fork on GitHub may be behind.")
 
 
+def _clear_model_catalog_cache() -> None:
+    """Clear hosted model-catalog caches using the resolved Hermes home."""
+    try:
+        from hermes_cli.model_catalog import clear_disk_cache
+
+        clear_disk_cache()
+    except Exception as exc:
+        logger.debug("Model catalog cache invalidation failed: %s", exc)
+
+
 def _invalidate_update_cache():
     """Delete the update-check cache for ALL profiles so no banner
-    reports a stale "commits behind" count after a successful update.
+    reports a stale "commits behind" count after a successful update, and
+    drop the hosted model catalog cache so ``hermes model`` sees the newly
+    bundled/remote catalog after ``hermes update``.
 
     The git repo is shared across profiles — when one profile runs
     ``hermes update``, every profile is now current.
     """
+    _clear_model_catalog_cache()
     homes = []
     # Default profile home (Docker-aware — uses /opt/data in Docker)
     from hermes_constants import get_default_hermes_root
@@ -6571,6 +6600,12 @@ def _invalidate_update_cache():
             cache_file = home / ".update_check"
             if cache_file.exists():
                 cache_file.unlink()
+        except Exception:
+            pass
+        try:
+            model_catalog_cache = home / "cache" / "model_catalog.json"
+            if model_catalog_cache.exists():
+                model_catalog_cache.unlink()
         except Exception:
             pass
 
@@ -9368,6 +9403,11 @@ def main():
         "--insecure",
         action="store_true",
         help="Disable TLS verification for Nous login (testing only)",
+    )
+    model_parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Clear cached remote model catalogs and fetch fresh picker data",
     )
     model_parser.set_defaults(func=cmd_model)
 

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -11,7 +11,9 @@ Pipeline
    - Checks in-process cache (invalidated by TTL).
    - Reads disk cache at ``~/.hermes/cache/model_catalog.json``.
    - Fetches the master URL if disk cache is stale or missing.
-   - On any fetch failure, keeps using the stale cache (or empty dict).
+   - On ordinary fetch failure, keeps using the stale cache (or empty dict).
+   - On explicit force-refresh failure, returns empty so callers fall back to
+     the bundled snapshot instead of reusing the stale disk cache.
 
 2. ``get_curated_openrouter_models()`` / ``get_curated_nous_models()`` —
    thin accessors returning the shapes existing callers expect. Each
@@ -234,7 +236,9 @@ def get_catalog(*, force_refresh: bool = False) -> dict[str, Any]:
         _catalog_cache_source_mtime = disk_mtime
         return disk_data
 
-    # Need to (re)fetch. If it fails, fall back to any stale disk copy.
+    # Need to (re)fetch. Ordinary offline use can keep a stale disk copy; an
+    # explicit force-refresh must not resurrect the same stale catalog the user
+    # is trying to bypass.
     fetched = _fetch_manifest(cfg["url"], DEFAULT_FETCH_TIMEOUT)
     if fetched is not None:
         _write_disk_cache(fetched)
@@ -247,7 +251,7 @@ def get_catalog(*, force_refresh: bool = False) -> dict[str, Any]:
         _catalog_cache_source_mtime = now
         return fetched
 
-    if disk_data is not None:
+    if not force_refresh and disk_data is not None:
         _catalog_cache = disk_data
         _catalog_cache_source_mtime = disk_mtime
         return disk_data
@@ -272,7 +276,11 @@ def _fetch_provider_override(provider: str) -> dict[str, Any] | None:
     return _fetch_manifest(override_url.strip(), DEFAULT_FETCH_TIMEOUT)
 
 
-def _get_provider_block(provider: str) -> dict[str, Any] | None:
+def _get_provider_block(
+    provider: str,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, Any] | None:
     """Return the provider's manifest block, respecting per-provider overrides."""
     override = _fetch_provider_override(provider)
     if override is not None:
@@ -280,20 +288,23 @@ def _get_provider_block(provider: str) -> dict[str, Any] | None:
         if isinstance(block, dict):
             return block
 
-    catalog = get_catalog()
+    catalog = get_catalog(force_refresh=force_refresh)
     if not catalog:
         return None
     block = catalog.get("providers", {}).get(provider)
     return block if isinstance(block, dict) else None
 
 
-def get_curated_openrouter_models() -> list[tuple[str, str]] | None:
+def get_curated_openrouter_models(
+    *,
+    force_refresh: bool = False,
+) -> list[tuple[str, str]] | None:
     """Return OpenRouter's curated ``[(id, description), ...]`` from the manifest.
 
     Returns ``None`` when the manifest is unavailable, so callers can fall
     back to their hardcoded list.
     """
-    block = _get_provider_block("openrouter")
+    block = _get_provider_block("openrouter", force_refresh=force_refresh)
     if not block:
         return None
     out: list[tuple[str, str]] = []
@@ -306,12 +317,15 @@ def get_curated_openrouter_models() -> list[tuple[str, str]] | None:
     return out or None
 
 
-def get_curated_nous_models() -> list[str] | None:
+def get_curated_nous_models(
+    *,
+    force_refresh: bool = False,
+) -> list[str] | None:
     """Return Nous Portal's curated list of model ids from the manifest.
 
     Returns ``None`` when the manifest is unavailable.
     """
-    block = _get_provider_block("nous")
+    block = _get_provider_block("nous", force_refresh=force_refresh)
     if not block:
         return None
     out: list[str] = []
@@ -327,3 +341,17 @@ def reset_cache() -> None:
     global _catalog_cache, _catalog_cache_source_mtime
     _catalog_cache = None
     _catalog_cache_source_mtime = 0.0
+
+
+def clear_disk_cache() -> None:
+    """Clear the in-process and disk model-catalog cache.
+
+    Uses ``get_hermes_home()`` via ``_cache_path()`` so Windows AppData,
+    custom ``HERMES_HOME``, Docker, and profile homes all resolve through the
+    same runtime path as normal catalog reads.
+    """
+    reset_cache()
+    try:
+        _cache_path().unlink(missing_ok=True)
+    except OSError as exc:
+        logger.info("model catalog cache delete failed: %s", exc)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -975,7 +975,7 @@ def fetch_openrouter_models(
     # free pricing) is applied on top either way.
     try:
         from hermes_cli.model_catalog import get_curated_openrouter_models
-        remote = get_curated_openrouter_models()
+        remote = get_curated_openrouter_models(force_refresh=force_refresh)
     except Exception:
         remote = None
     fallback = list(remote) if remote else list(OPENROUTER_MODELS)
@@ -1031,17 +1031,18 @@ def model_ids(*, force_refresh: bool = False) -> list[str]:
     return [mid for mid, _ in fetch_openrouter_models(force_refresh=force_refresh)]
 
 
-def get_curated_nous_model_ids() -> list[str]:
+def get_curated_nous_model_ids(*, force_refresh: bool = False) -> list[str]:
     """Return the curated Nous Portal model-id list.
 
     Prefers the remotely-hosted catalog manifest (published under
     ``website/static/api/model-catalog.json``); falls back to the in-repo
     snapshot in ``_PROVIDER_MODELS["nous"]`` when the manifest is
-    unreachable. Always returns a list (never None).
+    unreachable. Pass ``force_refresh=True`` to bypass the catalog TTL. Always
+    returns a list (never None).
     """
     try:
         from hermes_cli.model_catalog import get_curated_nous_models
-        remote = get_curated_nous_models()
+        remote = get_curated_nous_models(force_refresh=force_refresh)
     except Exception:
         remote = None
     if remote:

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -149,9 +149,35 @@ class TestFetchFailure:
         # Now wipe in-process cache and simulate network failure on refetch.
         model_catalog.reset_cache()
         with patch.object(model_catalog, "_fetch_manifest", return_value=None):
-            result = model_catalog.get_catalog(force_refresh=True)
+            result = model_catalog.get_catalog()
 
         assert result == manifest
+
+    def test_force_refresh_failure_ignores_stale_disk_cache(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        manifest = _valid_manifest()
+        cache = model_catalog._cache_path()
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        with open(cache, "w") as fh:
+            json.dump(manifest, fh)
+
+        model_catalog.reset_cache()
+        with patch.object(model_catalog, "_fetch_manifest", return_value=None):
+            result = model_catalog.get_catalog(force_refresh=True)
+
+        assert result == {}
+
+    def test_clear_disk_cache_uses_resolved_hermes_home(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        cache = model_catalog._cache_path()
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(json.dumps(_valid_manifest()))
+
+        assert cache.exists()
+        model_catalog.clear_disk_cache()
+        assert not cache.exists()
 
     def test_fetch_failure_falls_back_to_stale_cache(self, isolated_home):
         from hermes_cli import model_catalog
@@ -185,6 +211,18 @@ class TestCuratedAccessors:
             ("openrouter/elephant-alpha", "free"),
         ]
 
+    def test_openrouter_force_refresh_reaches_catalog_fetch(self, isolated_home):
+        from hermes_cli import model_catalog
+        manifest = _valid_manifest()
+
+        with patch.object(
+            model_catalog, "_fetch_manifest", return_value=manifest
+        ) as fetch:
+            model_catalog.get_curated_openrouter_models(force_refresh=True)
+            model_catalog.get_curated_openrouter_models(force_refresh=True)
+
+        assert fetch.call_count == 2
+
     def test_nous_returns_ids(self, isolated_home):
         from hermes_cli import model_catalog
         with patch.object(
@@ -192,6 +230,18 @@ class TestCuratedAccessors:
         ):
             result = model_catalog.get_curated_nous_models()
         assert result == ["anthropic/claude-opus-4.7", "moonshotai/kimi-k2.6"]
+
+    def test_nous_force_refresh_reaches_catalog_fetch(self, isolated_home):
+        from hermes_cli import model_catalog
+        manifest = _valid_manifest()
+
+        with patch.object(
+            model_catalog, "_fetch_manifest", return_value=manifest
+        ) as fetch:
+            model_catalog.get_curated_nous_models(force_refresh=True)
+            model_catalog.get_curated_nous_models(force_refresh=True)
+
+        assert fetch.call_count == 2
 
     def test_openrouter_returns_none_when_catalog_empty(self, isolated_home):
         from hermes_cli import model_catalog

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -59,6 +59,19 @@ class TestOpenRouterModels:
 
 
 class TestFetchOpenRouterModels:
+    def test_force_refresh_reaches_remote_manifest_catalog(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with patch(
+            "hermes_cli.model_catalog.get_curated_openrouter_models",
+            return_value=[("openrouter/test-model", "")],
+        ) as curated, patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            side_effect=OSError("offline"),
+        ):
+            fetch_openrouter_models(force_refresh=True)
+
+        curated.assert_called_once_with(force_refresh=True)
+
     def test_live_fetch_recomputes_free_tags(self, monkeypatch):
         class _Resp:
             def __enter__(self):
@@ -167,6 +180,20 @@ class TestFetchOpenRouterModels:
         ids = [mid for mid, _ in models]
         assert "anthropic/claude-opus-4.6" in ids
         assert "qwen/qwen3.6-plus" in ids
+
+
+class TestNousCuratedModelIds:
+    def test_force_refresh_reaches_remote_manifest_catalog(self):
+        from hermes_cli.models import get_curated_nous_model_ids
+
+        with patch(
+            "hermes_cli.model_catalog.get_curated_nous_models",
+            return_value=["nous/test-model"],
+        ) as curated:
+            result = get_curated_nous_model_ids(force_refresh=True)
+
+        assert result == ["nous/test-model"]
+        curated.assert_called_once_with(force_refresh=True)
 
 
 class TestOpenRouterToolSupportHelper:

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -121,12 +121,16 @@ def test_invalidate_update_cache_clears_all_profiles(tmp_path):
     default_home = tmp_path / ".hermes"
     default_home.mkdir()
     (default_home / ".update_check").write_text('{"ts":1,"behind":50}')
+    (default_home / "cache").mkdir()
+    (default_home / "cache" / "model_catalog.json").write_text('{"version":1}')
 
     profiles_root = default_home / "profiles"
     for name in ("ops", "dev"):
         p = profiles_root / name
         p.mkdir(parents=True)
         (p / ".update_check").write_text('{"ts":1,"behind":50}')
+        (p / "cache").mkdir()
+        (p / "cache" / "model_catalog.json").write_text('{"version":1}')
 
     with patch.object(Path, "home", return_value=tmp_path), \
          patch.dict(os.environ, {"HERMES_HOME": str(default_home)}):
@@ -136,6 +140,9 @@ def test_invalidate_update_cache_clears_all_profiles(tmp_path):
     assert not (default_home / ".update_check").exists(), "default profile cache not cleared"
     assert not (profiles_root / "ops" / ".update_check").exists(), "ops profile cache not cleared"
     assert not (profiles_root / "dev" / ".update_check").exists(), "dev profile cache not cleared"
+    assert not (default_home / "cache" / "model_catalog.json").exists()
+    assert not (profiles_root / "ops" / "cache" / "model_catalog.json").exists()
+    assert not (profiles_root / "dev" / "cache" / "model_catalog.json").exists()
 
 
 def test_invalidate_update_cache_no_profiles_dir(tmp_path):
@@ -145,9 +152,12 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
     default_home = tmp_path / ".hermes"
     default_home.mkdir()
     (default_home / ".update_check").write_text('{"ts":1,"behind":5}')
+    (default_home / "cache").mkdir()
+    (default_home / "cache" / "model_catalog.json").write_text('{"version":1}')
 
     with patch.object(Path, "home", return_value=tmp_path), \
          patch.dict(os.environ, {"HERMES_HOME": str(default_home)}):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+    assert not (default_home / "cache" / "model_catalog.json").exists()


### PR DESCRIPTION
## What does this PR do?

Fixes stale hosted model catalogs after `hermes update` and adds an explicit `hermes model --refresh` recovery path.

The remote model catalog is cached under the resolved Hermes home, but update previously refreshed the repo without invalidating that user-local cache. Users could update Hermes and still see an old OpenRouter/Nous curated model list until the 24 hour TTL expired. This change makes update semantics match user expectation: after update, the next model picker sees fresh remote catalog data or falls back to the newly bundled snapshot.

The implementation uses Hermes path resolvers instead of hardcoded Windows or Unix home paths, so AppData installs, custom `HERMES_HOME`, Docker, and profile homes follow the same runtime lookup.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add `hermes model --refresh`, clear the model catalog cache before opening the picker, and invalidate model catalog caches during `hermes update`, including already-up-to-date and ZIP update paths.
- `hermes_cli/model_catalog.py`: add force-refresh plumbing for provider accessors, clear both in-process and disk cache through the resolved Hermes home, and avoid reusing stale disk cache on explicit refresh failure.
- `hermes_cli/models.py`: thread `force_refresh` into OpenRouter and Nous hosted catalog lookups.
- `tests/hermes_cli/test_model_catalog.py`: cover stale-cache fallback, force-refresh behavior, resolved-home cache deletion, and provider accessor refresh propagation.
- `tests/hermes_cli/test_models.py`: cover OpenRouter and Nous force-refresh propagation into hosted catalog lookups.
- `tests/hermes_cli/test_update_check.py`: cover update invalidation of model catalog caches across default and profile homes.

## How to Test

1. Run `python -m pytest -n 0 tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py tests/hermes_cli/test_update_check.py -q`.
2. Run `python -m py_compile hermes_cli/main.py hermes_cli/model_catalog.py hermes_cli/models.py`.
3. Run `python -m hermes_cli.main model --help` and confirm `--refresh` is listed.
4. Run `scripts/run_tests.sh` for the full non-integration suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Checked #19005 and #14936; neither covers update-time invalidation of `cache/model_catalog.json`.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted validation before opening the draft:

- `python -m pytest -n 0 tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py tests/hermes_cli/test_update_check.py -q`
  - Result: `94 passed in 3.21s`
- `python -m py_compile hermes_cli/main.py hermes_cli/model_catalog.py hermes_cli/models.py`
  - Result: passed
- `python -m hermes_cli.main model --help`
  - Result: `--refresh` is listed

Full-suite validation after opening the draft:

- `scripts/run_tests.sh`
  - Result: failed locally with `63 failed, 22124 passed, 59 skipped, 236 warnings, 19 errors in 622.55s (0:10:22)`.
  - The run used the project runner's pinned `4` workers.
  - `HERMES_HOME` was empty before the run and empty after the run.
  - The failure set is broad and includes existing environment/dependency/process-test failures such as missing `ruamel`, missing `psutil`, Dingtalk async mock comparison failures, browser supervisor runtime errors, and process-timeout/zombie cleanup tests. The targeted tests for this PR passed.
