### PR TITLE
fix(kanban): reset failure counters on unblock_task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2678,7 +2678,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"
         cur = conn.execute(
-            "UPDATE tasks SET status = ?, current_run_id = NULL "
+            "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "consecutive_failures = 0, last_failure_error = NULL "
             "WHERE id = ? AND status = 'blocked'",
             (new_status, task_id),
         )

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -378,6 +378,26 @@ def test_block_then_unblock(kanban_home):
         assert kb.get_task(conn, t).status == "ready"
 
 
+def test_unblock_resets_failure_counters(kanban_home):
+    """unblock_task must reset consecutive_failures and last_failure_error."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        assert kb.block_task(conn, t, reason="need input")
+        # Simulate accumulated failures from the circuit breaker
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 5, "
+            "last_failure_error = 'test error' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        assert kb.unblock_task(conn, t)
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+
+
 # ---------------------------------------------------------------------------
 # Parent-completion invariant at the claim gate (RCA t_a6acd07d)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `unblock_task()` resets task status but leaves `consecutive_failures` and `last_failure_error` intact. The next failure immediately re-trips the circuit breaker because the counter is still at max.

## Related Issue

No existing issue — discovered during operational review of fleet-wide kanban dispatch failures.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — Added `consecutive_failures = 0, last_failure_error = NULL` to the UPDATE in `unblock_task()`
- `tests/hermes_cli/test_kanban_db.py` — Added `test_unblock_resets_failure_counters` regression test

## How to Test

1. Create a task, claim it, block it
2. Set `consecutive_failures = 5` via raw SQL
3. Call `unblock_task()` — verify counters are zeroed
4. Run: `python -m pytest tests/hermes_cli/test_kanban_db.py -q -k unblock`

```
4 passed, 79 deselected in 0.55s
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicates found
- [x] My PR contains only changes related to this fix
- [x] I've run tests and they pass
- [x] I've added tests for my changes
- [x] Tested on macOS 15