### PR TITLE
fix(skills): fall back to bundled skill files in Docker

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -249,15 +249,28 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            get_bundled_manifest_names,
+            get_bundled_skills_dir,
+            get_skill_search_dirs,
+            iter_skill_index_files,
+        )
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        # Scan local dir first, then external dirs, then the read-only bundled
+        # install tree as a fallback for Docker/package installs whose active
+        # HERMES_HOME was not seeded with bundled skill copies.
+        dirs_to_scan = get_skill_search_dirs(SKILLS_DIR, include_bundled_fallback=True)
+        bundled_dir = get_bundled_skills_dir()
+        manifest_names = get_bundled_manifest_names(SKILLS_DIR)
+
+        def _from_bundled_fallback(path: Path) -> bool:
+            try:
+                path.resolve().relative_to(bundled_dir.resolve())
+                return True
+            except (OSError, ValueError):
+                return False
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -270,6 +283,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     if not skill_matches_platform(frontmatter):
                         continue
                     name = frontmatter.get('name', skill_md.parent.name)
+                    if (
+                        manifest_names
+                        and _from_bundled_fallback(skill_md)
+                        and name in manifest_names
+                    ):
+                        continue
                     if name in seen_names:
                         continue
                     # Respect user's disabled skills config

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -281,6 +281,78 @@ def get_all_skills_dirs() -> List[Path]:
     return dirs
 
 
+def get_bundled_skills_dir() -> Path:
+    """Return the read-only bundled skills directory shipped with Hermes.
+
+    Package-manager wrappers may expose bundled skills outside the source tree
+    via ``HERMES_BUNDLED_SKILLS``.  Otherwise the repo/package layout keeps
+    them at ``<repo>/skills``.
+    """
+    env_override = os.getenv("HERMES_BUNDLED_SKILLS", "").strip()
+    if env_override:
+        return Path(os.path.expandvars(os.path.expanduser(env_override)))
+    return Path(__file__).resolve().parents[1] / "skills"
+
+
+def get_bundled_manifest_names(local_skills_dir: Path | None = None) -> Set[str]:
+    """Return bundled skill names tracked in the local sync manifest."""
+    skills_dir = local_skills_dir or get_skills_dir()
+    manifest_file = skills_dir / ".bundled_manifest"
+    if not manifest_file.exists():
+        return set()
+    names: Set[str] = set()
+    try:
+        for line in manifest_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            name = line.partition(":")[0].strip()
+            if name:
+                names.add(name)
+    except OSError:
+        return set()
+    return names
+
+
+def get_skill_search_dirs(
+    local_skills_dir: Path | None = None,
+    *,
+    include_bundled_fallback: bool = False,
+) -> List[Path]:
+    """Return skill roots in precedence order.
+
+    Normal skill discovery searches the active Hermes home's skills directory
+    and configured external dirs.  Docker and other packaged deployments can
+    start with an empty/mismatched Hermes home while bundled skills are still
+    present in the install tree; ``include_bundled_fallback`` appends that
+    read-only bundled tree as the final fallback so bundled skills remain
+    invokable without being copied into the active profile first.
+    """
+    local_dir = local_skills_dir or get_skills_dir()
+    dirs: List[Path] = []
+    if local_dir.exists():
+        dirs.append(local_dir)
+    dirs.extend(get_external_skills_dirs())
+
+    if include_bundled_fallback:
+        bundled_dir = get_bundled_skills_dir()
+        if bundled_dir.is_dir():
+            try:
+                bundled_resolved = bundled_dir.resolve()
+            except OSError:
+                bundled_resolved = bundled_dir
+            seen: Set[Path] = set()
+            for existing in dirs:
+                try:
+                    seen.add(existing.resolve())
+                except OSError:
+                    seen.add(existing)
+            if bundled_resolved not in seen:
+                dirs.append(bundled_dir)
+
+    return dirs
+
+
 # ── Condition extraction ──────────────────────────────────────────────────
 
 

