### PR TITLE
Fix headed browser sessions being killed after every turn

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3941,6 +3941,11 @@ class AIAgent:
         ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
         torn down per-turn as before to prevent resource leakage (the original
         intent of this hook for the Morph backend, see commit fbd3a2fd).
+
+        Skips ``cleanup_browser`` in headed mode so the browser window stays
+        visible between turns. The inactivity reaper in
+        ``browser_tool._cleanup_inactive_browser_sessions`` still handles
+        idle sessions.
         """
         try:
             if is_persistent_env(task_id):
@@ -3955,7 +3960,14 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup VM for task {task_id}: {e}")
         try:
-            cleanup_browser(task_id)
+            if os.environ.get("AGENT_BROWSER_HEADED"):
+                if self.verbose_logging:
+                    logging.debug(
+                        f"Skipping per-turn cleanup_browser for headed session {task_id}; "
+                        f"idle reaper will handle it."
+                    )
+            else:
+                cleanup_browser(task_id)
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -567,6 +567,40 @@ def _get_browser_engine() -> str:
     return _cached_browser_engine
 
 
+_cached_headed_mode: Optional[bool] = None
+_headed_mode_resolved = False
+
+
+def _is_headed_mode() -> bool:
+    """Return True when the browser should launch in headed (visible) mode.
+
+    Reads ``config["browser"]["headed"]`` with ``AGENT_BROWSER_HEADED`` env
+    var as fallback.  Result is cached after the first call.
+    """
+    global _cached_headed_mode, _headed_mode_resolved
+    if _headed_mode_resolved:
+        return _cached_headed_mode  # type: ignore[return-value]
+
+    _headed_mode_resolved = True
+    _cached_headed_mode = False
+
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg.get("browser", {}).get("headed")
+        if val is not None:
+            _cached_headed_mode = str(val).strip().lower() in ("true", "1", "yes")
+    except Exception as e:
+        logger.debug("Could not read browser.headed from config: %s", e)
+
+    if not _cached_headed_mode:
+        env_val = os.environ.get("AGENT_BROWSER_HEADED", "").strip()
+        if env_val and env_val.lower() in ("true", "1", "yes"):
+            _cached_headed_mode = True
+
+    return _cached_headed_mode
+
+
 def _should_inject_engine(engine: str) -> bool:
     """Return True when the engine flag should be added to agent-browser commands.
 
@@ -1812,8 +1846,10 @@ def _run_browser_command(
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
-        # Local mode — launch a headless Chromium instance
+        # Local mode — launch Chromium (headless by default, headed when configured)
         backend_args = ["--session", session_info["session_name"]]
+        if _is_headed_mode():
+            backend_args.append("--headed")
 
     # Lightpanda engine injection (local mode only, agent-browser v0.25.3+).
     # Use the resolved session backend rather than global cloud-provider state:


### PR DESCRIPTION
## Summary

Fixes #11020 (lead bug) — per-turn `cleanup_browser` kills headed browser sessions immediately after each bot reply, making `AGENT_BROWSER_HEADED=1` unusable. The browser window flashes up and disappears on every response.

**Two changes:**

1. **`run_agent.py`** — Skip `cleanup_browser` in `_cleanup_task_resources` when `AGENT_BROWSER_HEADED` is set, mirroring the existing `is_persistent_env` opt-out for VMs. The inactivity reaper still handles idle sessions; full-session teardown on gateway shutdown remains unconditional.

2. **`tools/browser_tool.py`** — Add `_is_headed_mode()` helper that reads `browser.headed` from `config.yaml` (with `AGENT_BROWSER_HEADED` env var as fallback), and passes `--headed` to agent-browser in local mode when configured.

### Configuration

Either approach enables headed mode:

```yaml
# config.yaml
browser:
  headed: true
```

```bash
# .env or shell
AGENT_BROWSER_HEADED=1
```

### Why this matters

For headed-browser workflows (Docker + VNC, macOS desktop, etc.), users need the browser window to persist between turns so they can:
- Watch what the agent is doing in real time
- Intervene manually (sign-in challenges, captchas, account confirmations)
- Keep login state warm across the conversation

Without this fix, headed mode is cosmetic — the window appears and immediately disappears.

## Test plan

- [ ] Set `AGENT_BROWSER_HEADED=1` in `~/.hermes/.env`, ask the agent to open a browser — window should stay open after the response completes
- [ ] Set `browser.headed: true` in `config.yaml` — same behavior
- [ ] Without either setting, browser should still be cleaned up per-turn (no regression)
- [ ] After inactivity timeout (default 300s), headed browser sessions should still be reaped
- [ ] On gateway shutdown, all browser sessions should still be cleaned up