### PR TITLE
fix(docs): correct broken internal links to webhooks and mlops skill pages

### DIFF
--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -233,7 +233,7 @@ Silent when both filesystems are under 90%; fires exactly one line per over-thre
 |----------|-----------|-------------|
 | `cronjob --no-agent` (this page) | Your script on Hermes' schedule | Recurring watchdogs / alerts / metrics that don't need reasoning |
 | `cronjob` (default, LLM) | Agent with optional pre-check script | When the message content requires reasoning over data |
-| OS cron + `curl` to a [webhook subscription](/docs/user-guide/features/webhooks) | Your script on the OS schedule | When Hermes might be unhealthy (the thing you're monitoring) |
+| OS cron + `curl` to a [webhook subscription](/docs/user-guide/messaging/webhooks) | Your script on the OS schedule | When Hermes might be unhealthy (the thing you're monitoring) |
 
 For critical system-health watchdogs that must fire *even when the gateway is down*, use OS-level cron with a plain `curl` to a Hermes webhook subscription (or any external alerting endpoint) — those run as independent OS processes and don't depend on Hermes being up. The in-gateway scheduler is the right choice when the thing being monitored is external.
 
@@ -241,5 +241,5 @@ For critical system-health watchdogs that must fire *even when the gateway is do
 
 - [Automate Anything with Cron](/docs/guides/automate-with-cron) — LLM-driven cron patterns.
 - [Scheduled Tasks (Cron) reference](/docs/user-guide/features/cron) — full schedule syntax, lifecycle, delivery routing.
-- [Webhook Subscriptions](/docs/user-guide/features/webhooks) — fire-and-forget HTTP entry points for external schedulers.
+- [Webhook Subscriptions](/docs/user-guide/messaging/webhooks) — fire-and-forget HTTP entry points for external schedulers.
 - [Gateway Internals](/docs/developer-guide/gateway-internals) — delivery-router internals.

--- a/website/docs/user-guide/skills/optional/mlops/mlops-hermes-atropos-environments.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-hermes-atropos-environments.md
@@ -21,7 +21,7 @@ Build, test, and debug Hermes Agent RL environments for Atropos training. Covers
 | License | MIT |
 | Platforms | linux, macos, windows |
 | Tags | `atropos`, `rl`, `environments`, `training`, `reinforcement-learning`, `reward-functions` |
-| Related skills | [`axolotl`](/docs/user-guide/skills/bundled/mlops/mlops-training-axolotl), [`fine-tuning-with-trl`](/docs/user-guide/skills/bundled/mlops/mlops-training-trl-fine-tuning), `lm-evaluation-harness` |
+| Related skills | [`axolotl`](/docs/user-guide/skills/optional/mlops/mlops-training-axolotl), [`fine-tuning-with-trl`](/docs/user-guide/skills/optional/mlops/mlops-training-trl-fine-tuning), `lm-evaluation-harness` |
 
 ## Reference: full SKILL.md
 


### PR DESCRIPTION
## What does this PR do?

Fixes three broken internal `/docs/...` links across the documentation site. Each one points to a path that no longer matches where the file lives, so readers land on the Docusaurus 404 page when they click through.

- **`cron-script-only.md`** had two links to `/docs/user-guide/features/webhooks`, but the webhooks page lives at `/docs/user-guide/messaging/webhooks` (file: `website/docs/user-guide/messaging/webhooks.md`).
- **`mlops-hermes-atropos-environments.md`** linked to `/docs/user-guide/skills/bundled/mlops/mlops-training-axolotl` and `/docs/user-guide/skills/bundled/mlops/mlops-training-trl-fine-tuning`, but both related-skill pages live under `skills/optional/mlops/`, not `skills/bundled/mlops/`.

Verified by directory listing (`find website/docs -iname "*webhooks*"`, `find website/docs -iname "*axolotl*"`) — these are the only matching files in the docs tree.

## Related Issue

fixes https://github.com/NousResearch/hermes-agent/issues/24108
## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/guides/cron-script-only.md` (lines 236, 244) — `/docs/user-guide/features/webhooks` → `/docs/user-guide/messaging/webhooks` (×2)
- `website/docs/user-guide/skills/optional/mlops/mlops-hermes-atropos-environments.md` (line 24) — `/docs/user-guide/skills/bundled/mlops/` → `/docs/user-guide/skills/optional/mlops/` (×2, for `mlops-training-axolotl` and `mlops-training-trl-fine-tuning`)

Total: 3 lines changed across 2 files.

## How to Test

1. `cd website && npm install && npm start`
2. Open `http://localhost:3000/docs/guides/cron-script-only` and click both **webhook subscription** links — each should land on the Webhooks messaging page rather than the 404 page.
3. Open `http://localhost:3000/docs/user-guide/skills/optional/mlops/mlops-hermes-atropos-environments`, scroll to the **Related skills** row at the top, and click both `axolotl` and `fine-tuning-with-trl` — each should land on the corresponding skill page under `skills/optional/mlops/` instead of the 404 page.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A — markdown-only change -->
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) <!-- N/A — docs only -->
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A — `cli-config.yaml.example` (no config changes)
- [x] N/A — `CONTRIBUTING.md` / `AGENTS.md` (no architecture changes)
- [x] N/A — cross-platform impact (markdown-only)
- [x] N/A — tool descriptions/schemas (no tool changes)

## Screenshots / Logs

Diff:

```
 website/docs/guides/cron-script-only.md                                | 4 ++--
 .../skills/optional/mlops/mlops-hermes-atropos-environments.md         | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)