### PR TITLE
[codex] fix installer launcher symlink overwrite

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1119,16 +1119,24 @@ setup_path() {
     command_link_display_dir="$(get_command_link_display_dir)"
 
     # Create a user-facing shim for the hermes command.
-    # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
-    # can't make this launcher import modules from another checkout.
+    # Write via a temp file + mv instead of redirecting directly to the final
+    # path. Some older installs used ~/.local/bin/hermes as a symlink to the
+    # venv entry point; shell redirection follows that symlink and overwrites
+    # the real entry point with a self-referential shim.
     mkdir -p "$command_link_dir"
-    cat > "$command_link_dir/hermes" <<EOF
+    local command_link_path
+    local command_link_tmp
+    command_link_path="$command_link_dir/hermes"
+    command_link_tmp="$(mktemp "$command_link_dir/.hermes.XXXXXX")"
+
+    cat > "$command_link_tmp" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
 exec "$HERMES_BIN" "\$@"
 EOF
-    chmod +x "$command_link_dir/hermes"
+    chmod +x "$command_link_tmp"
+    mv -f "$command_link_tmp" "$command_link_path"
     log_success "Installed hermes launcher → $command_link_display_dir/hermes"
 
     if [ "$DISTRO" = "termux" ]; then


### PR DESCRIPTION
## Summary

- write the user-facing `hermes` launcher through a temporary file before moving it into place
- avoid direct shell redirection to `~/.local/bin/hermes`, which follows pre-existing symlinks
- document why the launcher write needs to be symlink-safe

## Root Cause

Older installs may have `~/.local/bin/hermes` as a symlink to the virtualenv entry point at `~/.hermes/hermes-agent/venv/bin/hermes`. The installer currently writes the user-facing shim with `cat > "$command_link_dir/hermes"`, and shell redirection follows that symlink.

That can overwrite the venv entry point with a shim that executes the venv entry point itself, producing a self-referential launcher loop:

```bash
exec "$INSTALL_DIR/venv/bin/hermes" "$@"
```

After reinstalling, `hermes version`, `hermes status`, and the interactive CLI can appear to hang or flicker because the command never reaches Python.

## Validation

- `bash -n scripts/install.sh`
- local reproduction using a temporary `~/.local/bin/hermes`-style symlink confirmed that the venv entry point remains unchanged and the command launcher becomes a regular file
