### PR TITLE
fix(homeassistant): coerce watch_all instead of bool()

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -35,6 +35,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._watch_domains: Set[str] = set(extra.get("watch_domains", []))
         self._watch_entities: Set[str] = set(extra.get("watch_entities", []))
         self._ignore_entities: Set[str] = set(extra.get("ignore_entities", []))
-        self._watch_all: bool = bool(extra.get("watch_all", False))
+        self._watch_all: bool = is_truthy_value(extra.get("watch_all"), default=False)
         self._cooldown_seconds: int = int(extra.get("cooldown_seconds", 30))
 
         # Cooldown tracking: entity_id -> last_event_timestamp

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -231,6 +231,15 @@ class TestAdapterInit:
         adapter = HomeAssistantAdapter(config)
         assert adapter._watch_all is True
 
+    def test_watch_all_quoted_false_stays_false(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"watch_all": "false"},
+        )
+        adapter = HomeAssistantAdapter(config)
+        assert adapter._watch_all is False
+
     def test_defaults_when_no_extra(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "tok")
         config = PlatformConfig(enabled=True, token="***")
@@ -320,6 +329,12 @@ class TestEventFilteringPipeline:
         adapter = _make_adapter(watch_all=True, cooldown_seconds=0)
         await adapter._handle_ha_event(_make_event("cover.blinds", "closed", "open"))
         adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_quoted_false_watch_all_does_not_pass_everything(self):
+        adapter = _make_adapter(watch_all="false", cooldown_seconds=0)
+        await adapter._handle_ha_event(_make_event("cover.blinds", "closed", "open"))
+        adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_same_state_not_forwarded(self):


### PR DESCRIPTION
## Summary

This fixes Home Assistant `watch_all` parsing when the config value is a quoted string.

Previously, `watch_all: "false"` was interpreted via `bool(...)`, which evaluates any non-empty string as `True`. That caused the Home Assistant adapter to treat `"false"` as enabled and forward events that should have been dropped when no explicit filters were configured.

## What changed

- replace raw `bool(extra.get("watch_all", False))` with `is_truthy_value(..., default=False)`
- add regression coverage for quoted `"false"` at initialization time
- add regression coverage to verify that `"false"` does not allow unfiltered event forwarding

## Repro

With config equivalent to:


platforms:
  homeassistant:
    extra:
      watch_all: "false"

the adapter previously behaved as if watch_all were enabled.

## Testing
pytest tests/gateway/test_homeassistant.py -q -k "watch_all"
4 passed in 4.52s