### PR TITLE
fix(curator): repair orphan usage records

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -384,6 +384,24 @@ def _cmd_prune(args) -> int:
     return 0
 
 
+def _cmd_repair_usage(args) -> int:
+    """Synchronize curator-managed usage records with active/archive dirs."""
+    from tools import skill_usage
+
+    summary = skill_usage.repair_orphan_usage_records()
+    changed = sum(len(v) for v in summary.values())
+    if changed == 0:
+        print("curator: usage records already match filesystem")
+        return 0
+
+    print("curator: repaired usage records")
+    for key in ("marked_active", "marked_archived", "removed"):
+        names = summary.get(key) or []
+        if names:
+            print(f"  {key}: {', '.join(names)}")
+    return 0
+
+
 def _cmd_backup(args) -> int:
     """Take a manual snapshot of the skills tree. Same mechanism as the
     automatic pre-run snapshot, just user-initiated."""
@@ -650,6 +668,12 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
         help="Show what would be archived without doing it",
     )
     p_prune.set_defaults(func=_cmd_prune)
+
+    p_repair_usage = subs.add_parser(
+        "repair-usage",
+        help="Repair curator-managed .usage.json records against active/.archive dirs",
+    )
+    p_repair_usage.set_defaults(func=_cmd_repair_usage)
 
     p_backup = subs.add_parser(
         "backup",

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -388,7 +388,12 @@ def _cmd_repair_usage(args) -> int:
     """Synchronize curator-managed usage records with active/archive dirs."""
     from tools import skill_usage
 
-    summary = skill_usage.repair_orphan_usage_records()
+    try:
+        summary = skill_usage.repair_orphan_usage_records()
+    except skill_usage.UsagePersistenceError as e:
+        print(f"curator: failed to repair usage records: {e}")
+        return 1
+
     changed = sum(len(v) for v in summary.values())
     if changed == 0:
         print("curator: usage records already match filesystem")

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -177,6 +177,43 @@ def test_status_no_skills_produces_clean_empty_output(curator_status_env):
     assert "least active" not in out
 
 
+def test_repair_usage_command_prints_summary(monkeypatch, capsys):
+    from hermes_cli import curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    monkeypatch.setattr(
+        skill_usage,
+        "repair_orphan_usage_records",
+        lambda: {
+            "marked_active": ["restored-skill"],
+            "marked_archived": ["archived-skill"],
+            "removed": ["missing-skill"],
+        },
+    )
+
+    assert curator_cli._cmd_repair_usage(Namespace()) == 0
+    out = capsys.readouterr().out
+    assert "curator: repaired usage records" in out
+    assert "marked_active: restored-skill" in out
+    assert "marked_archived: archived-skill" in out
+    assert "removed: missing-skill" in out
+
+
+def test_repair_usage_command_prints_noop(monkeypatch, capsys):
+    from hermes_cli import curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    monkeypatch.setattr(
+        skill_usage,
+        "repair_orphan_usage_records",
+        lambda: {"marked_active": [], "marked_archived": [], "removed": []},
+    )
+
+    assert curator_cli._cmd_repair_usage(Namespace()) == 0
+    out = capsys.readouterr().out
+    assert "usage records already match filesystem" in out
+
+
 def test_status_marks_missing_last_report_path(monkeypatch, capsys, tmp_path):
     import agent.curator as curator_state
     import hermes_cli.curator as curator_cli

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -199,6 +199,22 @@ def test_repair_usage_command_prints_summary(monkeypatch, capsys):
     assert "removed: missing-skill" in out
 
 
+def test_repair_usage_command_fails_when_persistence_fails(monkeypatch, capsys):
+    from hermes_cli import curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    def _fail():
+        raise skill_usage.UsagePersistenceError("simulated write failure")
+
+    monkeypatch.setattr(skill_usage, "repair_orphan_usage_records", _fail)
+
+    assert curator_cli._cmd_repair_usage(Namespace()) == 1
+    out = capsys.readouterr().out
+    assert "failed to repair usage records" in out
+    assert "simulated write failure" in out
+    assert "curator: repaired usage records" not in out
+
+
 def test_repair_usage_command_prints_noop(monkeypatch, capsys):
     from hermes_cli import curator as curator_cli
     import tools.skill_usage as skill_usage

--- a/tests/hermes_cli/test_curator_usage.py
+++ b/tests/hermes_cli/test_curator_usage.py
@@ -110,3 +110,14 @@ def test_usage_command_is_registered():
     assert args.sort == "recent"
     assert args.provenance == "hub"
     assert args.json is True
+
+
+def test_repair_usage_command_is_registered():
+    """The `repair-usage` subcommand must be wired into the argparse tree."""
+    import argparse
+    import hermes_cli.curator as curator_cli
+
+    parser = argparse.ArgumentParser(prog="hermes curator")
+    curator_cli.register_cli(parser)
+    args = parser.parse_args(["repair-usage"])
+    assert args.func is curator_cli._cmd_repair_usage

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -563,6 +563,88 @@ def test_restore_prefers_timestamped_dupe_over_unrelated_sibling(skills_home):
     assert sibling.exists()        # the unrelated sibling stayed put
 
 
+def test_repair_orphan_usage_records_reconciles_managed_records(skills_home):
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+
+    _write_skill(skills_dir, "back-active")
+    skill_usage.mark_agent_created("back-active")
+    skill_usage.set_state("back-active", skill_usage.STATE_ARCHIVED)
+
+    archived = skills_dir / ".archive" / "imports" / "archived-only"
+    archived.mkdir(parents=True)
+    (archived / "SKILL.md").write_text(
+        "---\nname: archived-only\ndescription: archived\n---\n",
+        encoding="utf-8",
+    )
+    skill_usage.mark_agent_created("archived-only")
+
+    skill_usage.mark_agent_created("missing-skill")
+    data = skill_usage.load_usage()
+    data["manual-record"] = {"created_by": None, "state": skill_usage.STATE_ACTIVE}
+    data["bundled-record"] = {"created_by": "agent", "state": skill_usage.STATE_ACTIVE}
+    skill_usage.save_usage(data)
+    (skills_dir / ".bundled_manifest").write_text("bundled-record:abc\n", encoding="utf-8")
+
+    summary = skill_usage.repair_orphan_usage_records()
+
+    assert summary == {
+        "marked_active": ["back-active"],
+        "marked_archived": ["archived-only"],
+        "removed": ["missing-skill"],
+    }
+    repaired = skill_usage.load_usage()
+    assert repaired["back-active"]["state"] == skill_usage.STATE_ACTIVE
+    assert repaired["back-active"]["archived_at"] is None
+    assert repaired["archived-only"]["state"] == skill_usage.STATE_ARCHIVED
+    assert repaired["archived-only"]["archived_at"] is not None
+    assert "missing-skill" not in repaired
+    assert repaired["manual-record"]["state"] == skill_usage.STATE_ACTIVE
+    assert repaired["bundled-record"]["state"] == skill_usage.STATE_ACTIVE
+
+
+def test_repair_orphan_usage_records_noops_when_already_consistent(skills_home):
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "steady")
+    skill_usage.mark_agent_created("steady")
+
+    assert skill_usage.repair_orphan_usage_records() == {
+        "marked_active": [],
+        "marked_archived": [],
+        "removed": [],
+    }
+
+
+def test_repair_does_not_accept_frontmatter_only_archive_match(skills_home):
+    """Repair must not claim an archive is recoverable when restore cannot
+    resolve its directory name, even if SKILL.md frontmatter matches."""
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+    renamed = skills_dir / ".archive" / "imports" / "renamed-directory"
+    renamed.mkdir(parents=True)
+    (renamed / "SKILL.md").write_text(
+        "---\nname: orphan-record\ndescription: archived\n---\n",
+        encoding="utf-8",
+    )
+    skill_usage.mark_agent_created("orphan-record")
+
+    ok, msg = skill_usage.restore_skill("orphan-record")
+    assert not ok
+    assert "not found" in msg.lower()
+
+    assert skill_usage.repair_orphan_usage_records() == {
+        "marked_active": [],
+        "marked_archived": [],
+        "removed": ["orphan-record"],
+    }
+    assert "orphan-record" not in skill_usage.load_usage()
+    assert renamed.exists()
+
+
 # ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -16,6 +16,63 @@ def _bump_view_many(hermes_home: str, skill_name: str, iterations: int) -> None:
         bump_view(skill_name)
 
 
