### PR TITLE
fix(kanban): reject direct running transitions in dashboard bulk updates

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -868,7 +868,17 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             ok = _set_status_direct(conn, tid, "ready")
-                    elif s in ("todo", "running", "triage"):
+                    elif s == "running":
+                        entry.update(
+                            ok=False,
+                            error=(
+                                "Cannot set status to 'running' directly; "
+                                "use the dispatcher/claim path"
+                            ),
+                        )
+                        results.append(entry)
+                        continue
+                    elif s in ("todo", "triage"):
                         ok = _set_status_direct(conn, tid, s)
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -710,6 +710,31 @@ def test_bulk_status_done_forwards_completion_summary(client):
         conn.close()
 
 
+def test_bulk_status_running_rejected(client):
+    """Bulk updates must match single-task PATCH: direct 'running' is invalid."""
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [t["id"]], "status": "running"},
+    )
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == t["id"]
+    assert results[0]["ok"] is False
+    assert "running" in results[0]["error"]
+
+    board = client.get("/api/plugins/kanban/board").json()
+    statuses = {
+        tt["id"]: col["name"]
+        for col in board["columns"]
+        for tt in col["tasks"]
+    }
+    assert statuses.get(t["id"]) != "running"
+
+
 def test_dashboard_done_actions_prompt_for_completion_summary():
     repo_root = Path(__file__).resolve().parents[2]
     bundle = (


### PR DESCRIPTION
## Summary

Align the dashboard bulk update endpoint with the single-task PATCH behavior by rejecting direct transitions to `running`.

The kanban lifecycle requires tasks to enter `running` only through the dispatcher/claim path, which creates the run row and claim metadata atomically. Before this change, `/tasks/bulk` still allowed `status="running"`, which could strand tasks in a fake running state without proper run/claim bookkeeping.

## Changes

- Reject `status="running"` in `POST /api/plugins/kanban/tasks/bulk`
- Keep per-item bulk semantics: the affected item returns `ok=false` with a clear error
- Add a regression test covering the bulk rejection path

## Why

Single-task dashboard PATCH already rejects direct `running` transitions. Bulk updates had drifted from that invariant and could bypass the dispatcher lifecycle.

## Testing

Passed:
- `test_patch_status_running_rejected`
- `test_bulk_status_ready`
- `test_bulk_status_done_forwards_completion_summary`
- `test_bulk_status_running_rejected`
- `test_bulk_archive`
- `test_bulk_reassign`
- `test_bulk_unassign_via_empty_string`
- `test_bulk_partial_failure_doesnt_abort_siblings`
- `test_bulk_empty_ids_400`

