### PR TITLE
fix: report manual compression no-ops

### DIFF
--- a/agent/manual_compression_feedback.py
+++ b/agent/manual_compression_feedback.py
@@ -10,6 +10,8 @@ def summarize_manual_compression(
     after_messages: Sequence[dict[str, Any]],
     before_tokens: int,
     after_tokens: int,
+    *,
+    noop_reason: str | None = None,
 ) -> dict[str, Any]:
     """Return consistent user-facing feedback for manual compression."""
     before_count = len(before_messages)
@@ -35,7 +37,11 @@ def summarize_manual_compression(
         )
 
     note = None
-    if not noop and after_count < before_count and after_tokens > before_tokens:
+    if noop:
+        reason = (noop_reason or "").strip() if isinstance(noop_reason, str) else ""
+        if reason:
+            note = f"Reason: {reason}"
+    elif after_count < before_count and after_tokens > before_tokens:
         note = (
             "Note: fewer messages can still raise this estimate when "
             "compression rewrites the transcript into denser summaries."

--- a/cli.py
+++ b/cli.py
@@ -8592,11 +8592,17 @@ class HermesCLI:
                     system_prompt=_sys_prompt,
                     tools=_tools,
                 )
+                _noop_reason = getattr(
+                    getattr(self.agent, "context_compressor", None),
+                    "_last_compression_noop_reason",
+                    "",
+                )
                 summary = summarize_manual_compression(
                     original_history,
                     self.conversation_history,
                     approx_tokens,
                     new_tokens,
+                    noop_reason=_noop_reason,
                 )
                 icon = "🗜️" if summary["noop"] else "✅"
                 print(f"  {icon} {summary['headline']}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10730,7 +10730,7 @@ class GatewayRunner:
 
                 if compressed != msgs or new_session_id != original_session_id:
                     self.session_store.rewrite_transcript(new_session_id, compressed)
-                    # Reset stored token count — transcript changed, old value is stale
+                    # Reset stored token count; transcript changed, old value is stale
                     self.session_store.update_session(
                         session_entry.session_key, last_prompt_tokens=0
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10722,24 +10722,33 @@ class GatewayRunner:
                 # (preserving its full transcript in SQLite) and creates a new
                 # session_id for the continuation.  Write the compressed messages
                 # into the NEW session so the original history stays searchable.
+                original_session_id = session_entry.session_id
                 new_session_id = tmp_agent.session_id
-                if new_session_id != session_entry.session_id:
+                if new_session_id != original_session_id:
                     session_entry.session_id = new_session_id
                     self.session_store._save()
 
-                self.session_store.rewrite_transcript(new_session_id, compressed)
-                # Reset stored token count — transcript changed, old value is stale
-                self.session_store.update_session(
-                    session_entry.session_key, last_prompt_tokens=0
-                )
+                if compressed != msgs or new_session_id != original_session_id:
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                    # Reset stored token count — transcript changed, old value is stale
+                    self.session_store.update_session(
+                        session_entry.session_key, last_prompt_tokens=0
+                    )
                 new_tokens = estimate_request_tokens_rough(
                     compressed, system_prompt=_sys_prompt, tools=_tools
                 )
+                _noop_reason = getattr(
+                    compressor,
+                    "_last_compression_noop_reason",
+                    "",
+                )
+                _noop_reason = _noop_reason.strip() if isinstance(_noop_reason, str) else ""
                 summary = summarize_manual_compression(
                     msgs,
                     compressed,
                     approx_tokens,
                     new_tokens,
+                    noop_reason=_noop_reason,
                 )
                 # Detect summary-generation failure so we can surface a
                 # visible warning to the user even on the manual /compress

--- a/run_agent.py
+++ b/run_agent.py
@@ -10229,6 +10229,20 @@ class AIAgent:
                         "check auxiliary.compression.model in config.yaml."
                     )
 
+        if list(compressed) == list(messages):
+            _noop_reason = getattr(
+                self.context_compressor,
+                "_last_compression_noop_reason",
+                "",
+            )
+            logger.info(
+                "context compression no-op: session=%s messages=%d reason=%s",
+                self.session_id or "none",
+                _pre_msg_count,
+                _noop_reason or "unchanged context",
+            )
+            return messages, getattr(self, "_cached_system_prompt", None)
+
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -38,6 +38,28 @@ def test_manual_compress_reports_noop_without_success_banner(capsys):
     assert "Approx request size: ~100 tokens (unchanged)" in output
 
 
+def test_manual_compress_reports_context_engine_noop_reason(capsys):
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+    shell.agent.context_compressor._last_compression_noop_reason = (
+        "no eligible raw backlog outside fresh tail"
+    )
+    shell.agent._compress_context.return_value = (list(history), "")
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "No changes from compression" in output
+    assert "Reason: no eligible raw backlog outside fresh tail" in output
+
+
 def test_manual_compress_explains_when_token_estimate_rises(capsys):
     shell = _make_cli()
     history = _make_history()

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -67,6 +67,9 @@ async def test_compress_command_reports_noop_without_success_banner():
     agent_instance._cached_system_prompt = ""
     agent_instance.tools = None
     agent_instance.context_compressor.has_content_to_compress.return_value = True
+    agent_instance.context_compressor._last_compression_noop_reason = (
+        "no eligible raw backlog outside fresh tail"
+    )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (list(history), "")
 
@@ -84,7 +87,11 @@ async def test_compress_command_reports_noop_without_success_banner():
 
     assert "No changes from compression" in result
     assert "Compressed:" not in result
+    assert "Reason: no eligible raw backlog outside fresh tail" in result
     assert "Approx request size: ~100 tokens (unchanged)" in result
+    runner.session_store.rewrite_transcript.assert_not_called()
+    runner.session_store.update_session.assert_not_called()
+    runner.session_store._save.assert_not_called()
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()
 

--- a/tests/run_agent/test_compress_focus_plugin_fallback.py
+++ b/tests/run_agent/test_compress_focus_plugin_fallback.py
@@ -73,3 +73,47 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
     assert captured_kwargs == [{"current_tokens": 100}]
     # Silence unused-var warning on agent.
     assert agent.context_compressor is engine
+
+
+def test_compress_context_noop_skips_todo_injection_and_session_split(tmp_path):
+    class _NoopEngine:
+        compression_count = 0
+        _last_compression_noop_reason = "no eligible raw backlog outside fresh tail"
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            return list(messages)
+
+    engine = _NoopEngine()
+    agent = _make_agent_with_engine(engine)
+    agent.logs_dir = tmp_path
+    agent.tools = None
+    agent._session_db = MagicMock()
+    agent._session_db.get_session_title.return_value = None
+    agent._session_init_model_config = {}
+    agent._todo_store.format_for_injection.return_value = (
+        "[Your active task list was preserved across context compression]"
+    )
+    agent._invalidate_system_prompt = MagicMock()
+    agent._build_system_prompt = MagicMock(return_value="new-system-prompt")
+
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+
+    compressed, system_prompt = agent._compress_context(
+        messages,
+        None,
+        approx_tokens=100,
+    )
+
+    assert compressed == messages
+    assert system_prompt == agent._cached_system_prompt
+    assert agent.session_id == "sess-1"
+    agent._todo_store.format_for_injection.assert_not_called()
+    agent._invalidate_system_prompt.assert_not_called()
+    agent._build_system_prompt.assert_not_called()
+    agent._session_db.end_session.assert_not_called()
+    agent._session_db.create_session.assert_not_called()

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -752,6 +752,30 @@ def test_dispatch_long_handler_does_not_block_fast_handler(server):
     released.set()
 
 
+def test_compress_session_history_noop_does_not_bump_history_version(server):
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    agent = MagicMock()
+    agent._compress_context.return_value = (list(history), "")
+    agent.context_compressor = None
+    agent.model = "test/model"
+    session = {
+        "agent": agent,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 3,
+    }
+
+    removed, usage = server._compress_session_history(session)
+
+    assert removed == 0
+    assert usage["model"] == "test/model"
+    assert session["history"] is history
+    assert session["history_version"] == 3
+
+
 def test_dispatch_session_compress_does_not_block_fast_handler(server):
     """Manual TUI compaction can take minutes, so it must not block the RPC loop."""
     released = threading.Event()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1190,8 +1190,9 @@ def _compress_session_history(
             # result so we don't clobber concurrent edits.
             usage = _get_usage(agent)
             return 0, usage
-        session["history"] = compressed
-        session["history_version"] = history_version + 1
+        if compressed != history:
+            session["history"] = compressed
+            session["history_version"] = history_version + 1
     usage = _get_usage(agent)
     return len(history) - len(compressed), usage
 
@@ -2574,8 +2575,18 @@ def _(rid, params: dict) -> dict:
             )
             agent = session["agent"]
             _sync_session_key_after_compress(sid, session)
+            _noop_reason = getattr(
+                getattr(agent, "context_compressor", None),
+                "_last_compression_noop_reason",
+                "",
+            )
+            _noop_reason = _noop_reason.strip() if isinstance(_noop_reason, str) else ""
             summary = summarize_manual_compression(
-                before_messages, messages, before_tokens, after_tokens
+                before_messages,
+                messages,
+                before_tokens,
+                after_tokens,
+                noop_reason=_noop_reason,
             )
             info = _session_info(agent)
             _emit("session.info", sid, info)


### PR DESCRIPTION
## What does this PR do?

Manual `/compress` now reports context-engine no-op reasons instead of implying compression succeeded or silently doing session churn. It also avoids injecting carryover metadata, rebuilding prompts, rewriting gateway transcripts, or bumping TUI history versions when compression returns an unchanged transcript.

## Related Issue

No existing issue. This was found while debugging hermes-lcm auxiliary model routing and manual compression behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/manual_compression_feedback.py`: accepts and displays a no-op reason.
- `cli.py`: passes compressor no-op reasons into manual compression feedback.
- `run_agent.py`: returns early when `_compress_context` makes no transcript change, avoiding carryover metadata, session split churn, and prompt rebuilds.
- `gateway/run.py`: passes no-op reasons into gateway `/compress` feedback and skips transcript rewrites on no-op.
- `tui_gateway/server.py`: passes no-op reasons into TUI compression feedback and does not bump `history_version` on no-op.
- Added regression tests for CLI, gateway, TUI, and `_compress_context` behavior.

## How to Test

1. Configure a context-engine compressor that reports `_last_compression_noop_reason` and returns the original transcript.
2. Run manual `/compress` from CLI, gateway, or TUI.
3. Confirm the response says no changes were made, includes the reason, and does not mutate session state.

## Validation Status

- [x] `scripts/run_tests.sh tests/gateway/test_compress_command.py tests/cli/test_manual_compress.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/tui_gateway/test_protocol.py::test_compress_session_history_noop_does_not_bump_history_version tests/tui_gateway/test_protocol.py::test_dispatch_session_compress_does_not_block_fast_handler` -> `15 passed`
- [x] `git diff --check` -> passed
- [x] Added-line static scan for obvious secret, shell, eval/exec, pickle, and SQL injection patterns -> passed
- [ ] Full `scripts/run_tests.sh` suite was not run locally due scope. This PR is limited to manual compression no-op handling paths.
- [ ] GitHub CI currently shows inherited base failures. `Windows footguns (blocking)` is failing on latest `origin/main` at `tools/process_registry.py:588` with bare `os.killpg` / `signal.SIGKILL`; latest `main` `Tests` is also red. This branch does not touch those files or failure areas.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A, behavior is covered by user-facing feedback tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide -- pure Python state/feedback changes, no platform-specific paths or process behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation:

```text
15 passed
```
