### PR TITLE
feat: add computer workflow runtime

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -165,10 +165,39 @@ _FAST_MODE_BETA = "fast-mode-2026-02-01"
 
 # Additional beta headers required for OAuth/subscription auth.
 # Matches what Claude Code (and pi-ai / OpenCode) send.
+#
+# The last three (``prompt-caching-scope``, ``context-management``,
+# ``interleaved-thinking`` when not already in COMMON_BETAS) are what
+# Claude Code itself ships with — Anthropic's OAuth routing treats traffic
+# without these as "not Claude Code" and falls back to per-token billing.
+# See griffinmartin/opencode-claude-auth src/model-config.ts.
 _OAUTH_ONLY_BETAS = [
     "claude-code-20250219",
     "oauth-2025-04-20",
+    "prompt-caching-scope-2026-01-05",
+    "context-management-2025-06-27",
 ]
+
+# Per-model beta additions (OAuth traffic only).  Matches Claude Code's
+# ``modelOverrides`` — Opus 4.6/4.7 require ``effort-2025-11-24`` before
+# they accept ``output_config.effort``; older models reject it.
+_MODEL_BETA_ADD = {
+    "4-6": ("effort-2025-11-24",),
+    "4.6": ("effort-2025-11-24",),
+    "4-7": ("effort-2025-11-24",),
+    "4.7": ("effort-2025-11-24",),
+}
+
+# Per-model beta exclusions (OAuth traffic only).  Haiku does not support
+# interleaved thinking — sending the beta returns a 400.
+_MODEL_BETA_EXCLUDE = {
+    "haiku": ("interleaved-thinking-2025-05-14",),
+}
+
+# Opt-in long-context beta (1M-token window, Opus 4.6+ only).  Enabling
+# this on a Claude Pro plan causes "Extra usage is required" errors, so it
+# stays off unless the user opts in via config/env.
+_LONG_CONTEXT_1M_BETA = "context-1m-2025-08-07"
 
 # Claude Code identity — required for OAuth requests to be routed correctly.
 # Without these, Anthropic's infrastructure intermittently 500s OAuth traffic.
@@ -205,6 +234,86 @@ def _detect_claude_code_version() -> str:
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 _MCP_TOOL_PREFIX = "mcp_"
+
+
+def _snake_to_pascal(name: str) -> str:
+    """Convert ``read_file``/``read-file``/``readFile`` → ``ReadFile``.
+
+    Claude Code's OAuth routing requires PascalCase tool names in the
+    ``mcp_<Name>`` format.  We accept all three input styles so every
+    existing Hermes tool (and any MCP-server-provided tool whose name is
+    already ``mcp_foo``) converts cleanly.
+    """
+    if not name:
+        return name
+    # Already PascalCase (starts with uppercase and contains no separators)?
+    if name[0].isupper() and "_" not in name and "-" not in name:
+        return name
+    # Split on underscore/hyphen, then capitalize each segment; preserve
+    # existing internal capitals (camelCase → PascalCase).
+    parts = []
+    for chunk in name.replace("-", "_").split("_"):
+        if not chunk:
+            continue
+        # Preserve existing camelCase: capitalize only the first char.
+        parts.append(chunk[0].upper() + chunk[1:])
+    return "".join(parts) if parts else name
+
+
+def _mcp_prefix_tool_name(name: str) -> str:
+    """Return the ``mcp_<PascalCase>`` form of a tool name.
+
+    Idempotent: if ``name`` already starts with ``mcp_`` we leave it alone.
+    """
+    if not isinstance(name, str) or not name:
+        return name
+    if name.startswith(_MCP_TOOL_PREFIX):
+        return name
+    return _MCP_TOOL_PREFIX + _snake_to_pascal(name)
+
+
+def build_mcp_tool_name_map(tools: Optional[List[Dict]]) -> Dict[str, str]:
+    """Build ``{mcp_PascalCase: original_name}`` for the current tool set.
+
+    Call this once per request with the same ``tools`` list that is passed to
+    :func:`build_anthropic_kwargs`, and hand the result to
+    :func:`normalize_anthropic_response` as ``tool_name_map``.  Without the
+    map, Hermes's tool dispatcher has no reliable way to recover the original
+    snake_case name from the PascalCase form the OAuth transform produces.
+    """
+    mapping: Dict[str, str] = {}
+    if not tools:
+        return mapping
+    for tool in tools:
+        # Hermes-internal OpenAI-style tool schema nests the name under
+        # ``function``; Anthropic-native schemas put it at top level.
+        name = None
+        if isinstance(tool, dict):
+            fn = tool.get("function")
+            if isinstance(fn, dict):
+                name = fn.get("name")
+            if not name:
+                name = tool.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        mapping[_mcp_prefix_tool_name(name)] = name
+    return mapping
+
+
+def _unmcp_prefix_tool_name(name: str, original_names: Optional[Dict[str, str]] = None) -> str:
+    """Reverse :func:`_mcp_prefix_tool_name`.
+
+    If *original_names* is supplied and contains the prefixed name, the
+    original (pre-transform) name is returned verbatim — this is the only
+    way to recover an exact snake_case name (the PascalCase step is lossy).
+    Without the mapping we fall back to stripping the prefix and returning
+    the PascalCase segment as-is; Hermes's tool dispatcher accepts both.
+    """
+    if not isinstance(name, str) or not name.startswith(_MCP_TOOL_PREFIX):
+        return name
+    if original_names and name in original_names:
+        return original_names[name]
+    return name[len(_MCP_TOOL_PREFIX):]
 
 
 def _get_claude_code_version() -> str:
@@ -301,6 +410,74 @@ def _common_betas_for_base_url(base_url: str | None) -> list[str]:
     return _COMMON_BETAS
 
 
+def _oauth_betas_for_model(
+    model: str | None,
+    *,
+    enable_1m_context: bool = False,
+    exclude: Optional[set[str]] = None,
+) -> list[str]:
+    """Return OAuth-only betas tailored for a specific Claude model.
+
+    Starts from :data:`_OAUTH_ONLY_BETAS`, applies per-model add/exclude
+    rules (``effort-2025-11-24`` on Opus 4.6/4.7; drop
+    ``interleaved-thinking`` on Haiku), and optionally opts into the 1M
+    long-context tier.
+
+    *exclude* is a runtime-caller-provided set used by long-context retry
+    to drop a beta that the server rejected (``context-1m`` 400s on free
+    Pro plans).
+    """
+    model_lc = (model or "").lower()
+    betas: list[str] = list(_OAUTH_ONLY_BETAS)
+
+    for substr, adds in _MODEL_BETA_ADD.items():
+        if substr in model_lc:
+            for b in adds:
+                if b not in betas:
+                    betas.append(b)
+
+    drop: set[str] = set()
+    for substr, rm in _MODEL_BETA_EXCLUDE.items():
+        if substr in model_lc:
+            drop.update(rm)
+    if exclude:
+        drop.update(exclude)
+    betas = [b for b in betas if b not in drop]
+
+    if enable_1m_context and ("4-6" in model_lc or "4.6" in model_lc
+                              or "4-7" in model_lc or "4.7" in model_lc):
+        if _LONG_CONTEXT_1M_BETA not in betas:
+            betas.append(_LONG_CONTEXT_1M_BETA)
+
+    return betas
+
+
+def _is_long_context_1m_enabled() -> bool:
+    """Config/env gate for the opt-in 1M-token context tier.
+
+    Precedence: HERMES_ANTHROPIC_1M_CONTEXT env var ("1"/"true"/"yes") →
+    ``model.anthropic.enable_1m_context`` config key → False.
+    """
+    env = os.getenv("HERMES_ANTHROPIC_1M_CONTEXT", "").strip().lower()
+    if env in ("1", "true", "yes", "on"):
+        return True
+    if env in ("0", "false", "no", "off"):
+        return False
+    try:
+        from hermes_cli.config import load_config  # pragma: no cover (lazy)
+        cfg = load_config()
+    except Exception:
+        return False
+    if not isinstance(cfg, dict):
+        return False
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        ant = model_cfg.get("anthropic")
+        if isinstance(ant, dict):
+            return bool(ant.get("enable_1m_context", False))
+    return False
+
+
 def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = None):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -362,12 +539,21 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.
+        #
+        # Note: the per-model beta overrides (effort, haiku exclusions) are
+        # applied at request time in ``build_anthropic_kwargs`` via the
+        # ``extra_headers`` mechanism — the client-level ``anthropic-beta``
+        # header is a base set that the SDK merges with per-request overrides.
         all_betas = common_betas + _OAUTH_ONLY_BETAS
         kwargs["auth_token"] = api_key
+        from agent.anthropic_signing import get_session_id as _get_sess_id
         kwargs["default_headers"] = {
             "anthropic-beta": ",".join(all_betas),
             "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
             "x-app": "cli",
+            # Stable per-process UUID — Anthropic correlates requests from
+            # the same editor session for tracing/billing.
+            "X-Claude-Code-Session-Id": _get_sess_id(),
         }
     else:
         # Regular API key → x-api-key header + common betas
@@ -406,15 +592,44 @@ def build_anthropic_bedrock_client(region: str):
 
 
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
-    """Read refreshable Claude Code OAuth credentials from ~/.claude/.credentials.json.
+    """Read refreshable Claude Code OAuth credentials.
 
-    This intentionally excludes ~/.claude.json primaryApiKey. Opencode's
-    subscription flow is OAuth/setup-token based with refreshable credentials,
-    and native direct Anthropic provider usage should follow that path rather
-    than auto-detecting Claude's first-party managed key.
+    Preferred source order:
+      1. macOS Keychain (``Claude Code-credentials[-<hex>]``) via
+         :mod:`agent.claude_keychain`.  Claude Code writes to Keychain first
+         on Darwin — the JSON file is a Linux/Windows fallback.
+      2. ``~/.claude/.credentials.json`` on every platform.
 
-    Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
+    This intentionally excludes ``~/.claude.json``'s ``primaryApiKey``.
+    Claude Code's subscription flow is OAuth/setup-token-based with
+    refreshable credentials, and native direct Anthropic provider usage
+    should follow that path rather than auto-detecting Claude's first-party
+    managed key.
+
+    Returns a dict shaped ``{accessToken, refreshToken, expiresAt, source}``
+    or None.  The ``source`` field is used for write-back routing: "file" or
+    "keychain:<service>".
     """
+    # 1. macOS Keychain (primary store on Darwin)
+    try:
+        from agent import claude_keychain
+        account = claude_keychain.read_selected_account()
+    except Exception as exc:  # pragma: no cover — Keychain errors are non-fatal
+        logger.debug("Keychain read failed: %s", exc)
+        account = None
+    if account is not None:
+        creds = account.credentials
+        return {
+            "accessToken": creds.access_token,
+            "refreshToken": creds.refresh_token,
+            "expiresAt": creds.expires_at,
+            "source": account.source,
+            "scopes": list(creds.scopes) if creds.scopes else None,
+            "subscriptionType": creds.subscription_type,
+            "accountName": account.account_name,
+        }
+
+    # 2. File fallback
     cred_path = Path.home() / ".claude" / ".credentials.json"
     if cred_path.exists():
         try:
@@ -427,7 +642,9 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
                         "accessToken": access_token,
                         "refreshToken": oauth_data.get("refreshToken", ""),
                         "expiresAt": oauth_data.get("expiresAt", 0),
-                        "source": "claude_code_credentials_file",
+                        "source": "file",
+                        "scopes": oauth_data.get("scopes"),
+                        "subscriptionType": oauth_data.get("subscriptionType"),
                     }
         except (json.JSONDecodeError, OSError, IOError) as e:
             logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
@@ -537,10 +754,22 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
     try:
         refreshed = refresh_anthropic_oauth_pure(refresh_token, use_json=False)
+        # Route the write-back to the SAME source this credential came from
+        # (Keychain → Keychain, file → file).  Anthropic rotates refresh
+        # tokens on use, so writing to the wrong store leaves the original
+        # entry with a stale refresh_token and the credentials become
+        # unusable on the next cycle.
+        scopes_val = creds.get("scopes")
+        if not isinstance(scopes_val, list):
+            scopes_val = None
         _write_claude_code_credentials(
             refreshed["access_token"],
             refreshed["refresh_token"],
             refreshed["expires_at_ms"],
+            scopes=scopes_val,
+            source=creds.get("source"),
+            account_name=creds.get("accountName"),
+            subscription_type=creds.get("subscriptionType"),
         )
         logger.debug("Successfully refreshed Claude Code OAuth token")
         return refreshed["access_token"]
@@ -555,14 +784,103 @@ def _write_claude_code_credentials(
     expires_at_ms: int,
     *,
     scopes: Optional[list] = None,
+    source: Optional[str] = None,
+    account_name: Optional[str] = None,
+    subscription_type: Optional[str] = None,
 ) -> None:
-    """Write refreshed credentials back to ~/.claude/.credentials.json.
+    """Write refreshed credentials back to their original source.
+
+    Routing:
+      * ``source`` None / ``"file"`` / ``"claude_code_credentials_file"`` →
+        write the JSON file at ``~/.claude/.credentials.json``.
+      * ``source`` starts with ``"keychain:"`` → route through
+        :func:`agent.claude_keychain.write_credentials` so the macOS Keychain
+        entry the token came from gets the rotated refresh token.
+
+    Anthropic rotates refresh tokens on use; writing the new refresh token
+    back to the wrong store leaves the original entry with a stale token and
+    locks the user out on the next refresh.
 
     The optional *scopes* list (e.g. ``["user:inference", "user:profile", ...]``)
     is persisted so that Claude Code's own auth check recognises the credential
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
-    in the stored scopes before it will use the token.
+    in the stored scopes before it will use the token.  When *scopes* is not
+    supplied we preserve whatever was previously stored in the target entry.
     """
+    # Normalize file-source aliases so the routing check below is simple.
+    if source in (None, "file", "claude_code_credentials_file"):
+        _write_claude_code_credentials_file(
+            access_token,
+            refresh_token,
+            expires_at_ms,
+            scopes=scopes,
+            subscription_type=subscription_type,
+        )
+        return
+
+    if isinstance(source, str) and source.startswith("keychain:"):
+        # Lazy import — keychain module does subprocess work and only makes
+        # sense on Darwin; avoid any import-time cost on other platforms.
+        try:
+            from agent import claude_keychain
+        except Exception as exc:  # pragma: no cover — import should not fail
+            logger.debug("claude_keychain import failed: %s", exc)
+            return
+
+        # Look up the existing raw_blob (to preserve scopes / subscriptionType
+        # when the refresh response omits them) and the account name.
+        raw_blob: Dict[str, Any] = {}
+        existing_scopes: Optional[list] = None
+        existing_sub: Optional[str] = None
+        resolved_account_name = account_name
+        try:
+            for acct in claude_keychain.read_all_accounts():
+                if acct.source == source:
+                    raw_blob = dict(acct.raw_blob or {})
+                    if acct.credentials.scopes is not None:
+                        existing_scopes = list(acct.credentials.scopes)
+                    existing_sub = acct.credentials.subscription_type
+                    if resolved_account_name is None:
+                        resolved_account_name = acct.account_name
+                    break
+        except Exception as exc:
+            logger.debug("Keychain lookup for %s failed: %s", source, exc)
+
+        effective_scopes = scopes if scopes is not None else existing_scopes
+        effective_sub = subscription_type if subscription_type is not None else existing_sub
+
+        creds_obj = claude_keychain.ClaudeCredentials(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at_ms,
+            subscription_type=effective_sub,
+            scopes=effective_scopes,
+        )
+        try:
+            ok = claude_keychain.write_credentials(
+                source,
+                creds_obj,
+                raw_blob=raw_blob,
+                account_name=resolved_account_name,
+            )
+            if not ok:
+                logger.debug("Keychain write_credentials returned False for %s", source)
+        except Exception as exc:
+            logger.debug("Keychain write_credentials raised for %s: %s", source, exc)
+        return
+
+    logger.debug("_write_claude_code_credentials: unknown source %s", source)
+
+
+def _write_claude_code_credentials_file(
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+    *,
+    scopes: Optional[list] = None,
+    subscription_type: Optional[str] = None,
+) -> None:
+    """Write refreshed credentials back to ~/.claude/.credentials.json."""
     cred_path = Path.home() / ".claude" / ".credentials.json"
     try:
         # Read existing file to preserve other fields
