### PR TITLE
feat: add dashboard chat file uploads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -50,7 +51,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+    from fastapi import FastAPI, File, HTTPException, Request, UploadFile, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
@@ -73,6 +74,9 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+_DASHBOARD_UPLOAD_MAX_BYTES = 5 * 1024 * 1024
+_DASHBOARD_UPLOAD_DIRNAME = "dashboard-uploads"
+_SAFE_UPLOAD_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
@@ -134,6 +138,31 @@ def _require_token(request: Request) -> None:
     """Validate the ephemeral session token.  Raises 401 on mismatch."""
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def _dashboard_upload_dir() -> Path:
+    """Directory for files the dashboard injects into chat sessions."""
+    path = get_hermes_home() / _DASHBOARD_UPLOAD_DIRNAME
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _sanitize_upload_filename(filename: str) -> str:
+    """Return a safe display/storage filename while preserving useful suffixes."""
+    base = Path(filename or "upload.txt").name.strip().replace("\x00", "")
+    if not base or base in {".", ".."}:
+        base = "upload.txt"
+    base = _SAFE_UPLOAD_NAME_RE.sub("_", base).strip("._")
+    return base[:120] or "upload.txt"
+
+
+def _quote_chat_path(path: Path) -> str:
+    """Single-quote a path for insertion into the TUI prompt."""
+    return "'" + str(path).replace("'", "'\"'\"'") + "'"
 
 
 # Accepted Host header values for loopback binds. DNS rebinding attacks
@@ -3126,6 +3155,60 @@ async def get_models_analytics(days: int = 30):
         }
     finally:
         db.close()
