### PR TITLE
feat(auth): show usage for pooled Codex accounts

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -5,11 +5,17 @@ import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlparse
 
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import (
+    AuthError,
+    _read_codex_tokens,
+    extract_codex_account_id,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -436,80 +442,15 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _resolve_codex_usage_credentials(
-    base_url: Optional[str],
-    api_key: Optional[str],
-) -> tuple[str, str, Optional[str]]:
-    """Resolve Codex quota credentials from the native runtime path.
-
-    Prefer explicit live-agent credentials, then the legacy singleton OAuth
-    state, then the credential pool.  Hermes's native OAuth setup now stores
-    device-code logins in the pool, so quota diagnostics must not depend only
-    on the older singleton store.
-    """
-    explicit_key = str(api_key or "").strip()
-    if explicit_key:
-        return explicit_key, str(base_url or "").strip(), None
-
-    # Tier 2: the native runtime resolver. It ALREADY falls back to the
-    # credential pool when the singleton is empty (see
-    # ``resolve_codex_runtime_credentials`` — issue #32992), so in a pool-only
-    # setup this returns a usable ``source="credential_pool"`` token.
-    #
-    # Only ``AuthError`` ("no creds" / rate-limited) is caught so tier 3 can
-    # run: a broad ``except Exception`` would (a) mask a transient refresh /
-    # network failure and silently hand back a DIFFERENT pool account's usage,
-    # and (b) hide genuine programming errors. A refresh/network error must
-    # propagate — the outer ``fetch_account_usage`` guard fails open (shows
-    # nothing this turn) rather than reporting the wrong account.
-    #
-    # The ``account_id`` (for the ``ChatGPT-Account-Id`` header) is read
-    # best-effort: a partial/missing singleton token store must not sink an
-    # otherwise-usable resolver credential and force a header-less pool fallback.
-    try:
-        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-        account_id: Optional[str] = None
-        try:
-            token_data = _read_codex_tokens()
-            tokens = token_data.get("tokens") or {}
-            account_id = str(tokens.get("account_id", "") or "").strip() or None
-        except AuthError:
-            # Pool-only creds carry no singleton account_id; header is optional.
-            logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
-        return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
-    except AuthError:
-        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
-
-    # Tier 3: direct pool select. Reached only when the resolver itself raises
-    # AuthError (e.g. singleton missing AND its own pool read found nothing at
-    # resolve time, but a pool entry is usable now). Pool credentials have no
-    # account_id concept, so the ChatGPT-Account-Id header is intentionally
-    # omitted here.
-    from agent.credential_pool import load_pool
-
-    pool = load_pool("openai-codex")
-    entry = pool.select()
-    if entry is None:
-        raise RuntimeError("No available openai-codex credential in credential pool")
-    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
+def _trusted_codex_usage_host(url: str) -> bool:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return host == "chatgpt.com" or host.endswith(".chatgpt.com")
 
 
-def _fetch_codex_account_usage(
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[AccountUsageSnapshot]:
-    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-        "User-Agent": "codex-cli",
-    }
-    if account_id:
-        headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+def _codex_usage_snapshot_from_payload(payload: dict[str, Any]) -> AccountUsageSnapshot:
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
@@ -539,6 +480,137 @@ def _fetch_codex_account_usage(
         plan=_title_case_slug(payload.get("plan_type")),
         windows=tuple(windows),
         details=tuple(details),
+    )
+
+
+def fetch_codex_account_usage_for_token(
+    access_token: str,
+    *,
+    base_url: Optional[str] = None,
+    account_id: Optional[str] = None,
+    timeout_seconds: float = 15.0,
+) -> AccountUsageSnapshot:
+    """Fetch Codex usage for one OAuth token without selecting a pool entry."""
+    token = str(access_token or "").strip()
+    if not token:
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason="missing access token",
+        )
+    try:
+        timeout = max(1.0, float(timeout_seconds))
+    except (TypeError, ValueError):
+        timeout = 15.0
+    usage_url = _resolve_codex_usage_url(base_url or "")
+    if not _trusted_codex_usage_host(usage_url):
+        host = (urlparse(usage_url).hostname or "unknown host").lower()
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=_utc_now(),
+            unavailable_reason=(
+                "refusing to send Codex OAuth token to non-ChatGPT "
+                f"usage endpoint ({host})"
+            ),
+        )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "User-Agent": "codex-cli",
+    }
+    # A freshly-issued token is authoritative over a stored pool hint. This
+    # avoids sending a stale account id after reauthentication switches users.
+    resolved_account_id = extract_codex_account_id(token) or str(account_id or "").strip()
+    if resolved_account_id:
+        headers["ChatGPT-Account-Id"] = resolved_account_id
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(usage_url, headers=headers)
+        response.raise_for_status()
+    return _codex_usage_snapshot_from_payload(response.json() or {})
+
+
+def _resolve_codex_usage_credentials(
+    base_url: Optional[str],
+    api_key: Optional[str],
+) -> tuple[str, str, Optional[str]]:
+    """Resolve Codex quota credentials from the native runtime path.
+
+    Prefer explicit live-agent credentials, then the legacy singleton OAuth
+    state, then the credential pool.  Hermes's native OAuth setup now stores
+    device-code logins in the pool, so quota diagnostics must not depend only
+    on the older singleton store.
+    """
+    explicit_key = str(api_key or "").strip()
+    if explicit_key:
+        return explicit_key, str(base_url or "").strip(), None
+
+    # Tier 2: the native runtime resolver. It ALREADY falls back to the
+    # credential pool when the singleton is empty (see
+    # ``resolve_codex_runtime_credentials`` — issue #32992), so in a pool-only
+    # setup this returns a usable ``source="credential_pool"`` token.
+    #
+    # Only ``AuthError`` ("no creds" / rate-limited) is caught so tier 3 can
+    # run: a broad ``except Exception`` would (a) mask a transient refresh /
+    # network failure and silently hand back a DIFFERENT pool account's usage,
+    # and (b) hide genuine programming errors. A refresh/network error must
+    # propagate — the outer ``fetch_account_usage`` guard fails open (shows
+    # nothing this turn) rather than reporting the wrong account.
+    #
+    # The resolver carries the selected pool entry's account id in the same
+    # envelope. Singleton lookup remains a best-effort compatibility fallback.
+    try:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        token = str(creds["api_key"] or "").strip()
+        account_id: Optional[str] = (
+            extract_codex_account_id(token)
+            or str(creds.get("account_id") or "").strip()
+            or None
+        )
+        try:
+            token_data = _read_codex_tokens()
+            tokens = token_data.get("tokens") or {}
+            singleton_token = str(tokens.get("access_token") or "").strip()
+            if (
+                not account_id
+                and creds.get("source") != "credential_pool"
+                and singleton_token == token
+            ):
+                account_id = str(tokens.get("account_id", "") or "").strip() or None
+        except AuthError:
+            logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
+        return token, str(creds.get("base_url", "") or "").strip(), account_id
+    except AuthError:
+        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
+
+    # Tier 3: direct pool select. Reached only when the resolver itself raises
+    # AuthError (e.g. singleton missing AND its own pool read found nothing at
+    # resolve time, but a pool entry is usable now).
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    if entry is None:
+        raise RuntimeError("No available openai-codex credential in credential pool")
+    token = entry.runtime_api_key
+    account_id = (
+        extract_codex_account_id(token)
+        or str(getattr(entry, "account_id", None) or "").strip()
+        or None
+    )
+    return token, str(entry.runtime_base_url or base_url or "").strip(), account_id
+
+
+def _fetch_codex_account_usage(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Optional[AccountUsageSnapshot]:
+    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
+    return fetch_codex_account_usage_for_token(
+        token,
+        base_url=resolved_base_url,
+        account_id=account_id,
     )
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -28,6 +28,7 @@ from hermes_cli.auth import (
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
+    extract_codex_account_id,
     _load_auth_store,
     _load_provider_state,
     _resolve_kimi_base_url,
@@ -125,6 +126,7 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "account_id",
 })
 
 
