### PR TITLE
fix(kanban): use 'is not None' check for max_runtime_seconds in create_task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1393,7 +1393,7 @@ def create_task(
                         workspace_path,
                         tenant,
                         idempotency_key,
-                        int(max_runtime_seconds) if max_runtime_seconds else None,
+                        int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
                     ),


### PR DESCRIPTION
## What does this PR do?

`create_task()` in `hermes_cli/kanban_db.py` used a falsy check for `max_runtime_seconds`:

```python
# before
int(max_runtime_seconds) if max_runtime_seconds else None,
```

This silently coerces `max_runtime_seconds=0` to `None`, losing the caller's intent. Zero is a valid value — it causes the dispatcher to immediately time out a task.

The adjacent `max_retries` parameter (one line below) already uses the correct pattern:

```python
int(max_retries) if max_retries is not None else None,
```

## Type of Change
🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `hermes_cli/kanban_db.py` line 1396: replaced `if max_runtime_seconds` with `if max_runtime_seconds is not None`

## How to Test
```python
from hermes_cli.kanban_db import create_task
# max_runtime_seconds=0 should persist as 0, not become None
```

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tested on: Ubuntu 24.04 (WSL2)