--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -20,20 +20,20 @@ pip install youtube-transcript-api
 
 ## Helper Script
 
-`SKILL_DIR` is the directory containing this SKILL.md file. The script accepts any standard YouTube URL format, short links (youtu.be), shorts, embeds, live links, or a raw 11-character video ID.
+`${HERMES_SKILL_DIR}` is the directory containing this SKILL.md file. The script accepts any standard YouTube URL format, short links (youtu.be), shorts, embeds, live links, or a raw 11-character video ID.
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -155,3 +155,65 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+    def test_skill_view_falls_back_to_bundled_install_tree(self, hermes_home, tmp_path):
+        """Bundled skills should work even when Docker starts with an unseeded home."""
+        local_skills = hermes_home / "skills"
+        bundled_root = tmp_path / "install" / "skills"
+        skill_dir = bundled_root / "media" / "youtube-content"
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: youtube-content\n"
+            "description: YouTube helper\n"
+            "---\n\n"
+            "Run `${HERMES_SKILL_DIR}/scripts/fetch_transcript.py`.\n"
+        )
+        (scripts_dir / "fetch_transcript.py").write_text("print('ok')\n")
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+            patch("agent.skill_utils.get_bundled_skills_dir", return_value=bundled_root),
+        ):
+            from tools.skills_tool import _find_all_skills, skill_view
+
+            listed = _find_all_skills()
+            result = json.loads(skill_view("youtube-content"))
+
+        assert [s["name"] for s in listed] == ["youtube-content"]
+        assert result["success"] is True
+        assert result["skill_dir"] == str(skill_dir)
+        assert f"{skill_dir}/scripts/fetch_transcript.py" in result["content"]
+        assert result["linked_files"]["scripts"] == ["scripts/fetch_transcript.py"]
+
+    def test_skill_view_does_not_resurrect_deleted_bundled_skill(
+        self, hermes_home, tmp_path
+    ):
+        """Manifest-tracked local deletions still opt out of bundled skill fallback."""
+        local_skills = hermes_home / "skills"
+        (local_skills / ".bundled_manifest").write_text("youtube-content:abc123\n")
+        bundled_root = tmp_path / "install" / "skills"
+        skill_dir = bundled_root / "media" / "youtube-content"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: youtube-content\n"
+            "description: YouTube helper\n"
+            "---\n\n"
+            "Bundled copy.\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+            patch("agent.skill_utils.get_bundled_skills_dir", return_value=bundled_root),
+        ):
+            from tools.skills_tool import _find_all_skills, skill_view
+
+            listed = _find_all_skills()
+            result = json.loads(skill_view("youtube-content"))
+
+        assert "youtube-content" not in [s["name"] for s in listed]
+        assert result["success"] is False

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -57,7 +57,13 @@ class TestScanSkillCommands:
         assert result["/my-skill"]["name"] == "my-skill"
 
     def test_empty_dir(self, tmp_path):
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_utils.get_bundled_skills_dir",
+                return_value=tmp_path / "no-bundled-skills",
+            ),
+        ):
             result = scan_skill_commands()
         assert result == {}
 
@@ -124,6 +130,47 @@ class TestScanSkillCommands:
 
         assert "/knowledge-brain" in result
         assert result["/knowledge-brain"]["name"] == "knowledge-brain"
