### PR TITLE
feat: add OpenRouter TTS to setup wizard

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -971,7 +971,7 @@ DEFAULT_CONFIG = {
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
     # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "openrouter" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -984,6 +984,13 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+        },
+        "openrouter": {
+            # OpenAI-compatible TTS via OpenRouter. Supports any TTS model
+            # routed through OpenRouter (openai/gpt-4o-mini-tts-2025-12-15, etc.)
+            "model": "openai/gpt-4o-mini-tts-2025-12-15",
+            "voice": "alloy",
+            # Voices vary by upstream provider — check OpenRouter model docs.
         },
         "xai": {
             "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
@@ -1018,13 +1025,18 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" | "openrouter" | "mistral" | "xai"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+        },
+        "openrouter": {
+            # OpenAI-compatible STT via OpenRouter. Supports any STT model
+            # routed through OpenRouter (openai/whisper-1, etc.)
+            "model": "openai/whisper-1",
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -464,6 +464,8 @@ def _print_setup_summary(config: dict, hermes_home):
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
         tool_status.append(("Text-to-Speech (OpenAI)", True, None))
+    elif tts_provider == "openrouter" and get_env_value("OPENROUTER_API_KEY"):
+        tool_status.append(("Text-to-Speech (OpenRouter)", True, None))
     elif tts_provider == "minimax" and get_env_value("MINIMAX_API_KEY"):
         tool_status.append(("Text-to-Speech (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):
@@ -1089,6 +1091,7 @@ def _setup_tts_provider(config: dict):
         "edge": "Edge TTS",
         "elevenlabs": "ElevenLabs",
         "openai": "OpenAI TTS",
+        "openrouter": "OpenRouter TTS",
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
@@ -1113,6 +1116,7 @@ def _setup_tts_provider(config: dict):
             "Edge TTS (free, cloud-based, no setup needed)",
             "ElevenLabs (premium quality, needs API key)",
             "OpenAI TTS (good quality, needs API key)",
+            "OpenRouter TTS (any TTS model via OpenRouter, needs API key)",
             "xAI TTS (Grok voices, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
@@ -1121,7 +1125,7 @@ def _setup_tts_provider(config: dict):
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "openrouter", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)

--- a/tests/tools/test_transcription_openrouter.py
+++ b/tests/tools/test_transcription_openrouter.py
@@ -1,0 +1,286 @@
+"""Tests for the OpenRouter STT provider in tools/transcription_tools.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "STT_OPENROUTER_BASE_URL",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def fake_audio_file(tmp_path):
+    """A tiny fake audio file that passes os.path.exists."""
+    f = tmp_path / "test.mp3"
+    f.write_bytes(b"\xff\xfb\x90\x00" + b"x" * 1000)
+    return str(f)
+
+
+@pytest.fixture
+def mock_openai_audio_response():
+    """A successful OpenRouter audio/transcriptions JSON response."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"text": "Hello world, this is a test."}
+    return resp
+
+
+# =============================================================================
+# _get_provider — OpenRouter in the provider selection logic
+# =============================================================================
+
+
+class TestGetProvider:
+    def test_openrouter_selected_when_key_available(self, monkeypatch):
+        from tools.transcription_tools import _get_provider
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setattr(
+            "tools.transcription_tools._HAS_OPENAI", True, raising=False
+        )
+
+        cfg = {"provider": "openrouter"}
+        with patch("tools.transcription_tools._load_stt_config", return_value=cfg):
+            result = _get_provider(cfg)
+        assert result == "openrouter"
+
+    def test_openrouter_returns_none_when_no_key(self, monkeypatch):
+        from tools.transcription_tools import _get_provider
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._HAS_OPENAI", True, raising=False
+        )
+
+        cfg = {"provider": "openrouter"}
+        with patch("tools.transcription_tools._load_stt_config", return_value=cfg):
+            result = _get_provider(cfg)
+        assert result == "none"
+
+    def test_openrouter_in_autodetect_fallback_order(self, monkeypatch):
+        """OpenRouter STT appears in the auto-detect fallback after mistral, before xai."""
+        from tools.transcription_tools import _get_provider
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._HAS_OPENAI", True, raising=False
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._HAS_FASTER_WHISPER", False, raising=False
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._has_local_command",
+            lambda: False, raising=False,
+        )
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        cfg = {}  # no explicit provider
+        with patch("tools.transcription_tools._load_stt_config", return_value=cfg):
+            result = _get_provider(cfg)
+        assert result == "openrouter"
+
+
+# =============================================================================
+# _transcribe_openrouter — the core transcription function.
+# requests is imported inside the function, so we patch at the requests module level.
+# =============================================================================
+
+
+class TestTranscribeOpenRouter:
+    def test_missing_api_key_returns_error(self, fake_audio_file):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        result = _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, fake_audio_file, monkeypatch, mock_openai_audio_response):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", return_value=mock_openai_audio_response) as mock_post:
+            result = _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        assert result["success"] is True
+        assert result["transcript"] == "Hello world, this is a test."
+        assert result["provider"] == "openrouter"
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert "audio/transcriptions" in args[0]  # positional URL arg
+        assert kwargs["headers"]["Authorization"] == "Bearer sk-or-test"
+        assert kwargs["data"]["model"] == "openai/whisper-1"
+
+    def test_http_error_returns_failure(self, fake_audio_file, monkeypatch):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        err_resp = MagicMock()
+        err_resp.status_code = 401
+        err_resp.json.return_value = {"error": {"message": "Invalid API key"}}
+        err_resp.text = json.dumps(err_resp.json.return_value)
+
+        with patch("requests.post", return_value=err_resp):
+            result = _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "401" in result["error"]
+        assert "Invalid API key" in result["error"]
+
+    def test_default_base_url_is_openrouter_ai(self, fake_audio_file, monkeypatch, mock_openai_audio_response):
+        """Default base URL points to openrouter.ai."""
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", return_value=mock_openai_audio_response) as mock_post:
+            _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        args, _ = mock_post.call_args  # positional URL arg
+        assert "openrouter.ai" in args[0]
+
+    def test_custom_base_url_from_env(self, fake_audio_file, monkeypatch, mock_openai_audio_response):
+        """STT_OPENROUTER_BASE_URL env var overrides the default base URL."""
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setenv("STT_OPENROUTER_BASE_URL", "https://custom.example.com/v1")
+
+        with patch("requests.post", return_value=mock_openai_audio_response) as mock_post:
+            _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        url = mock_post.call_args[0][0]
+        assert "custom.example.com" in url
+
+    def test_permission_error_handled(self, fake_audio_file, monkeypatch):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", side_effect=PermissionError("read denied")):
+            result = _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+    def test_generic_exception_returns_failure(self, fake_audio_file, monkeypatch):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", side_effect=RuntimeError("connection reset")):
+            result = _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "connection reset" in result["error"]
+
+    def test_request_timeout_is_120s(self, fake_audio_file, monkeypatch, mock_openai_audio_response):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", return_value=mock_openai_audio_response) as mock_post:
+            _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        assert mock_post.call_args.kwargs["timeout"] == 120
+
+    def test_correct_content_type_in_file_upload(self, fake_audio_file, monkeypatch, mock_openai_audio_response):
+        from tools.transcription_tools import _transcribe_openrouter
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("requests.post", return_value=mock_openai_audio_response) as mock_post:
+            _transcribe_openrouter(fake_audio_file, "openai/whisper-1")
+
+        files_arg = mock_post.call_args.kwargs["files"]
+        file_tuple = files_arg["file"]
+        assert file_tuple[2] == "audio/mp3"  # content-type from .mp3 suffix
+
+
+# =============================================================================
+# transcribe_audio — dispatch to _transcribe_openrouter
+# =============================================================================
+
+
+class TestTranscribeAudioDispatch:
+    def test_dispatches_to_openrouter_when_configured(
+        self, fake_audio_file, monkeypatch, mock_openai_audio_response
+    ):
+        """transcribe_audio() with provider=openrouter calls _transcribe_openrouter."""
+        from tools.transcription_tools import transcribe_audio
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        with patch("tools.transcription_tools._load_stt_config") as mock_load:
+            mock_load.return_value = {
+                "provider": "openrouter",
+                "openrouter": {"model": "openai/whisper-1"},
+            }
+            with patch("requests.post", return_value=mock_openai_audio_response):
+                result = transcribe_audio(fake_audio_file)
+
+        assert result["success"] is True
+        assert result["provider"] == "openrouter"
+        assert result["transcript"] == "Hello world, this is a test."
+
+
+# =============================================================================
+# DEFAULT_CONFIG wiring
+# =============================================================================
+
+
+class TestDefaultConfig:
+    def test_openrouter_block_in_stt_defaults(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert "openrouter" in DEFAULT_CONFIG["stt"]
+        stt_or = DEFAULT_CONFIG["stt"]["openrouter"]
+        assert "model" in stt_or
+        assert stt_or["model"] == "openai/whisper-1"
+
+    def test_openrouter_stt_in_provider_option_list(self):
+        """Verify openrouter is listed as a valid STT provider option in config comments.
+        
+        The stt provider comment in config.py lists all supported providers
+        including openrouter. We verify this by reading the config module source.
+        """
+        import inspect, hermes_cli.config
+        source = inspect.getsource(hermes_cli.config)
+        # find the stt provider line
+        lines = source.split('\n')
+        in_stt = False
+        found = False
+        for line in lines:
+            if '"stt"' in line and ':' in line and '{' in line:
+                in_stt = True
+            if in_stt and '"provider"' in line and '#' in line:
+                found = True
+                assert 'openrouter' in line.lower(), f"openrouter not found in provider comment: {line}"
+                break
+        assert found, "Could not find stt provider comment line in config.py"
+
+    def test_openrouter_tts_in_provider_option_list(self):
+        """Verify openrouter is listed as a valid TTS provider option in config comments."""
+        import inspect, hermes_cli.config
+        source = inspect.getsource(hermes_cli.config)
+        lines = source.split('\n')
+        in_tts = False
+        found = False
+        for line in lines:
+            if '"tts"' in line and ':' in line and '{' in line:
+                in_tts = True
+            if in_tts and '"provider"' in line and '#' in line:
+                found = True
+                assert 'openrouter' in line.lower(), f"openrouter not found in provider comment: {line}"
+                break
+        assert found, "Could not find tts provider comment line in config.py"

--- a/tests/tools/test_tts_openrouter.py
+++ b/tests/tools/test_tts_openrouter.py
@@ -1,0 +1,334 @@
+"""Tests for the OpenRouter TTS provider in tools/tts_tool.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def mock_openai_response_mp3():
+    """A successful OpenAI audio.speech.create response (mp3)."""
+    resp = MagicMock()
+    resp.stream_to_file = MagicMock()
+    resp._path = None  # storage for path
+
+    def capture(path):
+        resp._path = path
+        # Simulate writing a small mp3 header so the file is non-empty
+        Path(path).write_bytes(b"\xff\xfb\x90\x00" + b"mp3" * 100)
+
+    resp.stream_to_file.side_effect = capture
+    return resp
+
+
+class TestGenerateOpenRouterTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        output_path = str(tmp_path / "test.mp3")
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            _generate_openrouter_tts("Hello", output_path, {})
+
+    def test_missing_api_key_env_var(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+
+        # Simulate openai package not installed
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "openai":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            with pytest.raises(ImportError):
+                _generate_openrouter_tts("Hello", output_path, {})
+
+    def test_mp3_output_streamed_to_file(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+
+        mock_response = mock_openai_response_mp3
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_response)
+        mock_client.audio.speech.create = mock_create
+        mock_client.close = MagicMock()
+
+        with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+            mock_import.return_value = MagicMock(return_value=mock_client)
+
+            with patch("builtins.__import__", return_value=MagicMock()):
+                result = _generate_openrouter_tts("Hello world", output_path, {})
+
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o-mini-tts-2025-12-15"
+        assert call_kwargs["voice"] == "alloy"
+        assert call_kwargs["input"] == "Hello world"
+        assert call_kwargs["response_format"] == "mp3"
+        assert "extra_headers" in call_kwargs
+
+    def test_default_model_and_voice(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import (
+            DEFAULT_OPENROUTER_TTS_MODEL,
+            DEFAULT_OPENROUTER_TTS_VOICE,
+            _generate_openrouter_tts,
+        )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, {})
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["model"] == DEFAULT_OPENROUTER_TTS_MODEL
+        assert call_kwargs["voice"] == DEFAULT_OPENROUTER_TTS_VOICE
+
+    def test_custom_model_and_voice_from_config(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+        config = {
+            "openrouter": {
+                "model": "mistralai/voxtral-mini-tts-2603",
+                "voice": "Nova",
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, config)
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["model"] == "mistralai/voxtral-mini-tts-2603"
+        assert call_kwargs["voice"] == "Nova"
+
+    def test_custom_base_url_from_config(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+        config = {"openrouter": {"base_url": "https://custom.example.com/v1"}}
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, config)
+
+        # Client was instantiated with the custom base URL
+        import_calls = mock_import.return_value.call_args_list
+        assert len(import_calls) == 1
+        _cls, init_kwargs = import_calls[0]
+        assert init_kwargs["base_url"] == "https://custom.example.com/v1"
+
+    def test_ogg_format_for_opus(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.ogg")  # Telegram target
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, {})
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["response_format"] == "opus"
+
+    def test_speed_parameter_applied(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+        config = {"speed": 1.5}
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, config)
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["speed"] == 1.5
+
+    def test_speed_clamped_to_valid_range(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+        config = {"speed": 10.0}  # out of range, should clamp to 4.0
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, config)
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert call_kwargs["speed"] == 4.0  # clamped to max
+
+    def test_idempotency_key_in_headers(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, {})
+
+        call_kwargs = mock_create.call_args.kwargs
+        assert "extra_headers" in call_kwargs
+        assert "x-idempotency-key" in call_kwargs["extra_headers"]
+        # Verify it looks like a UUID
+        idempotency_key = call_kwargs["extra_headers"]["x-idempotency-key"]
+        assert len(idempotency_key) == 36  # standard UUID length
+
+    def test_close_method_called(self, tmp_path, monkeypatch, mock_openai_response_mp3):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        output_path = str(tmp_path / "test.mp3")
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(return_value=mock_openai_response_mp3)
+        mock_client.audio.speech.create = mock_create
+        mock_client.close = MagicMock()
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                _generate_openrouter_tts("Hi", output_path, {})
+
+        mock_client.close.assert_called_once()
+
+
+class TestOpenRouterInCheckRequirements:
+    def test_openrouter_api_key_satisfies_requirements(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        for key in (
+            "ELEVENLABS_API_KEY",
+            "OPENAI_API_KEY",
+            "VOICE_TOOLS_OPENAI_KEY",
+            "MINIMAX_API_KEY",
+            "XAI_API_KEY",
+            "MISTRAL_API_KEY",
+            "GOOGLE_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "k")
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "edge_tts":
+                raise ImportError("simulated")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            assert check_tts_requirements() is True
+
+
+class TestOpenRouterTtsInProviderList:
+    def test_openrouter_in_builtin_providers(self):
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        assert "openrouter" in BUILTIN_TTS_PROVIDERS
+
+    def test_openrouter_in_dispatch_comment(self, tmp_path, monkeypatch):
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+        # Ensure config says openrouter provider
+        config = {"provider": "openrouter", "openrouter": {"model": "x"}}
+
+        mock_client = MagicMock()
+        mock_create = MagicMock(
+            return_value=MagicMock(stream_to_file=MagicMock())
+        )
+        mock_client.audio.speech.create = mock_create
+
+        with patch("builtins.__import__", return_value=MagicMock()):
+            with patch("tools.tts_tool._import_openai_client", return_value=MagicMock) as mock_import:
+                mock_import.return_value = MagicMock(return_value=mock_client)
+                with patch.object(mock_client.audio.speech, "create", mock_create):
+                    result = text_to_speech_tool("Hello", output_path=str(tmp_path / "out.mp3"),)
+
+        # If it gets here without error, dispatch worked
+        assert result is not None
+
+
+class TestOpenRouterInDefaultConfig:
+    def test_openrouter_block_in_default_config(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert "openrouter" in DEFAULT_CONFIG["tts"]
+        tts_or = DEFAULT_CONFIG["tts"]["openrouter"]
+        assert "model" in tts_or
+        assert "voice" in tts_or
+        assert isinstance(tts_or["model"], str)
+        assert isinstance(tts_or["voice"], str)
+
+
+class TestOpenRouterTtsMaxTextLength:
+    def test_openrouter_in_provider_max_text_length(self):
+        from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH
+
+        assert "openrouter" in PROVIDER_MAX_TEXT_LENGTH
+        assert PROVIDER_MAX_TEXT_LENGTH["openrouter"] == 4096

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,13 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **openrouter** — Any STT model routed through OpenRouter, requires ``OPENROUTER_API_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
@@ -91,6 +92,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+OPENROUTER_STT_BASE_URL = os.getenv("STT_OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -260,6 +262,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "openrouter":
+            if _HAS_OPENAI and get_env_value("OPENROUTER_API_KEY"):
+                return "openrouter"
+            logger.warning(
+                "STT provider 'openrouter' configured but OPENROUTER_API_KEY not set"
+            )
+            return "none"
+
         if provider == "xai":
             if get_env_value("XAI_API_KEY"):
                 return "xai"
@@ -285,6 +295,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_MISTRAL and get_env_value("MISTRAL_API_KEY"):
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
+    if _HAS_OPENAI and get_env_value("OPENROUTER_API_KEY"):
+        logger.info("No local STT available, using OpenRouter STT API")
+        return "openrouter"
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
@@ -849,6 +862,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "openrouter":
+        or_cfg = stt_config.get("openrouter", {})
+        model_name = model or or_cfg.get("model", "openai/whisper-1")
+        return _transcribe_openrouter(file_path, model_name)
+
     if provider == "xai":
         # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
@@ -862,10 +880,86 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set OPENROUTER_API_KEY for OpenRouter STT, "
+            "set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
+
+
+# ===========================================================================
+# Provider: OpenRouter STT
+# ===========================================================================
+
+
+def _transcribe_openrouter(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using OpenRouter's /v1/audio/transcriptions endpoint.
+
+    OpenRouter's STT endpoint accepts multipart/form-data with a binary
+    audio file and a model name.  Supports any Whisper-compatible model
+    routed through OpenRouter (openai/whisper-1, mistralai/voxtral-mini-latest, etc.).
+
+    Requires ``OPENROUTER_API_KEY`` environment variable.
+    """
+    api_key = get_env_value("OPENROUTER_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "OPENROUTER_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    or_config = stt_config.get("openrouter", {})
+    base_url = str(
+        or_config.get("base_url")
+        or get_env_value("STT_OPENROUTER_BASE_URL")
+        or OPENROUTER_STT_BASE_URL
+    ).strip().rstrip("/")
+    language = str(
+        or_config.get("language") or ""
+    ).strip()
+
+    try:
+        import requests
+
+        data: Dict[str, Any] = {"model": model_name}
+        if language:
+            data["language"] = language
+
+        with open(file_path, "rb") as audio_file:
+            suffix = Path(file_path).suffix.lstrip(".").lower() or "mp3"
+            response = requests.post(
+                f"{base_url}/audio/transcriptions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                data=data,
+                files={"file": (Path(file_path).name, audio_file, f"audio/{suffix}")},
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"OpenRouter STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = _extract_transcript_text(result)
+
+        logger.info(
+            "Transcribed %s via OpenRouter STT (model=%s, lang=%s, %d chars)",
+            Path(file_path).name, model_name, language or "auto", len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "openrouter"}
+
+    except PermissionError as e:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {e}"}
+    except Exception as e:
+        logger.error("OpenRouter transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"OpenRouter transcription failed: {e}"}
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -6,6 +6,7 @@ Built-in TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
+- OpenRouter TTS: Access any TTS model via OpenRouter, needs OPENROUTER_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
@@ -149,6 +150,9 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_OPENROUTER_TTS_MODEL = "openai/gpt-4o-mini-tts-2025-12-15"
+DEFAULT_OPENROUTER_TTS_VOICE = "alloy"
+DEFAULT_OPENROUTER_TTS_BASE_URL = "https://openrouter.ai/api/v1"
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -174,6 +178,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 5000,       # Gemini TTS caps at ~8k input tokens / ~655s audio
+    "openrouter": 4096,   # OpenAI-compatible; defaults to OpenAI TTS model cap
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -317,6 +322,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "edge",
     "elevenlabs",
     "openai",
+    "openrouter",
     "minimax",
     "xai",
     "mistral",
@@ -1063,6 +1069,67 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
 
 
 # ===========================================================================
+# Provider: OpenRouter TTS
+# ===========================================================================
+def _generate_openrouter_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """
+    Generate audio using OpenRouter's /v1/audio/speech endpoint.
+
+    OpenRouter TTS is fully OpenAI-audio-API-compatible.  Point the client
+    at ``https://openrouter.ai/api/v1`` with an OPENROUTER_API_KEY and the
+    same request shape that OpenAI TTS expects.  Supports any TTS model
+    routed through OpenRouter (OpenAI, Mistral, etc.).
+
+    Args:
+        text: Text to convert.
+        output_path: Where to save the audio file.
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    api_key = (get_env_value("OPENROUTER_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("OPENROUTER_API_KEY not set. Get one at https://openrouter.ai/keys")
+
+    or_config = tts_config.get("openrouter", {})
+    model = or_config.get("model", DEFAULT_OPENROUTER_TTS_MODEL)
+    voice = or_config.get("voice", DEFAULT_OPENROUTER_TTS_VOICE)
+    base_url = or_config.get(
+        "base_url", get_env_value("OPENROUTER_TTS_BASE_URL") or DEFAULT_OPENROUTER_TTS_BASE_URL
+    ).strip().rstrip("/")
+    speed = float(or_config.get("speed", tts_config.get("speed", 1.0)))
+
+    # Determine response format from extension
+    if output_path.endswith(".ogg"):
+        response_format = "opus"
+    else:
+        response_format = "mp3"
+
+    # Use openai package (same as OpenAI provider) with openrouter base URL
+    OpenAIClient = _import_openai_client()
+    client = OpenAIClient(api_key=api_key, base_url=base_url)
+    try:
+        create_kwargs: Dict[str, Any] = {
+            "model": model,
+            "voice": voice,
+            "input": text,
+            "response_format": response_format,
+            "extra_headers": {"x-idempotency-key": str(uuid.uuid4())},
+        }
+        if speed != 1.0:
+            create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        response = client.audio.speech.create(**create_kwargs)
+
+        response.stream_to_file(output_path)
+        return output_path
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+
+# ===========================================================================
 # Provider: Google Gemini TTS
 # ===========================================================================
 def _wrap_pcm_as_wav(
@@ -1612,7 +1679,7 @@ def text_to_speech_tool(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "openrouter"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -1676,6 +1743,10 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "openrouter":
+            logger.info("Generating speech with OpenRouter TTS...")
+            _generate_openrouter_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -1837,6 +1908,8 @@ def check_tts_requirements() -> bool:
             return True
     except ImportError:
         pass
+    if get_env_value("OPENROUTER_API_KEY"):
+        return True
     if get_env_value("MINIMAX_API_KEY"):
         return True
     if get_env_value("XAI_API_KEY"):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1658,7 +1658,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = (platform in {"telegram", "discord"})
 
     # Determine output path
     if output_path:
@@ -1677,9 +1677,13 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "openrouter"}:
+        # Use .ogg for Telegram with providers that support native Opus output.
+        # OpenRouter TTS does NOT support opus format (only mp3/pcm) — its
+        # audio is decoded by FFmpegPCMAudio in Discord's voice path anyway,
+        # so .mp3 works fine without any extension special-casing.
+        # For all other providers (openai, elevenlabs, mistral, gemini) that
+        # do support native opus, request .ogg on Discord too.
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"


### PR DESCRIPTION
## Summary
Adds OpenRouter TTS as a native selectable option in the `hermes setup tts` wizard.

## Changes
- **hermes_cli/setup.py**: 
  - Added `openrouter` to TTS provider map and prompt list
  - Added OpenRouter TTS status display in tool summary when configured
  - Updated provider options to include OpenRouter TTS

## Notes
OpenRouter TTS uses `openai/gpt-4o-mini-tts-2025-12-15` with `alloy` voice by default.