### PR TITLE
fix(bedrock): align Claude context-window table with Anthropic docs

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1230,11 +1230,15 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
-    "anthropic.claude-sonnet-4-5":   200_000,
-    "anthropic.claude-haiku-4-5":    200_000,
+    # Anthropic Claude models on Bedrock.
+    # Claude 4.x (opus/sonnet/haiku) support a 1M-token context window via the
+    # ``context-1m-2025-08-07`` beta header, which Hermes injects automatically
+    # in ``build_anthropic_bedrock_client`` (see agent/anthropic_adapter.py).
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
+    "anthropic.claude-sonnet-4-5":   1_000_000,
+    "anthropic.claude-haiku-4-5":    1_000_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
     "anthropic.claude-3-5-sonnet":   200_000,

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1231,14 +1231,17 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock.
-    # Claude 4.x (opus/sonnet/haiku) support a 1M-token context window via the
-    # ``context-1m-2025-08-07`` beta header, which Hermes injects automatically
-    # in ``build_anthropic_bedrock_client`` (see agent/anthropic_adapter.py).
+    # Context windows per Anthropic's official models comparison
+    # (https://platform.claude.com/docs/en/about-claude/models/overview).
+    # Opus 4.7 / Opus 4.6 / Sonnet 4.6 have 1M generally available
+    # (no beta header required as of April 2026). Sonnet 4.5 and Sonnet 4
+    # had their `context-1m-2025-08-07` beta retired on April 30, 2026,
+    # so they are standard 200K; Haiku 4.5 is 200K.
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,
     "anthropic.claude-sonnet-4-6":   1_000_000,
-    "anthropic.claude-sonnet-4-5":   1_000_000,
-    "anthropic.claude-haiku-4-5":    1_000_000,
+    "anthropic.claude-sonnet-4-5":   200_000,
+    "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,
     "anthropic.claude-sonnet-4":     200_000,
     "anthropic.claude-3-5-sonnet":   200_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1088,13 +1088,33 @@ class TestBedrockErrorClassification:
 class TestBedrockContextLength:
     """Test Bedrock model context length lookup."""
 
