### PR TITLE
fix(telegram): honour reply_to_mode="off" in DM topic fallback path

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -471,21 +471,25 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
 
-    @classmethod
     def _reply_to_message_id_for_send(
-        cls,
+        self,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Optional[int]:
         if reply_to:
             return int(reply_to)
         if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
-            return cls._metadata_reply_to_message_id(metadata)
+            # reply_to_mode="off" means the user does not want quote bubbles.
+            # Suppress the implicit DM-topic reply anchor — _thread_kwargs_for_send
+            # still emits message_thread_id, which is enough to keep the message
+            # routed to the private topic lane on python-telegram-bot clients.
+            if self._reply_to_mode == "off":
+                return None
+            return self._metadata_reply_to_message_id(metadata)
         return None
 
-    @classmethod
     def _thread_kwargs_for_send(
-        cls,
+        self,
         chat_id: str,
         thread_id: Optional[str],
         metadata: Optional[Dict[str, Any]] = None,
@@ -496,23 +500,30 @@ class TelegramAdapter(BasePlatformAdapter):
         Supergroup/forum topics use ``message_thread_id``. True Bot API Direct
         Messages topics can opt in with explicit ``direct_messages_topic_id``
         metadata. Hermes-created private-chat topic lanes are marked with
-        ``telegram_dm_topic_reply_fallback`` and must send the private topic
+        ``telegram_dm_topic_reply_fallback`` and normally send the private topic
         thread id together with a reply anchor. Live testing showed that either
-        parameter alone can render outside the visible lane.
+        parameter alone can render outside the visible lane on some clients,
+        but when the user has opted out of quote bubbles via
+        ``reply_to_mode="off"`` we honour that preference and rely on
+        ``message_thread_id`` alone for routing.
         """
         if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
+            if self._reply_to_mode == "off":
+                # User opted out of quote bubbles. Drop the reply anchor and
+                # rely on message_thread_id for DM-topic routing.
+                return {"message_thread_id": self._message_thread_id_for_send(thread_id)}
             if reply_to_message_id is None:
-                reply_to_message_id = cls._metadata_reply_to_message_id(metadata)
+                reply_to_message_id = self._metadata_reply_to_message_id(metadata)
             if reply_to_message_id is None:
                 return {}
-            return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
-        direct_topic_id = cls._metadata_direct_messages_topic_id(metadata)
+            return {"message_thread_id": self._message_thread_id_for_send(thread_id)}
+        direct_topic_id = self._metadata_direct_messages_topic_id(metadata)
         if direct_topic_id is not None:
             return {
                 "message_thread_id": None,
                 "direct_messages_topic_id": int(direct_topic_id),
             }
-        return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
+        return {"message_thread_id": self._message_thread_id_for_send(thread_id)}
 
     @classmethod
     def _message_thread_id_for_send(cls, thread_id: Optional[str]) -> Optional[int]:
@@ -1489,7 +1500,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     str(metadata_reply_to)
                     if metadata and metadata.get("telegram_dm_topic_reply_fallback") and metadata_reply_to is not None else None
                 )
-                if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
+                if self._reply_to_mode == "off":
+                    # User opted out of quote bubbles entirely. Skip both the
+                    # explicit reply_to anchor and the DM-topic reply fallback;
+                    # _thread_kwargs_for_send still emits message_thread_id so
+                    # DM-topic routing is preserved.
+                    should_thread = False
+                elif metadata and metadata.get("telegram_dm_topic_reply_fallback"):
                     should_thread = reply_to_source is not None
                 else:
                     should_thread = self._should_thread_reply(reply_to_source, i)

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -184,6 +184,119 @@ class TestSendWithReplyToMode:
         assert calls[0].kwargs.get("reply_to_message_id") == 999
 
 
+class TestDmTopicReplyFallback:
+    """Tests for reply_to_mode interaction with DM-topic reply fallback metadata.
+
+    Telegram private chats don't have native forum topics, so Hermes fakes per-topic
+    routing by attaching reply_to_message_id to an anchor message in each topic.
+    That metadata path was added in b3239572f and originally unconditionally injected
+    a quote anchor, ignoring reply_to_mode=off. These tests guard the regression fix
+    that honours reply_to_mode=off in DM-topic mode by relying on message_thread_id
+    alone for routing.
+    """
+
+    def _dm_topic_metadata(self, thread_id="13682", anchor="555"):
+        return {
+            "thread_id": thread_id,
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": anchor,
+        }
+
+    def test_reply_to_message_id_for_send_off_drops_anchor(self, adapter_factory):
+        """mode=off must suppress the implicit DM-topic reply anchor."""
+        adapter = adapter_factory(reply_to_mode="off")
+        result = adapter._reply_to_message_id_for_send(None, self._dm_topic_metadata())
+        assert result is None
+
+    def test_reply_to_message_id_for_send_first_keeps_anchor(self, adapter_factory):
+        """mode=first must keep the implicit DM-topic reply anchor (existing behavior)."""
+        adapter = adapter_factory(reply_to_mode="first")
+        result = adapter._reply_to_message_id_for_send(None, self._dm_topic_metadata(anchor="555"))
+        assert result == 555
+
+    def test_reply_to_message_id_for_send_all_keeps_anchor(self, adapter_factory):
+        """mode=all must keep the implicit DM-topic reply anchor (existing behavior)."""
+        adapter = adapter_factory(reply_to_mode="all")
+        result = adapter._reply_to_message_id_for_send(None, self._dm_topic_metadata(anchor="777"))
+        assert result == 777
+
+    def test_reply_to_message_id_for_send_off_honours_explicit_reply_to(self, adapter_factory):
+        """mode=off does NOT override an explicitly provided reply_to (e.g. media reply)."""
+        adapter = adapter_factory(reply_to_mode="off")
+        result = adapter._reply_to_message_id_for_send("999", self._dm_topic_metadata())
+        assert result == 999
+
+    def test_thread_kwargs_off_emits_thread_id_only(self, adapter_factory):
+        """mode=off + DM fallback: emit message_thread_id without requiring a reply anchor."""
+        adapter = adapter_factory(reply_to_mode="off")
+        kwargs = adapter._thread_kwargs_for_send(
+            "12345", "13682", metadata=self._dm_topic_metadata(thread_id="13682"),
+        )
+        assert kwargs == {"message_thread_id": 13682}
+
+    def test_thread_kwargs_first_emits_thread_id_with_anchor(self, adapter_factory):
+        """mode=first + DM fallback: existing behavior — thread id present when anchor exists."""
+        adapter = adapter_factory(reply_to_mode="first")
+        kwargs = adapter._thread_kwargs_for_send(
+            "12345", "13682",
+            metadata=self._dm_topic_metadata(thread_id="13682", anchor="555"),
+            reply_to_message_id=555,
+        )
+        assert kwargs == {"message_thread_id": 13682}
+
+    @pytest.mark.asyncio
+    async def test_send_off_mode_strips_dm_fallback_quote(self, adapter_factory):
+        """End-to-end: mode=off + DM fallback metadata → no quote bubble, thread preserved."""
+        adapter = adapter_factory(reply_to_mode="off")
+        adapter._bot = MagicMock()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2"]
+
+        await adapter.send(
+            "12345", "test content", reply_to=None,
+            metadata={
+                "thread_id": "13682",
+                "telegram_dm_topic_reply_fallback": True,
+                "telegram_reply_to_message_id": "555",
+            },
+        )
+
+        calls = adapter._bot.send_message.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            # quote bubble removed
+            assert call.kwargs.get("reply_to_message_id") is None
+            # routing still works via message_thread_id
+            assert call.kwargs.get("message_thread_id") == 13682
+
+    @pytest.mark.asyncio
+    async def test_send_first_mode_preserves_dm_fallback_quote(self, adapter_factory):
+        """Regression guard: mode=first keeps b3239572f's DM-topic anchor behavior."""
+        adapter = adapter_factory(reply_to_mode="first")
+        adapter._bot = MagicMock()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+        adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2"]
+
+        await adapter.send(
+            "12345", "test content", reply_to=None,
+            metadata={
+                "thread_id": "13682",
+                "telegram_dm_topic_reply_fallback": True,
+                "telegram_reply_to_message_id": "555",
+            },
+        )
+
+        calls = adapter._bot.send_message.call_args_list
+        assert len(calls) == 2
+        # In DM fallback mode the first chunk anchors via reply_to_message_id;
+        # subsequent chunks rely on message_thread_id only (b3239572f behavior:
+        # should_thread = reply_to_source is not None applies to every chunk in
+        # the DM fallback path, so anchor is preserved on every chunk).
+        for call in calls:
+            assert call.kwargs.get("reply_to_message_id") == 555
+            assert call.kwargs.get("message_thread_id") == 13682
+
+
 class TestConfigSerialization:
     """Tests for reply_to_mode serialization."""
 


### PR DESCRIPTION
## Problem

Since b3239572f ("fix(telegram): preserve DM topic routing via reply fallback"), the `telegram.reply_to_mode = "off"` user setting has been silently ignored whenever the user has DM topics configured (`platforms.telegram.extra.dm_topics`). Every bot reply gets a quote bubble of the user's message attached, even though the user explicitly opted out.

The DM-topic-fallback path in `send()`, `_reply_to_message_id_for_send`, and `_thread_kwargs_for_send` unconditionally injects `reply_to_message_id` so the message visually lands in the right private-chat "topic" (Telegram DMs don't have native forum topics — Hermes fakes them via reply chains). That override breaks the user preference.

Reproduction:

```yaml
# ~/.hermes/config.yaml
telegram:
  reply_to_mode: "off"
platforms:
  telegram:
    extra:
      dm_topics:
        - chat_id: <your-id>
          topics:
            - name: Daily chat
              thread_id: <thread-id>
```

→ Every bot reply still attaches a quote bubble of the user's message.

## Fix

When `reply_to_mode == "off"`, skip the reply anchor and rely on `message_thread_id` alone for DM-topic routing. Verified live on python-telegram-bot's reference client — messages still land in the correct private topic, quote bubble gone.

Two private helpers (`_reply_to_message_id_for_send`, `_thread_kwargs_for_send`) become instance methods (were `@classmethod`) so they can read `self._reply_to_mode`. All call sites already use `self.xxx(...)` — no caller changes needed.

## Trade-off

b3239572f's commit message notes _"either parameter alone can render outside the visible lane"_ on some clients. In practice on python-telegram-bot's reference client `message_thread_id` alone is sufficient. If a client genuinely needs the reply anchor for routing, users can keep `reply_to_mode = "first"` (the default) — only users who explicitly opt out are affected by this change.

## Tests

New `TestDmTopicReplyFallback` class in `tests/gateway/test_telegram_reply_mode.py`:

- `mode=off` drops the implicit DM-topic reply anchor
- `mode=first` / `mode=all` keep it (existing behavior preserved)
- `mode=off` honours an explicitly provided `reply_to` (media reply path)
- thread kwargs emit `message_thread_id` alone under `mode=off`
- end-to-end `send()` verifies no quote bubble, topic still routed
- regression guard for the b3239572f DM-topic-anchor behavior

```
$ pytest tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_thread_fallback.py
72 passed in 5.08s
```

Also verified live in production DM topic for ~30 minutes — quote bubbles gone, no message lost to wrong topic.
