### PR TITLE
fix(providers): refresh model-provider plugins on change

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _discovered = False
+_DISCOVERY_CACHE_KEY: tuple | None = None
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -67,16 +68,14 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
 
     Returns None if the provider has no profile (falls back to generic).
     """
-    if not _discovered:
-        _discover_providers()
+    _ensure_providers_discovered()
     canonical = _ALIASES.get(name, name)
     return _REGISTRY.get(canonical)
 
 
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
-    if not _discovered:
-        _discover_providers()
+    _ensure_providers_discovered()
     # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
     seen: set[int] = set()
     result: list[ProviderProfile] = []
@@ -95,6 +94,16 @@ def _user_plugins_dir() -> Path | None:
 
         d = get_hermes_home() / "plugins" / "model-providers"
         return d if d.is_dir() else None
+    except Exception:
+        return None
+
+
+def _user_plugins_root_path() -> Path | None:
+    """Return the expected user provider-plugins root, even if it does not exist yet."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "plugins" / "model-providers"
     except Exception:
         return None
 
@@ -135,6 +144,94 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
             "Failed to load %s provider plugin %s: %s", source, plugin_dir.name, exc
         )
         sys.modules.pop(module_name, None)
+
+
+def _path_signature(path: Path) -> tuple[int, int]:
+    """Return a stable `(mtime_ns, size)` signature for a path."""
+    stat = path.stat()
+    return (stat.st_mtime_ns, stat.st_size)
+
+
+def _plugin_root_cache_key(root: Path) -> tuple:
+    """Build a cache key for a provider-plugin directory tree."""
+    if not root.is_dir():
+        return (str(root), "missing")
+
+    entries: list[tuple] = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if not child.is_dir() or child.name.startswith(("_", ".")):
+            continue
+        child_entry = [child.name, _path_signature(child)]
+        for filename in ("__init__.py", "plugin.yaml", "plugin.yml"):
+            file_path = child / filename
+            if file_path.exists():
+                child_entry.append((filename, _path_signature(file_path)))
+        entries.append(tuple(child_entry))
+    return (str(root), _path_signature(root), tuple(entries))
+
+
+def _legacy_modules_cache_key() -> tuple:
+    """Track legacy `providers/*.py` modules so edits can trigger refresh."""
+    providers_dir = Path(__file__).resolve().parent
+    entries: list[tuple] = []
+    for path in sorted(providers_dir.glob("*.py")):
+        if path.name in {"__init__.py", "base.py"} or path.name.startswith("_"):
+            continue
+        entries.append((path.name, _path_signature(path)))
+    return tuple(entries)
+
+
+def _providers_cache_key() -> tuple:
+    """Return the current discovery cache key for bundled + user provider sources."""
+    user_dir = _user_plugins_root_path()
+    user_key = (
+        _plugin_root_cache_key(user_dir)
+        if user_dir is not None
+        else ("<unknown-user-provider-root>", "missing")
+    )
+    return (
+        _plugin_root_cache_key(_BUNDLED_PLUGINS_DIR),
+        user_key,
+        _legacy_modules_cache_key(),
+    )
+
+
+def _clear_provider_modules() -> None:
+    """Evict dynamically discovered provider modules so imports re-execute."""
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("plugins.model_providers") or mod.startswith(
+            "_hermes_user_provider"
+        ):
+            del sys.modules[mod]
+
+    providers_dir = Path(__file__).resolve().parent
+    for path in providers_dir.glob("*.py"):
+        if path.name in {"__init__.py", "base.py"} or path.name.startswith("_"):
+            continue
+        sys.modules.pop(f"providers.{path.stem}", None)
+
+
+def _reset_provider_discovery_state(*, clear_modules: bool) -> None:
+    """Clear provider registry state so the next discovery pass is clean."""
+    global _discovered, _DISCOVERY_CACHE_KEY
+    _REGISTRY.clear()
+    _ALIASES.clear()
+    _discovered = False
+    _DISCOVERY_CACHE_KEY = None
+    if clear_modules:
+        _clear_provider_modules()
+
+
+def _ensure_providers_discovered(force: bool = False) -> None:
+    """Discover provider plugins and refresh when their source tree changes."""
+    global _DISCOVERY_CACHE_KEY
+    key = _providers_cache_key()
+    if _discovered and not force and key == _DISCOVERY_CACHE_KEY:
+        return
+    if _discovered:
+        _reset_provider_discovery_state(clear_modules=True)
+    _discover_providers()
+    _DISCOVERY_CACHE_KEY = key
 
 
 def _discover_providers() -> None:

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -8,8 +8,6 @@ Verifies that:
 
 from __future__ import annotations
 
-import importlib
-import sys
 from pathlib import Path
 
 import pytest
@@ -21,16 +19,38 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def _clear_provider_caches():
     """Force providers/__init__.py to re-discover on next list_providers()."""
     import providers as _pkg
