### PR TITLE
fix(cli): preserve custom fallback runtime overrides

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3772,8 +3772,19 @@ class HermesCLI:
                     _fb_model = (_fb.get("model") or "").strip()
                     if not _fb_provider or not _fb_model:
                         continue
+                    _fb_base_url = (_fb.get("base_url") or "").strip() or None
+                    _fb_api_key = (_fb.get("api_key") or "").strip() or None
+                    if not _fb_api_key:
+                        _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
+                        if _fb_key_env:
+                            _fb_api_key = os.getenv(_fb_key_env, "").strip() or None
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        runtime = resolve_runtime_provider(
+                            requested=_fb_provider,
+                            explicit_api_key=_fb_api_key,
+                            explicit_base_url=_fb_base_url,
+                            target_model=_fb_model,
+                        )
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -61,7 +61,7 @@ class CLIAgentSetupMixin:
                     try:
                         from hermes_cli.fallback_config import resolve_entry_api_key
 
-                        _fb_kwargs = {"requested": _fb_provider}
+                        _fb_kwargs = {"requested": _fb_provider, "target_model": _fb_model}
                         if _fb.get("base_url"):
                             _fb_kwargs["explicit_base_url"] = _fb["base_url"]
                         _fb_api_key = resolve_entry_api_key(_fb)

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -115,6 +115,8 @@ def _import_cli():
 
     if "firecrawl" not in sys.modules:
         sys.modules["firecrawl"] = types.SimpleNamespace(Firecrawl=object)
+    if "fire" not in sys.modules:
+        sys.modules["fire"] = types.SimpleNamespace(Fire=lambda *args, **kwargs: None)
 
     try:
         importlib.import_module("prompt_toolkit")
@@ -198,6 +200,49 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.agent is None
     assert shell.provider == "openai-codex"
     assert shell.api_mode == "codex_responses"
+
+
+def test_primary_auth_failure_custom_fallback_preserves_explicit_base_url(monkeypatch):
+    cli = _import_cli()
+    monkeypatch.setenv("FALLBACK_CUSTOM_KEY", "fallback-secret")
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise AuthError("primary auth failed")
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": kwargs["explicit_base_url"],
+            "api_key": kwargs["explicit_api_key"],
+            "source": "direct-alias",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+
+    shell = cli.HermesCLI(model="claude-sonnet-4-6", compact=True, max_turns=1)
+    shell.requested_provider = "anthropic"
+    shell._fallback_model = [
+        {
+            "provider": "custom",
+            "model": "local-fallback-model",
+            "base_url": "http://127.0.0.1:8080/v1",
+            "api_key_env": "FALLBACK_CUSTOM_KEY",
+        }
+    ]
+
+    assert shell._ensure_runtime_credentials() is True
+    assert calls[1] == {
+        "requested": "custom",
+        "explicit_api_key": "fallback-secret",
+        "explicit_base_url": "http://127.0.0.1:8080/v1",
+        "target_model": "local-fallback-model",
+    }
+    assert shell.provider == "custom"
+    assert shell.base_url == "http://127.0.0.1:8080/v1"
+    assert shell.api_key == "fallback-secret"
 
 
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -260,6 +260,55 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
 
 
 
+def test_primary_auth_failure_custom_fallback_forwards_target_model(monkeypatch):
+    cli = _import_cli()
+    monkeypatch.setenv("FALLBACK_CUSTOM_KEY", "fallback-secret")
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise AuthError("primary auth failed")
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": kwargs["explicit_base_url"],
+            "api_key": kwargs["explicit_api_key"],
+            "source": "direct-alias",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _runtime_resolve,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.format_runtime_provider_error",
+        lambda exc: str(exc),
+    )
+
+    shell = cli.HermesCLI(model="claude-sonnet-4-6", compact=True, max_turns=1)
+    shell.requested_provider = "anthropic"
+    shell._fallback_model = [
+        {
+            "provider": "custom",
+            "model": "local-fallback-model",
+            "base_url": "http://127.0.0.1:8080/v1",
+            "api_key_env": "FALLBACK_CUSTOM_KEY",
+        }
+    ]
+
+    assert shell._ensure_runtime_credentials() is True
+    assert calls[1] == {
+        "requested": "custom",
+        "target_model": "local-fallback-model",
+        "explicit_api_key": "fallback-secret",
+        "explicit_base_url": "http://127.0.0.1:8080/v1",
+    }
+    assert shell.provider == "custom"
+    assert shell.base_url == "http://127.0.0.1:8080/v1"
+    assert shell.api_key == "fallback-secret"
+
+
 
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()


### PR DESCRIPTION
## What does this PR do?

Fixes the CLI's primary-auth-failure fallback path so `fallback_providers`
entries keep their runtime overrides.

When the primary provider fails credential resolution, `HermesCLI` tries the
configured fallback chain before giving up. That path previously called
`resolve_runtime_provider(requested=<fallback provider>)` without passing the
fallback entry's `base_url`, `api_key`, `key_env` / `api_key_env`, or target
model.

For `provider: custom`, that meant the resolver had no explicit custom endpoint
context. If the main `model.provider` was a named provider such as
`anthropic`, the bare `custom` fallback could resolve through the default
OpenRouter path instead of the configured custom endpoint.

This PR forwards the fallback entry's runtime fields into
`resolve_runtime_provider()` so `provider: custom` fallbacks use their explicit
`base_url` and credentials during CLI startup/auth failover.

## Related Issue

Fixes #24092

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `cli.py` so primary-auth-failure fallback resolution passes:
  - fallback `base_url` as `explicit_base_url`
  - fallback inline `api_key` or `key_env` / `api_key_env` as `explicit_api_key`
  - fallback model as `target_model`
- Add a regression test covering:
  - main requested provider is `anthropic`
  - primary runtime resolution raises `AuthError`
  - fallback entry is `provider: custom` with explicit `base_url`
  - fallback resolution receives the custom endpoint instead of falling through to OpenRouter
- Add a lightweight `fire` module stub in the CLI provider-resolution test helper so the targeted CLI import test can run in minimal test environments.

## How to Test

1. Run:
   `python3 -m py_compile cli.py tests/cli/test_cli_provider_resolution.py`
2. Run the focused regression:
   `PYTHONPATH=. uv run --no-project --with pytest --with pytest-xdist python -m pytest tests/cli/test_cli_provider_resolution.py::test_primary_auth_failure_custom_fallback_preserves_explicit_base_url -q -n0`
3. Run related fallback/runtime provider coverage:
   `PYTHONPATH=. uv run --no-project --with pytest --with pytest-xdist --with fire python -m pytest tests/run_agent/test_fallback_model.py tests/run_agent/test_provider_fallback.py tests/hermes_cli/test_runtime_provider_resolution.py -q -n0`

Local targeted results:

- `py_compile`: passed
- focused regression: `1 passed`
- fallback/runtime provider subset: `162 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (WSL-style dev environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted CLI fallback/runtime provider tests passed locally.
