### PR TITLE
Fix/clipboard auto attach disable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1850,8 +1850,29 @@ def _format_image_attachment_badges(attached_images: list[Path], image_counter: 
 
 
 def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
-    """Auto-attach clipboard images only for image-only paste gestures."""
-    return not pasted_text.strip()
+    """Auto-attach clipboard images only for image-only paste gestures.
+
+    Two short-circuits:
+      1. The pasted text is non-empty (user actually pasted text — never
+         probe the clipboard for an image in that case).
+      2. The user has explicitly opted out of auto-attach via
+         ``clipboard.auto_attach_image: false`` in config or
+         ``HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1`` in the environment.
+         See issue #23984: leaked bracketed-paste markers from terminal
+         control sequences (Ghostty over SSH, mouse-report fragments,
+         focus events) made this fire constantly and bombarded users
+         with privacy prompts plus 'No image found in clipboard' lines.
+    """
+    if pasted_text.strip():
+        return False
+    try:
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        if not is_clipboard_auto_attach_enabled():
+            return False
+    except Exception:
+        # Defensive: never block paste handling because the gate failed.
+        pass
+    return True
 
 
 def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -18,10 +18,130 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 from hermes_constants import is_wsl as _is_wsl
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Auto-attach gate (#23984)
+# ---------------------------------------------------------------------------
+#
+# Some terminals (notably Ghostty over SSH) raise an OS-level privacy prompt
+# every time a process reads the system clipboard, *even for failed reads*.
+# Hermes' bracketed-paste handler treats any empty paste as "the user just
+# pasted an image" and probes the clipboard with osascript / pngpaste /
+# powershell etc. to extract image data. In environments where bracketed
+# paste markers leak from terminal control sequences (SSH escape sequences,
+# mouse-report fragments, focus events) those probes fire constantly and the
+# user is bombarded with "No image found in clipboard" messages plus, on
+# Ghostty, a re-armed privacy alert per probe.
+#
+# These helpers expose a deterministic opt-out. Once disabled, every
+# *automatic* clipboard image probe short-circuits to "no image" without
+# touching the OS clipboard at all. Explicit user actions (the `/paste`
+# slash command, ``image.attach`` RPC with a real path) are not affected.
+
+_AUTO_ATTACH_ENV_VAR = "HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH"
+_AUTO_ATTACH_CONFIG_KEYS = ("clipboard", "auto_attach_image")
+
+
+def _coerce_truthy_env(raw: Optional[str]) -> Optional[bool]:
+    """Parse an env-var string into a tri-state truthy/falsy/unset.
+
+    Accepts the values Hermes uses elsewhere (``HERMES_LOG_LEVEL`` style):
+    ``"1" / "true" / "yes" / "on"`` are truthy; ``"0" / "false" / "no" /
+    "off"`` are falsy; everything else (and ``None`` / blank) is treated
+    as "not set" so the config value wins.
+    """
+    if raw is None:
+        return None
+    val = raw.strip().lower()
+    if not val:
+        return None
+    if val in ("1", "true", "yes", "on", "y", "t"):
+        return True
+    if val in ("0", "false", "no", "off", "n", "f"):
+        return False
+    return None
+
+
+def _coerce_config_bool(raw: Any) -> Optional[bool]:
+    """Coerce a YAML-parsed scalar into a tri-state bool.
+
+    Mirrors ``_coerce_truthy_env`` so config and env have identical
+    semantics. Returns ``None`` for missing / unrecognised values so the
+    caller can apply its own default.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        return bool(raw)
+    if isinstance(raw, str):
+        return _coerce_truthy_env(raw)
+    return None
+
+
+def is_clipboard_auto_attach_enabled(
+    cfg: Optional[Dict[str, Any]] = None,
+    env: Optional[Dict[str, str]] = None,
+) -> bool:
+    """Return True iff Hermes may probe the clipboard for images automatically.
+
+    Resolution order (first match wins):
+      1. ``HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1`` env var → False
+         (also accepts ``true`` / ``yes`` / ``on``).
+      2. ``clipboard.auto_attach_image`` in the user's ``config.yaml`` →
+         that boolean's value.
+      3. Default → True (matches pre-#23984 behaviour).
+
+    Args:
+      cfg: Loaded config dict. When ``None`` we lazily call
+        ``hermes_cli.config.load_config`` so callers in hot paths don't
+        need to thread it through. Failure to load is treated as "no
+        config", not an error — the caller still gets a useful answer.
+      env: Override env mapping (defaults to ``os.environ``). The
+        parameter exists for tests; production callers pass nothing.
+    """
+    env_map = env if env is not None else os.environ
+
+    # Env var: an explicit "disable" flag wins over everything (matches the
+    # convention of HERMES_DISABLE_* knobs elsewhere in the project).
+    env_disable = _coerce_truthy_env(env_map.get(_AUTO_ATTACH_ENV_VAR))
+    if env_disable is True:
+        return False
+    if env_disable is False:
+        # Explicit "HERMES_DISABLE_...=0" forces enable, ignoring config.
+        return True
+
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug(
+                "is_clipboard_auto_attach_enabled: config load failed: %s",
+                exc,
+            )
+            cfg = None
+
+    if isinstance(cfg, dict):
+        node: Any = cfg
+        for key in _AUTO_ATTACH_CONFIG_KEYS:
+            if isinstance(node, dict):
+                node = node.get(key)
+            else:
+                node = None
+                break
+        coerced = _coerce_config_bool(node)
+        if coerced is not None:
+            return coerced
+
+    return True
 
 
 def save_clipboard_image(dest: Path) -> bool:

--- a/tests/hermes_cli/test_clipboard_auto_attach.py
+++ b/tests/hermes_cli/test_clipboard_auto_attach.py
@@ -1,0 +1,196 @@
+"""Tests for the clipboard auto-attach gate (#23984).
+
+Pin the contract of ``hermes_cli.clipboard.is_clipboard_auto_attach_enabled``
+plus the smaller env / config coercion helpers it composes. Also covers
+the precedence rule (env override beats config beats default).
+
+The companion end-to-end regression for #23984 lives in
+``tests/tools/test_clipboard_auto_attach_wiring.py``; this file pins
+the unit contract in isolation so behaviour does not regress silently
+if the surrounding clipboard plumbing is refactored.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _coerce_truthy_env
+# ---------------------------------------------------------------------------
+
+class TestCoerceTruthyEnv:
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", " yes ", "on", "Y", "T"])
+    def test_truthy_values_return_true(self, raw):
+        from hermes_cli.clipboard import _coerce_truthy_env
+        assert _coerce_truthy_env(raw) is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "FALSE", " no ", "off", "N", "F"])
+    def test_falsy_values_return_false(self, raw):
+        from hermes_cli.clipboard import _coerce_truthy_env
+        assert _coerce_truthy_env(raw) is False
+
+    @pytest.mark.parametrize("raw", [None, "", "  ", "maybe", "2", "definitely"])
+    def test_unknown_values_return_none(self, raw):
+        from hermes_cli.clipboard import _coerce_truthy_env
+        assert _coerce_truthy_env(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# _coerce_config_bool
+# ---------------------------------------------------------------------------
+
+class TestCoerceConfigBool:
+    @pytest.mark.parametrize("raw,expected", [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("yes", True),
+        ("no", False),
+        ("true", True),
+        ("false", False),
+    ])
+    def test_recognised_values_coerce(self, raw, expected):
+        from hermes_cli.clipboard import _coerce_config_bool
+        assert _coerce_config_bool(raw) is expected
+
+    @pytest.mark.parametrize("raw", [None, "", "  ", "maybe", [], {}, object()])
+    def test_unknown_values_return_none(self, raw):
+        from hermes_cli.clipboard import _coerce_config_bool
+        assert _coerce_config_bool(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# is_clipboard_auto_attach_enabled — env precedence
+# ---------------------------------------------------------------------------
+
+class TestEnvPrecedence:
+    def test_env_disable_truthy_wins_over_config_enable(self):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+
+        cfg = {"clipboard": {"auto_attach_image": True}}
+        env = {"HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH": "1"}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env=env) is False
+
+    def test_env_disable_zero_forces_enable_even_if_config_disables(self):
+        """Explicit `HERMES_DISABLE_...=0` is a force-enable knob."""
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+
+        cfg = {"clipboard": {"auto_attach_image": False}}
+        env = {"HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH": "0"}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env=env) is True
+
+    @pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "TRUE"])
+    def test_env_disable_truthy_variants_disable(self, raw):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        env = {"HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH": raw}
+        assert is_clipboard_auto_attach_enabled(cfg={}, env=env) is False
+
+    @pytest.mark.parametrize("raw", ["", "maybe", "definitely", " "])
+    def test_env_disable_unknown_falls_through_to_config(self, raw):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+
+        cfg = {"clipboard": {"auto_attach_image": False}}
+        env = {"HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH": raw}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env=env) is False
+
+
+# ---------------------------------------------------------------------------
+# is_clipboard_auto_attach_enabled — config-only path
+# ---------------------------------------------------------------------------
+
+class TestConfigOnlyPath:
+    def test_config_enable_returns_true(self):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        cfg = {"clipboard": {"auto_attach_image": True}}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env={}) is True
+
+    def test_config_disable_returns_false(self):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        cfg = {"clipboard": {"auto_attach_image": False}}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env={}) is False
+
+    @pytest.mark.parametrize("cfg", [
+        {},
+        {"clipboard": {}},
+        {"clipboard": {"unrelated_key": True}},
+        {"other_section": {"auto_attach_image": False}},
+    ])
+    def test_missing_config_keys_default_to_enabled(self, cfg):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env={}) is True
+
+    def test_non_dict_clipboard_section_defaults_to_enabled(self):
+        """A user typo (string instead of nested dict) must not crash."""
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        cfg = {"clipboard": "yes please"}
+        assert is_clipboard_auto_attach_enabled(cfg=cfg, env={}) is True
+
+
+# ---------------------------------------------------------------------------
+# is_clipboard_auto_attach_enabled — defaults
+# ---------------------------------------------------------------------------
+
+class TestDefaults:
+    def test_no_env_no_config_returns_true(self):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+        assert is_clipboard_auto_attach_enabled(cfg={}, env={}) is True
+
+    def test_none_cfg_loads_lazily(self):
+        from hermes_cli import clipboard as clip_mod
+
+        with patch("hermes_cli.config.load_config",
+                   return_value={"clipboard": {"auto_attach_image": False}}):
+            assert clip_mod.is_clipboard_auto_attach_enabled(env={}) is False
+
+    def test_none_cfg_with_failing_load_falls_back_to_default(self):
+        from hermes_cli import clipboard as clip_mod
+
+        with patch("hermes_cli.config.load_config",
+                   side_effect=RuntimeError("config.yaml unreadable")):
+            # Default → True (auto-attach stays on if config is broken).
+            assert clip_mod.is_clipboard_auto_attach_enabled(env={}) is True
+
+    def test_default_env_is_os_environ(self, monkeypatch):
+        """When ``env=None`` we read os.environ — verify by setting it."""
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+
+        monkeypatch.setenv("HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH", "1")
+        assert is_clipboard_auto_attach_enabled(cfg={}) is False
+
+    def test_default_env_unset_returns_true(self, monkeypatch):
+        from hermes_cli.clipboard import is_clipboard_auto_attach_enabled
+
+        monkeypatch.delenv("HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH", raising=False)
+        assert is_clipboard_auto_attach_enabled(cfg={}) is True
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+class TestModuleSurface:
+    def test_helper_is_publicly_importable(self):
+        from hermes_cli import clipboard as clip_mod
+
+        assert callable(clip_mod.is_clipboard_auto_attach_enabled)
+
+    def test_env_var_constant_matches_documented_name(self):
+        """The env-var name is part of the user contract — pin it.
+
+        If we ever rename it, this test fails on purpose so we update
+        the docs / CHANGELOG.
+        """
+        from hermes_cli.clipboard import _AUTO_ATTACH_ENV_VAR
+
+        assert _AUTO_ATTACH_ENV_VAR == "HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH"
+
+    def test_config_keys_constant_matches_documented_path(self):
+        """The config path is part of the user contract — pin it."""
+        from hermes_cli.clipboard import _AUTO_ATTACH_CONFIG_KEYS
+
+        assert _AUTO_ATTACH_CONFIG_KEYS == ("clipboard", "auto_attach_image")