-    _pkg._REGISTRY.clear()
-    _pkg._ALIASES.clear()
-    _pkg._discovered = False
-    # Evict any cached plugin modules so the next import re-executes.
-    for mod in list(sys.modules.keys()):
-        if (
-            mod.startswith("plugins.model_providers")
-            or mod.startswith("_hermes_user_provider")
-        ):
-            del sys.modules[mod]
+    _pkg._reset_provider_discovery_state(clear_modules=True)
+
+
+def _write_user_provider_plugin(
+    hermes_home: Path,
+    name: str,
+    *,
+    aliases: tuple[str, ...] = (),
+    base_url: str = "https://user-override.example.com/v1",
+) -> Path:
+    """Create a minimal user model-provider plugin under HERMES_HOME."""
+    plugin_dir = hermes_home / "plugins" / "model-providers" / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "\n"
+        "register_provider(ProviderProfile(\n"
+        f'    name="{name}",\n'
+        f"    aliases={aliases!r},\n"
+        f'    env_vars=("{name.upper().replace("-", "_")}_API_KEY",),\n'
+        f'    base_url="{base_url}",\n'
+        '    auth_type="api_key",\n'
+        "))\n"
+    )
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {name}\n"
+        "kind: model-provider\n"
+        "version: 0.0.1\n"
+        "description: Test user override\n"
+    )
+    return plugin_dir
 
 
 def test_bundled_plugins_discovered():
@@ -73,26 +93,11 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
     # env var is the source of truth. Most code paths re-read it each call.
 
     # Drop a user plugin that replaces 'gmi'
-    user_gmi = hermes_home / "plugins" / "model-providers" / "gmi"
-    user_gmi.mkdir(parents=True)
-    (user_gmi / "__init__.py").write_text(
-        "from providers import register_provider\n"
-        "from providers.base import ProviderProfile\n"
-        "\n"
-        "custom_gmi = ProviderProfile(\n"
-        '    name="gmi",\n'
-        '    aliases=("gmi-user-override-test",),\n'
-        '    env_vars=("GMI_API_KEY",),\n'
-        '    base_url="https://user-override.example.com/v1",\n'
-        '    auth_type="api_key",\n'
-        ")\n"
-        "register_provider(custom_gmi)\n"
-    )
-    (user_gmi / "plugin.yaml").write_text(
-        "name: gmi-user-override\n"
-        "kind: model-provider\n"
-        "version: 0.0.1\n"
-        "description: Test user override\n"
+    _write_user_provider_plugin(
+        hermes_home,
+        "gmi",
+        aliases=("gmi-user-override-test",),
+        base_url="https://user-override.example.com/v1",
     )
 
     _clear_provider_caches()
@@ -106,6 +111,32 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
     assert "gmi-user-override-test" in gmi.aliases
 
     # Clean up: reset discovery state so other tests see the bundled version
+    _clear_provider_caches()
+
+
+def test_runtime_discovers_new_user_provider_without_manual_reset(tmp_path, monkeypatch):
+    """A newly created user provider plugin should be picked up mid-process."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _clear_provider_caches()
+    from providers import get_provider_profile
+
+    assert get_provider_profile("repro-provider") is None
+
+    _write_user_provider_plugin(
+        hermes_home,
+        "repro-provider",
+        aliases=("repro",),
+        base_url="https://repro.example/v1",
+    )
+
+    profile = get_provider_profile("repro-provider")
+    assert profile is not None
+    assert profile.base_url == "https://repro.example/v1"
+    assert get_provider_profile("repro").name == "repro-provider"
+
     _clear_provider_caches()
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes stale model-provider discovery in long-running processes.

`providers/__init__.py` only discovered bundled and user model-provider plugins once per process by gating on a module-level `_discovered` flag. After the first lookup, newly added or modified provider plugins under `$HERMES_HOME/plugins/model-providers/` were invisible until restart.

This change makes provider discovery refresh automatically when the provider plugin tree changes. It tracks a cache key derived from bundled plugins, user plugins, and legacy `providers/*.py` modules, and clears the provider registry plus imported provider modules before re-discovering when that key changes.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/__init__.py`
  - route `get_provider_profile()` and `list_providers()` through a refresh-aware discovery helper
  - add a provider discovery cache key based on bundled plugin dirs, user plugin dirs, and legacy `providers/*.py` modules
  - clear provider registry state and evict imported provider modules before re-discovery when the source tree changes
- `tests/providers/test_plugin_discovery.py`
  - factor a helper for writing temporary user provider plugins
  - add a regression test covering "first lookup misses, plugin is created, second lookup succeeds without manual cache reset"

## How to Test

1. Call `get_provider_profile("repro-provider")` before any user plugin exists and confirm it returns `None`.
2. Create `$HERMES_HOME/plugins/model-providers/repro-provider/{__init__.py,plugin.yaml}` in the same process.
3. Call `get_provider_profile("repro-provider")` again and confirm the provider now resolves without manually resetting `providers._discovered`.

Test commands run:

- `python3 -m py_compile providers/__init__.py tests/providers/test_plugin_discovery.py`
- `PYTHONPATH=. uv run --no-project --with pytest --with pytest-xdist python -m pytest tests/providers/test_plugin_discovery.py -q`
- `PYTHONPATH=. uv run --no-project --with pytest --with pytest-xdist python -m pytest tests/providers/test_provider_profiles.py -q`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