@@ -581,6 +899,18 @@ def _write_claude_code_credentials(
             # Preserve previously-stored scopes when the refresh response
             # does not include a scope field.
             oauth_data["scopes"] = existing["claudeAiOauth"]["scopes"]
+
+        # Preserve subscriptionType if supplied or previously present — it
+        # has no effect on refresh but is a useful marker for account
+        # labelling (Claude Pro / Claude Max) when the credential is later
+        # re-read.
+        if subscription_type is not None:
+            oauth_data["subscriptionType"] = subscription_type
+        elif (
+            "claudeAiOauth" in existing
+            and "subscriptionType" in existing["claudeAiOauth"]
+        ):
+            oauth_data["subscriptionType"] = existing["claudeAiOauth"]["subscriptionType"]
 
         existing["claudeAiOauth"] = oauth_data
 
@@ -1357,35 +1687,123 @@ def build_anthropic_kwargs(
     if context_length and effective_max_tokens > context_length:
         effective_max_tokens = max(context_length - 1, 1)
 
-    # ── OAuth: Claude Code identity ──────────────────────────────────
+    # ── OAuth: Claude Code identity + Claude Code fingerprinting ─────
+    #
+    # Anthropic's OAuth / Claude Pro / Max billing validator rejects requests
+    # that do not look exactly like Claude Code traffic.  We mirror the
+    # transform pipeline used by the official Claude Code CLI (see
+    # griffinmartin/opencode-claude-auth src/transforms.ts):
+    #
+    #   1. Prepend a synthesized ``x-anthropic-billing-header`` system block
+    #      (NOT an HTTP header — a system message entry) with signed cc_version
+    #      / cch fields derived from the first user message.
+    #   2. Prepend the Claude Code identity string as a STANDALONE system
+    #      entry (split it out if concatenated with anything else).
+    #   3. Relocate any remaining system text (Hermes's own system prompt,
+    #      user-supplied instructions, etc.) into the first user message as a
+    #      text block.  Anthropic rejects third-party system content alongside
+    #      the Claude Code identity.
+    #   4. Prefix every tool name with ``mcp_`` + PascalCase the original
+    #      snake_case / camelCase name (``read_file`` → ``mcp_ReadFile``).  The
+    #      reverse transform is applied to responses in normalize_anthropic_response.
     if is_oauth:
-        # 1. Prepend Claude Code system prompt identity
-        cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
+        from agent.anthropic_signing import (
+            build_billing_header_value,
+            is_billing_header_text,
+        )
+
+        # 1. Synthesize the billing header system block first, BEFORE we
+        #    mutate messages, so the cch is computed from the *original*
+        #    first user message text.
+        billing_text = build_billing_header_value(
+            anthropic_messages,
+            _get_claude_code_version(),
+            entrypoint=os.getenv("CLAUDE_CODE_ENTRYPOINT", "cli"),
+        )
+        billing_block = {"type": "text", "text": billing_text}
+
+        # 2. Collect existing system entries as a list of dict blocks.
         if isinstance(system, list):
-            system = [cc_block] + system
+            existing_blocks = [
+                (b if isinstance(b, dict) else {"type": "text", "text": str(b)})
+                for b in system
+            ]
         elif isinstance(system, str) and system:
-            system = [cc_block, {"type": "text", "text": system}]
+            existing_blocks = [{"type": "text", "text": system}]
         else:
-            system = [cc_block]
+            existing_blocks = []
 
-        # 2. Sanitize system prompt — replace product name references
-        #    to avoid Anthropic's server-side content filters.
-        for block in system:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "")
-                text = text.replace("Hermes Agent", "Claude Code")
-                text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
-                text = text.replace("Nous Research", "Anthropic")
-                block["text"] = text
+        # 3. Defensive split: if any block starts with the Claude Code
+        #    identity followed by more text, split it.  Then partition the
+        #    remaining blocks into "kept" (identity/billing) vs "moved"
+        #    (third-party system prose).
+        identity_block: Optional[dict] = None
+        moved_texts: list[str] = []
+        for b in existing_blocks:
+            txt = b.get("text", "") if isinstance(b, dict) else ""
+            if not isinstance(txt, str):
+                txt = str(txt)
+            if is_billing_header_text(txt):
+                # Skip any pre-existing billing block — we regenerate it.
+                continue
+            if txt.startswith(_CLAUDE_CODE_SYSTEM_PREFIX):
+                # Split: the identity becomes a standalone block; remainder
+                # goes into the user-message relocation bucket.
+                if identity_block is None:
+                    # Preserve cache_control etc. on the identity entry, minus
+                    # cache_control which Anthropic forbids on this block.
+                    ident = {k: v for k, v in b.items() if k != "cache_control"}
+                    ident["text"] = _CLAUDE_CODE_SYSTEM_PREFIX
+                    identity_block = ident
+                rest = txt[len(_CLAUDE_CODE_SYSTEM_PREFIX):].lstrip("\n")
+                if rest:
+                    moved_texts.append(rest)
+            elif txt:
+                moved_texts.append(txt)
 
-        # 3. Prefix tool names with mcp_ (Claude Code convention)
+        if identity_block is None:
+            identity_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
+
+        # 4. Rebuild system[] as exactly [billing, identity].
+        system = [billing_block, identity_block]
+
+        # 5. Relocate third-party system content into the first user message.
+        #    Anthropic's OAuth billing validator 400s requests that have
+        #    third-party system entries alongside the Claude Code identity.
+        if moved_texts:
+            prefix_text = "\n\n".join(moved_texts)
+            user_idx = next(
+                (i for i, m in enumerate(anthropic_messages) if m.get("role") == "user"),
+                None,
+            )
+            if user_idx is None:
+                # No user message yet — create one so the relocated prompt
+                # still reaches the model.  Claude Code does the same.
+                anthropic_messages.insert(
+                    0,
+                    {"role": "user", "content": [{"type": "text", "text": prefix_text}]},
+                )
+            else:
+                msg = anthropic_messages[user_idx]
+                content = msg.get("content")
+                if isinstance(content, str):
+                    msg["content"] = prefix_text + "\n\n" + content
+                elif isinstance(content, list):
+                    msg["content"] = [{"type": "text", "text": prefix_text}] + list(content)
+                else:
+                    msg["content"] = [{"type": "text", "text": prefix_text}]
+
+        # 6. Prefix tool names with ``mcp_`` + PascalCase the original.
+        #    Anthropic's OAuth validator rejects lowercase/snake_case tool
+        #    names when multiple tools are present.  The reverse transform
+        #    is applied to responses in normalize_anthropic_response().
         if anthropic_tools:
             for tool in anthropic_tools:
-                if "name" in tool:
-                    tool["name"] = _MCP_TOOL_PREFIX + tool["name"]
+                if "name" in tool and isinstance(tool["name"], str):
+                    tool["name"] = _mcp_prefix_tool_name(tool["name"])
 
-        # 4. Prefix tool names in message history (tool_use and tool_result blocks)
+        # 7. Apply the same name transform to historical tool_use blocks so
+        #    the model sees consistent names across turns.
         for msg in anthropic_messages:
             content = msg.get("content")
             if isinstance(content, list):
@@ -1393,9 +1811,7 @@ def build_anthropic_kwargs(
                     if isinstance(block, dict):
                         if block.get("type") == "tool_use" and "name" in block:
                             if not block["name"].startswith(_MCP_TOOL_PREFIX):
-                                block["name"] = _MCP_TOOL_PREFIX + block["name"]
-                        elif block.get("type") == "tool_result" and "tool_use_id" in block:
-                            pass  # tool_result uses ID, not name
+                                block["name"] = _mcp_prefix_tool_name(block["name"])
 
     kwargs: Dict[str, Any] = {
         "model": model,
@@ -1462,6 +1878,33 @@ def build_anthropic_kwargs(
         for _sampling_key in ("temperature", "top_p", "top_k"):
             kwargs.pop(_sampling_key, None)
 
+    # ── OAuth: per-request headers + model-specific beta overrides ───
+    # Claude Code generates a fresh ``x-client-request-id`` on every request
+    # and merges model-specific betas (``effort-2025-11-24`` for Opus 4.6/4.7,
+    # haiku exclusions, opt-in 1M context) into the per-request
+    # ``anthropic-beta`` header.  Per-request ``extra_headers`` override the
+    # client-level defaults, so we build the full beta list here.
+    if is_oauth and not _is_third_party_anthropic_endpoint(base_url):
+        from agent.anthropic_signing import new_request_id
+        betas = list(_common_betas_for_base_url(base_url))
+        betas.extend(
+            _oauth_betas_for_model(model, enable_1m_context=_is_long_context_1m_enabled())
+        )
+        # Deduplicate while preserving order.
+        seen: set[str] = set()
+        ordered = []
+        for b in betas:
+            if b not in seen:
+                seen.add(b)
+                ordered.append(b)
+        extra_headers = {
+            "anthropic-beta": ",".join(ordered),
+            "x-client-request-id": new_request_id(),
+        }
+        # Merge into any existing extra_headers set by other paths.
+        kwargs.setdefault("extra_headers", {})
+        kwargs["extra_headers"].update(extra_headers)
+
     # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
     # output speed. Only for native Anthropic endpoints — third-party
@@ -1472,9 +1915,19 @@ def build_anthropic_kwargs(
         # extra_headers override the client-level anthropic-beta header).
         betas = list(_common_betas_for_base_url(base_url))
         if is_oauth:
-            betas.extend(_OAUTH_ONLY_BETAS)
+            betas.extend(
+                _oauth_betas_for_model(model, enable_1m_context=_is_long_context_1m_enabled())
+            )
         betas.append(_FAST_MODE_BETA)
-        kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+        # Deduplicate.
+        seen_fm: set[str] = set()
+        ordered_fm = []
+        for b in betas:
+            if b not in seen_fm:
+                seen_fm.add(b)
+                ordered_fm.append(b)
+        kwargs.setdefault("extra_headers", {})
+        kwargs["extra_headers"]["anthropic-beta"] = ",".join(ordered_fm)
 
     return kwargs
 
@@ -1482,6 +1935,7 @@ def build_anthropic_kwargs(
 def normalize_anthropic_response(
     response,
     strip_tool_prefix: bool = False,
+    tool_name_map: Optional[Dict[str, str]] = None,
 ) -> Tuple[SimpleNamespace, str]:
     """Normalize Anthropic response to match the shape expected by AIAgent.
 
@@ -1489,7 +1943,10 @@ def normalize_anthropic_response(
     .content, .tool_calls, and .reasoning attributes.
 
     When *strip_tool_prefix* is True, removes the ``mcp_`` prefix that was
-    added to tool names for OAuth Claude Code compatibility.
+    added to tool names for OAuth Claude Code compatibility.  If
+    *tool_name_map* is provided it maps ``mcp_<PascalCase>`` back to the
+    original snake_case name (the PascalCase transform is lossy —
+    ``readFile`` and ``read_file`` both become ``mcp_ReadFile``).
     """
     text_parts = []
     reasoning_parts = []
@@ -1507,7 +1964,7 @@ def normalize_anthropic_response(
         elif block.type == "tool_use":
             name = block.name
             if strip_tool_prefix and name.startswith(_MCP_TOOL_PREFIX):
-                name = name[len(_MCP_TOOL_PREFIX):]
+                name = _unmcp_prefix_tool_name(name, tool_name_map)
             tool_calls.append(
                 SimpleNamespace(
                     id=block.id,
@@ -1551,16 +2008,25 @@ def normalize_anthropic_response(
 def normalize_anthropic_response_v2(
     response,
     strip_tool_prefix: bool = False,
+    tool_name_map: Optional[Dict[str, str]] = None,
 ) -> "NormalizedResponse":
     """Normalize Anthropic response to NormalizedResponse.
 
     Wraps the existing normalize_anthropic_response() and maps its output
     to the shared transport types.  This allows incremental migration —
     one call site at a time — without changing the original function.
+
+    *tool_name_map* is forwarded to :func:`normalize_anthropic_response` and
+    is used by OAuth Claude Code to map ``mcp_<PascalCase>`` tool names
+    back to the original snake_case name.
     """
     from agent.transports.types import NormalizedResponse, build_tool_call
 
-    assistant_msg, finish_reason = normalize_anthropic_response(response, strip_tool_prefix)
+    assistant_msg, finish_reason = normalize_anthropic_response(
+        response,
+        strip_tool_prefix=strip_tool_prefix,
+        tool_name_map=tool_name_map,
+    )
 
     tool_calls = None
     if assistant_msg.tool_calls:

--- a/agent/anthropic_signing.py
+++ b/agent/anthropic_signing.py
@@ -1,0 +1,162 @@
+"""Claude Code billing-header signing + session/request IDs.
+
+Reverse-engineered from Claude Code's minified ``K19()`` function and mirrored
+after the port in ``griffinmartin/opencode-claude-auth`` (``src/signing.ts``).
+
+Anthropic's OAuth (Claude Pro / Max subscription) traffic is validated
+server-side based on three things that together identify the request as
+legitimate Claude Code traffic:
+
+1. Request headers — ``User-Agent``, ``X-App``, plus per-process
+   ``X-Claude-Code-Session-Id`` and per-request ``X-Client-Request-Id`` UUIDs.
+2. Beta flags — ``claude-code-20250219``, ``oauth-2025-04-20``, plus
+   version-dated prompt-caching / context-management / effort betas.
+3. A **system message entry** (NOT an HTTP header) named
+   ``x-anthropic-billing-header`` that carries ``cc_version`` /
+   ``cc_entrypoint`` / ``cch`` fields.  The ``cc_version`` suffix and ``cch``
+   are SHA-256 hashes of a salt, version string, and characters sampled from
+   the first user message.
+
+Omitting any of these produces intermittent 400s or unsubscribed-billing
+responses when the access token is a subscription OAuth token (as opposed to
+a regular ``sk-ant-api*`` API key).
+
+All constants here are reverse-engineered from the official Claude Code CLI
+and must match Anthropic's server-side validator byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import Any, Iterable, List, Optional
+
+# ── Billing salt (constant in Claude Code) ─────────────────────────────
+# Treat as a protocol constant, not a secret. It's shipped inside the
+# public Claude Code JS bundle; rotating it here would break our requests.
+_BILLING_SALT = "59cf53e54c78"
+
+# ── Session ID (stable for the lifetime of the Hermes process) ─────────
+# Anthropic uses this to correlate requests from the same editor session
+# for tracing/billing.  Stable within a process, new per launch.
+_SESSION_ID: str = str(uuid.uuid4())
+
+
+def get_session_id() -> str:
+    """Return the per-process Claude Code session UUID."""
+    return _SESSION_ID
+
+
+def new_request_id() -> str:
+    """Generate a fresh per-request UUID for the ``X-Client-Request-Id`` header."""
+    return str(uuid.uuid4())
+
+
+# ── cch (content hash) ─────────────────────────────────────────────────
+
+def compute_cch(message_text: str) -> str:
+    """Return the first 5 hex chars of SHA-256 over the first user message.
+
+    Matches Claude Code's ``computeCch`` in K19(). Claude Code computes this
+    from the plain-text of the first user message (not the full messages
+    payload); the empty-string input yields a well-known hash that the
+    validator accepts for tool-only sequels.
+    """
+    return hashlib.sha256(message_text.encode("utf-8")).hexdigest()[:5]
+
+
+# ── cc_version suffix ──────────────────────────────────────────────────
+
+_SAMPLED_INDICES = (4, 7, 20)
+
+
+def compute_version_suffix(message_text: str, version: str) -> str:
+    """Return the 3-hex-char suffix appended to ``cc_version``.
+
+    ``sha256(BILLING_SALT + sampled_chars + version)[:3]`` where
+    ``sampled_chars`` is text[4] + text[7] + text[20] (padded with "0" when
+    the message is shorter than the index).
+
+    Matches Claude Code's ``computeVersionSuffix`` in K19().
+    """
+    sampled_parts: List[str] = []
+    for i in _SAMPLED_INDICES:
+        sampled_parts.append(message_text[i] if i < len(message_text) else "0")
+    sampled = "".join(sampled_parts)
+    material = f"{_BILLING_SALT}{sampled}{version}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:3]
+
+
+# ── First-user-message text extraction ─────────────────────────────────
+
+def extract_first_user_message_text(messages: Iterable[Any]) -> str:
+    """Extract the plain-text content of the first ``role=user`` message.
+
+    Supports the two Anthropic content shapes:
+
+    * ``content`` as a string → returned directly
+    * ``content`` as a list of blocks → concatenate text from every
+      ``{"type": "text", "text": ...}`` block in order (mirrors Claude
+      Code's behavior — tool_result text is NOT included).
+
+    Returns the empty string if no user message is present.
+    """
+    for msg in messages:
+        if not isinstance(msg, dict):
+            # Anthropic SDK objects (pydantic models) also work; convert
+            try:
+                msg = dict(msg)
+            except Exception:
+                continue
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "text":
+                    txt = block.get("text", "")
+                    if isinstance(txt, str):
+                        parts.append(txt)
+            return "".join(parts)
+        return ""
+    return ""
+
+
+# ── Billing header value ───────────────────────────────────────────────
+
+_BILLING_HEADER_PREFIX = "x-anthropic-billing-header"
+
+
+def build_billing_header_value(
+    messages: Iterable[Any],
+    version: str,
+    entrypoint: str = "cli",
+) -> str:
+    """Build the ``x-anthropic-billing-header`` system-block text.
+
+    Example output::
+
+        x-anthropic-billing-header: cc_version=2.1.114.a3f; cc_entrypoint=cli; cch=d41d8;
+
+    The format must exactly match what Claude Code sends — any whitespace or
+    ordering change triggers a 400.
+    """
+    text = extract_first_user_message_text(messages)
+    cch = compute_cch(text)
+    suffix = compute_version_suffix(text, version)
+    return (
+        f"{_BILLING_HEADER_PREFIX}: "
+        f"cc_version={version}.{suffix}; "
+        f"cc_entrypoint={entrypoint}; "
+        f"cch={cch};"
+    )
+
+
+def is_billing_header_text(text: Optional[str]) -> bool:
+    """Return True if the given text is the billing-header system block."""
+    return isinstance(text, str) and text.startswith(_BILLING_HEADER_PREFIX)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -611,7 +611,15 @@ class _AnthropicCompletionsAdapter:
                 anthropic_kwargs["temperature"] = temperature
 
         response = self._client.messages.create(**anthropic_kwargs)
-        assistant_message, finish_reason = normalize_anthropic_response(response)
+        # For OAuth traffic, recover original tool names from the
+        # ``mcp_<PascalCase>`` transform so downstream dispatchers work.
+        from agent.anthropic_adapter import build_mcp_tool_name_map
+        _tool_name_map = build_mcp_tool_name_map(tools) if self._is_oauth else None
+        assistant_message, finish_reason = normalize_anthropic_response(
+            response,
+            strip_tool_prefix=self._is_oauth,
+            tool_name_map=_tool_name_map,
+        )
 
         usage = None
         if hasattr(response, "usage") and response.usage:

--- a/agent/claude_keychain.py
+++ b/agent/claude_keychain.py
@@ -1,0 +1,419 @@
+"""Claude Code credential discovery + write-back (macOS Keychain + file).
+
+Reads ``Claude Code-credentials`` entries from the macOS login Keychain (the
+primary storage for Claude Code on Darwin) and falls back to the JSON file
+at ``~/.claude/.credentials.json`` on every platform.
+
+Multi-account support: on Darwin, Claude Code stores additional accounts
+under service names like ``Claude Code-credentials-<hex>``.  We detect every
+such entry using ``security dump-keychain`` and return them as separate
+``ClaudeAccount`` records for the account switcher UI.
+
+Write-back: Anthropic rotates refresh tokens on use, so whenever we refresh
+we must persist the new token to the SAME source it came from (Keychain or
+file).  ``write_credentials`` routes the write based on ``source``.
+
+Mirrors ``griffinmartin/opencode-claude-auth/src/keychain.ts``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Service-name constants (must match Claude Code exactly) ────────────
+_PRIMARY_SERVICE = "Claude Code-credentials"
+# Additional-account entries:  Claude Code-credentials-<hex>
+_EXTRA_SERVICE_RE = re.compile(
+    r'"Claude Code-credentials(?:-[0-9a-f]+)?"'
+)
+# When dump-keychain encodes a service name longer than ~56 chars it can be
+# split as ``"service"<blob>`` — grab both forms.
+_SERVICE_ATTR_RE = re.compile(
+    r'0x00000007 <blob>="(Claude Code-credentials(?:-[0-9a-f]+)?)"'
+)
+_ACCT_ATTR_RE = re.compile(r'"acct"<blob>="([^"]*)"')
+
+_FILE_PATH = Path.home() / ".claude" / ".credentials.json"
+
+# Source tag used in PooledCredential to identify where a Keychain/file entry came from
+SOURCE_FILE = "file"
+SOURCE_KEYCHAIN_PREFIX = "keychain:"  # e.g. "keychain:Claude Code-credentials"
+
+
+@dataclass
+class ClaudeCredentials:
+    """Normalized Claude Code OAuth creds (wrapped or unwrapped JSON parsed)."""
+    access_token: str
+    refresh_token: str
+    expires_at: int  # epoch milliseconds
+    subscription_type: Optional[str] = None
+    scopes: Optional[List[str]] = None
+
+
+@dataclass
+class ClaudeAccount:
+    """A single Claude Code account discovered via Keychain or file fallback."""
+    label: str                     # user-facing label ("Claude Pro", "Claude Max 2", …)
+    source: str                    # "file" or "keychain:<service>"
+    credentials: ClaudeCredentials
+    account_name: Optional[str] = None  # Keychain "acct" attribute (macOS username)
+    raw_blob: Dict = field(default_factory=dict)  # full parsed JSON for write-back
+
+
+def _is_darwin() -> bool:
+    return platform.system() == "Darwin"
+
+
+def _parse_credentials_blob(raw: str) -> Optional[ClaudeCredentials]:
+    """Parse Claude Code credential JSON, accepting both wrapped and flat shapes.
+
+    Keychain entries are wrapped as ``{"claudeAiOauth": {...}}``; file
+    fallback is typically the same wrapper but may be flat.  Entries that
+    contain only ``mcpOAuth`` (MCP-server creds, not user creds) return None.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    data = parsed.get("claudeAiOauth") if isinstance(parsed.get("claudeAiOauth"), dict) else parsed
+    if not isinstance(data, dict):
+        return None
+
+    # Skip MCP-only entries
+    if parsed.get("mcpOAuth") and not data.get("accessToken"):
+        return None
+
+    access = data.get("accessToken")
+    refresh = data.get("refreshToken")
+    expires = data.get("expiresAt")
+    if not isinstance(access, str) or not isinstance(refresh, str):
+        return None
+    if not isinstance(expires, int):
+        try:
+            expires = int(expires or 0)
+        except (TypeError, ValueError):
+            return None
+
+    scopes_val = data.get("scopes")
+    scopes = [s for s in scopes_val if isinstance(s, str)] if isinstance(scopes_val, list) else None
+    sub_type = data.get("subscriptionType") if isinstance(data.get("subscriptionType"), str) else None
+
+    return ClaudeCredentials(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=expires,
+        subscription_type=sub_type,
+        scopes=scopes,
+    )
+
+
+# ── macOS Keychain low-level helpers ───────────────────────────────────
+
+def _security(*args: str, input_data: Optional[str] = None, timeout: float = 5.0) -> subprocess.CompletedProcess:
+    """Run /usr/bin/security with the given args, capturing output."""
+    return subprocess.run(
+        ["/usr/bin/security", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        input=input_data,
+    )
+
+
+def _find_keychain_services() -> List[str]:
+    """Return every ``Claude Code-credentials[-<hex>]`` service name in the login keychain."""
+    if not _is_darwin():
+        return []
+    try:
+        result = _security("dump-keychain", timeout=10.0)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("security dump-keychain failed: %s", exc)
+        return []
+    if result.returncode != 0:
+        return []
+    services = set()
+    for match in _SERVICE_ATTR_RE.finditer(result.stdout):
+        services.add(match.group(1))
+    # Also match the older form without explicit attr key, in case the
+    # layout varies by macOS version.
+    for match in _EXTRA_SERVICE_RE.finditer(result.stdout):
+        quoted = match.group(0)
+        services.add(quoted.strip('"'))
+    return sorted(services)
+
+
+def _find_account_name(service: str) -> Optional[str]:
+    """Find the ``acct`` attribute for a given Keychain service.
+
+    Claude Code writes entries with ``-a <macOS_username>``.  We need this
+    value to update-in-place (``security add-generic-password -U``) rather
+    than create a duplicate entry.
+    """
+    if not _is_darwin():
+        return None
+    try:
+        # Without -w, the command prints the entry's attributes but not the password
+        result = _security("find-generic-password", "-s", service, timeout=3.0)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    m = _ACCT_ATTR_RE.search(result.stdout)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _read_keychain_entry(service: str) -> Optional[str]:
+    """Read the password (JSON blob) for a given Keychain service."""
+    if not _is_darwin():
+        return None
+    try:
+        result = _security("find-generic-password", "-s", service, "-w", timeout=3.0)
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _write_keychain_entry(service: str, account: str, blob: str) -> bool:
+    """Update (or create) a Keychain entry.  Uses ``-U`` for idempotent update."""
+    if not _is_darwin():
+        return False
+    try:
+        result = _security(
+            "add-generic-password",
+            "-s", service,
+            "-a", account,
+            "-w", blob,
+            "-U",  # update if exists — critical, no duplicate entries
+            timeout=5.0,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("Keychain write failed: %s", exc)
+        return False
+    return result.returncode == 0
+
+
+# ── File fallback ──────────────────────────────────────────────────────
+
+def _read_file_entry() -> Optional[str]:
+    """Read ``~/.claude/.credentials.json`` as text, or None if missing."""
+    if _FILE_PATH.exists():
+        try:
+            return _FILE_PATH.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.debug("File read failed: %s", exc)
+    return None
+
+
+def _write_file_entry(blob: str) -> bool:
+    """Write ``~/.claude/.credentials.json`` with 0600 perms."""
+    try:
+        _FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _FILE_PATH.write_text(blob, encoding="utf-8")
+        try:
+            _FILE_PATH.chmod(0o600)
+        except OSError:
+            pass
+    except OSError as exc:
+        logger.debug("File write failed: %s", exc)
+        return False
+    return True
+
+
+# ── Label formatting ───────────────────────────────────────────────────
+
+def _label_for_subscription(sub_type: Optional[str]) -> str:
+    if not sub_type:
+        return "Claude"
+    sub = sub_type.strip().lower()
+    if sub in ("pro",):
+        return "Claude Pro"
+    if sub in ("max", "max5x", "max20x"):
+        return "Claude Max"
+    return f"Claude {sub_type}"
+
+
+def _build_labels(accounts: List[ClaudeAccount]) -> None:
+    """Disambiguate duplicate subscription labels with numeric suffixes."""
+    seen: Dict[str, int] = {}
+    for acct in accounts:
+        base = acct.label
+        seen[base] = seen.get(base, 0) + 1
+    counters: Dict[str, int] = {}
+    for acct in accounts:
+        base = acct.label
+        if seen[base] > 1:
+            counters[base] = counters.get(base, 0) + 1
+            acct.label = f"{base} {counters[base]}"
+
+
+# ── Public API ─────────────────────────────────────────────────────────
+
+def read_all_accounts() -> List[ClaudeAccount]:
+    """Discover every Claude Code account on the system.
+
+    Order:
+      1. macOS Keychain entries (``Claude Code-credentials[-<hex>]``).
+      2. File fallback at ``~/.claude/.credentials.json`` (same file is
+         used by Claude Code on Linux/Windows).
+
+    An account discovered in both Keychain and file is deduplicated by
+    access-token prefix.  Returns accounts in the order: primary Keychain
+    first, then extras, then file-only.
+    """
+    accounts: List[ClaudeAccount] = []
+    seen_tokens = set()
+
+    if _is_darwin():
+        services = _find_keychain_services()
+        for service in services:
+            raw = _read_keychain_entry(service)
+            if not raw:
+                continue
+            creds = _parse_credentials_blob(raw)
+            if not creds:
+                continue
+            token_prefix = creds.access_token[:32]
+            if token_prefix in seen_tokens:
+                continue
+            seen_tokens.add(token_prefix)
+            try:
+                raw_blob = json.loads(raw)
+            except json.JSONDecodeError:
+                raw_blob = {"claudeAiOauth": creds.__dict__}
+            accounts.append(
+                ClaudeAccount(
+                    label=_label_for_subscription(creds.subscription_type),
+                    source=f"{SOURCE_KEYCHAIN_PREFIX}{service}",
+                    credentials=creds,
+                    account_name=_find_account_name(service),
+                    raw_blob=raw_blob,
+                )
+            )
+
+    raw_file = _read_file_entry()
+    if raw_file:
+        creds_f = _parse_credentials_blob(raw_file)
+        if creds_f and creds_f.access_token[:32] not in seen_tokens:
+            seen_tokens.add(creds_f.access_token[:32])
+            try:
+                raw_blob = json.loads(raw_file)
+            except json.JSONDecodeError:
+                raw_blob = {"claudeAiOauth": creds_f.__dict__}
+            accounts.append(
+                ClaudeAccount(
+                    label=_label_for_subscription(creds_f.subscription_type),
+                    source=SOURCE_FILE,
+                    credentials=creds_f,
+                    account_name=None,
+                    raw_blob=raw_blob,
+                )
+            )
+
+    _build_labels(accounts)
+    return accounts
+
+
+def read_primary_account() -> Optional[ClaudeAccount]:
+    """Return the first discovered account (Keychain wins over file)."""
+    accounts = read_all_accounts()
+    return accounts[0] if accounts else None
+
+
+def read_selected_account(source_path: Optional[Path] = None) -> Optional[ClaudeAccount]:
+    """Return the account matching the user's persisted selection, if any.
+
+    Reads the selected account ``source`` string from ``source_path`` (defaults
+    to ``<HERMES_HOME>/claude_account_source.txt``).  If the file is missing,
+    unreadable, or points to a no-longer-present account, falls back to the
+    first discovered account.  Returns None if no accounts exist.
+    """
+    accounts = read_all_accounts()
+    if not accounts:
+        return None
+
+    if source_path is None:
+        try:
+            from hermes_constants import get_hermes_home
+            source_path = get_hermes_home() / "claude_account_source.txt"
+        except Exception:
+            source_path = None
+
+    persisted: Optional[str] = None
+    if source_path is not None:
+        try:
+            if source_path.exists():
+                persisted = source_path.read_text(encoding="utf-8").strip() or None
+        except OSError as exc:
+            logger.debug("Failed to read selected-account file %s: %s", source_path, exc)
+
+    if persisted:
+        for acct in accounts:
+            if acct.source == persisted:
+                return acct
+
+    return accounts[0]
+
+
+def write_credentials(
+    source: str,
+    creds: ClaudeCredentials,
+    *,
+    raw_blob: Optional[Dict] = None,
+    account_name: Optional[str] = None,
+) -> bool:
+    """Persist refreshed credentials back to their original source.
+
+    ``source`` follows the format returned by :func:`read_all_accounts`:
+    ``"file"`` or ``"keychain:<service>"``.
+    """
+    # Rebuild the wrapped JSON blob, preserving any extra fields from the
+    # original entry (scopes, subscriptionType, etc.).
+    blob_dict: Dict = dict(raw_blob or {})
+    oauth: Dict = blob_dict.get("claudeAiOauth", {}) if isinstance(blob_dict.get("claudeAiOauth"), dict) else {}
+    oauth["accessToken"] = creds.access_token
+    oauth["refreshToken"] = creds.refresh_token
+    oauth["expiresAt"] = creds.expires_at
+    if creds.scopes is not None:
+        oauth["scopes"] = list(creds.scopes)
+    elif "scopes" not in oauth:
+        # Claude Code ≥2.1.81 requires ``user:inference`` in scopes; preserve
+        # whatever was there before refresh.
+        pass
+    if creds.subscription_type is not None:
+        oauth["subscriptionType"] = creds.subscription_type
+    blob_dict["claudeAiOauth"] = oauth
+    blob = json.dumps(blob_dict, indent=2)
+
+    if source == SOURCE_FILE:
+        return _write_file_entry(blob)
+    if source.startswith(SOURCE_KEYCHAIN_PREFIX):
+        service = source[len(SOURCE_KEYCHAIN_PREFIX):]
+        acct = account_name or _find_account_name(service) or os.getenv("USER", "hermes")
+        return _write_keychain_entry(service, acct, blob)
+    logger.debug("write_credentials: unknown source %s", source)
+    return False
+
+
+def find_account_by_access_token_prefix(prefix: str) -> Optional[ClaudeAccount]:
+    """Locate the stored account that owns a given access-token prefix."""
+    for acct in read_all_accounts():
+        if acct.credentials.access_token.startswith(prefix):
+            return acct
+    return None

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -79,12 +79,20 @@ class AnthropicTransport(ProviderTransport):
         """Normalize Anthropic response to NormalizedResponse.
 
         kwargs:
-            strip_tool_prefix: bool — strip 'mcp_mcp_' prefixes from tool names.
+            strip_tool_prefix: bool — strip 'mcp_' prefixes from tool names.
+            tool_name_map: Optional[Dict[str, str]] — map ``mcp_<PascalCase>``
+                back to the original snake_case name (OAuth Claude Code
+                roundtrip; the PascalCase transform is lossy).
         """
         from agent.anthropic_adapter import normalize_anthropic_response_v2
 
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
-        return normalize_anthropic_response_v2(response, strip_tool_prefix=strip_tool_prefix)
+        tool_name_map = kwargs.get("tool_name_map")
+        return normalize_anthropic_response_v2(
+            response,
+            strip_tool_prefix=strip_tool_prefix,
+            tool_name_map=tool_name_map,
+        )
 
     def validate_response(self, response: Any) -> bool:
         """Check Anthropic response structure is valid."""

--- a/cli.py
+++ b/cli.py
@@ -3153,6 +3153,10 @@ class HermesCLI:
             bool: True if successful, False otherwise
         """
         if self.agent is not None:
+            # These are per-turn request knobs, not part of the frozen prompt/
+            # tool schema cache key, so keep the cached agent but refresh them.
+            self.agent.service_tier = self.service_tier
+            self.agent.request_overrides = dict(request_overrides or {})
             return True
 
         if not self._ensure_runtime_credentials():

--- a/computer/__init__.py
+++ b/computer/__init__.py
@@ -1,0 +1,8 @@
+"""Perplexity Computer-style persistent workflow runtime for Hermes."""
+
+from .runtime import (  # noqa: F401
+    ComputerStore,
+    build_computer_prompt,
+    build_scheduled_computer_prompt,
+    start_computer_run,
+)

--- a/computer/runtime.py
+++ b/computer/runtime.py
@@ -62,6 +62,66 @@ _DEFAULT_FEATURES = (
 )
 
 
+# ── Process probes / watcher registry ─────────────────────────────────────────
+#
+# ``_is_pid_alive`` is the single shared "is this background hermes child
+# still running?" probe used by both the in-process watcher and the
+# best-effort ``reconcile_running_runs`` cleanup path. Tests monkeypatch
+# this so they don't depend on real system pids.
+
+
+def _is_pid_alive(pid: int) -> bool:
+    """Return True if ``pid`` looks alive (signal 0 succeeds).
+
+    Best-effort: returns False for invalid/missing pids. ``PermissionError``
+    is treated as **alive** — the pid exists but belongs to another user /
+    we cannot signal it, so it would be wrong to reconcile the run as
+    failed on that basis. ``ProcessLookupError`` and other ``OSError``
+    values return False. Callers must treat False as "probably not ours /
+    not alive" rather than a hard kill.
+    """
+    if pid is None:
+        return False
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+    try:
+        os.kill(pid_int, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Permission denied means the pid exists but we can't signal it —
+        # treat as alive so we don't wrongly mark a run failed.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+# Map of run_id -> daemon Thread watching the spawned child. Only used so
+# tests (and future tooling) can join on watcher completion deterministically.
+_WATCHERS: Dict[str, threading.Thread] = {}
+_WATCHERS_LOCK = threading.Lock()
+
+
+def wait_for_watcher(run_id: str, timeout: float = 5.0) -> bool:
+    """Block until the watcher for ``run_id`` finishes or ``timeout`` elapses.
+
+    Returns True if the watcher thread finished within the timeout (or no
+    watcher was registered), False otherwise. Tests rely on this to avoid
+    polling races without sprinkling ``time.sleep`` calls.
+    """
+    with _WATCHERS_LOCK:
+        thread = _WATCHERS.get(run_id)
+    if thread is None:
+        return True
+    thread.join(timeout)
+    return not thread.is_alive()
+
+
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -302,6 +362,54 @@ class ComputerStore:
             logger.warning("could not read events for %s: %s", run_id, exc)
         return out
 
+    def reconcile_running_runs(self) -> List[str]:
+        """Mark obviously stale ``running`` records as ``failed``.
+
+        For each persisted run currently in status ``running``:
+
+        * If the recorded background pid is still alive (per
+          :func:`_is_pid_alive`) the run is left untouched — an in-process
+          watcher (or another hermes process) is presumed to be tracking it.
+        * Otherwise the run is transitioned to ``failed`` with an
+          explanatory error and a ``computer.background.reconciled_stale``
+          event appended so the audit trail shows why the status moved.
+
+        Returns the list of run ids that were reconciled.  This API is
+        intentionally pid-only — we never shell out to ``pkill`` / ``ps``
+        / similar, and we never broaden process identification beyond the
+        pid we ourselves stored at launch time.
+        """
+        reconciled: List[str] = []
+        with self._lock:
+            ids = self._load_index()
+        for run_id in ids:
+            run = self.get_run(run_id)
+            if run is None or run.get("status") != "running":
+                continue
+            background = run.get("background") or {}
+            pid = background.get("pid")
+            if pid and _is_pid_alive(pid):
+                # Live (or at least signal-able) — leave for its watcher.
+                continue
+            error_msg = (
+                f"background process for run {run_id} is not alive "
+                f"(pid={pid!r}); reconciled by ComputerStore"
+            )
+            try:
+                self.update_run(run_id, status="failed", error=error_msg)
+                self.append_event(
+                    run_id,
+                    "computer.background.reconciled_stale",
+                    {"pid": pid, "reason": "pid not alive"},
+                )
+                reconciled.append(run_id)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning(
+                    "reconcile_running_runs: failed to mark %s failed: %s",
+                    run_id, exc,
+                )
+        return reconciled
+
     # ── internal helpers ─────────────────────────────────────────────────
 
     def _load_run_unlocked(self, run_id: str) -> Optional[Dict[str, Any]]:
@@ -494,6 +602,8 @@ def start_computer_run(
     stdout_path = artifact_dir / "background.stdout.log"
     stderr_path = artifact_dir / "background.stderr.log"
 
+    stdout_fh = None
+    stderr_fh = None
     try:
         # Open the log files now and hand them to the child. We do NOT call
         # ``shell=True`` — the prompt is passed as a single argv element so
@@ -508,6 +618,12 @@ def start_computer_run(
             start_new_session=True,
         )
     except Exception as exc:  # pragma: no cover — defensive
+        for fh in (stdout_fh, stderr_fh):
+            try:
+                if fh is not None:
+                    fh.close()
+            except Exception:
+                pass
         target_store.update_run(
             run_id,
             status="failed",
@@ -530,7 +646,133 @@ def start_computer_run(
         "computer.background.launched",
         {"pid": proc.pid, "binary": binary},
     )
+
+    _spawn_watcher(
+        run_id,
+        proc,
+        binary=binary,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        stdout_fh=stdout_fh,
+        stderr_fh=stderr_fh,
+        store=target_store,
+    )
     return True
+
+
+def _spawn_watcher(
+    run_id: str,
+    proc: Any,
+    *,
+    binary: str,
+    stdout_path: Path,
+    stderr_path: Path,
+    stdout_fh: Any,
+    stderr_fh: Any,
+    store: "ComputerStore",
+) -> threading.Thread:
+    """Spawn a daemon thread that reconciles the run's status on child exit.
+
+    The watcher:
+
+    * blocks on ``proc.wait()``,
+    * closes the stdout/stderr log file handles we opened for the child,
+    * looks up the latest run record so a user-issued ``cancel`` is not
+      overwritten,
+    * updates ``background.exit_code`` and either flips status to
+      ``completed`` / ``failed`` (with an explanatory error on failure),
+    * appends an explicit ``computer.background.completed`` /
+      ``computer.background.failed`` event for the audit trail.
+
+    Watchers are daemonized so they never block interpreter shutdown, and
+    they are registered in :data:`_WATCHERS` so tests / future tooling can
+    join on completion without racing.
+    """
+
+    def _watch() -> None:
+        exit_code: Optional[int] = None
+        wait_error: Optional[str] = None
+        try:
+            exit_code = proc.wait()
+        except Exception as exc:  # pragma: no cover — defensive
+            wait_error = f"watcher proc.wait() failed: {exc!r}"
+            logger.warning("computer watcher %s wait failed: %s", run_id, exc)
+        finally:
+            for fh in (stdout_fh, stderr_fh):
+                try:
+                    if fh is not None:
+                        fh.close()
+                except Exception:  # pragma: no cover — defensive
+                    pass
+
+        try:
+            latest = store.get_run(run_id) or {}
+            background = dict(latest.get("background") or {})
+            background.update({
+                "pid": getattr(proc, "pid", background.get("pid")),
+                "binary": binary,
+                "stdout_log": str(stdout_path),
+                "stderr_log": str(stderr_path),
+                "exit_code": exit_code,
+            })
+
+            current_status = latest.get("status")
+            if current_status == "cancelled":
+                # User (or another reconciler) already cancelled this run.
+                # Record exit_code in background metadata but do not flip
+                # the lifecycle status — cancelled is terminal.
+                store.update_run(run_id, background=background)
+                store.append_event(
+                    run_id,
+                    "computer.background.exited_after_cancel",
+                    {"pid": background.get("pid"), "exit_code": exit_code},
+                )
+                return
+
+            if wait_error is not None or exit_code is None or exit_code != 0:
+                error_text = wait_error or (
+                    f"background hermes process exited with code {exit_code}"
+                )
+                store.update_run(
+                    run_id,
+                    status="failed",
+                    background=background,
+                    error=error_text,
+                )
+                store.append_event(
+                    run_id,
+                    "computer.background.failed",
+                    {"pid": background.get("pid"), "exit_code": exit_code},
+                )
+            else:
+                store.update_run(
+                    run_id,
+                    status="completed",
+                    background=background,
+                )
+                store.append_event(
+                    run_id,
+                    "computer.background.completed",
+                    {"pid": background.get("pid"), "exit_code": exit_code},
+                )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("computer watcher %s post-exit update failed: %s", run_id, exc)
+        finally:
+            with _WATCHERS_LOCK:
+                # Only clear if we're still the registered watcher for
+                # this run — a future relaunch may have replaced us.
+                if _WATCHERS.get(run_id) is threading.current_thread():
+                    _WATCHERS.pop(run_id, None)
+
+    thread = threading.Thread(
+        target=_watch,
+        name=f"computer-watcher-{run_id}",
+        daemon=True,
+    )
+    with _WATCHERS_LOCK:
+        _WATCHERS[run_id] = thread
+    thread.start()
+    return thread
 
 
 __all__ = [
@@ -539,4 +781,5 @@ __all__ = [
     "build_computer_prompt",
     "build_scheduled_computer_prompt",
     "start_computer_run",
+    "wait_for_watcher",
 ]

--- a/computer/runtime.py
+++ b/computer/runtime.py
@@ -1,0 +1,542 @@
+"""Persistent runtime for Perplexity Computer-style workflows in Hermes.
+
+Implements the three feature ports requested in the clone plan:
+
+1. **Persistent Computer runtime** — a goal becomes a tracked run record with
+   a plan, an event log, an artifact directory, lifecycle status, and a
+   structured place for background execution metadata.
+2. **Parallel research / browser / workflow orchestration** — the Computer
+   prompt (see :func:`build_computer_prompt`) explicitly steers Hermes to use
+   ``delegate_task`` in parallel and to lean on browser/web/file/MCP tools
+   instead of re-inventing an agent framework.
+3. **Continuous monitoring / scheduled runs** — :func:`build_scheduled_computer_prompt`
+   produces a fully self-contained prompt that a cron job can fire in a fresh
+   session, with traceability back to a stored run.
+
+Storage layout (under ``base_dir``, default ``~/.hermes/computer``)::
+
+    base_dir/
+        index.json                # ordered list of run ids (newest first)
+        runs/<run_id>/run.json    # persisted run record
+        runs/<run_id>/events.jsonl
+        runs/<run_id>/artifacts/  # per-run artifact dir written by the agent
+
+All storage operations are best-effort durable: each write goes through a
+temp-file + ``os.replace`` to avoid leaving torn files on crash.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Lifecycle statuses ────────────────────────────────────────────────────────
+#
+# Computer runs follow a small, explicit state machine:
+#
+#     queued    — created, not yet started (foreground or background)
+#     running   — background execution underway
+#     scheduled — backed by a cron job firing on a schedule
+#     completed — background execution finished successfully
+#     failed    — background execution exited non-zero / raised
+#     cancelled — user cancelled via the tool
+
+VALID_STATUSES = frozenset({
+    "queued", "running", "scheduled", "completed", "failed", "cancelled",
+})
+
+_DEFAULT_FEATURES = (
+    "runtime",
+    "parallel_research",
+    "continuous_monitoring",
+)
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    """Write ``data`` to ``path`` atomically (temp file + ``os.replace``)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _resolve_base_dir(base_dir: Optional[Path]) -> Path:
+    if base_dir is not None:
+        return Path(base_dir)
+    # Lazy import so the module is importable in tests without HERMES_HOME.
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "computer"
+
+
+class ComputerStore:
+    """JSON-backed store for Computer runs and their event logs.
+
+    The store is process-safe (uses an in-process lock + atomic file
+    replacement) and is intentionally simple — no database, no migrations,
+    so tests can spin up an isolated store with ``base_dir=tmp_path``.
+    """
+
+    def __init__(self, base_dir: Optional[Path] = None):
+        self.base_dir = _resolve_base_dir(base_dir)
+        self.runs_dir = self.base_dir / "runs"
+        self.index_path = self.base_dir / "index.json"
+        # Serialize index reads/writes so concurrent create_run / update_run
+        # calls don't clobber each other.
+        self._lock = threading.RLock()
+        self._ensure_dirs()
+
+    # ── filesystem helpers ────────────────────────────────────────────────
+
+    def _ensure_dirs(self) -> None:
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+    def _run_dir(self, run_id: str) -> Path:
+        return self.runs_dir / run_id
+
+    def _run_path(self, run_id: str) -> Path:
+        return self._run_dir(run_id) / "run.json"
+
+    def _events_path(self, run_id: str) -> Path:
+        return self._run_dir(run_id) / "events.jsonl"
+
+    def _artifact_dir(self, run_id: str) -> Path:
+        # The artifact dir IS the run dir — keeping them merged makes
+        # ``Path(run["artifact_dir"]).name == run["id"]`` true and means
+        # ``run.json`` / ``events.jsonl`` / agent-written artifacts all live
+        # in one tidy location named after the run id.
+        return self._run_dir(run_id)
+
+    # ── index ────────────────────────────────────────────────────────────
+
+    def _load_index(self) -> List[str]:
+        if not self.index_path.exists():
+            return []
+        try:
+            with self.index_path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, list):
+                return [str(x) for x in data]
+            if isinstance(data, dict) and isinstance(data.get("runs"), list):
+                return [str(x) for x in data["runs"]]
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("ComputerStore index unreadable, resetting: %s", exc)
+        return []
+
+    def _save_index(self, run_ids: List[str]) -> None:
+        _atomic_write(self.index_path, json.dumps({"runs": run_ids}, indent=2))
+
+    def _add_to_index(self, run_id: str) -> None:
+        with self._lock:
+            ids = self._load_index()
+            if run_id in ids:
+                return
+            ids.insert(0, run_id)  # newest first
+            self._save_index(ids)
+
+    # ── public API ───────────────────────────────────────────────────────
+
+    def create_run(
+        self,
+        goal: str,
+        features: Optional[List[str]] = None,
+        source: Optional[str] = None,
+        plan: Optional[Dict[str, Any]] = None,
+        deliver: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create and persist a new Computer run.
+
+        Returns the freshly created run dict.  An initial
+        ``computer.run.created`` event is appended so reloading the events
+        log always shows the lifecycle from the very first moment.
+        """
+        if not goal or not str(goal).strip():
+            raise ValueError("goal must be a non-empty string")
+
+        feature_list = list(features) if features else list(_DEFAULT_FEATURES)
+        # Use a short hex suffix — readable in logs and CLI but collision-safe.
+        run_id = f"computer_{secrets.token_hex(6)}"
+        artifact_dir = self._artifact_dir(run_id)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        now = _utcnow_iso()
+        run = {
+            "id": run_id,
+            "goal": str(goal).strip(),
+            "features": feature_list,
+            "status": "queued",
+            "source": source,
+            "deliver": deliver,
+            "plan": plan,
+            "metadata": metadata or {},
+            "artifact_dir": str(artifact_dir),
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "completed_at": None,
+            "schedule": None,
+            "schedule_job_id": None,
+            "background": None,
+            "error": None,
+            "output": None,
+        }
+
+        with self._lock:
+            _atomic_write(self._run_path(run_id), json.dumps(run, indent=2))
+            self._add_to_index(run_id)
+            self._append_event_unlocked(
+                run_id,
+                "computer.run.created",
+                {"goal": run["goal"], "features": feature_list},
+                at=now,
+            )
+
+        return dict(run)
+
+    def update_run(self, run_id: str, **fields: Any) -> Dict[str, Any]:
+        """Update fields on a run and log a ``computer.run.updated`` event.
+
+        Unknown fields are stored as-is so callers can stash extra metadata
+        (background pid, exit code, scheduled job id, etc.) without a schema
+        migration.  Status values outside :data:`VALID_STATUSES` raise.
+        """
+        with self._lock:
+            run = self._load_run_unlocked(run_id)
+            if run is None:
+                raise KeyError(f"unknown computer run: {run_id}")
+
+            status = fields.get("status")
+            if status is not None and status not in VALID_STATUSES:
+                raise ValueError(
+                    f"invalid computer run status: {status!r} "
+                    f"(expected one of {sorted(VALID_STATUSES)})"
+                )
+
+            now = _utcnow_iso()
+            for key, value in fields.items():
+                run[key] = value
+            run["updated_at"] = now
+            if status == "running" and not run.get("started_at"):
+                run["started_at"] = now
+            if status in {"completed", "failed", "cancelled"} and not run.get("completed_at"):
+                run["completed_at"] = now
+
+            _atomic_write(self._run_path(run_id), json.dumps(run, indent=2))
+            self._append_event_unlocked(
+                run_id,
+                "computer.run.updated",
+                {"changes": {k: fields[k] for k in fields}},
+                at=now,
+            )
+            return dict(run)
+
+    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._load_run_unlocked(run_id)
+
+    def list_runs(self) -> List[Dict[str, Any]]:
+        """Return all runs newest-first.
+
+        Runs whose ``run.json`` is missing are silently skipped — they can
+        happen if an artifact dir was nuked manually.
+        """
+        with self._lock:
+            ids = self._load_index()
+        runs: List[Dict[str, Any]] = []
+        for rid in ids:
+            run = self.get_run(rid)
+            if run:
+                runs.append(run)
+        return runs
+
+    def append_event(self, run_id: str, event_type: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        with self._lock:
+            return self._append_event_unlocked(run_id, event_type, payload or {})
+
+    def list_events(self, run_id: str) -> List[Dict[str, Any]]:
+        events_path = self._events_path(run_id)
+        if not events_path.exists():
+            return []
+        out: List[Dict[str, Any]] = []
+        try:
+            with events_path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        out.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "skipping malformed event line in %s", events_path
+                        )
+        except OSError as exc:
+            logger.warning("could not read events for %s: %s", run_id, exc)
+        return out
+
+    # ── internal helpers ─────────────────────────────────────────────────
+
+    def _load_run_unlocked(self, run_id: str) -> Optional[Dict[str, Any]]:
+        path = self._run_path(run_id)
+        if not path.exists():
+            return None
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if not isinstance(data, dict):
+                return None
+            return data
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("could not load run %s: %s", run_id, exc)
+            return None
+
+    def _append_event_unlocked(
+        self,
+        run_id: str,
+        event_type: str,
+        payload: Dict[str, Any],
+        *,
+        at: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        run_dir = self._run_dir(run_id)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        event = {
+            "type": str(event_type),
+            "at": at or _utcnow_iso(),
+            "payload": payload,
+        }
+        events_path = self._events_path(run_id)
+        # JSONL append — durable enough for an event log; we don't fsync per
+        # line because event-log loss on crash is acceptable (run.json is
+        # the source of truth for resumability).
+        with events_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+        return event
+
+
+# ── Prompt construction ───────────────────────────────────────────────────────
+
+
+_FEATURE_LABELS = {
+    "runtime": (
+        "First-class persistent Computer runtime — write the plan, intermediate "
+        "notes, and final deliverables into the run artifact directory."
+    ),
+    "parallel_research": (
+        "Parallel research / browser / workflow orchestration — fan out using "
+        "delegate_task in parallel for independent research threads and only "
+        "then synthesize."
+    ),
+    "continuous_monitoring": (
+        "Continuous monitoring — when the goal implies recurring work, schedule "
+        "a cron job via the cronjob tool. Otherwise, treat this run as one-shot."
+    ),
+}
+
+
+def _format_feature_block(features: List[str]) -> str:
+    lines = []
+    for feat in features:
+        label = _FEATURE_LABELS.get(feat, f"Feature: {feat}")
+        lines.append(f"- [{feat}] {label}")
+    return "\n".join(lines) if lines else "- (no specific feature ports requested)"
+
+
+def build_computer_prompt(run: Dict[str, Any]) -> str:
+    """Build the system/user prompt that drives a Computer run.
+
+    The prompt explicitly instructs Hermes to act as a Perplexity
+    Computer-style workflow orchestrator and to use existing Hermes
+    primitives (delegate_task, browser, web, files, MCP).  Tests assert on
+    several specific phrases; treat those phrases as part of the contract.
+    """
+    features = list(run.get("features") or [])
+    artifact_dir = run.get("artifact_dir") or ""
+    deliver = run.get("deliver") or "the originating conversation"
+
+    return f"""You are operating as a Perplexity Computer-style workflow orchestrator inside Hermes.
+This is a persistent Computer run; everything you produce is tied to a tracked run record.
+
+Run id: {run.get("id", "<unknown>")}
+Goal: {run.get("goal", "<no goal>")}
+Artifact directory (write deliverables here): {artifact_dir}
+Delivery target: {deliver}
+
+Active feature ports:
+{_format_feature_block(features)}
+
+Operating rules:
+1. Treat this as a Perplexity Computer-style task: plan first, then execute,
+   then synthesize a clear deliverable. Maintain a short written plan inside
+   the artifact directory ("{artifact_dir}/plan.md") and update it as you go.
+2. Use Hermes primitives — do not invent a second agent framework. Prefer:
+     - delegate_task for parallel research sub-tasks (run independent
+       branches in parallel, then synthesize in the parent).
+     - browser_* tools for live web navigation when search/extract is not
+       enough.
+     - web_search / web_extract for fast research.
+     - read_file / write_file / patch / search_files for local-file work.
+     - cronjob for continuous monitoring when the goal is recurring.
+     - MCP / connector tools when available for first-party integrations.
+3. Write every deliverable (briefings, summaries, csv/json/markdown
+   artifacts) into the run artifact directory above so the user can find
+   them later. Reference artifact paths in your final reply.
+4. Respect approvals and user-control boundaries. Do not bypass the normal
+   approval flow, do not silently send messages outside configured
+   delivery, and do not exfiltrate secrets.
+5. If the goal includes continuous monitoring, schedule it via the cronjob
+   tool with a self-contained prompt rather than looping forever in this
+   run. The cron run will spawn a fresh Computer run on each tick.
+6. End with a short, structured summary: what you did, key findings, and
+   the absolute paths of the artifacts you wrote.
+"""
+
+
+def build_scheduled_computer_prompt(run: Dict[str, Any]) -> str:
+    """Build a self-contained prompt for a *scheduled* Computer run.
+
+    This is what the cron scheduler stores as the job ``prompt``.  Each
+    tick fires it in a fresh session, so the prompt must carry all the
+    context the agent needs and must explicitly forbid recursive cron
+    creation.
+    """
+    base = build_computer_prompt(run)
+    deliver = run.get("deliver") or "the originating conversation"
+
+    return f"""This is a scheduled Perplexity Computer-style run firing in a fresh session.
+
+Originating Computer run id: {run.get("id", "<unknown>")}
+Continuous monitoring tick goal: {run.get("goal", "<no goal>")}
+Deliver the resulting briefing to: {deliver}
+
+Do not recursively create cron jobs. Run the goal once for this tick, write
+artifacts into the originating run's artifact directory below, and rely on
+the existing cron schedule for future ticks.
+
+--- Computer operating instructions (same as the parent run) ---
+{base}
+"""
+
+
+# ── Background execution helper ───────────────────────────────────────────────
+
+
+def start_computer_run(
+    run_id: str,
+    *,
+    store: Optional[ComputerStore] = None,
+    hermes_executable: Optional[str] = None,
+) -> bool:
+    """Launch a background Hermes session that executes a Computer run.
+
+    Best-effort: returns True if a background process was launched and
+    metadata recorded, False otherwise.  Tests monkey-patch this so the
+    real launch never runs in CI — keep the signature stable.
+
+    The implementation deliberately uses ``subprocess.Popen`` to fire off
+    ``hermes chat -q <self-contained prompt>`` instead of re-inventing a
+    second agent framework. The subprocess inherits the user's normal
+    approval/delivery configuration, so security boundaries are preserved.
+    """
+    import shutil
+    import subprocess
+
+    target_store = store if store is not None else ComputerStore()
+    run = target_store.get_run(run_id)
+    if run is None:
+        logger.warning("start_computer_run: unknown run %s", run_id)
+        return False
+
+    if run.get("status") in {"running", "completed", "cancelled"}:
+        # Already in a terminal/active state — refuse to relaunch.
+        return False
+
+    prompt = build_computer_prompt(run)
+    binary = hermes_executable or shutil.which("hermes")
+    if not binary:
+        target_store.update_run(
+            run_id,
+            status="failed",
+            error="hermes executable not on PATH; cannot launch background run",
+        )
+        return False
+
+    artifact_dir = Path(run.get("artifact_dir") or target_store._artifact_dir(run_id))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = artifact_dir / "background.stdout.log"
+    stderr_path = artifact_dir / "background.stderr.log"
+
+    try:
+        # Open the log files now and hand them to the child. We do NOT call
+        # ``shell=True`` — the prompt is passed as a single argv element so
+        # quoting/escaping cannot collapse into shell metacharacters.
+        stdout_fh = open(stdout_path, "ab", buffering=0)
+        stderr_fh = open(stderr_path, "ab", buffering=0)
+        proc = subprocess.Popen(  # noqa: S603 — explicit argv, no shell
+            [binary, "chat", "-q", prompt],
+            stdout=stdout_fh,
+            stderr=stderr_fh,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        target_store.update_run(
+            run_id,
+            status="failed",
+            error=f"failed to launch background run: {exc!r}",
+        )
+        return False
+
+    target_store.update_run(
+        run_id,
+        status="running",
+        background={
+            "pid": proc.pid,
+            "binary": binary,
+            "stdout_log": str(stdout_path),
+            "stderr_log": str(stderr_path),
+        },
+    )
+    target_store.append_event(
+        run_id,
+        "computer.background.launched",
+        {"pid": proc.pid, "binary": binary},
+    )
+    return True
+
+
+__all__ = [
+    "VALID_STATUSES",
+    "ComputerStore",
+    "build_computer_prompt",
+    "build_scheduled_computer_prompt",
+    "start_computer_run",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6789,9 +6789,9 @@ class GatewayRunner:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
 
     async def _handle_fast_command(self, event: MessageEvent) -> str:
-        """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats."""
+        """Handle /fast — mirror the CLI fast-mode toggle in gateway chats."""
         import yaml
-        from hermes_cli.models import model_supports_fast_mode
+        from hermes_cli.models import _is_anthropic_fast_model, model_supports_fast_mode
 
         args = event.get_command_args().strip().lower()
         config_path = _hermes_home / "config.yaml"
@@ -6800,7 +6800,9 @@ class GatewayRunner:
         user_config = _load_gateway_config()
         model = _resolve_gateway_model(user_config)
         if not model_supports_fast_mode(model):
-            return "⚡ /fast is only available for OpenAI models that support Priority Processing."
+            return "⚡ /fast is only available for models that support OpenAI Priority Processing or Anthropic Fast Mode."
+
+        feature_name = "Anthropic Fast Mode" if _is_anthropic_fast_model(model) else "Priority Processing"
 
         def _save_config_key(key_path: str, value):
             """Save a dot-separated key to config.yaml."""
@@ -6825,7 +6827,7 @@ class GatewayRunner:
         if not args or args == "status":
             status = "fast" if self._service_tier == "priority" else "normal"
             return (
-                "⚡ Priority Processing\n\n"
+                f"⚡ {feature_name}\n\n"
                 f"Current mode: `{status}`\n\n"
                 "_Usage:_ `/fast <normal|fast|status>`"
             )
@@ -6845,8 +6847,8 @@ class GatewayRunner:
             )
 
         if _save_config_key("agent.service_tier", saved_value):
-            return f"⚡ ✓ Priority Processing: **{label}** (saved to config)\n_(takes effect on next message)_"
-        return f"⚡ ✓ Priority Processing: **{label}** (this session only)"
+            return f"⚡ ✓ {feature_name}: **{label}** (saved to config)\n_(takes effect on next message)_"
+        return f"⚡ ✓ {feature_name}: **{label}** (this session only)"
 
     async def _handle_yolo_command(self, event: MessageEvent) -> str:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2979,10 +2979,101 @@ def _save_model_choice(model_id: str) -> None:
 
 
 def login_command(args) -> None:
-    """Deprecated: use 'hermes model' or 'hermes setup' instead."""
-    print("The 'hermes login' command has been removed.")
-    print("Use 'hermes auth' to manage credentials,")
-    print("'hermes model' to select a provider, or 'hermes setup' for full setup.")
+    """Provider login entry point.
+
+    ``hermes login --provider anthropic`` runs Hermes's pure-Python PKCE flow
+    (``run_hermes_oauth_login_pure``) for Claude Pro/Max subscriptions and
+    persists the tokens both in ``~/.hermes/.anthropic_oauth.json`` and the
+    credential pool — matching what ``hermes auth add anthropic`` does.
+
+    For all other providers, this stub defers to the canonical entry points
+    (``hermes auth``, ``hermes model``, ``hermes setup``).
+    """
+    provider = (getattr(args, "provider", "") or "").strip().lower()
+    if provider == "anthropic":
+        from agent import anthropic_adapter as _ant
+        from hermes_cli.auth_commands import _provider_base_url
+
+        creds = _ant.run_hermes_oauth_login_pure()
+        if not creds:
+            print("Anthropic OAuth login was cancelled or failed.")
+            raise SystemExit(1)
+
+        access_token = creds.get("access_token") or ""
+        refresh_token = creds.get("refresh_token") or ""
+        expires_at_ms = int(creds.get("expires_at_ms") or 0)
+
+        # Mirror web_server._save_anthropic_oauth_creds / auth_commands.add:
+        # persist to ``_HERMES_OAUTH_FILE`` AND credential pool so both the
+        # runtime resolver and `hermes auth list` see the new entry.
+        try:
+            payload = {
+                "accessToken": access_token,
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at_ms,
+            }
+            _ant._HERMES_OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _ant._HERMES_OAUTH_FILE.write_text(
+                json.dumps(payload, indent=2), encoding="utf-8"
+            )
+        except Exception as e:
+            logger.warning("Writing Hermes OAuth file failed: %s", e)
+
+        try:
+            from agent.credential_pool import (
+                PooledCredential,
+                load_pool,
+                AUTH_TYPE_OAUTH,
+                SOURCE_MANUAL,
+            )
+            from hermes_cli.auth_commands import label_from_token, _oauth_default_label
+
+            pool = load_pool("anthropic")
+            label = label_from_token(
+                access_token,
+                _oauth_default_label("anthropic", len(pool.entries()) + 1),
+            )
+            entry = PooledCredential(
+                provider="anthropic",
+                id=uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source=f"{SOURCE_MANUAL}:hermes_login",
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at_ms=expires_at_ms,
+                base_url=_provider_base_url("anthropic"),
+            )
+            pool.add_entry(entry)
+        except Exception as e:
+            logger.warning("Anthropic pool insert failed: %s", e)
+
+        # Activate the credential file path in ``.env`` (clears static
+        # ANTHROPIC_TOKEN so refresh can proceed).
+        try:
+            from hermes_cli.config import (
+                save_env_value,
+                use_anthropic_claude_code_credentials,
+            )
+            use_anthropic_claude_code_credentials(save_fn=save_env_value)
+        except Exception as e:
+            logger.debug("Activating Anthropic credential file path failed: %s", e)
+
+        print()
+        print("Anthropic OAuth login successful.")
+        from hermes_constants import display_hermes_home as _dhh
+        print(f"  Credentials saved: {_dhh()}/.anthropic_oauth.json")
+        print(f"  Pool entry added:  provider=anthropic label={label!r}")
+        print()
+        print("Run 'hermes model' to choose a Claude model.")
+        raise SystemExit(0)
+
+    print("The 'hermes login' command now only handles OAuth flows that do")
+    print("not have a dedicated wizard. For this provider use:")
+    print("  • 'hermes auth add <provider>' — add a pooled credential")
+    print("  • 'hermes model'               — pick a provider + model")
+    print("  • 'hermes setup'               — full interactive setup")
     raise SystemExit(0)
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3900,97 +3900,237 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         print("No change.")
 
 
+# Stores the user-selected Claude Code account ``source`` string (e.g.
+# "keychain:Claude Code-credentials" or "file").  Consumed by
+# ``agent.claude_keychain.read_selected_account`` so the runtime uses the
+# same account the user picked during ``hermes model``.
+_CLAUDE_ACCOUNT_SOURCE_FILE = get_hermes_home() / "claude_account_source.txt"
+
+
+def _save_anthropic_oauth_creds_cli(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
+    """Persist Anthropic PKCE creds to both the Hermes OAuth file AND the credential pool.
+
+    Mirrors ``hermes_cli.web_server._save_anthropic_oauth_creds`` so the CLI
+    login flow leaves the system in the same state as the dashboard flow.
+    """
+    import json as _json
+
+    from agent.anthropic_adapter import _HERMES_OAUTH_FILE
+
+    payload = {
+        "accessToken": access_token,
+        "refreshToken": refresh_token,
+        "expiresAt": expires_at_ms,
+    }
+    _HERMES_OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _HERMES_OAUTH_FILE.write_text(_json.dumps(payload, indent=2), encoding="utf-8")
+
+    try:
+        import uuid as _uuid
+
+        from agent.credential_pool import (
+            AUTH_TYPE_OAUTH,
+            PooledCredential,
+            SOURCE_MANUAL,
+            load_pool,
+        )
+        from hermes_cli.auth_commands import label_from_token
+
+        pool = load_pool("anthropic")
+        # Avoid duplicate entries: drop any prior CLI-issued OAuth entry.
+        existing = [
+            e for e in pool.entries()
+            if getattr(e, "source", "").startswith(f"{SOURCE_MANUAL}:hermes_pkce_cli")
+        ]
+        for e in existing:
+            try:
+                pool.remove_entry(getattr(e, "id", ""))
+            except Exception:
+                pass
+        label = label_from_token(access_token, f"anthropic-oauth-{len(pool.entries()) + 1}")
+        entry = PooledCredential(
+            provider="anthropic",
+            id=_uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:hermes_pkce_cli",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at_ms=expires_at_ms,
+        )
+        pool.add_entry(entry)
+    except Exception as exc:
+        logger.warning("anthropic pool add (cli pkce) failed: %s", exc)
+
+
 def _run_anthropic_oauth_flow(save_env_value):
-    """Run the Claude OAuth setup-token flow. Returns True if credentials were saved."""
+    """Run the Claude OAuth login flow. Returns True if credentials were saved.
+
+    Offers three paths:
+      1. Hermes-native PKCE browser login (no external dependencies).
+      2. Paste an existing Claude Code setup-token.
+      3. Legacy ``claude setup-token`` npm CLI.
+    """
     from agent.anthropic_adapter import (
+        run_hermes_oauth_login_pure,
         run_oauth_setup_token,
-        read_claude_code_credentials,
-        is_claude_code_token_valid,
     )
     from hermes_cli.config import (
         save_anthropic_oauth_token,
         use_anthropic_claude_code_credentials,
     )
 
-    def _activate_claude_code_credentials_if_available() -> bool:
-        try:
-            creds = read_claude_code_credentials()
-        except Exception:
-            creds = None
-        if creds and (
-            is_claude_code_token_valid(creds) or bool(creds.get("refreshToken"))
-        ):
-            use_anthropic_claude_code_credentials(save_fn=save_env_value)
-            print("  ✓ Claude Code credentials linked.")
-            from hermes_constants import display_hermes_home as _dhh_fn
-
-            print(
-                f"    Hermes will use Claude's credential store directly instead of copying a setup-token into {_dhh_fn()}/.env."
-            )
-            return True
-        return False
-
+    print()
+    print("  Choose how to sign in:")
+    print()
+    print("    1. Hermes browser login (recommended — no extra tools required)")
+    print("    2. Paste an existing Claude Code setup-token (sk-ant-oat-...)")
+    print("    3. Run 'claude setup-token' via npm CLI (legacy — only if you already have Claude Code installed)")
+    print("    4. Cancel")
+    print()
     try:
+        raw = input("  Choice [1/2/3/4] (default 1): ").strip()
+    except (KeyboardInterrupt, EOFError):
         print()
-        print("  Running 'claude setup-token' — follow the prompts below.")
-        print("  A browser window will open for you to authorize access.")
-        print()
-        token = run_oauth_setup_token()
-        if token:
-            if _activate_claude_code_credentials_if_available():
-                return True
-            save_anthropic_oauth_token(token, save_fn=save_env_value)
-            print("  ✓ OAuth credentials saved.")
-            return True
+        return False
+    choice = raw or "1"
 
-        # Subprocess completed but no token auto-detected — ask user to paste
+    if choice == "1":
+        try:
+            creds = run_hermes_oauth_login_pure()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return False
+        if not creds or not creds.get("access_token"):
+            print("  ⚠ Login did not complete.")
+            return False
+        _save_anthropic_oauth_creds_cli(
+            creds["access_token"],
+            creds.get("refresh_token", "") or "",
+            int(creds.get("expires_at_ms") or 0),
+        )
+        use_anthropic_claude_code_credentials(save_fn=save_env_value)
+        print("  ✓ Signed in — OAuth credentials saved.")
+        return True
+
+    if choice == "2":
         print()
-        print("  If the setup-token was displayed above, paste it here:")
+        print("  Paste your Claude Code setup-token (starts with sk-ant-oat-).")
         print()
         try:
             import getpass
 
             manual_token = getpass.getpass(
-                "  Paste setup-token (or Enter to cancel): "
+                "  Setup-token (or Enter to cancel): "
             ).strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return False
-        if manual_token:
-            save_anthropic_oauth_token(manual_token, save_fn=save_env_value)
-            print("  ✓ Setup-token saved.")
-            return True
-
-        print("  ⚠ Could not detect saved credentials.")
-        return False
-
-    except FileNotFoundError:
-        # Claude CLI not installed — guide user through manual setup
-        print()
-        print("  The 'claude' CLI is required for OAuth login.")
-        print()
-        print("  To install and authenticate:")
-        print()
-        print("    1. Install Claude Code:  npm install -g @anthropic-ai/claude-code")
-        print("    2. Run:                  claude setup-token")
-        print("    3. Follow the browser prompts to authorize")
-        print("    4. Re-run:               hermes model")
-        print()
-        print("  Or paste an existing setup-token now (sk-ant-oat-...):")
-        print()
-        try:
-            import getpass
-
-            token = getpass.getpass("  Setup-token (or Enter to cancel): ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print()
+        if not manual_token:
+            print("  Cancelled.")
             return False
-        if token:
-            save_anthropic_oauth_token(token, save_fn=save_env_value)
-            print("  ✓ Setup-token saved.")
-            return True
-        print("  Cancelled — install Claude Code and try again.")
-        return False
+        save_anthropic_oauth_token(manual_token, save_fn=save_env_value)
+        print("  ✓ Setup-token saved.")
+        return True
+
+    if choice == "3":
+        from agent.anthropic_adapter import (
+            is_claude_code_token_valid,
+            read_claude_code_credentials,
+        )
+
+        def _activate_claude_code_credentials_if_available() -> bool:
+            """Prefer Claude Code's refreshable credential file over static env token.
+
+            Claude Code stores refreshable OAuth creds in ``~/.claude/.credentials.json``
+            (or macOS Keychain).  If the subprocess populated that store, route
+            Hermes through the credential file so refresh keeps working —
+            otherwise the static setup-token embedded in ``.env`` decays after
+            expiry.
+            """
+            try:
+                creds = read_claude_code_credentials()
+            except Exception:
+                creds = None
+            if creds and (
+                is_claude_code_token_valid(creds) or bool(creds.get("refreshToken"))
+            ):
+                use_anthropic_claude_code_credentials(save_fn=save_env_value)
+                print("  ✓ Claude Code credentials linked.")
+                from hermes_constants import display_hermes_home as _dhh_fn
+
+                print(
+                    f"    Hermes will use Claude's credential store directly instead of copying a setup-token into {_dhh_fn()}/.env."
+                )
+                return True
+            return False
+
+        try:
+            print()
+            print("  Running 'claude setup-token' — follow the prompts below.")
+            print("  A browser window will open for you to authorize access.")
+            print()
+            token = run_oauth_setup_token()
+            if token:
+                if _activate_claude_code_credentials_if_available():
+                    return True
+                save_anthropic_oauth_token(token, save_fn=save_env_value)
+                print("  ✓ OAuth credentials saved.")
+                return True
+
+            # Subprocess completed but no token auto-detected — ask user to paste
+            print()
+            print("  If the setup-token was displayed above, paste it here:")
+            print()
+            try:
+                import getpass
+
+                manual_token = getpass.getpass(
+                    "  Paste setup-token (or Enter to cancel): "
+                ).strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return False
+            if manual_token:
+                save_anthropic_oauth_token(manual_token, save_fn=save_env_value)
+                print("  ✓ Setup-token saved.")
+                return True
+
+            print("  ⚠ Could not detect saved credentials.")
+            return False
+
+        except FileNotFoundError:
+            # Claude CLI not installed — guide user through manual setup
+            print()
+            print("  The 'claude' CLI is required for this legacy flow.")
+            print()
+            print("  To install and authenticate:")
+            print()
+            print("    1. Install Claude Code:  npm install -g @anthropic-ai/claude-code")
+            print("    2. Run:                  claude setup-token")
+            print("    3. Follow the browser prompts to authorize")
+            print("    4. Re-run:               hermes model")
+            print()
+            print("  Or paste an existing setup-token now (sk-ant-oat-...):")
+            print()
+            try:
+                import getpass
+
+                token = getpass.getpass("  Setup-token (or Enter to cancel): ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return False
+            if token:
+                save_anthropic_oauth_token(token, save_fn=save_env_value)
+                print("  ✓ Setup-token saved.")
+                return True
+            print("  Cancelled — install Claude Code and try again.")
+            return False
+
+    # choice == "4" or anything else
+    print("  Cancelled.")
+    return False
 
 
 def _model_flow_anthropic(config, current_model=""):
@@ -4024,6 +4164,104 @@ def _model_flow_anthropic(config, current_model=""):
             cc_available = True
     except Exception:
         pass
+
+    # Multi-account / single-account Claude Code detection.  If the user has
+    # one or more Claude Code accounts (Keychain or file), offer to use them
+    # directly before falling through to the legacy prompts.  We only take
+    # this branch when there is no explicit Anthropic API key in the env —
+    # an API key is a stronger signal of user intent.
+    if not existing_key:
+        try:
+            from agent import claude_keychain
+
+            cc_accounts = claude_keychain.read_all_accounts()
+        except Exception:
+            cc_accounts = []
+
+        if cc_accounts:
+            from hermes_cli.config import use_anthropic_claude_code_credentials
+
+            selected_account = None
+            if len(cc_accounts) == 1:
+                acct = cc_accounts[0]
+                try:
+                    ans = input(f"  Detected: {acct.label} — use it? [Y/n]: ").strip().lower()
+                except (KeyboardInterrupt, EOFError):
+                    print()
+                    return
+                if ans in ("", "y", "yes"):
+                    selected_account = acct
+            else:
+                print()
+                print("  Multiple Claude Code accounts detected:")
+                print()
+                for i, acct in enumerate(cc_accounts, start=1):
+                    preview = (acct.credentials.access_token or "")[:10]
+                    src = "keychain" if acct.source.startswith("keychain:") else "file"
+                    print(f"    {i}. {acct.label:<22} ({preview}...)  {src}")
+                extra_idx = len(cc_accounts) + 1
+                cancel_idx = len(cc_accounts) + 2
+                print(f"    {extra_idx}. Sign in with a different account")
+                print(f"    {cancel_idx}. Cancel")
+                print()
+                try:
+                    raw = input(f"  Choice [1-{cancel_idx}]: ").strip()
+                except (KeyboardInterrupt, EOFError):
+                    print()
+                    return
+                try:
+                    pick = int(raw)
+                except ValueError:
+                    pick = 0
+                if 1 <= pick <= len(cc_accounts):
+                    selected_account = cc_accounts[pick - 1]
+                elif pick == extra_idx:
+                    # Fall through to the normal auth prompt below.
+                    pass
+                else:
+                    print("  Cancelled.")
+                    return
+
+            if selected_account is not None:
+                try:
+                    _CLAUDE_ACCOUNT_SOURCE_FILE.parent.mkdir(parents=True, exist_ok=True)
+                    _CLAUDE_ACCOUNT_SOURCE_FILE.write_text(
+                        selected_account.source, encoding="utf-8"
+                    )
+                except OSError as exc:
+                    logger.debug("Failed to persist selected account: %s", exc)
+                use_anthropic_claude_code_credentials(save_fn=save_env_value)
+                print(f"  ✓ Using {selected_account.label}.")
+                print()
+                # Skip auth — proceed straight to model selection.
+                model_list = _PROVIDER_MODELS.get("anthropic", [])
+                if model_list:
+                    selected = _prompt_model_selection(
+                        model_list, current_model=current_model
+                    )
+                else:
+                    try:
+                        selected = input(
+                            "Model name (e.g., claude-sonnet-4-20250514): "
+                        ).strip()
+                    except (KeyboardInterrupt, EOFError):
+                        selected = None
+
+                if selected:
+                    _save_model_choice(selected)
+                    cfg = load_config()
+                    model = cfg.get("model")
+                    if not isinstance(model, dict):
+                        model = {"default": model} if model else {}
+                        cfg["model"] = model
+                    model["provider"] = "anthropic"
+                    model.pop("base_url", None)
+                    save_config(cfg)
+                    deactivate_provider()
+                    print(f"Default model set to: {selected} (via Anthropic)")
+                else:
+                    print("No change.")
+                return
 
     has_creds = bool(existing_key) or cc_available
     needs_auth = not has_creds
@@ -6862,7 +7100,7 @@ For more help on a command:
     )
     login_parser.add_argument(
         "--provider",
-        choices=["nous", "openai-codex"],
+        choices=["nous", "openai-codex", "anthropic"],
         default=None,
         help="Provider to authenticate with (default: nous)",
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1526,18 +1526,22 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     return list(_PROVIDER_MODELS.get(normalized, []))
 
 
-def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:
+def _fetch_anthropic_models(
+    api_key: Optional[str] = None,
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
     """Fetch available models from the Anthropic /v1/models endpoint.
 
-    Uses resolve_anthropic_token() to find credentials (env vars or
-    Claude Code auto-discovery).  Returns sorted model IDs or None.
+    Uses the explicitly provided *api_key* when present; otherwise falls back
+    to ``resolve_anthropic_token()`` (env vars, Hermes PKCE creds, Claude Code
+    auto-discovery).  Returns sorted model IDs or None.
     """
     try:
         from agent.anthropic_adapter import resolve_anthropic_token, _is_oauth_token
     except ImportError:
         return None
 
-    token = resolve_anthropic_token()
+    token = (api_key or "").strip() or resolve_anthropic_token()
     if not token:
         return None
 
@@ -2344,8 +2348,18 @@ def validate_requested_model(
                 ),
             }
 
-    # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    # Probe the live API to check if the model actually exists.
+    # Anthropic's native ``/v1/models`` endpoint is NOT OpenAI-compatible:
+    # it needs ``anthropic-version`` and uses ``x-api-key`` for regular API
+    # keys, while OAuth/setup tokens use Bearer auth.  The gateway /model path
+    # passes Anthropic credentials/base_url into this validator, so routing the
+    # request through the generic ``fetch_api_models()`` probe incorrectly
+    # treats Anthropic as an OpenAI-compatible endpoint and reports valid
+    # Claude models as unreachable.  Use the provider-specific fetcher.
+    if normalized == "anthropic":
+        api_models = _fetch_anthropic_models(api_key=api_key)
+    else:
+        api_models = fetch_api_models(api_key, base_url)
 
     if api_models is not None:
         if requested_for_lookup in set(api_models):
@@ -2388,8 +2402,41 @@ def validate_requested_model(
             ),
         }
 
-    # api_models is None — couldn't reach API.  Accept and persist,
-    # but warn so typos don't silently break things.
+    # api_models is None — couldn't reach API.
+
+    if normalized == "anthropic":
+        # Anthropic's /model inline switch is often used with Claude Max / Pro
+        # OAuth tokens.  If the live catalog probe is temporarily unavailable,
+        # still allow exact matches from Hermes's built-in Anthropic catalog so
+        # known-good models like ``claude-opus-4-7`` continue to switch.
+        known_models = list(_PROVIDER_MODELS.get("anthropic", []))
+        known_set = set(known_models)
+        if requested_for_lookup in known_set:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": (
+                    f"Could not reach the Anthropic API to validate `{requested}`, "
+                    f"but Hermes recognizes it as a known Anthropic model."
+                ),
+            }
+
+        suggestions = get_close_matches(requested, known_models, n=3, cutoff=0.5)
+        suggestion_text = ""
+        if suggestions:
+            suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+
+        return {
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
+            "message": (
+                f"Could not reach the Anthropic API to validate `{requested}`. "
+                f"If the service isn't down, this model may not be valid."
+                f"{suggestion_text}"
+            ),
+        }
 
     # Bedrock: use our own discovery instead of HTTP /models endpoint.
     # Bedrock's bedrock-runtime URL doesn't support /models — it uses the

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -79,6 +79,33 @@ def _effective_provider_label() -> str:
     return provider_label(effective)
 
 
+def _service_tier_mode(config: dict) -> str | None:
+    raw = str(config.get("agent", {}).get("service_tier", "") or "").strip().lower()
+    if not raw or raw in {"normal", "default", "standard", "off", "none"}:
+        return None
+    if raw in {"fast", "priority", "on"}:
+        return "fast"
+    return None
+
+
+def _fast_mode_status_line(config: dict) -> str | None:
+    from hermes_cli.models import _is_anthropic_fast_model, model_supports_fast_mode
+
+    model = _configured_model_label(config)
+    if not model or model == "(not set)":
+        return None
+
+    mode = _service_tier_mode(config)
+    if not model_supports_fast_mode(model):
+        if mode == "fast":
+            return "Fast Mode:    configured as fast, but current model does not support it"
+        return None
+
+    feature_name = "Anthropic Fast Mode" if _is_anthropic_fast_model(model) else "Priority Processing"
+    current = "fast" if mode == "fast" else "normal"
+    return f"Fast Mode:    {current} ({feature_name})"
+
+
 from hermes_constants import is_termux as _is_termux
 
 
@@ -110,6 +137,9 @@ def show_status(args):
 
     print(f"  Model:        {_configured_model_label(config)}")
     print(f"  Provider:     {_effective_provider_label()}")
+    fast_mode_line = _fast_mode_status_line(config)
+    if fast_mode_line:
+        print(f"  {fast_mode_line}")
     
     # =========================================================================
     # API Keys

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -298,8 +298,8 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     },
     "agent.service_tier": {
         "type": "select",
-        "description": "API service tier (OpenAI/Anthropic)",
-        "options": ["", "auto", "default", "flex"],
+        "description": "Fast mode preference (normal/fast) for OpenAI Priority Processing or Anthropic Fast Mode",
+        "options": ["", "normal", "fast"],
     },
     "delegation.reasoning_effort": {
         "type": "select",

--- a/model_tools.py
+++ b/model_tools.py
@@ -177,6 +177,7 @@ _LEGACY_TOOLSET_MAP = {
         "browser_vision", "browser_console"
     ],
     "cronjob_tools": ["cronjob"],
+    "computer_tools": ["computer"],
     "rl_tools": [
         "rl_list_environments", "rl_select_environment",
         "rl_get_current_config", "rl_edit_config",

--- a/run_agent.py
+++ b/run_agent.py
@@ -10851,9 +10851,16 @@ class AIAgent:
                     )
                     finish_reason = _cnr.finish_reason
                 elif self.api_mode == "anthropic_messages":
+                    from agent.anthropic_adapter import build_mcp_tool_name_map
+                    _tool_name_map = (
+                        build_mcp_tool_name_map(self.tools)
+                        if self._is_anthropic_oauth else None
+                    )
                     _transport = self._get_anthropic_transport()
                     _nr = _transport.normalize_response(
-                        response, strip_tool_prefix=self._is_anthropic_oauth
+                        response,
+                        strip_tool_prefix=self._is_anthropic_oauth,
+                        tool_name_map=_tool_name_map,
                     )
                     # Back-compat shim: downstream code expects SimpleNamespace with
                     # .content, .tool_calls, .reasoning, .reasoning_content,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -132,7 +132,11 @@ class TestReadClaudeCodeCredentials:
         assert creds is not None
         assert creds["accessToken"] == "sk-ant-oat01-token"
         assert creds["refreshToken"] == "sk-ant-oat01-refresh"
-        assert creds["source"] == "claude_code_credentials_file"
+        # After the Keychain-aware refactor, file-backed creds report
+        # source="file" (was "claude_code_credentials_file").  The new
+        # value matches claude_keychain.SOURCE_FILE and is what
+        # write_credentials() routes on.
+        assert creds["source"] == "file"
 
     def test_ignores_primary_api_key_for_native_anthropic_resolution(self, tmp_path, monkeypatch):
         claude_json = tmp_path / ".claude.json"

--- a/tests/agent/test_anthropic_adapter_oauth.py
+++ b/tests/agent/test_anthropic_adapter_oauth.py
@@ -1,0 +1,447 @@
+"""OAuth-specific adapter tests for agent/anthropic_adapter.py.
+
+These complement ``tests/agent/test_anthropic_adapter.py`` — this file only
+covers OAuth transforms (billing/identity system blocks, tool name PascalCase
+prefixing, per-request headers, 1M context env gate).  Cases already covered
+by ``test_anthropic_adapter.py`` (auth detection, model normalization,
+``_to_plain_data``, conversion of plain message/tool formats, etc.) are NOT
+duplicated here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from agent.anthropic_adapter import (
+    _is_long_context_1m_enabled,
+    _mcp_prefix_tool_name,
+    _oauth_betas_for_model,
+    _snake_to_pascal,
+    _unmcp_prefix_tool_name,
+    build_anthropic_kwargs,
+    build_mcp_tool_name_map,
+    normalize_anthropic_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Snake / Pascal / MCP prefix helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSnakeToPascal:
+    def test_snake_case(self):
+        assert _snake_to_pascal("read_file") == "ReadFile"
+
+    def test_camel_case_is_title_cased(self):
+        assert _snake_to_pascal("readFile") == "ReadFile"
+
+    def test_kebab_case(self):
+        assert _snake_to_pascal("read-file") == "ReadFile"
+
+    def test_pascal_case_is_idempotent(self):
+        assert _snake_to_pascal("ReadFile") == "ReadFile"
+
+    def test_empty_string(self):
+        assert _snake_to_pascal("") == ""
+
+    def test_multi_part_snake(self):
+        assert _snake_to_pascal("read_file_contents") == "ReadFileContents"
+
+
+class TestMcpPrefix:
+    def test_prefixes_snake_case(self):
+        assert _mcp_prefix_tool_name("read_file") == "mcp_ReadFile"
+
+    def test_idempotent_when_already_prefixed(self):
+        assert _mcp_prefix_tool_name("mcp_already") == "mcp_already"
+
+    def test_empty_string_passes_through(self):
+        assert _mcp_prefix_tool_name("") == ""
+
+
+class TestUnmcpPrefix:
+    def test_without_map_strips_prefix_only(self):
+        # PascalCase step is lossy — without the map the dispatcher gets the
+        # PascalCase form.
+        assert _unmcp_prefix_tool_name("mcp_ReadFile") == "ReadFile"
+
+    def test_map_wins_over_pascal_stripping(self):
+        result = _unmcp_prefix_tool_name(
+            "mcp_ReadFile", {"mcp_ReadFile": "read_file"}
+        )
+        assert result == "read_file"
+
+    def test_non_prefixed_name_passes_through(self):
+        assert _unmcp_prefix_tool_name("plain_name") == "plain_name"
+
+
+class TestBuildMcpToolNameMap:
+    def test_top_level_name(self):
+        assert build_mcp_tool_name_map([{"name": "x"}]) == {"mcp_X": "x"}
+
+    def test_nested_function_name(self):
+        assert build_mcp_tool_name_map(
+            [{"function": {"name": "y"}}]
+        ) == {"mcp_Y": "y"}
+
+    def test_mixed_list(self):
+        tools = [
+            {"name": "a"},
+            {"function": {"name": "b_tool"}},
+        ]
+        assert build_mcp_tool_name_map(tools) == {
+            "mcp_A": "a",
+            "mcp_BTool": "b_tool",
+        }
+
+    def test_none_returns_empty_dict(self):
+        assert build_mcp_tool_name_map(None) == {}
+
+    def test_empty_list_returns_empty_dict(self):
+        assert build_mcp_tool_name_map([]) == {}
+
+    def test_skips_tools_without_a_name(self):
+        assert build_mcp_tool_name_map([{"foo": "bar"}]) == {}
+
+
+# ---------------------------------------------------------------------------
+# _oauth_betas_for_model
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthBetasForModel:
+    def test_opus_4_7_includes_expected_betas(self):
+        betas = _oauth_betas_for_model("claude-opus-4-7-20250101")
+        for required in (
+            "effort-2025-11-24",
+            "claude-code-20250219",
+            "oauth-2025-04-20",
+            "prompt-caching-scope-2026-01-05",
+            "context-management-2025-06-27",
+        ):
+            assert required in betas, f"missing {required} in {betas}"
+
+    def test_haiku_excludes_interleaved_thinking(self):
+        # Haiku rejects interleaved-thinking; the function must drop it even
+        # though it's not in the OAuth-only base list (defense in depth).
+        betas = _oauth_betas_for_model("claude-haiku-4-5")
+        assert "interleaved-thinking-2025-05-14" not in betas
+
+    def test_opus_4_6_includes_1m_context_when_enabled(self):
+        betas = _oauth_betas_for_model(
+            "claude-opus-4-6", enable_1m_context=True
+        )
+        assert "context-1m-2025-08-07" in betas
+
+    def test_opus_4_6_omits_1m_context_by_default(self):
+        betas = _oauth_betas_for_model("claude-opus-4-6")
+        assert "context-1m-2025-08-07" not in betas
+
+    def test_haiku_never_gets_1m_context(self):
+        # 1M context is Opus/Sonnet 4.6+ only — Haiku doesn't qualify.
+        betas = _oauth_betas_for_model(
+            "claude-haiku-4-5", enable_1m_context=True
+        )
+        assert "context-1m-2025-08-07" not in betas
+
+    def test_exclude_removes_specific_beta(self):
+        betas = _oauth_betas_for_model(
+            "claude-opus-4-7", exclude={"effort-2025-11-24"}
+        )
+        assert "effort-2025-11-24" not in betas
+        # Other OAuth-only betas should still be present.
+        assert "oauth-2025-04-20" in betas
+
+
+# ---------------------------------------------------------------------------
+# _is_long_context_1m_enabled — env gate
+# ---------------------------------------------------------------------------
+
+
+class TestIsLongContext1mEnabled:
+    def test_env_1_enables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ANTHROPIC_1M_CONTEXT", "1")
+        assert _is_long_context_1m_enabled() is True
+
+    def test_env_true_enables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ANTHROPIC_1M_CONTEXT", "true")
+        assert _is_long_context_1m_enabled() is True
+
+    def test_env_0_disables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ANTHROPIC_1M_CONTEXT", "0")
+        assert _is_long_context_1m_enabled() is False
+
+    def test_env_false_disables(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ANTHROPIC_1M_CONTEXT", "false")
+        assert _is_long_context_1m_enabled() is False
+
+    def test_unset_env_returns_false_absent_config(self, monkeypatch):
+        # The autouse test fixtures already isolate HERMES_HOME so
+        # load_config() falls through to the default (which has no
+        # anthropic.enable_1m_context set).
+        monkeypatch.delenv("HERMES_ANTHROPIC_1M_CONTEXT", raising=False)
+        assert _is_long_context_1m_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# build_anthropic_kwargs — OAuth behavioural tests
+# ---------------------------------------------------------------------------
+
+
+def _minimal_oauth_kwargs(model: str = "claude-opus-4-7", **overrides):
+    """Helper: call build_anthropic_kwargs with OAuth defaults."""
+    base = dict(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=4096,
+        reasoning_config=None,
+        is_oauth=True,
+    )
+    base.update(overrides)
+    return build_anthropic_kwargs(**base)
+
+
+class TestBuildAnthropicKwargsOAuthSystem:
+    def test_billing_block_is_system_index_0(self):
+        kwargs = _minimal_oauth_kwargs()
+        assert isinstance(kwargs["system"], list)
+        assert kwargs["system"][0]["text"].startswith(
+            "x-anthropic-billing-header:"
+        )
+
+    def test_identity_block_is_system_index_1(self):
+        kwargs = _minimal_oauth_kwargs()
+        assert (
+            kwargs["system"][1]["text"]
+            == "You are Claude Code, Anthropic's official CLI for Claude."
+        )
+
+    def test_system_list_has_exactly_two_entries(self):
+        kwargs = _minimal_oauth_kwargs()
+        assert len(kwargs["system"]) == 2
+
+    def test_third_party_system_is_relocated_into_first_user_message(self):
+        # Pre-existing system prose must move into the first user message.
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+
+        # (a) system stays at 2 entries (billing + identity only).
+        assert len(kwargs["system"]) == 2
+        assert kwargs["system"][0]["text"].startswith("x-anthropic-billing-header:")
+        assert kwargs["system"][1]["text"].startswith("You are Claude Code")
+
+        # (b) Third-party prose was prepended to the first user message.
+        first_user = next(
+            m for m in kwargs["messages"] if m["role"] == "user"
+        )
+        content = first_user["content"]
+        if isinstance(content, str):
+            assert "You are a helpful assistant." in content
+            assert content.startswith("You are a helpful assistant.")
+        else:
+            # Content is a list of blocks.
+            joined = "".join(
+                b.get("text", "") for b in content if isinstance(b, dict)
+            )
+            assert "You are a helpful assistant." in joined
+
+
+class TestBuildAnthropicKwargsOAuthTools:
+    def test_tool_names_are_pascal_mcp_prefixed(self):
+        kwargs = _minimal_oauth_kwargs(
+            tools=[
+                {
+                    "function": {
+                        "name": "read_file",
+                        "description": "x",
+                        "parameters": {},
+                    }
+                }
+            ],
+        )
+        tools = kwargs["tools"]
+        assert len(tools) == 1
+        assert tools[0]["name"] == "mcp_ReadFile"
+
+    def test_historical_tool_use_blocks_are_renamed(self):
+        # An earlier assistant tool_use block with the pre-transform name
+        # must be rewritten so the model sees consistent names across turns.
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "t1",
+                            "name": "read_file",
+                            "input": {},
+                        }
+                    ],
+                },
+                # Matching tool_result so the orphan-stripping pass doesn't
+                # remove the tool_use before we can inspect it.
+                {"role": "tool", "tool_call_id": "t1", "content": "result"},
+            ],
+            tools=[
+                {
+                    "function": {
+                        "name": "read_file",
+                        "description": "x",
+                        "parameters": {},
+                    }
+                }
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+
+        assistant = next(
+            m for m in kwargs["messages"] if m["role"] == "assistant"
+        )
+        tool_use_blocks = [
+            b for b in assistant["content"] if b.get("type") == "tool_use"
+        ]
+        assert len(tool_use_blocks) == 1
+        assert tool_use_blocks[0]["name"] == "mcp_ReadFile"
+
+
+class TestBuildAnthropicKwargsOAuthExtraHeaders:
+    def test_x_client_request_id_is_a_uuid(self):
+        kwargs = _minimal_oauth_kwargs()
+        req_id = kwargs["extra_headers"]["x-client-request-id"]
+        assert isinstance(req_id, str)
+        # Raises ValueError on invalid UUID — test fails fast.
+        uuid.UUID(req_id)
+
+    def test_anthropic_beta_includes_effort_for_opus_4_7(self):
+        kwargs = _minimal_oauth_kwargs(model="claude-opus-4-7")
+        beta = kwargs["extra_headers"]["anthropic-beta"]
+        assert "effort-2025-11-24" in beta
+
+    def test_anthropic_beta_includes_effort_for_opus_4_6(self):
+        kwargs = _minimal_oauth_kwargs(model="claude-opus-4-6")
+        beta = kwargs["extra_headers"]["anthropic-beta"]
+        assert "effort-2025-11-24" in beta
+
+    def test_anthropic_beta_includes_oauth_only_betas(self):
+        kwargs = _minimal_oauth_kwargs()
+        beta = kwargs["extra_headers"]["anthropic-beta"]
+        for required in (
+            "oauth-2025-04-20",
+            "claude-code-20250219",
+            "prompt-caching-scope-2026-01-05",
+            "context-management-2025-06-27",
+        ):
+            assert required in beta
+
+
+class TestBuildAnthropicKwargsNonOAuth:
+    def test_is_oauth_false_does_not_inject_billing_block(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=False,
+        )
+        system = kwargs.get("system")
+        # system can be string or list; in either case the billing prefix
+        # must NOT appear.
+        if isinstance(system, list):
+            for block in system:
+                text = block.get("text", "") if isinstance(block, dict) else ""
+                assert not text.startswith("x-anthropic-billing-header:")
+                assert not text.startswith(
+                    "You are Claude Code, Anthropic's official CLI"
+                )
+        else:
+            assert isinstance(system, (str, type(None)))
+            if system:
+                assert not system.startswith("x-anthropic-billing-header:")
+
+    def test_is_oauth_false_does_not_mcp_prefix_tools(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "function": {
+                        "name": "read_file",
+                        "description": "x",
+                        "parameters": {},
+                    }
+                }
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=False,
+        )
+        assert kwargs["tools"][0]["name"] == "read_file"
+
+
+# ---------------------------------------------------------------------------
+# normalize_anthropic_response — strip_tool_prefix path
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAnthropicResponseStripPrefix:
+    def _fake_response(self, *, name: str, stop_reason: str = "tool_use"):
+        return SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="t1",
+                    name=name,
+                    input={"path": "/tmp"},
+                )
+            ],
+            stop_reason=stop_reason,
+        )
+
+    def test_map_recovers_original_snake_case_name(self):
+        response = self._fake_response(name="mcp_ReadFile")
+        msg, finish = normalize_anthropic_response(
+            response,
+            strip_tool_prefix=True,
+            tool_name_map={"mcp_ReadFile": "read_file"},
+        )
+        assert msg.tool_calls is not None
+        assert msg.tool_calls[0].function.name == "read_file"
+        assert finish == "tool_calls"
+
+    def test_strip_without_map_falls_back_to_pascal(self):
+        response = self._fake_response(name="mcp_ReadFile")
+        msg, _ = normalize_anthropic_response(
+            response, strip_tool_prefix=True, tool_name_map=None
+        )
+        # Without the map the PascalCase step is lossy — dispatcher accepts
+        # either form, but the function returns the stripped PascalCase name.
+        assert msg.tool_calls[0].function.name == "ReadFile"
+
+    def test_no_strip_leaves_name_intact(self):
+        response = self._fake_response(name="mcp_ReadFile")
+        msg, _ = normalize_anthropic_response(
+            response, strip_tool_prefix=False
+        )
+        assert msg.tool_calls[0].function.name == "mcp_ReadFile"

--- a/tests/agent/test_anthropic_signing.py
+++ b/tests/agent/test_anthropic_signing.py
@@ -1,0 +1,276 @@
+"""Tests for agent/anthropic_signing.py — Claude Code billing-header signing."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+
+import pytest
+
+from agent.anthropic_signing import (
+    build_billing_header_value,
+    compute_cch,
+    compute_version_suffix,
+    extract_first_user_message_text,
+    get_session_id,
+    is_billing_header_text,
+    new_request_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_cch
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCch:
+    def test_empty_string_returns_known_sha256_prefix(self):
+        # Empty input — first 5 hex chars of SHA-256("") == "e3b0c".
+        # Reference: sha256(b"").hexdigest()[:5]
+        result = compute_cch("")
+        assert result == "e3b0c"
+        # Double-check vs the stdlib, not just the constant.
+        assert result == hashlib.sha256(b"").hexdigest()[:5]
+
+    def test_hello_world_returns_known_sha256_prefix(self):
+        result = compute_cch("hello world")
+        assert result == "b94d2"
+        assert result == hashlib.sha256(b"hello world").hexdigest()[:5]
+
+    def test_returns_5_char_hex_string(self):
+        result = compute_cch("some random input 123")
+        assert isinstance(result, str)
+        assert len(result) == 5
+        assert re.fullmatch(r"[0-9a-f]{5}", result)
+
+    def test_unicode_is_utf8_encoded(self):
+        text = "héllo"
+        result = compute_cch(text)
+        assert result == hashlib.sha256(text.encode("utf-8")).hexdigest()[:5]
+
+
+# ---------------------------------------------------------------------------
+# compute_version_suffix
+# ---------------------------------------------------------------------------
+
+
+# Billing salt is a protocol constant from Claude Code's bundle; replicated
+# here so the tests assert against an independently computed expected value
+# rather than trusting the module constant.
+_EXPECTED_BILLING_SALT = "59cf53e54c78"
+
+
+class TestComputeVersionSuffix:
+    def test_empty_message_pads_sampled_chars_with_zeros(self):
+        # When the message is empty, indices 4/7/20 all fall past end, so
+        # sampled_chars = "000" and the hash material is
+        #   salt + "000" + version
+        version = "2.1.114"
+        expected = hashlib.sha256(
+            (_EXPECTED_BILLING_SALT + "000" + version).encode("utf-8")
+        ).hexdigest()[:3]
+        assert compute_version_suffix("", version) == expected
+
+    def test_sampled_indices_are_4_7_and_20(self):
+        # "abcdefghijklmnopqrstuvwxyz" — indices 4/7/20 = 'e', 'h', 'u'.
+        # Material:  salt + "ehu" + "2.1.114"
+        text = "abcdefghijklmnopqrstuvwxyz"
+        version = "2.1.114"
+        expected = hashlib.sha256(
+            (_EXPECTED_BILLING_SALT + "ehu" + version).encode("utf-8")
+        ).hexdigest()[:3]
+        assert compute_version_suffix(text, version) == expected
+
+    def test_returns_3_char_hex_string(self):
+        result = compute_version_suffix("anything", "2.1.114")
+        assert isinstance(result, str)
+        assert len(result) == 3
+        assert re.fullmatch(r"[0-9a-f]{3}", result)
+
+    def test_partial_length_pads_missing_indices(self):
+        # "abcde" — indices 4='e', 7=OOB→'0', 20=OOB→'0'.  So sampled="e00".
+        text = "abcde"
+        version = "2.1.114"
+        expected = hashlib.sha256(
+            (_EXPECTED_BILLING_SALT + "e00" + version).encode("utf-8")
+        ).hexdigest()[:3]
+        assert compute_version_suffix(text, version) == expected
+
+
+# ---------------------------------------------------------------------------
+# extract_first_user_message_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFirstUserMessageText:
+    def test_empty_list(self):
+        assert extract_first_user_message_text([]) == ""
+
+    def test_string_content(self):
+        assert extract_first_user_message_text(
+            [{"role": "user", "content": "hi"}]
+        ) == "hi"
+
+    def test_list_content_concatenates_text_blocks_in_order(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        ]
+        assert extract_first_user_message_text(msgs) == "ab"
+
+    def test_skips_assistant_messages_to_find_first_user(self):
+        msgs = [
+            {"role": "assistant", "content": "x"},
+            {"role": "user", "content": "y"},
+        ]
+        assert extract_first_user_message_text(msgs) == "y"
+
+    def test_tool_result_text_is_not_included(self):
+        # Only ``{"type": "text"}`` blocks contribute — tool_result blocks
+        # must be skipped (Claude Code's behaviour).
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "content": "nope"},
+                    {"type": "text", "text": "keep"},
+                ],
+            }
+        ]
+        assert extract_first_user_message_text(msgs) == "keep"
+
+    def test_handles_mapping_like_object_via_dict_coercion(self):
+        # Anthropic SDK returns pydantic-ish objects; the signer coerces them
+        # via ``dict(msg)`` when ``isinstance(..., dict)`` is False.  A simple
+        # Mapping subclass is enough to exercise that path.
+
+        class MsgMapping(dict):
+            """Dict subclass passes the isinstance(dict) check directly."""
+
+        msg = MsgMapping({"role": "user", "content": "hello"})
+        assert extract_first_user_message_text([msg]) == "hello"
+
+    def test_unknown_content_shape_returns_empty_string(self):
+        msgs = [{"role": "user", "content": 123}]
+        assert extract_first_user_message_text(msgs) == ""
+
+    def test_list_content_with_non_text_blocks_only(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "source": {}},
+                ],
+            }
+        ]
+        assert extract_first_user_message_text(msgs) == ""
+
+
+# ---------------------------------------------------------------------------
+# build_billing_header_value
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBillingHeaderValue:
+    HEADER_PATTERN = re.compile(
+        r"^x-anthropic-billing-header: "
+        r"cc_version=2\.1\.114\.[0-9a-f]{3}; "
+        r"cc_entrypoint=cli; "
+        r"cch=[0-9a-f]{5};$"
+    )
+
+    def test_matches_exact_pattern(self):
+        value = build_billing_header_value(
+            [{"role": "user", "content": "hi"}],
+            "2.1.114",
+            entrypoint="cli",
+        )
+        assert self.HEADER_PATTERN.match(value), f"Header mismatch: {value!r}"
+
+    def test_matches_pattern_for_empty_messages(self):
+        # Empty user list → cch = e3b0c (empty-string SHA-256 prefix).
+        value = build_billing_header_value([], "2.1.114", entrypoint="cli")
+        assert self.HEADER_PATTERN.match(value), f"Header mismatch: {value!r}"
+        assert "cch=e3b0c;" in value
+
+    def test_matches_pattern_for_list_content(self):
+        value = build_billing_header_value(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hello"},
+                        {"type": "text", "text": " world"},
+                    ],
+                }
+            ],
+            "2.1.114",
+            entrypoint="cli",
+        )
+        assert self.HEADER_PATTERN.match(value), f"Header mismatch: {value!r}"
+        assert f"cch={compute_cch('hello world')};" in value
+
+    def test_uses_provided_entrypoint(self):
+        value = build_billing_header_value(
+            [{"role": "user", "content": "x"}],
+            "2.1.114",
+            entrypoint="cli",
+        )
+        assert "cc_entrypoint=cli;" in value
+
+
+# ---------------------------------------------------------------------------
+# Session / request IDs
+# ---------------------------------------------------------------------------
+
+
+class TestSessionAndRequestIds:
+    def test_get_session_id_is_stable_within_process(self):
+        a = get_session_id()
+        b = get_session_id()
+        assert a == b
+
+    def test_get_session_id_is_valid_uuid(self):
+        # Just try parsing — raises ValueError on bad input.
+        uuid.UUID(get_session_id())
+
+    def test_new_request_id_returns_distinct_values(self):
+        ids = {new_request_id() for _ in range(10)}
+        assert len(ids) == 10
+
+    def test_new_request_id_returns_valid_uuid(self):
+        for _ in range(5):
+            uuid.UUID(new_request_id())
+
+
+# ---------------------------------------------------------------------------
+# is_billing_header_text
+# ---------------------------------------------------------------------------
+
+
+class TestIsBillingHeaderText:
+    def test_recognises_real_billing_header(self):
+        value = build_billing_header_value(
+            [{"role": "user", "content": "hi"}],
+            "2.1.114",
+            entrypoint="cli",
+        )
+        assert is_billing_header_text(value) is True
+
+    def test_recognises_bare_prefix(self):
+        assert is_billing_header_text("x-anthropic-billing-header: foo") is True
+
+    def test_rejects_unrelated_string(self):
+        assert is_billing_header_text("You are Claude Code") is False
+
+    def test_rejects_none(self):
+        assert is_billing_header_text(None) is False
+
+    def test_rejects_non_string(self):
+        assert is_billing_header_text(12345) is False

--- a/tests/agent/test_claude_keychain.py
+++ b/tests/agent/test_claude_keychain.py
@@ -1,0 +1,478 @@
+"""Tests for agent/claude_keychain.py — Claude Code credential discovery.
+
+Parsing and label tests are platform-agnostic. Tests that depend on
+``/usr/bin/security`` behaviour are gated behind ``platform.system() == 'Darwin'``
+and still mock subprocess so they never actually shell out.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import claude_keychain
+from agent.claude_keychain import (
+    ClaudeAccount,
+    ClaudeCredentials,
+    SOURCE_FILE,
+    SOURCE_KEYCHAIN_PREFIX,
+    _ACCT_ATTR_RE,
+    _SERVICE_ATTR_RE,
+    _build_labels,
+    _label_for_subscription,
+    _parse_credentials_blob,
+    read_all_accounts,
+    read_selected_account,
+    write_credentials,
+)
+
+_IS_DARWIN = platform.system() == "Darwin"
+
+
+# ---------------------------------------------------------------------------
+# _parse_credentials_blob
+# ---------------------------------------------------------------------------
+
+
+class TestParseCredentialsBlob:
+    def test_wrapped_shape(self):
+        raw = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "a",
+                "refreshToken": "r",
+                "expiresAt": 100,
+            }
+        })
+        creds = _parse_credentials_blob(raw)
+        assert creds is not None
+        assert creds.access_token == "a"
+        assert creds.refresh_token == "r"
+        assert creds.expires_at == 100
+        assert creds.scopes is None
+        assert creds.subscription_type is None
+
+    def test_flat_shape(self):
+        raw = json.dumps({
+            "accessToken": "a",
+            "refreshToken": "r",
+            "expiresAt": 100,
+        })
+        creds = _parse_credentials_blob(raw)
+        assert creds is not None
+        assert creds.access_token == "a"
+        assert creds.refresh_token == "r"
+        assert creds.expires_at == 100
+
+    def test_missing_refresh_token_returns_none(self):
+        raw = json.dumps({"accessToken": "a"})
+        assert _parse_credentials_blob(raw) is None
+
+    def test_missing_access_token_returns_none(self):
+        raw = json.dumps({"refreshToken": "r", "expiresAt": 1})
+        assert _parse_credentials_blob(raw) is None
+
+    def test_mcp_only_entry_returns_none(self):
+        # mcpOAuth without a claudeAiOauth/accessToken is an MCP-server
+        # credential, not a user credential.
+        raw = json.dumps({"mcpOAuth": {"foo": "bar"}})
+        assert _parse_credentials_blob(raw) is None
+
+    def test_preserves_scopes_list(self):
+        raw = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "a",
+                "refreshToken": "r",
+                "expiresAt": 100,
+                "scopes": ["user:inference", "user:profile"],
+            }
+        })
+        creds = _parse_credentials_blob(raw)
+        assert creds is not None
+        assert creds.scopes == ["user:inference", "user:profile"]
+
+    def test_string_expires_at_is_coerced_to_int(self):
+        raw = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "a",
+                "refreshToken": "r",
+                "expiresAt": "1234",
+            }
+        })
+        creds = _parse_credentials_blob(raw)
+        assert creds is not None
+        assert creds.expires_at == 1234
+        assert isinstance(creds.expires_at, int)
+
+    def test_invalid_json_returns_none(self):
+        assert _parse_credentials_blob("{not json") is None
+        assert _parse_credentials_blob("") is None
+
+    def test_non_dict_json_returns_none(self):
+        assert _parse_credentials_blob(json.dumps([1, 2, 3])) is None
+        assert _parse_credentials_blob(json.dumps("string")) is None
+
+    def test_subscription_type_preserved(self):
+        raw = json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "a",
+                "refreshToken": "r",
+                "expiresAt": 100,
+                "subscriptionType": "max",
+            }
+        })
+        creds = _parse_credentials_blob(raw)
+        assert creds is not None
+        assert creds.subscription_type == "max"
+
+
+# ---------------------------------------------------------------------------
+# Labels
+# ---------------------------------------------------------------------------
+
+
+class TestLabelForSubscription:
+    def test_pro(self):
+        assert _label_for_subscription("pro") == "Claude Pro"
+
+    def test_max(self):
+        assert _label_for_subscription("max") == "Claude Max"
+
+    def test_max5x(self):
+        assert _label_for_subscription("max5x") == "Claude Max"
+
+    def test_max20x(self):
+        assert _label_for_subscription("max20x") == "Claude Max"
+
+    def test_none_returns_bare_claude(self):
+        assert _label_for_subscription(None) == "Claude"
+
+    def test_empty_string_returns_bare_claude(self):
+        assert _label_for_subscription("") == "Claude"
+
+    def test_custom_subscription_formats_title(self):
+        assert _label_for_subscription("custom") == "Claude custom"
+
+    def test_mixed_case_pro_is_normalized(self):
+        # Implementation lowercases before matching.
+        assert _label_for_subscription("PRO") == "Claude Pro"
+
+
+def _mk_account(label: str, source: str = "file") -> ClaudeAccount:
+    creds = ClaudeCredentials(access_token="a", refresh_token="r", expires_at=0)
+    return ClaudeAccount(label=label, source=source, credentials=creds)
+
+
+class TestBuildLabels:
+    def test_single_account_label_unchanged(self):
+        accts = [_mk_account("Claude Pro")]
+        _build_labels(accts)
+        assert accts[0].label == "Claude Pro"
+
+    def test_duplicates_get_numeric_suffix(self):
+        accts = [
+            _mk_account("Claude Max", source="keychain:a"),
+            _mk_account("Claude Max", source="keychain:b"),
+            _mk_account("Claude Pro", source="keychain:c"),
+        ]
+        _build_labels(accts)
+        labels = [a.label for a in accts]
+        assert labels == ["Claude Max 1", "Claude Max 2", "Claude Pro"]
+
+    def test_mixed_duplicates(self):
+        accts = [
+            _mk_account("Claude Pro"),
+            _mk_account("Claude Max"),
+            _mk_account("Claude Pro"),
+            _mk_account("Claude Max"),
+        ]
+        _build_labels(accts)
+        assert [a.label for a in accts] == [
+            "Claude Pro 1",
+            "Claude Max 1",
+            "Claude Pro 2",
+            "Claude Max 2",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# write_credentials — file branch (platform-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCredentialsFile:
+    def test_writes_expected_json_to_file_source(self, tmp_path, monkeypatch):
+        target = tmp_path / ".credentials.json"
+        monkeypatch.setattr(claude_keychain, "_FILE_PATH", target)
+
+        creds = ClaudeCredentials(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            expires_at=12345,
+        )
+        ok = write_credentials(SOURCE_FILE, creds, raw_blob={})
+        assert ok is True
+        assert target.exists()
+
+        data = json.loads(target.read_text(encoding="utf-8"))
+        oauth = data["claudeAiOauth"]
+        assert oauth["accessToken"] == "new-access"
+        assert oauth["refreshToken"] == "new-refresh"
+        assert oauth["expiresAt"] == 12345
+
+    def test_preserves_scopes_when_provided(self, tmp_path, monkeypatch):
+        target = tmp_path / ".credentials.json"
+        monkeypatch.setattr(claude_keychain, "_FILE_PATH", target)
+
+        creds = ClaudeCredentials(
+            access_token="a",
+            refresh_token="r",
+            expires_at=1,
+            scopes=["user:inference", "user:profile"],
+        )
+        write_credentials(SOURCE_FILE, creds, raw_blob={})
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data["claudeAiOauth"]["scopes"] == [
+            "user:inference",
+            "user:profile",
+        ]
+
+    def test_preserves_subscription_type_when_provided(self, tmp_path, monkeypatch):
+        target = tmp_path / ".credentials.json"
+        monkeypatch.setattr(claude_keychain, "_FILE_PATH", target)
+
+        creds = ClaudeCredentials(
+            access_token="a",
+            refresh_token="r",
+            expires_at=1,
+            subscription_type="max",
+        )
+        write_credentials(SOURCE_FILE, creds, raw_blob={})
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data["claudeAiOauth"]["subscriptionType"] == "max"
+
+    def test_preserves_extra_raw_blob_fields(self, tmp_path, monkeypatch):
+        target = tmp_path / ".credentials.json"
+        monkeypatch.setattr(claude_keychain, "_FILE_PATH", target)
+
+        creds = ClaudeCredentials("a", "r", 1)
+        write_credentials(
+            SOURCE_FILE,
+            creds,
+            raw_blob={"unrelatedField": "preserve-me"},
+        )
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data["unrelatedField"] == "preserve-me"
+
+    def test_unknown_source_returns_false(self, tmp_path, monkeypatch):
+        target = tmp_path / ".credentials.json"
+        monkeypatch.setattr(claude_keychain, "_FILE_PATH", target)
+
+        creds = ClaudeCredentials("a", "r", 1)
+        ok = write_credentials("not-a-real-source", creds, raw_blob={})
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Regex extraction (platform-agnostic — tests the parser only)
+# ---------------------------------------------------------------------------
+
+
+class TestKeychainRegexParsers:
+    def test_service_attr_extracts_primary_and_extra(self):
+        # Representative fragment from `security dump-keychain` output —
+        # two Claude Code entries, one primary, one with a -<hex> suffix.
+        sample = """
+        keychain: "login.keychain-db"
+        class: "genp"
+        attributes:
+            0x00000007 <blob>="Claude Code-credentials"
+            "acct"<blob>="se0nghe0n"
+        ---
+        keychain: "login.keychain-db"
+        class: "genp"
+        attributes:
+            0x00000007 <blob>="Claude Code-credentials-abc123"
+            "acct"<blob>="other-user"
+        """
+
+        services = sorted({m.group(1) for m in _SERVICE_ATTR_RE.finditer(sample)})
+        assert services == [
+            "Claude Code-credentials",
+            "Claude Code-credentials-abc123",
+        ]
+
+    def test_acct_attr_extracts_username(self):
+        sample = '"acct"<blob>="se0nghe0n"'
+        m = _ACCT_ATTR_RE.search(sample)
+        assert m is not None
+        assert m.group(1) == "se0nghe0n"
+
+    def test_acct_attr_extracts_empty_username(self):
+        sample = '"acct"<blob>=""'
+        m = _ACCT_ATTR_RE.search(sample)
+        assert m is not None
+        assert m.group(1) == ""
+
+    def test_service_attr_ignores_unrelated_services(self):
+        sample = """
+            0x00000007 <blob>="Some Other App-credentials"
+            0x00000007 <blob>="Claude Code-credentials"
+        """
+        services = sorted({m.group(1) for m in _SERVICE_ATTR_RE.finditer(sample)})
+        assert services == ["Claude Code-credentials"]
+
+
+# ---------------------------------------------------------------------------
+# Keychain lookup — Darwin only (still mocked, never touches the real CLI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _IS_DARWIN, reason="Keychain subprocess paths only on macOS")
+class TestFindKeychainServicesDarwin:
+    def test_parses_dump_keychain_output(self):
+        sample_stdout = (
+            'keychain: "login.keychain-db"\n'
+            'class: "genp"\n'
+            'attributes:\n'
+            '    0x00000007 <blob>="Claude Code-credentials"\n'
+            'keychain: "login.keychain-db"\n'
+            'class: "genp"\n'
+            'attributes:\n'
+            '    0x00000007 <blob>="Claude Code-credentials-deadbeef"\n'
+        )
+        fake = MagicMock(returncode=0, stdout=sample_stdout, stderr="")
+
+        with patch.object(claude_keychain, "_security", return_value=fake) as mock_sec:
+            services = claude_keychain._find_keychain_services()
+
+        mock_sec.assert_called_once()
+        assert services == [
+            "Claude Code-credentials",
+            "Claude Code-credentials-deadbeef",
+        ]
+
+    def test_returns_empty_list_on_security_failure(self):
+        fake = MagicMock(returncode=1, stdout="", stderr="error")
+        with patch.object(claude_keychain, "_security", return_value=fake):
+            assert claude_keychain._find_keychain_services() == []
+
+    def test_returns_empty_list_on_security_exception(self):
+        with patch.object(
+            claude_keychain,
+            "_security",
+            side_effect=subprocess.TimeoutExpired("security", 10.0),
+        ):
+            assert claude_keychain._find_keychain_services() == []
+
+
+@pytest.mark.skipif(not _IS_DARWIN, reason="Keychain subprocess paths only on macOS")
+class TestFindAccountNameDarwin:
+    def test_extracts_acct_from_security_output(self):
+        fake = MagicMock(
+            returncode=0,
+            stdout='attributes:\n    "acct"<blob>="se0nghe0n"\n',
+            stderr="",
+        )
+        with patch.object(claude_keychain, "_security", return_value=fake):
+            name = claude_keychain._find_account_name("Claude Code-credentials")
+        assert name == "se0nghe0n"
+
+    def test_returns_none_when_security_fails(self):
+        fake = MagicMock(returncode=1, stdout="", stderr="err")
+        with patch.object(claude_keychain, "_security", return_value=fake):
+            assert claude_keychain._find_account_name("whatever") is None
+
+    def test_returns_none_when_acct_attr_missing(self):
+        fake = MagicMock(
+            returncode=0,
+            stdout="attributes:\n    0x00000007 <blob>=\"x\"\n",
+            stderr="",
+        )
+        with patch.object(claude_keychain, "_security", return_value=fake):
+            assert claude_keychain._find_account_name("whatever") is None
+
+
+# ---------------------------------------------------------------------------
+# read_selected_account
+# ---------------------------------------------------------------------------
+
+
+def _acct(label: str, source: str, token: str = "a") -> ClaudeAccount:
+    creds = ClaudeCredentials(
+        access_token=token,
+        refresh_token="r",
+        expires_at=0,
+    )
+    return ClaudeAccount(label=label, source=source, credentials=creds)
+
+
+class TestReadSelectedAccount:
+    def test_returns_none_when_no_accounts(self, tmp_path):
+        with patch.object(claude_keychain, "read_all_accounts", return_value=[]):
+            assert read_selected_account(source_path=tmp_path / "sel.txt") is None
+
+    def test_uses_persisted_source_when_present(self, tmp_path):
+        sel_file = tmp_path / "sel.txt"
+        sel_file.write_text("keychain:Claude Code-credentials-second", encoding="utf-8")
+        accts = [
+            _acct("Claude Max", "keychain:Claude Code-credentials", token="first"),
+            _acct(
+                "Claude Max",
+                "keychain:Claude Code-credentials-second",
+                token="second",
+            ),
+        ]
+        with patch.object(claude_keychain, "read_all_accounts", return_value=accts):
+            chosen = read_selected_account(source_path=sel_file)
+        assert chosen is not None
+        assert chosen.credentials.access_token == "second"
+
+    def test_falls_back_to_first_when_persisted_missing(self, tmp_path):
+        sel_file = tmp_path / "sel.txt"  # not created
+        accts = [
+            _acct("Claude Pro", "file", token="first"),
+            _acct("Claude Max", "keychain:X", token="second"),
+        ]
+        with patch.object(claude_keychain, "read_all_accounts", return_value=accts):
+            chosen = read_selected_account(source_path=sel_file)
+        assert chosen is not None
+        assert chosen.credentials.access_token == "first"
+
+    def test_falls_back_to_first_when_persisted_value_no_longer_matches(self, tmp_path):
+        sel_file = tmp_path / "sel.txt"
+        sel_file.write_text("keychain:gone", encoding="utf-8")
+        accts = [
+            _acct("Claude Pro", "file", token="first"),
+        ]
+        with patch.object(claude_keychain, "read_all_accounts", return_value=accts):
+            chosen = read_selected_account(source_path=sel_file)
+        assert chosen is not None
+        assert chosen.credentials.access_token == "first"
+
+    def test_respects_hermes_home_when_source_path_omitted(
+        self, tmp_path, monkeypatch
+    ):
+        # When ``source_path`` is None, the function should read
+        # ``<HERMES_HOME>/claude_account_source.txt``.  The autouse
+        # ``_isolate_hermes_home`` fixture already points HERMES_HOME at a
+        # tmp dir, but we override it explicitly to be unambiguous.
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        sel_file = hermes_home / "claude_account_source.txt"
+        sel_file.write_text("file", encoding="utf-8")
+
+        accts = [
+            _acct("Claude Max", "keychain:X", token="kc"),
+            _acct("Claude Pro", "file", token="file-tok"),
+        ]
+        with patch.object(claude_keychain, "read_all_accounts", return_value=accts):
+            chosen = read_selected_account()
+        assert chosen is not None
+        assert chosen.credentials.access_token == "file-tok"

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -108,6 +108,19 @@ class TestHandleFastCommand(unittest.TestCase):
         self.assertTrue(mock_cprint.called)
 
 
+class TestInitAgentRuntimeSync(unittest.TestCase):
+    def test_cached_agent_updates_request_overrides(self):
+        cli_mod = _import_cli()
+        agent = SimpleNamespace(service_tier=None, request_overrides={"speed": "fast"})
+        stub = SimpleNamespace(agent=agent, service_tier=None)
+
+        result = cli_mod.HermesCLI._init_agent(stub, request_overrides=None)
+
+        assert result is True
+        assert agent.service_tier is None
+        assert agent.request_overrides == {}
+
+
 class TestPriorityProcessingModels(unittest.TestCase):
     """Verify the expanded Priority Processing model registry."""
 

--- a/tests/computer/test_computer_lifecycle.py
+++ b/tests/computer/test_computer_lifecycle.py
@@ -1,0 +1,228 @@
+"""Lifecycle tests for the Computer runtime watcher + reconciliation.
+
+These exercise the gap between ``start_computer_run`` flipping a run to
+``running`` and the run finishing — the watcher must reconcile the run's
+status on child exit, and ``ComputerStore.reconcile_running_runs`` must
+clean up obviously stale ``running`` records on later reads.
+"""
+
+from __future__ import annotations
+
+import shutil
+import threading
+import time
+
+
+# Real short-lived helpers we hand to ``start_computer_run`` so we exercise
+# the production subprocess.Popen path without mocking it. ``/usr/bin/true``
+# returns 0; ``/usr/bin/false`` returns 1; both ignore their argv tail.
+TRUE_BIN = shutil.which("true") or "/usr/bin/true"
+FALSE_BIN = shutil.which("false") or "/usr/bin/false"
+
+
+def _wait_for(predicate, timeout: float = 5.0, interval: float = 0.02) -> bool:
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+# ── Watcher: completed ────────────────────────────────────────────────────────
+
+
+def test_watcher_marks_run_completed_when_child_exits_zero(tmp_path):
+    from computer.runtime import ComputerStore, start_computer_run, wait_for_watcher
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="watcher-completed", features=["runtime"])
+
+    assert start_computer_run(run["id"], store=store, hermes_executable=TRUE_BIN) is True
+
+    # Wait for the watcher to observe the child exit.
+    assert wait_for_watcher(run["id"], timeout=5.0)
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "completed", reloaded
+    background = reloaded.get("background") or {}
+    assert background.get("pid")
+    assert background.get("binary") == TRUE_BIN
+    assert background.get("stdout_log")
+    assert background.get("stderr_log")
+    assert background.get("exit_code") == 0
+
+    events = [event["type"] for event in store.list_events(run["id"])]
+    assert "computer.background.launched" in events
+    assert "computer.background.completed" in events
+
+
+# ── Watcher: failed ───────────────────────────────────────────────────────────
+
+
+def test_watcher_marks_run_failed_when_child_exits_nonzero(tmp_path):
+    from computer.runtime import ComputerStore, start_computer_run, wait_for_watcher
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="watcher-failed", features=["runtime"])
+
+    assert start_computer_run(run["id"], store=store, hermes_executable=FALSE_BIN) is True
+    assert wait_for_watcher(run["id"], timeout=5.0)
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "failed", reloaded
+    background = reloaded.get("background") or {}
+    assert background.get("exit_code") not in (None, 0)
+    assert "exit" in (reloaded.get("error") or "").lower()
+
+    events = [event["type"] for event in store.list_events(run["id"])]
+    assert "computer.background.failed" in events
+
+
+# ── Watcher: does not overwrite cancelled ─────────────────────────────────────
+
+
+def test_watcher_does_not_overwrite_cancelled_run(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore, start_computer_run, wait_for_watcher
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="watcher-cancelled", features=["runtime"])
+
+    # Use ``sleep`` so the child stays alive long enough for us to cancel
+    # before the watcher observes its exit.
+    sleep_bin = shutil.which("sleep") or "/bin/sleep"
+
+    # The runtime currently hardcodes argv as [binary, "chat", "-q", prompt].
+    # ``sleep`` will treat "chat" / "-q" / prompt as invalid duration and
+    # exit nonzero almost immediately, which would let the watcher race the
+    # cancel and we'd get a flaky test. To keep this deterministic and
+    # cancel-first, monkeypatch subprocess.Popen with a fake long-lived
+    # process whose returncode the test controls.
+    import subprocess as _subprocess
+
+    class _FakeProc:
+        def __init__(self):
+            self.pid = 999_999
+            self._done = threading.Event()
+            self.returncode = None
+
+        def wait(self, timeout=None):
+            self._done.wait(timeout)
+            return self.returncode
+
+        def poll(self):
+            return self.returncode
+
+        def finish(self, code=0):
+            self.returncode = code
+            self._done.set()
+
+    fake = _FakeProc()
+
+    def _fake_popen(*args, **kwargs):
+        for fh in (kwargs.get("stdout"), kwargs.get("stderr")):
+            try:
+                if fh and hasattr(fh, "close"):
+                    pass  # leave open; runtime/watcher must close them
+            except Exception:
+                pass
+        return fake
+
+    monkeypatch.setattr(_subprocess, "Popen", _fake_popen)
+
+    assert start_computer_run(run["id"], store=store, hermes_executable=sleep_bin) is True
+    assert store.get_run(run["id"])["status"] == "running"
+
+    # Cancel BEFORE the fake child exits.
+    store.update_run(run["id"], status="cancelled", error="user cancelled")
+    # Now let the fake child finish with success — the watcher must NOT
+    # flip ``cancelled`` back to ``completed``.
+    fake.finish(0)
+
+    assert wait_for_watcher(run["id"], timeout=5.0)
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "cancelled", reloaded
+    # The watcher is still allowed to record exit_code into background
+    # metadata, but the lifecycle status must stay cancelled.
+    background = reloaded.get("background") or {}
+    assert background.get("exit_code") == 0
+
+
+# ── Reconcile: stale running ──────────────────────────────────────────────────
+
+
+def test_reconcile_running_runs_marks_stale_running_as_failed(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="stale-running", features=["runtime"])
+
+    # Persist a run that *claims* to be running with a pid that no longer
+    # exists, as if hermes was killed before its watcher could reconcile.
+    store.update_run(
+        run["id"],
+        status="running",
+        background={
+            "pid": 424242,
+            "binary": "/fake/hermes",
+            "stdout_log": str(tmp_path / "out.log"),
+            "stderr_log": str(tmp_path / "err.log"),
+        },
+    )
+
+    # Force the runtime's "is pid alive?" probe to return False so we don't
+    # depend on whether pid 424242 really happens to exist on this host.
+    import computer.runtime as runtime_mod
+
+    monkeypatch.setattr(runtime_mod, "_is_pid_alive", lambda pid: False)
+
+    changed = store.reconcile_running_runs()
+    assert run["id"] in changed
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "failed", reloaded
+    assert reloaded.get("error")
+    events = [event["type"] for event in store.list_events(run["id"])]
+    assert "computer.background.reconciled_stale" in events
+
+
+def test_reconcile_running_runs_leaves_live_process_alone(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="live-running", features=["runtime"])
+    store.update_run(
+        run["id"],
+        status="running",
+        background={"pid": 12345, "binary": "/fake/hermes"},
+    )
+
+    import computer.runtime as runtime_mod
+
+    monkeypatch.setattr(runtime_mod, "_is_pid_alive", lambda pid: True)
+
+    changed = store.reconcile_running_runs()
+    assert run["id"] not in changed
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "running"
+
+
+def test_reconcile_running_runs_ignores_non_running_states(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    queued = store.create_run(goal="queued-run", features=["runtime"])
+    done = store.create_run(goal="done-run", features=["runtime"])
+    store.update_run(done["id"], status="completed")
+
+    import computer.runtime as runtime_mod
+
+    # Even if the probe says "dead", non-running states must not be touched.
+    monkeypatch.setattr(runtime_mod, "_is_pid_alive", lambda pid: False)
+    changed = store.reconcile_running_runs()
+    assert queued["id"] not in changed
+    assert done["id"] not in changed
+    assert store.get_run(queued["id"])["status"] == "queued"
+    assert store.get_run(done["id"])["status"] == "completed"

--- a/tests/computer/test_computer_runtime.py
+++ b/tests/computer/test_computer_runtime.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+
+def test_store_creates_persistent_run_and_events(tmp_path):
+    from computer.runtime import ComputerStore
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(
+        goal="Monitor competitor pricing every weekday",
+        features=["runtime", "parallel_research", "continuous_monitoring"],
+        source="unit-test",
+    )
+
+    assert run["id"].startswith("computer_")
+    assert run["goal"] == "Monitor competitor pricing every weekday"
+    assert run["status"] == "queued"
+    assert run["features"] == ["runtime", "parallel_research", "continuous_monitoring"]
+    assert Path(run["artifact_dir"]).name == run["id"]
+
+    store.append_event(run["id"], "computer.plan.created", {"steps": 3})
+    store.update_run(run["id"], status="running", plan={"steps": ["research", "synthesize"]})
+
+    reloaded = ComputerStore(base_dir=tmp_path / "computer")
+    loaded = reloaded.get_run(run["id"])
+    assert loaded["status"] == "running"
+    assert loaded["plan"]["steps"] == ["research", "synthesize"]
+    assert reloaded.list_runs()[0]["id"] == run["id"]
+
+    events = reloaded.list_events(run["id"])
+    assert [event["type"] for event in events] == ["computer.run.created", "computer.plan.created", "computer.run.updated"]
+
+
+def test_computer_prompt_enforces_requested_feature_ports(tmp_path):
+    from computer.runtime import ComputerStore, build_computer_prompt
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(
+        goal="Research AI browser changes and produce a briefing",
+        features=["runtime", "parallel_research", "continuous_monitoring"],
+    )
+
+    prompt = build_computer_prompt(run)
+
+    assert "Perplexity Computer-style" in prompt
+    assert "persistent Computer run" in prompt
+    assert "delegate_task" in prompt
+    assert "parallel" in prompt.lower()
+    assert "browser" in prompt.lower()
+    assert "continuous monitoring" in prompt.lower()
+    assert run["artifact_dir"] in prompt
+
+
+def test_schedule_prompt_is_self_contained_and_traceable(tmp_path):
+    from computer.runtime import ComputerStore, build_scheduled_computer_prompt
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(
+        goal="Send me a morning briefing on AI browser products",
+        features=["runtime", "parallel_research", "continuous_monitoring"],
+    )
+
+    prompt = build_scheduled_computer_prompt(run)
+
+    assert run["id"] in prompt
+    assert "fresh session" in prompt.lower()
+    assert "continuous monitoring" in prompt.lower()
+    assert "deliver" in prompt.lower()
+    assert "Do not recursively create cron jobs" in prompt
+
+
+def test_invalid_status_rejected(tmp_path):
+    from computer.runtime import ComputerStore
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="x", features=["runtime"])
+
+    import pytest
+
+    with pytest.raises(ValueError):
+        store.update_run(run["id"], status="not-a-real-status")
+
+
+def test_start_computer_run_marks_failure_when_hermes_missing(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore, start_computer_run
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    run = store.create_run(goal="x", features=["runtime"])
+
+    # Force shutil.which to return None so the launcher gives up rather than
+    # actually spawning a subprocess in CI.
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    launched = start_computer_run(run["id"], store=store, hermes_executable=None)
+    assert launched is False
+
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "failed"
+    assert "hermes executable" in (reloaded.get("error") or "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -384,6 +384,32 @@ def _reset_module_state():
     yield
 
 
+@pytest.fixture(autouse=True)
+def _isolate_claude_keychain(monkeypatch):
+    """Prevent tests from reading Claude Code's real macOS Keychain entries.
+
+    ``agent.anthropic_adapter.read_claude_code_credentials`` was extended to
+    read the ``Claude Code-credentials`` service from the login keychain
+    before falling back to ``~/.claude/.credentials.json``.  On developer
+    machines with Claude Code already authenticated, that would leak the
+    real user's OAuth token into every test that patches ``Path.home()``
+    but not the keychain.  Neutralise the keychain lookup by default; tests
+    that need to exercise the Keychain path can re-override these within
+    their own scope.
+    """
+    try:
+        from agent import claude_keychain as _ck
+    except Exception:
+        return
+    # Neutralise the *public* discovery API at the adapter boundary — tests
+    # of the internal helpers (``_find_keychain_services`` et al.) remain
+    # free to exercise the raw subprocess-parsing logic with their own
+    # mocks.  Adapter code never touches the internals directly.
+    monkeypatch.setattr(_ck, "read_all_accounts", lambda: [])
+    monkeypatch.setattr(_ck, "read_primary_account", lambda: None)
+    monkeypatch.setattr(_ck, "read_selected_account", lambda *a, **kw: None)
+
+
 @pytest.fixture()
 def tmp_dir(tmp_path):
     """Provide a temporary directory that is cleaned up automatically."""

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -1,12 +1,12 @@
-"""Tests for gateway /fast support and Priority Processing routing."""
+"""Tests for gateway /fast support and model-aware messaging."""
 
+import asyncio
 import sys
 import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import pytest
 import yaml
 
 import gateway.run as gateway_run
@@ -121,15 +121,14 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
     assert route["request_overrides"] is None
 
 
-@pytest.mark.asyncio
-async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
+def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
 
-    response = await runner._handle_fast_command(_make_event("/fast fast"))
+    response = asyncio.run(runner._handle_fast_command(_make_event("/fast fast")))
 
     assert "FAST" in response
     assert runner._service_tier == "priority"
@@ -138,8 +137,33 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     assert saved["agent"]["service_tier"] == "fast"
 
 
-@pytest.mark.asyncio
-async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch, tmp_path):
+def test_handle_fast_command_uses_anthropic_feature_name(monkeypatch, tmp_path):
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "anthropic/claude-opus-4.6")
+
+    response = asyncio.run(runner._handle_fast_command(_make_event("/fast status")))
+
+    assert "Anthropic Fast Mode" in response
+    assert "Current mode: `normal`" in response
+
+
+def test_handle_fast_command_reports_generic_unsupported_message(monkeypatch, tmp_path):
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "anthropic/claude-sonnet-4.6")
+
+    response = asyncio.run(runner._handle_fast_command(_make_event("/fast")))
+
+    assert "OpenAI Priority Processing" in response
+    assert "Anthropic Fast Mode" in response
+
+
+def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch, tmp_path):
     _install_fake_agent(monkeypatch)
     runner = _make_runner()
 
