### PR TITLE
fix(context): avoid 100 percent threshold at minimum context length

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -358,6 +358,23 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    @staticmethod
+    def _compute_threshold_tokens(context_length: int, threshold_percent: float) -> int:
+        """Return the auto-compression trigger for a model context window.
+
+        Keep the historical 64K floor for larger windows, but never let that
+        floor consume the entire window on minimum-context models. Otherwise a
+        64K model configured for a 50% or 70% threshold does not compress
+        until the full context window is already exhausted.
+        """
+        threshold_tokens = max(
+            int(context_length * threshold_percent),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        if context_length <= MINIMUM_CONTEXT_LENGTH and threshold_tokens >= context_length:
+            return int(context_length * threshold_percent)
+        return threshold_tokens
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()
@@ -389,9 +406,9 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
+        self.threshold_tokens = self._compute_threshold_tokens(
+            context_length,
+            self.threshold_percent,
         )
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
@@ -432,13 +449,11 @@ class ContextCompressor(ContextEngine):
             config_context_length=config_context_length,
             provider=provider,
         )
-        # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
+        # Keep the historical 64K floor for larger windows without letting it
+        # suppress compression entirely on minimum-context models.
+        self.threshold_tokens = self._compute_threshold_tokens(
+            self.context_length,
+            threshold_percent,
         )
         self.compression_count = 0
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1272,12 +1272,28 @@ class TestSummaryTargetRatio:
         assert c.summary_target_ratio == 0.80
 
     def test_default_threshold_is_50_percent(self):
-        """Default compression threshold should be 50%, with a 64K floor."""
+        """Default compression threshold should keep the historical 64K floor."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
             c = ContextCompressor(model="test", quiet_mode=True)
         assert c.threshold_percent == 0.50
         # 50% of 100K = 50K, but the floor is 64K
         assert c.threshold_tokens == 64_000
+
+    def test_minimum_context_window_uses_percentage_threshold(self):
+        """At the 64K minimum, the floor must not suppress compression entirely."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=64_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.threshold_percent == 0.50
+        assert c.threshold_tokens == 32_000
+        assert c.should_compress(prompt_tokens=31_999) is False
+        assert c.should_compress(prompt_tokens=32_000) is True
+
+    def test_update_model_preserves_percentage_threshold_at_minimum_context(self):
+        """Model switches should not restore the broken 100% threshold at 64K."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        c.update_model("test", 64_000)
+        assert c.threshold_tokens == 32_000
 
     def test_threshold_floor_does_not_apply_above_128k(self):
         """On large-context models the 50% percentage is used directly."""


### PR DESCRIPTION
## Summary

Fix context compression threshold calculation for minimum-context models.

Previously, `ContextCompressor` always applied the 64K floor directly to
`threshold_tokens`. On models with a 64K context window, that could raise the
effective trigger to 100% of the window, so auto-compression would not fire
until the context was already exhausted.

This change keeps the historical 64K floor for larger context windows, but
falls back to the configured percentage when the floor would otherwise consume
the entire minimum context window.

Closes #14690.

## What changed

- Added a shared `_compute_threshold_tokens()` helper in `ContextCompressor`
- Applied the same threshold logic in both `__init__()` and `update_model()`
- Added regression coverage for:
  - 64K models using the percentage threshold
  - exact trigger behavior at 32K for the default 50% threshold
  - model updates preserving the corrected threshold behavior

## Why this is safe

- Larger context windows keep the existing 64K floor behavior
- The behavior change is limited to the broken minimum-context case
- Existing threshold-related feasibility tests still pass

## Tests

- `uv run --group dev pytest tests/agent/test_context_compressor.py -k "threshold or minimum_context_window or update_model_preserves" -n 0`
- `uv run --group dev pytest tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compressor_fallback_update.py -k "threshold or exact_threshold_boundary_no_warning or just_below_threshold_auto_corrects" -n 0`