@@ -166,13 +168,21 @@ class PooledCredential:
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
-        if self.extra is None:
-            self.extra = {}
+        self.extra = dict(self.extra or {})
         self.auth_type = _normalize_pool_auth_type(
             self.provider,
             self.access_token,
             self.auth_type,
         )
+        if self.provider == "openai-codex":
+            account_id = (
+                extract_codex_account_id(self.access_token)
+                or str(self.extra.get("account_id") or "").strip()
+            )
+            if account_id:
+                self.extra["account_id"] = account_id
+            else:
+                self.extra.pop("account_id", None)
 
     def __getattr__(self, name: str):
         if name in _EXTRA_KEYS:
@@ -760,6 +770,17 @@ class CredentialPool:
                 }
                 if state.get("last_refresh"):
                     field_updates["last_refresh"] = state["last_refresh"]
+                extra_updates = dict(entry.extra)
+                account_id = (
+                    extract_codex_account_id(store_access)
+                    or str(tokens.get("account_id") or "").strip()
+                )
+                if account_id:
+                    extra_updates["account_id"] = account_id
+                else:
+                    extra_updates.pop("account_id", None)
+                if extra_updates != entry.extra:
+                    field_updates["extra"] = extra_updates
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
                 self._persist()
@@ -984,6 +1005,14 @@ class CredentialPool:
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
+                    account_id = (
+                        extract_codex_account_id(entry.access_token)
+                        or str(entry.account_id or "").strip()
+                    )
+                    if account_id:
+                        tokens["account_id"] = account_id
+                    else:
+                        tokens.pop("account_id", None)
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
                     _store_provider_state(auth_store, "openai-codex", state, set_active=False)
@@ -1086,11 +1115,22 @@ class CredentialPool:
                     entry.access_token,
                     entry.refresh_token,
                 )
+                refreshed_access_token = refreshed["access_token"]
+                account_id = (
+                    extract_codex_account_id(refreshed_access_token)
+                    or str(refreshed.get("account_id") or "").strip()
+                )
+                extra_updates = dict(entry.extra)
+                if account_id:
+                    extra_updates["account_id"] = account_id
+                else:
+                    extra_updates.pop("account_id", None)
                 updated = replace(
                     entry,
-                    access_token=refreshed["access_token"],
+                    access_token=refreshed_access_token,
                     refresh_token=refreshed["refresh_token"],
                     last_refresh=refreshed.get("last_refresh"),
+                    extra=extra_updates,
                 )
             elif self.provider == "xai-oauth":
                 # Adopt fresher tokens from auth.json before spending the
@@ -2105,6 +2145,26 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # existing Codex CLI credentials get a one-time, explicit prompt
         # via `hermes auth openai-codex`.
         if isinstance(tokens, dict) and tokens.get("access_token"):
