### PR TITLE
Fix dashboard config path display

### DIFF
--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -117,6 +117,7 @@ export default function ConfigPage() {
   const [yamlText, setYamlText] = useState("");
   const [yamlLoading, setYamlLoading] = useState(false);
   const [yamlSaving, setYamlSaving] = useState(false);
+  const [configPath, setConfigPath] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState<string>("");
   const { toast, showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -174,6 +175,10 @@ export default function ConfigPage() {
     api
       .getDefaults()
       .then(setDefaults)
+      .catch(() => {});
+    api
+      .getStatus()
+      .then((resp) => setConfigPath(resp.config_path))
       .catch(() => {});
   }, []);
 
@@ -408,7 +413,7 @@ export default function ConfigPage() {
         <div className="flex items-center gap-2">
           <Settings2 className="h-4 w-4 text-muted-foreground" />
           <code className="text-xs text-muted-foreground bg-muted/50 px-2 py-0.5">
-            {t.config.configPath}
+            {configPath ?? t.config.configPath}
           </code>
         </div>
         <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
- load the dashboard status payload on the Config page
- display the backend-reported config_path instead of the hard-coded ~/.hermes/config.yaml label
- keep the existing localized label as a fallback if status loading fails

Fixes #24042

## Checks
- npx tsc -b
- npx vite build

Note: npm run lint currently fails on pre-existing React/compiler lint errors in unrelated files and existing ConfigPage hooks; this change does not add those lint failures. npm run build also uses Unix rm in prebuild, so on Windows I synced assets with PowerShell before running Vite build directly.