### PR TITLE
fix(model-metadata): extend Kimi 32k guard to Nous OpenRouter suffix-match

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1338,16 +1338,31 @@ def _resolve_nous_context_length(model: str) -> Optional[int]:
     with version normalization (dot↔dash).
     """
     metadata = fetch_model_metadata()  # OpenRouter cache
+
+    def _accept(ctx: Optional[int]) -> Optional[int]:
+        # Mirror the Kimi-32k guard applied to the step-6 OpenRouter fallback
+        # in ``get_model_context_length``. OpenRouter reports 32768 for
+        # moonshotai/kimi-k2.6 even though the model supports 262144; without
+        # this filter, Nous-routed Kimi models return 32k here and trip the
+        # 64k minimum-context guard before reaching DEFAULT_CONTEXT_LENGTHS.
+        if ctx == 32768 and _model_name_suggests_kimi(model):
+            return None
+        return ctx
+
     # Exact match first
     if model in metadata:
-        return metadata[model].get("context_length")
+        ctx = _accept(metadata[model].get("context_length"))
+        if ctx is not None:
+            return ctx
 
     normalized = _normalize_model_version(model).lower()
 
     for or_id, entry in metadata.items():
         bare = or_id.split("/", 1)[1] if "/" in or_id else or_id
         if bare.lower() == model.lower() or _normalize_model_version(bare).lower() == normalized:
-            return entry.get("context_length")
+            ctx = _accept(entry.get("context_length"))
+            if ctx is not None:
+                return ctx
 
     # Partial prefix match for cases like gemini-3-flash → gemini-3-flash-preview
     # Require match to be at a word boundary (followed by -, :, or end of string)
@@ -1358,7 +1373,9 @@ def _resolve_nous_context_length(model: str) -> Optional[int]:
             if candidate.startswith(query) and (
                 len(candidate) == len(query) or candidate[len(query)] in "-:."
             ):
-                return entry.get("context_length")
+                ctx = _accept(entry.get("context_length"))
+                if ctx is not None:
+                    return ctx
 
     return None
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -649,6 +649,59 @@ class TestGetModelContextLength:
 
         assert result == 200000
 
+    @patch("agent.model_metadata._query_ollama_api_show", return_value=None)
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_nous_kimi_32k_guard_falls_through_to_default(
+        self, mock_fetch, _mock_cache, _mock_ollama
+    ):
+        """Regression for #24000.
+
+        OpenRouter reports 32768 for moonshotai/kimi-k2.6 even though the
+        model supports 262144. When provider='nous', the suffix-match path
+        in ``_resolve_nous_context_length`` used to return that 32k value
+        directly, tripping the 64k minimum-context guard at run_agent.py
+        and blocking boot. The Kimi guard in step 6 didn't help because
+        nous is a known provider and step 6 is gated on
+        ``not effective_provider``.
+
+        Expectation: the resolver rejects the stale 32k value and falls
+        through to ``DEFAULT_CONTEXT_LENGTHS['kimi'] == 262144``.
+        """
+        mock_fetch.return_value = {
+            "moonshotai/kimi-k2.6": {"context_length": 32768},
+        }
+
+        result = get_model_context_length(
+            "moonshotai/kimi-k2.6",
+            base_url="https://inference-api.nousresearch.com/v1",
+            provider="nous",
+        )
+
+        assert result == 262144
+
+    @patch("agent.model_metadata._query_ollama_api_show", return_value=None)
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_nous_non_kimi_32k_is_preserved(
+        self, mock_fetch, _mock_cache, _mock_ollama
+    ):
+        """The Kimi guard is narrow: a real 32k Nous-routed non-Kimi model
+        should still resolve to 32k via the OpenRouter suffix-match. Only
+        the Kimi-family 32768-vs-262144 underreport is filtered out.
+        """
+        mock_fetch.return_value = {
+            "example/legit-32k-model": {"context_length": 32768},
+        }
+
+        result = get_model_context_length(
+            "example/legit-32k-model",
+            base_url="https://inference-api.nousresearch.com/v1",
+            provider="nous",
+        )
+
+        assert result == 32768
+
 
 # =========================================================================
 # Bedrock context resolution — must run BEFORE custom-endpoint probe


### PR DESCRIPTION
## Summary

`provider: nous` with a Kimi-family model (e.g. `moonshotai/kimi-k2.6`) cannot boot Hermes Agent: `get_model_context_length()` resolves the model to **32,768** tokens, which trips the 64K minimum-context guard at `run_agent.py:2254`. The user-facing message claims the model has a 32k window, but kimi-k2.6 actually supports 262,144.

Fixes #24000.

## The bug

PR #23980 (Kimi-family 32k guard) and the related #23950 / e2b713cce (skip OpenRouter for known providers, add `kimi`/`moonshot` to `PROVIDER_TO_MODELS_DEV`) landed a guard that rejects OpenRouter's stale `moonshotai/kimi-k2.6 → 32768` metadata. But that guard lives inside the step-6 OpenRouter fallback in `get_model_context_length`, gated on `if not effective_provider:`.

`provider: nous` is a *known* provider that intentionally piggybacks on OpenRouter via suffix-match (Nous Portal doesn't appear in models.dev, and adding it would be wrong). For nous, the resolver hits step 5b's `_resolve_nous_context_length` first — which queries the same OpenRouter cache and returned the 32,768 value directly. The step-6 guard never gets a chance to run because step 5b's return is non-`None`.

Trace for `provider=nous, model=moonshotai/kimi-k2.6`:

```
get_model_context_length(model="moonshotai/kimi-k2.6", provider="nous", ...)
  -> step 5b _resolve_nous_context_length(model)
       metadata["moonshotai/kimi-k2.6"] -> {"context_length": 32768}
       return 32768                                            <-- bug
  -> step 6 (if not effective_provider:)                       <-- skipped
  -> step 7 DEFAULT_CONTEXT_LENGTHS "kimi" -> 262144           <-- unreached
```

## The fix

Apply the same narrow Kimi guard inside `_resolve_nous_context_length`: when a suffix-matched entry yields exactly **32768** AND `_model_name_suggests_kimi(model)` matches, treat the entry as not found and let later resolution paths fire. The resolver then falls through to `DEFAULT_CONTEXT_LENGTHS["kimi"] = 262144` via the existing longest-substring match.

The filter is intentionally narrow:

- It only rejects `32768`, not other context values OpenRouter might report.
- It only fires for model names starting with `kimi` or containing `moonshot` (existing helper).
- It does not change behavior for any non-Kimi nous-routed model. A real 32k non-Kimi model still resolves to 32k correctly (covered by the second regression test).

If OpenRouter ever updates its metadata for kimi-k2.6, the filter becomes dead code with no impact, matching the existing comment on the step-6 guard.

## Why this is the right scope

Adding `nous` to `PROVIDER_TO_MODELS_DEV` would not help: Nous Portal is documented as suffix-matching against OpenRouter, not as a first-class models.dev entry. The suffix-match path is the correct flow; the fix is to make it as robust as the step-6 fallback that #23980 already hardened.

## Test plan

- [x] Focused regression test: `test_nous_kimi_32k_guard_falls_through_to_default` — mocks `fetch_model_metadata` to return the stale `{"moonshotai/kimi-k2.6": 32768}` entry, asserts result is 262144.
- [x] Negative case: `test_nous_non_kimi_32k_is_preserved` — verifies a legitimate 32k non-Kimi model still resolves to 32k (the guard is narrow).
- [x] Adjacent suite: `tests/agent/test_model_metadata.py` (96 passed), `tests/agent/test_nous_rate_guard.py` (32 passed), `tests/hermes_cli/test_runtime_provider_resolution.py` (109 passed).
- [x] Regression guard: with the fix reverted, `test_nous_kimi_32k_guard_falls_through_to_default` fails with `assert 32768 == 262144` — confirms the test actually exercises the new code path.

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 \
  -m pytest tests/agent/test_model_metadata.py -v
# 96 passed in 1.99s
```

## Related

- Fixes #24000
- Related: #23980 (Kimi 32k guard inside step-6 OR fallback) and e2b713cce / #23950 (skip OR for known providers, add kimi/moonshot to PROVIDER_TO_MODELS_DEV) — those two landed the same guard idea for the `provider: kimi/moonshot/ollama-cloud/kimi-coding` routes. This PR closes the remaining gap for `provider: nous`, which uses the OR cache via a separate suffix-match resolver.

> Sibling code paths that may need the same fix: none I'm aware of in the current tree — the step-6 OR fallback already has its own Kimi guard, and `_resolve_nous_context_length` is the only other place that reads OR's `context_length` field directly without going through `lookup_models_dev_context`. Happy to widen if I missed one.