### PR TITLE
fix(gateway): guard check_fn() call in platform_registry with try/except

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -290,7 +290,16 @@ class PlatformRegistry:
         if entry is None:
             return None
 
-        if not entry.check_fn():
+        try:
+            check_ok = entry.check_fn()
+        except Exception as e:
+            logger.warning(
+                "Platform '%s' check_fn raised an exception: %s",
+                entry.label,
+                e,
+            )
+            return None
+        if not check_ok:
             hint = f" ({entry.install_hint})" if entry.install_hint else ""
             logger.warning(
                 "Platform '%s' requirements not met%s",

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -147,6 +147,20 @@ class TestPlatformRegistry:
         # factory raises → create_adapter returns None instead of propagating
         assert reg.create_adapter("broken", MagicMock()) is None
 
+    def test_create_adapter_check_fn_raises(self):
+        """check_fn() raising must not propagate — create_adapter returns None."""
+        reg = PlatformRegistry()
+        entry = PlatformEntry(
+            name="check_raises",
+            label="CheckRaises",
+            adapter_factory=lambda cfg: MagicMock(),
+            check_fn=lambda: (_ for _ in ()).throw(ImportError("optional dep missing")),
+            validate_config=None,
+            source="plugin",
+        )
+        reg.register(entry)
+        assert reg.create_adapter("check_raises", MagicMock()) is None
+
     def test_create_adapter_no_validate(self):
         """When validate_config is None, skip validation."""
         reg = PlatformRegistry()


### PR DESCRIPTION
## What does this PR do?

`create_adapter()` in `gateway/platform_registry.py` calls `entry.check_fn()` without any exception handling. If a plugin's `check_fn()` raises (e.g. `ImportError` on an optional dependency), the entire adapter creation crashes instead of gracefully returning `None`.

`validate_config()` and `adapter_factory()` at the same call site are already wrapped in `try/except` — `check_fn()` was the only unguarded call.

## Type of Change
🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `gateway/platform_registry.py`: wrapped `entry.check_fn()` in `try/except Exception`, logs a warning and returns `None` on failure — mirrors the existing pattern used by `validate_config()` and `adapter_factory()`

## How to Test
Register a platform plugin whose `check_fn()` raises `ImportError` — before this fix it crashes, after it gracefully returns `None` with a warning log.

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Tested on: Ubuntu 24.04 (WSL2)