+def _repair_with_paused_active_scan(
+    hermes_home: str,
+    skill_name: str,
+    active_checked,
+    continue_scan,
+    result_queue,
+) -> None:
+    """Pause repair after its active lookup while it holds lifecycle locks."""
+    os.environ["HERMES_HOME"] = hermes_home
+    import importlib
+    import tools.skill_usage as skill_usage
+
+    importlib.reload(skill_usage)
+    original_find = skill_usage._find_skill_dir
+
+    def _paused_find(name: str):
+        result = original_find(name)
+        if name == skill_name:
+            active_checked.set()
+            if not continue_scan.wait(10):
+                raise RuntimeError("timed out waiting to continue repair scan")
+        return result
+
+    skill_usage._find_skill_dir = _paused_find
+    try:
+        result_queue.put(("ok", skill_usage.repair_orphan_usage_records()))
+    except Exception as exc:  # pragma: no cover - asserted through child result
+        result_queue.put(("error", repr(exc)))
+
+
+def _restore_with_state_signal(
+    hermes_home: str,
+    skill_name: str,
+    restore_started,
+    state_update_reached,
+    result_queue,
+) -> None:
+    """Signal when restore reaches metadata update after its directory move."""
+    os.environ["HERMES_HOME"] = hermes_home
+    import importlib
+    import tools.skill_usage as skill_usage
+
+    importlib.reload(skill_usage)
+    original_set_state = skill_usage.set_state
+
+    def _signaled_set_state(name: str, state: str) -> None:
+        state_update_reached.set()
+        original_set_state(name, state)
+
+    skill_usage.set_state = _signaled_set_state
+    restore_started.set()
+    try:
+        result_queue.put(("ok", skill_usage.restore_skill(skill_name)))
+    except Exception as exc:  # pragma: no cover - asserted through child result
+        result_queue.put(("error", repr(exc)))
+
+
 @pytest.fixture
 def skills_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with a clean skills/ dir for each test.
