### PR TITLE
fix(approval): block quoted hardline rm targets

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -43,10 +43,23 @@ _HARDLINE_BLOCK = [
     "rm --recursive --force /",
     "rm -fr /",
     "sudo rm -rf /",
+    'rm -rf --no-preserve-root "/"',
+    "rm -rf --no-preserve-root '/'",
+    'rm -rf "/"*',
+    "sudo rm -rf '/etc'",
+    'rm -rf "/home"',
+    'rm -rf "/home/"',
+    'rm -rf "/home/"*',
+    "rm -rf '/var'",
     "rm -rf ~",
     "rm -rf ~/",
     "rm -rf ~/*",
     "rm -rf $HOME",
+    'rm -rf "$HOME"',
+    'rm -rf "${HOME}"',
+    'rm -rf "$HOME"/*',
+    'rm -rf "$HOME/"*',
+    'rm -rf "${HOME}/"',
     # Filesystem format
     "mkfs.ext4 /dev/sda1",
     "mkfs /dev/sdb",
@@ -95,11 +108,16 @@ _HARDLINE_ALLOW = [
     # rm on non-protected paths
     "rm -rf /tmp/foo",
     "rm -rf /tmp/*",
+    'rm -rf "/tmp/foo"',
     "rm -rf ./build",
     "rm -rf node_modules",
     "rm -rf /home/user/scratch",  # subpath of /home, not /home itself
+    'rm -rf "/home/user/scratch"',
     "rm -rf ~/Downloads/old",
     "rm -rf $HOME/tmp",
+    'rm -rf "$HOME/tmp"',
+    'rm -rf "${HOME}/tmp"',
+    'rm -rf "~"',  # quoted tilde is a literal filename, not home expansion
     "rm foo.txt",
     "rm -rf some/path",
     # dd to regular files
@@ -191,7 +209,14 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
     """HERMES_YOLO_MODE=1 must not bypass the hardline floor."""
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
 
-    for cmd in ["rm -rf /", "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot"]:
+    for cmd in [
+        "rm -rf /",
+        'rm -rf --no-preserve-root "/"',
+        'rm -rf "$HOME"/*',
+        "shutdown -h now",
+        "mkfs.ext4 /dev/sda",
+        "reboot",
+    ]:
         r1 = check_dangerous_command(cmd, "local")
         assert r1["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_dangerous_command)"
         assert r1.get("hardline") is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -186,9 +186,22 @@ _CMDPOS = (
 
 HARDLINE_PATTERNS = [
     # rm recursive targeting the root filesystem or protected roots
-    (r'\brm\s+(-[^\s]*\s+)*(/|/\*|/ \*)(\s|$)', "recursive delete of root filesystem"),
-    (r'\brm\s+(-[^\s]*\s+)*(/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/\*|/var|/var/\*|/bin|/bin/\*|/sbin|/sbin/\*|/boot|/boot/\*|/lib|/lib/\*)(\s|$)', "recursive delete of system directory"),
-    (r'\brm\s+(-[^\s]*\s+)*(~|\$HOME)(/?|/\*)?(\s|$)', "recursive delete of home directory"),
+    (
+        r'\brm\s+(-[^\s]*\s+)*(?:"/"\*?|\'/\'\*?|/|/\*|/ \*)(\s|$)',
+        "recursive delete of root filesystem",
+    ),
+    (
+        r'\brm\s+(-[^\s]*\s+)*(?:"/(home|root|etc|usr|var|bin|sbin|boot|lib)/?"(?:\*|/\*)?|'
+        r'\'/(home|root|etc|usr|var|bin|sbin|boot|lib)/?\'(?:\*|/\*)?|'
+        r'/(home|root|etc|usr|var|bin|sbin|boot|lib)(?:/?|/\*)?)(\s|$)',
+        "recursive delete of system directory",
+    ),
+    (
+        r'\brm\s+(-[^\s]*\s+)*(?:~(?:/?|/\*)?|'
+        r'(?:\$home|\$\{home\})(?:/?|/\*)?|'
+        r'"(?:\$home|\$\{home\})/?"(?:\*|/\*)?)(\s|$)',
+        "recursive delete of home directory",
+    ),
     # Filesystem format
     (r'\bmkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
     # Raw block device overwrites (dd + redirection)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -585,7 +585,7 @@ class ProcessRegistry:
             try:
                 if not _IS_WINDOWS:
                     try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)  # windows-footgun: ok - gated by _IS_WINDOWS
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:


### PR DESCRIPTION
## Summary
- Extend the approval hardline `rm` patterns to catch quoted root, protected system directories, and `$HOME` targets.
- Keep non-protected quoted paths such as `/tmp/foo`, `/home/user/scratch`, and `$HOME/tmp` outside the hardline floor.
- Add regressions proving yolo still cannot bypass these quoted catastrophic targets.
- Suppress the current all-repo Windows-footgun false positive on a POSIX-gated `os.killpg(..., signal.SIGKILL)` cleanup path so the blocking lint job can complete on this merge.

## Root Cause
The hardline blocklist ran before yolo/off/cron-approve, but its `rm` regexes only matched unquoted protected targets. Shell-equivalent forms like `rm -rf --no-preserve-root "/"`, `rm -rf "/var"`, or `rm -rf "$HOME"/*` missed hardline detection and could continue through yolo-style bypass paths.

The Windows-footgun checker also scans the whole merge tree and flagged an existing POSIX-only cleanup line in `tools/process_registry.py`; that line is guarded by `_IS_WINDOWS`, so it only needed the checker suppression marker.

## Validation
- `python3 -m pytest tests/tools/test_hardline_blocklist.py tests/tools/test_yolo_mode.py tests/tools/test_command_guards.py tests/tools/test_cron_approval_mode.py -q -n0`
- `python3 -m pytest tests/tools/test_approval.py -q -n0`
- `python3 scripts/check-windows-footguns.py --all`
- `python3 -m py_compile tools/approval.py`
- `git diff --check`