### PR TITLE
fix(tools): log unknown toolsets in quiet mode

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -384,8 +384,14 @@ def _compute_tool_definitions(
                 tools_to_include.update(legacy_tools)
                 if not quiet_mode:
                     print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                if quiet_mode:
+                    logger.warning(
+                        "Unknown toolset in enabled_toolsets: %s",
+                        toolset_name,
+                    )
+                else:
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
         # Default: start with everything
         from toolsets import get_all_toolsets
@@ -432,8 +438,14 @@ def _compute_tool_definitions(
                 tools_to_include.difference_update(legacy_tools)
                 if not quiet_mode:
                     print(f"🚫 Disabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
-            elif not quiet_mode:
-                print(f"⚠️  Unknown toolset: {toolset_name}")
+            else:
+                if quiet_mode:
+                    logger.warning(
+                        "Unknown toolset in disabled_toolsets: %s",
+                        toolset_name,
+                    )
+                else:
+                    print(f"⚠️  Unknown toolset: {toolset_name}")
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -592,11 +592,13 @@ class TestDisabledToolsetsPostureToolset:
 
 class TestUnknownToolsetDiagnostics:
     def test_enabled_unknown_logs_in_quiet_mode(self, caplog):
-        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from model_tools import _compute_tool_definitions
 
-        _clear_tool_defs_cache()
-        with caplog.at_level(logging.WARNING, logger="model_tools"):
-            get_tool_definitions(
+        with (
+            patch("model_tools.registry.get_definitions", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+        ):
+            _compute_tool_definitions(
                 enabled_toolsets=["definitely-missing-toolset"],
                 quiet_mode=True,
             )
@@ -607,11 +609,13 @@ class TestUnknownToolsetDiagnostics:
         )
 
     def test_disabled_unknown_logs_in_quiet_mode(self, caplog):
-        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from model_tools import _compute_tool_definitions
 
-        _clear_tool_defs_cache()
-        with caplog.at_level(logging.WARNING, logger="model_tools"):
-            get_tool_definitions(
+        with (
+            patch("model_tools.registry.get_definitions", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+        ):
+            _compute_tool_definitions(
                 enabled_toolsets=[],
                 disabled_toolsets=["definitely-missing-toolset"],
                 quiet_mode=True,
@@ -623,11 +627,13 @@ class TestUnknownToolsetDiagnostics:
         )
 
     def test_known_toolsets_do_not_log_unknown_warning(self, caplog):
-        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from model_tools import _compute_tool_definitions
 
-        _clear_tool_defs_cache()
-        with caplog.at_level(logging.WARNING, logger="model_tools"):
-            get_tool_definitions(
+        with (
+            patch("model_tools.registry.get_definitions", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="model_tools"),
+        ):
+            _compute_tool_definitions(
                 enabled_toolsets=["terminal"],
                 disabled_toolsets=["file"],
                 quiet_mode=True,

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,6 +1,7 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
+import logging
 from unittest.mock import ANY, call, patch
 
 
@@ -587,3 +588,49 @@ class TestDisabledToolsetsPostureToolset:
             )
         }
         assert "write_file" not in no_file
+
+
+class TestUnknownToolsetDiagnostics:
+    def test_enabled_unknown_logs_in_quiet_mode(self, caplog):
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+        _clear_tool_defs_cache()
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            get_tool_definitions(
+                enabled_toolsets=["definitely-missing-toolset"],
+                quiet_mode=True,
+            )
+
+        assert (
+            "Unknown toolset in enabled_toolsets: definitely-missing-toolset"
+            in caplog.messages
+        )
+
+    def test_disabled_unknown_logs_in_quiet_mode(self, caplog):
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+        _clear_tool_defs_cache()
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            get_tool_definitions(
+                enabled_toolsets=[],
+                disabled_toolsets=["definitely-missing-toolset"],
+                quiet_mode=True,
+            )
+
+        assert (
+            "Unknown toolset in disabled_toolsets: definitely-missing-toolset"
+            in caplog.messages
+        )
+
+    def test_known_toolsets_do_not_log_unknown_warning(self, caplog):
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+
+        _clear_tool_defs_cache()
+        with caplog.at_level(logging.WARNING, logger="model_tools"):
+            get_tool_definitions(
+                enabled_toolsets=["terminal"],
+                disabled_toolsets=["file"],
+                quiet_mode=True,
+            )
+
+        assert not any("Unknown toolset" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- Emit a warning when enabled_toolsets contains an unknown entry while quiet_mode is enabled.
- Emit the same targeted warning for unknown disabled_toolsets entries.
- Preserve the existing interactive console warning when quiet_mode is disabled.
- Do not add new MCP alias or Cron resolution behavior.

## Scope correction
The original Cron MCP-availability gap is already fixed on current main by 74a5905ae. The previous server:tool and mcp:server normalization changes have therefore been removed.

Current behavior remains explicit:
- server:tool selection is persisted under mcp_servers.<server>.tools configuration.
- MCP server toolset references use the existing registered alias / mcp-<server> contract.
- Cron already merges enabled MCP servers into per-job toolset allowlists.

This PR now addresses only the remaining observability gap: background agents commonly use quiet_mode=True, so an invalid toolset entry was silently ignored and could make scheduled tasks lose tools without leaving an actionable diagnostic.

## Tests
- Added coverage for unknown enabled and disabled toolsets under quiet mode.
- Added a no-false-positive case for known toolsets.
- tests/test_model_tools.py: 35 passed.
- CLI MCP persistence + Cron MCP merge + model-tools coverage: 60 passed.