### PR TITLE
Molten Hub Code: 100% Unit Test Coverage

### DIFF
--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -10,6 +10,7 @@ import acp
 from acp.schema import ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
 
 from acp_adapter.events import (
+    _send_update,
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
@@ -31,6 +32,18 @@ def event_loop_fixture():
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
+
+
+def test_send_update_swallows_threadsafe_failures(event_loop_fixture):
+    """Failed notification delivery must not break the agent worker thread."""
+    conn = MagicMock()
+    conn.session_update.return_value = object()
+
+    with patch(
+        "acp_adapter.events.asyncio.run_coroutine_threadsafe",
+        side_effect=RuntimeError("loop closed"),
+    ):
+        _send_update(conn, "session-1", event_loop_fixture, object())
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +110,49 @@ class TestToolProgressCallback:
             cb("tool.started", "terminal", "$ echo hi", None)
 
         assert "terminal" in tool_call_ids
+
+    def test_ignores_non_started_events(self, mock_conn, event_loop_fixture):
+        """Only started events create ACP tool calls."""
+        cb = make_tool_progress_cb(mock_conn, "session-1", event_loop_fixture, {}, {})
+
+        with patch("acp_adapter.events._send_update") as mock_send:
+            cb("tool.completed", "terminal", "$ echo hi", {"command": "echo hi"})
+
+        mock_send.assert_not_called()
+
+    def test_invalid_json_string_args_stored_as_raw(self, mock_conn, event_loop_fixture):
+        tool_call_ids = {}
+        tool_call_meta = {}
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-raw"), \
+             patch("acp_adapter.events._send_update"):
+            cb = make_tool_progress_cb(mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta)
+            cb("tool.started", "terminal", "$ echo", "{not json")
+
+        assert tool_call_meta["tc-raw"]["args"] == {"raw": "{not json"}
+
+    def test_existing_string_tool_id_is_promoted_to_queue(self, mock_conn, event_loop_fixture):
+        tool_call_ids = {"terminal": "tc-existing"}
+        tool_call_meta = {}
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-new"), \
+             patch("acp_adapter.events._send_update"):
+            cb = make_tool_progress_cb(mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta)
+            cb("tool.started", "terminal", "$ pwd", {"command": "pwd"})
+
+        assert list(tool_call_ids["terminal"]) == ["tc-existing", "tc-new"]
+
+    def test_snapshot_capture_failure_is_ignored(self, mock_conn, event_loop_fixture):
+        tool_call_ids = {}
+        tool_call_meta = {}
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-snapshot"), \
+             patch("acp_adapter.events._send_update"), \
+             patch("agent.display.capture_local_edit_snapshot", side_effect=RuntimeError("boom")):
+            cb = make_tool_progress_cb(mock_conn, "session-1", event_loop_fixture, tool_call_ids, tool_call_meta)
+            cb("tool.started", "patch", None, {"patch": "*** Begin Patch"})
+
+        assert tool_call_meta["tc-snapshot"]["snapshot"] is None
 
     def test_duplicate_same_name_tool_calls_use_fifo_ids(self, mock_conn, event_loop_fixture):
         """Multiple same-name tool calls should be tracked independently in order."""
@@ -191,6 +247,38 @@ class TestStepCallback:
             cb(1, [{"name": "unknown_tool", "result": "ok"}])
 
         mock_rcts.assert_not_called()
+
+    def test_ignores_missing_or_non_list_prev_tools(self, mock_conn, event_loop_fixture):
+        cb = make_step_cb(mock_conn, "session-1", event_loop_fixture, {}, {})
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
+            cb(1, None)
+            cb(2, {"name": "terminal"})
+            cb(3, [object()])
+
+        mock_rcts.assert_not_called()
+
+    def test_function_name_output_and_args_aliases(self, mock_conn, event_loop_fixture):
+        from collections import deque
+
+        tool_call_ids = {"search": deque(["tc-search"])}
+        cb = make_step_cb(mock_conn, "session-1", event_loop_fixture, tool_call_ids, {})
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb(1, [{"function_name": "search", "output": "found", "args": {"query": "hermes"}}])
+
+        mock_btc.assert_called_once_with(
+            "tc-search",
+            "search",
+            result="found",
+            function_args={"query": "hermes"},
+            snapshot=None,
+        )
 
     def test_handles_string_tool_info(self, mock_conn, event_loop_fixture):
         """Tool info as a string (just the name) should work."""

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -87,3 +87,9 @@ class TestApprovalMapping:
             result = cb("echo hi", "demo")
 
         assert result == "deny"
+
+    def test_unknown_allowed_option_falls_back_to_once(self):
+        """Unknown allowed option IDs preserve Hermes' permissive fallback."""
+        outcome = AllowedOutcome(option_id="future_allow_variant", outcome="selected")
+        result = _setup_callback(outcome)
+        assert result == "once"


### PR DESCRIPTION
Proposed changes from Molten.Bot

This PR implements the requested changes described below.
Built using an AI augmented engineering and reviewed before submission.
Only relevant files were modified.

Original task prompt:
```text
You are a senior software engineer focused on 100% unit-test coverage and test quality.

Task:
- Analyze current unit test coverage for this repository.
- Identify all uncovered lines, branches, and functions.
- Write focused unit tests to close every coverage gap.
- Follow existing test patterns and frameworks in use.
- Do not modify production code unless a change is strictly required to make code testable.
- Do not skip or exclude coverage without an explicit justification comment.

Validation:
- Validate coverage locally.
- Keep iterating on focused repository changes until the coverage target is met or you can prove a concrete blocker.
- If local test or validation tooling is unavailable in this runtime, for example `command not found`, do not fail solely for that. Continue with any alternative checks available and clearly report the validation gap.

Failure reporting:
- If failures occur, send a response back to the calling agent with these fields:
  Failure: <short failure summary>
  Error details: <failing command, coverage report detail, or concrete blocker>.
```

Curious how this was built? See how AI agents can help with your own projects: [MoltenBot Code](https://molten.bot/code?source=pr)