### PR TITLE
fix(model_tools): log warning when enabled/disabled toolset is unknown

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -367,9 +367,12 @@ def _compute_tool_definitions(
             else:
                 # Surface unresolved entries through the logger so cron / gateway
                 # / oneshot sessions (which all run with quiet_mode=True) don't
-                # silently drop misnamed toolsets. The cache key includes
-                # registry._generation, so this only fires once per unique
-                # (config, registry-state) pair — not on every turn. (#23997)
+                # silently drop misnamed toolsets. Under quiet_mode, the cache
+                # in get_tool_definitions() collapses repeat calls to once per
+                # unique (config, registry-state) pair; in interactive mode
+                # (quiet_mode=False) the cache is bypassed and the warning may
+                # repeat per call, which is acceptable because the print()
+                # below is also visible there. (#23997)
                 logger.warning(
                     "Unknown toolset '%s' in enabled_toolsets — dropping. "
                     "Check spelling against `hermes tools list` (MCP servers "

--- a/model_tools.py
+++ b/model_tools.py
@@ -364,8 +364,20 @@ def _compute_tool_definitions(
                 tools_to_include.update(legacy_tools)
                 if not quiet_mode:
                     print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                # Surface unresolved entries through the logger so cron / gateway
+                # / oneshot sessions (which all run with quiet_mode=True) don't
+                # silently drop misnamed toolsets. The cache key includes
+                # registry._generation, so this only fires once per unique
+                # (config, registry-state) pair — not on every turn. (#23997)
+                logger.warning(
+                    "Unknown toolset '%s' in enabled_toolsets — dropping. "
+                    "Check spelling against `hermes tools list` (MCP servers "
+                    "are exposed as the alias registered by mcp_tool).",
+                    toolset_name,
+                )
+                if not quiet_mode:
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
         # Default: start with everything
         from toolsets import get_all_toolsets
@@ -388,8 +400,14 @@ def _compute_tool_definitions(
                 tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                logger.warning(
+                    "Unknown toolset '%s' in disabled_toolsets — ignoring. "
+                    "Check spelling against `hermes tools list`.",
+                    toolset_name,
+                )
+                if not quiet_mode:
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -357,3 +357,82 @@ class TestCoerceNumberInfNan:
         assert _coerce_number("42") == 42
         assert _coerce_number("3.14") == 3.14
         assert _coerce_number("1e3") == 1000
+
+
+# =========================================================================
+# Unknown-toolset rejection must surface through the logger, not just stdout
+# (regression: #23997 — silent rejection in quiet_mode hid an MCP misconfig
+#  in 283 cron sessions across a 13-profile fleet)
+# =========================================================================
+
+class TestUnknownToolsetWarnsInQuietMode:
+    """``_compute_tool_definitions`` is invoked with ``quiet_mode=True`` from
+    every production code path (cron, gateway, oneshot, TUI, delegate, ACP).
+    When an entry in ``enabled_toolsets`` / ``disabled_toolsets`` does not
+    resolve, the user-facing ``print("⚠️  Unknown toolset")`` is suppressed
+    in that mode — the rejection becomes invisible, which is exactly how
+    #23997's MCP-toolset-name misconfig stayed undiagnosed for 90 minutes
+    across a 283-session fleet sample. The rejection must still go through
+    ``logger.warning`` so it lands in ``gateway.log`` / cron logs."""
+
+    def test_unknown_enabled_toolset_logs_warning_in_quiet_mode(self, caplog):
+        from model_tools import _compute_tool_definitions
+
+        with caplog.at_level("WARNING", logger="model_tools"):
+            _compute_tool_definitions(
+                enabled_toolsets=["definitely_not_a_real_toolset_xyz"],
+                quiet_mode=True,
+            )
+
+        unknown_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "definitely_not_a_real_toolset_xyz" in r.getMessage()
+            and "Unknown toolset" in r.getMessage()
+        ]
+        assert unknown_warnings, (
+            "Unknown enabled_toolsets entry must emit a WARNING-level log "
+            "record even when quiet_mode=True — otherwise cron/gateway "
+            "sessions silently drop misnamed toolsets (#23997)."
+        )
+
+    def test_unknown_disabled_toolset_logs_warning_in_quiet_mode(self, caplog):
+        from model_tools import _compute_tool_definitions
+
+        with caplog.at_level("WARNING", logger="model_tools"):
+            _compute_tool_definitions(
+                enabled_toolsets=["file"],
+                disabled_toolsets=["definitely_not_a_real_toolset_xyz"],
+                quiet_mode=True,
+            )
+
+        unknown_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "definitely_not_a_real_toolset_xyz" in r.getMessage()
+            and "Unknown toolset" in r.getMessage()
+        ]
+        assert unknown_warnings, (
+            "Unknown disabled_toolsets entry must also emit a WARNING — the "
+            "subtractive path is just as silent in quiet_mode as the "
+            "additive path (#23997)."
+        )
+
+    def test_known_toolset_does_not_log_warning(self, caplog):
+        """Negative case: a recognized toolset must not produce the
+        unknown-toolset warning even in quiet_mode."""
+        from model_tools import _compute_tool_definitions
+
+        with caplog.at_level("WARNING", logger="model_tools"):
+            _compute_tool_definitions(
+                enabled_toolsets=["file"],
+                quiet_mode=True,
+            )
+
+        unknown_warnings = [
+            r for r in caplog.records
+            if "Unknown toolset" in r.getMessage()
+        ]
+        assert not unknown_warnings, (
+            "Known toolsets must not trigger the unknown-toolset warning."
+        )


### PR DESCRIPTION
## What does this PR do?

Every production code path that calls `get_tool_definitions` passes `quiet_mode=True` (cron, gateway, oneshot, TUI, delegate, ACP, curator). The `⚠️  Unknown toolset` line in `_compute_tool_definitions` is a bare `print()` gated on `if not quiet_mode`, so in real runtime an unrecognized entry in `enabled_toolsets` / `disabled_toolsets` is silently dropped with no record anywhere.

This PR promotes the conditional `print` to an unconditional `logger.warning(...)` plus the original `print` preserved for interactive sessions, applied symmetrically to both `enabled_toolsets` and `disabled_toolsets`. `get_tool_definitions` memoizes on `(enabled, disabled, registry._generation, config-mtime)`, so a stable misconfig logs exactly one WARNING at startup — not one per turn. When MCP discovery later registers the alias, `registry._generation` bumps, the cache invalidates, and the next compute resolves cleanly. This is option (c) only from the reporter's three suggestions — no change to resolution rules.

## Related Issue

Fixes #23997 (visibility piece)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `model_tools.py` — in `_compute_tool_definitions`, the `else` branch now emits `logger.warning("Unknown toolset '%s' in {enabled,disabled}_toolsets — dropping. Check spelling against `hermes tools list` …", toolset_name)` unconditionally, then falls through to the existing `print` for interactive sessions. Applied symmetrically to enabled and disabled.
- `tests/test_model_tools.py` — `TestUnknownToolsetWarnsInQuietMode` (3 cases: unknown enabled, unknown disabled, known toolset doesn't warn) using `caplog` against the `model_tools` logger.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_model_tools.py tests/test_toolsets.py tests/test_get_tool_definitions_cache_isolation.py tests/hermes_cli/test_tools_disable_enable.py tests/tools/test_delegate_composite_toolsets.py -v`
2. Expected: 79 passed.
3. Regression guard: stash `model_tools.py` only — 2 of the 3 new tests fail with `assert []`. Restore — all 3 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (79/79)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — logger.warning is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #23997 — option (c) (observability) only. Option (a) (extend `validate_toolset()` to accept `<server>:*`) and option (b) (have `hermes tools enable <server>:* --platform cron` write the resolved alias) are deliberately out of scope; this PR is the visibility piece.
- Builds on registry-alias architecture from #9947 (teknium1) which gave us the `mcp-<name>` alias, but didn't add observability when that alias misses.

> Sibling code paths that may need the same observability treatment: alias-resolution timing in `tools/mcp_tool.py::_register_server_tools` (option a) and the platform-toolset writer in `hermes_cli/tools_config.py` (option b). Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.