+            access_token = tokens.get("access_token", "")
+            account_id = (
+                extract_codex_account_id(access_token)
+                or str(tokens.get("account_id") or "").strip()
+            )
+            if not account_id:
+                # A device-code reauth may switch accounts while returning an
+                # opaque access token and no explicit account id. Do not carry
+                # the previous token's account hint into the replacement.
+                for index, existing in enumerate(entries):
+                    if (
+                        existing.source == "device_code"
+                        and existing.access_token != access_token
+                        and "account_id" in existing.extra
+                    ):
+                        updated_extra = dict(existing.extra)
+                        updated_extra.pop("account_id", None)
+                        entries[index] = replace(existing, extra=updated_extra)
+                        changed = True
+                        break
             active_sources.add("device_code")
             custom_label = str(state.get("label") or "").strip()
             changed |= _upsert_entry(
@@ -2114,11 +2174,12 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 {
                     "source": "device_code",
                     "auth_type": AUTH_TYPE_OAUTH,
-                    "access_token": tokens.get("access_token", ""),
+                    "access_token": access_token,
                     "refresh_token": tokens.get("refresh_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
-                    "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "account_id": account_id,
+                    "label": custom_label or label_from_token(access_token, "device_code"),
                 },
             )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2026,6 +2026,21 @@ def _decode_jwt_claims(token: Any) -> Dict[str, Any]:
     return claims if isinstance(claims, dict) else {}
 
 
+def extract_codex_account_id(access_token: Any) -> Optional[str]:
+    """Best-effort extraction of a ChatGPT account id from a Codex OAuth JWT."""
+    claims = _decode_jwt_claims(access_token)
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if isinstance(auth_claims, dict):
+        value = auth_claims.get("chatgpt_account_id") or auth_claims.get("account_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("chatgpt_account_id", "account_id"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def _scope_values(raw_scope: Any) -> set[str]:
     # OAuth token responses normally return a space-separated string. Keep
     # collection support for JWT ``scp`` claims and older stored test fixtures.
@@ -3331,6 +3346,10 @@ def _sync_codex_pool_entries(
     if not access_token:
         return
     refresh_token = tokens.get("refresh_token")
+    account_id = (
+        extract_codex_account_id(access_token)
+        or str(tokens.get("account_id") or "").strip()
+    )
     pool = auth_store.get("credential_pool")
     if not isinstance(pool, dict):
         return
@@ -3369,6 +3388,10 @@ def _sync_codex_pool_entries(
         entry["access_token"] = access_token
         if refresh_token:
             entry["refresh_token"] = refresh_token
+        if account_id:
+            entry["account_id"] = account_id
+        else:
+            entry.pop("account_id", None)
         if last_refresh:
             entry["last_refresh"] = last_refresh
         entry["last_status"] = None
@@ -3381,6 +3404,15 @@ def _sync_codex_pool_entries(
 
 def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
+    tokens = dict(tokens)
+    account_id = (
+        extract_codex_account_id(tokens.get("access_token"))
+        or str(tokens.get("account_id") or "").strip()
+    )
+    if account_id:
+        tokens["account_id"] = account_id
+    else:
+        tokens.pop("account_id", None)
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
@@ -3554,6 +3586,12 @@ def refresh_codex_oauth_pure(
     next_refresh = refresh_payload.get("refresh_token")
     if isinstance(next_refresh, str) and next_refresh.strip():
         updated["refresh_token"] = next_refresh.strip()
+    account_id = (
+        extract_codex_account_id(refreshed_access)
+        or str(refresh_payload.get("account_id") or "").strip()
+    )
+    if account_id:
+        updated["account_id"] = account_id
     return updated
 
 
@@ -3594,8 +3632,17 @@ def _refresh_codex_auth_tokens(
         return imported
 
     updated_tokens = dict(tokens)
-    updated_tokens["access_token"] = refreshed["access_token"]
+    refreshed_access_token = refreshed["access_token"]
+    updated_tokens["access_token"] = refreshed_access_token
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
+    account_id = (
+        extract_codex_account_id(refreshed_access_token)
+        or str(refreshed.get("account_id") or "").strip()
+    )
+    if account_id:
+        updated_tokens["account_id"] = account_id
+    else:
+        updated_tokens.pop("account_id", None)
 
     _save_codex_tokens(updated_tokens)
     return updated_tokens
@@ -3671,8 +3718,8 @@ def resolve_codex_runtime_credentials(
             data = None
 
     if data is None:
-        pool_token = _pool_codex_access_token()
-        if pool_token:
+        pool_credentials = _pool_codex_runtime_credentials()
+        if pool_credentials:
             base_url = (
                 os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
                 or DEFAULT_CODEX_BASE_URL
@@ -3680,9 +3727,11 @@ def resolve_codex_runtime_credentials(
             return {
                 "provider": "openai-codex",
                 "base_url": base_url,
-                "api_key": pool_token,
+                "api_key": pool_credentials["api_key"],
+                "account_id": pool_credentials.get("account_id"),
+                "credential_id": pool_credentials.get("credential_id"),
                 "source": "credential_pool",
-                "last_refresh": None,
+                "last_refresh": pool_credentials.get("last_refresh"),
                 "auth_mode": "chatgpt",
             }
         pool_rate_limit = _codex_pool_rate_limit_status()
@@ -3745,6 +3794,11 @@ def resolve_codex_runtime_credentials(
         "provider": "openai-codex",
         "base_url": base_url,
         "api_key": access_token,
+        "account_id": (
+            extract_codex_account_id(access_token)
+            or str(tokens.get("account_id") or "").strip()
+            or None
+        ),
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
@@ -3824,31 +3878,35 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     return None
 
 
-def _pool_codex_access_token() -> str:
-    """Return the most-recent usable access_token from the openai-codex pool.
+def _pool_codex_runtime_credentials() -> Optional[Dict[str, Any]]:
+    """Return the exact selected openai-codex pool credential envelope.
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
-    singleton has no creds.  Reads ``credential_pool.openai-codex`` entries
-    directly from auth.json and picks the first non-empty access_token,
+    singleton has no creds. Reads ``credential_pool.openai-codex`` entries
+    directly from auth.json and picks the first non-empty credential,
     preferring entries that are not currently in an exhaustion cooldown.
-    Returns ``""`` when no usable entry is found (caller handles by raising
-    the original AuthError).
+    The account id travels with the selected entry so duplicate token aliases
+    cannot pair a usable credential with another entry's sidecar. Returns
+    ``None`` when no usable entry is found (caller handles by raising the
+    original AuthError).
     """
     try:
         with _auth_store_lock():
             auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
-            return ""
+            return None
         entries = pool.get("openai-codex")
         if not isinstance(entries, list):
-            return ""
+            return None
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
             if not isinstance(entry, dict):
                 return False
             token = entry.get("access_token")
             if not isinstance(token, str) or not token.strip():
+                return False
+            if str(entry.get("last_status") or "").strip().lower() == "dead":
                 return False
             # Skip entries currently in an exhaustion cooldown window.
             reset_at = entry.get("last_error_reset_at")
@@ -3858,10 +3916,21 @@ def _pool_codex_access_token() -> str:
 
         for entry in entries:
             if _entry_usable(entry):
-                return str(entry.get("access_token", "")).strip()
+                access_token = str(entry.get("access_token", "")).strip()
+                account_id = (
+                    extract_codex_account_id(access_token)
+                    or str(entry.get("account_id") or "").strip()
+                    or None
+                )
+                return {
+                    "api_key": access_token,
+                    "account_id": account_id,
+                    "credential_id": entry.get("id"),
+                    "last_refresh": entry.get("last_refresh"),
+                }
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
-    return ""
+    return None
 
 
 # =============================================================================
@@ -7452,11 +7521,19 @@ def _codex_device_code_login() -> Dict[str, Any]:
         or DEFAULT_CODEX_BASE_URL
     )
 
+    persisted_tokens = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+    }
+    account_id = (
+        extract_codex_account_id(access_token)
+        or str(tokens.get("account_id") or "").strip()
+    )
+    if account_id:
+        persisted_tokens["account_id"] = account_id
+
     return {
-        "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        },
+        "tokens": persisted_tokens,
         "base_url": base_url,
         "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "auth_mode": "chatgpt",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -8,12 +8,14 @@ import time
 from types import SimpleNamespace
 import uuid
 
+from agent.account_usage import fetch_codex_account_usage_for_token, render_account_usage_lines
 from agent.credential_pool import (
     AUTH_TYPE_API_KEY,
     AUTH_TYPE_OAUTH,
     CUSTOM_POOL_PREFIX,
     SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE,
+    STATUS_DEAD,
     STATUS_EXHAUSTED,
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
@@ -309,8 +311,13 @@ def auth_add_command(args) -> None:
 
     if provider == "openai-codex":
         creds = auth_mod._codex_device_code_login()
+        access_token = creds["tokens"]["access_token"]
+        account_id = (
+            auth_mod.extract_codex_account_id(access_token)
+            or str(creds["tokens"].get("account_id") or "").strip()
+        )
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
-            creds["tokens"]["access_token"],
+            access_token,
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
         # Add a distinct, self-contained pool entry per account (matching the
@@ -329,10 +336,11 @@ def auth_add_command(args) -> None:
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
             source=SOURCE_MANUAL_DEVICE_CODE,
-            access_token=creds["tokens"]["access_token"],
+            access_token=access_token,
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),
             last_refresh=creds.get("last_refresh"),
+            extra={"account_id": account_id} if account_id else {},
         )
         first_credential = not pool.entries()
         pool.add_entry(entry)
@@ -482,6 +490,100 @@ def auth_reset_command(args) -> None:
     pool = load_pool(provider)
     count = pool.reset_statuses()
     print(f"Reset status on {count} {provider} credentials")
+
+
+def _entry_account_id(entry) -> str | None:
+    value = getattr(entry, "account_id", None)
+    if value in {None, ""}:
+        extra = getattr(entry, "extra", None)
+        if isinstance(extra, dict):
+            value = extra.get("account_id")
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _format_usage_error(exc: BaseException) -> str:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    reason = str(getattr(response, "reason_phrase", "") or "").strip()
+    if status_code:
+        return f"HTTP {status_code}{f' {reason}' if reason else ''}"
+    message = str(exc).strip()
+    return message or exc.__class__.__name__
+
+
+def _maybe_refresh_usage_entry(pool, entry, *, refresh: bool):
+    if not refresh:
+        return entry, None
+    entry_status = getattr(entry, "last_status", None)
+    if entry_status == STATUS_DEAD:
+        return entry, None
+    if entry_status == STATUS_EXHAUSTED:
+        exhausted_until = _exhausted_until(entry)
+        if exhausted_until is not None and time.time() < exhausted_until:
+            return entry, None
+    needs_refresh = getattr(pool, "_entry_needs_refresh", None)
+    refresh_entry = getattr(pool, "_refresh_entry", None)
+    if not callable(needs_refresh) or not callable(refresh_entry):
+        return entry, None
+    try:
+        if not needs_refresh(entry):
+            return entry, None
+        refreshed = refresh_entry(entry, force=False)
+    except Exception as exc:
+        return entry, f"token refresh failed: {_format_usage_error(exc)}"
+    if refreshed is None:
+        return entry, "token refresh failed"
+    return refreshed, None
+
+
+def _print_usage_snapshot_lines(snapshot) -> None:
+    rendered = render_account_usage_lines(snapshot)
+    body = rendered[2:] if len(rendered) >= 2 else rendered
+    if snapshot and getattr(snapshot, "plan", None):
+        body = [f"Plan: {snapshot.plan}", *body]
+    if not body:
+        body = ["No usage windows returned by provider."]
+    for line in body:
+        print(f"    {line}")
+
+
+def auth_usage_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", "") or "")
+    if provider != "openai-codex":
+        raise SystemExit("`hermes auth usage` currently supports pooled usage for openai-codex only.")
+    pool = load_pool(provider)
+    current_fn = getattr(pool, "current", None)
+    current = current_fn() if callable(current_fn) else None
+    entries = pool.entries()
+    if not entries:
+        print("No pooled credentials found for openai-codex.")
+        return
+    timeout = getattr(args, "timeout", 15.0)
+    refresh = not bool(getattr(args, "no_refresh", False))
+    print(f"openai-codex account usage ({len(entries)} credentials):")
+    for idx, entry in enumerate(entries, start=1):
+        marker = " ← current" if current is not None and entry.id == current.id else ""
+        source = _display_source(entry.source)
+        print(f"  #{idx} {entry.label} [{entry.id}] {entry.auth_type} {source}{marker}")
+        if entry.auth_type != AUTH_TYPE_OAUTH:
+            print("    Unavailable: Codex account usage requires OAuth credentials.")
+            continue
+        entry, refresh_error = _maybe_refresh_usage_entry(pool, entry, refresh=refresh)
+        if refresh_error:
+            print(f"    Unavailable: {refresh_error}")
+            continue
+        try:
+            snapshot = fetch_codex_account_usage_for_token(
+                entry.access_token,
+                base_url=entry.base_url,
+                account_id=_entry_account_id(entry),
+                timeout_seconds=timeout,
+            )
+        except Exception as exc:
+            print(f"    Unavailable: {_format_usage_error(exc)}")
+            continue
+        _print_usage_snapshot_lines(snapshot)
 
 
 def auth_status_command(args) -> None:
@@ -766,6 +868,9 @@ def auth_command(args) -> None:
         return
     if action == "reset":
         auth_reset_command(args)
+        return
+    if action == "usage":
+        auth_usage_command(args)
         return
     if action == "status":
         auth_status_command(args)

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -62,6 +62,21 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         "reset", help="Clear exhaustion status for all credentials for a provider"
     )
     auth_reset.add_argument("provider", help="Provider id")
+    auth_usage = auth_subparsers.add_parser(
+        "usage", help="Show account usage for each pooled credential"
+    )
+    auth_usage.add_argument("provider", help="Provider id (currently openai-codex)")
+    auth_usage.add_argument(
+        "--timeout",
+        type=float,
+        default=15.0,
+        help="Per-account usage API timeout in seconds",
+    )
+    auth_usage.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Do not refresh expiring OAuth tokens before checking usage",
+    )
     auth_status = auth_subparsers.add_parser(
         "status", help="Show auth status for a provider"
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9355,11 +9355,15 @@ def _codex_full_login_worker(session_id: str) -> None:
 
         from hermes_cli.auth import _save_codex_tokens
 
+        persisted_tokens = {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        }
+        account_id = str(tokens.get("account_id") or "").strip()
+        if account_id:
+            persisted_tokens["account_id"] = account_id
         with _profile_scope(_oauth_session_profile(session_id)):
-            _save_codex_tokens({
-                "access_token": access_token,
-                "refresh_token": refresh_token,
-            })
+            _save_codex_tokens(persisted_tokens)
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: openai-codex login completed (session=%s)", session_id)

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -50,6 +52,89 @@ def codex_usage_payload():
     }
 
 
+def test_codex_usage_for_token_uses_explicit_account_id(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_codex_account_usage_for_token(
+        " access-token ",
+        base_url="https://chatgpt.com/backend-api/codex",
+        account_id="acct_456",
+        timeout_seconds=2.5,
+    )
+
+    assert snapshot.plan == "Plus"
+    assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
+    assert calls[0]["headers"]["Authorization"] == "Bearer access-token"
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct_456"
+
+
+def test_codex_usage_for_token_prefers_jwt_account_id_over_stored_hint(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    payload = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acct_from_jwt"},
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    token = f"header.{encoded}.signature"
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_codex_account_usage_for_token(
+        token,
+        account_id="acct_stale",
+    )
+
+    assert snapshot.windows[0].used_percent == 21
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct_from_jwt"
+
+
+def test_codex_usage_for_token_refuses_untrusted_host(monkeypatch):
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("untrusted host must not receive OAuth token")
+        ),
+    )
+
+    snapshot = account_usage.fetch_codex_account_usage_for_token(
+        "access-token",
+        base_url="https://example.invalid/backend-api/codex",
+    )
+
+    assert snapshot.unavailable_reason is not None
+    assert "non-ChatGPT" in snapshot.unavailable_reason
+
+
+def test_codex_existing_usage_refuses_untrusted_explicit_base_url(monkeypatch):
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("untrusted host must not receive OAuth token")
+        ),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://example.invalid/backend-api/codex",
+        api_key="access-token",
+    )
+
+    assert snapshot is not None
+    assert snapshot.unavailable_reason is not None
+    assert "non-ChatGPT" in snapshot.unavailable_reason
+
+
 def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_usage_payload):
     calls = []
     monkeypatch.setattr(
@@ -99,6 +184,7 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     pool_entry = SimpleNamespace(
         runtime_api_key="pooled-token",
         runtime_base_url="https://chatgpt.com/backend-api/codex",
+        account_id="acct-required",
     )
     pool = SimpleNamespace(select=lambda: pool_entry)
 
@@ -113,9 +199,95 @@ def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usa
     assert snapshot.windows[1].label == "Weekly"
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer pooled-token"
-    # Pool creds have no account_id concept — the ChatGPT-Account-Id header must
-    # be omitted rather than sent stale/wrong.
-    assert "ChatGPT-Account-Id" not in calls[0]["headers"]
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct-required"
+
+
+def test_codex_usage_runtime_pool_envelope_preserves_selected_account_id(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {
+            "api_key": "shared-opaque-token",
+            "account_id": "acct-selected",
+            "credential_id": "usable-alias",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "source": "credential_pool",
+        },
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_read_codex_tokens",
+        lambda: {
+            "tokens": {
+                "access_token": "shared-opaque-token",
+                "account_id": "acct-wrong-singleton-alias",
+            }
+        },
+    )
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["Authorization"] == "Bearer shared-opaque-token"
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct-selected"
+
+
+def test_codex_usage_real_resolver_keeps_duplicate_alias_envelope(
+    tmp_path, monkeypatch, codex_usage_payload
+):
+    calls = []
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "openai-codex": [
+                        {
+                            "id": "cooldown-alias",
+                            "source": "manual:device_code",
+                            "auth_type": "oauth",
+                            "access_token": "shared-opaque-token",
+                            "account_id": "acct-wrong",
+                            "last_status": "exhausted",
+                            "last_error_reset_at": 4_102_444_800,
+                        },
+                        {
+                            "id": "usable-alias",
+                            "source": "manual:device_code",
+                            "auth_type": "oauth",
+                            "access_token": "shared-opaque-token",
+                            "account_id": "acct-selected",
+                            "last_status": "ok",
+                        },
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "empty-codex-home"))
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["Authorization"] == "Bearer shared-opaque-token"
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct-selected"
 
 
 def test_codex_usage_does_not_swap_to_pool_on_transient_resolver_error(monkeypatch, codex_usage_payload):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2694,8 +2694,13 @@ def test_nous_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch
 
 # ── OpenAI Codex OAuth cross-process sync tests ────────────────────────────
 
-def _codex_auth_store(access: str, refresh: str) -> dict:
-    return {
+def _codex_sync_auth_store(
+    access: str,
+    refresh: str,
+    *,
+    account_id: str | None = None,
+) -> dict:
+    payload = {
         "version": 1,
         "active_provider": "openai-codex",
         "providers": {
@@ -2710,12 +2715,15 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
             }
         },
     }
+    if account_id is not None:
+        payload["providers"]["openai-codex"]["tokens"]["account_id"] = account_id
+    return payload
 
 
 def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypatch):
     """When auth.json has newer Codex tokens, the pool entry should adopt them."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-OLD", "refresh-OLD"))
 
     from agent.credential_pool import load_pool
 
@@ -2726,7 +2734,7 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
     assert entry.refresh_token == "refresh-OLD"
 
     # Simulate `hermes auth openai-codex` replacing the token pair on disk.
-    _write_auth_store(tmp_path, _codex_auth_store("access-NEW", "refresh-NEW"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-NEW", "refresh-NEW"))
 
     synced = pool._sync_codex_entry_from_auth_store(entry)
     assert synced is not entry
@@ -2740,7 +2748,7 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
 def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
     """When auth.json has the same tokens, sync should be a no-op."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-same", "refresh-same"))
 
     from agent.credential_pool import load_pool
 
@@ -2750,6 +2758,191 @@ def test_sync_codex_entry_noop_when_tokens_match(tmp_path, monkeypatch):
 
     synced = pool._sync_codex_entry_from_auth_store(entry)
     assert synced is entry
+
+
+def test_sync_codex_entry_replaces_stale_account_id_from_new_token(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store(
+            "access-OLD",
+            "refresh-OLD",
+            account_id="acct_old",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    assert entry.account_id == "acct_old"
+
+    new_access = _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_new",
+            }
+        }
+    )
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store(
+            new_access,
+            "refresh-NEW",
+            account_id="acct_stale",
+        ),
+    )
+
+    synced = pool._sync_codex_entry_from_auth_store(entry)
+
+    assert synced.access_token == new_access
+    assert synced.account_id == "acct_new"
+
+
+def test_load_pool_reseed_clears_stale_account_id_for_opaque_token(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store(
+            "access-OLD",
+            "refresh-OLD",
+            account_id="acct_old",
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    initial = load_pool("openai-codex").select()
+    assert initial is not None
+    assert initial.account_id == "acct_old"
+
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store("opaque-access-NEW", "refresh-NEW"),
+    )
+
+    reseeded = load_pool("openai-codex").select()
+
+    assert reseeded is not None
+    assert reseeded.access_token == "opaque-access-NEW"
+    assert reseeded.account_id is None
+
+
+def test_codex_pool_refresh_syncs_and_clears_account_id_across_reseed(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token_a = _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_A",
+            }
+        }
+    )
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store(
+            token_a,
+            "refresh-A",
+            account_id="acct_A",
+        ),
+    )
+
+    from agent import credential_pool
+
+    pool = credential_pool.load_pool("openai-codex")
+    entry = pool.entries()[0]
+    token_b = _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_B",
+            }
+        }
+    )
+    responses = iter(
+        [
+            {
+                "access_token": token_b,
+                "refresh_token": "refresh-B",
+                "last_refresh": "2026-07-13T09:00:00Z",
+                "account_id": "acct_stale",
+            },
+            {
+                "access_token": "opaque-B",
+                "refresh_token": "refresh-B2",
+                "last_refresh": "2026-07-13T10:00:00Z",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        credential_pool.auth_mod,
+        "refresh_codex_oauth_pure",
+        lambda access_token, refresh_token: next(responses),
+    )
+
+    refreshed = pool._refresh_entry(entry, force=True)
+    assert refreshed is not None
+    assert refreshed.account_id == "acct_B"
+
+    auth_path = tmp_path / "hermes" / "auth.json"
+    stored_tokens = json.loads(auth_path.read_text())["providers"]["openai-codex"]["tokens"]
+    assert stored_tokens["account_id"] == "acct_B"
+
+    opaque = pool._refresh_entry(refreshed, force=True)
+    assert opaque is not None
+    assert opaque.access_token == "opaque-B"
+    assert opaque.account_id is None
+
+    stored_tokens = json.loads(auth_path.read_text())["providers"]["openai-codex"]["tokens"]
+    assert "account_id" not in stored_tokens
+
+    reloaded = credential_pool.load_pool("openai-codex").entries()[0]
+    assert reloaded.access_token == "opaque-B"
+    assert reloaded.account_id is None
+
+
+def test_codex_sync_back_prefers_current_jwt_account_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        _codex_sync_auth_store(
+            "opaque-A",
+            "refresh-A",
+            account_id="acct_A",
+        ),
+    )
+
+    from dataclasses import replace
+    from agent import credential_pool
+
+    pool = credential_pool.load_pool("openai-codex")
+    entry = pool.entries()[0]
+    token_b = _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_B",
+            }
+        }
+    )
+    conflicting = replace(
+        entry,
+        access_token=token_b,
+        refresh_token="refresh-B",
+        extra={**entry.extra, "account_id": "acct_stale"},
+    )
+
+    pool._sync_device_code_entry_to_auth_store(conflicting)
+
+    auth_path = tmp_path / "hermes" / "auth.json"
+    stored_tokens = json.loads(auth_path.read_text())["providers"]["openai-codex"]["tokens"]
+    assert stored_tokens["access_token"] == token_b
+    assert stored_tokens["account_id"] == "acct_B"
+    assert credential_pool.load_pool("openai-codex").entries()[0].account_id == "acct_B"
 
 
 def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch):
@@ -2765,7 +2958,7 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
-    _write_auth_store(tmp_path, _codex_auth_store("access-OLD", "refresh-OLD"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-OLD", "refresh-OLD"))
 
     pool = load_pool("openai-codex")
     entry = pool.select()
@@ -2791,7 +2984,7 @@ def test_codex_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatc
     assert available_before == []
 
     # Simulate `hermes model` / `hermes auth` refreshing the tokens.
-    _write_auth_store(tmp_path, _codex_auth_store("access-FRESH", "refresh-FRESH"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-FRESH", "refresh-FRESH"))
 
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert len(available) == 1
@@ -2809,7 +3002,7 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     from agent.credential_pool import load_pool, STATUS_EXHAUSTED
     from dataclasses import replace as dc_replace
 
-    _write_auth_store(tmp_path, _codex_auth_store("access-same", "refresh-same"))
+    _write_auth_store(tmp_path, _codex_sync_auth_store("access-same", "refresh-same"))
 
     pool = load_pool("openai-codex")
     entry = pool.select()

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -44,8 +44,12 @@ def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refre
     return auth_file
 
 
-def _jwt_with_exp(exp_epoch: int) -> str:
-    payload = {"exp": exp_epoch}
+def _jwt_with_exp(exp_epoch: int, account_id: str | None = None) -> str:
+    payload: dict[str, object] = {"exp": exp_epoch}
+    if account_id is not None:
+        payload["https://api.openai.com/auth"] = {
+            "chatgpt_account_id": account_id,
+        }
     encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
     return f"h.{encoded}.s"
 
@@ -104,6 +108,110 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
     assert resolved["api_key"] == "access-new"
 
 
+def test_runtime_refresh_replaces_and_clears_account_id_for_usage(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    token_a = _jwt_with_exp(int(time.time()) - 10, "acct_A")
+    auth_path = _setup_hermes_auth(
+        hermes_home,
+        access_token=token_a,
+        refresh_token="refresh-A",
+    )
+    auth_store = json.loads(auth_path.read_text())
+    auth_store["providers"]["openai-codex"]["tokens"]["account_id"] = "acct_A"
+    auth_path.write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent import account_usage, credential_pool
+
+    assert credential_pool.load_pool("openai-codex").entries()[0].account_id == "acct_A"
+
+    token_b = _jwt_with_exp(int(time.time()) + 3600, "acct_B")
+    refresh_payloads = iter(
+        [
+            {
+                "access_token": token_b,
+                "refresh_token": "refresh-B",
+                "account_id": "acct_stale",
+            },
+            {
+                "access_token": "opaque-B",
+                "refresh_token": "refresh-B2",
+                "account_id": "acct_opaque",
+            },
+            {"access_token": "opaque-C", "refresh_token": "refresh-C"},
+        ]
+    )
+    requests = []
+
+    class _Response:
+        def __init__(self, payload):
+            self.status_code = 200
+            self.headers = {}
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, *args, **kwargs):
+            return _Response(next(refresh_payloads))
+
+        def get(self, url, *, headers):
+            requests.append(headers)
+            return _Response({"rate_limit": {}})
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *args, **kwargs: _Client())
+
+    resolved = resolve_codex_runtime_credentials()
+    assert resolved["api_key"] == token_b
+    stored = json.loads(auth_path.read_text())
+    assert stored["providers"]["openai-codex"]["tokens"]["account_id"] == "acct_B"
+    assert credential_pool.load_pool("openai-codex").entries()[0].account_id == "acct_B"
+
+    runtime_token = {"value": token_b}
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {
+            "api_key": runtime_token["value"],
+            "base_url": DEFAULT_CODEX_BASE_URL,
+        },
+    )
+    account_usage._fetch_codex_account_usage()
+    assert requests[-1]["ChatGPT-Account-Id"] == "acct_B"
+
+    opaque_with_id = resolve_codex_runtime_credentials(force_refresh=True)
+    assert opaque_with_id["api_key"] == "opaque-B"
+    stored = json.loads(auth_path.read_text())
+    assert stored["providers"]["openai-codex"]["tokens"]["account_id"] == "acct_opaque"
+    assert credential_pool.load_pool("openai-codex").entries()[0].account_id == "acct_opaque"
+
+    runtime_token["value"] = "opaque-B"
+    account_usage._fetch_codex_account_usage()
+    assert requests[-1]["ChatGPT-Account-Id"] == "acct_opaque"
+
+    opaque_without_id = resolve_codex_runtime_credentials(force_refresh=True)
+    assert opaque_without_id["api_key"] == "opaque-C"
+    stored = json.loads(auth_path.read_text())
+    assert "account_id" not in stored["providers"]["openai-codex"]["tokens"]
+    assert credential_pool.load_pool("openai-codex").entries()[0].account_id is None
+
+    runtime_token["value"] = "opaque-C"
+    account_usage._fetch_codex_account_usage()
+    assert "ChatGPT-Account-Id" not in requests[-1]
+
+
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="access-current", refresh_token="refresh-old")
@@ -143,9 +251,11 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
         "credential_pool": {
             "openai-codex": [
                 {
+                    "id": "pool-only",
                     "source": "device_code",
                     "access_token": "pool-fallback-token",
                     "refresh_token": "pool-refresh",
+                    "account_id": "acct-pool",
                     "last_status": "ok",
                     "auth_type": "oauth",
                 },
@@ -157,6 +267,8 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "pool-fallback-token"
+    assert resolved["account_id"] == "acct-pool"
+    assert resolved["credential_id"] == "pool-only"
     assert resolved["source"] == "credential_pool"
     assert resolved["base_url"]  # default codex backend URL
 
@@ -174,13 +286,17 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
         "credential_pool": {
             "openai-codex": [
                 {
+                    "id": "cooldown-alias",
                     "source": "device_code",
-                    "access_token": "wedged-token",
+                    "access_token": "shared-token",
+                    "account_id": "acct-wrong",
                     "last_error_reset_at": future_reset,  # in cooldown
                 },
                 {
+                    "id": "usable-alias",
                     "source": "device_code",
-                    "access_token": "usable-token",
+                    "access_token": "shared-token",
+                    "account_id": "acct-selected",
                     "last_status": "ok",
                 },
             ],
@@ -190,7 +306,9 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     resolved = resolve_codex_runtime_credentials()
-    assert resolved["api_key"] == "usable-token"
+    assert resolved["api_key"] == "shared-token"
+    assert resolved["account_id"] == "acct-selected"
+    assert resolved["credential_id"] == "usable-alias"
     assert resolved["source"] == "credential_pool"
 
 
@@ -232,6 +350,74 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
 
     assert data["tokens"]["access_token"] == "at123"
     assert data["tokens"]["refresh_token"] == "rt456"
+
+
+def test_save_codex_tokens_prefers_current_jwt_account_id(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent.credential_pool import load_pool
+
+    token = _jwt_with_exp(int(time.time()) + 3600, "acct_new")
+    _save_codex_tokens(
+        {
+            "access_token": token,
+            "refresh_token": "refresh-new",
+            "account_id": "acct_stale",
+        }
+    )
+
+    assert _read_codex_tokens()["tokens"]["account_id"] == "acct_new"
+    assert load_pool("openai-codex").entries()[0].account_id == "acct_new"
+
+
+def test_save_codex_tokens_clears_stale_account_id_on_opaque_reauth(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent.credential_pool import load_pool
+
+    _save_codex_tokens(
+        {
+            "access_token": "opaque-old",
+            "refresh_token": "refresh-old",
+            "account_id": "acct_old",
+        }
+    )
+    initial = load_pool("openai-codex").select()
+    assert initial is not None
+    assert initial.account_id == "acct_old"
+
+    _save_codex_tokens(
+        {
+            "access_token": "opaque-new",
+            "refresh_token": "refresh-new",
+        }
+    )
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    seeded = next(
+        entry
+        for entry in auth["credential_pool"]["openai-codex"]
+        if entry["source"] == "device_code"
+    )
+    assert seeded["access_token"] == "opaque-new"
+    assert "account_id" not in seeded
+
+    reloaded = load_pool("openai-codex").select()
+    assert reloaded is not None
+    assert reloaded.access_token == "opaque-new"
+    assert reloaded.account_id is None
 
 
 def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):
@@ -1038,7 +1224,20 @@ def _patch_httpx_post(monkeypatch, responses):
     monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: _FakeClient())
 
 
-def test_device_code_login_retries_on_429_then_succeeds(monkeypatch):
+@pytest.mark.parametrize(
+    ("access_token", "response_account_id", "expected_account_id"),
+    [
+        ("opaque-device-token", "acct-device", "acct-device"),
+        (
+            _jwt_with_exp(int(time.time()) + 3600, "acct-jwt"),
+            "acct-stale",
+            "acct-jwt",
+        ),
+    ],
+)
+def test_device_code_login_retries_on_429_then_succeeds(
+    monkeypatch, access_token, response_account_id, expected_account_id
+):
     """A transient 429 on the device-code request is retried, not surfaced."""
     from hermes_cli import auth as auth_mod
 
@@ -1053,14 +1252,23 @@ def test_device_code_login_retries_on_429_then_succeeds(monkeypatch):
             _FakeResp(429, headers={"retry-after": "1"}),
             _FakeResp(200, {"user_code": "ABCD", "device_auth_id": "dev-1", "interval": "5"}),
             _FakeResp(200, {"authorization_code": "auth-code", "code_verifier": "verifier"}),
-            _FakeResp(200, {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}),
+            _FakeResp(
+                200,
+                {
+                    "access_token": access_token,
+                    "refresh_token": "rt",
+                    "expires_in": 3600,
+                    "account_id": response_account_id,
+                },
+            ),
         ],
     )
     # Skip the polling sleep too (shares time.sleep, already patched).
 
     creds = auth_mod._codex_device_code_login()
 
-    assert creds["tokens"]["access_token"] == "at"
+    assert creds["tokens"]["access_token"] == access_token
+    assert creds["tokens"]["account_id"] == expected_account_id
     # The 429 caused exactly one backoff sleep before the retry succeeded.
     assert 1 in sleeps
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -18,10 +18,15 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
 
-def _jwt_with_email(email: str) -> str:
+def _jwt_with_email(email: str, account_id: str | None = None) -> str:
     header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    claims: dict[str, object] = {"email": email}
+    if account_id is not None:
+        claims["https://api.openai.com/auth"] = {
+            "chatgpt_account_id": account_id,
+        }
     payload = base64.urlsafe_b64encode(
-        json.dumps({"email": email}).encode()
+        json.dumps(claims).encode()
     ).rstrip(b"=").decode()
     return f"{header}.{payload}.signature"
 
@@ -359,13 +364,14 @@ def test_auth_add_nous_oauth_honors_custom_label(tmp_path, monkeypatch):
 def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
-    token = _jwt_with_email("codex@example.com")
+    token = _jwt_with_email("codex@example.com", "acct_jwt")
     monkeypatch.setattr(
         "hermes_cli.auth._codex_device_code_login",
         lambda: {
             "tokens": {
                 "access_token": token,
                 "refresh_token": "refresh-token",
+                "account_id": "acct_stale",
             },
             "base_url": "https://chatgpt.com/backend-api/codex",
             "last_refresh": "2026-03-23T10:00:00Z",
@@ -396,6 +402,7 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == token
     assert entry["refresh_token"] == "refresh-token"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert entry["account_id"] == "acct_jwt"
 
 
 def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch):
@@ -1058,6 +1065,181 @@ def test_auth_list_prefers_explicit_reset_time(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "device_code_exhausted" in out
     assert "7d 0h left" in out
+
+
+def test_auth_usage_checks_each_codex_pool_entry_without_select(monkeypatch, capsys):
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+    from hermes_cli.auth_commands import auth_usage_command
+
+    class _Entry:
+        def __init__(self, id, label, token, account_id):
+            self.id = id
+            self.label = label
+            self.auth_type = "oauth"
+            self.source = "manual:device_code"
+            self.access_token = token
+            self.refresh_token = None
+            self.base_url = "https://chatgpt.com/backend-api/codex"
+            self.extra = {"account_id": account_id} if account_id else {}
+
+    entries = [
+        _Entry("cred-1", "primary", "token-1", "acct_1"),
+        _Entry("cred-2", "backup", "token-2", None),
+    ]
+
+    class _Pool:
+        def entries(self):
+            return entries
+
+        def current(self):
+            return entries[0]
+
+        def peek(self):
+            raise AssertionError("auth_usage_command should not call peek()")
+
+        def select(self):
+            raise AssertionError("auth_usage_command should not select a credential")
+
+        def _entry_needs_refresh(self, entry):
+            return False
+
+    calls = []
+
+    def _fake_fetch(access_token, *, base_url=None, account_id=None, timeout_seconds=15.0):
+        calls.append((access_token, base_url, account_id, timeout_seconds))
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            plan="Pro",
+            windows=(AccountUsageWindow(label="Weekly", used_percent=25),),
+        )
+
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
+    monkeypatch.setattr("hermes_cli.auth_commands.fetch_codex_account_usage_for_token", _fake_fetch)
+
+    class _Args:
+        provider = "openai-codex"
+        timeout = 2.5
+        no_refresh = False
+
+    auth_usage_command(_Args())
+
+    assert calls == [
+        ("token-1", "https://chatgpt.com/backend-api/codex", "acct_1", 2.5),
+        ("token-2", "https://chatgpt.com/backend-api/codex", None, 2.5),
+    ]
+    out = capsys.readouterr().out
+    assert "openai-codex account usage (2 credentials):" in out
+    assert "#1 primary [cred-1] oauth device_code ← current" in out
+    assert "#2 backup [cred-2] oauth device_code" in out
+    assert out.count("Weekly: 75% remaining (25% used)") == 2
+
+
+def test_auth_usage_refresh_preserves_active_exhaustion_cooldown():
+    from hermes_cli.auth_commands import _maybe_refresh_usage_entry
+
+    reset_at = time.time() + 3600
+
+    class _Entry:
+        last_status = "exhausted"
+        last_status_at = time.time()
+        last_error_code = 429
+        last_error_reset_at = reset_at
+
+    entry = _Entry()
+
+    class _Pool:
+        def _entry_needs_refresh(self, candidate):
+            assert candidate is entry
+            return True
+
+        def _refresh_entry(self, candidate, *, force):
+            raise AssertionError("usage must not refresh an actively exhausted entry")
+
+    returned, error = _maybe_refresh_usage_entry(_Pool(), entry, refresh=True)
+
+    assert returned is entry
+    assert error is None
+    assert entry.last_status == "exhausted"
+    assert entry.last_error_reset_at == reset_at
+
+
+def test_auth_usage_refresh_does_not_reactivate_dead_credential():
+    from hermes_cli.auth_commands import _maybe_refresh_usage_entry
+
+    class _Entry:
+        last_status = "dead"
+
+    entry = _Entry()
+
+    class _Pool:
+        def _entry_needs_refresh(self, candidate):
+            assert candidate is entry
+            return True
+
+        def _refresh_entry(self, candidate, *, force):
+            raise AssertionError("usage must not refresh a dead entry")
+
+    returned, error = _maybe_refresh_usage_entry(_Pool(), entry, refresh=True)
+
+    assert returned is entry
+    assert error is None
+    assert entry.last_status == "dead"
+
+
+def test_auth_usage_continues_after_per_credential_failure(monkeypatch, capsys):
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+    from hermes_cli.auth_commands import auth_usage_command
+
+    class _Entry:
+        def __init__(self, id, label, token):
+            self.id = id
+            self.label = label
+            self.auth_type = "oauth"
+            self.source = "device_code"
+            self.access_token = token
+            self.refresh_token = None
+            self.base_url = "https://chatgpt.com/backend-api/codex"
+            self.extra = {}
+
+    entries = [_Entry("bad", "bad", "bad-token"), _Entry("ok", "ok", "ok-token")]
+
+    class _Pool:
+        def entries(self):
+            return entries
+
+        def peek(self):
+            return None
+
+        def _entry_needs_refresh(self, entry):
+            return False
+
+    def _fake_fetch(access_token, **kwargs):
+        if access_token == "bad-token":
+            raise RuntimeError("simulated usage failure")
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="Session", used_percent=10),),
+        )
+
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
+    monkeypatch.setattr("hermes_cli.auth_commands.fetch_codex_account_usage_for_token", _fake_fetch)
+
+    class _Args:
+        provider = "openai-codex"
+        timeout = 15.0
+        no_refresh = False
+
+    auth_usage_command(_Args())
+
+    out = capsys.readouterr().out
+    assert "#1 bad [bad]" in out
+    assert "Unavailable: simulated usage failure" in out
+    assert "#2 ok [ok]" in out
+    assert "Session: 90% remaining (10% used)" in out
 
 
 def test_auth_remove_env_seeded_clears_env_var(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -215,8 +215,9 @@ def test_nous_dashboard_device_flow_does_not_retry_legacy_scope_on_invoke_refusa
 
 
 def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch):
+    from agent.credential_pool import load_pool
     from hermes_cli import web_server as ws
-    from hermes_cli.auth import get_active_provider
+    from hermes_cli.auth import _read_codex_tokens, get_active_provider
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     access_token = "h.eyJleHAiOjk5OTk5OTk5OTl9.s"
@@ -254,6 +255,7 @@ def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch)
             return _Resp(200, {
                 "access_token": access_token,
                 "refresh_token": "codex-refresh",
+                "account_id": "acct-dashboard",
             })
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -271,6 +273,8 @@ def test_codex_dashboard_worker_persists_runtime_provider(tmp_path, monkeypatch)
         assert runtime["provider"] == "openai-codex"
         assert runtime["api_key"] == access_token
         assert runtime["api_mode"] == "codex_responses"
+        assert _read_codex_tokens()["tokens"]["account_id"] == "acct-dashboard"
+        assert load_pool("openai-codex").entries()[0].account_id == "acct-dashboard"
     finally:
         ws._oauth_sessions.pop(sid, None)
 


### PR DESCRIPTION
## Summary

Adds a CLI path for checking Codex account limits across every pooled `openai-codex` credential:

- `hermes auth usage openai-codex` iterates the credential pool without selecting/rotating accounts or making a model request.
- Each credential is fetched independently, so one failed/expired account reports `Unavailable` without hiding the rest of the pool.
- Expiring OAuth entries can refresh through the existing pool refresh path; `--no-refresh` keeps the check read-only against stored access tokens.
- The selected credential envelope carries its own `account_id`, including when duplicate token aliases exist; JWT identity remains authoritative after reauthentication.
- The replay uses current main's centralized auth-type normalization instead of restoring the older per-path normalization.
- Both pooled and explicit runtime usage paths refuse to send Codex OAuth tokens to non-HTTPS/non-`chatgpt.com` usage hosts.

## Related work

This is intentionally narrower than the broader account-selector direction.

- Builds on the account-limits plumbing from #13428.
- Related to #15167 and #17480, which cover active Codex `/usage` credential resolution from auth fallbacks/pool state.
- Adjacent to #20075, but this PR does not add account switching/selection UX; it only adds an explicit pooled usage report.

## Current-main refresh

- Semantically replayed onto current main as one commit.
- Preserved all credential producer paths (device-code, singleton, pool, web OAuth) while carrying account identity with the selected credential.
- Added regressions for duplicate-token aliases, exhausted/dead entries, selected account identity, current-main OAT auth normalization, and untrusted explicit usage endpoints.

## Verification

- Focused auth/account-usage matrix: **224 passed**.
- `ruff check` on all touched Python files: passed.
- `git diff --check`: passed.
- One-commit invariant and clean worktree verified before push.
- Exact-SHA independent review and post-fix closure: clean.
