### PR TITLE
fix: harden doctor gemini and wal checks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -823,11 +823,22 @@ def run_doctor(args):
                 if should_fix:
                     import sqlite3
                     conn = sqlite3.connect(str(state_db_path))
-                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                    conn.close()
+                    try:
+                        # PASSIVE checkpoints copy frames but usually leave the
+                        # WAL file allocated at its original size, so doctor
+                        # would claim a fix while the next run reported the
+                        # same large-WAL issue. TRUNCATE is the user-visible
+                        # cleanup `doctor --fix` promises.
+                        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    finally:
+                        conn.close()
                     new_size = wal_path.stat().st_size if wal_path.exists() else 0
-                    check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
-                    fixed_count += 1
+                    if new_size <= 50 * 1024 * 1024:
+                        check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
+                        fixed_count += 1
+                    else:
+                        check_warn(f"WAL checkpoint incomplete ({wal_size // 1024}K → {new_size // 1024}K)")
+                        issues.append("Large WAL file remains after checkpoint; close active Hermes processes and rerun 'hermes doctor --fix'")
                 else:
                     issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
             elif wal_size > 10 * 1024 * 1024:  # 10 MB
@@ -1359,10 +1370,14 @@ def run_doctor(args):
             if base_url_host_matches(base, "api.kimi.com") and base.rstrip("/").endswith("/coding"):
                 base = base.rstrip("/") + "/v1"
             url = (base.rstrip("/") + "/models") if base else default_url
-            headers = {
-                "Authorization": f"Bearer {key}",
-                "User-Agent": _HERMES_USER_AGENT,
-            }
+            headers = {"User-Agent": _HERMES_USER_AGENT}
+            if pname == "gemini":
+                # Gemini's native API expects x-goog-api-key on the models
+                # endpoint. A generic Bearer probe falsely reports valid
+                # GOOGLE_API_KEY values as unauthorized.
+                headers["x-goog-api-key"] = key
+            else:
+                headers["Authorization"] = f"Bearer {key}"
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
             r = httpx.get(url, headers=headers, timeout=10)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -657,6 +657,118 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
 
 
+def test_run_doctor_fix_uses_truncate_checkpoint_and_reports_if_wal_remains(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    for dirname in ("cron", "sessions", "logs", "skills", "memories"):
+        (home / dirname).mkdir()
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("persona\n", encoding="utf-8")
+    (home / "memories" / "MEMORY.md").write_text("m\n", encoding="utf-8")
+    (home / "memories" / "USER.md").write_text("u\n", encoding="utf-8")
+    (home / "state.db").write_text("", encoding="utf-8")
+    with (home / "state.db-wal").open("wb") as f:
+        f.truncate(51 * 1024 * 1024)
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    executed = []
+
+    class FakeCursor:
+        def fetchone(self):
+            return (0,)
+
+    class FakeConn:
+        def execute(self, statement):
+            executed.append(statement)
+            return FakeCursor()
+
+        def close(self):
+            pass
+
+    import sqlite3
+    monkeypatch.setattr(sqlite3, "connect", lambda *a, **kw: FakeConn())
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True))
+    out = buf.getvalue()
+
+    assert "PRAGMA wal_checkpoint(TRUNCATE)" in executed
+    assert "WAL checkpoint incomplete" in out
+    assert "Large WAL file remains after checkpoint" in out
+
+
+def test_run_doctor_gemini_uses_x_goog_api_key_for_native_models_probe(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("GOOGLE_API_KEY=sk-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-test")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    gemini_calls = [
+        (url, headers)
+        for url, headers, _ in calls
+        if url == "https://generativelanguage.googleapis.com/v1beta/models"
+    ]
+    assert gemini_calls
+    assert gemini_calls[0][1]["x-goog-api-key"] == "sk-test"
+    assert "Authorization" not in gemini_calls[0][1]
+    assert "gemini" in out
+    assert "invalid API key" not in out
+
+
 def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- fix the doctor Gemini native API probe to use `x-goog-api-key` instead of generic Bearer auth
- switch `hermes doctor --fix` WAL cleanup from `wal_checkpoint(PASSIVE)` to `wal_checkpoint(TRUNCATE)`
- report incomplete WAL cleanup honestly when the WAL remains large after checkpoint
- add regression tests covering both the Gemini probe and WAL checkpoint behavior

## Why
`hermes doctor` was producing a false negative for valid Gemini API keys because the native Gemini `/v1beta/models` endpoint does not use Bearer auth. Separately, doctor could claim it fixed a large SQLite WAL file even when the file size did not materially shrink.

## Evidence
- direct Gemini API probe to `https://generativelanguage.googleapis.com/v1beta/models` returned HTTP 200 with the configured key
- local doctor output now shows `✓ gemini`
- targeted test suite passes: `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q`

## Verification
- `hermes doctor`
- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q`
- `git diff --check`

## Notes
This PR comes from a fork because direct push permission to `NousResearch/hermes-agent` was not available from this machine.