+    def test_claude_opus_4_7(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Opus 4.7 has 1M context generally available (no beta header required)
+        # per https://platform.claude.com/docs/en/about-claude/models/overview
+        assert get_bedrock_context_length("anthropic.claude-opus-4-7") == 1_000_000
+
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        # Opus 4.6 has 1M context generally available (no beta header required).
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        # Sonnet 4.6 has 1M context generally available (no beta header required).
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
+
+    def test_claude_sonnet_4_5_is_200k(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Sonnet 4.5's 1M beta was retired on April 30, 2026;
+        # it is now standard 200K.
+        # https://platform.claude.com/docs/en/release-notes/overview
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5") == 200_000
+
+    def test_claude_haiku_4_5_is_200k(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        # Haiku 4.5 is a 200K-context model per the Anthropic models overview.
+        assert get_bedrock_context_length("anthropic.claude-haiku-4-5-20251001-v1:0") == 200_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1110,8 +1130,9 @@ class TestBedrockContextLength:
 
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        # Cross-region inference profiles contain the base model ID.
+        # Sonnet 4.6 is 1M, so a 'us.' profile of it should also resolve to 1M.
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length


### PR DESCRIPTION
## What does this PR do?

The `BEDROCK_CONTEXT_LENGTHS` table in `agent/bedrock_adapter.py` reported
stale values for recent Anthropic Claude models on Bedrock:

- **No entry for `claude-opus-4-7`** — falls through via substring match to
  the generic `claude-opus-4` entry at 200K, i.e. 5x too small.
- **`claude-opus-4-6` reported 200K**, but is 1M generally available.
- **`claude-sonnet-4-6` reported 200K**, but is 1M generally available.

This table feeds `get_bedrock_context_length()` → `get_model_context_length()`,
which drives the displayed context window in `/usage`, the compression
threshold (`compression.threshold * context_length`), and subagent
context budgets. A 5x-too-small value causes premature context
compression and under-utilizes the context window users are paying for.

This PR is **metadata-only** — no API routing, transport behavior, or
beta-header handling is changed. Claude-on-Bedrock continues to route
through `AnthropicBedrock` SDK via `api_mode: anthropic_messages` exactly
as before.

### Values per Anthropic's official models comparison

Source: https://platform.claude.com/docs/en/about-claude/models/overview
(the "Latest models comparison" table, column: "Context window"):

| Bedrock model ID | Before | After | Anthropic docs |
|---|---|---|---|
| `anthropic.claude-opus-4-7`   | (missing) | **1_000_000** | 1M tokens |
| `anthropic.claude-opus-4-6`   | 200_000   | **1_000_000** | 1M tokens |
| `anthropic.claude-sonnet-4-6` | 200_000   | **1_000_000** | 1M tokens |
| `anthropic.claude-sonnet-4-5` | 200_000   | 200_000 (unchanged) | 200K (1M beta retired Apr 30 2026) |
| `anthropic.claude-haiku-4-5`  | 200_000   | 200_000 (unchanged) | 200k tokens |

Why Sonnet 4.5 and Haiku 4.5 remain at 200K — and `claude-opus-4` /
`claude-sonnet-4` / `claude-3-*` also remain at 200K:

- **Sonnet 4.5**: per the [April 30, 2026 release note](https://platform.claude.com/docs/en/release-notes/overview),
  > "We've retired the 1M token context window beta (`context-1m-2025-08-07`)
  > for Claude Sonnet 4.5 and Claude Sonnet 4. The beta header now has no
  > effect on these models, and requests exceeding the standard 200k-token
  > context window return an error."
- **Haiku 4.5**: listed as 200k tokens in the Anthropic models comparison.
- **Sonnet 4 / Opus 4 / Claude 3**: never had 1M support.

## Related Issue

No existing issue — discovered while running `us.anthropic.claude-opus-4-7`
on Bedrock and seeing a 200K window displayed instead of 1M.

Related (but distinct) bugs in the same resolution chain:
- #15563 — separate custom-endpoint short-circuit in
  `get_model_context_length()` step 2
- #21557 — inverse concern: some Anthropic Enterprise OAuth accounts
  cannot use the 1M beta

Fixes #

## Prior art

A previous PR — #16686 by @mmcclean-aws (opened April 27, 2026) — had
the same core insight and the same three source lines (add
`claude-opus-4-7`, bump `claude-opus-4-6` and `claude-sonnet-4-6` to 1M).
This PR is a superset of that work:

- Identical source diff to #16686 on those three entries.
- Adds tests — 3 updated assertions (opus-4-6, sonnet-4-6 versioned,
  inference-profile) + 3 new guard tests (opus-4-7 → 1M,
  sonnet-4-5 → 200K, haiku-4-5 → 200K) with docstring citations to
  Anthropic's sources.
- Adds inline Anthropic-doc citations in the `BEDROCK_CONTEXT_LENGTHS`
  header comment so the next contributor who touches this table has
  an upstream source of truth.
- Leaves `claude-sonnet-4-5` and `claude-haiku-4-5` at 200K *explicitly*
  (with commentary + guard tests), citing the April 30 2026 release
  note that retired the 1M beta for Sonnet 4.5.  #16686 left those
  lines untouched with no commentary; my worry was that a future
  contributor might "helpfully" bump them alongside the others without
  knowing Anthropic has actually capped them at 200K now.

Happy for maintainers to close #16686 in favor of this PR, or to
incorporate @mmcclean-aws's commit with authorship preserved and layer
the tests/docs on top — whatever's easier for review.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/bedrock_adapter.py` (`BEDROCK_CONTEXT_LENGTHS`):
  - Add `anthropic.claude-opus-4-7: 1_000_000`
  - Change `anthropic.claude-opus-4-6: 200_000 → 1_000_000`
  - Change `anthropic.claude-sonnet-4-6: 200_000 → 1_000_000`
  - Update header comment with links to Anthropic's models overview and
    the April 30 2026 release note, so future readers have an upstream
    source of truth when this table needs another update.
- `tests/agent/test_bedrock_adapter.py` (`TestBedrockContextLength`):
  - Update `test_claude_opus_4_6`, `test_claude_sonnet_versioned`, and
    `test_inference_profile_resolves` to assert the new 1M values.
  - Add `test_claude_opus_4_7` — guards the new entry + doc-links it.
  - Add `test_claude_sonnet_4_5_is_200k` — guards against regressions
    that would re-bump it, citing the retirement release note.
  - Add `test_claude_haiku_4_5_is_200k` — guards against regressions
    that would bump it to 1M.

`agent/model_metadata.py`'s non-Bedrock `DEFAULT_CONTEXT_LENGTHS` table
already lists `claude-opus-4-7`, `claude-opus-4-6`, and
`claude-sonnet-4-6` at 1M for the chat-completions / Anthropic direct
paths. This PR brings the Bedrock-specific fallback table into alignment.

## How to Test

1. Run the focused test module:
   ```
   scripts/run_tests.sh tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_integration.py -q
   ```
   Expected: `178 passed`.

2. Manual verification with any Claude-on-Bedrock model:
   ```
   hermes --model us.anthropic.claude-opus-4-7 --provider bedrock
   > /usage
   ```
   Context window should now show ~1,000,000 (was 200,000).

3. Verify older Claude models (Sonnet 4 / Opus 4 / 3.x) still display 200K
   and that Haiku 4.5 / Sonnet 4.5 still display 200K — those are
   Anthropic's current context windows for those models, not stale values.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(bedrock):`, `test(bedrock):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_integration.py -q` — 178 passed
- [x] I've added tests for my changes (3 new tests doc-linking Anthropic's published context windows)
- [x] I've tested on my platform: macOS 26.3 (Apple Silicon), Python 3.11, against `us.anthropic.claude-opus-4-7` on Bedrock `us-east-1`

### Documentation & Housekeeping

- [x] I've updated relevant documentation — header comment in
  `BEDROCK_CONTEXT_LENGTHS` now links to Anthropic's models overview and
  the April 30 2026 release note
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] N/A — no file I/O, process management, or cross-platform code touched
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

Net diff against `main` (single file, +10/-3):

```diff
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    # Anthropic Claude models on Bedrock.
+    # Context windows per Anthropic's official models comparison
+    # (https://platform.claude.com/docs/en/about-claude/models/overview).
+    # Opus 4.7 / Opus 4.6 / Sonnet 4.6 have 1M generally available
+    # (no beta header required as of April 2026). Sonnet 4.5 and Sonnet 4
+    # had their `context-1m-2025-08-07` beta retired on April 30, 2026,
+    # so they are standard 200K; Haiku 4.5 is 200K.
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,
```
