### PR TITLE
fix(docs): repair malformed Voice & TTS table in integrations overview

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -56,12 +56,12 @@ See [Browser Automation](/docs/user-guide/features/browser) for setup and usage.
 Text-to-speech and speech-to-text across all messaging platforms:
 
 | Provider | Quality | Cost | API Key |
-||----------|---------|------|---------|
-|| **Edge TTS** (default) | Good | Free | None needed |
-|| **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
-|| **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
-|| **MiniMax** | Good | Paid | `MINIMAX_API_KEY` |
-|| **NeuTTS** | Good | Free | None needed |
+|----------|---------|------|---------|
+| **Edge TTS** (default) | Good | Free | None needed |
+| **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
+| **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
+| **MiniMax** | Good | Paid | `MINIMAX_API_KEY` |
+| **NeuTTS** | Good | Free | None needed |
 
 Speech-to-text supports six providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, OpenAI Whisper API, Mistral, and xAI. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/docs/user-guide/features/tts) and [Voice Mode](/docs/user-guide/features/voice-mode) for details.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a malformed markdown table in the Integrations overview doc. The "Voice & TTS Providers" table had stray leading double-pipes (`||`) on its separator row and every data row, which broke rendering in Docusaurus — readers saw an extra empty leading column and misaligned cells. Changing each `||` to `|` restores a properly-aligned 4-column table.


## Related Issue

fixes https://github.com/NousResearch/hermes-agent/issues/24101

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/integrations/index.md` — replaced leading `||` with `|` on the Voice & TTS table separator and 5 data rows (lines 59–64).

## How to Test

1. `cd website && npm install && npm start`
2. Open `http://localhost:3000/docs/integrations` and scroll to "Voice & TTS Providers".
3. Confirm the table renders as 4 columns (Provider / Quality / Cost / API Key) with no empty leading column or misaligned rows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — markdown-only change -->
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) <!-- N/A — docs only -->
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — `cli-config.yaml.example` (no config changes)
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md` (no architecture changes)
- [x] N/A — cross-platform impact (markdown-only)
- [x] N/A — tool descriptions/schemas (no tool changes)

## Screenshots / Logs

Before — note the empty leading column produced by `||`:

| | Provider | Quality | Cost | API Key |
|---|---|---|---|---|
| | **Edge TTS** (default) | Good | Free | None needed |

After:

| Provider | Quality | Cost | API Key |
|---|---|---|---|
| **Edge TTS** (default) | Good | Free | None needed |