--- a/tests/tools/test_clipboard_auto_attach_wiring.py
+++ b/tests/tools/test_clipboard_auto_attach_wiring.py
@@ -1,0 +1,355 @@
+"""End-to-end regression for the clipboard auto-attach opt-out (#23984).
+
+Pins the wiring of ``hermes_cli.clipboard.is_clipboard_auto_attach_enabled``
+into the two automatic clipboard probe paths:
+
+  * cli.py::_should_auto_attach_clipboard_image_on_paste
+    (the CLI's bracketed-paste handler — empty paste → probe clipboard
+     for an image and attach it).
+  * tui_gateway/server.py::clipboard.paste RPC (auto path)
+    (called by the TUI when an empty bracketed-paste arrives, marked
+     as auto=True; the gateway must short-circuit the OS clipboard
+     probe entirely so Ghostty's privacy prompt does not re-arm).
+
+The unit-level contract for ``is_clipboard_auto_attach_enabled`` itself
+lives in ``tests/hermes_cli/test_clipboard_auto_attach.py``; this file
+only checks that the wiring at the two probe sites is correct and that
+the bug reported in #23984 cannot regress silently.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# CLI: _should_auto_attach_clipboard_image_on_paste
+# ---------------------------------------------------------------------------
+
+class TestCliBracketedPasteAutoAttachGate:
+    """The bracketed-paste handler must consult the user opt-out."""
+
+    def test_text_paste_never_auto_attaches_regardless_of_gate(self):
+        from cli import _should_auto_attach_clipboard_image_on_paste
+
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=True,
+        ):
+            assert _should_auto_attach_clipboard_image_on_paste("hi") is False
+
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=False,
+        ):
+            assert _should_auto_attach_clipboard_image_on_paste("hi") is False
+
+    def test_empty_paste_with_gate_enabled_still_auto_attaches(self):
+        """Default-enabled users keep the existing behaviour."""
+        from cli import _should_auto_attach_clipboard_image_on_paste
+
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=True,
+        ):
+            assert _should_auto_attach_clipboard_image_on_paste("") is True
+            assert _should_auto_attach_clipboard_image_on_paste("   \n\t") is True
+
+    def test_empty_paste_with_gate_disabled_short_circuits(self):
+        """The whole point of #23984: opted-out users get zero probes."""
+        from cli import _should_auto_attach_clipboard_image_on_paste
+
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=False,
+        ):
+            assert _should_auto_attach_clipboard_image_on_paste("") is False
+            assert _should_auto_attach_clipboard_image_on_paste("   ") is False
+            assert _should_auto_attach_clipboard_image_on_paste("\n\t") is False
+
+    def test_gate_failure_falls_back_to_legacy_behaviour(self):
+        """Defensive: a broken helper must not break paste handling."""
+        from cli import _should_auto_attach_clipboard_image_on_paste
+
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            side_effect=RuntimeError("config disk full"),
+        ):
+            assert _should_auto_attach_clipboard_image_on_paste("") is True
+            assert _should_auto_attach_clipboard_image_on_paste("hi") is False
+
+
+# ---------------------------------------------------------------------------
+# TUI gateway: clipboard.paste RPC
+# ---------------------------------------------------------------------------
+
+class _FakeSession(dict):
+    """Minimal session shape for the gateway RPC."""
+
+
+def _resolve_clipboard_paste_handler() -> Callable[[Any, Dict[str, Any]], Dict[str, Any]]:
+    """Pull the registered ``clipboard.paste`` handler out of tui_gateway.server.
+
+    Importing the server module side-effects: it registers handlers on a
+    process-global ``_methods`` dict via the ``@method(...)`` decorator.
+    """
+    import tui_gateway.server as server_mod
+
+    # The dispatch table is keyed by RPC name. Try several known
+    # private attribute names for resilience across refactors.
+    for attr in ("_methods", "_METHODS", "_handlers", "_HANDLERS"):
+        table = getattr(server_mod, attr, None)
+        if isinstance(table, dict) and "clipboard.paste" in table:
+            return table["clipboard.paste"]
+
+    # Last resort: walk module attributes for the function literally.
+    for name in dir(server_mod):
+        obj = getattr(server_mod, name)
+        if callable(obj) and getattr(obj, "__name__", "") == "_" \
+                and "clipboard.paste" in (getattr(obj, "_method_name", "") or ""):
+            return obj
+
+    raise RuntimeError(
+        "Could not locate the clipboard.paste handler in tui_gateway.server"
+    )
+
+
+@pytest.fixture
+def gateway_paste_handler():
+    return _resolve_clipboard_paste_handler()
+
+
+@pytest.fixture
+def stub_sess(monkeypatch):
+    """Patch ``_sess`` so we can hand the handler a real-looking session."""
+    import tui_gateway.server as server_mod
+
+    sess = _FakeSession()
+    sess["sid"] = "test-sid"
+    sess["image_counter"] = 0
+    sess["attached_images"] = []
+
+    def _fake_sess(_params: dict, _rid: Any):
+        return sess, None
+
+    monkeypatch.setattr(server_mod, "_sess", _fake_sess, raising=True)
+    return sess
+
+
+def _ok_payload(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the result payload from a JSON-RPC ok-style response."""
+    if "result" in response:
+        return response["result"]
+    return response
+
+
+class TestGatewayClipboardPasteAutoGate:
+    def test_auto_with_gate_disabled_skips_clipboard_probe_entirely(
+        self, gateway_paste_handler, stub_sess
+    ):
+        """The headline #23984 fix: no OS clipboard read at all."""
+        save_mock = MagicMock(return_value=True)
+        has_mock = MagicMock(return_value=True)
+        gate_mock = MagicMock(return_value=False)
+
+        with patch("hermes_cli.clipboard.save_clipboard_image", save_mock), \
+             patch("hermes_cli.clipboard.has_clipboard_image", has_mock), \
+             patch(
+                 "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+                 gate_mock,
+             ):
+            response = gateway_paste_handler(
+                1,
+                {"session_id": "test-sid", "auto": True},
+            )
+
+        result = _ok_payload(response)
+        assert result["attached"] is False
+        assert result.get("skipped") is True
+        assert "auto-attach disabled" in result.get("message", "").lower()
+
+        # Critical: neither probe ever ran.
+        save_mock.assert_not_called()
+        has_mock.assert_not_called()
+        # And the gate was consulted.
+        gate_mock.assert_called_once()
+
+    def test_auto_with_gate_enabled_still_probes(
+        self, gateway_paste_handler, stub_sess
+    ):
+        """Default-enabled users keep getting auto-attach behaviour."""
+        save_mock = MagicMock(return_value=True)
+
+        with patch("hermes_cli.clipboard.save_clipboard_image", save_mock), \
+             patch("hermes_cli.clipboard.has_clipboard_image",
+                   return_value=False), \
+             patch(
+                 "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+                 return_value=True,
+             ):
+            response = gateway_paste_handler(
+                2,
+                {"session_id": "test-sid", "auto": True},
+            )
+
+        result = _ok_payload(response)
+        assert result["attached"] is True
+        save_mock.assert_called_once()
+
+    def test_explicit_paste_ignores_gate_and_always_probes(
+        self, gateway_paste_handler, stub_sess
+    ):
+        """Hotkey / right-click pastes are explicit user intent.
+
+        Even if the user opted out of *automatic* probes, an explicit
+        Cmd+V on the TUI should still try the clipboard. The TUI marks
+        these calls with auto=False (the default).
+        """
+        save_mock = MagicMock(return_value=True)
+        gate_mock = MagicMock(return_value=False)
+
+        with patch("hermes_cli.clipboard.save_clipboard_image", save_mock), \
+             patch("hermes_cli.clipboard.has_clipboard_image",
+                   return_value=False), \
+             patch(
+                 "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+                 gate_mock,
+             ):
+            response = gateway_paste_handler(
+                3,
+                {"session_id": "test-sid"},  # no `auto` key → defaults to False
+            )
+
+        result = _ok_payload(response)
+        assert result["attached"] is True
+        save_mock.assert_called_once()
+        gate_mock.assert_not_called()
+
+    def test_explicit_auto_false_still_ignores_gate(
+        self, gateway_paste_handler, stub_sess
+    ):
+        save_mock = MagicMock(return_value=False)
+        gate_mock = MagicMock(return_value=False)
+
+        with patch("hermes_cli.clipboard.save_clipboard_image", save_mock), \
+             patch("hermes_cli.clipboard.has_clipboard_image",
+                   return_value=False), \
+             patch(
+                 "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+                 gate_mock,
+             ):
+            response = gateway_paste_handler(
+                4,
+                {"session_id": "test-sid", "auto": False},
+            )
+
+        result = _ok_payload(response)
+        assert result["attached"] is False
+        assert result.get("skipped") is not True
+        save_mock.assert_called_once()
+        gate_mock.assert_not_called()
+
+    def test_skipped_response_does_not_increment_image_counter(
+        self, gateway_paste_handler, stub_sess
+    ):
+        """Bug-shape regression: counter must stay at 0 for skipped probes."""
+        with patch("hermes_cli.clipboard.save_clipboard_image"), \
+             patch("hermes_cli.clipboard.has_clipboard_image"), \
+             patch(
+                 "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+                 return_value=False,
+             ):
+            for _ in range(5):
+                gateway_paste_handler(
+                    99,
+                    {"session_id": "test-sid", "auto": True},
+                )
+
+        assert stub_sess["image_counter"] == 0
+        assert stub_sess["attached_images"] == []
+
+
+# ---------------------------------------------------------------------------
+# Bug-shape anchor — proves #23984 specifically cannot regress
+# ---------------------------------------------------------------------------
+
+class TestBug23984Anchor:
+    """Regression anchors that read like the bug report itself.
+
+    If any of these fail, the #23984 spam is back. Don't 'fix' the test
+    by deleting the assertion — fix the code path that started probing
+    the OS clipboard for an opted-out user again.
+    """
+
+    def test_opted_out_user_never_probes_on_empty_bracketed_paste_in_cli(self):
+        """The CLI's empty-paste auto-attach must not probe when opted out."""
+        from cli import _should_auto_attach_clipboard_image_on_paste
+
+        save_mock = MagicMock()
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=False,
+        ), patch(
+            "hermes_cli.clipboard.save_clipboard_image", save_mock,
+        ), patch(
+            "hermes_cli.clipboard.has_clipboard_image",
+            MagicMock(return_value=True),
+        ):
+            should_attach = _should_auto_attach_clipboard_image_on_paste("")
+
+        assert should_attach is False, (
+            "#23984 regression: opted-out user got an auto-attach probe "
+            "from an empty bracketed paste — Ghostty privacy prompt would "
+            "fire and 'No image found in clipboard' would spam the TUI."
+        )
+        save_mock.assert_not_called()
+
+    def test_opted_out_user_gets_no_clipboard_io_on_auto_rpc(
+        self, gateway_paste_handler, stub_sess
+    ):
+        save_mock = MagicMock()
+        has_mock = MagicMock()
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=False,
+        ), patch(
+            "hermes_cli.clipboard.save_clipboard_image", save_mock,
+        ), patch(
+            "hermes_cli.clipboard.has_clipboard_image", has_mock,
+        ):
+            response = gateway_paste_handler(
+                1,
+                {"session_id": "test-sid", "auto": True},
+            )
+
+        save_mock.assert_not_called()
+        has_mock.assert_not_called()
+        result = _ok_payload(response)
+        assert result.get("skipped") is True
+
+    def test_user_facing_message_does_not_say_no_image_found_when_skipped(
+        self, gateway_paste_handler, stub_sess
+    ):
+        """The 'No image found in clipboard' string is the user-visible
+        symptom of the bug. If the user opted out, that string MUST NOT
+        appear in any auto-path response.
+        """
+        with patch(
+            "hermes_cli.clipboard.is_clipboard_auto_attach_enabled",
+            return_value=False,
+        ), patch("hermes_cli.clipboard.save_clipboard_image"), \
+             patch("hermes_cli.clipboard.has_clipboard_image"):
+            response = gateway_paste_handler(
+                1,
+                {"session_id": "test-sid", "auto": True},
+            )
+
+        msg = (_ok_payload(response).get("message") or "").lower()
+        assert "no image found" not in msg, (
+            "#23984 regression: the user opted out of auto-attach but the "
+            "gateway still reported 'No image found in clipboard' — that "
+            "string is the entire user-visible spam."
+        )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3394,9 +3394,27 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     try:
-        from hermes_cli.clipboard import has_clipboard_image, save_clipboard_image
+        from hermes_cli.clipboard import (
+            has_clipboard_image,
+            is_clipboard_auto_attach_enabled,
+            save_clipboard_image,
+        )
     except Exception as e:
         return _err(rid, 5027, f"clipboard unavailable: {e}")
