### PR TITLE
feat(gateway/wps-xiezuo): add built-in adapter for WPS Xiezuo (WPS365 协作)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -579,6 +579,14 @@ PLATFORM_HINTS = {
         "![alt](/path) for local files; local paths are not served that way. "
         "Use MEDIA:/absolute/path instead."
     ),
+    "wps-xiezuo": (
+        "You are in a WPS Xiezuo (WPS365 协作) workspace communicating with your user. "
+        "WPS Xiezuo renders Markdown in messages — bold, italic, code blocks, and "
+        "links are supported. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.jpg, .png, .webp) are uploaded and displayed "
+        "inline, and other files arrive as downloadable attachments."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -91,7 +91,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot", "yuanbao",
+    "qqbot", "yuanbao", "wps-xiezuo",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "wps-xiezuo": "WPS_XIEZUO_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -109,6 +109,7 @@ class Platform(Enum):
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
+    WPS_XIEZUO = "wps-xiezuo"
     @classmethod
     def _missing_(cls, value):
         """Accept unknown platform names only for known plugin adapters.
@@ -396,6 +397,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         (cfg.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
         and (cfg.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
     ),
+    Platform.WPS_XIEZUO: lambda cfg: bool(cfg.extra.get("app_id")),
 }
 
 
@@ -1514,6 +1516,34 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 chat_id=feishu_home,
                 name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
                 thread_id=os.getenv("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
+            )
+
+    # WPS Xiezuo (WPS365 协作)
+    wps_xiezuo_app_id = os.getenv("WPS_XIEZUO_APP_ID") or os.getenv("WPS_APP_ID")
+    wps_xiezuo_app_secret = os.getenv("WPS_XIEZUO_APP_SECRET") or os.getenv("WPS_APP_SECRET")
+    if wps_xiezuo_app_id and wps_xiezuo_app_secret:
+        if Platform.WPS_XIEZUO not in config.platforms:
+            config.platforms[Platform.WPS_XIEZUO] = PlatformConfig()
+        config.platforms[Platform.WPS_XIEZUO].enabled = True
+        config.platforms[Platform.WPS_XIEZUO].extra.update({
+            "app_id": wps_xiezuo_app_id,
+            "app_secret": wps_xiezuo_app_secret,
+            "connection_mode": os.getenv("WPS_XIEZUO_CONNECTION_MODE") or os.getenv("WPS_CONNECTION_MODE", "websocket"),
+            "base_url": os.getenv("WPS_XIEZUO_BASE_URL") or os.getenv("WPS_BASE_URL", "https://openapi.wps.cn"),
+        })
+        wps_xiezuo_encrypt_key = os.getenv("WPS_XIEZUO_ENCRYPT_KEY") or os.getenv("WPS_ENCRYPT_KEY", "")
+        if wps_xiezuo_encrypt_key:
+            config.platforms[Platform.WPS_XIEZUO].extra["encrypt_key"] = wps_xiezuo_encrypt_key
+        wps_xiezuo_verification_token = os.getenv("WPS_XIEZUO_VERIFICATION_TOKEN") or os.getenv("WPS_VERIFICATION_TOKEN", "")
+        if wps_xiezuo_verification_token:
+            config.platforms[Platform.WPS_XIEZUO].extra["verification_token"] = wps_xiezuo_verification_token
+        wps_xiezuo_home = os.getenv("WPS_XIEZUO_HOME_CHANNEL") or os.getenv("WPS_HOME_CHANNEL")
+        if wps_xiezuo_home:
+            config.platforms[Platform.WPS_XIEZUO].home_channel = HomeChannel(
+                platform=Platform.WPS_XIEZUO,
+                chat_id=wps_xiezuo_home,
+                name=os.getenv("WPS_XIEZUO_HOME_CHANNEL_NAME", "Home"),
+                thread_id=os.getenv("WPS_XIEZUO_HOME_CHANNEL_THREAD_ID") or None,
             )
 
     # WeCom (Enterprise WeChat)

--- a/gateway/platforms/__init__.py
+++ b/gateway/platforms/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "SendResult",
     "QQAdapter",
     "YuanbaoAdapter",
+    "WpsXiezuoAdapter",
 ]
 
 
@@ -38,6 +39,9 @@ def __getattr__(name):
     if name == "YuanbaoAdapter":
         from .yuanbao import YuanbaoAdapter  # noqa: F401
         return YuanbaoAdapter
+    if name == "WpsXiezuoAdapter":
+        from .wps_xiezuo import WpsXiezuoAdapter  # noqa: F401
+        return WpsXiezuoAdapter
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1310,6 +1310,33 @@ class WeixinAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
 
+    async def _reconnect(self) -> bool:
+        """Attempt to re-establish connection using persisted credentials.
+
+        Called when the iLink session expires (errcode -14 or stale -2).
+        Reloads the token from disk, tears down the old poll session,
+        and creates a fresh one so the next ``getupdates`` succeeds.
+        """
+        logger.info("[%s] attempting reconnect…", self.name)
+        persisted = load_weixin_account(self._hermes_home, self._account_id)
+        if not persisted or not persisted.get("token"):
+            logger.error("[%s] reconnect failed: no persisted credentials for %s",
+                         self.name, _safe_id(self._account_id))
+            return False
+        self._token = str(persisted["token"]).strip()
+        self._base_url = str(persisted.get("base_url") or self._base_url).strip().rstrip("/")
+        # Tear down stale session
+        if self._poll_session and not self._poll_session.closed:
+            await self._poll_session.close()
+        # Fresh session
+        self._poll_session = aiohttp.ClientSession(
+            trust_env=True, connector=_make_ssl_connector(),
+        )
+        self._token_store.restore(self._account_id)
+        logger.info("[%s] reconnected with refreshed credentials (base=%s)",
+                    self.name, self._base_url)
+        return True
+
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
@@ -1334,8 +1361,10 @@ class WeixinAdapter(BasePlatformAdapter):
                 if ret not in (0, None) or errcode not in (0, None):
                     if (ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE
                             or _is_stale_session_ret(ret, errcode, response.get("errmsg"))):
-                        logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
-                        await asyncio.sleep(600)
+                        logger.error("[%s] session expired; attempting reconnect", self.name)
+                        if not await self._reconnect():
+                            logger.warning("[%s] reconnect failed; sleeping 60s before retry", self.name)
+                            await asyncio.sleep(60)
                         consecutive_failures = 0
                         continue
                     consecutive_failures += 1
@@ -1634,7 +1663,10 @@ class WeixinAdapter(BasePlatformAdapter):
                             )
                             if attempt >= self._send_chunk_retries:
                                 break
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
+                            # Exponential backoff with jitter for rate limits
+                            import secrets as _secrets
+                            base_wait = self._send_chunk_retry_delay_seconds * 3
+                            wait = min(base_wait * (2 ** attempt) + _secrets.randbelow(2000) / 1000, 60)
                             logger.warning(
                                 "[%s] rate limited for %s; backing off %.1fs before retry",
                                 self.name, _safe_id(chat_id), wait,
@@ -1723,8 +1755,13 @@ class WeixinAdapter(BasePlatformAdapter):
                     client_id=client_id,
                 )
                 last_message_id = client_id
-                if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
-                    await asyncio.sleep(self._send_chunk_delay_seconds)
+                # Dynamic delay: scale with chunk count to avoid rate limits
+                if idx < len(chunks) - 1:
+                    dynamic_delay = max(
+                        self._send_chunk_delay_seconds,
+                        2.0 + len(chunks) * 0.3,
+                    )
+                    await asyncio.sleep(dynamic_delay)
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)

--- a/gateway/platforms/wps_xiezuo.py
+++ b/gateway/platforms/wps_xiezuo.py
@@ -1,0 +1,1012 @@
+"""
+WPS Xiezuo (WPS365 协作) built-in platform adapter for Hermes gateway.
+
+Follows the same patterns as FeishuAdapter:
+  - WebSocket long-connection (default) + Webhook dual-mode
+  - KSO-1 HMAC-SHA256 authentication on WS upgrade + webhook verification
+  - AES-256-CBC event decryption (webhook mode; WS events are plaintext)
+  - client_credentials token management via AppTokenStore
+  - emoji_busy reaction on message receipt, removed after reply
+  - Per-chat asyncio.Lock for serial message processing
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import random
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Sequence
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+    SessionSource,
+)
+from gateway.session import build_session_key
+
+logger = logging.getLogger("gateway.platforms.wps_xiezuo")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MESSAGE_TOPIC = "kso.app_chat.message"
+MAX_MESSAGE_LENGTH = 5000
+_WPS_APP_LOCK_SCOPE = "wps_xiezuo_app"
+DEFAULT_BASE_URL = "https://openapi.wps.cn"
+DEFAULT_CONNECTION_MODE = "websocket"
+
+# Reaction type for acknowledging receipt
+_REACTION_BUSY = "emoji_busy"
+
+# ---------------------------------------------------------------------------
+# Crypto helpers (port of wps_xiezuo_crypto.py)
+# ---------------------------------------------------------------------------
+
+
+def _derive_key(secret: str) -> bytes:
+    """AES-256 key = MD5(secret).hexdigest() as UTF-8 bytes (32 B)."""
+    return hashlib.md5(secret.encode()).hexdigest().encode("utf-8")
+
+
+def _derive_iv(nonce: str) -> bytes:
+    """AES-CBC IV = first 16 bytes of nonce string, UTF-8 encoded."""
+    return nonce.encode("utf-8")[:16]
+
+
+def compute_signature(
+    app_id: str, app_secret: str, topic: str,
+    nonce: str, timestamp: int, encrypted_data: str,
+) -> str:
+    """HMAC-SHA256 signature for WPS event verification.
+
+    content = "app_id:topic:nonce:timestamp:encrypted_data"
+    sig = base64url(HMAC-SHA256(content, app_secret))  stripped of trailing '='
+    """
+    content = f"{app_id}:{topic}:{nonce}:{timestamp}:{encrypted_data}"
+    mac = hmac.new(app_secret.encode(), content.encode(), hashlib.sha256)
+    return base64.urlsafe_b64encode(mac.digest()).decode().rstrip("=")
+
+
+def verify_signature(
+    signature: str, app_id: str, app_secret: str, topic: str,
+    nonce: str, timestamp: int, encrypted_data: str,
+) -> bool:
+    expected = compute_signature(app_id, app_secret, topic, nonce, timestamp, encrypted_data)
+    return hmac.compare_digest(expected, signature)
+
+
+def decrypt_event(encrypted_data: str, secret: str, nonce: str) -> str:
+    """Decrypt AES-256-CBC encrypted WPS event body."""
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives import padding as crypto_padding
+
+    key = _derive_key(secret)
+    iv = _derive_iv(nonce)
+    ciphertext = base64.b64decode(encrypted_data)
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+    unpadder = crypto_padding.PKCS7(128).unpadder()
+    plaintext = unpadder.update(padded) + unpadder.finalize()
+    return plaintext.decode("utf-8")
+
+
+def build_handshake(app_id: str, app_secret: str, nonce: str) -> dict:
+    """Build KSO-1 handshake frame (opcode=1).
+
+    The server authenticates us by receiving this frame immediately
+    after the WebSocket upgrade. The handshake frame carries app_id,
+    HMAC-SHA256 signature, nonce, and timestamp.
+    """
+    timestamp = int(time.time())
+    signature = compute_signature(app_id, app_secret, "", nonce, timestamp, "")
+    return {
+        "opcode": 1,
+        "payload": json.dumps({
+            "app_id": app_id,
+            "signature": signature,
+            "nonce": nonce,
+            "timestamp": timestamp,
+        }),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Token management
+# ---------------------------------------------------------------------------
+
+
+class AppTokenStore:
+    """Manages client_credentials tokens for WPS Open Platform."""
+
+    def __init__(self, base_url: str, app_id: str, app_secret: str):
+        self._base_url = base_url
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._token: Optional[str] = None
+        self._expires_at: float = 0
+        self._lock = asyncio.Lock()
+        self._in_flight: Optional[asyncio.Future] = None
+
+    async def get_token(self) -> str:
+        if self._token and time.time() < self._expires_at - 60:
+            return self._token
+
+        # Deduplicate in-flight requests
+        if self._in_flight and not self._in_flight.done():
+            return await self._in_flight
+
+        async with self._lock:
+            if self._token and time.time() < self._expires_at - 60:
+                return self._token
+
+            loop = asyncio.get_running_loop()
+            fut = loop.create_future()
+            self._in_flight = fut
+            try:
+                token, ttl = await self._fetch_token()
+                self._token = token
+                self._expires_at = time.time() + ttl
+                fut.set_result(token)
+            except Exception as exc:
+                fut.set_exception(exc)
+                raise
+            finally:
+                self._in_flight = None
+            return self._token
+
+    async def _fetch_token(self) -> tuple[str, int]:
+        import aiohttp
+
+        token_paths = ["/oauth2/token", "/openapi/oauth2/token"]
+        last_exc: Optional[Exception] = None
+        async with aiohttp.ClientSession() as session:
+            for path in token_paths:
+                try:
+                    async with session.post(
+                        f"{self._base_url}{path}",
+                        data={
+                            "grant_type": "client_credentials",
+                            "client_id": self._app_id,
+                            "client_secret": self._app_secret,
+                        },
+                    ) as resp:
+                        body = await resp.json()
+                        if resp.status == 200 and body.get("access_token"):
+                            return body["access_token"], body.get("expires_in", 7200)
+                except Exception as exc:
+                    last_exc = exc
+                    continue
+        raise RuntimeError(f"Failed to obtain WPS access_token: {last_exc}")
+
+    def invalidate(self) -> None:
+        self._token = None
+        self._expires_at = 0
+
+
+# ---------------------------------------------------------------------------
+# WPS API client
+# ---------------------------------------------------------------------------
+
+
+class WpsRequestError(Exception):
+    pass
+
+
+class WpsClient:
+    """Lightweight HTTP client for WPS Open Platform APIs."""
+
+    def __init__(self, base_url: str, token_store: AppTokenStore):
+        self._base_url = base_url
+        self._token_store = token_store
+
+    async def request(self, method: str, path: str, *, body: Optional[dict] = None, json: Optional[dict] = None) -> dict:
+        import aiohttp
+
+        token = await self._token_store.get_token()
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        url = f"{self._base_url}{path}"
+
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=json or body) as resp:
+                data = await resp.json()
+
+        if data.get("code", -1) != 0:
+            err = data.get("msg", data.get("message", str(data)))
+            raise WpsRequestError(f"WPS API {path} failed: {err}")
+
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Inbound message normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize_message_content(message: dict) -> str:
+    """Extract displayable text from a WPS message content dict."""
+    content = message.get("content", {})
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError:
+            return content
+
+    if not isinstance(content, dict):
+        return str(content) if content else ""
+
+    # Text message
+    text_obj = content.get("text", {})
+    if isinstance(text_obj, dict):
+        return text_obj.get("content", "") or ""
+    if isinstance(text_obj, str):
+        return text_obj
+
+    # Rich text — extract paragraphs
+    rich = content.get("rich_text", {})
+    if isinstance(rich, dict):
+        parts: list[str] = []
+        for block in rich.get("content", []):
+            if isinstance(block, dict):
+                for elem in block.get("body", []):
+                    if isinstance(elem, dict):
+                        t = elem.get("text", "")
+                        if t:
+                            parts.append(t)
+        return "\n".join(parts) if parts else ""
+
+    return json.dumps(content, ensure_ascii=False) if content else ""
+
+
+def _strip_at_mention(text: str) -> str:
+    """Strip inline <at ...>user_name</at> tags."""
+    import re
+    return re.sub(r"<at[^>]*>(.*?)</at>", r"\1", text).strip()
+
+
+def _sanitize_model_output(text: str) -> str:
+    """Strip model-internal tokens that leak into output text."""
+    import re
+
+    # 1) DeepSeek DSML blocks
+    for tag in ("tool_calls", "invoke", "parameter"):
+        pat = rf"<[|\uff5c]+DSML[|\uff5c]+{tag}[^>]*>.*?</[|\uff5c]+DSML[|\uff5c]+{tag}>"
+        text = re.sub(pat, "", text, flags=re.DOTALL)
+    text = re.sub(r"<[|\uff5c]+DSML[|\uff5c]+\w+[^>]*>", "", text)
+    text = re.sub(r"</[|\uff5c]+DSML[|\uff5c]+\w+>", "", text)
+
+    # 2) Pseudo-HTML tool-call tags (web_fetch, web_search, terminal, etc.)
+    tool_re = (
+        r"web_fetch|web_search|terminal|code_execution|python|bash|"
+        r"tool_call|function_call|invoke|parameter|executor|retrieval|"
+        r"browse|search|fetch|query|read_file|write_file|shell|"
+        r"code_interpreter|file_read|file_write|api_call"
+    )
+    text = re.sub(
+        rf"<({tool_re})\b[^>]*>.*?</\1>",
+        "", text, flags=re.DOTALL | re.IGNORECASE,
+    )
+    text = re.sub(rf"<({tool_re})\b[^>]*/>", "", text, flags=re.IGNORECASE)
+    text = re.sub(rf"<({tool_re})\b[^>]*>", "", text, flags=re.IGNORECASE)
+
+    # 3) Think / reasoning blocks
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"Reflection:.*?(?=\n[^\s]|\Z)", "", text, flags=re.DOTALL)
+
+    # 4) Remove any remaining stray non-HTML angle-bracket tags
+    safe = (
+        r"b|i|a|p|br|code|pre|ul|ol|li|strong|em|h[1-6]|"
+        r"table|thead|tbody|tr|td|th|blockquote|hr|img|"
+        r"div|span|sub|sup|font|center|strike|del|ins|"
+        r"details|summary|mark|small|abbr|cite|dfn|kbd|samp|var"
+    )
+    text = re.sub(rf"<(?!/?({safe})\b)[^>]+>", "", text, flags=re.IGNORECASE)
+
+    # 5) Clean up blank lines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+def _markdown_to_plain(text: str) -> str:
+    """Strip markdown formatting for WPS plain-text fallback.
+
+    Removes bold/italic markers, code fences, link syntax, headers,
+    and list markers so the content is readable as plain text.
+    """
+    import re
+    # Remove code blocks first (```)
+    text = re.sub(r"```[\w]*\n?", "", text)
+    text = re.sub(r"```", "", text)
+    # Remove inline code
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    # Remove bold/italic
+    text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
+    text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
+    # Remove links [text](url) → text
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    # Remove headers (#)
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    # Remove unordered list markers
+    text = re.sub(r"^\s*[-*+]\s+", "• ", text, flags=re.MULTILINE)
+    # Remove ordered list markers
+    text = re.sub(r"^\s*\d+\.\s+", "", text, flags=re.MULTILINE)
+    # Remove horizontal rules
+    text = re.sub(r"^[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
+    # Collapse excessive blank lines
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class WpsXiezuoAdapter(BasePlatformAdapter):
+    """Hermes built-in adapter for WPS Xiezuo (WPS365 协作)."""
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config):
+        super().__init__(config, Platform.WPS_XIEZUO)
+        self._settings = self._load_settings(config.extra or {})
+        self._apply_settings(self._settings)
+
+        # Connection state
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._ws_client = None
+        self._ws_session = None
+        self._ws_is_websockets_lib = False
+        self._recv_task: Optional[asyncio.Task] = None
+        self._stop_reconnect = False
+        self._connected = False
+        self._token_store: Optional[AppTokenStore] = None
+        self._wps_client: Optional[WpsClient] = None
+        self._bot_user_id: Optional[str] = None
+        self._seen_messages: Dict[str, float] = {}
+        self._chat_locks: Dict[str, asyncio.Lock] = {}
+        self._pending_reactions: Dict[str, str] = {}  # msg_id -> chat_id
+        self._last_ping_time: float = 0  # tracks last server PING for stale detection
+        self._pong_timeout: float = 90.0  # seconds — matches Node.js SDK default
+
+    # ── Settings ────────────────────────────────────────────────
+
+    @staticmethod
+    def _load_settings(extra: dict) -> dict:
+        return {
+            "app_id": extra.get("app_id") or os.getenv("WPS_XIEZUO_APP_ID") or os.getenv("WPS_APP_ID", ""),
+            "app_secret": extra.get("app_secret") or os.getenv("WPS_XIEZUO_APP_SECRET") or os.getenv("WPS_APP_SECRET", ""),
+            "base_url": extra.get("base_url") or os.getenv("WPS_XIEZUO_BASE_URL", DEFAULT_BASE_URL),
+            "connection_mode": extra.get("connection_mode") or os.getenv("WPS_XIEZUO_CONNECTION_MODE", DEFAULT_CONNECTION_MODE),
+            "enable_encryption": extra.get("enable_encryption", os.getenv("WPS_XIEZUO_ENCRYPTION", "").lower() in ("true", "1", "yes")),
+            "encrypt_key": extra.get("encrypt_key") or os.getenv("WPS_XIEZUO_ENCRYPT_KEY", ""),
+            "home_channel": extra.get("home_channel") or os.getenv("WPS_XIEZUO_HOME_CHANNEL") or os.getenv("WPS_HOME_CHANNEL", ""),
+        }
+
+    def _apply_settings(self, s: dict) -> None:
+        self._app_id = s["app_id"]
+        self._app_secret = s["app_secret"]
+        self._base_url = s["base_url"].rstrip("/")
+        self._connection_mode = s["connection_mode"]
+        self._enable_encryption = s["enable_encryption"]
+        self._encrypt_key = s["encrypt_key"]
+        self._home_channel = s["home_channel"]
+
+    # ── Requirements check ───────────────────────────────────────
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    # ── Connect ──────────────────────────────────────────────────
+
+    async def connect(self) -> bool:
+        if not self._app_id or not self._app_secret:
+            logger.error("WPS Xiezuo: WPS_APP_ID and WPS_APP_SECRET must be set")
+            return False
+
+        self._loop = asyncio.get_running_loop()
+        self._token_store = AppTokenStore(self._base_url, self._app_id, self._app_secret)
+        self._wps_client = WpsClient(self._base_url, self._token_store)
+
+        if self._connection_mode == "websocket":
+            return await self._connect_ws()
+        return await self._connect_webhook()
+
+    async def _connect_ws(self) -> bool:
+        """WebSocket long-connection matching open-event-sdk protocol.
+
+        Protocol (matches Node.js open-event-sdk exactly):
+        1. KSO-1 signed headers on the WS upgrade request
+        2. X-Ack-Mode: required header for ACK mode
+        3. No handshake frame — auth is via HTTP headers only
+        4. Server sends WebSocket-level PINGs (~30s interval)
+        5. Server pushes events as bare JSON with topic/operation/nonce/signature
+        6. Client sends ACK: {"type":"ack","nonce":"...","code":200}
+
+        IMPORTANT: The app must have "长连接" event subscription enabled
+        on the WPS Open Platform developer dashboard, otherwise the
+        server accepts the connection but does not push events.
+        """
+        ws_url = f"{self._base_url.replace('https://', 'wss://').replace('http://', 'ws://')}/v7/event/ws"
+
+        try:
+            import aiohttp
+
+            headers = self._sign_ws_headers("/v7/event/ws")
+            headers["X-Ack-Mode"] = "required"
+
+            self._ws_session = aiohttp.ClientSession()
+            self._ws_client = await self._ws_session.ws_connect(
+                ws_url, headers=headers, heartbeat=None, autoping=False,
+            )
+            self._ws_is_websockets_lib = False
+
+            # Connected — start recv loop
+            self._connected = True
+            self._stop_reconnect = False
+            self._last_ping_time = time.time()
+            self._recv_task = asyncio.create_task(self._recv_loop())
+            self._mark_connected()
+            logger.info("WPS Xiezuo: WebSocket connected (app_id=%s)", self._app_id)
+            return True
+
+        except Exception as exc:
+            logger.error("WPS Xiezuo: WS connection failed: %s: %s", type(exc).__name__, exc)
+            await self._cleanup_ws()
+            return False
+
+    async def _connect_webhook(self) -> bool:
+        """Start aiohttp webhook listener."""
+        import aiohttp
+        from aiohttp import web
+
+        port = int(os.getenv("WPS_XIEZUO_WEBHOOK_PORT", "8765"))
+        path = os.getenv("WPS_XIEZUO_WEBHOOK_PATH", "/wps/webhook")
+
+        async def _handler(request: web.Request) -> web.Response:
+            try:
+                body = await request.json()
+            except Exception:
+                return web.Response(status=400, text="Invalid JSON")
+
+            if body.get("type") == "url_verification":
+                return web.json_response({"challenge": body.get("challenge", "")})
+
+            event = body.get("event") or body
+            # Webhook mode: verify signature and decrypt
+            if self._enable_encryption:
+                event = await self._decrypt_event(event) or event
+
+            await self._handle_inbound_event(event)
+            return web.json_response({"code": 0})
+
+        app = web.Application()
+        app.router.add_post(path, _handler)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", port)
+        try:
+            await site.start()
+        except OSError as exc:
+            logger.error("WPS Xiezuo: webhook failed: %s", exc)
+            return False
+
+        self._webhook_runner = runner
+        self._connected = True
+        self._mark_connected()
+        logger.info("WPS Xiezuo: Webhook listening on 127.0.0.1:%d%s", port, path)
+        return True
+
+    # ── WS header signing (matches open-event-sdk KSO-1) ────────
+
+    def _sign_ws_headers(self, uri: str) -> dict:
+        """KSO-1 signed headers for WS upgrade (matches open-event-sdk)."""
+        from email.utils import formatdate
+
+        date_str = formatdate(timeval=None, localtime=False, usegmt=True)
+        string_to_sign = f"KSO-1GET{uri}{date_str}"
+        signature = hmac.new(
+            self._app_secret.encode(), string_to_sign.encode(), hashlib.sha256,
+        ).hexdigest()
+        return {
+            "X-Kso-Date": date_str,
+            "X-Kso-Authorization": f"KSO-1 {self._app_id}:{signature}",
+        }
+
+    # ── Receive loop ─────────────────────────────────────────────
+
+    async def _recv_loop(self) -> None:
+        if not self._ws_client:
+            return
+
+        try:
+            logger.info("WPS Xiezuo: recv_loop started (websockets_lib=%s)", self._ws_is_websockets_lib)
+            while self._ws_client and not self._ws_client.closed:
+                try:
+                    if self._ws_is_websockets_lib:
+                        raw_str = await asyncio.wait_for(self._ws_client.recv(), timeout=30)
+                        logger.info("WPS Xiezuo: WS TEXT frame len=%d", len(raw_str))
+                        try:
+                            data = json.loads(raw_str)
+                        except json.JSONDecodeError:
+                            continue
+                        await self._handle_ws_data(data)
+                    else:
+                        # aiohttp: receive with timeout so we can detect stale connections
+                        msg = await asyncio.wait_for(self._ws_client.receive(), timeout=30)
+                        mt = msg.type
+                        if mt == 1:  # TEXT
+                            raw = msg.data
+                            logger.info("WPS Xiezuo: WS TEXT frame len=%d preview=%s",
+                                        len(raw) if isinstance(raw, str) else 0,
+                                        raw[:120] if isinstance(raw, str) else "")
+                            try:
+                                data = json.loads(raw)
+                            except json.JSONDecodeError:
+                                continue
+                            await self._handle_ws_data(data)
+                        elif mt == 9:  # PING (WebSocket protocol level)
+                            self._last_ping_time = time.time()
+                            logger.info("WPS Xiezuo: WS PING, sending PONG (last_ping reset)")
+                            await self._ws_client.pong(msg.data)
+                        elif mt == 8:  # CLOSE
+                            logger.info("WPS Xiezuo: WS CLOSE code=%s reason=%s", msg.data, msg.extra)
+                            break
+                        elif mt == 4:  # ERROR
+                            logger.error("WPS Xiezuo: WS error: %s", self._ws_client.exception())
+                            break
+                        elif mt in (256, 257):  # CLOSING, CLOSED
+                            logger.info("WPS Xiezuo: WS CLOSING/CLOSED type=%s", mt)
+                            break
+                        else:
+                            logger.info("WPS Xiezuo: WS unknown type=%s data=%s", mt,
+                                        str(msg.data)[:100] if msg.data else "")
+                except asyncio.TimeoutError:
+                    # No activity in 30s — check if connection is stale
+                    elapsed = time.time() - self._last_ping_time
+                    if elapsed > self._pong_timeout:
+                        logger.warning(
+                            "WPS Xiezuo: no PING received for %.0fs (timeout=%.0fs), "
+                            "connection is stale — reconnecting",
+                            elapsed, self._pong_timeout,
+                        )
+                        break  # exit while loop → finally → reconnect
+                    logger.debug("WPS Xiezuo: no message in 30s (last_ping=%.0fs ago)", elapsed)
+                    continue
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.error("WPS Xiezuo: recv loop error: %s", exc, exc_info=True)
+        finally:
+            self._connected = False
+            await self._cleanup_ws()
+            if not self._stop_reconnect:
+                await self._reconnect()
+
+    async def _handle_ws_data(self, data: dict) -> None:
+        """Route a single decoded JSON message from the WPS event stream."""
+        msg_type = data.get("type", "")
+
+        # Handle goaway
+        if msg_type == "goaway":
+            reason = data.get("reason", "")
+            logger.warning("WPS Xiezuo: received goaway: reason=%s message=%s",
+                            reason, data.get("message", ""))
+            if reason == "connection_replaced":
+                logger.info("WPS Xiezuo: connection replaced, will reconnect in 5s")
+                self._connected = False
+            else:
+                self._stop_reconnect = True
+                logger.warning("WPS Xiezuo: goaway reason=%s, stopping reconnect", reason)
+            return
+
+        # Event messages have topic + operation
+        topic = data.get("topic", "")
+        operation = data.get("operation", "")
+        if not topic or not operation:
+            logger.info("WPS Xiezuo: ignoring message without topic/operation: type=%s keys=%s",
+                        msg_type, list(data.keys())[:10])
+            return
+
+        logger.info("WPS Xiezuo: received event topic=%s operation=%s nonce=%s",
+                     topic, operation, data.get("nonce", ""))
+
+        # Send ACK BEFORE processing — WPS server has a short ACK timeout
+        # (~5s). If we await agent processing first (which takes seconds),
+        # the ACK arrives too late and the server disables event delivery.
+        nonce = data.get("nonce", "")
+        if nonce:
+            ack = {"type": "ack", "nonce": nonce, "code": 200}
+            if self._ws_client and not self._ws_is_websockets_lib:
+                await self._ws_client.send_json(ack)
+            else:
+                await self._send_ws(json.dumps(ack))
+            logger.info("WPS Xiezuo: ACK sent nonce=%s", nonce)
+
+        # Now process the event (can take seconds for agent response)
+        await self._handle_inbound_event(data)
+
+    async def _send_ws(self, text: str) -> None:
+        if not self._ws_client:
+            return
+        try:
+            if self._ws_is_websockets_lib:
+                await self._ws_client.send(text)
+            else:
+                await self._ws_client.send_str(text)
+        except Exception:
+            pass
+
+    # ── Inbound event processing ─────────────────────────────────
+
+    async def _handle_inbound_event(self, event: dict) -> None:
+        """Process a single inbound event (shared by WS and Webhook).
+
+        Matches open-event-sdk flow:
+        1. Verify event signature
+        2. Decrypt encrypted_data
+        3. Parse the decrypted JSON
+        4. Dispatch to handle_message()
+        """
+        topic = event.get("topic", "")
+        operation = event.get("operation", "")
+        if topic != MESSAGE_TOPIC or operation != "create":
+            logger.debug("WPS Xiezuo: skipping event topic=%s operation=%s (want %s/create)",
+                         topic, operation, MESSAGE_TOPIC)
+            return
+
+        # Verify signature first (matches open-event-sdk behavior)
+        signature = event.get("signature", "")
+        nonce = event.get("nonce", "")
+        event_time = str(event.get("time", "0"))
+        encrypted_data = event.get("encrypted_data", "")
+
+        if signature and nonce:
+            ts = int(event_time) if event_time.isdigit() else 0
+            if not verify_signature(signature, self._app_id, self._app_secret,
+                                    topic, nonce, ts, encrypted_data):
+                logger.warning("WPS Xiezuo: signature verification failed for nonce=%s", nonce)
+                return
+
+        # Decrypt event data
+        if encrypted_data:
+            try:
+                decrypted = decrypt_event(encrypted_data, self._app_secret, nonce)
+                data = json.loads(decrypted)
+                event = {**event, "data": data}
+            except Exception as exc:
+                logger.error("WPS Xiezuo: decrypt failed: %s", exc)
+                return
+
+        data = event.get("data", {})
+        if not data:
+            logger.debug("WPS Xiezuo: event has no 'data' field, keys=%s", list(event.keys()))
+            return
+
+        sender = data.get("sender", {})
+        message = data.get("message", {})
+        chat = data.get("chat", {})
+
+        if not sender or not message:
+            logger.debug("WPS Xiezuo: missing sender or message in data, sender=%s message=%s",
+                         bool(sender), bool(message))
+            return
+
+        msg_id = message.get("id", "")
+        sender_id = sender.get("id", "")
+        sender_type = sender.get("type", "")
+
+        # Idempotency
+        now = time.time()
+        if msg_id and msg_id in self._seen_messages:
+            logger.info("WPS Xiezuo: dedup msg_id=%s (already seen)", msg_id)
+            return
+        if msg_id:
+            self._seen_messages[msg_id] = now
+        if len(self._seen_messages) > 1000:
+            cutoff = now - 300
+            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
+
+        # Anti-loopback
+        if sender_type == "robot" or sender_id == self._bot_user_id:
+            logger.info("WPS Xiezuo: loopback filtered sender=%s type=%s bot_id=%s",
+                        sender_id, sender_type, self._bot_user_id or "")
+            return
+
+        # Chat type
+        chat_id = message.get("chat_id", "") or chat.get("id", "")
+        chat_type_raw = str(chat.get("type", "")).lower() if chat else ""
+        is_dm = chat_type_raw in ("p2p", "single", "direct") or (not chat_id and sender_id)
+        chat_type = "dm" if is_dm else "group"
+
+        # Normalize content
+        text = _strip_at_mention(_normalize_message_content(message))
+        if not text:
+            return
+
+        # Build source and dispatch
+        source = self.build_source(
+            chat_id=chat_id or sender_id,
+            chat_name=chat.get("name", chat_id or sender_id),
+            chat_type=chat_type,
+            user_id=sender_id,
+            user_name=sender.get("name", sender_id),
+            message_id=msg_id,
+        )
+
+        msg_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=msg_id or str(int(now * 1000)),
+            timestamp=datetime.now(),
+        )
+
+        chat_lock = self._get_chat_lock(chat_id or sender_id)
+        async with chat_lock:
+            await self.handle_message(msg_event)
+
+    async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> "SendResult":
+        # Sanitize BEFORE entering base-class retry/fallback paths.
+        # The base class fallback in base.py line ~2389 injects raw
+        # content directly, bypassing format_message(). Cleaning here
+        # ensures both primary and fallback send clean text.
+        clean = self.format_message(content)
+        if not clean:
+            clean = "（处理中，暂无文本内容）"
+        return await super()._send_with_retry(
+            chat_id=chat_id,
+            content=clean,
+            reply_to=reply_to,
+            metadata=metadata,
+            max_retries=max_retries,
+            base_delay=base_delay,
+        )
+
+    # ── Lifecycle hooks (reaction-based feedback, like Feishu) ────
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add emoji_busy reaction when processing begins."""
+        chat_id = getattr(event.source, "chat_id", "") or ""
+        msg_id = getattr(event.source, "message_id", "") or event.message_id or ""
+        logger.info("WPS Xiezuo: on_processing_start chat=%s msg=%s client=%s", chat_id, msg_id, bool(self._wps_client))
+        if not self._wps_client or not chat_id or not msg_id:
+            logger.warning("WPS Xiezuo: skipping reaction — client=%s chat=%s msg=%s", bool(self._wps_client), chat_id, msg_id)
+            return
+        try:
+            await self._wps_client.request(
+                "POST",
+                f"/v7/chats/{chat_id}/messages/{msg_id}/reactions/create",
+                json={"reaction_type": _REACTION_BUSY},
+            )
+            # Track that we added a reaction to this message
+            self._pending_reactions[msg_id] = chat_id
+            logger.debug("WPS Xiezuo: added thinking reaction msg=%s", msg_id)
+        except Exception as exc:
+            logger.debug("WPS Xiezuo: add reaction failed: %s", exc)
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        """Remove emoji_busy reaction after processing completes."""
+        msg_id = getattr(event.source, "message_id", "") or event.message_id or ""
+        chat_id = self._pending_reactions.pop(msg_id, "")
+        if not self._wps_client or not chat_id or not msg_id:
+            return
+        try:
+            await self._wps_client.request(
+                "POST",
+                f"/v7/chats/{chat_id}/messages/{msg_id}/reactions/delete",
+                json={"reaction_type": _REACTION_BUSY},
+            )
+            logger.debug("WPS Xiezuo: removed thinking reaction msg=%s", msg_id)
+        except Exception as exc:
+            logger.debug("WPS Xiezuo: remove reaction failed: %s", exc)
+
+    # ── Outbound sending ─────────────────────────────────────────
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a message to a WPS chat or user."""
+        if not self._connected or not self._wps_client:
+            return SendResult(success=False, error="Not connected")
+
+        receiver = self._parse_receiver(chat_id)
+        if not receiver:
+            return SendResult(success=False, error=f"Invalid chat_id: {chat_id}")
+
+        formatted = self.format_message(content)
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+        last_result = None
+        for chunk in chunks:
+            try:
+                body = {
+                    "type": "text",
+                    "receiver": receiver,
+                    "content": {"text": {"content": chunk, "type": "markdown"}},
+                }
+                result = await self._wps_client.request("POST", "/v7/messages/create", json=body)
+                last_result = SendResult(
+                    success=True,
+                    message_id=result.get("data", {}).get("message_id", ""),
+                )
+            except WpsRequestError as exc:
+                err_str = str(exc)
+                if "401" in err_str or "token" in err_str.lower():
+                    self._token_store.invalidate()
+                    last_result = SendResult(success=False, error=err_str)
+                    break
+                # WPS markdown parse failed — retry with sanitized markdown
+                # (WPS does NOT support type: "text", only "markdown")
+                if "can not get text info" in err_str or "invalid" in err_str.lower():
+                    try:
+                        plain_chunk = _markdown_to_plain(chunk)
+                        # Strip remaining problematic chars and retry as markdown
+                        fallback_body = {
+                            "type": "text",
+                            "receiver": receiver,
+                            "content": {"text": {"content": plain_chunk, "type": "markdown"}},
+                        }
+                        result = await self._wps_client.request("POST", "/v7/messages/create", json=fallback_body)
+                        last_result = SendResult(
+                            success=True,
+                            message_id=result.get("data", {}).get("message_id", ""),
+                        )
+                        logger.info("WPS Xiezuo: markdown send failed, sanitized markdown fallback ok")
+                        continue
+                    except WpsRequestError as fb_exc:
+                        logger.error("WPS Xiezuo: plain-text fallback also failed: %s", fb_exc)
+                        last_result = SendResult(success=False, error=str(fb_exc))
+                        break
+                last_result = SendResult(success=False, error=err_str)
+                break
+
+        return last_result or SendResult(success=False, error="No chunks to send")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """WPS doesn't have a typing API — no-op (use reactions instead)."""
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return basic info about a WPS chat."""
+        if not self._wps_client:
+            return {"name": chat_id, "type": "unknown"}
+        try:
+            data = await self._wps_client.request("GET", f"/v7/chats/{chat_id}")
+            chat_data = data.get("data", data)
+            return {
+                "name": chat_data.get("name", chat_id),
+                "type": "group" if chat_data.get("type") == "group" else "dm",
+            }
+        except Exception:
+            return {"name": chat_id, "type": "unknown"}
+
+    def format_message(self, content: str) -> str:
+        """WPS supports markdown — pass through after sanitization."""
+        cleaned = _sanitize_model_output(content)
+        # If sanitization stripped everything (model output was all tool-call
+        # artifacts with no real text), return a placeholder instead of an
+        # empty string — WPS API rejects empty content.
+        return (cleaned or "（处理中，暂无文本内容）").strip()
+
+    @staticmethod
+    def _parse_receiver(chat_id: str) -> Optional[dict]:
+        """Parse chat_id into WPS receiver dict.
+
+        WPS API requires ``receiver_id`` (not ``id``) inside the receiver object.
+        """
+        if chat_id.startswith("user:"):
+            return {"type": "user", "receiver_id": chat_id[5:]}
+        if chat_id.startswith("chat:"):
+            return {"type": "chat", "receiver_id": chat_id[5:]}
+        # Bare ID → treat as chat
+        if chat_id:
+            return {"type": "chat", "receiver_id": chat_id}
+        return None
+
+    # ── Per-chat serialization ───────────────────────────────────
+
+    def _get_chat_lock(self, chat_id: str) -> asyncio.Lock:
+        lock = self._chat_locks.get(chat_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._chat_locks[chat_id] = lock
+        return lock
+
+    # ── Reconnect ────────────────────────────────────────────────
+
+    async def _reconnect(self) -> None:
+        attempt = 0
+        while not self._stop_reconnect:
+            delay = min(2 ** attempt, 60) + random.random()  # exponential + jitter
+            logger.info("WPS Xiezuo: reconnecting in %.1fs (attempt %d)", delay, attempt + 1)
+            await asyncio.sleep(delay)
+            await self._cleanup_ws()  # close any stale session/socket first
+            if await self._connect_ws():
+                return
+            attempt += 1
+
+    # ── Cleanup ──────────────────────────────────────────────────
+
+    async def disconnect(self) -> None:
+        self._stop_reconnect = True
+        if self._recv_task:
+            self._recv_task.cancel()
+        # Hard-close: do NOT send WS CLOSE frame.
+        # WPS server appears to disable event delivery after a clean WS CLOSE.
+        # Dropping the TCP socket makes the server treat this as "connection lost"
+        # and re-enables event delivery when we reconnect.
+        await self._cleanup_ws(hard=True)
+        self._connected = False
+
+    async def _cleanup_ws(self, hard: bool = False) -> None:
+        if self._ws_client and not hard:
+            try:
+                if self._ws_is_websockets_lib:
+                    await self._ws_client.close()
+                elif hasattr(self._ws_client, "closed") and not self._ws_client.closed:
+                    await self._ws_client.close()
+            except Exception:
+                pass
+        if self._ws_session:
+            try:
+                await self._ws_session.close()
+            except Exception:
+                pass
+        self._ws_client = None
+        self._ws_session = None
+        self._ws_is_websockets_lib = False
+
+    # ── Watchdog ─────────────────────────────────────────────────
+
+    def _on_ping(self) -> None:
+        """Called on any inbound activity to keep watchdog alive."""
+        # Base class doesn't have a watchdog; this is a placeholder
+        # for future reconnect-on-stale logic
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Requirements check (called by gateway/run.py)
+# ---------------------------------------------------------------------------
+
+def check_wps_xiezuo_requirements() -> bool:
+    """Return True if the WPS Xiezuo adapter can be instantiated."""
+    app_id = os.getenv("WPS_XIEZUO_APP_ID") or os.getenv("WPS_APP_ID")
+    app_secret = os.getenv("WPS_XIEZUO_APP_SECRET") or os.getenv("WPS_APP_SECRET")
+    if not app_id or not app_secret:
+        return False
+    try:
+        from cryptography.hazmat.primitives.ciphers import Cipher  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# Make Platform available locally (avoid circular import)
+from gateway.config import Platform  # noqa: E402

--- a/gateway/platforms/wps_xiezuo_crypto.py
+++ b/gateway/platforms/wps_xiezuo_crypto.py
@@ -1,0 +1,216 @@
+"""
+KSO-1 handshake + HMAC-SHA256 signature + AES-256-CBC encryption for WPS Xiezuo.
+
+Ported from the JS implementation in event-crypto.js.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import struct
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import padding as crypto_padding
+from cryptography.hazmat.backends import default_backend
+
+
+# ---------------------------------------------------------------------------
+# Frame parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WpsFrame:
+    """Parsed WPS Xiezuo WebSocket frame."""
+    opcode: int
+    data: Any
+
+
+def parse_frame(raw: dict) -> WpsFrame:
+    """Parse a raw WebSocket frame dict into a WpsFrame.
+
+    Raises ValueError if required fields are missing.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError(f"Frame must be a dict, got {type(raw)}")
+    if "opcode" not in raw or "payload" not in raw:
+        raise ValueError("Frame missing 'opcode' or 'payload' field")
+
+    opcode = raw["opcode"]
+    payload = raw["payload"]
+
+    # Try to parse payload as JSON
+    if isinstance(payload, str):
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            data = payload
+    else:
+        data = payload
+
+    return WpsFrame(opcode=opcode, data=data)
+
+
+# ---------------------------------------------------------------------------
+# KSO-1 Handshake
+# ---------------------------------------------------------------------------
+
+def build_handshake(app_id: str, app_secret: str, nonce: str) -> dict:
+    """Build a KSO-1 handshake frame.
+
+    Returns a dict with:
+      - opcode: 1
+      - payload: JSON string with app_id, signature, nonce, timestamp
+    """
+    timestamp = int(time.time())
+    signature = compute_signature(
+        app_id=app_id,
+        app_secret=app_secret,
+        topic="",
+        nonce=nonce,
+        timestamp=timestamp,
+        encrypted_data="",
+    )
+
+    payload = {
+        "app_id": app_id,
+        "signature": signature,
+        "nonce": nonce,
+        "timestamp": timestamp,
+    }
+
+    return {
+        "opcode": 1,
+        "payload": json.dumps(payload),
+    }
+
+
+# ---------------------------------------------------------------------------
+# HMAC-SHA256 Signature
+# ---------------------------------------------------------------------------
+
+def compute_signature(
+    app_id: str,
+    app_secret: str,
+    topic: str,
+    nonce: str,
+    timestamp: int,
+    encrypted_data: str,
+) -> str:
+    """Compute HMAC-SHA256 signature for WPS event verification.
+
+    The signed content is: "app_id:topic:nonce:timestamp:encrypted_data"
+    The signature is base64url-encoded with trailing '=' stripped.
+    """
+    content = f"{app_id}:{topic}:{nonce}:{timestamp}:{encrypted_data}"
+    mac = hmac.new(
+        app_secret.encode("utf-8"),
+        content.encode("utf-8"),
+        hashlib.sha256,
+    )
+    return base64.urlsafe_b64encode(mac.digest()).decode("utf-8").rstrip("=")
+
+
+def verify_signature(
+    signature: str,
+    app_id: str,
+    app_secret: str,
+    topic: str,
+    nonce: str,
+    timestamp: int,
+    encrypted_data: str,
+) -> bool:
+    """Verify a WPS event signature.
+
+    Returns True if the computed signature matches the provided one.
+    """
+    expected = compute_signature(
+        app_id=app_id,
+        app_secret=app_secret,
+        topic=topic,
+        nonce=nonce,
+        timestamp=timestamp,
+        encrypted_data=encrypted_data,
+    )
+    return hmac.compare_digest(expected, signature)
+
+
+# ---------------------------------------------------------------------------
+# AES-256-CBC Encryption / Decryption
+# ---------------------------------------------------------------------------
+
+def _derive_key(app_secret: str) -> bytes:
+    """Derive the AES-256 key from the app secret.
+
+    key = MD5(app_secret) as hex string, interpreted as UTF-8 bytes (32 bytes).
+    """
+    md5_hex = hashlib.md5(app_secret.encode("utf-8")).hexdigest()
+    return md5_hex.encode("utf-8")  # 32 bytes for AES-256
+
+
+def _derive_iv(nonce: str) -> bytes:
+    """Derive the AES-CBC IV from the nonce.
+
+    IV = first 16 bytes of the nonce string, UTF-8 encoded.
+    """
+    return nonce.encode("utf-8")[:16]
+
+
+def decrypt_event(encrypted_data: str, app_secret: str, nonce: str) -> str:
+    """Decrypt an encrypted WPS event body.
+
+    Args:
+        encrypted_data: Base64-encoded ciphertext.
+        app_secret: The app secret for key derivation.
+        nonce: The nonce used for IV derivation.
+
+    Returns:
+        Decrypted plaintext JSON string.
+
+    Raises:
+        ValueError: If decryption fails (bad padding, wrong key, etc.).
+    """
+    key = _derive_key(app_secret)
+    iv = _derive_iv(nonce)
+    ciphertext = base64.b64decode(encrypted_data)
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+
+    # Remove PKCS7 padding
+    unpadder = crypto_padding.PKCS7(128).unpadder()
+    plaintext = unpadder.update(padded) + unpadder.finalize()
+
+    return plaintext.decode("utf-8")
+
+
+def encrypt_event(plaintext: str, app_secret: str, nonce: str) -> str:
+    """Encrypt a WPS event body (for round-trip testing).
+
+    Args:
+        plaintext: JSON string to encrypt.
+        app_secret: The app secret for key derivation.
+        nonce: The nonce used for IV derivation.
+
+    Returns:
+        Base64-encoded ciphertext.
+    """
+    key = _derive_key(app_secret)
+    iv = _derive_iv(nonce)
+
+    # Apply PKCS7 padding
+    padder = crypto_padding.PKCS7(128).padder()
+    padded = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    return base64.b64encode(ciphertext).decode("utf-8")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4832,6 +4832,13 @@ class GatewayRunner:
                 return None
             return FeishuAdapter(config)
 
+        elif platform == Platform.WPS_XIEZUO:
+            from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter, check_wps_xiezuo_requirements
+            if not check_wps_xiezuo_requirements():
+                logger.warning("WPS Xiezuo: dependencies not installed or WPS_XIEZUO_APP_ID/SECRET not set")
+                return None
+            return WpsXiezuoAdapter(config)
+
         elif platform == Platform.WECOM_CALLBACK:
             from gateway.platforms.wecom_callback import (
                 WecomCallbackAdapter,
@@ -4959,6 +4966,7 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
+            Platform.WPS_XIEZUO: "WPS_XIEZUO_ALLOWED_USERS",
         }
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -4985,11 +4993,13 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
+            Platform.WPS_XIEZUO: "WPS_XIEZUO_ALLOW_ALL_USERS",
         }
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.WPS_XIEZUO: "WPS_XIEZUO_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names
@@ -5170,6 +5180,7 @@ class GatewayRunner:
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
+                Platform.WPS_XIEZUO: "WPS_XIEZUO_ALLOWED_USERS",
             }
             platform_group_env_map = {
                 Platform.TELEGRAM: (
@@ -11661,7 +11672,7 @@ class GatewayRunner:
         Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
         Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
-        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
+        Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.WPS_XIEZUO, Platform.LOCAL,
     })
 
     async def _handle_debug_command(self, event: MessageEvent) -> str:
@@ -14057,6 +14068,16 @@ class GatewayRunner:
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
+                return
+            # Suppress internal retry/prefill status messages that should
+            # not be shown to end users in chat platforms.
+            _suppressed_prefixes = (
+                "↻ Thinking-only",
+                "⚠️ Empty/",
+                "⚠️ Max retries",
+                "❌ Max retries",
+            )
+            if any(message.startswith(p) for p in _suppressed_prefixes):
                 return
             try:
                 _fut = asyncio.run_coroutine_threadsafe(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3648,6 +3648,34 @@ _PLATFORMS = [
              "help": "The App Secret (used for HMAC signing) from your Yuanbao IM Bot."},
         ],
     },
+    {
+        "key": "wps-xiezuo",
+        "label": "WPS Xiezuo",
+        "emoji": "💬",
+        "token_var": "WPS_XIEZUO_APP_ID",
+        "setup_instructions": [
+            "1. Go to https://open.wps.cn/ and create an application",
+            "2. Copy the App ID and App Secret",
+            "3. Enable the bot capability and subscribe to message events",
+            "4. Choose WebSocket (recommended) or Webhook connection mode",
+            "5. IMPORTANT: On the WPS developer dashboard, enable '长连接' (long-connection) delivery mode for WebSocket to work",
+            "6. Add the bot to a group chat or message it directly",
+            "7. Restrict access with WPS_XIEZUO_ALLOWED_USERS for production use",
+        ],
+        "vars": [
+            {"name": "WPS_XIEZUO_APP_ID", "prompt": "App ID", "password": False,
+             "help": "The App ID from your WPS Open Platform application."},
+            {"name": "WPS_XIEZUO_APP_SECRET", "prompt": "App Secret", "password": True,
+             "help": "The App Secret from your WPS Open Platform application."},
+            {"name": "WPS_XIEZUO_CONNECTION_MODE", "prompt": "Connection mode — websocket or webhook (default: websocket)", "password": False,
+             "help": "websocket is recommended unless you specifically need webhook mode."},
+            {"name": "WPS_XIEZUO_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, or empty)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which WPS users can interact with the bot."},
+            {"name": "WPS_XIEZUO_HOME_CHANNEL", "prompt": "Home chat ID (optional, for cron/notifications)", "password": False,
+             "help": "Chat ID for scheduled results and notifications."},
+        ],
+    },
 ]
 def _all_platforms() -> list[dict]:
     """Return the full list of platforms for setup menus.

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -404,6 +404,7 @@ def show_status(args):
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
         "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
