### PR TITLE
fix(gateway): remove stale os.environ HERMES_SESSION_KEY write that leaks session key across concurrent gateway sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14645,9 +14645,11 @@ class GatewayRunner:
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
-            # session_key is now set via contextvars in _set_session_env()
-            # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
-            os.environ["HERMES_SESSION_KEY"] = session_key or ""
+            # session_key is set via contextvars in _set_session_env()
+            # (concurrency-safe). Removing the os.environ write prevents stale
+            # key leakage into tool threads spawned by other concurrent sessions.
+            # The approval system (set_current_session_key at _run_agent) and
+            # get_session_env() fallback provide correct session routing.
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))


### PR DESCRIPTION
## Problem

When running Hermes via the Discord gateway (or any multi-thread gateway), command approval prompts are routed to the wrong thread. See issue #24100 for full details.

**Root cause:** `gateway/run.py` writes the current session key to the process-global `os.environ` on every `_run_agent()` call:

```python
os.environ["HERMES_SESSION_KEY"] = session_key or ""
```

Because `os.environ` is process-global, concurrent gateway sessions overwrite each other's value. When a tool thread (`run_in_executor`, `ThreadPoolExecutor` for subagents) encounters a dangerous command, `get_current_session_key()` cannot inherit the correct contextvar and falls back to `os.environ` — receiving whichever session key was written last.

## Fix

Removes the `os.environ["HERMES_SESSION_KEY"]` write. The contextvar-based session state (`gateway/session_context`) already provides concurrency-safe session isolation. The approval-specific `_approval_session_key` contextvar is set at `_run_agent` via `set_current_session_key()`.

**Why it's safe to remove:**
- Gateway sessions: contextvars properly isolate per-task session state
- CLI/cron: this code path (`GatewayRunner._run_agent`) is gateway-only
- `get_session_env()` still falls back to `os.environ` for `_UNSET` contextvars (CLI/cron/test compat), but no longer receives a stale gateway-pinned value
- All existing tests pass (21 approve/deny tests, 12 session_env tests, 154 approval tests, and the full gateway test suite) — only pre-existing failures unrelated to this change

## Testing

- `tests/gateway/test_approve_deny_commands.py`: 21 passed ✅
- `tests/gateway/test_session_env.py`: 12 passed ✅
- `tests/tools/test_approval.py`: 154 passed ✅
- `tests/gateway/` (full suite): 2192 passed, 2 pre-existing failures (unrelated: `test_config.py` and `test_api_server.py`)

Closes #24100