@@ -164,13 +188,15 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
 
     _CapturingAgent.last_init = None
-    result = await runner._run_agent(
-        message="hi",
-        context_prompt="",
-        history=[],
-        source=_make_source(),
-        session_id="session-1",
-        session_key="agent:main:telegram:dm:12345",
+    result = asyncio.run(
+        runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=_make_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+        )
     )
 
     assert result["final_response"] == "ok"

--- a/tests/hermes_cli/test_anthropic_oauth_flow.py
+++ b/tests/hermes_cli/test_anthropic_oauth_flow.py
@@ -1,52 +1,137 @@
-"""Tests for Anthropic OAuth setup flow behavior."""
+"""Tests for the ``_run_anthropic_oauth_flow`` menu in ``hermes_cli.main``.
+
+The flow now presents a 4-choice menu:
+
+  1. Hermes browser login (pure PKCE — default)
+  2. Paste an existing Claude Code setup-token
+  3. Run 'claude setup-token' via the npm CLI (legacy)
+  4. Cancel
+
+These tests cover the three non-cancel branches.  Option 1 is covered in
+depth because it's the new default — it calls
+``run_hermes_oauth_login_pure``, persists via ``_HERMES_OAUTH_FILE`` and
+the credential pool, and signals use-credential-file via ``.env``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
 
 from hermes_cli.config import load_env, save_env_value
 
 
-def test_run_anthropic_oauth_flow_prefers_claude_code_credentials(tmp_path, monkeypatch, capsys):
+def _iter_inputs(*responses: str):
+    it = iter(responses)
+    def _next(_prompt: str = "") -> str:
+        try:
+            return next(it)
+        except StopIteration:  # pragma: no cover
+            return ""
+    return _next
+
+
+def test_oauth_flow_default_choice_runs_pure_pkce(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent import anthropic_adapter as ant
     monkeypatch.setattr(
-        "agent.anthropic_adapter.run_oauth_setup_token",
-        lambda: "sk-ant-oat01-from-claude-setup",
+        ant,
+        "_HERMES_OAUTH_FILE",
+        tmp_path / ".anthropic_oauth.json",
     )
     monkeypatch.setattr(
-        "agent.anthropic_adapter.read_claude_code_credentials",
+        ant,
+        "run_hermes_oauth_login_pure",
+        lambda: {
+            "access_token": "sk-ant-oat01-pkce-new",
+            "refresh_token": "sk-ant-ort01-pkce-new",
+            "expires_at_ms": 9_999_999_999_000,
+        },
+    )
+
+    # Bare Enter defaults to choice 1 (Hermes PKCE).
+    monkeypatch.setattr("builtins.input", _iter_inputs(""))
+
+    from hermes_cli.main import _run_anthropic_oauth_flow
+
+    assert _run_anthropic_oauth_flow(save_env_value) is True
+
+    oauth_file = tmp_path / ".anthropic_oauth.json"
+    assert oauth_file.exists()
+    saved = json.loads(oauth_file.read_text(encoding="utf-8"))
+    assert saved["accessToken"] == "sk-ant-oat01-pkce-new"
+    assert saved["refreshToken"] == "sk-ant-ort01-pkce-new"
+    assert saved["expiresAt"] == 9_999_999_999_000
+
+    # ``.env`` should signal use-credential-file (both Anthropic env vars
+    # cleared so the file becomes the source of truth).
+    env_vars = load_env()
+    assert env_vars.get("ANTHROPIC_TOKEN", "") == ""
+    assert env_vars.get("ANTHROPIC_API_KEY", "") == ""
+
+    output = capsys.readouterr().out
+    assert "Hermes browser login" in output
+
+
+def test_oauth_flow_manual_setup_token_choice_persists(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Choice 2 + setup-token.
+    monkeypatch.setattr("builtins.input", _iter_inputs("2"))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "sk-ant-oat01-manual")
+
+    from hermes_cli.main import _run_anthropic_oauth_flow
+
+    assert _run_anthropic_oauth_flow(save_env_value) is True
+
+    env_vars = load_env()
+    assert env_vars["ANTHROPIC_TOKEN"] == "sk-ant-oat01-manual"
+    out = capsys.readouterr().out
+    assert "Setup-token saved" in out or "saved" in out.lower()
+
+
+def test_oauth_flow_legacy_npm_choice_uses_setup_token_subprocess(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent import anthropic_adapter as ant
+    monkeypatch.setattr(
+        ant,
+        "run_oauth_setup_token",
+        lambda: "sk-ant-oat01-from-claude-setup",
+    )
+    # Simulate the Claude Code credentials file appearing after subprocess.
+    monkeypatch.setattr(
+        ant,
+        "read_claude_code_credentials",
         lambda: {
             "accessToken": "cc-access-token",
             "refreshToken": "cc-refresh-token",
             "expiresAt": 9999999999999,
+            "source": "file",
         },
     )
-    monkeypatch.setattr(
-        "agent.anthropic_adapter.is_claude_code_token_valid",
-        lambda creds: True,
-    )
+    monkeypatch.setattr(ant, "is_claude_code_token_valid", lambda creds: True)
+
+    # Choice 3 = legacy npm ``claude setup-token``.
+    monkeypatch.setattr("builtins.input", _iter_inputs("3"))
 
     from hermes_cli.main import _run_anthropic_oauth_flow
 
+    # Stale env var — the legacy flow should clear it because Claude Code's
+    # refreshable credential file is preferred when available.
     save_env_value("ANTHROPIC_TOKEN", "stale-env-token")
+
     assert _run_anthropic_oauth_flow(save_env_value) is True
 
     env_vars = load_env()
     assert env_vars["ANTHROPIC_TOKEN"] == ""
     assert env_vars["ANTHROPIC_API_KEY"] == ""
-    output = capsys.readouterr().out
-    assert "Claude Code credentials linked" in output
+    out = capsys.readouterr().out
+    assert "Claude Code credentials linked" in out
 
 
-def test_run_anthropic_oauth_flow_manual_token_still_persists(tmp_path, monkeypatch, capsys):
+def test_oauth_flow_cancel_returns_false(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setattr("agent.anthropic_adapter.run_oauth_setup_token", lambda: None)
-    monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
-    monkeypatch.setattr("agent.anthropic_adapter.is_claude_code_token_valid", lambda creds: False)
-    monkeypatch.setattr("builtins.input", lambda _prompt="": "sk-ant-oat01-manual-token")
-    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "sk-ant-oat01-manual-token")
-
+    monkeypatch.setattr("builtins.input", _iter_inputs("4"))
     from hermes_cli.main import _run_anthropic_oauth_flow
-
-    assert _run_anthropic_oauth_flow(save_env_value) is True
-
-    env_vars = load_env()
-    assert env_vars["ANTHROPIC_TOKEN"] == "sk-ant-oat01-manual-token"
-    output = capsys.readouterr().out
-    assert "Setup-token saved" in output
+    assert _run_anthropic_oauth_flow(save_env_value) is False

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from hermes_cli.models import (
+    _fetch_anthropic_models,
     copilot_model_api_mode,
     fetch_github_model_catalog,
     curated_models_for_provider,
@@ -286,6 +287,50 @@ class TestFetchApiModels:
         assert [item["id"] for item in catalog] == ["gpt-5.4"]
 
 
+class TestFetchAnthropicModels:
+    def test_regular_api_key_uses_x_api_key_header(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "claude-opus-4-7"}]}'
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+            models = _fetch_anthropic_models(api_key="sk-ant-api03-test")
+
+        assert models == ["claude-opus-4-7"]
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://api.anthropic.com/v1/models"
+        assert req.headers.get("X-api-key") == "sk-ant-api03-test"
+        assert req.headers.get("Anthropic-version") == "2023-06-01"
+        assert req.headers.get("Authorization") is None
+
+    def test_oauth_token_uses_bearer_and_beta_headers(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "claude-opus-4-7"}]}'
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+            models = _fetch_anthropic_models(api_key="sk-ant-oat01-test")
+
+        assert models == ["claude-opus-4-7"]
+        req = mock_urlopen.call_args[0][0]
+        assert req.headers.get("Authorization") == "Bearer sk-ant-oat01-test"
+        assert req.headers.get("Anthropic-version") == "2023-06-01"
+        assert req.headers.get("Anthropic-beta")
+        assert req.headers.get("X-api-key") is None
+
+
 class TestGithubReasoningEfforts:
     def test_gpt5_supports_minimal_to_high(self):
         catalog = [{
@@ -513,6 +558,48 @@ class TestValidateApiFallback:
         assert result["persist"] is True
         assert result["recognized"] is False
         assert "note" in result["message"].lower()
+
+    def test_anthropic_uses_provider_specific_catalog_fetch_not_generic_probe(self):
+        with patch("hermes_cli.models._fetch_anthropic_models", return_value=["claude-opus-4-7"]) as mock_fetch, \
+             patch("hermes_cli.models.fetch_api_models", side_effect=AssertionError("generic probe should not be used for anthropic")):
+            result = validate_requested_model(
+                "claude-opus-4-7",
+                "anthropic",
+                api_key="sk-ant-oat01-test",
+                base_url="https://api.anthropic.com",
+            )
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        mock_fetch.assert_called_once_with(api_key="sk-ant-oat01-test")
+
+    def test_known_anthropic_model_allowed_when_live_catalog_unreachable(self):
+        with patch("hermes_cli.models._fetch_anthropic_models", return_value=None):
+            result = validate_requested_model(
+                "claude-opus-4-7",
+                "anthropic",
+                api_key="sk-ant-oat01-test",
+                base_url="https://api.anthropic.com",
+            )
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert "known anthropic model" in result["message"].lower()
+
+    def test_unknown_anthropic_model_rejected_when_live_catalog_unreachable(self):
+        with patch("hermes_cli.models._fetch_anthropic_models", return_value=None):
+            result = validate_requested_model(
+                "claude-opus-next",
+                "anthropic",
+                api_key="sk-ant-oat01-test",
+                base_url="https://api.anthropic.com",
+            )
+
+        assert result["accepted"] is False
+        assert result["persist"] is False
+        assert "could not reach the anthropic api" in result["message"].lower()
+        assert "similar models" in result["message"].lower()
 
     def test_custom_endpoint_warns_with_probed_url_and_v1_hint(self):
         with patch(

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -47,6 +47,72 @@ def test_show_status_displays_configured_dict_model_and_provider_label(monkeypat
     assert "Provider:     Anthropic" in out
 
 
+def test_show_status_displays_anthropic_fast_mode_when_supported(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "anthropic"},
+            "agent": {"service_tier": "fast"},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Anthropic", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Fast Mode:    fast (Anthropic Fast Mode)" in out
+
+
+def test_show_status_hides_fast_mode_for_unsupported_model_without_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {"model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"}},
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Anthropic", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Fast Mode:" not in out
+
+
+def test_show_status_flags_unsupported_fast_mode_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(
+        status_mod,
+        "load_config",
+        lambda: {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "anthropic"},
+            "agent": {"service_tier": "fast"},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "anthropic", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "Anthropic", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Fast Mode:    configured as fast, but current model does not support it" in out
+
+
 def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -307,6 +307,27 @@ def test_config_set_personality_resets_history_and_returns_info(monkeypatch):
     assert ("session.info", "sid", {"model": "x"}) in emits
 
 
+def test_mirror_fast_side_effects_syncs_live_request_overrides():
+    emits = []
+    agent = types.SimpleNamespace(
+        model="claude-opus-4-6",
+        service_tier="priority",
+        request_overrides={"speed": "fast"},
+    )
+    server._sessions["sid"] = _session(agent=agent)
+
+    try:
+        with patch("tui_gateway.server._emit", lambda *args: emits.append(args)):
+            server._mirror_slash_side_effects("sid", server._sessions["sid"], "/fast normal")
+
+        assert agent.service_tier is None
+        assert agent.request_overrides == {}
+        assert emits
+        assert emits[-1][0] == "session.info"
+    finally:
+        server._sessions.clear()
+
+
 def test_session_compress_uses_compress_helper(monkeypatch):
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent)

--- a/tests/tools/test_computer_tool.py
+++ b/tests/tools/test_computer_tool.py
@@ -1,0 +1,147 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_computer_tool_starts_persistent_run(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+    starter = MagicMock(return_value=True)
+    monkeypatch.setattr(tool, "start_computer_run", starter)
+
+    result = json.loads(tool.computer(
+        action="start",
+        goal="Research Perplexity Computer and build a clone plan",
+        features=["runtime", "parallel_research", "continuous_monitoring"],
+        start_background=True,
+    ))
+
+    assert result["success"] is True
+    assert result["run"]["status"] == "queued"
+    assert result["run"]["goal"].startswith("Research Perplexity")
+    starter.assert_called_once_with(result["run"]["id"], store=store)
+
+    events = store.list_events(result["run"]["id"])
+    assert events[0]["type"] == "computer.run.created"
+
+
+def test_computer_tool_lists_gets_events_and_cancels(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+    run = store.create_run(goal="Organize Downloads", features=["runtime"])
+    store.append_event(run["id"], "computer.note", {"message": "hello"})
+
+    listing = json.loads(tool.computer(action="list"))
+    assert listing["success"] is True
+    assert listing["runs"][0]["id"] == run["id"]
+
+    fetched = json.loads(tool.computer(action="get", run_id=run["id"]))
+    assert fetched["run"]["goal"] == "Organize Downloads"
+
+    events = json.loads(tool.computer(action="events", run_id=run["id"]))
+    assert [event["type"] for event in events["events"]] == ["computer.run.created", "computer.note"]
+
+    cancelled = json.loads(tool.computer(action="cancel", run_id=run["id"]))
+    assert cancelled["success"] is True
+    assert cancelled["run"]["status"] == "cancelled"
+
+
+def test_computer_tool_schedules_monitoring_job(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+
+    fake_job = {"id": "job123", "name": "AI browser watch", "schedule_display": "0 9 * * *"}
+    create_job = MagicMock(return_value=fake_job)
+    monkeypatch.setattr(tool, "_cron_create_job", create_job)
+
+    result = json.loads(tool.computer(
+        action="schedule",
+        goal="Monitor AI browser product updates",
+        schedule="0 9 * * *",
+        name="AI browser watch",
+        deliver="origin",
+    ))
+
+    assert result["success"] is True
+    assert result["cron_job"] == fake_job
+    assert result["run"]["status"] == "scheduled"
+    assert result["run"]["schedule_job_id"] == "job123"
+    prompt = create_job.call_args.kwargs["prompt"]
+    assert result["run"]["id"] in prompt
+    assert "Do not recursively create cron jobs" in prompt
+    assert create_job.call_args.kwargs["deliver"] == "origin"
+
+
+def test_computer_tool_rejects_unknown_action(tmp_path, monkeypatch):
+    import tools.computer_tool as tool
+
+    result = json.loads(tool.computer(action="explode"))
+    assert result["success"] is False
+    assert "explode" in result["error"]
+
+
+def test_computer_tool_start_requires_goal(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+
+    result = json.loads(tool.computer(action="start"))
+    assert result["success"] is False
+    assert "goal" in result["error"].lower()
+
+
+def test_computer_tool_get_returns_error_for_unknown_run(tmp_path, monkeypatch):
+    from computer.runtime import ComputerStore
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+
+    result = json.loads(tool.computer(action="get", run_id="computer_doesnotexist"))
+    assert result["success"] is False
+    assert "computer_doesnotexist" in result["error"]
+
+
+class TestComputerToolWiring:
+    """The `computer` tool must be reachable via the registry and toolset wiring."""
+
+    def test_in_registry(self):
+        from tools import computer_tool  # noqa: F401 — triggers registration
+        from tools.registry import registry
+
+        entry = registry.get_entry("computer")
+        assert entry is not None
+        assert entry.toolset == "computer"
+
+    def test_in_computer_toolset(self):
+        from toolsets import TOOLSETS
+
+        assert "computer" in TOOLSETS
+        assert "computer" in TOOLSETS["computer"]["tools"]
+
+    def test_in_hermes_core_tools(self):
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "computer" in _HERMES_CORE_TOOLS
+
+    def test_in_api_server_toolset(self):
+        from toolsets import TOOLSETS
+
+        assert "computer" in TOOLSETS["hermes-api-server"]["tools"]
+
+    def test_in_legacy_toolset_map(self):
+        from model_tools import _LEGACY_TOOLSET_MAP
+
+        assert _LEGACY_TOOLSET_MAP.get("computer_tools") == ["computer"]

--- a/tests/tools/test_computer_tool_reconcile.py
+++ b/tests/tools/test_computer_tool_reconcile.py
@@ -1,0 +1,67 @@
+"""Tool-level reconciliation: list / get / events must surface fresh state.
+
+When a background hermes process has died but nothing flipped its run
+record to ``failed``, the next time the agent reads the run via the
+computer tool we should reconcile it before returning so the model never
+sees a phantom ``running`` status.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _seed_stale_running_run(tmp_path, monkeypatch):
+    """Create a store + tool wired to a stale running run with a dead pid."""
+    from computer.runtime import ComputerStore
+    import computer.runtime as runtime_mod
+    import tools.computer_tool as tool
+
+    store = ComputerStore(base_dir=tmp_path / "computer")
+    monkeypatch.setattr(tool, "_get_store", lambda: store)
+    monkeypatch.setattr(runtime_mod, "_is_pid_alive", lambda pid: False)
+
+    run = store.create_run(goal="stale-tool-read", features=["runtime"])
+    store.update_run(
+        run["id"],
+        status="running",
+        background={"pid": 4242424, "binary": "/fake/hermes"},
+    )
+    return store, run
+
+
+def test_tool_list_reconciles_stale_running(tmp_path, monkeypatch):
+    import tools.computer_tool as tool
+
+    store, run = _seed_stale_running_run(tmp_path, monkeypatch)
+    raw = tool.computer(action="list")
+    result = json.loads(raw)
+
+    assert result["success"] is True
+    statuses = {r["id"]: r["status"] for r in result["runs"]}
+    assert statuses[run["id"]] == "failed", result
+
+
+def test_tool_get_reconciles_stale_running(tmp_path, monkeypatch):
+    import tools.computer_tool as tool
+
+    store, run = _seed_stale_running_run(tmp_path, monkeypatch)
+    result = json.loads(tool.computer(action="get", run_id=run["id"]))
+
+    assert result["success"] is True
+    assert result["run"]["status"] == "failed"
+
+
+def test_tool_events_reconciles_stale_running(tmp_path, monkeypatch):
+    import tools.computer_tool as tool
+
+    store, run = _seed_stale_running_run(tmp_path, monkeypatch)
+    result = json.loads(tool.computer(action="events", run_id=run["id"]))
+
+    assert result["success"] is True
+    event_types = [event["type"] for event in result["events"]]
+    assert "computer.background.reconciled_stale" in event_types
+
+    # And the underlying run is now failed (so a follow-up get is consistent).
+    reloaded = store.get_run(run["id"])
+    assert reloaded["status"] == "failed"

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -295,6 +295,7 @@ class TestBuiltinDiscovery:
             "tools.browser_tool",
             "tools.clarify_tool",
             "tools.code_execution_tool",