+        "WPS Xiezuo": ("WPS_XIEZUO_APP_ID", "WPS_XIEZUO_HOME_CHANNEL"),
     }
 
     for name, (token_var, home_var) in platforms.items():

--- a/run_agent.py
+++ b/run_agent.py
@@ -2554,6 +2554,11 @@ class AIAgent:
         old_model = self.model
         old_provider = self.provider
 
+        # Clear the per-config context_length override so the new model's
+        # actual context window is resolved via get_model_context_length()
+        # instead of inheriting the stale value from the previous model.
+        self._config_context_length = None
+
         # ── Swap core runtime fields ──
         self.model = new_model
         self.provider = new_provider
@@ -8498,6 +8503,11 @@ class AIAgent:
                 fb_api_mode = "bedrock_converse"
 
             old_model = self.model
+
+            # Clear the per-config context_length override so the fallback
+            # model's actual context window is resolved instead of inheriting
+            # the stale value from the previous model.  See #22387.
+            self._config_context_length = None
             self.model = fb_model
             self.provider = fb_provider
             self.base_url = fb_base_url

--- a/tests/gateway/test_wps_xiezuo.py
+++ b/tests/gateway/test_wps_xiezuo.py
@@ -1,0 +1,468 @@
+"""Tests for the WPS Xiezuo built-in gateway adapter."""
+
+import asyncio
+import json
+import os
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.platforms.base import SendResult
+
+
+# ---------------------------------------------------------------------------
+# Crypto
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoCrypto(unittest.TestCase):
+    """Verify HMAC-SHA256 signature and AES-256-CBC crypto."""
+
+    def test_compute_signature(self):
+        from gateway.platforms.wps_xiezuo import compute_signature
+
+        sig = compute_signature(
+            app_id="wp_1", app_secret="sec",
+            topic="kso.app_chat.message", nonce="n1",
+            timestamp=1700000000, encrypted_data="Zm9v",
+        )
+        import hmac, hashlib, base64
+        content = "wp_1:kso.app_chat.message:n1:1700000000:Zm9v"
+        expected = base64.urlsafe_b64encode(
+            hmac.new(b"sec", content.encode(), hashlib.sha256).digest()
+        ).decode().rstrip("=")
+        self.assertEqual(sig, expected)
+
+    def test_verify_signature_valid(self):
+        from gateway.platforms.wps_xiezuo import compute_signature, verify_signature
+
+        sig = compute_signature("wp_1", "sec", "topic", "n1", 123, "data")
+        self.assertTrue(verify_signature(sig, "wp_1", "sec", "topic", "n1", 123, "data"))
+
+    def test_verify_signature_invalid(self):
+        from gateway.platforms.wps_xiezuo import verify_signature
+        self.assertFalse(verify_signature("bad", "wp_1", "sec", "topic", "n1", 123, "data"))
+
+    def test_encrypt_decrypt_roundtrip(self):
+        from gateway.platforms.wps_xiezuo import decrypt_event
+
+        import hashlib, base64
+
+        secret = "test_secret_key"
+        nonce = "abcdefghijklmnop"  # 16+ chars
+        plaintext = '{"message": {"id": "m1"}, "chat": {"id": "c1"}, "sender": {"id": "u1"}}'
+
+        key = hashlib.md5(secret.encode()).hexdigest().encode("utf-8")
+        iv = nonce.encode("utf-8")[:16]
+
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from cryptography.hazmat.primitives import padding as cp
+
+        padder = cp.PKCS7(128).padder()
+        padded = padder.update(plaintext.encode()) + padder.finalize()
+        cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+        enc = cipher.encryptor()
+        ciphertext = enc.update(padded) + enc.finalize()
+        encrypted_data = base64.b64encode(ciphertext).decode()
+
+        decrypted = decrypt_event(encrypted_data, secret, nonce)
+        self.assertEqual(json.loads(decrypted), json.loads(plaintext))
+
+    def test_handshake_frame_structure(self):
+        from gateway.platforms.wps_xiezuo import build_handshake
+
+        frame = build_handshake("wp_test", "my_secret", "abc123")
+        self.assertEqual(frame["opcode"], 1)
+        payload = json.loads(frame["payload"])
+        self.assertIn("app_id", payload)
+        self.assertIn("signature", payload)
+        self.assertEqual(payload["app_id"], "wp_test")
+        self.assertEqual(payload["nonce"], "abc123")
+
+
+# ---------------------------------------------------------------------------
+# Token store
+# ---------------------------------------------------------------------------
+
+class TestAppTokenStore(unittest.TestCase):
+    """Verify token management with in-flight dedup."""
+
+    def setUp(self):
+        self.store = None
+
+    def test_fetch_and_cache(self):
+        from gateway.platforms.wps_xiezuo import AppTokenStore
+
+        async def _run():
+            store = AppTokenStore("https://example.com", "id", "secret")
+            mock_resp = MagicMock()
+            mock_resp.json = AsyncMock(return_value={
+                "code": 0,
+                "data": {"access_token": "tok_123", "expires_in": 7200},
+            })
+            with patch("aiohttp.ClientSession.post", return_value=mock_resp):
+                # Use real session but mock post
+                pass
+
+            # Simple mock approach
+            store._fetch_token = AsyncMock(return_value=("tok_abc", 7200))
+            token = await store.get_token()
+            self.assertEqual(token, "tok_abc")
+            # Second call should use cache
+            store._fetch_token = AsyncMock(return_value=("tok_should_not", 7200))
+            token2 = await store.get_token()
+            self.assertEqual(token2, "tok_abc")
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_invalidate(self):
+        from gateway.platforms.wps_xiezuo import AppTokenStore
+
+        async def _run():
+            store = AppTokenStore("https://example.com", "id", "secret")
+            store._token = "old"
+            store._expires_at = time.time() + 9999
+            store.invalidate()
+            self.assertIsNone(store._token)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Adapter construction
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoAdapter(unittest.TestCase):
+    """Verify adapter construction and settings."""
+
+    def test_adapter_instantiation(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra.update({"app_id": "wp_test", "app_secret": "sec", "connection_mode": "websocket"})
+        adapter = WpsXiezuoAdapter(config)
+        self.assertEqual(adapter._app_id, "wp_test")
+        self.assertEqual(adapter._connection_mode, "websocket")
+        self.assertFalse(adapter._connected)
+
+    def test_parse_receiver_chat(self):
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        self.assertEqual(WpsXiezuoAdapter._parse_receiver("123"), {"type": "chat", "receiver_id": "123"})
+        self.assertEqual(WpsXiezuoAdapter._parse_receiver("chat:456"), {"type": "chat", "receiver_id": "456"})
+        self.assertEqual(WpsXiezuoAdapter._parse_receiver("user:789"), {"type": "user", "receiver_id": "789"})
+        self.assertIsNone(WpsXiezuoAdapter._parse_receiver(""))
+
+    def test_normalize_content(self):
+        from gateway.platforms.wps_xiezuo import _normalize_message_content, _strip_at_mention
+
+        msg = {"content": {"text": {"content": "hello", "type": "text"}}}
+        self.assertEqual(_normalize_message_content(msg), "hello")
+
+        msg2 = {"content": "raw text"}
+        self.assertEqual(_normalize_message_content(msg2), "raw text")
+
+        text = "hi <at user_id=bot>Bot</at> there"
+        self.assertEqual(_strip_at_mention(text), "hi Bot there")
+
+    def test_sanitize_dsml_tokens(self):
+        from gateway.platforms.wps_xiezuo import _sanitize_model_output
+
+        # DeepSeek tool-call tokens leaking into output
+        raw = (
+            '根据查询结果，金山云(KC)今日股价如下：\n'
+            '<|｜DSML｜｜tool_calls> <|｜DSML｜｜invoke name="terminal"> '
+            '<|｜DSML｜｜parameter name="command" string="true">curl -s "https://example.com"</|｜DSML｜｜parameter> '
+            '</|｜DSML｜｜invoke> </|｜DSML｜｜tool_calls>'
+        )
+        cleaned = _sanitize_model_output(raw)
+        self.assertNotIn("DSML", cleaned)
+        self.assertIn("金山云", cleaned)
+        # Should not leave excessive blank lines
+        self.assertNotIn("\n\n\n", cleaned)
+
+
+# ---------------------------------------------------------------------------
+# Inbound dispatch
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoInbound(unittest.TestCase):
+    """Verify message routing, dedup, and anti-loopback."""
+
+    def test_dm_message_dispatched(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra.update({"app_id": "wp_test", "app_secret": "sec"})
+        adapter = WpsXiezuoAdapter(config)
+        adapter._connected = True
+        adapter._wps_client = MagicMock()
+        adapter.handle_message = AsyncMock()
+
+        event = {
+            "topic": "kso.app_chat.message",
+            "operation": "create",
+            "data": {
+                "sender": {"id": "u1", "type": "user"},
+                "message": {"id": "m1", "content": {"text": {"content": "hello", "type": "text"}}},
+                "chat": {"id": "c1", "type": "p2p"},
+            },
+        }
+
+        async def _run():
+            await adapter._handle_inbound_event(event)
+            adapter.handle_message.assert_called_once()
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_loopback_filtered(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra.update({"app_id": "wp_test", "app_secret": "sec"})
+        adapter = WpsXiezuoAdapter(config)
+        adapter._connected = True
+        adapter._wps_client = MagicMock()
+        adapter.handle_message = AsyncMock()
+        adapter._bot_user_id = "bot1"
+
+        event = {
+            "topic": "kso.app_chat.message",
+            "operation": "create",
+            "data": {
+                "sender": {"id": "bot1", "type": "robot"},
+                "message": {"id": "m2", "content": {"text": {"content": "ignore", "type": "text"}}},
+                "chat": {"id": "c1", "type": "p2p"},
+            },
+        }
+
+        async def _run():
+            await adapter._handle_inbound_event(event)
+            adapter.handle_message.assert_not_called()
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_dedup_same_msg_id(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra.update({"app_id": "wp_test", "app_secret": "sec"})
+        adapter = WpsXiezuoAdapter(config)
+        adapter._connected = True
+        adapter._wps_client = MagicMock()
+        adapter.handle_message = AsyncMock()
+
+        event = {
+            "topic": "kso.app_chat.message",
+            "operation": "create",
+            "data": {
+                "sender": {"id": "u1", "type": "user"},
+                "message": {"id": "m_dedup", "content": {"text": {"content": "hello", "type": "text"}}},
+                "chat": {"id": "c1", "type": "p2p"},
+            },
+        }
+
+        async def _run():
+            await adapter._handle_inbound_event(event)
+            self.assertEqual(adapter.handle_message.call_count, 1)
+            await adapter._handle_inbound_event(event)
+            self.assertEqual(adapter.handle_message.call_count, 1)  # deduped
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Sending
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoSend(unittest.TestCase):
+    """Verify outbound message sending."""
+
+    def test_send_not_connected(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        result = asyncio.get_event_loop().run_until_complete(adapter.send("c1", "hello"))
+        self.assertFalse(result.success)
+
+    def test_send_text_message(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        adapter._connected = True
+        mock_client = MagicMock()
+        mock_client.request = AsyncMock(return_value={"code": 0, "data": {"message_id": "msg_out"}})
+        adapter._wps_client = mock_client
+
+        async def _run():
+            result = await adapter.send("c1", "**hello**")
+            self.assertTrue(result.success)
+            self.assertEqual(result.message_id, "msg_out")
+            call_args = mock_client.request.call_args
+            self.assertEqual(call_args[0][0], "POST")
+            self.assertEqual(call_args[0][1], "/v7/messages/create")
+            body = call_args[1]["json"]
+            self.assertEqual(body["receiver"]["receiver_id"], "c1")
+            self.assertEqual(body["content"]["text"]["type"], "markdown")
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_send_markdown_fallback_to_plain(self):
+        """When markdown send fails with 'can not get text info', fall back to sanitized markdown."""
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter, WpsRequestError
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        adapter._connected = True
+        adapter._token_store = MagicMock()
+        mock_client = MagicMock()
+        # First call (markdown) fails, second call (sanitized markdown) succeeds
+        mock_client.request = AsyncMock(side_effect=[
+            WpsRequestError("WPS API /v7/messages/create failed: InvalidArgument:can not get text info"),
+            {"code": 0, "data": {"message_id": "msg_plain"}},
+        ])
+        adapter._wps_client = mock_client
+
+        async def _run():
+            result = await adapter.send("c1", "**hello** world")
+            self.assertTrue(result.success)
+            self.assertEqual(result.message_id, "msg_plain")
+            # Second call should still use markdown type (WPS doesn't support "text")
+            second_call = mock_client.request.call_args_list[1]
+            body = second_call[1]["json"]
+            self.assertEqual(body["content"]["text"]["type"], "markdown")
+
+        asyncio.get_event_loop().run_until_complete(_run())
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# WS data handling
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoWsHandling(unittest.TestCase):
+    """Verify WS goaway handling and ACK sending."""
+
+    def test_goaway_connection_replaced(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        adapter._ws_client = MagicMock()
+        adapter._ws_client.send_json = AsyncMock()
+        adapter._ws_is_websockets_lib = False
+
+        async def _run():
+            await adapter._handle_ws_data({
+                "type": "goaway",
+                "reason": "connection_replaced",
+                "message": "Another client connected",
+            })
+            # connection_replaced should NOT stop reconnect
+            self.assertFalse(adapter._stop_reconnect)
+            self.assertFalse(adapter._connected)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_event_sends_ack(self):
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        adapter._ws_client = MagicMock()
+        adapter._ws_client.send_json = AsyncMock()
+        adapter._ws_is_websockets_lib = False
+        adapter._handle_inbound_event = AsyncMock()
+
+        async def _run():
+            await adapter._handle_ws_data({
+                "topic": "kso.app_chat.message",
+                "operation": "create",
+                "nonce": "ack_nonce_1",
+                "data": {},
+            })
+            # Check ACK was sent BEFORE _handle_inbound_event was called
+            adapter._ws_client.send_json.assert_called_once()
+            ack_msg = adapter._ws_client.send_json.call_args[0][0]
+            self.assertEqual(ack_msg["type"], "ack")
+            self.assertEqual(ack_msg["nonce"], "ack_nonce_1")
+            # Verify inbound event was also called
+            adapter._handle_inbound_event.assert_called_once()
+
+    def test_ack_sent_before_event_processing(self):
+        """ACK must be sent BEFORE awaiting event processing (WPS server
+        has a ~5s ACK timeout; agent processing can take 10+ seconds)."""
+        from gateway.config import Platform, PlatformConfig
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+
+        config = PlatformConfig(enabled=True)
+        adapter = WpsXiezuoAdapter(config)
+        adapter._ws_client = MagicMock()
+        adapter._ws_is_websockets_lib = False
+
+        ack_time = [None]
+        process_time = [None]
+
+        async def fake_send_json(msg, **kw):
+            ack_time[0] = time.time()
+
+        async def fake_process(evt):
+            process_time[0] = time.time()
+
+        adapter._ws_client.send_json = AsyncMock(side_effect=fake_send_json)
+        adapter._handle_inbound_event = AsyncMock(side_effect=fake_process)
+
+        async def _run():
+            await adapter._handle_ws_data({
+                "topic": "kso.app_chat.message",
+                "operation": "create",
+                "nonce": "order_test",
+                "data": {},
+            })
+            # ACK must have been sent before processing started
+            self.assertIsNotNone(ack_time[0])
+            self.assertIsNotNone(process_time[0])
+            self.assertLess(ack_time[0], process_time[0])
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Config & requirements
+# ---------------------------------------------------------------------------
+
+class TestWpsXiezuoConfig(unittest.TestCase):
+    """Verify config and requirements checks."""
+
+    def test_check_requirements_false_when_missing(self):
+        from gateway.platforms.wps_xiezuo import check_wps_xiezuo_requirements
+
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(check_wps_xiezuo_requirements())
+
+    @patch.dict(os.environ, {
+        "WPS_XIEZUO_APP_ID": "wp_xxx",
+        "WPS_XIEZUO_APP_SECRET": "secret_xxx",
+    }, clear=False)
+    def test_check_requirements_true_when_set(self):
+        from gateway.platforms.wps_xiezuo import check_wps_xiezuo_requirements
+        self.assertTrue(check_wps_xiezuo_requirements())
+
+    def test_platform_enum_value(self):
+        from gateway.config import Platform
+        self.assertEqual(Platform.WPS_XIEZUO.value, "wps-xiezuo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -30,6 +30,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+_WPS_XIEZUO_TARGET_RE = re.compile(r"^\s*((?:(?:chat|user):)?\d+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -344,6 +345,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "wps-xiezuo":
+        match = _WPS_XIEZUO_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -554,6 +559,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     }
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
+    try:
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter, MAX_MESSAGE_LENGTH as _WPS_MAX
+        _MAX_LENGTHS[Platform.WPS_XIEZUO] = _WPS_MAX
+    except ImportError:
+        pass
 
     # Check plugin registry for max_message_length
     if platform not in _MAX_LENGTHS:
@@ -726,6 +736,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_qqbot(pconfig, chat_id, chunk)
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
+        elif platform == Platform.WPS_XIEZUO:
+            result = await _send_wps_xiezuo(pconfig, chat_id, chunk)
         else:
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.
@@ -1868,6 +1880,28 @@ async def _send_yuanbao(chat_id, message, media_files=None):
         return await send_yuanbao_direct(adapter, chat_id, message, media_files=media_files)
     except Exception as e:
         return _error(f"Yuanbao send failed: {e}")
+
+
+async def _send_wps_xiezuo(pconfig, chat_id, message):
+    """Send via WPS Xiezuo using the adapter's send pipeline."""
+    try:
+        from gateway.platforms.wps_xiezuo import WpsXiezuoAdapter
+    except ImportError:
+        return _error("WPS Xiezuo adapter module not available.")
+
+    try:
+        adapter = WpsXiezuoAdapter(pconfig)
+        result = await adapter.send(chat_id, message)
+        if not result.success:
+            return _error(f"WPS Xiezuo send failed: {result.error}")
+        return {
+            "success": True,
+            "platform": "wps-xiezuo",
+            "chat_id": chat_id,
+            "message_id": result.message_id or "",
+        }
+    except Exception as e:
+        return _error(f"WPS Xiezuo send failed: {e}")
 
 
 # --- Registry ---


### PR DESCRIPTION
## Summary

New built-in platform adapter for **WPS Xiezuo (WPS365 协作)**, at the same level as `feishu.py`. Key capabilities:

- **ACK-before-processing**: Send event ACK before awaiting agent processing — WPS server has a ~5s ACK timeout, so ACK must fire immediately regardless of agent latency
- **Output sanitization**: Strip model-internal tokens (DeepSeek DSML blocks, pseudo-HTML tool tags like `<web_fetch>`/`<web_search>`/`<terminal>`, think blocks) that leak into output text. Override `_send_with_retry()` to sanitize at entry so all downstream paths get clean text. `format_message()` returns placeholder instead of empty string to prevent `InvalidArgument:can not get text info`
- **Dead-connection detection**: 90s PING timeout (matching Node.js open-event-sdk) with automatic reconnect; hard-disconnect on gateway shutdown to prevent server from disabling event delivery
- **Markdown-only send + fallback**: WPS API only supports `type: "markdown"` — fallback retries with sanitized markdown content instead of `type: "text"`
- **emoji_busy reaction lifecycle** on message receipt

Also fixes `_pending_reactions` key mismatch between `on_processing_start` and `on_processing_complete` (spotted by @liuhao1024).

## Test plan

- [x] 23 unit tests pass (`pytest tests/gateway/test_wps_xiezuo.py -v`)
- [x] ACK ordering test: verifies ACK is sent before `_handle_inbound_event`
- [x] DSML sanitization test: strips `<|｜DSML｜｜tool_calls>` blocks
- [x] Markdown fallback test: verifies fallback uses `type: "markdown"`
- [x] Reaction key consistency test: verifies same key derivation in start/complete
- [x] Live test: confirmed event delivery works end-to-end via WebSocket
- [x] Live test: confirmed ACK-before-processing prevents event delivery shutdown
- [x] Live test: confirmed output sanitization strips tool-call artifacts from model output