### PR TITLE
fix(matrix): drop member-count DM fallback that misclassifies 2-person group rooms

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2516,21 +2516,14 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _is_dm_room(self, room_id: str) -> bool:
-        """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            return True
-        # Fallback: check member count via state store.
-        state_store = (
-            getattr(self._client, "state_store", None) if self._client else None
-        )
-        if state_store:
-            try:
-                members = await state_store.get_members(room_id)
-                if members and len(members) == 2:
-                    return True
-            except Exception:
-                pass
-        return False
+        """Check if a room is a DM via m.direct account data only.
+
+        Member-count is not consulted: a 2-member group room created via
+        Element's "Create a room" flow is not in m.direct and must not be
+        treated as a DM, otherwise MATRIX_REQUIRE_MENTION and group
+        auto-thread gating are silently disabled.
+        """
+        return self._dm_rooms.get(room_id, False)
 
     async def _refresh_dm_cache(self) -> None:
         """Refresh the DM room cache from m.direct account data."""

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -465,6 +465,47 @@ class TestMatrixDmDetection:
         assert self.adapter._dm_rooms["!room_b:ex.org"] is True
         assert self.adapter._dm_rooms["!room_c:ex.org"] is False
 
+    @pytest.mark.asyncio
+    async def test_is_dm_room_uses_m_direct_cache_only(self):
+        """A room flagged True in _dm_rooms is reported as DM."""
+        self.adapter._dm_rooms = {"!dm:ex.org": True}
+        assert await self.adapter._is_dm_room("!dm:ex.org") is True
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_two_member_group_is_not_dm(self):
+        """Regression for #24114: a 2-member group room (not in m.direct)
+        must not be classified as a DM via member-count fallback."""
+        self.adapter._dm_rooms = {"!group2:ex.org": False}
+
+        state_store = MagicMock()
+        state_store.get_members = AsyncMock(
+            return_value=["@alice:ex.org", "@bot:ex.org"]
+        )
+        mock_client = MagicMock()
+        mock_client.state_store = state_store
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!group2:ex.org") is False
+        state_store.get_members.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_unknown_room_defaults_to_false(self):
+        """Rooms missing from _dm_rooms (cache not refreshed yet) default to
+        not-DM. The conservative default keeps MATRIX_REQUIRE_MENTION effective
+        rather than silently disabling it via a member-count guess."""
+        self.adapter._dm_rooms = {}
+
+        state_store = MagicMock()
+        state_store.get_members = AsyncMock(
+            return_value=["@alice:ex.org", "@bot:ex.org"]
+        )
+        mock_client = MagicMock()
+        mock_client.state_store = state_store
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!unknown:ex.org") is False
+        state_store.get_members.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Reply fallback stripping


### PR DESCRIPTION
## Summary

- Make `m.direct` the only signal for `_is_dm_room`; drop the unsafe member-count fallback that was treating any 2-member room as a DM.
- Restores `MATRIX_REQUIRE_MENTION` and group auto-thread behavior in 2-person group rooms (rooms created via Element's "Create a room" flow that aren't in `m.direct`).
- Adds regression tests in `tests/gateway/test_matrix.py::TestMatrixDmDetection` exercising the state-store fallback path that the existing suite never touched.

## The bug

`gateway/platforms/matrix.py::_is_dm_room` previously fell back to a state-store member-count check when the `_dm_rooms` cache didn't already report the room as a DM:

```python
if self._dm_rooms.get(room_id, False):
    return True
state_store = getattr(self._client, "state_store", None) if self._client else None
if state_store:
    try:
        members = await state_store.get_members(room_id)
        if members and len(members) == 2:
            return True
    except Exception:
        pass
return False
```

Two compounding problems:

1. **False-positive DM classification.** A group room with exactly two members (you + bot) is not a DM, but the fallback returned `True` anyway. Downstream, `_resolve_message_context` uses `is_dm` as the sole gate for mention-checking and for choosing the thread-creation flag, so a single false-positive silently disabled two opt-in features at once:
   - `MATRIX_REQUIRE_MENTION=true` was ignored; the bot answered every message in the room.
   - `MATRIX_AUTO_THREAD=true` did not create a thread, because the DM branch uses `MATRIX_DM_AUTO_THREAD` (default `false`).
2. **Explicit negative cache entries were overridden.** `_refresh_dm_cache` writes `_dm_rooms[rid] = False` for every joined room not listed in `m.direct`. The prior code's `if self._dm_rooms.get(rid, False)` short-circuited on that falsy value and then the fallback reclassified the same room as DM by member count — defeating the m.direct refresh's authoritative negative answer.

## The fix

Make `m.direct` authoritative:

```python
async def _is_dm_room(self, room_id: str) -> bool:
    return self._dm_rooms.get(room_id, False)
```

`_join_room_by_id` already calls `_refresh_dm_cache` immediately after a successful join, so the cache is populated promptly for any room flagged as direct via `m.direct`. The conservative cache-miss default of `False` keeps `MATRIX_REQUIRE_MENTION` effective rather than silently disabling it via a member-count guess.

The reporter explicitly endorsed this approach in #24114 ("Cleanest and matches the strict-spec view"). The known trade-off — DMs whose inviter never wrote `m.direct` are classified as group rooms — degrades to a safer failure mode (the bot requires `@`-mention in those rooms) rather than the current bug's louder one (the bot replies to every message in group rooms it happens to share with one other user).

> Sibling code paths that may need the same fix: `_on_invite` in `gateway/platforms/matrix.py` could capture the invite event's `is_direct` flag and persist it into `_dm_rooms`, recovering the rare "DM where the inviting client never wrote `m.direct`" case. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

## Test plan

- [x] Focused regression test: `TestMatrixDmDetection` — added three tests, including the bug repro:
  - `test_is_dm_room_uses_m_direct_cache_only` (positive m.direct entry still classified as DM)
  - `test_is_dm_room_two_member_group_is_not_dm` (regression for #24114; 2-member room with `_dm_rooms[rid] = False` from m.direct refresh stays not-DM)
  - `test_is_dm_room_unknown_room_defaults_to_false` (cache miss defaults to not-DM rather than relying on state-store member count)
- [x] Adjacent suite: `tests/gateway/test_matrix.py` (197 tests pass) and `tests/gateway/test_matrix_mention.py` — no regressions.
- [x] Regression guard: reverting just the production change in `_is_dm_room` makes the two new regression tests fail with `assert True is False` (the fallback returns DM for the 2-member group), confirming the test exercises the buggy path.

## Related

- Fixes #24114.
- Adjacent PR #12803 (open since 2026-04-20) tightens the fallback into an "authoritative member count" check for fresh DM detection (issue #12614). It addresses the opposite direction — DMs that get classified as groups — and still reports DM for any 2-member room with authoritative state, so it does not fix #24114.