### PR TITLE
feat: add Discord channel admin actions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1229,8 +1229,10 @@ DEFAULT_CONFIG = {
         # Accepts comma-separated string ("list_guilds,list_channels,fetch_messages")
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
-        # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # create_category, create_channel, set_channel_topic,
+        # create_project_workspace, list_roles, member_info, search_members,
+        # fetch_messages, list_pins, pin_message, unpin_message, create_thread,
+        # add_role, remove_role.
         "server_actions": "",
     },
 

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -292,6 +292,95 @@ class TestChannelInfo:
 
 
 # ---------------------------------------------------------------------------
+# Actions: create_category / create_channel / set_channel_topic / create_project_workspace
+# ---------------------------------------------------------------------------
+
+class TestCreateChannels:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_category(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "10", "name": "DRONE STARTUP", "type": 4,
+            "guild_id": "111", "position": 2, "parent_id": None,
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_category", guild_id="111", name="DRONE STARTUP", position=2,
+        ))
+        assert result["success"] is True
+        assert result["category"]["type"] == "category"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "DRONE STARTUP", "type": 4, "position": 2},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel_under_category(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "11", "name": "engineering-cad", "type": 0,
+            "guild_id": "111", "position": 0, "parent_id": "10",
+            "topic": "CAD docs",
+        }
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="engineering-cad",
+            parent_id="10", topic="CAD docs",
+        ))
+        assert result["success"] is True
+        assert result["channel"]["parent_id"] == "10"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "engineering-cad", "type": 0, "parent_id": "10", "topic": "CAD docs"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_set_channel_topic(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "11", "name": "factory-rfq", "type": 0,
+            "guild_id": "111", "topic": "Factory packet prep",
+            "position": 1, "parent_id": "10",
+        }
+        result = json.loads(discord_admin_handler(
+            action="set_channel_topic", channel_id="11", topic="Factory packet prep",
+        ))
+        assert result["success"] is True
+        assert result["channel"]["topic"] == "Factory packet prep"
+        mock_req.assert_called_once_with(
+            "PATCH", "/channels/11", "test-token", body={"topic": "Factory packet prep"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_project_workspace_default_channels(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        category = {"id": "10", "name": "DRONE STARTUP", "type": 4, "guild_id": "111"}
+        channels = [
+            {"id": str(11 + i), "name": name, "type": 0, "guild_id": "111", "parent_id": "10"}
+            for i, name in enumerate([
+                "start-here", "documents", "engineering-cad",
+                "bom-suppliers", "factory-rfq", "actions-decisions",
+            ])
+        ]
+        mock_req.side_effect = [category, *channels]
+        result = json.loads(discord_admin_handler(
+            action="create_project_workspace", guild_id="111", name="DRONE STARTUP",
+        ))
+        assert result["success"] is True
+        assert result["category"]["id"] == "10"
+        assert result["count"] == 6
+        assert [c["name"] for c in result["channels"]] == [
+            "start-here", "documents", "engineering-cad",
+            "bom-suppliers", "factory-rfq", "actions-decisions",
+        ]
+        assert mock_req.call_count == 7
+        first_call = mock_req.call_args_list[0]
+        assert first_call.args == ("POST", "/guilds/111/channels", "test-token")
+        assert first_call.kwargs["body"] == {"name": "DRONE STARTUP", "type": 4}
+        second_call = mock_req.call_args_list[1]
+        assert second_call.kwargs["body"]["parent_id"] == "10"
+        assert second_call.kwargs["body"]["name"] == "start-here"
+
+
+# ---------------------------------------------------------------------------
 # Action: list_roles
 # ---------------------------------------------------------------------------
 

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -127,6 +127,53 @@ def _channel_type_name(type_id: int) -> str:
     return _CHANNEL_TYPE_NAMES.get(type_id, f"unknown({type_id})")
 
 
+_CHANNEL_NAME_TO_TYPE = {
+    "text": 0,
+    "voice": 2,
+    "category": 4,
+    "announcement": 5,
+    "forum": 15,
+    "media": 16,
+}
+
+
+def _channel_type_id(channel_type: Any) -> int:
+    """Accept Discord channel type names or raw integer IDs."""
+    if channel_type in (None, ""):
+        return 0
+    if isinstance(channel_type, int):
+        if channel_type in _CHANNEL_TYPE_NAMES:
+            return channel_type
+        raise ValueError(f"Unsupported Discord channel type id: {channel_type}")
+    value = str(channel_type).strip().lower()
+    if value.isdigit():
+        type_id = int(value)
+        if type_id in _CHANNEL_TYPE_NAMES:
+            return type_id
+    if value in _CHANNEL_NAME_TO_TYPE:
+        return _CHANNEL_NAME_TO_TYPE[value]
+    allowed = ", ".join(sorted(_CHANNEL_NAME_TO_TYPE))
+    raise ValueError(f"Unsupported channel_type '{channel_type}'. Use one of: {allowed}")
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _channel_summary(ch: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": ch["id"],
+        "name": ch.get("name"),
+        "type": _channel_type_name(ch["type"]),
+        "guild_id": ch.get("guild_id"),
+        "topic": ch.get("topic"),
+        "position": ch.get("position"),
+        "parent_id": ch.get("parent_id"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Capability detection (application intents)
 # ---------------------------------------------------------------------------
@@ -288,6 +335,147 @@ def _channel_info(token: str, channel_id: str, **_kwargs: Any) -> str:
         "parent_id": ch.get("parent_id"),
         "rate_limit_per_user": ch.get("rate_limit_per_user", 0),
         "last_message_id": ch.get("last_message_id"),
+    })
+
+
+def _create_guild_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: Any = "text",
+    parent_id: Optional[str] = None,
+    topic: Optional[str] = None,
+    position: Any = None,
+    nsfw: Any = None,
+) -> Dict[str, Any]:
+    """Create a guild channel/category and return Discord's channel object."""
+    type_id = _channel_type_id(channel_type)
+    body: Dict[str, Any] = {"name": name, "type": type_id}
+    maybe_position = _optional_int(position)
+    if maybe_position is not None:
+        body["position"] = maybe_position
+    if parent_id:
+        body["parent_id"] = parent_id
+    if topic and type_id in {0, 5, 15, 16}:
+        body["topic"] = topic
+    if nsfw not in (None, "") and type_id in {0, 5, 15, 16}:
+        body["nsfw"] = bool(nsfw)
+    return _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+
+
+def _create_category(
+    token: str,
+    guild_id: str,
+    name: str,
+    position: Any = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a Discord category."""
+    ch = _create_guild_channel(
+        token=token,
+        guild_id=guild_id,
+        name=name,
+        channel_type="category",
+        position=position,
+    )
+    return json.dumps({"success": True, "category": _channel_summary(ch)})
+
+
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: Any = "text",
+    parent_id: Optional[str] = None,
+    topic: Optional[str] = None,
+    position: Any = None,
+    nsfw: Any = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a Discord guild channel, optionally inside a category."""
+    ch = _create_guild_channel(
+        token=token,
+        guild_id=guild_id,
+        name=name,
+        channel_type=channel_type,
+        parent_id=parent_id,
+        topic=topic,
+        position=position,
+        nsfw=nsfw,
+    )
+    return json.dumps({"success": True, "channel": _channel_summary(ch)})
+
+
+def _set_channel_topic(token: str, channel_id: str, topic: str, **_kwargs: Any) -> str:
+    """Set the topic for a text/forum/media/announcement channel."""
+    ch = _discord_request("PATCH", f"/channels/{channel_id}", token, body={"topic": topic})
+    return json.dumps({"success": True, "channel": _channel_summary(ch)})
+
+
+def _workspace_channels(channels: Any) -> List[Dict[str, Any]]:
+    """Normalize create_project_workspace channel specs."""
+    if not channels:
+        return [
+            {"name": "start-here", "topic": "Project orientation, current priority, and links to live docs."},
+            {"name": "documents", "topic": "Finished or review-ready project documents."},
+            {"name": "engineering-cad", "topic": "CAD, schematics, STEP/DXF/PDF drawings, mounting patterns, tolerances, and keep-out zones."},
+            {"name": "bom-suppliers", "topic": "Parts, suppliers, availability, alternates, and BOM decisions."},
+            {"name": "factory-rfq", "topic": "Manufacturer quote packets, RFQ drafts, factory questions, and approval-gated outreach."},
+            {"name": "actions-decisions", "topic": "Durable decisions and action items with owner/date/blocker."},
+        ]
+    if isinstance(channels, str):
+        stripped = channels.strip()
+        if not stripped:
+            return _workspace_channels(None)
+        try:
+            channels = json.loads(stripped)
+        except json.JSONDecodeError:
+            channels = [c.strip() for c in stripped.split(",") if c.strip()]
+    normalized: List[Dict[str, Any]] = []
+    for item in channels:
+        if isinstance(item, str):
+            normalized.append({"name": item})
+        elif isinstance(item, dict) and item.get("name"):
+            normalized.append(item)
+        else:
+            raise ValueError("channels must be names or objects containing a name")
+    return normalized
+
+
+def _create_project_workspace(
+    token: str,
+    guild_id: str,
+    name: str,
+    channels: Any = None,
+    position: Any = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a project category and text channels in one operation."""
+    category = _create_guild_channel(
+        token=token,
+        guild_id=guild_id,
+        name=name,
+        channel_type="category",
+        position=position,
+    )
+    created = []
+    for spec in _workspace_channels(channels):
+        ch = _create_guild_channel(
+            token=token,
+            guild_id=guild_id,
+            name=spec["name"],
+            channel_type=spec.get("channel_type", spec.get("type", "text")),
+            parent_id=category["id"],
+            topic=spec.get("topic"),
+            position=spec.get("position"),
+            nsfw=spec.get("nsfw"),
+        )
+        created.append(_channel_summary(ch))
+    return json.dumps({
+        "success": True,
+        "category": _channel_summary(category),
+        "channels": created,
+        "count": len(created),
     })
 
 
@@ -475,6 +663,10 @@ _ACTIONS = {
     "server_info": _server_info,
     "list_channels": _list_channels,
     "channel_info": _channel_info,
+    "create_category": _create_category,
+    "create_channel": _create_channel,
+    "set_channel_topic": _set_channel_topic,
+    "create_project_workspace": _create_project_workspace,
     "list_roles": _list_roles,
     "member_info": _member_info,
     "search_members": _search_members,
@@ -502,6 +694,10 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("server_info", "(guild_id)", "server details + member counts"),
     ("list_channels", "(guild_id)", "all channels grouped by category"),
     ("channel_info", "(channel_id)", "single channel details"),
+    ("create_category", "(guild_id, name)", "create a server category"),
+    ("create_channel", "(guild_id, name)", "create a text/voice/forum/media/announcement channel; optional parent_id/topic"),
+    ("set_channel_topic", "(channel_id, topic)", "set a channel topic"),
+    ("create_project_workspace", "(guild_id, name)", "create a category plus a default project-channel set"),
     ("list_roles", "(guild_id)", "roles sorted by position"),
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
@@ -526,6 +722,10 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "member_info": ["guild_id", "user_id"],
     "search_members": ["guild_id", "query"],
     "channel_info": ["channel_id"],
+    "create_category": ["guild_id", "name"],
+    "create_channel": ["guild_id", "name"],
+    "set_channel_topic": ["channel_id", "topic"],
+    "create_project_workspace": ["guild_id", "name"],
     "fetch_messages": ["channel_id"],
     "list_pins": ["channel_id"],
     "pin_message": ["channel_id", "message_id"],
@@ -685,13 +885,41 @@ def _build_schema(
             "type": "string",
             "description": "Discord message ID.",
         },
+        "parent_id": {
+            "type": "string",
+            "description": "Parent category ID for create_channel.",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Channel topic for create_channel or set_channel_topic.",
+        },
+        "channel_type": {
+            "type": "string",
+            "enum": ["text", "voice", "category", "announcement", "forum", "media"],
+            "description": "Discord channel type for create_channel (default text).",
+        },
+        "position": {
+            "type": "integer",
+            "description": "Optional channel/category position.",
+        },
+        "nsfw": {
+            "type": "boolean",
+            "description": "Whether the created channel should be marked NSFW.",
+        },
+        "channels": {
+            "type": "string",
+            "description": (
+                "Optional create_project_workspace channel list as a JSON array "
+                "or comma-separated names. Empty uses the default project set."
+            ),
+        },
         "query": {
             "type": "string",
             "description": "Member name prefix to search for (search_members).",
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "Name for create_thread, create_channel, create_category, or create_project_workspace.",
         },
         "limit": {
             "type": "integer",
@@ -770,6 +998,18 @@ _ACTION_403_HINT = {
     "delete_message": (
         "Bot lacks MANAGE_MESSAGES permission in this channel, or cannot view the channel/message."
     ),
+    "create_category": (
+        "Bot lacks MANAGE_CHANNELS permission in this server."
+    ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS permission in this server or cannot place channels in the target category."
+    ),
+    "set_channel_topic": (
+        "Bot lacks MANAGE_CHANNELS permission for this channel."
+    ),
+    "create_project_workspace": (
+        "Bot lacks MANAGE_CHANNELS permission in this server."
+    ),
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
@@ -835,6 +1075,12 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    parent_id: str = "",
+    topic: str = "",
+    channel_type: str = "text",
+    channels: Any = None,
+    position: Any = None,
+    nsfw: Any = None,
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -872,6 +1118,7 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "topic": topic,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -890,6 +1137,12 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            parent_id=parent_id,
+            topic=topic,
+            channel_type=channel_type,
+            channels=channels,
+            position=position,
+            nsfw=nsfw,
             limit=limit,
             before=before,
             after=after,
@@ -922,6 +1175,8 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
+    "parent_id": "", "topic": "", "channel_type": "text", "channels": None,
+    "position": None, "nsfw": None,
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 


### PR DESCRIPTION
## Summary
- add Discord admin actions for creating categories and channels
- add set_channel_topic and a create_project_workspace helper for project channel bundles
- update discord.server_actions config documentation

## Test Plan
- python -m pytest tests/tools/test_discord_tool.py -q
- python -m pytest tests/test_toolsets.py -q