+            "tools.computer_tool",
             "tools.cronjob_tools",
             "tools.delegate_tool",
             "tools.discord_tool",

--- a/tools/computer_tool.py
+++ b/tools/computer_tool.py
@@ -55,6 +55,20 @@ def _get_store() -> ComputerStore:
 _VALID_ACTIONS = frozenset({"start", "list", "get", "events", "cancel", "schedule"})
 
 
+def _reconcile_quietly(store: ComputerStore) -> None:
+    """Best-effort: flip stale ``running`` runs to ``failed`` before a read.
+
+    The tool surface should never expose a phantom ``running`` row to the
+    model just because a previous background hermes died before reconciling
+    itself. We swallow exceptions here — reconciliation is a best-effort
+    enrichment and must not break the read path.
+    """
+    try:
+        store.reconcile_running_runs()
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("computer tool: reconcile_running_runs failed: %s", exc)
+
+
 def computer(
     action: str,
     goal: Optional[str] = None,
@@ -96,13 +110,16 @@ def computer(
             )
 
         if normalized == "list":
+            _reconcile_quietly(store)
             runs = store.list_runs()
             return tool_result(success=True, count=len(runs), runs=runs)
 
         if normalized == "get":
+            _reconcile_quietly(store)
             return _handle_get(store, run_id)
 
         if normalized == "events":
+            _reconcile_quietly(store)
             return _handle_events(store, run_id)
 
         if normalized == "cancel":

--- a/tools/computer_tool.py
+++ b/tools/computer_tool.py
@@ -1,0 +1,408 @@
+"""Computer tool — drive Perplexity Computer-style runs from inside the agent.
+
+Wraps :mod:`computer.runtime` so the model can:
+
+* start a persistent Computer run (foreground or background),
+* list / get / inspect events for prior runs,
+* cancel a running run,
+* schedule a recurring Computer run via the existing cron scheduler.
+
+Implementation notes:
+
+* The actual launch (``start_computer_run``) and cron creation
+  (``cron.jobs.create_job``) are referenced via module-level aliases so
+  tests can ``monkeypatch.setattr`` them without touching the tool's
+  internal logic.  Do not inline-import them or the test contract breaks.
+* All handlers return JSON strings via :func:`tools.registry.tool_result` /
+  :func:`tools.registry.tool_error`.
+* This tool deliberately does *not* try to invent a second agent loop —
+  every action delegates to runtime/cron primitives the rest of Hermes
+  already uses.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from computer.runtime import (
+    ComputerStore,
+    build_scheduled_computer_prompt,
+    start_computer_run as _runtime_start_computer_run,
+)
+from cron.jobs import create_job as _cron_create_job  # noqa: F401 — re-exported for tests
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level alias so tests can monkeypatch start launching without
+# patching the runtime module globally. Keep this name stable.
+start_computer_run = _runtime_start_computer_run
+
+
+# Cached store, lazy-instantiated. Tests monkeypatch ``_get_store`` directly.
+_store: Optional[ComputerStore] = None
+
+
+def _get_store() -> ComputerStore:
+    global _store
+    if _store is None:
+        _store = ComputerStore()
+    return _store
+
+
+_VALID_ACTIONS = frozenset({"start", "list", "get", "events", "cancel", "schedule"})
+
+
+def computer(
+    action: str,
+    goal: Optional[str] = None,
+    features: Optional[List[str]] = None,
+    start_background: bool = False,
+    run_id: Optional[str] = None,
+    schedule: Optional[str] = None,
+    name: Optional[str] = None,
+    deliver: Optional[str] = None,
+    source: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> str:
+    """Unified Computer-runtime tool.
+
+    Returns a JSON string matching the conventions of other Hermes tools
+    (``success`` / ``error`` plus payload fields).
+    """
+    del task_id  # accepted for handler-signature parity; unused
+
+    normalized = (action or "").strip().lower()
+    if normalized not in _VALID_ACTIONS:
+        return tool_error(
+            f"Unknown computer action {action!r}. "
+            f"Valid actions: {sorted(_VALID_ACTIONS)}",
+            success=False,
+        )
+
+    store = _get_store()
+
+    try:
+        if normalized == "start":
+            return _handle_start(
+                store,
+                goal=goal,
+                features=features,
+                start_background=start_background,
+                source=source,
+                deliver=deliver,
+            )
+
+        if normalized == "list":
+            runs = store.list_runs()
+            return tool_result(success=True, count=len(runs), runs=runs)
+
+        if normalized == "get":
+            return _handle_get(store, run_id)
+
+        if normalized == "events":
+            return _handle_events(store, run_id)
+
+        if normalized == "cancel":
+            return _handle_cancel(store, run_id)
+
+        if normalized == "schedule":
+            return _handle_schedule(
+                store,
+                goal=goal,
+                schedule=schedule,
+                name=name,
+                deliver=deliver,
+                features=features,
+                source=source,
+            )
+
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("computer tool failed: %s", exc)
+        return tool_error(f"computer tool failed: {exc!r}", success=False)
+
+    # Unreachable — every branch returns above.
+    return tool_error("computer tool: unreachable branch", success=False)
+
+
+# ── action handlers ───────────────────────────────────────────────────────────
+
+
+def _handle_start(
+    store: ComputerStore,
+    *,
+    goal: Optional[str],
+    features: Optional[List[str]],
+    start_background: bool,
+    source: Optional[str],
+    deliver: Optional[str],
+) -> str:
+    if not goal or not str(goal).strip():
+        return tool_error("computer(action='start') requires a non-empty goal.", success=False)
+
+    run = store.create_run(
+        goal=str(goal).strip(),
+        features=features,
+        source=source,
+        deliver=deliver,
+    )
+
+    launched = False
+    if start_background:
+        try:
+            launched = bool(start_computer_run(run["id"], store=store))
+        except Exception as exc:
+            store.update_run(run["id"], status="failed", error=f"launch failed: {exc!r}")
+            return tool_error(
+                f"failed to launch background Computer run: {exc!r}",
+                success=False,
+                run=store.get_run(run["id"]),
+            )
+        # Reload so the response reflects any status flip the launcher made.
+        run = store.get_run(run["id"]) or run
+
+    return tool_result(
+        success=True,
+        run=run,
+        launched=launched,
+        message=(
+            f"Computer run {run['id']} created"
+            + (" and background launch attempted." if start_background else ".")
+        ),
+    )
+
+
+def _handle_get(store: ComputerStore, run_id: Optional[str]) -> str:
+    if not run_id:
+        return tool_error("computer(action='get') requires run_id.", success=False)
+    run = store.get_run(run_id)
+    if run is None:
+        return tool_error(f"unknown computer run: {run_id}", success=False)
+    return tool_result(success=True, run=run)
+
+
+def _handle_events(store: ComputerStore, run_id: Optional[str]) -> str:
+    if not run_id:
+        return tool_error("computer(action='events') requires run_id.", success=False)
+    if store.get_run(run_id) is None:
+        return tool_error(f"unknown computer run: {run_id}", success=False)
+    events = store.list_events(run_id)
+    return tool_result(success=True, run_id=run_id, count=len(events), events=events)
+
+
+def _handle_cancel(store: ComputerStore, run_id: Optional[str]) -> str:
+    if not run_id:
+        return tool_error("computer(action='cancel') requires run_id.", success=False)
+    run = store.get_run(run_id)
+    if run is None:
+        return tool_error(f"unknown computer run: {run_id}", success=False)
+    if run.get("status") == "cancelled":
+        return tool_result(success=True, run=run, message="run already cancelled")
+
+    # We deliberately do NOT shell out to ``kill -9`` here. The background
+    # subprocess receives SIGTERM via os.kill only when we have a stored pid
+    # AND it still belongs to us. Broad ``pkill`` patterns are forbidden
+    # because they can take down unrelated hermes processes.
+    pid = (run.get("background") or {}).get("pid")
+    kill_error: Optional[str] = None
+    if pid:
+        try:
+            import os
+            import signal
+
+            os.kill(int(pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, ValueError) as exc:
+            kill_error = f"could not signal pid {pid}: {exc!r}"
+
+    updated = store.update_run(
+        run_id,
+        status="cancelled",
+        error=kill_error,
+    )
+    store.append_event(
+        run_id,
+        "computer.run.cancelled",
+        {"pid": pid, "kill_error": kill_error},
+    )
+    return tool_result(success=True, run=updated)
+
+
+def _handle_schedule(
+    store: ComputerStore,
+    *,
+    goal: Optional[str],
+    schedule: Optional[str],
+    name: Optional[str],
+    deliver: Optional[str],
+    features: Optional[List[str]],
+    source: Optional[str],
+) -> str:
+    if not goal or not str(goal).strip():
+        return tool_error("computer(action='schedule') requires a non-empty goal.", success=False)
+    if not schedule or not str(schedule).strip():
+        return tool_error("computer(action='schedule') requires a schedule.", success=False)
+
+    feature_list = list(features) if features else ["runtime", "parallel_research", "continuous_monitoring"]
+    if "continuous_monitoring" not in feature_list:
+        feature_list.append("continuous_monitoring")
+
+    run = store.create_run(
+        goal=str(goal).strip(),
+        features=feature_list,
+        source=source,
+        deliver=deliver,
+    )
+
+    scheduled_prompt = build_scheduled_computer_prompt(run)
+
+    try:
+        job = _cron_create_job(
+            prompt=scheduled_prompt,
+            schedule=str(schedule).strip(),
+            name=name or f"Computer: {run['goal'][:40]}",
+            deliver=deliver,
+        )
+    except Exception as exc:
+        store.update_run(run["id"], status="failed", error=f"cron create failed: {exc!r}")
+        return tool_error(
+            f"failed to create cron job: {exc!r}",
+            success=False,
+            run=store.get_run(run["id"]),
+        )
+
+    job_id = job.get("id") if isinstance(job, dict) else None
+    updated = store.update_run(
+        run["id"],
+        status="scheduled",
+        schedule=str(schedule).strip(),
+        schedule_job_id=job_id,
+    )
+    store.append_event(
+        run["id"],
+        "computer.schedule.created",
+        {"cron_job_id": job_id, "schedule": str(schedule).strip()},
+    )
+
+    return tool_result(
+        success=True,
+        run=updated,
+        cron_job=job,
+        message=(
+            f"Scheduled Computer run {run['id']} via cron job {job_id} "
+            f"on schedule '{schedule}'."
+        ),
+    )
+
+
+# ── Tool schema + registration ────────────────────────────────────────────────
+
+
+COMPUTER_SCHEMA = {
+    "name": "computer",
+    "description": (
+        "Drive Perplexity Computer-style persistent workflow runs inside Hermes. "
+        "Each run has a goal, a plan, an event log, an artifact directory, and a "
+        "lifecycle (queued/running/scheduled/completed/failed/cancelled). "
+        "Use action='start' to kick off a one-off Computer run (set "
+        "start_background=true to launch it in a background hermes process). "
+        "Use action='schedule' to register a recurring Computer run via the "
+        "cron scheduler — useful for continuous monitoring. "
+        "Use action='list' / 'get' / 'events' to inspect prior runs, and "
+        "action='cancel' to stop one. "
+        "All deliverables should be written into the run's artifact directory "
+        "so the user can find them later."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": sorted(_VALID_ACTIONS),
+                "description": "One of: start, list, get, events, cancel, schedule.",
+            },
+            "goal": {
+                "type": "string",
+                "description": "Natural-language goal for the Computer run (required for start/schedule).",
+            },
+            "features": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional feature labels to attach to the run, e.g. "
+                    "['runtime', 'parallel_research', 'continuous_monitoring']."
+                ),
+            },
+            "start_background": {
+                "type": "boolean",
+                "description": (
+                    "When true, start a background `hermes chat -q ...` process that "
+                    "executes the Computer prompt. Defaults to false (the calling "
+                    "session executes the run inline)."
+                ),
+            },
+            "run_id": {
+                "type": "string",
+                "description": "Required for get / events / cancel.",
+            },
+            "schedule": {
+                "type": "string",
+                "description": (
+                    "Cron-style schedule (e.g. '0 9 * * *') or any string parse_schedule accepts. "
+                    "Required for action='schedule'."
+                ),
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional friendly name for the scheduled cron job.",
+            },
+            "deliver": {
+                "type": "string",
+                "description": (
+                    "Optional cron delivery target. Pass 'origin' to deliver back to the "
+                    "originating chat (recommended), 'local' to save only, or a "
+                    "platform:chat_id[:thread_id] string for a specific destination."
+                ),
+            },
+            "source": {
+                "type": "string",
+                "description": "Optional free-form source label (e.g. 'cli', 'gateway').",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+registry.register(
+    name="computer",
+    toolset="computer",
+    schema=COMPUTER_SCHEMA,
+    handler=lambda args, **kw: computer(
+        action=args.get("action", ""),
+        goal=args.get("goal"),
+        features=args.get("features"),
+        start_background=bool(args.get("start_background", False)),
+        run_id=args.get("run_id"),
+        schedule=args.get("schedule"),
+        name=args.get("name"),
+        deliver=args.get("deliver"),
+        source=args.get("source"),
+        task_id=kw.get("task_id"),
+    ),
+    emoji="🖥️",
+    description=(
+        "Persistent Perplexity Computer-style workflow runtime — start, schedule, list, "
+        "inspect, and cancel long-running Hermes runs with artifacts and event logs."
+    ),
+)
+
+
+__all__ = [
+    "computer",
+    "start_computer_run",
+    "_cron_create_job",
+    "_get_store",
+    "COMPUTER_SCHEMA",
+]

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
+    # Perplexity Computer-style persistent workflow runtime
+    "computer",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -123,6 +125,12 @@ TOOLSETS = {
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
         "tools": ["cronjob"],
+        "includes": []
+    },
+
+    "computer": {
+        "description": "Perplexity Computer-style persistent workflow runtime — start, schedule, list, inspect, and cancel long-running Hermes runs with artifacts and event logs",
+        "tools": ["computer"],
         "includes": []
     },
     
@@ -283,6 +291,8 @@ TOOLSETS = {
             "execute_code", "delegate_task",
             # Cronjob management
             "cronjob",
+            # Perplexity Computer-style persistent workflow runtime
+            "computer",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
             "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2614,11 +2614,21 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 _compress_session_history(session, arg)
             _emit("session.info", sid, _session_info(agent))
         elif name == "fast" and agent:
+            from hermes_cli.models import resolve_fast_mode_overrides
+
             mode = arg.lower()
             if mode in {"fast", "on"}:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
+            try:
+                agent.request_overrides = (
+                    resolve_fast_mode_overrides(getattr(agent, "model", None))
+                    if agent.service_tier
+                    else {}
+                )
+            except Exception:
+                agent.request_overrides = {}
             _emit("session.info", sid, _session_info(agent))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()


### PR DESCRIPTION
## Summary
- Add a persistent Computer runtime with `run.json` / `events.jsonl` lifecycle state and artifact directories.
- Add a `computer` tool with `start`, `schedule`, `list`, `get`, `events`, and `cancel` actions.
- Wire the Computer prompt to existing Hermes primitives: `delegate_task`, browser/web/file/MCP tools, cron-backed monitoring, and approval/security boundaries.

## Tests
- `python -m pytest tests/computer/test_computer_runtime.py tests/tools/test_computer_tool.py -q` — 16 passed
- `python -m pytest tests/tools/test_cronjob_tools.py tests/tools/test_delegate.py tests/gateway/test_api_server_jobs.py tests/test_toolsets.py tests/tools/test_registry.py -q` — 219 passed, 35 warnings

## Notes
- Background launch currently starts `hermes chat -q <prompt>` and records process metadata; automatic completion reconciliation can be added in a follow-up.
