### PR TITLE
fix(setup): skip duplicate tool configuration across platforms during first install

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2398,6 +2398,11 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
 
     # ── First-time install: linear flow, no platform menu ──
     if first_install:
+        # Track toolsets already configured in this session to avoid
+        # re-prompting when multiple platforms share the same global
+        # tool config (e.g. browser, TTS, image_gen, firecrawl).
+        already_configured: set[str] = set()
+
         for pkey in enabled_platforms:
             pinfo = PLATFORMS[pkey]
             current_enabled = _get_platform_tools(config, pkey, include_default_mcp_servers=False)
@@ -2431,11 +2436,13 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             # Walk through ALL selected tools that have provider options or
             # need API keys.  This ensures browser (Local vs Browserbase),
             # TTS (Edge vs OpenAI vs ElevenLabs), etc. are shown even when
-            # a free provider exists.
+            # a free provider exists.  Skip toolsets already configured for
+            # a previous platform — their settings are global, not per-platform.
             to_configure = [
                 ts_key for ts_key in sorted(new_enabled)
                 if (TOOL_CATEGORIES.get(ts_key) or TOOLSET_ENV_REQUIREMENTS.get(ts_key))
                 and ts_key not in auto_configured
+                and ts_key not in already_configured
             ]
 
             if to_configure:
@@ -2448,6 +2455,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 print()
                 for ts_key in to_configure:
                     _configure_toolset(ts_key, config)
+                    already_configured.add(ts_key)
 
             _save_platform_tools(config, pkey, new_enabled)
             save_config(config)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -610,6 +610,70 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
     assert config["browser"]["cloud_provider"] == "browser-use"
     assert configured == []
 
+
+def test_first_install_skips_already_configured_toolsets_across_platforms(monkeypatch):
+    """Toolsets with global config (browser, TTS, etc.) should only be
+    configured once during first_install, even when multiple platforms
+    are enabled (e.g. cli + slack).  Regression test for #24069."""
+    config: dict = {
+        "model": {"provider": "openrouter"},
+        "platform_toolsets": {},
+    }
+    # Clean env so no auto-detection adds extra platforms
+    for env_var in (
+        "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN",
+        "WHATSAPP_ENABLED", "QQ_APP_ID",
+        "VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY",
+        "ELEVENLABS_API_KEY", "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+        "TAVILY_API_KEY", "PARALLEL_API_KEY",
+        "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY", "FAL_KEY",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    # Simulate two enabled platforms: cli and slack
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_enabled_platforms",
+        lambda: ["cli", "slack"],
+    )
+    # Both platforms select the same toolsets
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_toolset_checklist",
+        lambda *args, **kwargs: {"browser", "tts", "image_gen", "web"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.apply_nous_managed_defaults",
+        lambda config, enabled_toolsets: set(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.managed_nous_tools_enabled",
+        lambda: False,
+    )
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+
+    configured: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_toolset",
+        lambda ts_key, cfg: configured.append(ts_key),
+    )
+
+    tools_command(first_install=True, config=config)
+
+    # Each toolset should be configured exactly once, not once per platform
+    assert len(configured) == len(set(configured)), (
+        f"Duplicate toolset configuration detected: {configured}"
+    )
+    assert len(configured) > 0, "Expected at least one toolset to be configured"
+    # Verify no duplicates — each toolset appears exactly once
+    from collections import Counter
+    counts = Counter(configured)
+    for ts_key, count in counts.items():
+        assert count == 1, (
+            f"Toolset {ts_key!r} was configured {count} times "
+            f"(expected 1 — tool settings are global, not per-platform)"
+        )
+
+
 # ── Platform / toolset consistency ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

During first-time setup with multiple enabled platforms (e.g. CLI + Slack), the tool configuration flow prompts the user to configure global toolsets (browser, TTS, image generation, firecrawl) once per platform — even though these settings are global, not per-platform.


### Root Cause

In `tools_command()` (`hermes_cli/tools_config.py`), the `first_install` flow iterates over all enabled platforms and calls `_configure_toolset()` for each selected toolset on every platform. Since tool configurations (browser provider, TTS provider, API keys) are written to the global config dict, configuring them for the first platform and then again for the second is redundant.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A