@@ -643,6 +700,119 @@ def test_repair_does_not_accept_frontmatter_only_archive_match(skills_home):
     }
     assert "orphan-record" not in skill_usage.load_usage()
     assert renamed.exists()
+
+
+def test_repair_raises_and_preserves_disk_when_persistence_fails(
+    skills_home, monkeypatch
+):
+    import tools.skill_usage as skill_usage
+
+    skill_usage.mark_agent_created("gone")
+    usage_path = skill_usage._usage_file()
+    before = usage_path.read_bytes()
+
+    def _replace_fails(*_args, **_kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(skill_usage.os, "replace", _replace_fails)
+
+    with pytest.raises(skill_usage.UsagePersistenceError, match="failed to persist"):
+        skill_usage.repair_orphan_usage_records()
+
+    assert usage_path.read_bytes() == before
+    assert not any(
+        path.name.startswith(".usage_") for path in usage_path.parent.iterdir()
+    )
+
+
+def test_repair_and_restore_are_serialized_across_processes(skills_home):
+    """Repair must not erase provenance while restore is moving the same skill."""
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir / ".archive", "race-skill")
+    record = skill_usage._empty_record()
+    record.update(
+        {
+            "created_by": "agent",
+            "use_count": 7,
+            "view_count": 3,
+            "patch_count": 2,
+            "state": skill_usage.STATE_ACTIVE,
+        }
+    )
+    skill_usage.save_usage({"race-skill": record})
+
+    ctx = mp.get_context("spawn")
+    active_checked = ctx.Event()
+    continue_scan = ctx.Event()
+    restore_started = ctx.Event()
+    state_update_reached = ctx.Event()
+    repair_results = ctx.Queue()
+    restore_results = ctx.Queue()
+
+    repair = ctx.Process(
+        target=_repair_with_paused_active_scan,
+        args=(
+            str(skills_home),
+            "race-skill",
+            active_checked,
+            continue_scan,
+            repair_results,
+        ),
+    )
+    restore = ctx.Process(
+        target=_restore_with_state_signal,
+        args=(
+            str(skills_home),
+            "race-skill",
+            restore_started,
+            state_update_reached,
+            restore_results,
+        ),
+    )
+
+    repair.start()
+    assert active_checked.wait(10), "repair never reached the active-directory scan"
+    restore.start()
+    assert restore_started.wait(10), "restore process never started"
+
+    # While repair is paused holding the lifecycle lock, restore must not move
+    # the archive or reach set_state(). The old implementation reaches this
+    # event, then blocks on the usage lock and loses provenance after repair.
+    reached_before_release = state_update_reached.wait(2)
+    continue_scan.set()
+
+    repair.join(15)
+    restore.join(15)
+    if repair.is_alive():
+        repair.terminate()
+    if restore.is_alive():
+        restore.terminate()
+
+    assert repair.exitcode == 0
+    assert restore.exitcode == 0
+    assert not reached_before_release
+    assert state_update_reached.is_set()
+    assert repair_results.get(timeout=2) == (
+        "ok",
+        {
+            "marked_active": [],
+            "marked_archived": ["race-skill"],
+            "removed": [],
+        },
+    )
+    restore_status, restore_result = restore_results.get(timeout=2)
+    assert restore_status == "ok"
+    assert restore_result[0] is True
+
+    repaired = skill_usage.load_usage()["race-skill"]
+    assert repaired["created_by"] == "agent"
+    assert repaired["use_count"] == 7
+    assert repaired["view_count"] == 3
+    assert repaired["patch_count"] == 2
+    assert repaired["state"] == skill_usage.STATE_ACTIVE
+    assert (skills_dir / "race-skill" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -754,6 +754,38 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"archived to {dest}"
 
 
+def _find_archived_skill_candidates(skill_name: str) -> List[Path]:
+    """Return archive directories that ``restore_skill`` can restore by name.
+
+    Archive entries are either an exact directory-name match or the
+    ``<skill>-YYYYMMDDHHMMSS`` collision form written by ``archive_skill``.
+    Frontmatter names are deliberately not used: repair and restore must agree
+    about whether a record is recoverable.
+    """
+    archive_root = _archive_dir()
+    if not archive_root.exists():
+        return []
+
+    exact = sorted(
+        p for p in archive_root.rglob("*")
+        if p.is_dir() and p.name == skill_name
+    )
+    if exact:
+        return exact
+
+    prefix = f"{skill_name}-"
+    return sorted(
+        (
+            p for p in archive_root.rglob("*")
+            if p.is_dir()
+            and p.name.startswith(prefix)
+            and len(p.name) - len(prefix) == 14
+            and p.name[len(prefix):].isdigit()
+        ),
+        reverse=True,
+    )
+
+
 def restore_skill(skill_name: str) -> Tuple[bool, str]:
     """Move an archived skill back to ~/.hermes/skills/. Restores to the flat
     top-level layout; original category nesting is NOT reconstructed.
@@ -782,29 +814,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     if not archive_root.exists():
         return False, "no archive directory"
 
-    # Try exact name match first, then the timestamped-duplicate fallback.
-    # Recursive walk handles nested archive layouts (e.g. .archive/<category>/<skill>/)
-    # left behind by older archive paths or external imports.
-    candidates = [p for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
-    if not candidates:
-        # A name collision makes archive_skill() disambiguate by appending its
-        # UTC timestamp ("<skill>-YYYYMMDDHHMMSS", a 14-digit suffix), so only
-        # that exact shape is another copy of THIS skill. A bare
-        # startswith(f"{skill_name}-") also swallows unrelated sibling skills —
-        # restoring "git" would otherwise pull an archived "git-helpers" out of
-        # the archive and rename it to "git", destroying the sibling's only
-        # copy. Require the suffix to be the timestamp archive_skill writes.
-        prefix = f"{skill_name}-"
-        candidates = sorted(
-            [
-                p for p in archive_root.rglob("*")
-                if p.is_dir()
-                and p.name.startswith(prefix)
-                and len(p.name) - len(prefix) == 14
-                and p.name[len(prefix):].isdigit()
-            ],
-            reverse=True,
-        )
+    candidates = _find_archived_skill_candidates(skill_name)
     if not candidates:
         return False, f"skill '{skill_name}' not found in archive"
 
@@ -861,6 +871,60 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
             if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
                 return skill_md.parent
     return None
+
+
+def repair_orphan_usage_records() -> Dict[str, List[str]]:
+    """Repair curator-managed usage records that do not match disk state.
+
+    Reconciles only records explicitly opted into curator management and still
+    eligible for local curation. Bundled, hub-installed, and unmanaged records
+    are left untouched. An archive counts only when ``restore_skill()`` can
+    resolve it by the same exact-directory or timestamped-collision rules.
+
+    Returns a summary with three sorted lists:
+    - ``marked_active``: archived records whose skill dir is active again
+    - ``marked_archived``: active/stale records whose skill dir is restorable
+    - ``removed``: managed records with no active or restorable archived skill
+    """
+    removed: List[str] = []
+    marked_archived: List[str] = []
+    marked_active: List[str] = []
+
+    with _usage_file_lock():
+        data = load_usage()
+        for name, rec in list(data.items()):
+            if not _is_curator_managed_record(rec) or not is_agent_created(name):
+                continue
+
+            active_dir = _find_skill_dir(name)
+            archived_candidates = _find_archived_skill_candidates(name)
+            state = rec.get("state", STATE_ACTIVE)
+
+            if active_dir is not None:
+                if state == STATE_ARCHIVED:
+                    rec["state"] = STATE_ACTIVE
+                    rec["archived_at"] = None
+                    marked_active.append(name)
+                continue
+
+            if archived_candidates:
+                if state != STATE_ARCHIVED:
+                    rec["state"] = STATE_ARCHIVED
+                    rec["archived_at"] = rec.get("archived_at") or _now_iso()
+                    marked_archived.append(name)
+                continue
+
+            removed.append(name)
+            data.pop(name, None)
+
+        if removed or marked_archived or marked_active:
+            save_usage(data)
+
+    return {
+        "marked_active": sorted(marked_active),
+        "marked_archived": sorted(marked_archived),
+        "removed": sorted(removed),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -86,10 +86,13 @@ def _usage_file() -> Path:
     return _skills_dir() / ".usage.json"
 
 
+class UsagePersistenceError(RuntimeError):
+    """Raised when a required usage-sidecar write cannot be persisted."""
+
+
 @contextmanager
-def _usage_file_lock():
-    """Serialize .usage.json read-modify-write cycles across processes."""
-    lock_path = _usage_file().with_suffix(".json.lock")
+def _exclusive_file_lock(lock_path: Path):
+    """Hold an exclusive cross-process lock for the supplied path."""
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     if fcntl is None and msvcrt is None:
@@ -120,6 +123,25 @@ def _usage_file_lock():
             except (OSError, IOError):
                 pass
         fd.close()
+
+
+@contextmanager
+def _usage_file_lock():
+    """Serialize .usage.json read-modify-write cycles across processes."""
+    with _exclusive_file_lock(_usage_file().with_suffix(".json.lock")):
+        yield
+
+
+@contextmanager
+def _lifecycle_lock():
+    """Serialize archive/restore/repair filesystem and metadata transitions.
+
+    Lifecycle callers always acquire this lock before ``_usage_file_lock``.
+    Telemetry-only writers acquire the usage lock alone, so the ordering cannot
+    invert and deadlock.
+    """
+    with _exclusive_file_lock(_skills_dir() / ".lifecycle.lock"):
+        yield
 
 
 def _archive_dir() -> Path:
@@ -517,28 +539,33 @@ def load_usage() -> Dict[str, Dict[str, Any]]:
     return clean
 
 
+def _save_usage_strict(data: Dict[str, Dict[str, Any]]) -> None:
+    """Atomically persist the usage map, propagating every write failure."""
+    path = _usage_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".usage_", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
 def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
     """Write the usage map atomically. Best-effort — errors are logged, not raised."""
-    path = _usage_file()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(path.parent), prefix=".usage_", suffix=".tmp"
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+        _save_usage_strict(data)
     except Exception as e:
-        logger.debug("Failed to write %s: %s", path, e, exc_info=True)
+        logger.debug("Failed to write %s: %s", _usage_file(), e, exc_info=True)
 
 
 def get_record(skill_name: str) -> Dict[str, Any]:
@@ -694,6 +721,12 @@ def forget(skill_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 def archive_skill(skill_name: str) -> Tuple[bool, str]:
+    """Archive one skill as a serialized filesystem + metadata transition."""
+    with _lifecycle_lock():
+        return _archive_skill_locked(skill_name)
+
+
+def _archive_skill_locked(skill_name: str) -> Tuple[bool, str]:
     """Move a curator-eligible skill directory to ~/.hermes/skills/.archive/.
 
     Returns (ok, message). Never archives hub-installed skills. Bundled
@@ -787,6 +820,12 @@ def _find_archived_skill_candidates(skill_name: str) -> List[Path]:
 
 
 def restore_skill(skill_name: str) -> Tuple[bool, str]:
+    """Restore one skill as a serialized filesystem + metadata transition."""
+    with _lifecycle_lock():
+        return _restore_skill_locked(skill_name)
+
+
+def _restore_skill_locked(skill_name: str) -> Tuple[bool, str]:
     """Move an archived skill back to ~/.hermes/skills/. Restores to the flat
     top-level layout; original category nesting is NOT reconstructed.
 
@@ -890,7 +929,7 @@ def repair_orphan_usage_records() -> Dict[str, List[str]]:
     marked_archived: List[str] = []
     marked_active: List[str] = []
 
-    with _usage_file_lock():
+    with _lifecycle_lock(), _usage_file_lock():
         data = load_usage()
         for name, rec in list(data.items()):
             if not _is_curator_managed_record(rec) or not is_agent_created(name):
@@ -918,7 +957,12 @@ def repair_orphan_usage_records() -> Dict[str, List[str]]:
             data.pop(name, None)
 
         if removed or marked_archived or marked_active:
-            save_usage(data)
+            try:
+                _save_usage_strict(data)
+            except Exception as e:
+                raise UsagePersistenceError(
+                    f"failed to persist repaired usage records: {e}"
+                ) from e
 
     return {
         "marked_active": sorted(marked_active),

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -107,7 +107,14 @@ hermes curator restore <skill>  # move an archived skill back to active
 hermes curator list-archived    # list skills currently in ~/.hermes/skills/.archive/
 hermes curator archive <skill>  # manually archive a single skill now
 hermes curator prune [--days N] # bulk-archive agent-created skills idle >= N days (default 90)
+hermes curator repair-usage     # reconcile curator-managed usage records with restorable skills
 ```
+
+`repair-usage` is a recovery command for stale `.usage.json` records left by
+interrupted or manual filesystem changes. It changes usage metadata only; it
+does not move skill directories. Archived records are retained only when
+`hermes curator restore <name>` can resolve the same exact archive-directory or
+timestamped-collision name. Curator-ineligible records are left untouched.
 
 ## Backups and rollback
 


### PR DESCRIPTION
## Summary
- Add `repair_orphan_usage_records()` to reconcile curator-managed agent-created `.usage.json` records with active skill directories and archives.
- Add explicit `hermes curator repair-usage` CLI command for audited/manual repair.
- Keep repair scoped to curator-managed agent-created records so bundled, hub-installed, or manually authored skills are not modified.
- Reuse the same `_find_archived_skill_candidates()` resolver in both repair and restore so repair only marks an entry archived when `restore_skill(record_name)` can actually restore it.
- Serialize archive, restore, and repair lifecycle transitions across processes so repair cannot erase provenance or counters during a concurrent restore.
- Fail closed when repaired usage state cannot be persisted: the CLI now reports the write failure and exits non-zero instead of claiming success.
- Add the requested mismatched-directory/frontmatter regression, argparse registration coverage, and user documentation.

This is a surgical follow-up to feedback on #20480. It intentionally excludes fork-local routing, delegation, daemon, runtime-export, and local-ops changes.

## Automated review follow-up
Addressed the `hermes-sweeper` review on this PR:

1. Repair and restore now share one archive candidate resolver.
2. A renamed archive directory whose `SKILL.md` frontmatter matches the record is not reported as restorable.
3. `hermes curator repair-usage` is documented.
4. The command's argparse registration is regression-tested.
5. Archive, restore, and repair use one lifecycle lock with lifecycle-before-usage lock ordering; a deterministic multiprocessing regression covers the former repair/restore race.
6. Repair uses a strict atomic write path and `repair-usage` returns non-zero on persistence failure while preserving the existing sidecar.
7. The branch was rebased onto `main` at `10dc1571b` before the repair.

## Verification
- Ruff on all six changed files: **pass**.
- Canonical curator suite: **244 passed, 0 failed** across 11 files.
- Isolated temporary-`HERMES_HOME` end-to-end fixture: **15/15 checks passed**; exact and timestamped archives restore, frontmatter-only renamed archives do not, and a second repair is idempotent.
- Deterministic LoopOS validation: **PASS** in one iteration.
- Full repository runner: 54 failures in 13 unrelated files. Re-running those same 13 files on pristine `upstream/main` produced the identical **54 failures**, confirming no full-suite regressions introduced by this PR.
