### PR TITLE
fix(claw): avoid false-positive OpenClaw process detection during cleanup

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -103,13 +103,21 @@ def _detect_openclaw_processes() -> list[str]:
             pass
     else:
         try:
-            result = subprocess.run(
-                ["pgrep", "-f", "openclaw"],
-                capture_output=True, text=True, timeout=3,
-            )
-            if result.returncode == 0:
-                pids = result.stdout.strip().split()
-                found.append(f"openclaw process(es) (PIDs: {', '.join(pids)})")
+            matched_pids: list[str] = []
+            for proc_name in ("openclaw", "clawd"):
+                result = subprocess.run(
+                    ["pgrep", "-x", proc_name],
+                    capture_output=True, text=True, timeout=3,
+                )
+                if result.returncode == 0:
+                    matched_pids.extend(
+                        pid for pid in result.stdout.strip().split() if pid
+                    )
+            if matched_pids:
+                deduped = list(dict.fromkeys(matched_pids))
+                found.append(
+                    f"openclaw process(es) (PIDs: {', '.join(deduped)})"
+                )
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -683,19 +683,26 @@ class TestPrintMigrationReport:
 
 
 class TestDetectOpenclawProcesses:
-    def test_returns_match_when_pgrep_finds_openclaw(self):
+    def test_returns_match_when_exact_pgrep_finds_openclaw(self):
         with patch.object(claw_mod, "sys") as mock_sys:
             mock_sys.platform = "linux"
             with patch.object(claw_mod, "subprocess") as mock_subprocess:
-                # systemd check misses, pgrep finds openclaw
+                # systemd check misses, exact-name pgrep finds openclaw
                 mock_subprocess.run.side_effect = [
                     MagicMock(returncode=1, stdout=""),  # systemctl
-                    MagicMock(returncode=0, stdout="1234\n"),  # pgrep
+                    MagicMock(returncode=0, stdout="1234\n"),  # pgrep -x openclaw
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x clawd
                 ]
                 mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
                 result = claw_mod._detect_openclaw_processes()
                 assert len(result) == 1
                 assert "1234" in result[0]
+                assert mock_subprocess.run.call_args_list[1].args[0] == [
+                    "pgrep", "-x", "openclaw",
+                ]
+                assert mock_subprocess.run.call_args_list[2].args[0] == [
+                    "pgrep", "-x", "clawd",
+                ]
 
     def test_returns_empty_when_pgrep_finds_nothing(self):
         with patch.object(claw_mod, "sys") as mock_sys:
@@ -703,7 +710,35 @@ class TestDetectOpenclawProcesses:
             with patch.object(claw_mod, "subprocess") as mock_subprocess:
                 mock_subprocess.run.side_effect = [
                     MagicMock(returncode=1, stdout=""),  # systemctl (not found)
-                    MagicMock(returncode=1, stdout=""),  # pgrep
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x openclaw
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x clawd
+                ]
+                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
+                result = claw_mod._detect_openclaw_processes()
+                assert result == []
+
+    def test_returns_match_when_exact_pgrep_finds_clawd(self):
+        with patch.object(claw_mod, "sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch.object(claw_mod, "subprocess") as mock_subprocess:
+                mock_subprocess.run.side_effect = [
+                    MagicMock(returncode=1, stdout=""),  # systemctl
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x openclaw
+                    MagicMock(returncode=0, stdout="4321\n"),  # pgrep -x clawd
+                ]
+                mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
+                result = claw_mod._detect_openclaw_processes()
+                assert len(result) == 1
+                assert "4321" in result[0]
+
+    def test_ignores_substring_only_false_positive_on_non_windows(self):
+        with patch.object(claw_mod, "sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch.object(claw_mod, "subprocess") as mock_subprocess:
+                mock_subprocess.run.side_effect = [
+                    MagicMock(returncode=1, stdout=""),  # systemctl
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x openclaw
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x clawd
                 ]
                 mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
                 result = claw_mod._detect_openclaw_processes()
@@ -715,7 +750,8 @@ class TestDetectOpenclawProcesses:
             with patch.object(claw_mod, "subprocess") as mock_subprocess:
                 mock_subprocess.run.side_effect = [
                     MagicMock(returncode=0, stdout="active\n"),  # systemctl
-                    MagicMock(returncode=1, stdout=""),  # pgrep
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x openclaw
+                    MagicMock(returncode=1, stdout=""),  # pgrep -x clawd
                 ]
                 mock_subprocess.TimeoutExpired = subprocess.TimeoutExpired
                 result = claw_mod._detect_openclaw_processes()


### PR DESCRIPTION
## Summary

`hermes claw cleanup` on Linux/macOS could report that OpenClaw was still running even when no real OpenClaw daemon existed. The root cause was `_detect_openclaw_processes()` using `pgrep -f openclaw`, which matches arbitrary command-line substrings instead of real executable names.

This PR tightens non-Windows process detection by checking exact process names (`openclaw` and `clawd`) so unrelated commands containing the string `openclaw` no longer trigger false positives during cleanup.

## Related Issue

Fixes #12648

## Type of Change

- [x] Bug fix

## Changes Made

- Replaced substring-based non-Windows process detection with exact-name matching in `hermes_cli/claw.py`
- Kept Windows behavior unchanged
- Added regression coverage for substring-only false positives
- Added coverage for exact `clawd` matches in `tests/hermes_cli/test_claw.py`

## Testing

- `.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_claw.py -q`
- `.\.venv\Scripts\python.exe -m pytest tests/hermes_cli/test_claw.py -q -k "DetectOpenclawProcesses or cleanup"`

## Result

- `50 passed`
- `16 passed` for the focused detection/cleanup subset
