### PR TITLE
Fix/weekly maintenance profile aware

### DIFF
--- a/scripts/weekly_maintenance.py
+++ b/scripts/weekly_maintenance.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""Weekly maintenance for the active Hermes profile.
+
+Runs the safe-by-default housekeeping pass that long-lived Hermes
+installs benefit from once a week:
+
+  * ``state.db``      — WAL checkpoint (TRUNCATE) + ``VACUUM`` so the
+                        SQLite file actually shrinks after the gateway's
+                        opportunistic prune deleted rows.
+  * snapshot retention — drop ``state-snapshots/`` entries older than the
+                        configured horizon (default 90 days).
+  * log rotation       — gzip ``logs/*.log`` files larger than 10 MB and
+                        prune compressed logs older than 90 days.
+
+Why this script exists
+----------------------
+
+Hermes runs idempotent maintenance opportunistically at startup
+(``HermesState.maybe_auto_prune_and_vacuum``), but a long-running gateway
+that almost never restarts can drift far past the maintenance window. A
+small wrapper that the user can drop into ``cron`` / launchd / systemd
+keeps the file size bounded without depending on restarts.
+
+Critical: profile awareness (#24035)
+------------------------------------
+
+The previous community version of this script computed paths from
+``os.path.expanduser("~")`` directly, which silently no-op'd users on
+non-default profiles (``hermes -p work``) — VACUUM ran on the wrong
+database and the active profile's state.db kept growing.
+
+This version resolves every path through ``hermes_constants``:
+
+  * ``get_hermes_home()`` — honours ``$HERMES_HOME`` and the active
+    profile so the script always operates on the database the running
+    Hermes process is actually using.
+  * ``get_hermes_dir(new, old)`` — preserves the project's
+    backward-compatibility migration rules where applicable.
+
+Usage
+-----
+
+::
+
+    # Default — run all phases, log to stderr.
+    python scripts/weekly_maintenance.py
+
+    # Dry-run — show what would happen without touching anything.
+    python scripts/weekly_maintenance.py --dry-run
+
+    # Only one phase.
+    python scripts/weekly_maintenance.py --only vacuum
+    python scripts/weekly_maintenance.py --only snapshots
+    python scripts/weekly_maintenance.py --only logs
+
+    # Tighter retention (default: 90 days).
+    python scripts/weekly_maintenance.py --retention-days 30
+
+The script honours ``$HERMES_HOME`` so that the same binary works for
+every profile:
+
+::
+
+    HERMES_HOME=~/.hermes-work python scripts/weekly_maintenance.py
+    hermes -p work shell -- python scripts/weekly_maintenance.py
+"""
+
+import argparse
+import gzip
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Path resolution — every Hermes path MUST go through hermes_constants
+# (#24035).  We bend over backwards to make this importable from
+# ``~/.hermes/scripts/`` (where the community script lives) too — that's
+# why we add the source checkout to ``sys.path`` defensively before the
+# import attempt.
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).resolve().parent
+
+_CANDIDATE_REPO_ROOTS = (
+    _HERE.parent,                              # repo checkout: <repo>/scripts/
+    _HERE.parent / "hermes-agent",             # ~/.hermes/scripts/ → ~/.hermes/hermes-agent
+    Path.home() / ".hermes" / "hermes-agent",  # last-resort
+)
+
+for _candidate in _CANDIDATE_REPO_ROOTS:
+    if (_candidate / "hermes_constants.py").is_file():
+        _root_str = str(_candidate)
+        if _root_str not in sys.path:
+            sys.path.insert(0, _root_str)
+        break
+
+try:
+    from hermes_constants import get_hermes_home  # type: ignore[import-not-found]
+except Exception as exc:  # pragma: no cover - depends on user environment
+    print(
+        "weekly_maintenance: cannot import hermes_constants — make sure "
+        "the hermes-agent checkout is reachable from this script. "
+        f"({exc.__class__.__name__}: {exc})",
+        file=sys.stderr,
+    )
+    raise
+
+
+logger = logging.getLogger("hermes.weekly_maintenance")
+
+
+# ---------------------------------------------------------------------------
+# Resolved paths
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MaintenancePaths:
+    """Container for every path the script touches.
+
+    Constructed by :func:`resolve_paths` so the resolution logic is
+    testable in isolation. Every field is derived from
+    ``hermes_constants.get_hermes_home()`` — never from
+    ``Path.home() / ".hermes"`` (#24035).
+    """
+
+    home: Path
+    state_db: Path
+    snapshots_dir: Path
+    logs_dir: Path
+
+    def to_json(self) -> str:
+        """Serialise for ``--dry-run`` output."""
+        return json.dumps(
+            {
+                "home": str(self.home),
+                "state_db": str(self.state_db),
+                "snapshots_dir": str(self.snapshots_dir),
+                "logs_dir": str(self.logs_dir),
+            },
+            indent=2,
+        )
+
+
+def resolve_paths(home: Optional[Path] = None) -> MaintenancePaths:
+    """Resolve every maintenance path from the active profile.
+
+    *home* override exists for tests; production callers pass nothing
+    and we read from :func:`hermes_constants.get_hermes_home`.
+    """
+    base = (home or get_hermes_home()).resolve()
+    return MaintenancePaths(
+        home=base,
+        state_db=base / "state.db",
+        snapshots_dir=base / "state-snapshots",
+        logs_dir=base / "logs",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase results
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PhaseResult:
+    name: str
+    skipped: bool = False
+    error: Optional[str] = None
+    details: List[str] = field(default_factory=list)
+
+    def add(self, line: str) -> None:
+        self.details.append(line)
+
+    def fail(self, msg: str) -> None:
+        self.error = msg
+
+
+# ---------------------------------------------------------------------------
+# Phase: VACUUM state.db
+# ---------------------------------------------------------------------------
+
+
+def vacuum_state_db(paths: MaintenancePaths, *, dry_run: bool) -> PhaseResult:
+    """Run ``WAL checkpoint(TRUNCATE)`` + ``VACUUM`` against the active state.db.
+
+    Skips cleanly when:
+      - the file does not exist (fresh install / wrong profile),
+      - the file is currently locked by a live process (we never wait;
+        a lock means the gateway is running and will eventually do its
+        own opportunistic VACUUM at next restart).
+    """
+    result = PhaseResult(name="vacuum_state_db")
+    db = paths.state_db
+
+    if not db.exists():
+        result.skipped = True
+        result.add(f"state.db not found: {db} (skipping)")
+        return result
+
+    size_before = db.stat().st_size
+    result.add(f"state.db = {db} ({_human_bytes(size_before)})")
+
+    if dry_run:
+        result.skipped = True
+        result.add("dry-run — would WAL checkpoint(TRUNCATE) + VACUUM")
+        return result
+
+    try:
+        # ``timeout=0`` means "fail fast if the DB is busy". A live
+        # gateway with WAL-mode writes will hold an exclusive lock during
+        # VACUUM so we never wait — the next restart's opportunistic
+        # ``maybe_auto_prune_and_vacuum`` will pick up the slack.
+        conn = sqlite3.connect(str(db), timeout=0, isolation_level=None)
+        try:
+            try:
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except sqlite3.Error as exc:
+                logger.debug("wal_checkpoint(TRUNCATE) failed: %s", exc)
+            conn.execute("VACUUM")
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as exc:
+        # Most common: "database is locked" — a live gateway is using it.
+        result.fail(f"state.db busy ({exc}); skipping VACUUM")
+        return result
+    except Exception as exc:  # pragma: no cover - depends on env
+        result.fail(f"unexpected VACUUM failure: {exc}")
+        return result
+
+    size_after = db.stat().st_size
+    saved = size_before - size_after
+    result.add(
+        f"VACUUM done: {_human_bytes(size_before)} → {_human_bytes(size_after)} "
+        f"({_human_bytes(saved)} reclaimed)"
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase: prune snapshots
+# ---------------------------------------------------------------------------
+
+
+def prune_snapshots(
+    paths: MaintenancePaths,
+    *,
+    retention_days: int,
+    dry_run: bool,
+    now: Optional[float] = None,
+) -> PhaseResult:
+    """Drop ``state-snapshots/<id>/`` entries older than *retention_days*.
+
+    Only snapshot directories with a recognisable mtime older than the
+    cutoff are removed. Files (e.g. README, manifest stubs) at the
+    snapshot-root level are never touched.
+    """
+    result = PhaseResult(name="prune_snapshots")
+    root = paths.snapshots_dir
+    if not root.is_dir():
+        result.skipped = True
+        result.add(f"{root} not present (skipping)")
+        return result
+
+    cutoff = (now if now is not None else time.time()) - retention_days * 86400
+    removed = 0
+    kept = 0
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError as exc:
+            result.add(f"  ! stat failed: {entry.name} ({exc})")
+            continue
+        if mtime < cutoff:
+            removed += 1
+            if dry_run:
+                result.add(f"  - would remove: {entry.name}")
+            else:
+                try:
+                    shutil.rmtree(entry)
+                    result.add(f"  - removed: {entry.name}")
+                except Exception as exc:
+                    result.add(f"  ! remove failed: {entry.name} ({exc})")
+        else:
+            kept += 1
+
+    result.add(
+        f"snapshots: {removed} removed, {kept} kept "
+        f"(retention = {retention_days} days)"
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Phase: rotate logs
+# ---------------------------------------------------------------------------
+
+_LOG_ROTATE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def rotate_logs(
+    paths: MaintenancePaths,
+    *,
+    retention_days: int,
+    dry_run: bool,
+    now: Optional[float] = None,
+) -> PhaseResult:
+    """Gzip large ``*.log`` files and drop very old compressed logs."""
+    result = PhaseResult(name="rotate_logs")
+    root = paths.logs_dir
+    if not root.is_dir():
+        result.skipped = True
+        result.add(f"{root} not present (skipping)")
+        return result
+
+    rotated = 0
+    pruned = 0
+    cutoff = (now if now is not None else time.time()) - retention_days * 86400
+
+    for entry in sorted(root.glob("*.log")):
+        try:
+            size = entry.stat().st_size
+        except OSError as exc:
+            result.add(f"  ! stat failed: {entry.name} ({exc})")
+            continue
+        if size < _LOG_ROTATE_BYTES:
+            continue
+        rotated += 1
+        if dry_run:
+            result.add(f"  - would rotate: {entry.name} ({_human_bytes(size)})")
+            continue
+        target = entry.with_suffix(entry.suffix + f".{int(time.time())}.gz")
+        try:
+            with entry.open("rb") as src, gzip.open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            entry.unlink()
+            result.add(f"  - rotated: {entry.name} → {target.name}")
+        except Exception as exc:
+            result.add(f"  ! rotate failed: {entry.name} ({exc})")
+
+    for entry in sorted(root.glob("*.log.*.gz")):
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError as exc:
+            result.add(f"  ! stat failed: {entry.name} ({exc})")
+            continue
+        if mtime < cutoff:
+            pruned += 1
+            if dry_run:
+                result.add(f"  - would drop old archive: {entry.name}")
+            else:
+                try:
+                    entry.unlink()
+                    result.add(f"  - dropped old archive: {entry.name}")
+                except Exception as exc:
+                    result.add(f"  ! drop failed: {entry.name} ({exc})")
+
+    result.add(
+        f"logs: {rotated} rotated, {pruned} archives dropped "
+        f"(rotate ≥ {_human_bytes(_LOG_ROTATE_BYTES)}, retention = {retention_days} days)"
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+_PHASE_REGISTRY = {
+    "vacuum":    vacuum_state_db,
+    "snapshots": prune_snapshots,
+    "logs":      rotate_logs,
+}
+
+
+def run(
+    *,
+    only: Optional[str] = None,
+    retention_days: int = 90,
+    dry_run: bool = False,
+    home: Optional[Path] = None,
+) -> List[PhaseResult]:
+    """Execute the requested phase(s) and return per-phase results."""
+    paths = resolve_paths(home)
+    selected = _select_phases(only)
+
+    print(f"weekly_maintenance: HERMES_HOME = {paths.home}")
+    print(f"weekly_maintenance: paths = {paths.to_json()}")
+    if dry_run:
+        print("weekly_maintenance: DRY-RUN — no files will be modified")
+
+    results: List[PhaseResult] = []
+    for name in selected:
+        print(f"\n── phase: {name} ──")
+        fn = _PHASE_REGISTRY[name]
+        if name == "vacuum":
+            res = fn(paths, dry_run=dry_run)
+        else:
+            res = fn(paths, retention_days=retention_days, dry_run=dry_run)
+        for line in res.details:
+            print(f"  {line}")
+        if res.error:
+            print(f"  ! {res.error}")
+        results.append(res)
+
+    return results
+
+
+def _select_phases(only: Optional[str]) -> Iterable[str]:
+    if not only:
+        return list(_PHASE_REGISTRY.keys())
+    if only not in _PHASE_REGISTRY:
+        raise SystemExit(
+            f"--only must be one of {sorted(_PHASE_REGISTRY)}, got {only!r}"
+        )
+    return [only]
+
+
+def _human_bytes(n: int) -> str:
+    """Compact human-readable byte size."""
+    if n < 1024:
+        return f"{n} B"
+    units = ("KB", "MB", "GB", "TB")
+    val = float(n) / 1024.0
+    for unit in units:
+        if val < 1024 or unit == units[-1]:
+            return f"{val:.1f} {unit}"
+        val /= 1024.0
+    return f"{n} B"  # pragma: no cover - unreachable
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="weekly_maintenance.py",
+        description=(
+            "Run weekly maintenance against the active Hermes profile "
+            "(VACUUM state.db, prune snapshots, rotate logs). "
+            "Resolves every path through hermes_constants.get_hermes_home() "
+            "so a profile-specific HERMES_HOME is honoured (#24035)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Show what would happen without modifying anything.",
+    )
+    parser.add_argument(
+        "--only", choices=sorted(_PHASE_REGISTRY), default=None,
+        help="Run a single phase instead of all three.",
+    )
+    parser.add_argument(
+        "--retention-days", type=int, default=90,
+        help="Days to keep snapshots and rotated logs (default: 90).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.retention_days <= 0:
+        parser.error("--retention-days must be positive")
+
+    logging.basicConfig(
+        level=os.environ.get("HERMES_LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    results = run(
+        only=args.only,
+        retention_days=args.retention_days,
+        dry_run=args.dry_run,
+    )
+    return 1 if any(r.error for r in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_weekly_maintenance.py
+++ b/tests/scripts/test_weekly_maintenance.py
@@ -1,0 +1,376 @@
+"""Unit tests for ``scripts/weekly_maintenance.py``.
+
+Pin the contract of every helper in isolation:
+
+  * :func:`resolve_paths` — every Hermes path MUST come from
+    ``hermes_constants.get_hermes_home()``; never from ``Path.home() /
+    ".hermes"``. This is the heart of the #24035 fix.
+  * :func:`vacuum_state_db` — graceful skip on missing DB, dry-run is
+    inert, real VACUUM shrinks the file.
+  * :func:`prune_snapshots` — mtime-based eviction, retention boundary,
+    dry-run inertness.
+  * :func:`rotate_logs` — gzip threshold, archive-pruning horizon.
+  * :func:`_select_phases` / ``main()`` — argparse + exit codes.
+
+The end-to-end integration anchor that re-runs the whole driver under
+a synthetic ``HERMES_HOME`` lives in
+``tests/scripts/test_weekly_maintenance_integration.py``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "weekly_maintenance.py"
+
+
+@pytest.fixture(scope="module")
+def weekly_module() -> Any:
+    """Import ``scripts/weekly_maintenance.py`` as a module."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "weekly_maintenance_under_test", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader, "spec_from_file_location returned no loader"
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# ---------------------------------------------------------------------------
+# resolve_paths — the #24035 fix
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePaths:
+    def test_resolves_from_get_hermes_home_not_path_home(
+        self, weekly_module, tmp_path
+    ):
+        """The script MUST consult get_hermes_home, never Path.home()."""
+        target = tmp_path / "hermes-work"
+        target.mkdir()
+
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=target
+        ) as mock_home:
+            paths = weekly_module.resolve_paths()
+
+        mock_home.assert_called_once()
+        assert paths.home == target.resolve()
+        assert paths.state_db == target.resolve() / "state.db"
+        assert paths.snapshots_dir == target.resolve() / "state-snapshots"
+        assert paths.logs_dir == target.resolve() / "logs"
+
+    def test_explicit_home_override_wins_for_tests(self, weekly_module, tmp_path):
+        """``home=`` parameter exists for tests — pin that contract."""
+        with patch.object(weekly_module, "get_hermes_home") as mock_home:
+            paths = weekly_module.resolve_paths(home=tmp_path)
+        mock_home.assert_not_called()
+        assert paths.home == tmp_path.resolve()
+        assert paths.state_db == tmp_path.resolve() / "state.db"
+
+    def test_paths_object_is_immutable(self, weekly_module, tmp_path):
+        """``MaintenancePaths`` is a frozen dataclass — verify by attempting
+        a mutation. If this ever stops raising, the path-resolution contract
+        is no longer locked.
+        """
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        with pytest.raises((AttributeError, TypeError, Exception)):
+            paths.state_db = tmp_path / "wrong.db"  # type: ignore[misc]
+
+    def test_to_json_roundtrip_contains_every_path(
+        self, weekly_module, tmp_path
+    ):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        payload = json.loads(paths.to_json())
+        assert set(payload.keys()) == {
+            "home", "state_db", "snapshots_dir", "logs_dir",
+        }
+        for key, value in payload.items():
+            assert value.startswith(str(tmp_path)), (
+                f"{key} = {value!r} does not start with the override home "
+                "— resolve_paths is leaking a non-profile path"
+            )
+
+    @pytest.mark.parametrize("subpath", ["state.db", "state-snapshots", "logs"])
+    def test_paths_use_get_hermes_home_subdirectories(
+        self, weekly_module, tmp_path, subpath
+    ):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        attr = {
+            "state.db":         "state_db",
+            "state-snapshots":  "snapshots_dir",
+            "logs":             "logs_dir",
+        }[subpath]
+        assert getattr(paths, attr) == tmp_path.resolve() / subpath
+
+
+# ---------------------------------------------------------------------------
+# vacuum_state_db
+# ---------------------------------------------------------------------------
+
+
+class TestVacuumStateDb:
+    def test_missing_db_skips_cleanly(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        result = weekly_module.vacuum_state_db(paths, dry_run=False)
+        assert result.skipped is True
+        assert result.error is None
+        assert any("not found" in line for line in result.details)
+
+    def test_dry_run_does_not_modify_db(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        db = paths.state_db
+        self._make_db_with_garbage(db, rows=200)
+        size_before = db.stat().st_size
+
+        result = weekly_module.vacuum_state_db(paths, dry_run=True)
+        assert result.error is None
+        assert result.skipped is True
+        assert db.stat().st_size == size_before, (
+            "dry-run modified the DB — that's a safety regression"
+        )
+
+    def test_real_vacuum_shrinks_db(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        db = paths.state_db
+        self._make_db_with_garbage(db, rows=2000)
+        # Bloat the file by deleting all rows (SQLite keeps the pages).
+        with sqlite3.connect(str(db)) as c:
+            c.execute("DELETE FROM junk")
+            c.commit()
+        size_before = db.stat().st_size
+
+        result = weekly_module.vacuum_state_db(paths, dry_run=False)
+        assert result.error is None, result.error
+        assert result.skipped is False
+        size_after = db.stat().st_size
+        assert size_after < size_before, (
+            "VACUUM did not reclaim disk — fix path is broken"
+        )
+
+    @staticmethod
+    def _make_db_with_garbage(path: Path, *, rows: int) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(str(path)) as c:
+            c.execute("CREATE TABLE junk (k INTEGER PRIMARY KEY, v TEXT)")
+            c.executemany(
+                "INSERT INTO junk(v) VALUES (?)",
+                [("x" * 256,) for _ in range(rows)],
+            )
+            c.commit()
+
+
+# ---------------------------------------------------------------------------
+# prune_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestPruneSnapshots:
+    def test_missing_dir_skips_cleanly(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        result = weekly_module.prune_snapshots(
+            paths, retention_days=30, dry_run=False
+        )
+        assert result.skipped is True
+
+    def test_old_snapshots_are_removed(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        snapshots = paths.snapshots_dir
+        snapshots.mkdir(parents=True)
+        old = snapshots / "2024-01-01-old"
+        old.mkdir()
+        (old / "manifest.json").write_text("{}")
+        fresh = snapshots / "2026-05-08-fresh"
+        fresh.mkdir()
+        (fresh / "manifest.json").write_text("{}")
+
+        now = time.time()
+        # Force ``old`` to look 100 days stale.
+        for entry in old.rglob("*"):
+            entry.touch()
+        import os
+        os.utime(old, (now - 100 * 86400, now - 100 * 86400))
+
+        result = weekly_module.prune_snapshots(
+            paths, retention_days=30, dry_run=False, now=now
+        )
+        assert result.error is None
+        assert not old.exists(), "old snapshot was not removed"
+        assert fresh.exists(), "fresh snapshot must be kept"
+
+    def test_dry_run_keeps_old_snapshots(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.snapshots_dir.mkdir(parents=True)
+        old = paths.snapshots_dir / "old"
+        old.mkdir()
+        import os
+        now = time.time()
+        os.utime(old, (now - 100 * 86400, now - 100 * 86400))
+
+        result = weekly_module.prune_snapshots(
+            paths, retention_days=30, dry_run=True, now=now
+        )
+        assert result.error is None
+        assert old.exists(), "dry-run removed a snapshot — that's a regression"
+        assert any("would remove" in line for line in result.details)
+
+    def test_retention_boundary_keeps_snapshots_younger_than_cutoff(
+        self, weekly_module, tmp_path
+    ):
+        """A snapshot exactly *retention_days - 1 day* old must be kept."""
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.snapshots_dir.mkdir(parents=True)
+        recent = paths.snapshots_dir / "recent"
+        recent.mkdir()
+        import os
+        now = time.time()
+        os.utime(recent, (now - 29 * 86400, now - 29 * 86400))
+
+        result = weekly_module.prune_snapshots(
+            paths, retention_days=30, dry_run=False, now=now
+        )
+        assert result.error is None
+        assert recent.exists()
+
+
+# ---------------------------------------------------------------------------
+# rotate_logs
+# ---------------------------------------------------------------------------
+
+
+class TestRotateLogs:
+    def test_missing_dir_skips_cleanly(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        result = weekly_module.rotate_logs(
+            paths, retention_days=30, dry_run=False
+        )
+        assert result.skipped is True
+
+    def test_small_log_is_not_rotated(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.logs_dir.mkdir(parents=True)
+        small = paths.logs_dir / "agent.log"
+        small.write_text("only a few bytes")
+
+        result = weekly_module.rotate_logs(
+            paths, retention_days=30, dry_run=False
+        )
+        assert result.error is None
+        assert small.exists()
+        assert not list(paths.logs_dir.glob("agent.log.*.gz"))
+
+    def test_large_log_is_gzipped_and_removed(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.logs_dir.mkdir(parents=True)
+        big = paths.logs_dir / "gateway.log"
+        big.write_bytes(b"0" * (11 * 1024 * 1024))
+
+        result = weekly_module.rotate_logs(
+            paths, retention_days=30, dry_run=False
+        )
+        assert result.error is None, result.error
+        assert not big.exists(), "rotated log was not removed"
+        archives = list(paths.logs_dir.glob("gateway.log.*.gz"))
+        assert len(archives) == 1
+        with gzip.open(archives[0], "rb") as f:
+            content = f.read()
+        assert content == b"0" * (11 * 1024 * 1024)
+
+    def test_dry_run_does_not_rotate(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.logs_dir.mkdir(parents=True)
+        big = paths.logs_dir / "gateway.log"
+        big.write_bytes(b"0" * (11 * 1024 * 1024))
+
+        result = weekly_module.rotate_logs(
+            paths, retention_days=30, dry_run=True
+        )
+        assert result.error is None
+        assert big.exists()
+        assert not list(paths.logs_dir.glob("gateway.log.*.gz"))
+        assert any("would rotate" in line for line in result.details)
+
+    def test_old_archives_are_pruned(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.logs_dir.mkdir(parents=True)
+        archive = paths.logs_dir / "old.log.123.gz"
+        archive.write_bytes(b"\x1f\x8b\x08\x00")  # gzip header bytes
+        import os
+        now = time.time()
+        os.utime(archive, (now - 100 * 86400, now - 100 * 86400))
+
+        result = weekly_module.rotate_logs(
+            paths, retention_days=30, dry_run=False, now=now
+        )
+        assert result.error is None
+        assert not archive.exists()
+
+
+# ---------------------------------------------------------------------------
+# Driver — _select_phases + main()
+# ---------------------------------------------------------------------------
+
+
+class TestDriver:
+    def test_select_all_phases_by_default(self, weekly_module):
+        assert list(weekly_module._select_phases(None)) == [
+            "vacuum", "snapshots", "logs",
+        ]
+
+    @pytest.mark.parametrize("phase", ["vacuum", "snapshots", "logs"])
+    def test_select_single_phase(self, weekly_module, phase):
+        assert list(weekly_module._select_phases(phase)) == [phase]
+
+    def test_select_unknown_phase_exits(self, weekly_module):
+        with pytest.raises(SystemExit):
+            list(weekly_module._select_phases("nonexistent"))
+
+    def test_human_bytes_is_compact(self, weekly_module):
+        h = weekly_module._human_bytes
+        assert h(0) == "0 B"
+        assert h(1023) == "1023 B"
+        assert h(2048) == "2.0 KB"
+        assert h(5 * 1024 * 1024) == "5.0 MB"
+
+    def test_main_returns_zero_on_dry_run(self, weekly_module, tmp_path, capsys):
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=tmp_path
+        ):
+            rc = weekly_module.main(["--dry-run"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "DRY-RUN" in captured.out
+        assert str(tmp_path) in captured.out
+
+    def test_main_rejects_zero_retention(self, weekly_module):
+        with pytest.raises(SystemExit):
+            weekly_module.main(["--retention-days", "0"])
+
+    def test_main_rejects_negative_retention(self, weekly_module):
+        with pytest.raises(SystemExit):
+            weekly_module.main(["--retention-days", "-1"])
+
+    def test_main_returns_one_on_phase_error(self, weekly_module, tmp_path):
+        paths = weekly_module.resolve_paths(home=tmp_path)
+        paths.state_db.parent.mkdir(parents=True, exist_ok=True)
+        paths.state_db.write_bytes(b"not-a-sqlite-file")
+
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=tmp_path
+        ):
+            rc = weekly_module.main(["--only", "vacuum"])
+        assert rc == 1

--- a/tests/scripts/test_weekly_maintenance_integration.py
+++ b/tests/scripts/test_weekly_maintenance_integration.py
@@ -1,0 +1,353 @@
+"""End-to-end integration tests for ``scripts/weekly_maintenance.py``.
+
+These tests run the full driver under a synthetic ``HERMES_HOME`` and
+assert that the script
+
+  * resolves every path against the override (the headline #24035 fix),
+  * leaves the *real* user's ``~/.hermes`` completely untouched even
+    when there's a state.db sitting there, and
+  * actually shrinks a bloated state.db / removes old snapshots /
+    rotates large logs.
+
+The unit-level helper contracts live in
+``tests/scripts/test_weekly_maintenance.py``; this file is the
+regression anchor that catches anyone reintroducing
+``Path.home() / ".hermes"`` to the script — it would silently start
+operating on the developer's real Hermes home and the assertions below
+would explode.
+"""
+
+import importlib.util
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "weekly_maintenance.py"
+
+
+@pytest.fixture(scope="module")
+def weekly_module() -> Any:
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "weekly_maintenance_integration", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+@pytest.fixture
+def synthetic_profile(tmp_path):
+    """Create a realistic on-disk profile structure.
+
+    Layout (everything under tmp_path so the real ~/.hermes stays
+    untouched):
+
+      tmp_path/
+        state.db           — bloated SQLite file
+        state-snapshots/
+          2024-01-01-old/  — should be pruned (100 days stale)
+          2026-05-08-fresh/— should be kept
+        logs/
+          gateway.log      — 11 MB, should be rotated
+          agent.log        — 200 B, should be left alone
+          old.log.123.gz   — 100 days old, should be pruned
+    """
+    home = tmp_path / "synthetic-profile"
+    home.mkdir()
+
+    db = home / "state.db"
+    with sqlite3.connect(str(db)) as c:
+        c.execute("CREATE TABLE junk (k INTEGER PRIMARY KEY, v TEXT)")
+        c.executemany(
+            "INSERT INTO junk(v) VALUES (?)",
+            [("x" * 256,) for _ in range(2000)],
+        )
+        c.commit()
+        c.execute("DELETE FROM junk")
+        c.commit()
+    bloated_size = db.stat().st_size
+
+    snapshots = home / "state-snapshots"
+    snapshots.mkdir()
+    old_snap = snapshots / "2024-01-01-old"
+    old_snap.mkdir()
+    (old_snap / "manifest.json").write_text("{}")
+    fresh_snap = snapshots / "2026-05-08-fresh"
+    fresh_snap.mkdir()
+    (fresh_snap / "manifest.json").write_text("{}")
+
+    logs = home / "logs"
+    logs.mkdir()
+    big_log = logs / "gateway.log"
+    big_log.write_bytes(b"0" * (11 * 1024 * 1024))
+    small_log = logs / "agent.log"
+    small_log.write_text("a small log")
+    old_archive = logs / "old.log.123.gz"
+    old_archive.write_bytes(b"\x1f\x8b\x08\x00")
+
+    now = time.time()
+    os.utime(old_snap, (now - 100 * 86400, now - 100 * 86400))
+    os.utime(old_archive, (now - 100 * 86400, now - 100 * 86400))
+
+    return {
+        "home": home,
+        "bloated_size": bloated_size,
+        "old_snap": old_snap,
+        "fresh_snap": fresh_snap,
+        "big_log": big_log,
+        "small_log": small_log,
+        "old_archive": old_archive,
+        "now": now,
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end run() — the full driver under a synthetic profile
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_full_run_shrinks_db_prunes_snapshots_and_rotates_logs(
+        self, weekly_module, synthetic_profile
+    ):
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=synthetic_profile["home"]
+        ):
+            results = weekly_module.run()
+
+        # No phase errored.
+        assert all(r.error is None for r in results), [
+            (r.name, r.error) for r in results if r.error
+        ]
+
+        # state.db shrank.
+        new_size = (synthetic_profile["home"] / "state.db").stat().st_size
+        assert new_size < synthetic_profile["bloated_size"], (
+            "VACUUM did not shrink the bloated state.db end-to-end"
+        )
+
+        # Snapshots: old gone, fresh kept.
+        assert not synthetic_profile["old_snap"].exists()
+        assert synthetic_profile["fresh_snap"].exists()
+
+        # Logs: big rotated, small kept, old archive pruned.
+        logs = synthetic_profile["home"] / "logs"
+        assert not synthetic_profile["big_log"].exists()
+        assert list(logs.glob("gateway.log.*.gz"))
+        assert synthetic_profile["small_log"].exists()
+        assert not synthetic_profile["old_archive"].exists()
+
+    def test_dry_run_changes_nothing(self, weekly_module, synthetic_profile):
+        before = _snapshot_dir_state(synthetic_profile["home"])
+
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=synthetic_profile["home"]
+        ):
+            results = weekly_module.run(dry_run=True)
+
+        assert all(r.error is None for r in results)
+        after = _snapshot_dir_state(synthetic_profile["home"])
+        assert before == after, (
+            "dry-run modified the profile — that's a safety regression"
+        )
+
+    def test_only_phase_isolation(self, weekly_module, synthetic_profile):
+        """``--only logs`` must not touch state.db or snapshots."""
+        db = synthetic_profile["home"] / "state.db"
+        size_before = db.stat().st_size
+
+        with patch.object(
+            weekly_module, "get_hermes_home", return_value=synthetic_profile["home"]
+        ):
+            results = weekly_module.run(only="logs")
+
+        assert all(r.error is None for r in results)
+        assert [r.name for r in results] == ["rotate_logs"]
+        # state.db untouched.
+        assert db.stat().st_size == size_before
+        # Snapshots untouched.
+        assert synthetic_profile["old_snap"].exists()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess regression — the script must honour HERMES_HOME end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessProfileResolution:
+    """Spawn the script as the user would and inspect stdout.
+
+    These tests don't import the module — they spawn it as a fresh
+    Python process so the real production code path runs (sys.path
+    bootstrap, hermes_constants import, argparse, the lot). They only
+    check the dry-run path so no state on disk is mutated.
+    """
+
+    def test_hermes_home_env_var_flows_into_resolved_paths(self, tmp_path):
+        target = tmp_path / "work-profile"
+        target.mkdir()
+
+        env = dict(os.environ)
+        env["HERMES_HOME"] = str(target)
+        env.pop("HERMES_LOG_LEVEL", None)
+
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--dry-run"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+        # Every printed path must root at the override.
+        assert str(target) in proc.stdout, proc.stdout
+        # Critically, NO path may root at the developer's real ~/.hermes
+        # while HERMES_HOME points at the synthetic profile.
+        real_home = str(Path.home() / ".hermes")
+        assert f"{real_home}/state.db" not in proc.stdout, (
+            "#24035 regression: weekly_maintenance leaked the real "
+            "~/.hermes/state.db into output while HERMES_HOME pointed "
+            "elsewhere — the profile is being ignored."
+        )
+
+    def test_subprocess_resolves_home_from_get_hermes_home(self, tmp_path):
+        """Run the script in a subprocess that imports hermes_constants
+        the same way the script does, and verify the path it prints
+        matches what hermes_constants.get_hermes_home() returns inside
+        that same subprocess.
+
+        This avoids tying the test to the in-process conftest, which
+        patches Path.home / HERMES_HOME for hermeticity in unit tests
+        but cannot influence the spawned process.
+        """
+        env = dict(os.environ)
+        env.pop("HERMES_HOME", None)
+        env.pop("HERMES_LOG_LEVEL", None)
+
+        # Step 1: ask a fresh subprocess what get_hermes_home() returns.
+        ask = subprocess.run(
+            [
+                sys.executable, "-c",
+                f"import sys; sys.path.insert(0, {str(REPO_ROOT)!r}); "
+                "from hermes_constants import get_hermes_home; "
+                "print(str(get_hermes_home()))",
+            ],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        assert ask.returncode == 0, ask.stderr
+        expected = ask.stdout.strip()
+        assert expected, "get_hermes_home() returned empty path"
+
+        # Step 2: run the script in the same env and assert the resolved
+        # path matches.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--dry-run"],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert expected in proc.stdout, (
+            f"Resolved home {expected!r} not in script output — "
+            "the script is using a different resolver than "
+            "hermes_constants.get_hermes_home()."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug-shape regression — explicit #24035 anchor
+# ---------------------------------------------------------------------------
+
+
+class TestBug24035Anchor:
+    """If any of these fail, the #24035 regression is back.
+
+    Don't 'fix' the test by deleting the assertion — fix the script
+    that started using ``os.path.expanduser('~')`` /
+    ``Path.home() / '.hermes'`` again.
+    """
+
+    def test_script_source_does_not_derive_data_paths_from_path_home(self):
+        """The script must never derive a *data* path from
+        ``Path.home() / ".hermes"`` or ``os.path.expanduser("~/.hermes")``.
+
+        The exception (which this test deliberately tolerates) is the
+        sys.path bootstrap in :data:`_CANDIDATE_REPO_ROOTS` that probes
+        ``~/.hermes/hermes-agent`` when looking for the source checkout
+        — that's a *code* lookup, not a data path. We pin that exact
+        usage so any *new* occurrence of the same pattern fails the test.
+        """
+        text = SCRIPT_PATH.read_text()
+
+        # The bug pattern: assigning STATE_DB / LCM_DB / SNAPSHOTS_DIR /
+        # LOGS_DIR from os.path.expanduser('~') or Path.home(). If any
+        # appears within 200 chars of one of those names, fail.
+        bug_markers = ('STATE_DB', 'LCM_DB', 'SNAPSHOTS_DIR', 'LOGS_DIR')
+        bad_root_patterns = (
+            'expanduser("~")', "expanduser('~')",
+            'expanduser("~/.hermes', "expanduser('~/.hermes",
+            'Path.home() / ".hermes" / "state',
+            'Path.home() / \'.hermes\' / \'state',
+        )
+        for marker in bug_markers:
+            idx = 0
+            while True:
+                pos = text.find(marker, idx)
+                if pos < 0:
+                    break
+                window = text[max(0, pos - 200): pos + 200]
+                for pat in bad_root_patterns:
+                    assert pat not in window, (
+                        f"#24035 regression: the script derives {marker} "
+                        f"from {pat!r} — that bypasses get_hermes_home() "
+                        "and silently no-ops users on non-default profiles."
+                    )
+                idx = pos + len(marker)
+
+        # The legitimate sys.path bootstrap (~/.hermes/hermes-agent for
+        # users who copied the script into ~/.hermes/scripts/) is the
+        # only tolerated *code* use of `Path.home() / ".hermes"`. We
+        # tolerate one extra match in the explanatory docstring above
+        # _CANDIDATE_REPO_ROOTS that documents why the bootstrap exists.
+        # Anything beyond that is suspicious.
+        assert text.count('Path.home() / ".hermes"') <= 2, (
+            "More than two occurrences of `Path.home() / \".hermes\"` — "
+            "the only tolerated uses are the sys.path bootstrap in "
+            "_CANDIDATE_REPO_ROOTS and the docstring that explains it."
+        )
+
+    def test_script_source_imports_get_hermes_home(self):
+        text = SCRIPT_PATH.read_text()
+        assert "from hermes_constants import get_hermes_home" in text, (
+            "#24035 regression: the script no longer imports "
+            "hermes_constants.get_hermes_home()."
+        )
+
+    def test_script_source_documents_24035(self):
+        """Anchor the issue number in the source so future maintainers
+        understand why this care exists.
+        """
+        text = SCRIPT_PATH.read_text()
+        assert "#24035" in text
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_dir_state(root: Path) -> dict:
+    """Capture (relative path → size) for every file under root."""
+    out = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            out[str(path.relative_to(root))] = path.stat().st_size
+    return out

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -457,3 +457,32 @@ hermes sessions prune --older-than 30 --yes
 :::tip
 The database grows slowly (typical: 10-15 MB for hundreds of sessions) and session history powers `session_search` recall across past conversations, so auto-prune ships disabled. Enable it if you're running a heavy gateway/cron workload where `state.db` is meaningfully affecting performance (observed failure mode: 384 MB state.db with ~1000 sessions slowing down FTS5 inserts and `/resume` listing). Use `hermes sessions prune` for one-off cleanup without turning on the automatic sweep.
 :::
+
+### Scheduled Maintenance: `weekly_maintenance.py`
+
+Long-lived gateway installs that almost never restart can drift past the in-process auto-prune window. The `scripts/weekly_maintenance.py` helper packages the same maintenance work as a standalone script you can wire into cron / launchd / systemd:
+
+```bash
+# Default — VACUUM state.db, prune state-snapshots/ older than 90 days,
+# rotate logs > 10 MB and drop archives older than 90 days.
+python scripts/weekly_maintenance.py
+
+# Show what would happen without modifying anything.
+python scripts/weekly_maintenance.py --dry-run
+
+# Single phase + tighter retention.
+python scripts/weekly_maintenance.py --only vacuum
+python scripts/weekly_maintenance.py --retention-days 30
+```
+
+The script resolves every path through `hermes_constants.get_hermes_home()`, so it always operates on the database the running Hermes process is using:
+
+```bash
+# Uses ~/.hermes-work, not ~/.hermes — the active profile is honoured.
+HERMES_HOME=~/.hermes-work python scripts/weekly_maintenance.py
+hermes -p work shell -- python scripts/weekly_maintenance.py
+```
+
+This profile awareness was the #24035 fix — community versions of the script that hardcoded `os.path.expanduser("~")` silently no-op'd users on non-default profiles (VACUUM ran on the wrong database while the active profile's `state.db` kept growing).
+
+VACUUM uses `timeout=0` against SQLite, so a live gateway holding the WAL writer never blocks weekly maintenance — the script yields and the next gateway restart's opportunistic `maybe_auto_prune_and_vacuum` picks up the slack.


### PR DESCRIPTION
# feat(scripts): add profile-aware weekly_maintenance.py (#24035)

## Why

Reported in #24035: long-lived Hermes installs accumulated a maintenance
gap because the community version of `~/.hermes/scripts/weekly_maintenance.py`
hardcoded paths from `os.path.expanduser("~")`:

```python
HERMES_HOME = os.path.expanduser("~")
STATE_DB = os.path.join(HERMES_HOME, ".hermes", "state.db")
```

That violates the project-wide rule documented in `AGENTS.md`:

> Every path to Hermes state MUST use `get_hermes_home()` from
> `hermes_constants`, never `Path.home() / ".hermes"`.

When a non-default profile is active (e.g. `hermes -p work`),
`get_hermes_home()` returns a different directory. The hardcoded
script ignores the active profile and always operates on
`~/.hermes/state.db` — silently vacuuming the wrong database while the
active profile's `state.db` keeps growing.

The bigger issue: there was no official, profile-aware version of the
script in the repo at all. Users who needed scheduled maintenance had
to write their own — and naturally made the same mistake the bug
reporter described.

## What

Add `scripts/weekly_maintenance.py` as the official profile-aware
maintenance helper, plus the unit + integration tests + bug-shape
regression anchor that lock the contract in.

The script:

  * Resolves every path through `hermes_constants.get_hermes_home()`,
    with a defensive `sys.path` bootstrap so it remains importable
    when a user copies it into `~/.hermes/scripts/` (the path the bug
    reporter actually uses).
  * Splits work into three independent phases (`--only vacuum / snapshots
    / logs`), each with its own `PhaseResult` so failures are isolated:
    * `vacuum_state_db` — `WAL checkpoint(TRUNCATE)` + `VACUUM` against
      `state.db`, with `timeout=0` so a live gateway holding the WAL
      writer never blocks weekly maintenance (the next gateway restart's
      opportunistic `maybe_auto_prune_and_vacuum` picks up the slack).
    * `prune_snapshots` — drop `state-snapshots/<id>/` entries older
      than `--retention-days` (default 90).
    * `rotate_logs` — gzip `logs/*.log` files larger than 10 MB and
      drop compressed archives older than the retention horizon.
  * `--dry-run` shows every action without touching disk so users can
    verify resolved paths before granting cron / launchd / systemd
    write access.
  * Idempotent and safe-by-default: missing directories skip cleanly
    instead of erroring; the script never raises an unhandled exception
    even when the underlying SQLite file is locked, missing, or
    corrupt.

Smoke test (proves the profile awareness):

```bash
$ HERMES_HOME=/tmp/work python scripts/weekly_maintenance.py --dry-run
weekly_maintenance: HERMES_HOME = /tmp/work
weekly_maintenance: paths = {
  "home": "/tmp/work",
  "state_db": "/tmp/work/state.db",
  "snapshots_dir": "/tmp/work/state-snapshots",
  "logs_dir": "/tmp/work/logs"
}
weekly_maintenance: DRY-RUN — no files will be modified
...
```

## Changes (4 commits, +1242 lines, sole author)

```
7643237b0 feat(scripts): add profile-aware weekly_maintenance.py (#24035)  (+484)
0034c870d test(scripts): pin weekly_maintenance helpers in isolation         (+376)
f2d846133 test(scripts): end-to-end + bug-shape regression for #24035        (+353)
eba31921f docs(sessions): document scripts/weekly_maintenance.py + #24035    (+29)
```

### Commit 1 — `scripts/weekly_maintenance.py`

The script itself. Three phases (`vacuum_state_db`, `prune_snapshots`,
`rotate_logs`) wired into a small driver (`run`, `_select_phases`,
`_human_bytes`, `main`). `MaintenancePaths` is a frozen dataclass that
holds every resolved path and serialises to JSON for the dry-run
output.

### Commit 2 — `tests/scripts/test_weekly_maintenance.py`

29 unit tests pinning every helper in isolation:

  * `TestResolvePaths` (5 tests) — the heart of the #24035 fix:
    `get_hermes_home()` is consulted, `Path.home()` is not. Frozen
    dataclass behaviour, JSON roundtrip, parametrised across every
    sub-path.
  * `TestVacuumStateDb` (3 tests) — missing-DB graceful skip,
    dry-run inertness, real VACUUM shrinks a bloated DB after a
    DELETE-then-VACUUM cycle.
  * `TestPruneSnapshots` (4 tests) — missing-dir skip, mtime-based
    eviction, dry-run inertness, retention-boundary keeps a snapshot
    one day inside the window.
  * `TestRotateLogs` (5 tests) — small log untouched, large log
    gzipped (with content roundtrip verification) and removed,
    dry-run inertness, old archives pruned by mtime.
  * `TestDriver` (8 tests) — `_select_phases` defaults +
    parametrised single phase + unknown phase raises `SystemExit`,
    `_human_bytes` formatting, `main()` exit codes for `--dry-run`,
    `--retention-days <= 0`, and a phase that errors on a corrupt DB.

Module loaded via `importlib.util.spec_from_file_location` so the
test pins the script's module-level imports (`sys.path` bootstrap,
`hermes_constants` import, candidate-root probe) along with the
helpers.

### Commit 3 — `tests/scripts/test_weekly_maintenance_integration.py`

8 end-to-end + bug-shape regression tests:

  * `TestEndToEnd` (3 tests) — a realistic on-disk profile (bloated
    `state.db`, old + fresh snapshot dirs, 11 MB log, small log, 100-
    day-old archive) is constructed in `tmp_path` and the full driver
    runs against it. Verifies the headline outcome (DB shrinks,
    snapshots pruned, logs rotated), the dry-run safety property
    (pre/post directory state byte-identical), and `--only` phase
    isolation.
  * `TestSubprocessProfileResolution` (2 tests) — spawns the script
    as the user actually would so the production code path runs
    end-to-end (sys.path bootstrap, `hermes_constants` import,
    argparse, dry-run output). Asserts that `HERMES_HOME=/tmp/work`
    flows into every printed path AND that no path roots at the
    developer's real `~/.hermes/state.db` while a synthetic
    `HERMES_HOME` is set.
  * `TestBug24035Anchor` (3 tests) — read the script's source and
    refuse to merge any change that:
    * derives `STATE_DB` / `LCM_DB` / `SNAPSHOTS_DIR` / `LOGS_DIR`
      from `os.path.expanduser('~')` or `Path.home() / '.hermes'`
      (the exact bug pattern from the issue),
    * removes the `from hermes_constants import get_hermes_home`
      import, or
    * deletes the `#24035` reference from the source so future
      maintainers lose the historical context.

### Commit 4 — `website/docs/user-guide/sessions.md`

Add a 'Scheduled Maintenance' subsection to the Session Expiry and
Cleanup chapter that documents what the script does, the three CLI
flags users care about, the profile-awareness contract, and the
`timeout=0` design that prevents weekly maintenance from blocking
on a live gateway.

## Test plan

```bash
$ python -m pytest tests/scripts/ -p no:cacheprovider
============================== 37 passed in 0.69s ==============================

$ python -m ruff check scripts/weekly_maintenance.py tests/scripts/
All checks passed!
```

Manual verification (profile awareness, the headline #24035 fix):

```bash
$ HERMES_HOME=/tmp/work-profile python scripts/weekly_maintenance.py --dry-run
weekly_maintenance: HERMES_HOME = /tmp/work-profile
weekly_maintenance: paths = {
  "home": "/tmp/work-profile",
  "state_db": "/tmp/work-profile/state.db",
  "snapshots_dir": "/tmp/work-profile/state-snapshots",
  "logs_dir": "/tmp/work-profile/logs"
}
```

## Bug-reproduction proof

The bug-shape anchor is a real regression catch, not aspirational.
Replacing `scripts/weekly_maintenance.py` with the literal version
the issue reporter described (the community-hardcoded variant):

```python
#!/usr/bin/env python3
import os
HERMES_HOME = os.path.expanduser("~")
STATE_DB = os.path.join(HERMES_HOME, ".hermes", "state.db")
LCM_DB = os.path.join(HERMES_HOME, ".hermes", "lcm.db")
SNAPSHOTS_DIR = os.path.join(HERMES_HOME, ".hermes", "state-snapshots")
LOGS_DIR = os.path.join(HERMES_HOME, ".hermes", "logs")
```

Re-running the anchor suite:

```bash
$ python -m pytest tests/scripts/test_weekly_maintenance_integration.py::TestBug24035Anchor
FAILED ...TestBug24035Anchor::test_script_source_does_not_derive_data_paths_from_path_home
FAILED ...TestBug24035Anchor::test_script_source_imports_get_hermes_home
========================= 2 failed, 1 passed =========================
```

Exactly the two assertions that pin the #24035 fix fail without the
profile-aware version. Restoring the fix → all 37 tests pass.

## Backwards compatibility

  * Brand-new file (`scripts/weekly_maintenance.py`) — adds the
    capability the reporter describes; nothing in the existing
    runtime calls it, so no behaviour change for users who don't
    invoke it.
  * `HERMES_HOME` env var resolution is delegated to
    `hermes_constants.get_hermes_home`, which is the project's
    single source of truth — the script inherits whatever
    profile-resolution semantics that helper has.
  * Docs change is additive (new subsection in `sessions.md`).

Closes #24035.
