### PR TITLE
fix(search): CJK OR-token matching and session lineage resolution

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1977,6 +1977,9 @@ class SessionDB:
                 # Trigram FTS5 path — quote each non-operator token to handle
                 # FTS5 special chars (%, *, etc.) while preserving boolean
                 # operators (AND, OR, NOT) for multi-term queries.
+                # Default to OR for CJK tokens (no explicit operator) so that
+                # multi-term queries like "大别山 项目" match either term rather
+                # than requiring both (implicit AND misses too many results).
                 tokens = raw_query.split()
                 parts = []
                 for tok in tokens:
@@ -1984,7 +1987,12 @@ class SessionDB:
                         parts.append(tok)
                     else:
                         parts.append('"' + tok.replace('"', '""') + '"')
-                trigram_query = " ".join(parts)
+                # Join with OR if user didn't supply any explicit boolean op
+                has_explicit_op = any(t.upper() in ("AND", "OR", "NOT") for t in tokens)
+                if has_explicit_op:
+                    trigram_query = " ".join(parts)
+                else:
+                    trigram_query = " OR ".join(parts)
                 tri_where = ["messages_fts_trigram MATCH ?"]
                 tri_params: list = [trigram_query]
                 if source_filter is not None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+import unicodedata
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -1977,9 +1978,6 @@ class SessionDB:
                 # Trigram FTS5 path — quote each non-operator token to handle
                 # FTS5 special chars (%, *, etc.) while preserving boolean
                 # operators (AND, OR, NOT) for multi-term queries.
-                # Default to OR for CJK tokens (no explicit operator) so that
-                # multi-term queries like "大别山 项目" match either term rather
-                # than requiring both (implicit AND misses too many results).
                 tokens = raw_query.split()
                 parts = []
                 for tok in tokens:
@@ -1987,12 +1985,15 @@ class SessionDB:
                         parts.append(tok)
                     else:
                         parts.append('"' + tok.replace('"', '""') + '"')
-                # Join with OR if user didn't supply any explicit boolean op
+                # Gate OR-join on CJK characters so non-CJK queries keep
+                # implicit AND semantics. Without this, a query like
+                # "database migration" would become "database" OR "migration"
+                # and return excessive false positives.
                 has_explicit_op = any(t.upper() in ("AND", "OR", "NOT") for t in tokens)
-                if has_explicit_op:
-                    trigram_query = " ".join(parts)
-                else:
-                    trigram_query = " OR ".join(parts)
+                use_or = not has_explicit_op and any(
+                    unicodedata.category(c).startswith("Lo") for c in raw_query
+                )
+                trigram_query = (" OR " if use_or else " ").join(parts)
                 tri_where = ["messages_fts_trigram MATCH ?"]
                 tri_params: list = [trigram_query]
                 if source_filter is not None:

