### PR TITLE
fix(cli): @-file completion crashes the input loop on Windows when filenames aren't cp1252-decodable

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1359,9 +1359,9 @@ class SlashCommandCompleter(Completer):
             try:
                 proc = subprocess.run(
                     cmd, capture_output=True, text=True, timeout=2,
-                    cwd=cwd,
+                    cwd=cwd, encoding="utf-8", errors="replace",
                 )
-                if proc.returncode == 0 and proc.stdout.strip():
+                if proc.returncode == 0 and proc.stdout and proc.stdout.strip():
                     raw = proc.stdout.strip().split("\n")
                     # Store relative paths
                     for p in raw[:5000]:


### PR DESCRIPTION
## Problem

On Windows, typing `@<query>` in the Hermes CLI to attach a project file would sometimes crash the prompt_toolkit event loop with:

```
Exception in thread Thread-XX (_readerthread):
  UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position ...
  ...
Unhandled exception in event loop:
  File ".../hermes_cli/commands.py", line 1364, in _get_project_files
    if proc.returncode == 0 and proc.stdout.strip():
                                ^^^^^^^^^^^^^^^^^
Exception 'NoneType' object has no attribute 'strip'
Press ENTER to continue...
```

After the crash, the input box becomes unusable until the `@` query is cleared.

## Root cause

`SlashCommandCompleter._get_project_files()` shells out to `rg --files` via `subprocess.run(..., text=True)`. On Windows, Python 3.13 picks the system ANSI codepage (cp1252 on en-US) for decoding stdout. If any file under cwd has a name containing bytes that aren't valid in cp1252 (common with files copied from non-Windows sources, archived game assets, characters outside Latin-1, etc.), the **background reader thread** that subprocess uses to drain stdout dies with `UnicodeDecodeError`.

That exception happens off the main thread and is effectively swallowed — `subprocess.run` returns normally but with `proc.stdout = None`. The next line dereferences `.strip()` on `None` and the AttributeError propagates up into prompt_toolkit's completer coroutine, taking down the event loop.

## Fix

Two small changes in `hermes_cli/commands.py`:

1. **Force UTF-8 decoding.** `rg --files` emits UTF-8 on every platform, so pinning `encoding="utf-8", errors="replace"` makes the decode deterministic and tolerant of stray bytes.
2. **Defensive `None` guard.** Even if some future subprocess failure leaves `proc.stdout` unset, the completer now skips that candidate command instead of crashing the input loop.

```diff
             try:
                 proc = subprocess.run(
                     cmd, capture_output=True, text=True, timeout=2,
-                    cwd=cwd,
+                    cwd=cwd, encoding="utf-8", errors="replace",
                 )
-                if proc.returncode == 0 and proc.stdout.strip():
+                if proc.returncode == 0 and proc.stdout and proc.stdout.strip():
                     raw = proc.stdout.strip().split("\n")
```

## Repro

On Windows (cp1252 default codepage), in a directory containing a file with a non-cp1252 byte in its name:

1. Launch `hermes`.
2. Type `@` and start typing a query.
3. Crash as above.

After the fix, completions list normally; non-decodable bytes render as the Unicode replacement char in the displayed path.

## Risk

Minimal. The change is constrained to file-listing inside the completer. `errors="replace"` only affects display strings — paths with truly weird bytes may not match a fuzzy query perfectly, but that is strictly better than killing the input loop.

## Tested on

Windows 11, Python 3.13.3, fresh `hermes` install with a cwd containing files with cp1252-unmappable bytes. With the patch, `@` completion works without throwing.
