### PR TITLE
fix(state): use TRUNCATE checkpoint to shrink WAL file on close

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -328,6 +328,10 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
+    # WAL file size threshold (bytes) above which _try_wal_checkpoint uses
+    # TRUNCATE instead of PASSIVE.  TRUNCATE actually shrinks the WAL file
+    # on disk; PASSIVE only flushes pages without reclaiming space.
+    _WAL_TRUNCATE_THRESHOLD = 10 * 1024 * 1024  # 10 MiB
 
     def __init__(self, db_path: Path = None):
         self.db_path = db_path or DEFAULT_DB_PATH
@@ -425,22 +429,32 @@ class SessionDB:
         )
 
     def _try_wal_checkpoint(self) -> None:
-        """Best-effort PASSIVE WAL checkpoint.  Never blocks, never raises.
+        """Best-effort WAL checkpoint.  Never blocks, never raises.
 
         Flushes committed WAL frames back into the main DB file for any
         frames that no other connection currently needs.  Keeps the WAL
         from growing unbounded when many processes hold persistent
         connections.
+
+        Uses PASSIVE mode by default (non-blocking).  When the WAL file
+        exceeds ``_WAL_TRUNCATE_THRESHOLD`` (10 MiB), switches to TRUNCATE
+        which actually shrinks the WAL file on disk.  TRUNCATE returns
+        ``busy=1`` if another process holds a reader — the existing
+        try/except handles this safely.
         """
         try:
             with self._lock:
+                wal_path = Path(str(self.db_path) + "-wal")
+                mode = "PASSIVE"
+                if wal_path.exists() and wal_path.stat().st_size > self._WAL_TRUNCATE_THRESHOLD:
+                    mode = "TRUNCATE"
                 result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
+                    f"PRAGMA wal_checkpoint({mode})"
                 ).fetchone()
                 if result and result[1] > 0:
                     logger.debug(
-                        "WAL checkpoint: %d/%d pages checkpointed",
-                        result[2], result[1],
+                        "WAL checkpoint (%s): %d/%d pages checkpointed",
+                        mode, result[2], result[1],
                     )
         except Exception:
             pass  # Best effort — never fatal.
@@ -448,13 +462,17 @@ class SessionDB:
     def close(self):
         """Close the database connection.
 
-        Attempts a PASSIVE WAL checkpoint first so that exiting processes
-        help keep the WAL file from growing unbounded.
+        Attempts a TRUNCATE WAL checkpoint first so that exiting processes
+        shrink the WAL file on disk.  TRUNCATE is safe here because this
+        connection is about to close — no competing readers from this
+        process.  If another process holds a reader, TRUNCATE returns
+        ``busy=1`` and the WAL stays at its current size (handled by the
+        try/except).
         """
         with self._lock:
             if self._conn:
                 try:
-                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                 except Exception:
                     pass
                 self._conn.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1431,6 +1431,61 @@ class TestSchemaInit:
         mode = cursor.fetchone()[0]
         assert mode == "wal"
 
+
+    def test_close_uses_truncate_checkpoint(self, tmp_path):
+        """close() should use TRUNCATE to shrink the WAL file on disk."""
+        db_path = tmp_path / "test_state.db"
+        db = SessionDB(db_path=db_path)
+        # Write some data to generate WAL pages
+        db.create_session("s1", "gpt-4")
+        for i in range(100):
+            db.append_message("s1", "user", f"message {i}")
+        # WAL should exist and have content
+        wal_path = Path(str(db_path) + "-wal")
+        assert wal_path.exists()
+        wal_size_before = wal_path.stat().st_size
+        assert wal_size_before > 0
+        # close() should checkpoint with TRUNCATE, shrinking the WAL
+        db.close()
+        # After close, WAL should be gone or very small (truncated)
+        if wal_path.exists():
+            wal_size_after = wal_path.stat().st_size
+            # TRUNCATE shrinks to 0 or near-0; PASSIVE leaves it at high-water mark
+            assert wal_size_after < wal_size_before, (
+                f"WAL not shrunk: {wal_size_before} -> {wal_size_after}"
+            )
+
+    def test_try_wal_checkpoint_uses_passive_for_small_wal(self, tmp_path):
+        """_try_wal_checkpoint uses PASSIVE when WAL is below threshold."""
+        db_path = tmp_path / "test_state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", "gpt-4")
+        # WAL is small — should use PASSIVE (non-blocking)
+        # We verify indirectly: PASSIVE doesn't shrink the WAL file
+        wal_path = Path(str(db_path) + "-wal")
+        db._try_wal_checkpoint()
+        # PASSIVE checkpoint may or may not shrink — just verify no crash
+        db.close()
+
+    def test_try_wal_checkpoint_uses_truncate_for_large_wal(self, tmp_path, monkeypatch):
+        """_try_wal_checkpoint uses TRUNCATE when WAL exceeds threshold."""
+        db_path = tmp_path / "test_state.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session("s1", "gpt-4")
+        for i in range(200):
+            db.append_message("s1", "user", f"x" * 1000)
+        # Lower threshold so even our small test WAL triggers TRUNCATE
+        monkeypatch.setattr(db, "_WAL_TRUNCATE_THRESHOLD", 1)
+        wal_path = Path(str(db_path) + "-wal")
+        if wal_path.exists():
+            size_before = wal_path.stat().st_size
+            db._try_wal_checkpoint()
+            # TRUNCATE should have shrunk or eliminated the WAL
+            if wal_path.exists():
+                size_after = wal_path.stat().st_size
+                assert size_after <= size_before
+        db.close()
+
     def test_foreign_keys_enabled(self, db):
         cursor = db._conn.execute("PRAGMA foreign_keys")
         assert cursor.fetchone()[0] == 1


### PR DESCRIPTION
## What does this PR do?

`state.db-wal` grows without bound because both `close()` and `_try_wal_checkpoint()` use `PRAGMA wal_checkpoint(PASSIVE)`, which flushes dirty pages but **never shrinks the WAL file on disk**. The only TRUNCATE call is inside `vacuum()`, which requires sessions older than 90 days to actually exist — in active installs, TRUNCATE never fires.


### Root Cause

- `close()` (line 457): uses `PASSIVE` — WAL stays at high-water mark after process exit
- `_try_wal_checkpoint()` (line 438): uses `PASSIVE` — periodic checkpoint during writes never reclaims space
- `vacuum()` (line 2789): uses `TRUNCATE` but only runs when sessions are pruned (90+ days old)

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A