+
+    def test_finds_bundled_fallback_when_local_skills_unseeded(self, tmp_path):
+        """Docker/package installs can invoke bundled skills before sync copies them."""
+        local_skills = tmp_path / "home" / "skills"
+        bundled_skills = tmp_path / "install" / "skills"
+        _make_skill(
+            bundled_skills,
+            "youtube-content",
+            body='Run `${HERMES_SKILL_DIR}/scripts/fetch_transcript.py`.',
+            category="media",
+        )
+        script = bundled_skills / "media" / "youtube-content" / "scripts" / "fetch_transcript.py"
+        script.parent.mkdir(parents=True)
+        script.write_text("print('ok')\n")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+            patch("agent.skill_utils.get_bundled_skills_dir", return_value=bundled_skills),
+        ):
+            result = scan_skill_commands()
+
+        assert "/youtube-content" in result
+        assert result["/youtube-content"]["skill_dir"] == str(
+            bundled_skills / "media" / "youtube-content"
+        )
+
+    def test_bundled_fallback_respects_deleted_manifest_entry(self, tmp_path):
+        """A user-deleted bundled skill should stay hidden when the manifest tracks it."""
+        local_skills = tmp_path / "home" / "skills"
+        local_skills.mkdir(parents=True)
+        (local_skills / ".bundled_manifest").write_text("youtube-content:abc123\n")
+        bundled_skills = tmp_path / "install" / "skills"
+        _make_skill(bundled_skills, "youtube-content", category="media")
+
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+            patch("agent.skill_utils.get_bundled_skills_dir", return_value=bundled_skills),
+        ):
+            result = scan_skill_commands()
+
+        assert "/youtube-content" not in result
 
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.
@@ -327,7 +374,13 @@ class TestScanSkillCommands:
 
     def test_allspecial_name_skipped(self, tmp_path):
         """Skill with name consisting only of special chars is silently skipped."""
