### PR TITLE
fix(computer-use): pass app= through capture_after follow-up capture

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -593,6 +593,150 @@ class TestRunAgentMultimodalHelpers:
 
 
 # ---------------------------------------------------------------------------
+# capture_after app= passthrough (fix: side-effect window capture scoping)
+# ---------------------------------------------------------------------------
+
+class TestCaptureAfterAppPassthrough:
+    """capture_after=True must re-capture the *same app* that was targeted,
+    not whatever window happens to be frontmost after the action fires.
+
+    Regression: before the fix, _maybe_follow_capture always called
+    backend.capture(mode="som") with no app= — so a click that opened a new
+    Safari window (e.g. "Browse UTM Gallery" launching Safari) would cause the
+    follow-up capture to snap the newly-raised Safari window rather than the
+    app the agent was driving (UTM).
+    """
+
+    def _make_recording_backend(self, *, capture_return=None):
+        """Return a fake backend that records every call made to it."""
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        if capture_return is None:
+            capture_return = CaptureResult(
+                mode="som", width=800, height=600, png_b64=None,
+                elements=[], app="", window_title="", png_bytes_len=0,
+            )
+
+        class RecordingBackend:
+            def __init__(self):
+                self.capture_calls: list = []  # list of (mode, app) tuples
+                self.action_calls: list = []
+
+            def start(self): pass
+            def stop(self): pass
+            def is_available(self): return True
+
+            def capture(self, mode="som", app=None):
+                self.capture_calls.append((mode, app))
+                return capture_return
+
+            def click(self, **kw):
+                self.action_calls.append(("click", kw))
+                return ActionResult(ok=True, action="click", message="ok")
+
+            def drag(self, **kw):
+                self.action_calls.append(("drag", kw))
+                return ActionResult(ok=True, action="drag", message="ok")
+
+            def scroll(self, **kw):
+                self.action_calls.append(("scroll", kw))
+                return ActionResult(ok=True, action="scroll", message="ok")
+
+            def type_text(self, text):
+                self.action_calls.append(("type_text", {"text": text}))
+                return ActionResult(ok=True, action="type_text", message="ok")
+
+            def key(self, keys):
+                self.action_calls.append(("key", {"keys": keys}))
+                return ActionResult(ok=True, action="key", message="ok")
+
+            def set_value(self, value, element=None):
+                self.action_calls.append(("set_value", {"value": value, "element": element}))
+                return ActionResult(ok=True, action="set_value", message="ok")
+
+            def list_apps(self): return []
+
+            def focus_app(self, app, raise_window=False):
+                self.action_calls.append(("focus_app", {"app": app}))
+                return ActionResult(ok=True, action="focus_app", message="ok")
+
+        return RecordingBackend()
+
+    @pytest.mark.parametrize("action,extra_args", [
+        ("click",       {"element": 1}),
+        ("double_click",{"element": 1}),
+        ("right_click", {"element": 1}),
+        ("middle_click",{"element": 1}),
+        ("drag",        {"from_element": 1, "to_element": 2}),
+        ("scroll",      {"direction": "down", "amount": 3}),
+        ("type",        {"text": "hello"}),
+        ("key",         {"keys": "cmd+s"}),
+    ])
+    def test_capture_after_passes_app_to_follow_up_capture(self, action, extra_args):
+        """After any action with capture_after=True, the follow-up capture
+        must be scoped to the same app= that was passed to the action."""
+        from tools.computer_use import tool as cu_tool
+
+        backend = self._make_recording_backend()
+        cu_tool.reset_backend_for_tests()
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            args = {"action": action, "capture_after": True, "app": "UTM", **extra_args}
+            cu_tool.handle_computer_use(args)
+
+        # The follow-up capture (second call, since dispatch doesn't capture first)
+        # must have app="UTM", not app=None.
+        assert backend.capture_calls, "expected at least one capture call"
+        followup_mode, followup_app = backend.capture_calls[-1]
+        assert followup_app == "UTM", (
+            f"{action} with capture_after=True captured app={followup_app!r} "
+            f"instead of 'UTM' — the app= was dropped before the follow-up capture"
+        )
+
+    def test_capture_after_without_app_does_not_filter(self):
+        """When no app= is specified the follow-up capture should pass app=None
+        (i.e. capture whatever is frontmost — the original behaviour for
+        actions that don't target a specific app)."""
+        from tools.computer_use import tool as cu_tool
+
+        backend = self._make_recording_backend()
+        cu_tool.reset_backend_for_tests()
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            cu_tool.handle_computer_use({"action": "click", "element": 1, "capture_after": True})
+
+        _, followup_app = backend.capture_calls[-1]
+        assert followup_app is None
+
+    def test_focus_app_capture_after_passes_app(self):
+        """focus_app's capture_after must also pass app= through."""
+        from tools.computer_use import tool as cu_tool
+
+        backend = self._make_recording_backend()
+        cu_tool.reset_backend_for_tests()
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            cu_tool.handle_computer_use(
+                {"action": "focus_app", "app": "Safari", "capture_after": True}
+            )
+
+        _, followup_app = backend.capture_calls[-1]
+        assert followup_app == "Safari"
+
+    def test_capture_after_false_never_calls_capture(self):
+        """With capture_after=False (default) no follow-up capture should fire."""
+        from tools.computer_use import tool as cu_tool
+
+        backend = self._make_recording_backend()
+        cu_tool.reset_backend_for_tests()
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            cu_tool.handle_computer_use({"action": "click", "element": 1})
+
+        assert not backend.capture_calls, "unexpected capture call with capture_after=False"
+
+
+# ---------------------------------------------------------------------------
 # Universality: does the schema work without Anthropic?
 # ---------------------------------------------------------------------------
 

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -333,7 +333,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=app)
 
     if action in ("click", "double_click", "right_click", "middle_click"):
         button = args.get("button")
