### PR TITLE
feat(environments): add Alibaba Cloud AgentRun backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
+agentrun = ["agentrun-sdk>=0.0.35,<0.1.0"]
 hindsight = ["hindsight-client>=0.4.22"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
@@ -149,6 +150,7 @@ all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[vercel]",
+  "hermes-agent[agentrun]",
   "hermes-agent[messaging]",
   # matrix: python-olm (required by matrix-nio[e2e]) is upstream-broken on
   # modern macOS (archived libolm, C++ errors with Clang 21+).  On Linux the

--- a/tests/tools/test_agentrun_environment.py
+++ b/tests/tools/test_agentrun_environment.py
@@ -1,0 +1,436 @@
+"""Unit tests for the Alibaba Cloud AgentRun cloud sandbox backend.
+
+The real ``agentrun-sdk`` package is intentionally not imported here. We
+patch ``sys.modules['agentrun.sandbox']`` with a stand-in module so
+``AgentRunEnvironment`` can be constructed and exercised without any
+network or credentials. Every test in this file is expected to pass on
+CI without the SDK installed and without ``AGENTRUN_*`` env vars.
+"""
+
+from __future__ import annotations
+
+import types as _types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a stand-in agentrun.sandbox module
+# ---------------------------------------------------------------------------
+
+
+class _FakeTemplateType:
+    """Minimal stand-in for ``agentrun.sandbox.model.TemplateType``."""
+
+    CODE_INTERPRETER = "code-interpreter"
+    BROWSER = "browser"
+    AIO = "aio"
+    CUSTOM = "custom"
+
+
+def _make_fake_sandbox(sandbox_id: str = "sb-fake-123") -> MagicMock:
+    """Build a ``MagicMock`` shaped like a Code Interpreter sandbox."""
+    sb = MagicMock()
+    sb.sandbox_id = sandbox_id
+    sb.check_health.return_value = {"status": "ok"}
+    # Default cmd response matches the documented Code Interpreter shape.
+    sb.process.cmd.return_value = {
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 0,
+    }
+    return sb
+
+
+def _patch_agentrun_imports(monkeypatch, sandbox: MagicMock):
+    """Install a stand-in ``agentrun.sandbox`` module that the adapter imports.
+
+    Returns the fake ``Sandbox`` class so individual tests can assert on
+    its calls (``Sandbox.create`` / ``Sandbox.connect`` / ``Sandbox.get_template``
+    / ``Sandbox.create_template``).
+    """
+    fake_sandbox_cls = MagicMock(name="FakeSandboxClass")
+    # By default the template already exists (get_template succeeds) so we
+    # exercise the happy path. Individual tests override the side effects
+    # as needed.
+    fake_sandbox_cls.get_template.return_value = MagicMock(
+        template_type=_FakeTemplateType.CODE_INTERPRETER,
+    )
+    fake_sandbox_cls.create_template.return_value = MagicMock()
+    fake_sandbox_cls.create.return_value = sandbox
+    fake_sandbox_cls.connect.return_value = sandbox
+
+    fake_template_input = MagicMock(name="FakeTemplateInput")
+
+    sandbox_mod = _types.ModuleType("agentrun.sandbox")
+    sandbox_mod.Sandbox = fake_sandbox_cls
+    sandbox_mod.TemplateType = _FakeTemplateType
+    sandbox_mod.TemplateInput = fake_template_input
+
+    # We also expose top-level ``agentrun`` and ``agentrun.utils.log`` in
+    # case importlib walks the package; the adapter currently only
+    # touches ``agentrun.sandbox`` so these are defensive.
+    parent_mod = _types.ModuleType("agentrun")
+    parent_mod.sandbox = sandbox_mod
+
+    monkeypatch.setitem(__import__("sys").modules, "agentrun", parent_mod)
+    monkeypatch.setitem(__import__("sys").modules, "agentrun.sandbox", sandbox_mod)
+    return fake_sandbox_cls
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_sandbox():
+    return _make_fake_sandbox()
+
+
+@pytest.fixture()
+def agentrun_sdk(monkeypatch, fake_sandbox):
+    """Install the stand-in SDK and return the fake ``Sandbox`` class."""
+    # Quiet down hermes-side noise: skip is_interrupted checks and
+    # credential file enumeration so the test only sees calls we drove.
+    monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+    monkeypatch.setattr(
+        "tools.credential_files.get_credential_file_mounts", lambda: []
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.iter_skills_files", lambda **kw: []
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.iter_cache_files", lambda **kw: []
+    )
+    return _patch_agentrun_imports(monkeypatch, fake_sandbox)
+
+
+@pytest.fixture()
+def isolated_store(monkeypatch, tmp_path):
+    """Redirect the ``agentrun_sandboxes.json`` store at the module level.
+
+    The adapter binds ``_SANDBOX_STORE`` at import time, so we have to
+    patch the attribute directly rather than mutating ``HERMES_HOME``.
+    """
+    import tools.environments.agentrun as agentrun_mod
+
+    monkeypatch.setattr(
+        agentrun_mod, "_SANDBOX_STORE", tmp_path / "agentrun_sandboxes.json"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def make_env(agentrun_sdk, fake_sandbox, isolated_store):
+    """Factory that constructs an ``AgentRunEnvironment`` with sane defaults."""
+
+    def _factory(*, persistent: bool = True, task_id: str = "test-task", **kwargs):
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        env = AgentRunEnvironment(
+            cwd="/root",
+            timeout=60,
+            task_id=task_id,
+            persistent_filesystem=persistent,
+            **kwargs,
+        )
+        env._mock_sandbox_cls = agentrun_sdk
+        env._mock_sandbox = fake_sandbox
+        return env
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — create_sandbox: template name + create call wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSandbox:
+    def test_create_uses_task_scoped_template_and_idle_timeout(self, make_env):
+        env = make_env(task_id="alpha")
+        # template_name defaults to ``hermes-{task_id}``
+        env._mock_sandbox_cls.create.assert_called_once()
+        kwargs = env._mock_sandbox_cls.create.call_args.kwargs
+        assert kwargs["template_name"] == "hermes-alpha"
+        # template_type forwarded as CODE_INTERPRETER
+        assert kwargs["template_type"] == _FakeTemplateType.CODE_INTERPRETER
+        # idle timeout defaults to 5 minutes
+        assert kwargs["sandbox_idle_timeout_seconds"] == 300
+
+    def test_explicit_template_name_wins(self, make_env):
+        env = make_env(template_name="custom-tpl")
+        kwargs = env._mock_sandbox_cls.create.call_args.kwargs
+        assert kwargs["template_name"] == "custom-tpl"
+
+    def test_template_created_when_get_returns_not_found(
+        self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox
+    ):
+        """When the named template does not exist we create it once."""
+        # Suppress hermes-internal noise (the agentrun_sdk fixture would
+        # have done this, but we need a clean setup here so we replicate
+        # the few critical patches).
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+
+        agentrun_sdk.get_template.side_effect = RuntimeError("not found")
+
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        AgentRunEnvironment(
+            cwd="/root",
+            timeout=60,
+            task_id="beta",
+            persistent_filesystem=False,
+        )
+
+        agentrun_sdk.create_template.assert_called_once()
+        # template_name must propagate into the TemplateInput payload.
+        called_input = agentrun_sdk.create_template.call_args.kwargs.get("input")
+        # We constructed TemplateInput via a MagicMock — assert the mock
+        # was invoked with the right template_name keyword.
+        # MagicMock records call args; the adapter calls TemplateInput(...)
+        # imported from the patched module, so check that mock.
+        import agentrun.sandbox as patched_sandbox_mod  # type: ignore[import-not-found]
+
+        patched_sandbox_mod.TemplateInput.assert_called_once()
+        ti_kwargs = patched_sandbox_mod.TemplateInput.call_args.kwargs
+        assert ti_kwargs["template_name"] == "hermes-beta"
+        assert ti_kwargs["template_type"] == _FakeTemplateType.CODE_INTERPRETER
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — run_bash: cmd is invoked with the right args + timeout clamping
+# ---------------------------------------------------------------------------
+
+
+class TestRunBash:
+    def test_basic_command_forwards_to_sandbox_process_cmd(self, make_env):
+        env = make_env()
+        # init_session and bulk-sync may have invoked cmd() already.
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "hello\n",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+        result = env.execute("echo hello")
+        assert "hello" in result["output"]
+        assert result["returncode"] == 0
+        # The last cmd() call should have included our payload (wrapped
+        # by the base class' session-snapshot machinery; we only assert
+        # that ``cmd`` was reached at all and accepted a non-empty
+        # command string with the cwd we configured).
+        last_call = env._mock_sandbox.process.cmd.call_args
+        assert last_call is not None
+        assert "command" in last_call.kwargs
+        assert last_call.kwargs["command"]  # non-empty
+        assert last_call.kwargs["cwd"] == "/root"
+
+    def test_timeout_clamped_to_vendor_limit(self, make_env, caplog):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "ok",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+        with caplog.at_level("WARNING", logger="tools.environments.agentrun"):
+            env.execute("sleep 1", timeout=120)
+
+        # Vendor-side max is 30s; the adapter must not forward a larger
+        # value silently.
+        forwarded_timeouts = [
+            call.kwargs.get("timeout")
+            for call in env._mock_sandbox.process.cmd.call_args_list
+        ]
+        assert all(t is None or t <= 30 for t in forwarded_timeouts)
+        assert any("clamping" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — file sync: upload + delete + bulk download all reach the SDK
+# ---------------------------------------------------------------------------
+
+
+class TestFileSync:
+    def test_upload_calls_mkdir_then_upload(self, make_env):
+        env = make_env()
+        env._mock_sandbox.file_system.mkdir.reset_mock()
+        env._mock_sandbox.file_system.upload.reset_mock()
+
+        env._agentrun_upload("/tmp/host-file.txt", "/root/.hermes/foo/bar.txt")
+
+        env._mock_sandbox.file_system.mkdir.assert_called_once_with(
+            path="/root/.hermes/foo", parents=True,
+        )
+        env._mock_sandbox.file_system.upload.assert_called_once_with(
+            local_file_path="/tmp/host-file.txt",
+            target_file_path="/root/.hermes/foo/bar.txt",
+        )
+
+    def test_delete_invokes_rm_via_process_cmd(self, make_env):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "", "stderr": "", "exit_code": 0,
+        }
+
+        env._agentrun_delete([
+            "/root/.hermes/a.txt",
+            "/root/.hermes/b.txt",
+        ])
+
+        env._mock_sandbox.process.cmd.assert_called_once()
+        kwargs = env._mock_sandbox.process.cmd.call_args.kwargs
+        assert kwargs["command"].startswith("rm -f ")
+        assert "/root/.hermes/a.txt" in kwargs["command"]
+        assert "/root/.hermes/b.txt" in kwargs["command"]
+
+    def test_bulk_download_tars_then_downloads(self, make_env, tmp_path):
+        env = make_env()
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "", "stderr": "", "exit_code": 0,
+        }
+        env._mock_sandbox.file_system.download.reset_mock()
+
+        dest = tmp_path / "out.tar"
+        env._agentrun_bulk_download(dest)
+
+        # First we should have invoked ``tar cf`` inside the sandbox.
+        cmd_calls = env._mock_sandbox.process.cmd.call_args_list
+        assert any("tar cf" in c.kwargs.get("command", "") for c in cmd_calls)
+        # Then we pull the archive down.
+        env._mock_sandbox.file_system.download.assert_called_once()
+        download_kwargs = env._mock_sandbox.file_system.download.call_args.kwargs
+        assert download_kwargs["save_path"] == str(dest)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — cleanup: sync_back, then stop (persistent) or delete (ephemeral),
+#                   and both branches swallow underlying SDK errors.
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_persistent_cleanup_calls_sync_back_then_stop(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()
+
+        env._sync_manager.sync_back.assert_called_once()
+        sb.stop.assert_called_once()
+        sb.delete.assert_not_called()
+        assert env._sandbox is None
+
+    def test_non_persistent_cleanup_deletes_sandbox(self, make_env):
+        env = make_env(persistent=False)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()
+
+        sb.delete.assert_called_once()
+        sb.stop.assert_not_called()
+
+    def test_cleanup_swallows_sync_back_failure(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        env._sync_manager.sync_back = MagicMock(
+            name="sync_back", side_effect=RuntimeError("sync failed")
+        )
+
+        # The exception must be swallowed and stop() must still run, so
+        # that an unhealthy sync_back never leaks a dangling sandbox.
+        env.cleanup()
+        sb.stop.assert_called_once()
+
+    def test_cleanup_swallows_stop_failure(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._mock_sandbox
+        sb.stop.side_effect = RuntimeError("stop boom")
+        env._sync_manager.sync_back = MagicMock(name="sync_back")
+
+        env.cleanup()  # must not raise
+        assert env._sandbox is None
+
+
+# ---------------------------------------------------------------------------
+# Bonus — response normalisation: payload shape variants from the data API
+# ---------------------------------------------------------------------------
+
+
+class TestResponseNormalisation:
+    def test_handles_stdout_stderr_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(
+            {"stdout": "hi", "stderr": "warn", "exit_code": 0}
+        )
+        assert "hi" in out and "warn" in out
+        assert code == 0
+
+    def test_handles_output_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response({"output": "hi", "exit_code": 1})
+        assert out == "hi"
+        assert code == 1
+
+    def test_handles_nested_data_shape(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(
+            {"data": {"stdout": "x", "exit_code": 2}}
+        )
+        assert "x" in out
+        assert code == 2
+
+    def test_handles_none(self):
+        from tools.environments.agentrun import _normalise_cmd_response
+
+        out, code = _normalise_cmd_response(None)
+        assert out == ""
+        assert code == 1
+
+
+# ---------------------------------------------------------------------------
+# Persistence — task_id ↔ sandbox_id store survives across constructions
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_second_construction_reconnects(self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox):
+        # First construction should hit ``create`` and persist the id.
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        env1 = AgentRunEnvironment(
+            cwd="/root", timeout=60,
+            task_id="resume-me", persistent_filesystem=True,
+        )
+        first_create_calls = agentrun_sdk.create.call_count
+        first_connect_calls = agentrun_sdk.connect.call_count
+        env1.cleanup()
+
+        # Second construction with same task_id should reconnect, not
+        # re-create.
+        agentrun_sdk.create.reset_mock()
+        agentrun_sdk.connect.reset_mock()
+        agentrun_sdk.connect.return_value = fake_sandbox
+
+        env2 = AgentRunEnvironment(
+            cwd="/root", timeout=60,
+            task_id="resume-me", persistent_filesystem=True,
+        )
+
+        assert agentrun_sdk.connect.call_count == 1
+        assert agentrun_sdk.create.call_count == 0
+        env2.cleanup()

--- a/tests/tools/test_agentrun_environment.py
+++ b/tests/tools/test_agentrun_environment.py
@@ -10,7 +10,7 @@ CI without the SDK installed and without ``AGENTRUN_*`` env vars.
 from __future__ import annotations
 
 import types as _types
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -29,14 +29,24 @@ class _FakeTemplateType:
     CUSTOM = "custom"
 
 
-def _make_fake_sandbox(sandbox_id: str = "sb-fake-123") -> MagicMock:
-    """Build a ``MagicMock`` shaped like a Code Interpreter sandbox."""
+_FAKE_REMOTE_HOME = "/home/code"
+
+
+def _make_fake_sandbox(
+    sandbox_id: str = "sb-fake-123",
+    remote_home: str = _FAKE_REMOTE_HOME,
+) -> MagicMock:
+    """Build a ``MagicMock`` shaped like a Code Interpreter sandbox.
+
+    The default ``process.cmd`` response carries *remote_home* on stdout
+    so the adapter's ``_detect_remote_home`` probe resolves to a
+    realistic non-root directory.
+    """
     sb = MagicMock()
     sb.sandbox_id = sandbox_id
     sb.check_health.return_value = {"status": "ok"}
-    # Default cmd response matches the documented Code Interpreter shape.
     sb.process.cmd.return_value = {
-        "stdout": "",
+        "stdout": remote_home,
         "stderr": "",
         "exit_code": 0,
     }
@@ -62,11 +72,13 @@ def _patch_agentrun_imports(monkeypatch, sandbox: MagicMock):
     fake_sandbox_cls.connect.return_value = sandbox
 
     fake_template_input = MagicMock(name="FakeTemplateInput")
+    fake_container_configuration = MagicMock(name="FakeTemplateContainerConfiguration")
 
     sandbox_mod = _types.ModuleType("agentrun.sandbox")
     sandbox_mod.Sandbox = fake_sandbox_cls
     sandbox_mod.TemplateType = _FakeTemplateType
     sandbox_mod.TemplateInput = fake_template_input
+    sandbox_mod.TemplateContainerConfiguration = fake_container_configuration
 
     # We also expose top-level ``agentrun`` and ``agentrun.utils.log`` in
     # case importlib walks the package; the adapter currently only
@@ -129,8 +141,10 @@ def make_env(agentrun_sdk, fake_sandbox, isolated_store):
     def _factory(*, persistent: bool = True, task_id: str = "test-task", **kwargs):
         from tools.environments.agentrun import AgentRunEnvironment
 
+        # ``cwd`` left to the adapter so that the $HOME probe takes
+        # effect; individual tests pass ``cwd=...`` to override.
+        kwargs.setdefault("cwd", None)
         env = AgentRunEnvironment(
-            cwd="/root",
             timeout=60,
             task_id=task_id,
             persistent_filesystem=persistent,
@@ -179,7 +193,6 @@ class TestCreateSandbox:
         from tools.environments.agentrun import AgentRunEnvironment
 
         AgentRunEnvironment(
-            cwd="/root",
             timeout=60,
             task_id="beta",
             persistent_filesystem=False,
@@ -187,17 +200,73 @@ class TestCreateSandbox:
 
         agentrun_sdk.create_template.assert_called_once()
         # template_name must propagate into the TemplateInput payload.
-        called_input = agentrun_sdk.create_template.call_args.kwargs.get("input")
         # We constructed TemplateInput via a MagicMock — assert the mock
         # was invoked with the right template_name keyword.
-        # MagicMock records call args; the adapter calls TemplateInput(...)
-        # imported from the patched module, so check that mock.
         import agentrun.sandbox as patched_sandbox_mod  # type: ignore[import-not-found]
 
         patched_sandbox_mod.TemplateInput.assert_called_once()
         ti_kwargs = patched_sandbox_mod.TemplateInput.call_args.kwargs
         assert ti_kwargs["template_name"] == "hermes-beta"
         assert ti_kwargs["template_type"] == _FakeTemplateType.CODE_INTERPRETER
+
+    def test_default_image_targets_python_runtime(
+        self, agentrun_sdk, isolated_store, monkeypatch
+    ):
+        """The default ``agentrun_image`` must be a Python-bearing image.
+
+        AgentRun's stock CODE_INTERPRETER template ships with a minimal
+        image; the live e2e on 2026-05-12 reproduced a ``Python 3 is not
+        available`` error from ``execute_code``. The adapter now defaults
+        ``agentrun_image`` to a Python+Node image so that hermes' code
+        tooling works out of the box. This test pins the default by name
+        AND asserts it is forwarded into ``TemplateContainerConfiguration``
+        when a new template is created.
+        """
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+        agentrun_sdk.get_template.side_effect = RuntimeError("not found")
+
+        from tools.environments.agentrun import (
+            _DEFAULT_IMAGE,
+            AgentRunEnvironment,
+        )
+
+        assert "python" in _DEFAULT_IMAGE.lower(), (
+            "Default agentrun image must include Python; got " + _DEFAULT_IMAGE
+        )
+
+        AgentRunEnvironment(
+            timeout=60, task_id="image-check", persistent_filesystem=False,
+        )
+
+        import agentrun.sandbox as patched_sandbox_mod  # type: ignore[import-not-found]
+
+        # TemplateContainerConfiguration must have been instantiated with
+        # the default image (not None, not a placeholder).
+        patched_sandbox_mod.TemplateContainerConfiguration.assert_called_once()
+        cc_kwargs = patched_sandbox_mod.TemplateContainerConfiguration.call_args.kwargs
+        assert cc_kwargs.get("image") == _DEFAULT_IMAGE
+
+        # And TemplateInput must have received that container_configuration.
+        ti_kwargs = patched_sandbox_mod.TemplateInput.call_args.kwargs
+        assert ti_kwargs.get("container_configuration") is not None
+
+    def test_explicit_image_overrides_default(
+        self, agentrun_sdk, isolated_store, monkeypatch
+    ):
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+        agentrun_sdk.get_template.side_effect = RuntimeError("not found")
+
+        from tools.environments.agentrun import AgentRunEnvironment
+
+        AgentRunEnvironment(
+            timeout=60, task_id="custom-img", persistent_filesystem=False,
+            image="my-registry.example/custom-python:1.0",
+        )
+
+        import agentrun.sandbox as patched_sandbox_mod  # type: ignore[import-not-found]
+
+        cc_kwargs = patched_sandbox_mod.TemplateContainerConfiguration.call_args.kwargs
+        assert cc_kwargs.get("image") == "my-registry.example/custom-python:1.0"
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +296,9 @@ class TestRunBash:
         assert last_call is not None
         assert "command" in last_call.kwargs
         assert last_call.kwargs["command"]  # non-empty
-        assert last_call.kwargs["cwd"] == "/root"
+        # cwd resolved to the worker user's $HOME (detected via the
+        # mock's process.cmd response).
+        assert last_call.kwargs["cwd"] == _FAKE_REMOTE_HOME
 
     def test_timeout_clamped_to_vendor_limit(self, make_env, caplog):
         env = make_env()
@@ -308,6 +379,73 @@ class TestFileSync:
         env._mock_sandbox.file_system.download.assert_called_once()
         download_kwargs = env._mock_sandbox.file_system.download.call_args.kwargs
         assert download_kwargs["save_path"] == str(dest)
+
+    def test_sync_targets_detected_home_not_root(self, make_env):
+        """File sync MUST honour the probed ``$HOME`` of the worker user.
+
+        AgentRun's CODE_INTERPRETER prebuilt image runs as a non-root
+        user, so the legacy hard-coded ``/root/.hermes`` path triggers a
+        ``permission denied`` on the very first ``mkdir`` (this was the
+        Bug 3 surfaced by the 2026-05-12 live e2e). The adapter now
+        records ``_remote_home`` and every sync helper composes its
+        target path relative to it.
+        """
+        env = make_env()
+        # Probe should have written the mocked ``/home/code`` into the
+        # adapter's _remote_home, and the bulk_download path should use
+        # it rather than /root.
+        assert env._remote_home == _FAKE_REMOTE_HOME
+        assert env.cwd == _FAKE_REMOTE_HOME
+
+        env._mock_sandbox.process.cmd.reset_mock()
+        env._mock_sandbox.process.cmd.return_value = {
+            "stdout": "", "stderr": "", "exit_code": 0,
+        }
+        env._agentrun_bulk_download(env.__class__.__dict__.get(
+            "_throwaway_path", __import__("pathlib").Path("/tmp/throwaway.tar")
+        ))
+        tar_cmds = [
+            c.kwargs.get("command", "")
+            for c in env._mock_sandbox.process.cmd.call_args_list
+            if "tar cf" in c.kwargs.get("command", "")
+        ]
+        assert tar_cmds, "expected a tar command"
+        # Sandbox-side tar target must reference the probed HOME, not /root.
+        joined = " ".join(tar_cmds)
+        assert "home/code/.hermes" in joined
+        assert "/root/.hermes" not in joined
+
+    def test_remote_home_falls_back_when_probe_fails(
+        self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox
+    ):
+        """If the ``$HOME`` probe blows up we fall back to ``/workspace``.
+
+        Crashing the adapter on home-detection failure would tear every
+        AgentRun session down on transient errors; the fallback keeps
+        the backend usable (and writes still work because /workspace is
+        writable in every prebuilt template).
+        """
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+
+        # First cmd() call (the $HOME probe) raises; subsequent calls
+        # (init_session, file sync, etc.) return a clean response.
+        clean = {"stdout": "", "stderr": "", "exit_code": 0}
+        fake_sandbox.process.cmd.side_effect = [
+            RuntimeError("network blip"),
+            clean, clean, clean, clean, clean, clean,
+        ]
+
+        from tools.environments.agentrun import (
+            _FALLBACK_CWD,
+            AgentRunEnvironment,
+        )
+
+        env = AgentRunEnvironment(
+            timeout=60, task_id="fallback-task", persistent_filesystem=False,
+        )
+
+        assert env._remote_home == _FALLBACK_CWD
+        assert env.cwd == _FALLBACK_CWD
 
 
 # ---------------------------------------------------------------------------
@@ -406,18 +544,18 @@ class TestResponseNormalisation:
 
 
 class TestPersistence:
-    def test_second_construction_reconnects(self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox):
+    def test_second_construction_reconnects(
+        self, agentrun_sdk, isolated_store, monkeypatch, fake_sandbox,
+    ):
         # First construction should hit ``create`` and persist the id.
         monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
 
         from tools.environments.agentrun import AgentRunEnvironment
 
         env1 = AgentRunEnvironment(
-            cwd="/root", timeout=60,
+            timeout=60,
             task_id="resume-me", persistent_filesystem=True,
         )
-        first_create_calls = agentrun_sdk.create.call_count
-        first_connect_calls = agentrun_sdk.connect.call_count
         env1.cleanup()
 
         # Second construction with same task_id should reconnect, not
@@ -427,7 +565,7 @@ class TestPersistence:
         agentrun_sdk.connect.return_value = fake_sandbox
 
         env2 = AgentRunEnvironment(
-            cwd="/root", timeout=60,
+            timeout=60,
             task_id="resume-me", persistent_filesystem=True,
         )
 

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -2,8 +2,9 @@
 
 Each backend provides the same interface (BaseEnvironment ABC) for running
 shell commands in a specific execution context: local, Docker, SSH,
-Singularity, Modal, Daytona, or Vercel Sandbox. (Modal additionally has
-direct and Nous-managed modes, selected via terminal.modal_mode.)
+Singularity, Modal, Daytona, Vercel Sandbox, or Alibaba Cloud AgentRun.
+(Modal additionally has direct and Nous-managed modes, selected via
+terminal.modal_mode.)
 
 The terminal_tool.py factory (_create_environment) selects the backend
 based on the TERMINAL_ENV configuration.

--- a/tools/environments/agentrun.py
+++ b/tools/environments/agentrun.py
@@ -27,11 +27,9 @@ Compared to ``modal.py``:
 
 from __future__ import annotations
 
-import io
 import logging
 import os
 import shlex
-import tarfile
 import threading
 from pathlib import Path
 from typing import Any, Optional
@@ -64,8 +62,20 @@ _AGENTRUN_CMD_MAX_TIMEOUT = 30
 # conversation; short enough to keep the dormant-instance bill negligible.
 _DEFAULT_IDLE_TIMEOUT = 300
 
-# Remote home/working directory inside the Code Interpreter sandbox.
-_REMOTE_HOME = "/root"
+# Fallback working directory inside the sandbox when ``$HOME`` cannot be
+# detected (e.g. the sandbox image does not set HOME for the worker user).
+# AgentRun's Code Interpreter image runs commands as a non-root user, so we
+# can not assume ``/root`` is writable.
+_FALLBACK_CWD = "/workspace"
+
+# Default container image. AgentRun's CODE_INTERPRETER prebuilt template
+# image is minimal and (as of SDK 0.0.35) ships without ``python3`` on
+# PATH for the worker user. We default to the same Python+Node image
+# used by the Modal/Daytona backends so file_tools, execute_code, and the
+# rest of the toolchain just work. Users can override via
+# ``terminal.agentrun_image`` if they have a custom AgentRun container
+# pushed to ACR.
+_DEFAULT_IMAGE = "nikolaik/python-nodejs:python3.11-nodejs20"
 
 # Local store mapping ``task_id -> sandbox_id`` so we can resume across
 # process restarts (parallel to modal_snapshots.json).
@@ -101,7 +111,7 @@ def _delete_stored_sandbox(task_id: str, sandbox_id: str | None = None) -> None:
         _save_sandbox_map(data)
 
 
-def _ensure_template(template_name: str) -> None:
+def _ensure_template(template_name: str, image: str | None = None) -> None:
     """Create the named template if it does not already exist.
 
     AgentRun templates are durable server-side resources. The first time
@@ -110,8 +120,17 @@ def _ensure_template(template_name: str) -> None:
     ``already exists``-shaped errors because the SDK does not expose a
     typed ``AlreadyExists`` exception (it raises ``ServerError`` /
     ``APIError`` with the upstream HTTP message).
+
+    When *image* is provided it is forwarded as the template's
+    ``container_configuration.image``; otherwise AgentRun falls back to
+    its prebuilt CODE_INTERPRETER image.
     """
-    from agentrun.sandbox import Sandbox, TemplateInput, TemplateType
+    from agentrun.sandbox import (
+        Sandbox,
+        TemplateContainerConfiguration,
+        TemplateInput,
+        TemplateType,
+    )
 
     try:
         Sandbox.get_template(template_name)
@@ -124,14 +143,22 @@ def _ensure_template(template_name: str) -> None:
             template_name, exc,
         )
 
+    container_config = (
+        TemplateContainerConfiguration(image=image) if image else None
+    )
+
     try:
         Sandbox.create_template(
             input=TemplateInput(
                 template_name=template_name,
                 template_type=TemplateType.CODE_INTERPRETER,
+                container_configuration=container_config,
             )
         )
-        logger.info("AgentRun: created template %s", template_name)
+        logger.info(
+            "AgentRun: created template %s (image=%s)",
+            template_name, image or "<vendor default>",
+        )
     except Exception as exc:
         # Tolerate race with concurrent creators (e.g. parallel callers
         # with the same task_id). If get_template now succeeds, we are
@@ -160,20 +187,27 @@ class AgentRunEnvironment(BaseEnvironment):
 
     def __init__(
         self,
-        cwd: str = _REMOTE_HOME,
+        cwd: Optional[str] = None,
         timeout: int = 60,
         task_id: str = "default",
         template_name: Optional[str] = None,
         idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT,
         persistent_filesystem: bool = True,
+        image: Optional[str] = _DEFAULT_IMAGE,
     ):
-        super().__init__(cwd=cwd, timeout=timeout)
+        requested_cwd = cwd
+        # ``cwd`` will be re-resolved after we know the sandbox's $HOME.
+        # Pass a temporary placeholder so the base class is happy; we
+        # overwrite ``self.cwd`` after probing the sandbox.
+        super().__init__(cwd=cwd or _FALLBACK_CWD, timeout=timeout)
 
         self._persistent = persistent_filesystem
         self._task_id = task_id
         self._template_name = template_name or f"hermes-{task_id}"
         self._idle_timeout = idle_timeout_seconds
+        self._image = image
         self._sandbox = None
+        self._remote_home: str = _FALLBACK_CWD
         self._lock = threading.Lock()
 
         # Late import: SDK is only required when this backend is selected.
@@ -181,7 +215,7 @@ class AgentRunEnvironment(BaseEnvironment):
 
         self._TemplateType = TemplateType
 
-        _ensure_template(self._template_name)
+        _ensure_template(self._template_name, image=self._image)
 
         # Persistence path: try to resume an existing sandbox first. We
         # only attempt resume when persistent_filesystem=True; otherwise
@@ -233,8 +267,24 @@ class AgentRunEnvironment(BaseEnvironment):
         if self._persistent and self._sandbox.sandbox_id:
             _store_sandbox_id(self._task_id, self._sandbox.sandbox_id)
 
+        # Detect the worker user's $HOME. AgentRun runs commands as a
+        # non-root user; ``/root`` is not writable, so file sync MUST
+        # target the detected home. If detection fails we fall back to
+        # ``/workspace`` which is writable in every prebuilt template.
+        self._remote_home = self._detect_remote_home()
+        container_base = f"{self._remote_home.rstrip('/')}/.hermes"
+
+        # Resolve the user-requested cwd against the discovered home.
+        # Callers that did not pin a cwd land in $HOME by default; ``~``
+        # and the legacy ``/root`` default are remapped onto $HOME so the
+        # adapter behaves the same way regardless of the underlying user.
+        if requested_cwd in (None, "", "~", "/root"):
+            self.cwd = self._remote_home
+        else:
+            self.cwd = requested_cwd
+
         self._sync_manager = FileSyncManager(
-            get_files_fn=lambda: iter_sync_files(f"{_REMOTE_HOME}/.hermes"),
+            get_files_fn=lambda: iter_sync_files(container_base),
             upload_fn=self._agentrun_upload,
             delete_fn=self._agentrun_delete,
             bulk_upload_fn=self._agentrun_bulk_upload,
@@ -276,6 +326,43 @@ class AgentRunEnvironment(BaseEnvironment):
             f"AgentRun: sandbox {self._sandbox.sandbox_id} did not become "
             f"healthy within {retries}s"
         )
+
+    def _detect_remote_home(self) -> str:
+        """Best-effort probe of the sandbox worker user's ``$HOME``.
+
+        AgentRun's prebuilt CODE_INTERPRETER image runs commands as a
+        non-root user (sandbox image-specific; commonly ``code`` or
+        ``user``). Hardcoding ``/root`` for file sync triggers
+        ``permission denied`` on the very first ``mkdir`` and tears the
+        backend down before any user command runs. We instead ask the
+        sandbox where its writable home directory is, mirroring the
+        approach used by ``vercel_sandbox.py``.
+        """
+        try:
+            response = self._sandbox.process.cmd(
+                command='sh -lc \'printf %s "$HOME"\'',
+                cwd="/",
+                timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+            )
+        except Exception as exc:
+            logger.warning(
+                "AgentRun: home detection failed for task %s; "
+                "falling back to %s: %s",
+                self._task_id, _FALLBACK_CWD, exc,
+            )
+            return _FALLBACK_CWD
+
+        home, _ = _normalise_cmd_response(response)
+        home = home.strip()
+        if home.startswith("/"):
+            return home
+
+        logger.warning(
+            "AgentRun: $HOME probe returned %r (not absolute); "
+            "falling back to %s",
+            home, _FALLBACK_CWD,
+        )
+        return _FALLBACK_CWD
 
     # ------------------------------------------------------------------
     # File sync callbacks
@@ -337,7 +424,7 @@ class AgentRunEnvironment(BaseEnvironment):
         the host PID to avoid collisions when multiple processes share
         the same sandbox by accident.
         """
-        rel_base = f"{_REMOTE_HOME}/.hermes".lstrip("/")
+        rel_base = f"{self._remote_home.rstrip('/')}/.hermes".lstrip("/")
         remote_tar = f"/tmp/.hermes_sync.{os.getpid()}.tar"
 
         self._sandbox.process.cmd(

--- a/tools/environments/agentrun.py
+++ b/tools/environments/agentrun.py
@@ -1,0 +1,527 @@
+"""Alibaba Cloud AgentRun execution environment.
+
+Uses the ``agentrun-sdk`` Python package
+(`pip install agentrun-sdk`, ``import agentrun``) to run shell commands in
+managed Code Interpreter sandboxes on Alibaba Cloud Function Compute v3 /
+AgentRun. Supports persistent sandboxes across sessions: when enabled, the
+sandbox id is stored locally and the sandbox is reconnected on the next
+construction with the same ``task_id`` (vendor-side session affinity:
+sandboxes survive idle periods up to ``sandbox_idle_timeout_seconds``,
+and once their idle timeout fires the AgentRun control plane reaps them).
+
+Compared to ``modal.py``:
+
+* AgentRun does not expose a snapshot API. Filesystem persistence is
+  provided by reconnecting to the same long-lived sandbox via
+  ``Sandbox.connect(sandbox_id)``; the sandbox stays alive across calls
+  as long as it is reused within ``sandbox_idle_timeout_seconds``.
+* Templates are first-class server-side resources. We materialise a
+  template named ``hermes-{task_id}`` once via ``Sandbox.create_template``;
+  re-creates of the same template name are tolerated (idempotent on the
+  client side: we catch the conflict and re-use the existing one).
+* AgentRun caps single-command execution at ~30s server-side. The SDK's
+  ``sandbox.process.cmd(command, cwd, timeout=...)`` is invoked once per
+  ``_run_bash()`` call. We forward the caller's timeout but clamp to the
+  vendor maximum to avoid silent truncation surprises.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import shlex
+import tarfile
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+from tools.environments.base import (
+    BaseEnvironment,
+    _ThreadedProcessHandle,
+    _load_json_store,
+    _save_json_store,
+)
+from tools.environments.file_sync import (
+    FileSyncManager,
+    iter_sync_files,
+    quoted_mkdir_command,
+    quoted_rm_command,
+    unique_parent_dirs,
+)
+
+logger = logging.getLogger(__name__)
+
+# Hard upper bound on a single command's timeout as enforced by the AgentRun
+# Code Interpreter sandbox HTTP API (per the published Sandbox docs). Callers
+# may request more; the SDK will silently truncate. We clamp explicitly so
+# users see a warning rather than a surprise timeout.
+_AGENTRUN_CMD_MAX_TIMEOUT = 30
+
+# Default idle ttl for the sandbox itself: 5 minutes of inactivity before the
+# control plane reaps it. Long enough to cover a normal multi-tool-call
+# conversation; short enough to keep the dormant-instance bill negligible.
+_DEFAULT_IDLE_TIMEOUT = 300
+
+# Remote home/working directory inside the Code Interpreter sandbox.
+_REMOTE_HOME = "/root"
+
+# Local store mapping ``task_id -> sandbox_id`` so we can resume across
+# process restarts (parallel to modal_snapshots.json).
+_SANDBOX_STORE = get_hermes_home() / "agentrun_sandboxes.json"
+
+
+def _load_sandbox_map() -> dict:
+    return _load_json_store(_SANDBOX_STORE)
+
+
+def _save_sandbox_map(data: dict) -> None:
+    _save_json_store(_SANDBOX_STORE, data)
+
+
+def _get_stored_sandbox_id(task_id: str) -> str | None:
+    value = _load_sandbox_map().get(task_id)
+    return value if isinstance(value, str) and value else None
+
+
+def _store_sandbox_id(task_id: str, sandbox_id: str) -> None:
+    data = _load_sandbox_map()
+    data[task_id] = sandbox_id
+    _save_sandbox_map(data)
+
+
+def _delete_stored_sandbox(task_id: str, sandbox_id: str | None = None) -> None:
+    data = _load_sandbox_map()
+    current = data.get(task_id)
+    if current is None:
+        return
+    if sandbox_id is None or current == sandbox_id:
+        data.pop(task_id, None)
+        _save_sandbox_map(data)
+
+
+def _ensure_template(template_name: str) -> None:
+    """Create the named template if it does not already exist.
+
+    AgentRun templates are durable server-side resources. The first time
+    a backend instance is materialised for a given task_id we create the
+    template; subsequent instances re-use it. We swallow
+    ``already exists``-shaped errors because the SDK does not expose a
+    typed ``AlreadyExists`` exception (it raises ``ServerError`` /
+    ``APIError`` with the upstream HTTP message).
+    """
+    from agentrun.sandbox import Sandbox, TemplateInput, TemplateType
+
+    try:
+        Sandbox.get_template(template_name)
+        return  # already exists
+    except Exception as exc:
+        # Treat any "get" failure as "not found" — the create call below
+        # will raise distinctly if something else is wrong.
+        logger.debug(
+            "AgentRun: get_template(%s) failed (treating as not-found): %s",
+            template_name, exc,
+        )
+
+    try:
+        Sandbox.create_template(
+            input=TemplateInput(
+                template_name=template_name,
+                template_type=TemplateType.CODE_INTERPRETER,
+            )
+        )
+        logger.info("AgentRun: created template %s", template_name)
+    except Exception as exc:
+        # Tolerate race with concurrent creators (e.g. parallel callers
+        # with the same task_id). If get_template now succeeds, we are
+        # fine. Otherwise re-raise.
+        try:
+            Sandbox.get_template(template_name)
+            logger.info(
+                "AgentRun: template %s already existed (raced create)",
+                template_name,
+            )
+        except Exception:
+            raise exc
+
+
+class AgentRunEnvironment(BaseEnvironment):
+    """Alibaba Cloud AgentRun Code Interpreter sandbox execution backend.
+
+    Spawn-per-call via ``_ThreadedProcessHandle`` wrapping blocking SDK
+    calls. ``cancel_fn`` is wired to ``sandbox.stop()`` so an interrupt
+    tears the sandbox down cleanly. Persistence is by reconnecting to a
+    stored ``sandbox_id`` keyed on ``task_id``.
+    """
+
+    _stdin_mode = "heredoc"
+    _snapshot_timeout = 60
+
+    def __init__(
+        self,
+        cwd: str = _REMOTE_HOME,
+        timeout: int = 60,
+        task_id: str = "default",
+        template_name: Optional[str] = None,
+        idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT,
+        persistent_filesystem: bool = True,
+    ):
+        super().__init__(cwd=cwd, timeout=timeout)
+
+        self._persistent = persistent_filesystem
+        self._task_id = task_id
+        self._template_name = template_name or f"hermes-{task_id}"
+        self._idle_timeout = idle_timeout_seconds
+        self._sandbox = None
+        self._lock = threading.Lock()
+
+        # Late import: SDK is only required when this backend is selected.
+        from agentrun.sandbox import Sandbox, TemplateType
+
+        self._TemplateType = TemplateType
+
+        _ensure_template(self._template_name)
+
+        # Persistence path: try to resume an existing sandbox first. We
+        # only attempt resume when persistent_filesystem=True; otherwise
+        # we always create a fresh sandbox to enforce isolation between
+        # ephemeral runs.
+        stored_sandbox_id = (
+            _get_stored_sandbox_id(self._task_id) if self._persistent else None
+        )
+
+        if stored_sandbox_id:
+            try:
+                self._sandbox = Sandbox.connect(
+                    stored_sandbox_id,
+                    template_type=TemplateType.CODE_INTERPRETER,
+                )
+                logger.info(
+                    "AgentRun: resumed sandbox %s for task %s",
+                    stored_sandbox_id, self._task_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "AgentRun: failed to resume sandbox %s for task %s "
+                    "(%s); creating a fresh one",
+                    stored_sandbox_id, self._task_id, exc,
+                )
+                _delete_stored_sandbox(self._task_id, stored_sandbox_id)
+                self._sandbox = None
+
+        if self._sandbox is None:
+            self._sandbox = Sandbox.create(
+                template_type=TemplateType.CODE_INTERPRETER,
+                template_name=self._template_name,
+                sandbox_idle_timeout_seconds=self._idle_timeout,
+            )
+            logger.info(
+                "AgentRun: created sandbox %s for task %s "
+                "(template=%s, idle_ttl=%ds)",
+                self._sandbox.sandbox_id, self._task_id,
+                self._template_name, self._idle_timeout,
+            )
+
+        # Wait until the sandbox is actually ready to serve requests.
+        # ``check_health`` polls the data-plane endpoint inside the
+        # sandbox; ``Sandbox.create`` returns as soon as the control
+        # plane accepts the request, which is *before* the workload is
+        # actually accepting commands.
+        self._wait_for_health()
+
+        if self._persistent and self._sandbox.sandbox_id:
+            _store_sandbox_id(self._task_id, self._sandbox.sandbox_id)
+
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sync_files(f"{_REMOTE_HOME}/.hermes"),
+            upload_fn=self._agentrun_upload,
+            delete_fn=self._agentrun_delete,
+            bulk_upload_fn=self._agentrun_bulk_upload,
+            bulk_download_fn=self._agentrun_bulk_download,
+        )
+        self._sync_manager.sync(force=True)
+        self.init_session()
+
+    # ------------------------------------------------------------------
+    # Sandbox lifecycle helpers
+    # ------------------------------------------------------------------
+
+    def _wait_for_health(self, retries: int = 60) -> None:
+        """Poll ``check_health`` until the sandbox is ready or we give up.
+
+        The SDK's built-in context-manager (``with sandbox as sb:``) does
+        the same poll, but we are not using the context manager so we
+        replicate the wait explicitly.
+        """
+        import time
+
+        for attempt in range(1, retries + 1):
+            try:
+                health = self._sandbox.check_health()
+                if isinstance(health, dict) and health.get("status") == "ok":
+                    logger.debug(
+                        "AgentRun: sandbox %s ready after %ds",
+                        self._sandbox.sandbox_id, attempt,
+                    )
+                    return
+            except Exception as exc:
+                logger.debug(
+                    "AgentRun: health check %d/%d failed: %s",
+                    attempt, retries, exc,
+                )
+            time.sleep(1)
+
+        raise RuntimeError(
+            f"AgentRun: sandbox {self._sandbox.sandbox_id} did not become "
+            f"healthy within {retries}s"
+        )
+
+    # ------------------------------------------------------------------
+    # File sync callbacks
+    # ------------------------------------------------------------------
+
+    def _agentrun_upload(self, host_path: str, remote_path: str) -> None:
+        """Upload a single file via the SDK's multipart endpoint."""
+        parent = str(Path(remote_path).parent)
+        try:
+            self._sandbox.file_system.mkdir(path=parent, parents=True)
+        except Exception as exc:
+            # mkdir is idempotent in practice; log and proceed so the
+            # upload itself surfaces the real failure if any.
+            logger.debug(
+                "AgentRun: mkdir %s failed (continuing): %s", parent, exc,
+            )
+        self._sandbox.file_system.upload(
+            local_file_path=host_path,
+            target_file_path=remote_path,
+        )
+
+    def _agentrun_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload a batch of files.
+
+        The SDK does not expose a multi-file multipart endpoint, so we
+        ship each file individually via ``file_system.upload``. We still
+        batch-create parent directories with a single shell command to
+        keep the round-trip count down. For larger payloads (~hundreds of
+        files) callers should prefer this to ``upload_fn`` so the parent
+        ``mkdir -p`` only fires once.
+        """
+        if not files:
+            return
+
+        parents = unique_parent_dirs(files)
+        if parents:
+            try:
+                self._sandbox.process.cmd(
+                    command=quoted_mkdir_command(parents),
+                    cwd="/",
+                    timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "AgentRun: bulk mkdir failed (continuing): %s", exc,
+                )
+
+        for host_path, remote_path in files:
+            self._sandbox.file_system.upload(
+                local_file_path=host_path,
+                target_file_path=remote_path,
+            )
+
+    def _agentrun_bulk_download(self, dest: Path) -> None:
+        """Download remote ``.hermes/`` as a tar archive to *dest*.
+
+        We tar inside the sandbox, then pull the tar with
+        ``file_system.download``. The remote tar path is suffixed with
+        the host PID to avoid collisions when multiple processes share
+        the same sandbox by accident.
+        """
+        rel_base = f"{_REMOTE_HOME}/.hermes".lstrip("/")
+        remote_tar = f"/tmp/.hermes_sync.{os.getpid()}.tar"
+
+        self._sandbox.process.cmd(
+            command=f"tar cf {shlex.quote(remote_tar)} -C / {shlex.quote(rel_base)}",
+            cwd="/",
+            timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+        )
+        self._sandbox.file_system.download(
+            path=remote_tar,
+            save_path=str(dest),
+        )
+        try:
+            self._sandbox.process.cmd(
+                command=f"rm -f {shlex.quote(remote_tar)}",
+                cwd="/",
+                timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+            )
+        except Exception as exc:
+            # Best-effort cleanup; not fatal.
+            logger.debug("AgentRun: remote tar cleanup failed: %s", exc)
+
+    def _agentrun_delete(self, remote_paths: list[str]) -> None:
+        """Batch-delete remote files via a single shell ``rm -f``."""
+        if not remote_paths:
+            return
+        self._sandbox.process.cmd(
+            command=quoted_rm_command(remote_paths),
+            cwd="/",
+            timeout=_AGENTRUN_CMD_MAX_TIMEOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Hooks
+    # ------------------------------------------------------------------
+
+    def _before_execute(self) -> None:
+        """Sync files to sandbox via FileSyncManager (rate-limited internally)."""
+        self._sync_manager.sync()
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ):
+        """Run a bash command in the AgentRun sandbox.
+
+        Returns a ``_ThreadedProcessHandle`` whose worker performs a
+        single blocking ``sandbox.process.cmd`` call. ``cancel_fn`` is
+        wired to ``sandbox.stop`` so a ``kill`` from the base class
+        tears the instance down (subsequent commands will resume into a
+        fresh sandbox under the same task_id).
+        """
+        sandbox = self._sandbox
+        lock = self._lock
+
+        # Clamp timeout to the vendor limit, log once if we had to.
+        effective_timeout = timeout
+        if timeout > _AGENTRUN_CMD_MAX_TIMEOUT:
+            logger.warning(
+                "AgentRun: requested cmd timeout %ds exceeds vendor "
+                "maximum %ds; clamping",
+                timeout, _AGENTRUN_CMD_MAX_TIMEOUT,
+            )
+            effective_timeout = _AGENTRUN_CMD_MAX_TIMEOUT
+
+        if login:
+            shell_cmd = f"bash -l -c {shlex.quote(cmd_string)}"
+        else:
+            shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
+
+        def cancel():
+            with lock:
+                try:
+                    sandbox.stop()
+                except Exception as exc:
+                    logger.debug("AgentRun: sandbox.stop on cancel failed: %s", exc)
+
+        def exec_fn() -> tuple[str, int]:
+            response = sandbox.process.cmd(
+                command=shell_cmd,
+                cwd=self.cwd,
+                timeout=effective_timeout,
+            )
+            # SDK returns a raw HTTP body dict. Code Interpreter shapes
+            # it as ``{"stdout": ..., "stderr": ..., "exit_code": ...,
+            # "result": ...}``; older versions used ``output`` for the
+            # combined stream. Accept all variants and fall back to the
+            # full payload as a string.
+            output, exit_code = _normalise_cmd_response(response)
+            return output, exit_code
+
+        return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        """Sync changes back to the host, then stop or delete the sandbox.
+
+        When ``persistent_filesystem=True`` we call ``sandbox.stop()`` so
+        the filesystem is preserved server-side and the next constructor
+        call with the same ``task_id`` will reconnect. Otherwise we
+        ``delete()`` the sandbox outright.
+        """
+        with self._lock:
+            if self._sandbox is None:
+                return
+
+            if self._sync_manager:
+                logger.info("AgentRun: syncing files from sandbox...")
+                try:
+                    self._sync_manager.sync_back()
+                except Exception as exc:
+                    logger.warning("AgentRun: sync_back failed: %s", exc)
+
+            sandbox_id = self._sandbox.sandbox_id
+            try:
+                if self._persistent:
+                    self._sandbox.stop()
+                    logger.info(
+                        "AgentRun: stopped sandbox %s "
+                        "(filesystem preserved for resume)",
+                        sandbox_id,
+                    )
+                else:
+                    self._sandbox.delete()
+                    _delete_stored_sandbox(self._task_id, sandbox_id)
+                    logger.info("AgentRun: deleted sandbox %s", sandbox_id)
+            except Exception as exc:
+                logger.warning(
+                    "AgentRun: cleanup of sandbox %s failed: %s",
+                    sandbox_id, exc,
+                )
+            self._sandbox = None
+
+
+def _normalise_cmd_response(response: Any) -> tuple[str, int]:
+    """Coerce the SDK's cmd-response payload into ``(output, exit_code)``.
+
+    The SDK forwards the data-plane HTTP body unchanged. Across versions
+    we have seen these shapes:
+
+    * ``{"stdout": "...", "stderr": "...", "exit_code": 0}``
+    * ``{"output": "...", "exit_code": 0}``
+    * ``{"data": {"stdout": ..., "exit_code": ...}}``
+
+    We normalise to ``(combined_output, exit_code)``. Unknown shapes are
+    repr()d so the caller still sees *something* instead of an empty
+    string.
+    """
+    if response is None:
+        return "", 1
+    body = response
+    if isinstance(body, dict) and "data" in body and isinstance(body["data"], dict):
+        body = body["data"]
+
+    if isinstance(body, dict):
+        stdout = body.get("stdout") or body.get("output") or ""
+        stderr = body.get("stderr") or ""
+        exit_code = body.get("exit_code")
+        if exit_code is None:
+            exit_code = body.get("exitCode")
+        if exit_code is None:
+            exit_code = body.get("returncode", 0)
+        try:
+            exit_code = int(exit_code)
+        except (TypeError, ValueError):
+            exit_code = 0
+
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+
+        if stderr and stdout:
+            return f"{stdout}\n{stderr}", exit_code
+        return stdout or stderr or "", exit_code
+
+    return str(body), 0

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1248,7 +1248,10 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     elif env_type == "agentrun":
         # Lazy import so agentrun-sdk is only required when this backend
         # is selected.
-        from tools.environments.agentrun import AgentRunEnvironment as _AgentRunEnvironment
+        from tools.environments.agentrun import (
+            _DEFAULT_IMAGE as _AGENTRUN_DEFAULT_IMAGE,
+            AgentRunEnvironment as _AgentRunEnvironment,
+        )
         return _AgentRunEnvironment(
             cwd=cwd,
             timeout=timeout,
@@ -1256,6 +1259,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             template_name=cc.get("agentrun_template_name"),
             idle_timeout_seconds=int(cc.get("agentrun_idle_timeout_seconds", 300)),
             persistent_filesystem=persistent,
+            image=cc.get("agentrun_image") or _AGENTRUN_DEFAULT_IMAGE,
         )
 
     else:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3,18 +3,19 @@
 Terminal Tool Module
 
 A terminal tool that executes commands in local, Docker, Modal, SSH,
-Singularity, Daytona, and Vercel Sandbox environments. Supports local
-execution, containerized backends, and cloud sandboxes, including managed
-Modal mode.
+Singularity, Daytona, Vercel Sandbox, and Alibaba Cloud AgentRun
+environments. Supports local execution, containerized backends, and
+cloud sandboxes, including managed Modal mode.
 
 Environment Selection (via TERMINAL_ENV environment variable):
 - "local": Execute directly on the host machine (default, fastest)
 - "docker": Execute in Docker containers (isolated, requires Docker)
 - "modal": Execute in Modal cloud sandboxes (direct Modal or managed gateway)
 - "vercel_sandbox": Execute in Vercel Sandbox cloud sandboxes
+- "agentrun": Execute in Alibaba Cloud AgentRun Code Interpreter sandboxes
 
 Features:
-- Multiple execution backends (local, docker, modal, vercel_sandbox)
+- Multiple execution backends (local, docker, modal, vercel_sandbox, agentrun)
 - Background task support
 - VM/container lifecycle management
 - Automatic cleanup after inactivity
@@ -1041,7 +1042,7 @@ def _get_env_config() -> Dict[str, Any]:
         ):
             host_cwd = candidate
             cwd = "/workspace"
-    elif env_type in ("modal", "docker", "singularity", "daytona", "vercel_sandbox") and cwd:
+    elif env_type in ("modal", "docker", "singularity", "daytona", "vercel_sandbox", "agentrun") and cwd:
         # Host paths and relative paths that won't work inside containers
         is_host_path = any(cwd.startswith(p) for p in host_prefixes)
         is_relative = not os.path.isabs(cwd)  # e.g. "." or "src/"
@@ -1110,7 +1111,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
-            "daytona", "vercel_sandbox", "ssh"
+            "daytona", "vercel_sandbox", "agentrun", "ssh"
         image: Docker/Singularity/Modal image name (ignored for local/ssh/vercel)
         cwd: Working directory
         timeout: Default command timeout
@@ -1244,10 +1245,24 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             timeout=timeout,
         )
 
+    elif env_type == "agentrun":
+        # Lazy import so agentrun-sdk is only required when this backend
+        # is selected.
+        from tools.environments.agentrun import AgentRunEnvironment as _AgentRunEnvironment
+        return _AgentRunEnvironment(
+            cwd=cwd,
+            timeout=timeout,
+            task_id=task_id,
+            template_name=cc.get("agentrun_template_name"),
+            idle_timeout_seconds=int(cc.get("agentrun_idle_timeout_seconds", 300)),
+            persistent_filesystem=persistent,
+        )
+
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', "
+            f"'agentrun', or 'ssh'"
         )
 
 
@@ -2215,10 +2230,40 @@ def check_terminal_requirements() -> bool:
             from daytona import Daytona  # noqa: F401 — SDK presence check
             return os.getenv("DAYTONA_API_KEY") is not None
 
+        elif env_type == "agentrun":
+            # SDK is published as ``agentrun-sdk`` on PyPI but imports as
+            # ``agentrun``. Credentials are taken from environment
+            # variables (AGENTRUN_ACCESS_KEY_ID / AGENTRUN_ACCESS_KEY_SECRET
+            # / AGENTRUN_ACCOUNT_ID / AGENTRUN_REGION), matching the SDK
+            # default config loader.
+            if importlib.util.find_spec("agentrun") is None:
+                logger.error(
+                    "agentrun-sdk is required for the agentrun terminal "
+                    "backend: pip install agentrun-sdk"
+                )
+                return False
+            missing = [
+                name for name in (
+                    "AGENTRUN_ACCESS_KEY_ID",
+                    "AGENTRUN_ACCESS_KEY_SECRET",
+                    "AGENTRUN_ACCOUNT_ID",
+                )
+                if not os.getenv(name)
+            ]
+            if missing:
+                logger.error(
+                    "AgentRun backend selected but the following environment "
+                    "variables are not set: %s. Configure them or switch "
+                    "TERMINAL_ENV to a different value.",
+                    ", ".join(missing),
+                )
+                return False
+            return True
+
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, vercel_sandbox, agentrun, ssh.",
                 env_type,
             )
             return False
@@ -2261,7 +2306,7 @@ if __name__ == "__main__":
     print(
         "  TERMINAL_ENV: "
         f"{os.getenv('TERMINAL_ENV', 'local')} "
-        "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
+        "(local/docker/singularity/modal/daytona/vercel_sandbox/agentrun/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
     print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,51 @@ wheels = [
 ]
 
 [[package]]
+name = "agentrun-mem0ai"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mysql-connector-python" },
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
+    { name = "tablestore-for-agent-memory" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/83/1696d24eb17a62038d713a491a235f7818968c23577f85ffce19cf8f0781/agentrun_mem0ai-0.0.12.tar.gz", hash = "sha256:c52e7ba6fd1dba39c07a1fd5ce635e2a9f1cd390f6284ba0f2ab32ecbae4a93b", size = 184613, upload-time = "2026-01-26T07:53:22.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f4/09700f1bdbe2dcabbacdf5894cb6f2bb3a2af7602d1584399c51e21a7475/agentrun_mem0ai-0.0.12-py3-none-any.whl", hash = "sha256:4028139966458fe9f21c4989e5bc3f4cdededf68471e86f118c9839ce0aaa03a", size = 282033, upload-time = "2026-01-26T07:53:19.645Z" },
+]
+
+[[package]]
+name = "agentrun-sdk"
+version = "0.0.35"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agentrun-mem0ai" },
+    { name = "alibabacloud-agentrun20250910" },
+    { name = "alibabacloud-bailian20231229" },
+    { name = "alibabacloud-devs20230714" },
+    { name = "alibabacloud-gpdb20160503" },
+    { name = "alibabacloud-tea-openapi" },
+    { name = "crcmod" },
+    { name = "httpx" },
+    { name = "litellm" },
+    { name = "pydantic" },
+    { name = "pydash" },
+    { name = "python-dotenv" },
+    { name = "tablestore-agent-storage" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f9/2be8be302a4411574aee2b036d69403c6c132020c662060c16d2063d5f49/agentrun_sdk-0.0.35.tar.gz", hash = "sha256:9b71629eefefc74f16c402e0b3d1febe1ef6796b9809b24ad149b23eaaec644a", size = 367386, upload-time = "2026-05-07T10:28:41.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/1d/61e9bdaf939cd33719618a5b33470d87ce0901ea71967013c273687ccc5a/agentrun_sdk-0.0.35-py3-none-any.whl", hash = "sha256:1cada914c060c7a0bc7f79d207974b5f47cca92c26e0275f46d7bb22fd9fd060", size = 476088, upload-time = "2026-05-07T10:28:38.995Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -188,6 +233,32 @@ wheels = [
 ]
 
 [[package]]
+name = "alibabacloud-agentrun20250910"
+version = "5.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-tea-openapi" },
+    { name = "darabonba-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/75/0481d50e93b8ab824f135ffcdfca5e563cb3e3b82619df48acb4db1a5905/alibabacloud_agentrun20250910-5.6.4.tar.gz", hash = "sha256:4c4cd54d34af09403c57da3f59fe259ed518bd1e2524f794088c06e34a36d387", size = 130481, upload-time = "2026-04-24T10:01:56.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/7a/34d6040fa1f5d17e2f09b79d5f17290fac0b589037558f974e159e45e908/alibabacloud_agentrun20250910-5.6.4-py3-none-any.whl", hash = "sha256:4eebb7e36504f75d4d18a8c112fc482e348f069cd37749543c412859b3bf143a", size = 413707, upload-time = "2026-04-24T10:01:55.061Z" },
+]
+
+[[package]]
+name = "alibabacloud-bailian20231229"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-tea-openapi" },
+    { name = "darabonba-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/4b/efd24c3b4f86e1fe1edf83c7dd66c1d266e6d3ba3eba8b1702de96b68ef7/alibabacloud_bailian20231229-2.9.1.tar.gz", hash = "sha256:e3427d98a2b30a7a9d47a4dfd07ec63ef238869f3048194b99557b1c67db61bb", size = 71002, upload-time = "2026-04-20T17:40:51.763Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/92/759ba804c2a4f6933301f341377be32f8eead67d250914adb837e88ccdec/alibabacloud_bailian20231229-2.9.1-py3-none-any.whl", hash = "sha256:353338b5f57cbc686fcf3bd5bce031d6e8cb6a85808b5022a836e961bbd442d0", size = 188816, upload-time = "2026-04-20T17:40:50.372Z" },
+]
+
+[[package]]
 name = "alibabacloud-credentials"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -207,6 +278,21 @@ name = "alibabacloud-credentials-api"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a0/87/1d7019d23891897cb076b2f7e3c81ab3c2ba91de3bb067196f675d60d34c/alibabacloud-credentials-api-1.0.0.tar.gz", hash = "sha256:8c340038d904f0218d7214a8f4088c31912bfcf279af2cbc7d9be4897a97dd2f", size = 2330, upload-time = "2025-01-13T05:53:04.931Z" }
+
+[[package]]
+name = "alibabacloud-devs20230714"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-endpoint-util" },
+    { name = "alibabacloud-openapi-util" },
+    { name = "alibabacloud-tea-openapi" },
+    { name = "alibabacloud-tea-util" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/b4/a6425a5d54dbdd83206b9c0418e9fded4764a1125bbefbe9ff9511ed2a72/alibabacloud_devs20230714-2.4.1.tar.gz", hash = "sha256:461e7614dc382b49d576ac8713d949beb48b1979cea002922bdb284883360f20", size = 60979, upload-time = "2025-08-08T07:40:29.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/c6/7d375cc1b1cab0f46950f556b70a2b17235747429a0889b73f3d46ff6023/alibabacloud_devs20230714-2.4.1-py3-none-any.whl", hash = "sha256:dbd260718e6db50021d804218b40bc99ee9c7e40b1def382aef8e542f5921113", size = 59307, upload-time = "2025-08-08T07:40:28.504Z" },
+]
 
 [[package]]
 name = "alibabacloud-dingtalk"
@@ -249,6 +335,20 @@ dependencies = [
     { name = "alibabacloud-credentials" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/98/d7111245f17935bf72ee9bea60bbbeff2bc42cdfe24d2544db52bc517e1a/alibabacloud_gateway_spi-0.0.3.tar.gz", hash = "sha256:10d1c53a3fc5f87915fbd6b4985b98338a776e9b44a0263f56643c5048223b8b", size = 4249, upload-time = "2025-02-23T16:29:54.222Z" }
+
+[[package]]
+name = "alibabacloud-gpdb20160503"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alibabacloud-credentials" },
+    { name = "alibabacloud-tea-openapi" },
+    { name = "darabonba-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/94/78e3c5200a3a08d5521342bc2cb8d31755ed08a4d03028693b5eb9cc7a90/alibabacloud_gpdb20160503-5.3.0.tar.gz", hash = "sha256:0618e5376b8f632db8bc0460bfbdf66ec93237896e317fd5da3dad85c6cc8874", size = 300700, upload-time = "2026-04-27T19:25:53.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b6/f9bf3159fbc769c885fe3221bc8899c07483843b7c3e22f34a5b8594e927/alibabacloud_gpdb20160503-5.3.0-py3-none-any.whl", hash = "sha256:58d7873e410b4c0e4df31c6d50f53bfed48cb2897d51679912fe0aaa6adf198e", size = 862268, upload-time = "2026-04-27T19:25:52.101Z" },
+]
 
 [[package]]
 name = "alibabacloud-openapi-util"
@@ -299,6 +399,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/ee/ea90be94ad781a5055db29556744681fc71190ef444ae53adba45e1be5f3/alibabacloud_tea_util-0.3.14.tar.gz", hash = "sha256:708e7c9f64641a3c9e0e566365d2f23675f8d7c2a3e2971d9402ceede0408cdb", size = 7515, upload-time = "2025-11-19T06:01:08.504Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/9e/c394b4e2104766fb28a1e44e3ed36e4c7773b4d05c868e482be99d5635c9/alibabacloud_tea_util-0.3.14-py3-none-any.whl", hash = "sha256:10d3e5c340d8f7ec69dd27345eb2fc5a1dab07875742525edf07bbe86db93bfe", size = 6697, upload-time = "2025-11-19T06:01:07.355Z" },
+]
+
+[[package]]
+name = "aliyun-python-sdk-core"
+version = "2.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jmespath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/09/da9f58eb38b4fdb97ba6523274fbf445ef6a06be64b433693da8307b4bec/aliyun-python-sdk-core-2.16.0.tar.gz", hash = "sha256:651caad597eb39d4fad6cf85133dffe92837d53bdf62db9d8f37dab6508bb8f9", size = 449555, upload-time = "2024-10-09T06:01:01.762Z" }
+
+[[package]]
+name = "aliyun-python-sdk-kms"
+version = "2.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aliyun-python-sdk-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/2c/9877d0e6b18ecf246df671ac65a5d1d9fecbf85bdcb5d43efbde0d4662eb/aliyun-python-sdk-kms-2.16.5.tar.gz", hash = "sha256:f328a8a19d83ecbb965ffce0ec1e9930755216d104638cd95ecd362753b813b3", size = 12018, upload-time = "2024-08-30T09:01:20.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/5c/0132193d7da2c735669a1ed103b142fd63c9455984d48c5a88a1a516efaa/aliyun_python_sdk_kms-2.16.5-py2.py3-none-any.whl", hash = "sha256:24b6cdc4fd161d2942619479c8d050c63ea9cd22b044fe33b60bbb60153786f0", size = 99495, upload-time = "2024-08-30T09:01:18.462Z" },
 ]
 
 [[package]]
@@ -551,6 +673,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/ca/307740c6aa2980966bf11383ffcb04bacc5b13f3d268ab4cfb274ad6f793/av-17.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3649ab3d2c7f58049ded1a36e100c0d8fd529cf258f41dd88678ba824034d8c9", size = 40590681, upload-time = "2026-03-14T14:38:38.269Z" },
     { url = "https://files.pythonhosted.org/packages/35/f2/6fdb26d0651adf409864cb2a0d60da107e467d3d1aabc94b234ead54324a/av-17.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e5002271ab2135b551d980c2db8f3299d452e3b9d3633f24f6bb57fffe91cd10", size = 29216337, upload-time = "2026-03-14T14:38:40.83Z" },
     { url = "https://files.pythonhosted.org/packages/41/0a/0896b829a39b5669a2d811e1a79598de661693685cd62b31f11d0c18e65b/av-17.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dba98603fc4665b4f750de86fbaf6c0cfaece970671a9b529e0e3d1711e8367e", size = 22071058, upload-time = "2026-03-14T14:38:43.663Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -908,6 +1039,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
     { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
 ]
+
+[[package]]
+name = "crc32c"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/66/7e97aa77af7cf6afbff26e3651b564fe41932599bc2d3dce0b2f73d4829a/crc32c-2.8.tar.gz", hash = "sha256:578728964e59c47c356aeeedee6220e021e124b9d3e8631d95d9a5e5f06e261c", size = 48179, upload-time = "2025-10-17T06:20:13.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0b/5e03b22d913698e9cc563f39b9f6bbd508606bf6b8e9122cd6bf196b87ea/crc32c-2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e560a97fbb96c9897cb1d9b5076ef12fc12e2e25622530a1afd0de4240f17e1f", size = 66329, upload-time = "2025-10-17T06:19:01.771Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/38/2fe0051ffe8c6a650c8b1ac0da31b8802d1dbe5fa40a84e4b6b6f5583db5/crc32c-2.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6762d276d90331a490ef7e71ffee53b9c0eb053bd75a272d786f3b08d3fe3671", size = 62988, upload-time = "2025-10-17T06:19:02.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/30/5837a71c014be83aba1469c58820d287fc836512a0cad6b8fdd43868accd/crc32c-2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:60670569f5ede91e39f48fb0cb4060e05b8d8704dd9e17ede930bf441b2f73ef", size = 61522, upload-time = "2025-10-17T06:19:03.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/29/63972fc1452778e2092ae998c50cbfc2fc93e3fa9798a0278650cd6169c5/crc32c-2.8-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:711743da6ccc70b3c6718c328947b0b6f34a1fe6a6c27cc6c1d69cc226bf70e9", size = 80200, upload-time = "2025-10-17T06:19:04.617Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3a/60eb49d7bdada4122b3ffd45b0df54bdc1b8dd092cda4b069a287bdfcff4/crc32c-2.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5eb4094a2054774f13b26f21bf56792bb44fa1fcee6c6ad099387a43ffbfb4fa", size = 81757, upload-time = "2025-10-17T06:19:05.496Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/63/6efc1b64429ef7d23bd58b75b7ac24d15df327e3ebbe9c247a0f7b1c2ed1/crc32c-2.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fff15bf2bd3e95780516baae935ed12be88deaa5ebe6143c53eb0d26a7bdc7b7", size = 80830, upload-time = "2025-10-17T06:19:06.621Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/eb/0ae9f436f8004f1c88f7429e659a7218a3879bd11a6b18ed1257aad7e98b/crc32c-2.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4c0e11e3826668121fa53e0745635baf5e4f0ded437e8ff63ea56f38fc4f970a", size = 80095, upload-time = "2025-10-17T06:19:07.381Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/81/4afc9d468977a4cd94a2eb62908553345009a7c0d30e74463a15d4b48ec3/crc32c-2.8-cp311-cp311-win32.whl", hash = "sha256:38f915336715d1f1353ab07d7d786f8a789b119e273aea106ba55355dfc9101d", size = 64886, upload-time = "2025-10-17T06:19:08.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e8/94e839c9f7e767bf8479046a207afd440a08f5c59b52586e1af5e64fa4a0/crc32c-2.8-cp311-cp311-win_amd64.whl", hash = "sha256:60e0a765b1caab8d31b2ea80840639253906a9351d4b861551c8c8625ea20f86", size = 66639, upload-time = "2025-10-17T06:19:09.338Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/fd18ef23c42926b79c7003e16cb0f79043b5b179c633521343d3b499e996/crc32c-2.8-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:572ffb1b78cce3d88e8d4143e154d31044a44be42cb3f6fbbf77f1e7a941c5ab", size = 66379, upload-time = "2025-10-17T06:19:10.115Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b8/c584958e53f7798dd358f5bdb1bbfc97483134f053ee399d3eeb26cca075/crc32c-2.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cf827b3758ee0c4aacd21ceca0e2da83681f10295c38a10bfeb105f7d98f7a68", size = 63042, upload-time = "2025-10-17T06:19:10.946Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/6f2af0ec64a668a46c861e5bc778ea3ee42171fedfc5440f791f470fd783/crc32c-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:106fbd79013e06fa92bc3b51031694fcc1249811ed4364ef1554ee3dd2c7f5a2", size = 61528, upload-time = "2025-10-17T06:19:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/17/8b/4a04bd80a024f1a23978f19ae99407783e06549e361ab56e9c08bba3c1d3/crc32c-2.8-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6dde035f91ffbfe23163e68605ee5a4bb8ceebd71ed54bb1fb1d0526cdd125a2", size = 80028, upload-time = "2025-10-17T06:19:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8f/01c7afdc76ac2007d0e6a98e7300b4470b170480f8188475b597d1f4b4c6/crc32c-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e41ebe7c2f0fdcd9f3a3fd206989a36b460b4d3f24816d53e5be6c7dba72c5e1", size = 81531, upload-time = "2025-10-17T06:19:13.406Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2b/8f78c5a8cc66486be5f51b6f038fc347c3ba748d3ea68be17a014283c331/crc32c-2.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ecf66cf90266d9c15cea597d5cc86c01917cd1a238dc3c51420c7886fa750d7e", size = 80608, upload-time = "2025-10-17T06:19:14.223Z" },
+    { url = "https://files.pythonhosted.org/packages/db/86/fad1a94cdeeeb6b6e2323c87f970186e74bfd6fbfbc247bf5c88ad0873d5/crc32c-2.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:59eee5f3a69ad0793d5fa9cdc9b9d743b0cd50edf7fccc0a3988a821fef0208c", size = 79886, upload-time = "2025-10-17T06:19:15.345Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/db/1a7cb6757a1e32376fa2dfce00c815ea4ee614a94f9bff8228e37420c183/crc32c-2.8-cp312-cp312-win32.whl", hash = "sha256:a73d03ce3604aa5d7a2698e9057a0eef69f529c46497b27ee1c38158e90ceb76", size = 64896, upload-time = "2025-10-17T06:19:16.457Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8e/2024de34399b2e401a37dcb54b224b56c747b0dc46de4966886827b4d370/crc32c-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:56b3b7d015247962cf58186e06d18c3d75a1a63d709d3233509e1c50a2d36aa2", size = 66645, upload-time = "2025-10-17T06:19:17.235Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d8/3ae227890b3be40955a7144106ef4dd97d6123a82c2a5310cdab58ca49d8/crc32c-2.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:36f1e03ee9e9c6938e67d3bcb60e36f260170aa5f37da1185e04ef37b56af395", size = 66380, upload-time = "2025-10-17T06:19:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8b/178d3f987cd0e049b484615512d3f91f3d2caeeb8ff336bb5896ae317438/crc32c-2.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b2f3226b94b85a8dd9b3533601d7a63e9e3e8edf03a8a169830ee8303a199aeb", size = 63048, upload-time = "2025-10-17T06:19:18.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a1/48145ae2545ebc0169d3283ebe882da580ea4606bfb67cf4ca922ac3cfc3/crc32c-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6e08628bc72d5b6bc8e0730e8f142194b610e780a98c58cb6698e665cb885a5b", size = 61530, upload-time = "2025-10-17T06:19:19.974Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4b/cf05ed9d934cc30e5ae22f97c8272face420a476090e736615d9a6b53de0/crc32c-2.8-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:086f64793c5ec856d1ab31a026d52ad2b895ac83d7a38fce557d74eb857f0a82", size = 80001, upload-time = "2025-10-17T06:19:20.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ab/4b04801739faf36345f6ba1920be5b1c70282fec52f8280afd3613fb13e2/crc32c-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcf72ee7e0135b3d941c34bb2c26c3fc6bc207106b49fd89aaafaeae223ae209", size = 81543, upload-time = "2025-10-17T06:19:21.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/6e38dde5bfd2ea69b7f2ab6ec229fcd972a53d39e2db4efe75c0ac0382ce/crc32c-2.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a717dd9c3fd777d9bc6603717eae172887d402c4ab589d124ebd0184a83f89e", size = 80644, upload-time = "2025-10-17T06:19:22.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/45/012176ffee90059ae8ec7131019c71724ea472aa63e72c0c8edbd1fad1d7/crc32c-2.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0450bb845b3c3c7b9bdc0b4e95620ec9a40824abdc8c86d6285c919a90743c1a", size = 79919, upload-time = "2025-10-17T06:19:23.101Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/f557629842f9dec2b3461cb3a0d854bb586ec45b814cea58b082c32f0dde/crc32c-2.8-cp313-cp313-win32.whl", hash = "sha256:765d220bfcbcffa6598ac11eb1e10af0ee4802b49fe126aa6bf79f8ddb9931d1", size = 64896, upload-time = "2025-10-17T06:19:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/db/fd0f698c15d1e21d47c64181a98290665a08fcbb3940cd559e9c15bda57e/crc32c-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:171ff0260d112c62abcce29332986950a57bddee514e0a2418bfde493ea06bb3", size = 66646, upload-time = "2025-10-17T06:19:24.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b9/8e5d7054fe8e7eecab10fd0c8e7ffb01439417bdb6de1d66a81c38fc4a20/crc32c-2.8-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b977a32a3708d6f51703c8557008f190aaa434d7347431efb0e86fcbe78c2a50", size = 66203, upload-time = "2025-10-17T06:19:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/cc926c70057a63cc0c98a3c8a896eb15fc7e74d3034eadd53c94917c6cc3/crc32c-2.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7399b01db4adaf41da2fb36fe2408e75a8d82a179a9564ed7619412e427b26d6", size = 62956, upload-time = "2025-10-17T06:19:26.652Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8a/0660c44a2dd2cb6ccbb529eb363b9280f5c766f1017bc8355ed8d695bd94/crc32c-2.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4379f73f9cdad31958a673d11a332ec725ca71572401ca865867229f5f15e853", size = 61442, upload-time = "2025-10-17T06:19:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/6108d2dfc0fe33522ce83ba07aed4b22014911b387afa228808a278e27cd/crc32c-2.8-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e68264555fab19bab08331550dab58573e351a63ed79c869d455edd3b0aa417", size = 79109, upload-time = "2025-10-17T06:19:28.535Z" },
+    { url = "https://files.pythonhosted.org/packages/84/1e/c054f9e390090c197abf3d2936f4f9effaf0c6ee14569ae03d6ddf86958a/crc32c-2.8-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b48f2486727b8d0e7ccbae4a34cb0300498433d2a9d6b49cb13cb57c2e3f19cb", size = 80987, upload-time = "2025-10-17T06:19:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ad/1650e5c3341e4a485f800ea83116d72965030c5d48ccc168fcc685756e4d/crc32c-2.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ecf123348934a086df8c8fde7f9f2d716d523ca0707c5a1367b8bb00d8134823", size = 79994, upload-time = "2025-10-17T06:19:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/3b/f2ed924b177729cbb2ab30ca2902abff653c31d48c95e7b66717a9ca9fcc/crc32c-2.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e636ac60f76de538f7a2c0d0f3abf43104ee83a8f5e516f6345dc283ed1a4df7", size = 79046, upload-time = "2025-10-17T06:19:30.894Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/80/413b05ee6ace613208b31b3670c3135ee1cf451f0e72a9c839b4946acc04/crc32c-2.8-cp313-cp313t-win32.whl", hash = "sha256:8dd4a19505e0253892e1b2f1425cc3bd47f79ae5a04cb8800315d00aad7197f2", size = 64837, upload-time = "2025-10-17T06:19:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/1b/85eddb6ac5b38496c4e35c20298aae627970c88c3c624a22ab33e84f16c7/crc32c-2.8-cp313-cp313t-win_amd64.whl", hash = "sha256:4bb18e4bd98fb266596523ffc6be9c5b2387b2fa4e505ec56ca36336f49cb639", size = 66574, upload-time = "2025-10-17T06:19:33.143Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/df/50e9079b532ff53dbfc0e66eed781374bd455af02ed5df8b56ad538de4ff/crc32c-2.8-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3a3b2e4bcf7b3ee333050e7d3ff38e2ba46ea205f1d73d8949b248aaffe937ac", size = 66399, upload-time = "2025-10-17T06:19:34.279Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2e/67e3b0bc3d30e46ea5d16365cc81203286387671e22f2307eb41f19abb9c/crc32c-2.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:445e559e66dff16be54f8a4ef95aa6b01db799a639956d995c5498ba513fccc2", size = 63044, upload-time = "2025-10-17T06:19:35.062Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/1723b17437e4344ed8d067456382ecb1f5b535d83fdc5aaebab676c6d273/crc32c-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bf3040919e17afa5782e01b1875d6a05f44b8f19c05f211d8b9f8a1deb8bbd9c", size = 61541, upload-time = "2025-10-17T06:19:36.204Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6a/cbec8a235c5b46a01f319939b538958662159aec0ed3a74944e3a6de21f1/crc32c-2.8-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5607ab8221e1ffd411f64aa40dbb6850cf06dd2908c9debd05d371e1acf62ff3", size = 80139, upload-time = "2025-10-17T06:19:37.351Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/d096722fe74b692d6e8206c27da1ea5f6b2a12ff92c54a62a6ba2f376254/crc32c-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f5db4f16816926986d3c94253314920689706ae13a9bf4888b47336c6735ce", size = 81736, upload-time = "2025-10-17T06:19:38.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a2/f75ef716ff7e3c22f385ba6ef30c5de80c19a21ebe699dc90824a1903275/crc32c-2.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:70b0153c4d418b673309d3529334d117e1074c4a3b2d7f676e430d72c14de67b", size = 80795, upload-time = "2025-10-17T06:19:38.948Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/94/6d647a12d96ab087d9b8eacee3da073f981987827d57c7072f89ffc7b6cd/crc32c-2.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c8933531442042438753755a5c8a9034e4d88b01da9eb796f7e151b31a7256c", size = 80042, upload-time = "2025-10-17T06:19:39.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/dc/32b8896b40a0afee7a3c040536d0da5a73e68df2be9fadd21770fd158e16/crc32c-2.8-cp314-cp314-win32.whl", hash = "sha256:cdc83a3fe6c4e5df9457294cfd643de7d95bd4e9382c1dd6ed1e0f0f9169172c", size = 64914, upload-time = "2025-10-17T06:19:40.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b4/4308b27d307e8ecaf8dd1dcc63bbb0e47ae1826d93faa3e62d1ee00ee2d5/crc32c-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:509e10035106df66770fe24b9eb8d9e32b6fb967df17744402fb67772d8b2bc7", size = 66723, upload-time = "2025-10-17T06:19:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d5/a19d2489fa997a143bfbbf971a5c9a43f8b1ba9e775b1fb362d8fb15260c/crc32c-2.8-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:864359a39777a07b09b28eb31337c0cc603d5c1bf0fc328c3af736a8da624ec0", size = 66201, upload-time = "2025-10-17T06:19:43.273Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c2/5f82f22d2c1242cb6f6fe92aa9a42991ebea86de994b8f9974d9c1d128e2/crc32c-2.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:14511d7cfc5d9f5e1a6c6b64caa6225c2bdc1ed00d725e9a374a3e84073ce180", size = 62956, upload-time = "2025-10-17T06:19:44.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/61/3d43d33489cf974fb78bfb3500845770e139ae6d1d83473b660bd8f79a6c/crc32c-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:918b7999b52b5dcbcea34081e9a02d46917d571921a3f209956a9a429b2e06e5", size = 61443, upload-time = "2025-10-17T06:19:44.89Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6d/f306ce64a352a3002f76b0fc88a1373f4541f9d34fad3668688610bab14b/crc32c-2.8-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cc445da03fc012a5a03b71da1df1b40139729e6a5571fd4215ab40bfb39689c7", size = 79106, upload-time = "2025-10-17T06:19:45.688Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b7/1f74965dd7ea762954a69d172dfb3a706049c84ffa45d31401d010a4a126/crc32c-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e3dde2ec59a8a830511d72a086ead95c0b0b7f0d418f93ea106244c5e77e350", size = 80983, upload-time = "2025-10-17T06:19:46.792Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/af93f0d91ccd61833ce77374ebfbd16f5805f5c17d18c6470976d9866d76/crc32c-2.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:61d51681a08b6a2a2e771b7f0cd1947fb87cb28f38ed55a01cb7c40b2ac4cdd8", size = 80009, upload-time = "2025-10-17T06:19:47.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fa/94f394beb68a88258af694dab2f1284f55a406b615d7900bdd6235283bc4/crc32c-2.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:67c0716c3b1a02d5235be649487b637eed21f2d070f2b3f63f709dcd2fefb4c7", size = 79066, upload-time = "2025-10-17T06:19:48.409Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c6/a6050e0c64fd73c67a97da96cb59f08b05111e00b958fb87ecdce99f17ac/crc32c-2.8-cp314-cp314t-win32.whl", hash = "sha256:2e8fe863fbbd8bdb6b414a2090f1b0f52106e76e9a9c96a413495dbe5ebe492a", size = 64869, upload-time = "2025-10-17T06:19:49.197Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/c7735034e401cb1ea14f996a224518e3a3fa9987cb13680e707328a7d779/crc32c-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:20a9cfb897693eb6da19e52e2a7be2026fd4d9fc8ae318f086c0d71d5dd2d8e0", size = 66633, upload-time = "2025-10-17T06:19:50.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/dd926c68eb8aac8b142a1a10b8eb62d95212c1cf81775644373fe7cceac2/crc32c-2.8-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5833f4071da7ea182c514ba17d1eee8aec3c5be927d798222fbfbbd0f5eea02c", size = 62345, upload-time = "2025-10-17T06:20:09.39Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/803404e5abea2ef2c15042edca04bbb7f625044cca879e47f186b43887c2/crc32c-2.8-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:1dc4da036126ac07b39dd9d03e93e585ec615a2ad28ff12757aef7de175295a8", size = 61229, upload-time = "2025-10-17T06:20:10.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3a/00cc578cd27ed0b22c9be25cef2c24539d92df9fa80ebd67a3fc5419724c/crc32c-2.8-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:15905fa78344654e241371c47e6ed2411f9eeb2b8095311c68c88eccf541e8b4", size = 64108, upload-time = "2025-10-17T06:20:11.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/bc/0587ef99a1c7629f95dd0c9d4f3d894de383a0df85831eb16c48a6afdae4/crc32c-2.8-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c596f918688821f796434e89b431b1698396c38bf0b56de873621528fe3ecb1e", size = 64815, upload-time = "2025-10-17T06:20:11.919Z" },
+    { url = "https://files.pythonhosted.org/packages/73/42/94f2b8b92eae9064fcfb8deef2b971514065bd606231f8857ff8ae02bebd/crc32c-2.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8d23c4fe01b3844cb6e091044bc1cebdef7d16472e058ce12d9fadf10d2614af", size = 66659, upload-time = "2025-10-17T06:20:12.766Z" },
+]
+
+[[package]]
+name = "crcmod"
+version = "1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e", size = 89670, upload-time = "2010-06-27T14:35:29.538Z" }
 
 [[package]]
 name = "croniter"
@@ -1754,6 +1958,15 @@ http = [
 ]
 
 [[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1869,6 +2082,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -1877,6 +2091,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1885,6 +2100,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1893,6 +2109,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -1901,10 +2118,62 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -1990,8 +2259,12 @@ dependencies = [
 acp = [
     { name = "agent-client-protocol" },
 ]
+agentrun = [
+    { name = "agentrun-sdk" },
+]
 all = [
     { name = "agent-client-protocol" },
+    { name = "agentrun-sdk" },
     { name = "aiohttp" },
     { name = "aiohttp-socks", marker = "sys_platform == 'linux'" },
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
@@ -2180,6 +2453,7 @@ youtube = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.9.0,<1.0" },
+    { name = "agentrun-sdk", marker = "extra == 'agentrun'", specifier = ">=0.0.35,<0.1.0" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
@@ -2209,6 +2483,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.0,<2" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["agentrun"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
@@ -2302,7 +2577,7 @@ requires-dist = [
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.2.0" },
 ]
-provides-extras = ["modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "vercel", "agentrun", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2660,11 +2935,11 @@ wheels = [
 
 [[package]]
 name = "jmespath"
-version = "1.1.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/56/3f325b1eef9791759784aa5046a8f6a1aff8f7c898a2e34506771d3b99d8/jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9", size = 21607, upload-time = "2020-05-12T22:03:47.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cb/5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f", size = 24489, upload-time = "2020-05-12T22:03:45.643Z" },
 ]
 
 [[package]]
@@ -2863,18 +3138,18 @@ name = "litellm"
 version = "1.81.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.12'" },
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "fastuuid", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "importlib-metadata", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.12'" },
-    { name = "openai", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "tiktoken", marker = "python_full_version >= '3.12'" },
-    { name = "tokenizers", marker = "python_full_version >= '3.12'" },
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/0c/62a0fdc5adae6d205338f9239175aa6a93818e58b75cf000a9c7214a3d9f/litellm-1.81.15.tar.gz", hash = "sha256:a8a6277a53280762051c5818ebc76dd5f036368b9426c6f21795ae7f1ac6ebdc", size = 16597039, upload-time = "2026-02-24T06:52:50.892Z" }
 wheels = [
@@ -3361,6 +3636,30 @@ wheels = [
 ]
 
 [[package]]
+name = "mysql-connector-python"
+version = "9.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/5e/55b265cb95938e271208e5692d7e615c53f2aeea894ab72a9f14ab198e9a/mysql-connector-python-9.3.0.tar.gz", hash = "sha256:8b16d51447e3603f18478fb5a19b333bfb73fb58f872eb055a105635f53d2345", size = 942579, upload-time = "2025-05-07T18:50:34.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/59/fa9bef2d9a7eafdc5629b82916e4e1e29446c9bbb0b33706988bbf541b18/mysql_connector_python-9.3.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e8b0131006608e533b8eab20078f9e65486068c984ed3efd28413d350d241f44", size = 15148256, upload-time = "2025-04-15T11:21:55.05Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ae/4ac81d7dc2ce8dff22fd63fa16d4562b113ef0458b04bd958675da3adc74/mysql_connector_python-9.3.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:cb72fcda90b616f0b2d3dae257441e06e8896b2780c3dddc6a65275ec1408d9a", size = 15964339, upload-time = "2025-04-15T11:21:58.275Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f4/088022373f0b71aae6f3190278423fce1fe0c31ecbddf33eb5c0cbf87c4d/mysql_connector_python-9.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9cc8d3c2f45d16b064b0063db857f8a7187b8659253dd32e3f19df1bf1d55ea0", size = 33456359, upload-time = "2025-04-15T11:22:02.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/38/96a602ad402fb71175d83bed3178bd8c16e04251d279e314e0bc53e0b861/mysql_connector_python-9.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:9c898c5f3e34314ed825f2ffdd52d674e03d59c45d02ac8083a8ec5173c1e0f8", size = 33852738, upload-time = "2025-04-15T11:22:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/63567fa4082aa22bad5cecaf16fe3604f026aea40b06d0bf2a9fd75212ff/mysql_connector_python-9.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:f10fe89397e8da81026d8143e17fc5c12ae5e66e51753a0f49e1db179c4f7113", size = 16358431, upload-time = "2025-04-15T11:22:12.263Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/73/b42061ea4c0500edad4f92834ed7d75b1a740d11970e531c5be4dc1af5cd/mysql_connector_python-9.3.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2589af070babdff9c920ee37f929218d80afa704f4e2a99f1ddcb13d19de4450", size = 15151288, upload-time = "2025-04-15T18:43:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/27/87/9cd7e803c762c5098683c83837d2258c2f83cf82d33fabd1d0eaadae06ee/mysql_connector_python-9.3.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1916256ecd039f4673715550d28138416bac5962335e06d36f7434c47feb5232", size = 15967397, upload-time = "2025-04-15T18:43:20.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/cd63f31bf5d0536ee1e4216fb2f3f57175ca1e0dd37e1e8139083d2156e8/mysql_connector_python-9.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d33e2f88e1d4b15844cfed2bb6e90612525ba2c1af2fb10b4a25b2c89a1fe49a", size = 33457025, upload-time = "2025-04-15T18:43:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/76/65/9609a96edc0d015d1017176974c42b955cf87ba92cd31765f99cba835715/mysql_connector_python-9.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0aedee809e1f8dbab6b2732f51ee1619b54a56d15b9070655bc31fb822c1a015", size = 33853427, upload-time = "2025-04-15T18:43:28.441Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/da/f81eeb5b63dea3ebe035fbbbdc036ae517155ad73f2e9640ee7c9eace09d/mysql_connector_python-9.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:3853799f4b719357ea25eba05f5f278a158a85a5c8209b3d058947a948bc9262", size = 16358560, upload-time = "2025-04-15T18:43:32.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/5762061505a0d0d3a333613b6f5d7b8eb3222a689aa32f71ed15f1532ad1/mysql_connector_python-9.3.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9516a4cdbaee3c9200f0e7d9aafb31057692f45c202cdcb43a3f9b37c94e7c84", size = 15151425, upload-time = "2025-04-15T18:43:35.573Z" },
+    { url = "https://files.pythonhosted.org/packages/db/40/22de86e966e648ea0e3e438ad523c86d0cf4866b3841e248726fb4afded8/mysql_connector_python-9.3.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:495798dd34445d749991fb3a2aa87b4205100676939556d8d4aab5d5558e7a1f", size = 15967663, upload-time = "2025-04-15T18:43:38.248Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/36983937347b6a58af546950c88a9403cdce944893850e80ffb7f602a099/mysql_connector_python-9.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:be0ef15f6023ae2037347498f005a4471f694f8a6b8384c3194895e153120286", size = 33457288, upload-time = "2025-04-15T18:43:41.901Z" },
+    { url = "https://files.pythonhosted.org/packages/18/12/7ccbc678a130df0f751596b37eddb98b2e40930d0ebc9ee41965ffbf0b92/mysql_connector_python-9.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4364d3a37c449f1c0bb9e52fd4eddc620126b9897b6b9f2fd1b3f33dacc16356", size = 33853838, upload-time = "2025-04-15T18:43:45.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5e/c361caa024ce14ffc1f5b153d90f0febf5e9483a60c4b5c84e1e012363cc/mysql_connector_python-9.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:2a5de57814217077a8672063167b616b1034a37b614b93abcb602cc0b8c6fade", size = 16358561, upload-time = "2025-04-15T18:43:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1d/8c2c6672094b538f4881f7714e5332fdcddd05a7e196cbc9eb4a9b5e9a45/mysql_connector_python-9.3.0-py2.py3-none-any.whl", hash = "sha256:8ab7719d614cf5463521082fab86afc21ada504b538166090e00eeaa1ff729bc", size = 399302, upload-time = "2025-04-15T18:44:10.046Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3723,6 +4022,20 @@ wheels = [
 ]
 
 [[package]]
+name = "oss2"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aliyun-python-sdk-core" },
+    { name = "aliyun-python-sdk-kms" },
+    { name = "crcmod" },
+    { name = "pycryptodome" },
+    { name = "requests" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/f2cb1950dda46ac2284d6c950489fdacd0e743c2d79a347924d3cc44b86f/oss2-2.19.1.tar.gz", hash = "sha256:a8ab9ee7eb99e88a7e1382edc6ea641d219d585a7e074e3776e9dec9473e59c1", size = 298845, upload-time = "2024-10-25T11:37:46.638Z" }
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3949,6 +4262,33 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b1/7e2216f4aa258ac73d1b443c84da861bba0512d255c20a3880805af7a520/posthog-7.14.1.tar.gz", hash = "sha256:c9a65765d5d8dc80ead4196337e3933b6ccbde0eed8f0ce49675485fffe43a3c", size = 205114, upload-time = "2026-05-11T16:22:21.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/65/a19988a81412fa2b68f1807791a06cdb5cdb6c946b48638b0fee898bc576/posthog-7.14.1-py3-none-any.whl", hash = "sha256:eac0919136b11b5ce6b320990c32004c12031601ae8a7e7a9e46bb3276038145", size = 240201, upload-time = "2026-05-11T16:22:19.559Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -4073,17 +4413,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.5"
+version = "5.29.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623, upload-time = "2026-02-04T22:54:40.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
-    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
-    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357, upload-time = "2026-02-04T22:54:25.805Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", size = 435175, upload-time = "2026-02-04T22:54:28.592Z" },
+    { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", size = 418619, upload-time = "2026-02-04T22:54:30.266Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284, upload-time = "2026-02-04T22:54:31.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478, upload-time = "2026-02-04T22:54:32.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126, upload-time = "2026-02-04T22:54:39.462Z" },
 ]
 
 [[package]]
@@ -4369,6 +4708,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pydash"
+version = "8.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c1/1c55272f49d761cec38ddb80be9817935b9c91ebd6a8988e10f532868d56/pydash-8.0.6.tar.gz", hash = "sha256:b2821547e9723f69cf3a986be4db64de41730be149b2641947ecd12e1e11025a", size = 164338, upload-time = "2026-01-17T16:42:56.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/b7/cc5e7974699db40014d58c7dd7c4ad4ffc244d36930dc9ec7d06ee67d7a9/pydash-8.0.6-py3-none-any.whl", hash = "sha256:ee70a81a5b292c007f28f03a4ee8e75c1f5d7576df5457b836ec7ab2839cc5d0", size = 101561, upload-time = "2026-01-17T16:42:55.448Z" },
 ]
 
 [[package]]
@@ -4666,6 +5017,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/45/5b1bdd15a3c7730eefb9c113600829e20d689b82b5a23f9e07d107094004/qdrant_client-1.18.0.tar.gz", hash = "sha256:52e8ece1a7d40519801bf0b70713bfa0f6b7ae28c7275bbe0b0286fbed7f6db4", size = 352580, upload-time = "2026-05-11T14:12:38.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/10/c437bd2ac41ef30d3019063e6ce537dc111e9214473b337ee88f7fa6359a/qdrant_client-1.18.0-py3-none-any.whl", hash = "sha256:093aa8cf8a420ee3ad2a68b007e1378d7992b2600e0b53c193fc172674f659cd", size = 398126, upload-time = "2026-05-11T14:12:36.998Z" },
 ]
 
 [[package]]
@@ -5198,8 +5567,8 @@ name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "(python_full_version >= '3.12' and platform_machine == 'AMD64') or (python_full_version >= '3.12' and platform_machine == 'WIN32') or (python_full_version >= '3.12' and platform_machine == 'aarch64') or (python_full_version >= '3.12' and platform_machine == 'amd64') or (python_full_version >= '3.12' and platform_machine == 'ppc64le') or (python_full_version >= '3.12' and platform_machine == 'win32') or (python_full_version >= '3.12' and platform_machine == 'x86_64')" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
 wheels = [
@@ -5326,6 +5695,52 @@ wheels = [
 ]
 
 [[package]]
+name = "tablestore"
+version = "6.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "crc32c" },
+    { name = "flatbuffers" },
+    { name = "future" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/1b/03bee654a922a818a12df211bbf31b724773082db356d964579e4b004f5b/tablestore-6.4.6.tar.gz", hash = "sha256:b0f3fd864380b0448c0dfc648dc7bf28e41c35afab8ddf6ee75cf43e480a1abc", size = 5082221, upload-time = "2026-04-28T11:25:34.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/24/6cd95c15123a6b2a17fbc013e78a4f6119df987a2004f8996768f060a353/tablestore-6.4.6-py3-none-any.whl", hash = "sha256:060f24cff09c4e2912e01adaf1be3b9a69d609f3f82e83f7c979136357e7e8fd", size = 5123750, upload-time = "2026-04-28T11:25:30.716Z" },
+]
+
+[[package]]
+name = "tablestore-agent-storage"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oss2" },
+    { name = "tablestore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/b6/4929f7e257497c502b367ca27f0bd01e1a377791eda986b5c6152195ecd8/tablestore_agent_storage-1.0.5.tar.gz", hash = "sha256:aef312dc59a0d3cb467747b834406f3c7ab6880957f23090c79b0189460e2898", size = 14467, upload-time = "2026-03-31T06:31:50.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/33/d4e191857e1673614a7fdbbbeda1677e83e6f54974bdabd451ba971f2d15/tablestore_agent_storage-1.0.5-py3-none-any.whl", hash = "sha256:849d43bf03cff31c897093574381112858b42278ffe3e2536f0eca2267df9a65", size = 14183, upload-time = "2026-03-31T06:31:49.694Z" },
+]
+
+[[package]]
+name = "tablestore-for-agent-memory"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "tablestore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/a92ba26d87fb2be64c26847bb34a9ff207d42b7546c05d5a7af79455fe62/tablestore_for_agent_memory-1.1.3.tar.gz", hash = "sha256:522841fed7fdd655f122c516220950fa65ce469e9bf80c05db68d04d2021dcf6", size = 22233, upload-time = "2026-03-25T12:47:07.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/40/ea6ec162dc91ac55b3fd8ef7bcd2e1f04a039c8bbfcfa3dd8f6c6cbf7ef8/tablestore_for_agent_memory-1.1.3-py3-none-any.whl", hash = "sha256:0384ba823f09a47786ea050be35bb2d0f8b7c6d95dba0b31c04fbbac6e30622f", size = 33719, upload-time = "2026-03-25T12:47:06.353Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5357,8 +5772,8 @@ name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "regex" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
 wheels = [

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -87,7 +87,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | agentrun | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
@@ -108,6 +108,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
 | **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
 | **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
+| **agentrun** | Alibaba Cloud AgentRun Code Interpreter sandbox | Full (cloud microVM) | China-region cloud execution with idle-billed sandboxes |
 | **singularity** | Singularity/Apptainer container | Namespaces (--containall) | HPC clusters, shared machines |
 
 ### Local Backend
@@ -270,6 +271,45 @@ OIDC tokens are short-lived and should not be used as the documented deployment 
 
 **Disk sizing:** Vercel Sandbox does not currently support Hermes' `container_disk` resource knob. Leave `container_disk` unset or at the shared default `51200`; non-default values fail diagnostics and backend creation instead of being silently ignored.
 
+### AgentRun Backend
+
+Runs commands in an [Alibaba Cloud AgentRun](https://help.aliyun.com/zh/functioncompute/fc/what-is-agentrun) Code Interpreter sandbox — a managed microVM on Function Compute v3 with idle-billed sandboxes (vCPU is billed only while a command is actually executing; the rest is memory-only).
+
+```yaml
+terminal:
+  backend: agentrun
+  agentrun_template_name: "hermes-default"   # Optional; defaults to "hermes-{task_id}"
+  agentrun_idle_timeout_seconds: 300         # Sandbox idle TTL (server-side reaps after this)
+  container_persistent: true                 # Reconnect to the same sandbox across calls
+```
+
+**Required install:** Install the SDK:
+
+```bash
+pip install agentrun-sdk
+```
+
+**Required authentication:** Set the SDK's documented environment variables before launching Hermes. These are picked up automatically by the `agentrun` Python package:
+
+```bash
+export AGENTRUN_ACCESS_KEY_ID="<RAM AccessKey ID>"
+export AGENTRUN_ACCESS_KEY_SECRET="<RAM AccessKey secret>"
+export AGENTRUN_ACCOUNT_ID="<Aliyun account ID>"
+export AGENTRUN_REGION="cn-hangzhou"            # Any AgentRun-enabled region
+```
+
+Create a dedicated RAM sub-account (rather than the root key) with the `AliyunAgentRunFullAccess` managed policy, or a tighter custom policy if you do not need template/sandbox management at runtime.
+
+**Persistence model:** AgentRun does not expose a snapshot API. With `container_persistent: true` Hermes stores the live `sandbox_id` in `~/.hermes/agentrun_sandboxes.json`, keyed by `task_id`, and reconnects to that sandbox via `Sandbox.connect(sandbox_id)` on the next call. The sandbox stays alive across calls as long as it is reused within `agentrun_idle_timeout_seconds` (default 5 minutes); after that the control plane reaps it and the next construction transparently allocates a new one. With `container_persistent: false` Hermes deletes the sandbox at the end of every session.
+
+**Templates:** AgentRun sandboxes are launched from server-side *templates*. Hermes materialises one named `hermes-{task_id}` on first use (idempotent — concurrent constructions resolve to the existing template). Override `agentrun_template_name` to share a single curated template across tasks (useful if you customise the runtime image in the AgentRun console).
+
+**Command timeout:** AgentRun caps a single Code Interpreter command at 30 s server-side. Hermes clamps caller-supplied timeouts to that ceiling and emits a warning when it does. Longer-running shell workflows should be split into multiple commands (the sandbox itself stays alive across them).
+
+**Background commands:** `terminal(background=true)` uses Hermes' generic non-local background flow on top of the SDK's `process.cmd` endpoint. The 30-second command ceiling applies; for genuinely long-running work prefer detaching to `nohup ... &` and polling status via subsequent commands.
+
+**Region note:** AgentRun is currently an Alibaba Cloud product and runs in China + Singapore regions only. Outbound network from the sandbox follows the chosen region's egress.
+
 ### Singularity/Apptainer Backend
 
 Runs commands in a [Singularity/Apptainer](https://apptainer.org) container. Designed for HPC clusters and shared machines where Docker isn't available.
@@ -300,6 +340,7 @@ If terminal commands fail immediately or the terminal tool is reported as disabl
 - **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
 - **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.
 - **Daytona** — Needs `DAYTONA_API_KEY`. The Daytona SDK handles server URL configuration.
+- **AgentRun** — Needs `AGENTRUN_ACCESS_KEY_ID`, `AGENTRUN_ACCESS_KEY_SECRET`, and `AGENTRUN_ACCOUNT_ID`; `AGENTRUN_REGION` defaults to `cn-hangzhou`. Install `agentrun-sdk`. See the AgentRun Backend section above.
 - **Singularity** — Needs `apptainer` or `singularity` in `$PATH`. Common on HPC clusters.
 
 When in doubt, set `terminal.backend` back to `local` and verify that commands run there first.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -278,16 +278,19 @@ Runs commands in an [Alibaba Cloud AgentRun](https://help.aliyun.com/zh/function
 ```yaml
 terminal:
   backend: agentrun
-  agentrun_template_name: "hermes-default"   # Optional; defaults to "hermes-{task_id}"
-  agentrun_idle_timeout_seconds: 300         # Sandbox idle TTL (server-side reaps after this)
-  container_persistent: true                 # Reconnect to the same sandbox across calls
+  agentrun_image: "nikolaik/python-nodejs:python3.11-nodejs20"   # Container image; default matches Modal/Daytona
+  agentrun_template_name: "hermes-default"                       # Optional; defaults to "hermes-{task_id}"
+  agentrun_idle_timeout_seconds: 300                             # Sandbox idle TTL (server-side reaps after this)
+  container_persistent: true                                     # Reconnect to the same sandbox across calls
 ```
 
-**Required install:** Install the SDK:
+**Required install:** Install the SDK via the optional extra:
 
 ```bash
-pip install agentrun-sdk
+pip install 'hermes-agent[agentrun]'
 ```
+
+This pulls in `agentrun-sdk>=0.0.35,<0.1.0`. The package is intentionally an optional dependency so non-AgentRun users do not have to install the Alibaba Cloud client.
 
 **Required authentication:** Set the SDK's documented environment variables before launching Hermes. These are picked up automatically by the `agentrun` Python package:
 
@@ -300,9 +303,13 @@ export AGENTRUN_REGION="cn-hangzhou"            # Any AgentRun-enabled region
 
 Create a dedicated RAM sub-account (rather than the root key) with the `AliyunAgentRunFullAccess` managed policy, or a tighter custom policy if you do not need template/sandbox management at runtime.
 
+**Container image:** AgentRun's stock CODE_INTERPRETER template ships with a minimal image and runs commands as a non-root worker user. The Hermes adapter defaults `agentrun_image` to the same `nikolaik/python-nodejs:python3.11-nodejs20` image used by the Modal and Daytona backends so `execute_code`, file tools, and skills that shell out to `python3` / `node` work out of the box. Override with any registry image AgentRun can pull (including ACR images keyed via `acr_instance_id` in your template configuration on the AgentRun console).
+
+**Working directory:** AgentRun sandboxes run commands as a non-root user; `/root` is *not* writable. The adapter probes the sandbox's `$HOME` on construction and rewrites the default working directory (and the file-sync target `~/.hermes/`) accordingly. Override with `terminal.cwd` if your image uses a different writable root.
+
 **Persistence model:** AgentRun does not expose a snapshot API. With `container_persistent: true` Hermes stores the live `sandbox_id` in `~/.hermes/agentrun_sandboxes.json`, keyed by `task_id`, and reconnects to that sandbox via `Sandbox.connect(sandbox_id)` on the next call. The sandbox stays alive across calls as long as it is reused within `agentrun_idle_timeout_seconds` (default 5 minutes); after that the control plane reaps it and the next construction transparently allocates a new one. With `container_persistent: false` Hermes deletes the sandbox at the end of every session.
 
-**Templates:** AgentRun sandboxes are launched from server-side *templates*. Hermes materialises one named `hermes-{task_id}` on first use (idempotent — concurrent constructions resolve to the existing template). Override `agentrun_template_name` to share a single curated template across tasks (useful if you customise the runtime image in the AgentRun console).
+**Templates:** AgentRun sandboxes are launched from server-side *templates*. Hermes materialises one named `hermes-{task_id}` on first use (idempotent — concurrent constructions resolve to the existing template). Override `agentrun_template_name` to share a single curated template across tasks (useful if you customise the runtime image in the AgentRun console). Template-level container image is taken from `agentrun_image` when the template does not yet exist; existing templates are re-used as-is.
 
 **Command timeout:** AgentRun caps a single Code Interpreter command at 30 s server-side. Hermes clamps caller-supplied timeouts to that ceiling and emits a warning when it does. Longer-running shell workflows should be split into multiple commands (the sandbox itself stays alive across them).
 


### PR DESCRIPTION
Adds 8th sandbox backend for Alibaba Cloud AgentRun (Code Interpreter).

## What

- \`tools/environments/agentrun.py\` (~614 lines, mirrors modal.py pattern)
- \`AgentRunEnvironment(BaseEnvironment)\` with FileSyncManager, non-root home detection (\`/workspace\` fallback), persistent session reconnect
- Registered in \`tools/terminal_tool.py:_create_environment\` via \`TERMINAL_ENV=agentrun\`
- 21 unit tests (mocked SDK) · ruff clean · 0 regression on neighboring backends
- Optional dep \`agentrun-sdk>=0.0.35,<0.1.0\` (\`pip install hermes-agent[agentrun]\`)
- Docs added at \`website/docs/user-guide/configuration.md\`

## Why

AgentRun is Alibaba Cloud's managed sandbox service (analogous to Modal / E2B / Daytona) — first-class China-region option for users with China-side compliance / latency / data-sovereignty constraints. Mirrors how \`modal\` / \`daytona\` / \`vercel_sandbox\` backends are wired.

## Notes

Production validated against real Aliyun AgentRun workspace via the akong agent product (https://github.com/yarnovo/akong).

(Re-submitting prior PR #23922 — accidentally closed by author within 5min of opening · before any CI/review · new clean re-fork.)