-        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+            patch(
+                "agent.skill_utils.get_bundled_skills_dir",
+                return_value=tmp_path / "no-bundled-skills",
+            ),
+        ):
             skill_dir = tmp_path / "bad-name"
             skill_dir.mkdir()
             (skill_dir / "SKILL.md").write_text(

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -56,6 +56,16 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
     return external_category
 
 
+@pytest.fixture(autouse=True)
+def _disable_bundled_skill_fallback_for_unit_tests(tmp_path):
+    """Keep legacy unit tests scoped to their patched SKILLS_DIR trees."""
+    with patch(
+        "agent.skill_utils.get_bundled_skills_dir",
+        return_value=tmp_path / "no-bundled-skills",
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # _parse_frontmatter
 # ---------------------------------------------------------------------------

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -454,8 +454,11 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     # then fall back to external dirs from config.
     dirs_to_check = [SKILLS_DIR]
     try:
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_bundled_skills_dir, get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
+        bundled_dir = get_bundled_skills_dir()
+        if bundled_dir.exists():
+            dirs_to_check.append(bundled_dir)
     except Exception:
         pass
     for skills_dir in dirs_to_check:
@@ -467,6 +470,36 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
         except ValueError:
             continue
     return None
+
+
+def _is_within_dir(path: Path, root: Path | None) -> bool:
+    if root is None:
+        return False
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _read_skill_name_for_path(skill_md: Path) -> str:
+    try:
+        content = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+        frontmatter, _ = _parse_frontmatter(content)
+        return str(frontmatter.get("name") or skill_md.parent.name)
+    except Exception:
+        return skill_md.parent.name
+
+
+def _skip_bundled_fallback_skill(
+    skill_md: Path,
+    bundled_dir: Path | None,
+    manifest_names: Set[str],
+) -> bool:
+    """Respect explicit local deletions while using bundled skills as fallback."""
+    if not manifest_names or not _is_within_dir(skill_md, bundled_dir):
+        return False
+    return _read_skill_name_for_path(skill_md) in manifest_names
 
 
 def _parse_tags(tags_value) -> List[str]:
@@ -557,7 +590,12 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import (
+        get_bundled_manifest_names,
+        get_bundled_skills_dir,
+        get_skill_search_dirs,
+        iter_skill_index_files,
+    )
 
     skills = []
     seen_names: set = set()
@@ -565,15 +603,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    # Scan local dir first, then external dirs, then read-only bundled fallback
+    # for Docker/package installs where the active HERMES_HOME was not seeded.
+    dirs_to_scan = get_skill_search_dirs(SKILLS_DIR, include_bundled_fallback=True)
+    bundled_dir = get_bundled_skills_dir()
+    manifest_names = get_bundled_manifest_names(SKILLS_DIR)
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+                continue
+            if _skip_bundled_fallback_skill(skill_md, bundled_dir, manifest_names):
                 continue
 
             skill_dir = skill_md.parent
@@ -936,13 +976,18 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import (
+            get_bundled_manifest_names,
+            get_bundled_skills_dir,
+            get_skill_search_dirs,
+        )
 
-        # Build list of all skill directories to search
-        all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        # Build list of all skill directories to search.  The bundled install
+        # tree is a read-only fallback for packaged/Docker installs whose
+        # active HERMES_HOME was not seeded with user copies.
+        all_dirs = get_skill_search_dirs(SKILLS_DIR, include_bundled_fallback=True)
+        bundled_dir = get_bundled_skills_dir()
+        manifest_names = get_bundled_manifest_names(SKILLS_DIR)
 
         if not all_dirs:
             return json.dumps(
@@ -961,19 +1006,43 @@ def skill_view(
             # Try direct path first (e.g., "mlops/axolotl")
             direct_path = search_dir / name
             if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
+                if _skip_bundled_fallback_skill(
+                    direct_path / "SKILL.md",
+                    bundled_dir,
+                    manifest_names,
+                ):
+                    continue
                 skill_dir = direct_path
                 skill_md = direct_path / "SKILL.md"
                 break
             elif direct_path.with_suffix(".md").exists():
+                if _skip_bundled_fallback_skill(
+                    direct_path.with_suffix(".md"),
+                    bundled_dir,
+                    manifest_names,
+                ):
+                    continue
                 skill_md = direct_path.with_suffix(".md")
                 break
             if local_category_name:
                 categorized_path = search_dir / local_category_name
                 if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
+                    if _skip_bundled_fallback_skill(
+                        categorized_path / "SKILL.md",
+                        bundled_dir,
+                        manifest_names,
+                    ):
+                        continue
                     skill_dir = categorized_path
                     skill_md = categorized_path / "SKILL.md"
                     break
                 elif categorized_path.with_suffix(".md").exists():
+                    if _skip_bundled_fallback_skill(
+                        categorized_path.with_suffix(".md"),
+                        bundled_dir,
+                        manifest_names,
+                    ):
+                        continue
                     skill_md = categorized_path.with_suffix(".md")
                     break
 
@@ -983,6 +1052,12 @@ def skill_view(
                 from agent.skill_utils import iter_skill_index_files
 
                 for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    if _skip_bundled_fallback_skill(
+                        found_skill_md,
+                        bundled_dir,
+                        manifest_names,
+                    ):
+                        continue
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md
@@ -995,6 +1070,12 @@ def skill_view(
             for search_dir in all_dirs:
                 for found_md in search_dir.rglob(f"{name}.md"):
                     if found_md.name != "SKILL.md":
+                        if _skip_bundled_fallback_skill(
+                            found_md,
+                            bundled_dir,
+                            manifest_names,
+                        ):
+                            continue
                         skill_md = found_md
                         break
                 if skill_md:
@@ -1530,4 +1611,3 @@ registry.register(
     check_fn=check_skills_requirements,
     emoji="📚",
 )
-

--- a/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
+++ b/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
@@ -40,20 +40,20 @@ pip install youtube-transcript-api
 
 ## Helper Script
 
-`SKILL_DIR` is the directory containing this SKILL.md file. The script accepts any standard YouTube URL format, short links (youtu.be), shorts, embeds, live links, or a raw 11-character video ID.
+`${HERMES_SKILL_DIR}` is the directory containing this SKILL.md file. The script accepts any standard YouTube URL format, short links (youtu.be), shorts, embeds, live links, or a raw 11-character video ID.
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+python3 ${HERMES_SKILL_DIR}/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats


### PR DESCRIPTION
## What does this PR do?

Fixes bundled skills in Docker/package-style installs where the active `HERMES_HOME` does not have a synced `skills/` copy, but the bundled install tree still contains the skill files.

Before this change, `skill_view("youtube-content")` and `/youtube-content` could fail or hand the model a dead skill directory when Docker seeded skills under a different user/home than the runtime agent. This makes the bundled install tree a read-only fallback after profile skills and configured external skill dirs, so bundled skills still work out of the box.

The fallback preserves existing precedence and user intent:

- active profile skills still win
- configured `skills.external_dirs` still work
- bundled install files are only the final fallback
- manifest-tracked local deletions are still respected and not resurrected

It also updates the YouTube bundled skill to use `${HERMES_SKILL_DIR}` instead of the literal placeholder `SKILL_DIR`, so Hermes substitutes the real absolute skill path before the model sees the script commands.

## Related Issue

N/A. Reported from Discord support: bundled `youtube-content` skill was unusable in Docker because the synced profile skill path did not exist.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/skill_utils.py`: add helpers for bundled skill directory discovery, bundled manifest names, and ordered skill search dirs.
- `tools/skills_tool.py`: include the bundled install tree as a read-only fallback for skill listing and `skill_view`, while respecting manifest-tracked local deletions.
- `agent/skill_commands.py`: include the same bundled fallback in slash skill command discovery.
- `skills/media/youtube-content/SKILL.md`: replace literal `SKILL_DIR` examples with `${HERMES_SKILL_DIR}`.
- `website/docs/user-guide/skills/bundled/media/media-youtube-content.md`: mirror the YouTube skill docs update.
- `tests/agent/test_external_skills.py`: add coverage for bundled fallback `skill_view` and deleted-skill opt-out.
- `tests/agent/test_skill_commands.py`: add coverage for slash command discovery from bundled fallback and deleted-skill opt-out.
- `tests/tools/test_skills_tool.py`: keep existing unit tests scoped to their patched local skill trees now that bundled fallback discovery exists.

## How to Test

1. Run the targeted regression tests:
   `python -m pytest -n 0 -q tests/agent/test_external_skills.py::TestExternalSkillView::test_skill_view_falls_back_to_bundled_install_tree tests/agent/test_external_skills.py::TestExternalSkillView::test_skill_view_does_not_resurrect_deleted_bundled_skill tests/agent/test_skill_commands.py::TestScanSkillCommands::test_finds_bundled_fallback_when_local_skills_unseeded tests/agent/test_skill_commands.py::TestScanSkillCommands::test_bundled_fallback_respects_deleted_manifest_entry tests/skills/test_fetch_transcript.py`
2. Confirm `skill_view("youtube-content")` succeeds when the active local skills dir is empty and bundled skills exist under the install tree.
3. Confirm a manifest-tracked deleted bundled skill remains hidden instead of being resurrected from the fallback tree.

Validation performed:

- `17 passed in 0.89s` for targeted bundled fallback + YouTube transcript coverage.
- `82 passed in 2.61s` for `tests/tools/test_skills_tool.py` plus the key bundled fallback regressions, via `scripts/run_tests.sh`.
- `python -m py_compile agent/skill_utils.py agent/skill_commands.py tools/skills_tool.py`
- Full suite via `scripts/run_tests.sh` on PR head `f4336018b`: failed, `67 failed, 22131 passed, 59 skipped, 19 errors in 584.53s (0:09:44)`.

Full-suite notes:

- The PR-related `tests/tools/test_skills_tool.py` failure cluster from the first full run was fixed before the final full-suite run above.
- The remaining full-suite errors include `tests/tools/test_browser_supervisor.py` teardown failures where the live-system guard blocks `os.kill(..., SIGTERM)` for Chrome PIDs started by the tests.
- Remaining failures are spread across existing CLI/gateway/process/timeout/provider areas and are not specific to bundled skill fallback.
- `HERMES_HOME` was unset before and after the full-suite run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A. This fixes loading for an existing bundled skill.

## Screenshots / Logs

Targeted test output:

```text
.................                                                        [100%]
17 passed in 0.89s
```

Full-suite output:

```text
= 67 failed, 22131 passed, 59 skipped, 240 warnings, 19 errors in 584.53s (0:09:44) =
```
