### PR TITLE
fix(gateway): use sys.exit instead of raise SystemExit for graceful restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16828,7 +16828,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         pass
 
     if runner.exit_code is not None:
-        raise SystemExit(runner.exit_code)
+        sys.exit(runner.exit_code)
 
     # When an unexpected SIGTERM caused the shutdown and it wasn't a planned
     # restart (/restart, /update, SIGUSR1), exit non-zero so systemd's


### PR DESCRIPTION
## Problem\nWhen the gateway performs a graceful self-restart via SIGUSR1 (drain in-flight runs, then exit with code 75 for the service manager to relaunch), it currently uses:\n\n\n\nThis produces a full Python traceback in the logs every single time, making intentional restarts look like crashes and polluting error monitoring.\n\n## Fix\nReplace with:\n\n\n\nBoth exit with code 75 (sysexits.h EX_TEMPFAIL / GATEWAY_SERVICE_RESTART_EXIT_CODE), but sys.exit terminates cleanly with no traceback, matching the intended semantics of a service-manager-triggered restart.\n\n## Verification\n- Confirmed sys is already imported at the top of run.py.\n- Verified with py_compile that syntax is valid.\n