### PR TITLE
fix(gateway): support Windows drive-letter paths and GIS extensions in MEDIA: regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2064,7 +2064,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|kmz|kml|geojson|gpx|json|xml|html?)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -360,6 +360,69 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_windows_drive_letter_path_with_spaces(self):
+        """Windows drive-letter paths with spaces should not be truncated."""
+        content = "MEDIA:C:\\Users\\Confera\\OneDrive\\My Folder\\report.pdf"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "C:\\Users\\Confera\\OneDrive\\My Folder\\report.pdf"
+        assert cleaned == ""
+
+    def test_windows_drive_letter_path_no_spaces(self):
+        """Windows drive-letter paths without spaces should still work."""
+        content = "MEDIA:C:\\Users\\test\\file.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert "C:\\Users\\test\\file.png" == media[0][0]
+
+    def test_gis_extension_kmz(self):
+        """GIS .kmz extension should be recognized in spaced paths."""
+        content = "MEDIA:/home/user/My Folder/coords.kmz"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/home/user/My Folder/coords.kmz"
+
+    def test_gis_extension_geojson(self):
+        """GIS .geojson extension should be recognized."""
+        content = "MEDIA:/data/map.geojson"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/data/map.geojson"
+
+    def test_gis_extension_gpx(self):
+        """GIS .gpx extension should be recognized."""
+        content = "MEDIA:/data/track.gpx"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/data/track.gpx"
+
+    def test_json_extension(self):
+        """JSON extension should be recognized."""
+        content = "MEDIA:/tmp/data.json"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/data.json"
+
+    def test_xml_extension(self):
+        """XML extension should be recognized."""
+        content = "MEDIA:/tmp/data.xml"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/data.xml"
+
+    def test_html_extension(self):
+        """HTML extension should be recognized."""
+        content = "MEDIA:/tmp/page.html"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/page.html"
+
+    def test_windows_spaced_path_with_gis_extension(self):
+        """Windows spaced path with GIS extension should work end-to-end."""
+        content = "MEDIA:C:\\Users\\Foo\\OneDrive\\My Folder\\coords.kmz"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "C:\\Users\\Foo\\OneDrive\\My Folder\\coords.kmz"
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio


### PR DESCRIPTION
## What does this PR do?

The `MEDIA:` tag extractor in `gateway/platforms/base.py` (`extract_media`) fails on **Windows absolute paths containing spaces** (e.g. `C:\Users\Foo\OneDrive\My Folder\file.pdf`). The path is silently truncated at the first whitespace because the spaced-path branch only matches POSIX paths starting with `~/` or `/`.

Additionally, common GIS/structured-data extensions (`kmz`, `kml`, `geojson`, `gpx`, `json`, `xml`, `html`) are absent from the spaced-path extension allowlist, so even POSIX-style spaced paths fail for those file types.


### Root Cause

The `media_pattern` regex at line 2066 has a spaced-path branch anchored to `(?:~/|/)`, which only matches POSIX-style paths. Windows drive-letter paths (`C:\...`) and UNC paths (`\\server\share\...`) fall through to the `\S+` fallback branch, which stops at the first whitespace.

The extension allowlist also omits GIS and structured-data formats, causing `.kmz`, `.kml`, `.geojson`, `.gpx`, `.json`, `.xml`, and `.html` files to fail the spaced-path match even on POSIX systems.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A