--- a/tests/test_cjk_search_regression.py
+++ b/tests/test_cjk_search_regression.py
@@ -1,0 +1,87 @@
+"""Regression tests for CJK OR-token matching in trigram FTS5 search.
+
+Addresses review feedback on PR #24048:
+- CJK queries without explicit operators should OR-join tokens
+- Non-CJK queries without explicit operators should keep implicit AND
+- Explicit AND/OR/NOT operators are always respected
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def _make_db(tmp_path):
+    """Create a real SessionDB for integration-style tests."""
+    db_path = tmp_path / "test_cjk.db"
+    return SessionDB(db_path=db_path)
+
+
+def _seed_messages(db):
+    """Seed sessions with known CJK and English content."""
+    db.create_session(session_id="session_cjk_1", source="cli", model="test")
+    db.add_message("session_cjk_1", "user", "我在大别山工作")
+    db.add_message("session_cjk_1", "assistant", "大别山 is a mountain range in China")
+
+    db.create_session(session_id="session_cjk_2", source="cli", model="test")
+    db.add_message("session_cjk_2", "user", "项目进展很顺利")
+    db.add_message("session_cjk_2", "assistant", "The project is going well")
+
+    db.create_session(session_id="session_en_1", source="cli", model="test")
+    db.add_message("session_en_1", "user", "database migration completed successfully")
+    db.add_message("session_en_1", "assistant", "The database was migrated to PostgreSQL")
+
+    db.create_session(session_id="session_en_2", source="cli", model="test")
+    db.add_message("session_en_2", "user", "migration scripts are ready")
+    db.add_message("session_en_2", "assistant", "Scripts for the migration are done")
+
+
+class TestCJKImplicitOr:
+    """CJK queries without boolean operators should OR-join tokens."""
+
+    def test_cjk_multi_token_matches_either(self, tmp_path):
+        """Searching CJK tokens without operator should match EITHER token,
+        not require both."""
+        db = _make_db(tmp_path)
+        _seed_messages(db)
+
+        results = db.search_messages("大别山 项目")
+        session_ids = {r.get("session_id") for r in results}
+        # OR-join: should match sessions containing either token
+        assert len(session_ids) >= 1
+
+
+class TestNonCJKImplicitAnd:
+    """Non-CJK queries without boolean operators should keep implicit AND."""
+
+    def test_english_multi_token_prefers_both(self, tmp_path):
+        """Searching 'database migration' should prefer matches with BOTH words.
+        If OR-join leaked to non-CJK, session_en_2 (migration only, no database)
+        would return as a top match for 'database' which it doesn't contain."""
+        db = _make_db(tmp_path)
+        _seed_messages(db)
+
+        results = db.search_messages("database migration")
+        if results:
+            # With AND semantics, results should favor sessions with both terms.
+            # Check that at least one result actually contains "database"
+            contents = " ".join(r.get("content", "") for r in results).lower()
+            assert "database" in contents
+
+
+class TestExplicitOperatorsRespected:
+    """Explicit AND/OR/NOT operators are always preserved."""
+
+    def test_explicit_or_returns_results(self, tmp_path):
+        db = _make_db(tmp_path)
+        _seed_messages(db)
+
+        results = db.search_messages("database OR migration")
+        assert len(results) > 0
+
+    def test_explicit_and_returns_results(self, tmp_path):
+        db = _make_db(tmp_path)
+        _seed_messages(db)
+
+        results = db.search_messages("database AND migration")
+        assert len(results) > 0

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -434,6 +434,7 @@ def session_search(
             if resolved_sid not in seen_sessions:
                 result = dict(result)
                 result["session_id"] = resolved_sid
+                result["matched_session_id"] = raw_sid
                 seen_sessions[resolved_sid] = result
             if len(seen_sessions) >= limit:
                 break
@@ -442,7 +443,11 @@ def session_search(
         tasks = []
         for session_id, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                # Load from the FTS-matched session with ancestors so we get
+                # the full conversation chain (root -> matched child), not just
+                # the root's own messages.
+                matched_sid = match_info.get("matched_session_id", session_id)
+                messages = db.get_messages_as_conversation(matched_sid, include_ancestors=True)
                 if not messages:
                     continue
                 session_meta = db.get_session(session_id) or {}


### PR DESCRIPTION
## Summary

Two fixes for session search, particularly for CJK (Chinese/Japanese/Korean) users and session lineage resolution.

## Changes

### 1. CJK OR-token matching (`hermes_state.py`)

FTS5's default behavior is implicit AND between tokens. For CJK languages, this is too strict — a query like `大别山 项目` (two keywords) would only match sessions containing BOTH terms, missing many relevant results.

The fix defaults to OR joining when no explicit boolean operators (AND/OR/NOT) are present. Users who want AND semantics can explicitly write `term1 AND term2`.

### 2. Session lineage resolution (`session_search_tool.py`)

When FTS matches a child session (e.g., a branch created by `/resume`), the old code would resolve it to the lineage root and load only the root session's messages. This missed all content in the child session.

The fix:
- Tracks the original matched session ID (`matched_session_id`)
- Loads from the matched child with `include_ancestors=True` to get the full chain (root → matched child)
- Ensures search summaries include content from the entire conversation lineage

## Testing

- Verified CJK queries now return broader results with OR matching
- Confirmed explicit boolean operators still work as expected
- Tested that child session matches include ancestor messages in the summary