+
+
+@app.post("/api/chat/uploads")
+async def upload_chat_file(request: Request, file: UploadFile = File(...)):
+    """Store a dashboard-uploaded file and return paste text for the chat PTY.
+
+    The in-browser chat tab cannot give the PTY a browser File object directly.
+    Instead we save the file under HERMES_HOME and return a short command-like
+    prompt that gets pasted into the TUI input, so the agent sees an ordinary
+    local path it can read with its existing file tools.
+    """
+    _require_token(request)
+
+    safe_name = _sanitize_upload_filename(file.filename or "upload.txt")
+    upload_dir = _dashboard_upload_dir()
+    dest = upload_dir / f"{int(time.time())}-{secrets.token_hex(4)}-{safe_name}"
+    size = 0
+
+    try:
+        with dest.open("wb") as out:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                size += len(chunk)
+                if size > _DASHBOARD_UPLOAD_MAX_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=f"File too large. Maximum upload size is {_DASHBOARD_UPLOAD_MAX_BYTES // (1024 * 1024)} MB.",
+                    )
+                out.write(chunk)
+        try:
+            dest.chmod(0o600)
+        except OSError:
+            pass
+    except HTTPException:
+        try:
+            dest.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    finally:
+        await file.close()
+
+    prompt = f"Use the uploaded file at {_quote_chat_path(dest)}"
+    if safe_name.lower() == "cookies.txt" or safe_name.lower().endswith("cookies.txt"):
+        prompt = f"Use the uploaded cookies.txt file at {_quote_chat_path(dest)}"
+
+    return {
+        "filename": safe_name,
+        "path": str(dest),
+        "size": size,
+        "paste_text": prompt,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2061,6 +2061,7 @@ class TestDashboardPluginManifestExtensions:
 # ---------------------------------------------------------------------------
 
 import sys
+from pathlib import Path
 
 
 skip_on_windows = pytest.mark.skipif(
@@ -2213,6 +2214,45 @@ class TestPtyWebSocket:
                 if b"99" in buf and b"41" in buf:
                     break
             assert b"99" in buf and b"41" in buf
+
+    def test_chat_file_upload_stores_file_and_returns_paste_text(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(self.ws_module, "get_hermes_home", lambda: tmp_path)
+
+        response = self.client.post(
+            "/api/chat/uploads",
+            headers={"X-Hermes-Session-Token": self.token},
+            files={"file": ("cookies.txt", b"# Netscape HTTP Cookie File\n.example\tTRUE\t/\tFALSE\t0\tsid\tabc")},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        saved = Path(payload["path"])
+        assert saved.parent == tmp_path / "dashboard-uploads"
+        assert saved.name.endswith("-cookies.txt")
+        assert saved.read_bytes().startswith(b"# Netscape HTTP Cookie File")
+        assert "cookies.txt" in payload["paste_text"]
+        assert str(saved) in payload["paste_text"]
+
+    def test_chat_file_upload_requires_session_token(self):
+        response = self.client.post(
+            "/api/chat/uploads",
+            files={"file": ("cookies.txt", b"cookie-data")},
+        )
+
+        assert response.status_code == 401
+
+    def test_chat_file_upload_rejects_oversized_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(self.ws_module, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(self.ws_module, "_DASHBOARD_UPLOAD_MAX_BYTES", 4)
+
+        response = self.client.post(
+            "/api/chat/uploads",
+            headers={"X-Hermes-Session-Token": self.token},
+            files={"file": ("cookies.txt", b"too large")},
+        )
+
+        assert response.status_code == 413
+        assert not list((tmp_path / "dashboard-uploads").glob("*cookies.txt"))
 
     def test_unavailable_platform_closes_with_message(self, monkeypatch):
         from hermes_cli.pty_bridge import PtyUnavailableError

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { Copy, Paperclip, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -70,6 +70,14 @@ const TERMINAL_THEME = {
   selectionBackground: "#f0e6d244",
 };
 
+const MAX_CHAT_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+type ChatUploadResponse = {
+  paste_text?: string;
+};
+
+type Fileish = globalThis.File;
+
 /**
  * CSS width for xterm font tiers.
  *
@@ -105,6 +113,7 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -120,6 +129,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
       : null,
   );
+  const [uploadState, setUploadState] = useState<"idle" | "uploading">("idle");
   const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Raw state for the mobile side-sheet + a derived value that force-
@@ -264,9 +274,81 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     termRef.current?.focus();
   };
 
+  const pasteIntoTerminal = useCallback((text: string) => {
+    const term = termRef.current;
+    if (!term || !text) return;
+    term.paste(text);
+    term.focus();
+  }, []);
+
+  const uploadChatFile = useCallback(
+    async (file: Fileish) => {
+      const token = window.__HERMES_SESSION_TOKEN__;
+      if (!token) {
+        setBanner("Session token unavailable. Reload the dashboard and try again.");
+        return;
+      }
+      if (file.size > MAX_CHAT_UPLOAD_BYTES) {
+        setBanner("File is too large. Chat uploads are limited to 5 MB.");
+        return;
+      }
+
+      const body = new FormData();
+      body.append("file", file, file.name || "upload.txt");
+      setUploadState("uploading");
+      try {
+        const res = await fetch("/api/chat/uploads", {
+          method: "POST",
+          headers: { "X-Hermes-Session-Token": token },
+          body,
+        });
+        if (!res.ok) {
+          let detail = `Upload failed (${res.status})`;
+          try {
+            const err = (await res.json()) as { detail?: string };
+            if (err.detail) detail = err.detail;
+          } catch {
+            /* ignore */
+          }
+          setBanner(detail);
+          return;
+        }
+        const payload = (await res.json()) as ChatUploadResponse;
+        if (payload.paste_text) {
+          pasteIntoTerminal(payload.paste_text);
+          setBanner(null);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setBanner(`Upload failed: ${message}`);
+      } finally {
+        setUploadState("idle");
+      }
+    },
+    [pasteIntoTerminal],
+  );
+
+  const handlePickFile = () => fileInputRef.current?.click();
+
+  const handleFileInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    const file = ev.currentTarget.files?.[0];
+    ev.currentTarget.value = "";
+    if (file) void uploadChatFile(file);
+  };
+
   useEffect(() => {
     const host = hostRef.current;
-    if (!host) return;
+    const onPaste = (ev: ClipboardEvent) => {
+      const files = Array.from(ev.clipboardData?.files ?? []);
+      const file = files[0];
+      if (!file) return;
+      ev.preventDefault();
+      void uploadChatFile(file);
+    };
+    document.addEventListener("paste", onPaste);
+    if (!host) {
+      return () => document.removeEventListener("paste", onPaste);
+    }
 
     const token = window.__HERMES_SESSION_TOKEN__;
     // Banner already initialised above; just bail before wiring xterm/WS.
@@ -333,7 +415,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // original keydown event's activation. Log to aid debugging.
           console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
         });
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -639,6 +721,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onResizeDisposable.dispose();
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
+      document.removeEventListener("paste", onPaste);
       window.visualViewport?.removeEventListener(
         "resize",
         scheduleSyncTerminalMetrics,
@@ -657,7 +740,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, resumeParam, uploadChatFile]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -708,9 +791,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   //   outer flex column — sits inside the dashboard's content area
   //   row split — terminal pane (flex-1) + sidebar (fixed width, lg+)
   //   terminal wrapper — rounded, dark, padded — the "terminal window"
-  //   floating copy button — bottom-right corner, transparent with a
-  //     subtle border; stays out of the way until hovered.  Sends
-  //     `/copy\n` to Ink, which emits OSC 52 → our clipboard handler.
+  //   floating action buttons — bottom-right corner, transparent with a
+  //     subtle border; upload opens the native file picker and clipboard
+  //     paste also captures file objects. The server stores the file under
+  //     HERMES_HOME and pastes a local path into the TUI prompt.
+  //     Copy sends `/copy\n` to Ink, which emits OSC 52 → our clipboard handler.
   //   sidebar — ChatSidebar opens its own JSON-RPC sidecar; renders
   //     model badge, tool-call list, model picker. Best-effort: if the
   //     sidecar fails to connect the terminal pane keeps working.
@@ -822,29 +907,61 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
 
-          <Button
-            ghost
-            onClick={handleCopyLast}
-            title="Copy last assistant response as raw markdown"
-            aria-label="Copy last assistant response"
-            className={cn(
-              "absolute z-10",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-60 hover:opacity-100 hover:border-current/60",
-              "transition-opacity duration-150 normal-case font-normal tracking-normal",
-              "bottom-2 right-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
-              "lg:bottom-4 lg:right-4",
-            )}
-            style={{ color: TERMINAL_THEME.foreground }}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <Copy className="h-3 w-3 shrink-0" />
-              <span className="hidden min-[400px]:inline tracking-wide">
-                {copyState === "copied" ? "copied" : "copy last response"}
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            aria-hidden="true"
+            tabIndex={-1}
+            onChange={handleFileInputChange}
+          />
+
+          <div className="absolute bottom-2 right-2 z-10 flex items-center gap-2 sm:bottom-3 sm:right-3 lg:bottom-4 lg:right-4">
+            <Button
+              ghost
+              onClick={handlePickFile}
+              disabled={uploadState === "uploading"}
+              title="Upload a file into this chat, or paste one from your clipboard"
+              aria-label="Upload file into chat"
+              className={cn(
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-60 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+              )}
+              style={{ color: TERMINAL_THEME.foreground }}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Paperclip className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[520px]:inline tracking-wide">
+                  {uploadState === "uploading" ? "uploading" : "upload file"}
+                </span>
               </span>
-            </span>
-          </Button>
+            </Button>
+
+            <Button
+              ghost
+              onClick={handleCopyLast}
+              title="Copy last assistant response as raw markdown"
+              aria-label="Copy last assistant response"
+              className={cn(
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-60 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+              )}
+              style={{ color: TERMINAL_THEME.foreground }}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Copy className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[400px]:inline tracking-wide">
+                  {copyState === "copied" ? "copied" : "copy last response"}
+                </span>
+              </span>
+            </Button>
+          </div>
         </div>
 
         {!narrow && (


### PR DESCRIPTION
## Summary
- add a dashboard chat upload endpoint that converts small uploaded files into paste-ready `@/tmp/...` references
- add a paperclip button and paste-file handling in the web chat page
- cover upload behavior in `tests/hermes_cli/test_web_server.py`

## Verification
- `git diff --check origin/main..HEAD`
- `git ls-files -u && grep -R -n -E '^(<<<<<<<|=======|>>>>>>>)' web/src/pages/ChatPage.tsx hermes_cli/web_server.py tests/hermes_cli/test_web_server.py || true`
- `python -m py_compile hermes_cli/web_server.py`

## Local blockers
- `python -m pytest tests/hermes_cli/test_web_server.py -q` could not run in this worktree because no pytest module/venv was available.
- `npm --prefix web run lint -- --max-warnings=0 web/src/pages/ChatPage.tsx` could not run because `eslint` is not installed in the local worktree.