@@ -354,7 +354,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             x=x, y=y, button=button or "left", click_count=click_count,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     if action == "drag":
         res = backend.drag(
@@ -365,7 +365,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             button=args.get("button", "left"),
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     if action == "scroll":
         coord = args.get("coordinate") or (None, None)
@@ -377,22 +377,22 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
             y=coord[1] if coord and coord[1] is not None else None,
             modifiers=args.get("modifiers"),
         )
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     if action == "type":
         res = backend.type_text(args.get("text", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     if action == "key":
         res = backend.key(args.get("keys", ""))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     if action == "set_value":
         value = args.get("value")
         if value is None:
             return json.dumps({"error": "set_value requires `value`"})
         res = backend.set_value(value=str(value), element=args.get("element"))
-        return _maybe_follow_capture(backend, res, capture_after)
+        return _maybe_follow_capture(backend, res, capture_after, app=args.get("app"))
 
     return json.dumps({"error": f"unknown action {action!r}"})
 
@@ -453,11 +453,12 @@ def _capture_response(cap: CaptureResult) -> Any:
 
 def _maybe_follow_capture(
     backend: ComputerUseBackend, res: ActionResult, do_capture: bool,
+    app: Optional[str] = None,
 ) -> Any:
     if not do_capture:
         return _text_response(res)
     try:
-        cap = backend.capture(mode="som")
+        cap = backend.capture(mode="som", app=app)
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)


### PR DESCRIPTION
## Problem

When any action (click, drag, scroll, type, key, set\_value, focus\_app) was called with `capture\_after=True`, the follow-up snapshot always called `backend.capture(mode='som')` with **no `app=`**. This caused the post-action capture to grab whichever window happened to be frontmost rather than the window the agent was actually targeting.

The bug was most visible when a click triggered a side-effect that opened or raised a window in a different app — e.g. clicking **Browse UTM Gallery** in UTM causes Safari to open. The follow-up capture would snap the new Safari window instead of staying scoped to UTM, confusing the agent into thinking its action had done nothing.

## Fix

Add an optional `app: Optional[str] = None` parameter to `_maybe_follow_capture()` and thread `args.get('app')` through every action dispatcher (click, drag, scroll, type, key, set\_value, focus\_app). The follow-up capture is now scoped to the same `app=` the action was targeting.

When no `app=` was specified the behaviour is unchanged: the follow-up capture passes `app=None`, i.e. captures the frontmost window.

## Changes

- `tools/computer_use/tool.py` — 8 dispatcher call-sites + `_maybe_follow_capture` signature
- `tests/tools/test_computer_use.py` — `TestCaptureAfterAppPassthrough` (11 tests)

## Tests

```
11 passed in 0.36s
```

Covers:
- all 8 action types with `capture\_after=True` assert `app=` is forwarded to the follow-up capture
- no-`app=` case preserves `app=None` (original frontmost behaviour)
- `focus\_app` with `capture\_after` forwards the `app`
- `capture\_after=False` never triggers a follow-up capture