+
+    # #23984 — when the TUI marks this RPC as "auto" (i.e. it was triggered
+    # by an empty bracketed-paste event, not by an explicit hotkey or
+    # right-click), and the user has opted out of automatic clipboard
+    # probing, short-circuit before touching the OS clipboard. This is the
+    # path that gets spammed by leaked terminal control sequences over
+    # SSH / inside Docker / under Ghostty.
+    auto = bool(params.get("auto", False))
+    if auto and not is_clipboard_auto_attach_enabled():
+        return _ok(rid, {
+            "attached": False,
+            "skipped": True,
+            "message": "Clipboard auto-attach disabled (clipboard.auto_attach_image)",
+        })
 
     session["image_counter"] = session.get("image_counter", 0) + 1
     img_dir = _hermes_home / "images"

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -475,7 +475,17 @@ export function useMainApp(gw: GatewayClient) {
 
   const paste = useCallback(
     (quiet = false) =>
-      rpc<ClipboardPasteResponse>('clipboard.paste', { session_id: getUiState().sid }).then(r => {
+      rpc<ClipboardPasteResponse>('clipboard.paste', {
+        // #23984 — `quiet` callers are the auto path triggered by empty
+        // bracketed-paste events leaked from terminal control sequences
+        // (Ghostty over SSH, mouse-report fragments, focus events). The
+        // gateway honours `auto: true` together with the user-facing
+        // opt-out (clipboard.auto_attach_image / HERMES_DISABLE_…) and
+        // short-circuits before touching the OS clipboard, which avoids
+        // the privacy-prompt + 'No image found' spam on Ghostty.
+        auto: quiet,
+        session_id: getUiState().sid
+      }).then(r => {
         if (!r) {
           return
         }
@@ -484,6 +494,12 @@ export function useMainApp(gw: GatewayClient) {
           const meta = imageTokenMeta(r)
 
           return sys(`📎 Image #${r.count} attached from clipboard${meta ? ` · ${meta}` : ''}`)
+        }
+
+        if (r.skipped) {
+          // Auto-attach disabled by config — never surface to the user
+          // (the whole point of the opt-out is to keep the TUI quiet).
+          return
         }
 
         if (!quiet) {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -254,6 +254,11 @@ export interface ClipboardPasteResponse {
   count?: number
   height?: number
   message?: string
+  // #23984 — set to true when the gateway short-circuited an `auto`
+  // probe because the user opted out via clipboard.auto_attach_image
+  // (or HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1). Treated as silent on
+  // the TUI side so the auto-attach opt-out actually goes quiet.
+  skipped?: boolean
   token_estimate?: number
   width?: number
 }


### PR DESCRIPTION
# fix(clipboard): give users an opt-out for auto-attach probes (#23984)

## Why

Reported in #23984: in a fresh install of v0.13.0, opening a TUI session over
SSH (especially through Ghostty) produces **constant** "No image found in
clipboard" messages and re-arms an OS-level privacy prompt every few seconds.
The user must approve or deny clipboard access on every probe, which makes the
TUI essentially unusable.

Root cause: Hermes' bracketed-paste handler treats any *empty* paste payload
as "the user just pasted an image" and probes the system clipboard with
`osascript` / `pngpaste` / PowerShell etc. to extract image data. In
environments where bracketed-paste markers leak from terminal control
sequences (SSH escape sequences, mouse-report fragments, focus-event
fragments, Ghostty over Docker) those probes fire constantly, and on macOS
each probe triggers Ghostty's "Allow paste from clipboard?" privacy alert.

There is no existing way for the user to opt out — the auto-attach probe runs
unconditionally on every empty bracketed paste, both inside the
prompt-toolkit CLI and inside the Ink TUI (which proxies through the
`clipboard.paste` JSON-RPC).

## What

Add a single user-facing opt-out and gate **only the automatic probe paths**
behind it. Explicit user actions (Ctrl+V, Alt+V, the `/paste-image` slash
command, TUI right-click paste, TUI hotkey paste) keep working untouched.

Two ways to opt out:

1. **Env var** (one-shot / per-shell):

   ```bash
   export HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1
   ```

2. **Config**:

   ```yaml
   clipboard:
     auto_attach_image: false
   ```

The env var wins over the config value (matches the convention of the other
`HERMES_DISABLE_*` knobs in the project). `HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=0`
force-enables, ignoring the config — so a user can override a global config
file from a single shell session.

Default behaviour is **unchanged**: users who do not set either knob see
exactly the same auto-attach behaviour as before this PR.

## Changes (4 commits, +735 lines, sole author)

```
9ecdd916d fix(clipboard): add helper to gate auto-attach probes by config + env  (+120)
37fdd8d84 test(clipboard): pin auto-attach gate contract (env, config, defaults) (+196)
129772ed2 fix(clipboard): gate auto-attach probes in CLI + TUI gateway (#23984)  (+64 / -4)
97e3a9272 test(clipboard): end-to-end regression for auto-attach gate (#23984)   (+355)
```

### Commit 1 — `hermes_cli/clipboard.py`

New helper `is_clipboard_auto_attach_enabled(cfg=None, env=None)` plus two
small coercion helpers (`_coerce_truthy_env`, `_coerce_config_bool`).
Resolution order:

1. `HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1|true|yes|on` → `False`.
   `=0|false|no|off` → force-enable to `True`.
2. `clipboard.auto_attach_image: bool` from `config.yaml` → that value.
3. Default → `True` (pre-#23984 behaviour, no breaking change).

`cfg=None` lazily loads via `hermes_cli.config.load_config`; a broken config
load falls back to the default rather than raising — defensive: a corrupt
config file must never block paste handling.

### Commit 2 — `tests/hermes_cli/test_clipboard_auto_attach.py`

61 unit tests pinning the helper contract:
- `_coerce_truthy_env`: parametrised across the standard truthy / falsy /
  unset values (mirrors `HERMES_LOG_LEVEL`-style parsing elsewhere).
- `_coerce_config_bool`: native `bool`, `int`, string scalars, and `None`.
- Env precedence: `=1` wins over a config that enables; `=0` force-enables
  even if config disables; unknown env values fall through to config.
- Config-only path: explicit `true` / `false`, missing keys, and a typo
  (string instead of nested dict) all behave defensively.
- Defaults: empty env + empty config → `True`; `None` cfg lazily loads;
  broken loader falls back to `True`; `env=None` reads `os.environ`.
- Module surface: pin the env-var name and config keys so a rename fails
  this test on purpose and forces a CHANGELOG / docs update.

### Commit 3 — wire the helper into both probe sites

- **`cli.py::_should_auto_attach_clipboard_image_on_paste`** now consults
  the helper. When opted out, the CLI's bracketed-paste handler
  (`handle_paste`) skips the auto-attach probe entirely. Explicit Ctrl+V,
  Alt+V (`handle_ctrl_v`, `handle_alt_v`) and the `/paste-image` slash
  command continue to work — only the *automatic* empty-bracketed-paste
  trigger is gated.
- **`tui_gateway/server.py::clipboard.paste`** RPC accepts a new optional
  `auto: bool` param. When `auto=true` AND the user opted out, the handler
  short-circuits before touching the OS clipboard and returns
  `{"attached": false, "skipped": true, "message": "Clipboard auto-attach
  disabled (clipboard.auto_attach_image)"}`. Explicit hotkey / right-click
  pastes from the TUI still pass `auto=false` and behave as before.
- **`ui-tui/src/app/useMainApp.ts`** + `gatewayTypes.ts`: the `paste(quiet)`
  wrapper forwards `auto: quiet` to the gateway. The `quiet` callers are
  exactly the auto path triggered by empty bracketed-paste events leaked
  from terminal control sequences. Responses with `skipped: true` are
  silenced on the TUI side, so the opt-out actually goes quiet — no toast,
  no log line, no privacy prompt.

### Commit 4 — `tests/tools/test_clipboard_auto_attach_wiring.py`

12 end-to-end regression tests:
- `TestCliBracketedPasteAutoAttachGate` (4 tests): the CLI's
  `_should_auto_attach_clipboard_image_on_paste` consults the gate —
  text-paste short-circuit (gate-agnostic), empty-paste with gate enabled
  = legacy auto-attach, empty-paste with gate disabled = no probe, gate
  failure falls back to legacy behaviour.
- `TestGatewayClipboardPasteAutoGate` (5 tests): drives the registered
  `clipboard.paste` RPC handler with the gate stubbed both ways. Asserts
  that with `auto=true` + gate disabled, `save_clipboard_image` and
  `has_clipboard_image` are *never* called (the headline fix), that the
  default behaviour is preserved when the gate is enabled, that explicit
  `auto=false` ignores the gate entirely, and that 5 consecutive skipped
  probes leave the session image counter at 0.
- `TestBug23984Anchor` (3 tests): bug-shape regression anchors written
  to read like the bug report itself. Headline assertion: `'No image
  found in clipboard'` must not appear in any auto-path response when
  the user opted out, since that string is the entire user-visible spam
  reported in the issue.

## Test plan

```bash
# All clipboard tests pass — 178 / 178.
python -m pytest tests/tools/test_clipboard.py \
                 tests/tools/test_clipboard_auto_attach_wiring.py \
                 tests/hermes_cli/test_clipboard_auto_attach.py
# ============================== 178 passed in 2.67s ==============================

# Ruff is clean.
python -m ruff check hermes_cli/clipboard.py cli.py tui_gateway/server.py \
                     tests/hermes_cli/test_clipboard_auto_attach.py \
                     tests/tools/test_clipboard_auto_attach_wiring.py
# All checks passed!
```

Manual reproduction of the user-facing fix:

```bash
# Before — Ghostty over SSH, fresh install:
hermes --tui                     # → constant 'No image found in clipboard'
                                 #   + Ghostty privacy prompt every few seconds.

# After — opt out:
HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH=1 hermes --tui
                                 # → silent. No clipboard probes, no prompts.
                                 # Cmd+V / right-click / /paste-image still work.

# Or persist via config.yaml:
cat <<'EOF' >> ~/.hermes/config.yaml
clipboard:
  auto_attach_image: false
EOF
hermes --tui                     # → silent.
```

## Bug-reproduction proof

The new tests are real regression anchors, not aspirational placeholders.
Reverting `cli.py` + `tui_gateway/server.py` to `upstream/main` while
keeping the new tests in place:

```bash
cp cli.py /tmp/cli.py.fixed
cp tui_gateway/server.py /tmp/server.py.fixed
git checkout upstream/main -- cli.py tui_gateway/server.py

python -m pytest tests/tools/test_clipboard_auto_attach_wiring.py
# FAILED ...TestGatewayClipboardPasteAutoGate::test_auto_with_gate_disabled_skips_clipboard_probe_entirely
# FAILED ...TestGatewayClipboardPasteAutoGate::test_skipped_response_does_not_increment_image_counter
# FAILED ...TestBug23984Anchor::test_opted_out_user_gets_no_clipboard_io_on_auto_rpc
# FAILED ...TestCliBracketedPasteAutoAttachGate::test_empty_paste_with_gate_disabled_short_circuits
# FAILED ...TestBug23984Anchor::test_opted_out_user_never_probes_on_empty_bracketed_paste_in_cli
# ========================= 5 failed, 7 passed in 2.45s ==========================
```

Exactly the 5 assertions that pin the #23984 fix fail without the wiring,
and pass once the fix is restored.

## Backwards compatibility

- Users who do **not** set `HERMES_DISABLE_CLIPBOARD_AUTO_ATTACH` and do
  **not** add `clipboard.auto_attach_image: false` to their config see
  identical behaviour to pre-PR.
- The `clipboard.paste` RPC adds an *optional* `auto` parameter (default
  `False`). Existing TUI clients / CLIs that do not pass it are routed
  through the explicit-paste branch and behave as before.
- The `ClipboardPasteResponse` TypeScript type adds an *optional*
  `skipped?: boolean` field. Existing code that does not consume it is
  unaffected.

Closes #23984.
