### PR TITLE
fix(codex): account for Responses payload timeouts

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -726,7 +726,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers",
+        "extra_headers", "timeout",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -752,6 +752,13 @@ def _preflight_codex_api_kwargs(
     max_output_tokens = api_kwargs.get("max_output_tokens")
     if isinstance(max_output_tokens, (int, float)) and max_output_tokens > 0:
         normalized["max_output_tokens"] = int(max_output_tokens)
+    timeout = api_kwargs.get("timeout")
+    if (
+        isinstance(timeout, (int, float))
+        and not isinstance(timeout, bool)
+        and 0 < float(timeout) < float("inf")
+    ):
+        normalized["timeout"] = float(timeout)
     temperature = api_kwargs.get("temperature")
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -47,6 +47,7 @@ class ResponsesApiTransport(ProviderTransport):
             reasoning_config: dict | None — {effort, enabled}
             session_id: str | None — used for prompt_cache_key + xAI conv header
             max_tokens: int | None — max_output_tokens
+            timeout: float | None — per-request timeout
             request_overrides: dict | None — extra kwargs merged in
             provider: str | None — provider name for backend-specific logic
             base_url: str | None — endpoint URL
@@ -128,6 +129,16 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        timeout = kwargs.get("timeout", params.get("timeout"))
+        if (
+            isinstance(timeout, (int, float))
+            and not isinstance(timeout, bool)
+            and 0 < float(timeout) < float("inf")
+        ):
+            kwargs["timeout"] = float(timeout)
+        else:
+            kwargs.pop("timeout", None)
 
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")

--- a/run_agent.py
+++ b/run_agent.py
@@ -118,6 +118,52 @@ else:
     logger.info("No .env file found. Using system environment variables.")
 
 
+def _estimate_non_stream_request_context_tokens(api_payload: Any) -> int:
+    """Estimate request context/load tokens from API kwargs or legacy messages.
+
+    The stale-call detector historically accepted a Chat Completions
+    ``messages`` list and used a cheap character/4 estimate.  Responses API
+    requests carry their conversational payload in ``input`` with additional
+    load in ``instructions`` and ``tools``, so estimate those fields when a
+    full kwargs dict is available.
+    """
+
+    def _chars(value: Any) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, str):
+            return len(value)
+        return len(str(value))
+
+    def _message_chars(messages: Any) -> int:
+        if not isinstance(messages, list):
+            return _chars(messages)
+        return sum(_chars(item) for item in messages)
+
+    if isinstance(api_payload, list):
+        return _message_chars(api_payload) // 4
+
+    if isinstance(api_payload, dict):
+        messages = api_payload.get("messages")
+        if isinstance(messages, list):
+            total_chars = _message_chars(messages)
+            if "tools" in api_payload:
+                total_chars += _chars(api_payload.get("tools"))
+            return total_chars // 4
+
+        if "input" in api_payload:
+            total_chars = (
+                _chars(api_payload.get("input"))
+                + _chars(api_payload.get("instructions"))
+                + _chars(api_payload.get("tools"))
+            )
+            return total_chars // 4
+
+        return sum(_chars(value) for value in api_payload.values()) // 4
+
+    return _chars(api_payload) // 4
+
+
 # Import our tool system
 from model_tools import (
     get_tool_definitions,
@@ -3354,14 +3400,14 @@ class AIAgent:
 
         return 300.0, True
 
-    def _compute_non_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
+    def _compute_non_stream_stale_timeout(self, api_payload: Any) -> float:
         """Compute the effective non-stream stale timeout for this request."""
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
             return float("inf")
 
-        est_tokens = sum(len(str(v)) for v in messages) // 4
+        est_tokens = _estimate_non_stream_request_context_tokens(api_payload)
         if est_tokens > 100_000:
             return max(stale_base, 600.0)
         if est_tokens > 50_000:
@@ -7236,9 +7282,7 @@ class AIAgent:
         # httpx timeout (default 1800s) with zero feedback.  The stale
         # detector kills the connection early so the main retry loop can
         # apply richer recovery (credential rotation, provider fallback).
-        _stale_timeout = self._compute_non_stream_stale_timeout(
-            api_kwargs.get("messages", [])
-        )
+        _stale_timeout = self._compute_non_stream_stale_timeout(api_kwargs)
 
         _call_start = time.time()
         self._touch_activity("waiting for non-streaming API response")
@@ -7262,7 +7306,7 @@ class AIAgent:
             # arrives within the configured timeout.
             _elapsed = time.time() - _call_start
             if _elapsed > _stale_timeout:
-                _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+                _est_ctx = _estimate_non_stream_request_context_tokens(api_kwargs)
                 logger.warning(
                     "Non-streaming API call stale for %.0fs (threshold %.0fs). "
                     "model=%s context=~%s tokens. Killing connection.",
@@ -9273,6 +9317,7 @@ class AIAgent:
                 session_id=getattr(self, "session_id", None),
                 max_tokens=self.max_tokens,
                 request_overrides=self.request_overrides,
+                timeout=self._resolved_api_call_timeout(),
                 is_github_responses=is_github_responses,
                 is_codex_backend=is_codex_backend,
                 is_xai_responses=is_xai_responses,

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -108,6 +108,16 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("max_output_tokens") == 4096
 
+    def test_timeout(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            timeout=123.5,
+        )
+        assert kw["timeout"] == 123.5
+
     def test_codex_backend_no_max_output_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1178,6 +1178,41 @@ class TestBuildApiKwargs:
         assert kwargs["messages"] is messages
         assert kwargs["timeout"] == 1800.0
 
+    def test_non_stream_stale_timeout_counts_large_responses_payload(self, agent, monkeypatch):
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *_args, **_kwargs: None)
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        api_kwargs = {
+            "model": "gpt-5.5",
+            "instructions": "i" * 80_000,
+            "input": [{"role": "user", "content": "u" * 120_000}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "terminal",
+                    "description": "t" * 20_000,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "p" * 4_000}
+                        },
+                    },
+                }
+            ],
+            "store": False,
+        }
+
+        assert agent._compute_non_stream_stale_timeout(api_kwargs) == 450.0
+
+    def test_non_stream_stale_timeout_keeps_chat_messages_estimate(self, agent, monkeypatch):
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *_args, **_kwargs: None)
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        messages = [{"role": "user", "content": "x" * 220_000}]
+
+        legacy_timeout = agent._compute_non_stream_stale_timeout(messages)
+
+        assert legacy_timeout == 450.0
+        assert agent._compute_non_stream_stale_timeout({"messages": messages}) == legacy_timeout
+
     def test_public_moonshot_kimi_k2_5_omits_temperature(self, agent):
         """Kimi models should NOT have client-side temperature overrides.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -308,9 +308,23 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["parallel_tool_calls"] is True
     assert isinstance(kwargs["prompt_cache_key"], str)
     assert len(kwargs["prompt_cache_key"]) > 0
-    assert "timeout" not in kwargs
+    assert kwargs["timeout"] == 1800.0
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_build_api_kwargs_codex_preserves_configured_timeout(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr(run_agent, "get_provider_request_timeout", lambda *_args, **_kwargs: 123.0)
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert kwargs["timeout"] == 123.0
 
 
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
@@ -859,6 +873,28 @@ def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
     from agent.codex_responses_adapter import _preflight_codex_api_kwargs
     result = _preflight_codex_api_kwargs(kwargs)
     assert result["service_tier"] == "priority"
+
+
+def test_preflight_codex_api_kwargs_preserves_positive_timeout(monkeypatch):
+    _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["timeout"] = 42.5
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    result = _preflight_codex_api_kwargs(kwargs)
+    assert result["timeout"] == 42.5
+
+
+def test_preflight_codex_api_kwargs_omits_invalid_timeout(monkeypatch):
+    _build_agent(monkeypatch)
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    for timeout in (0, -1, "slow", True, None):
+        kwargs = _codex_request_kwargs()
+        kwargs["timeout"] = timeout
+        result = _preflight_codex_api_kwargs(kwargs)
+        assert "timeout" not in result
 
 
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes two closely related Codex Responses timeout-path gaps:

- The non-stream stale timeout estimator now uses the actual request payload, not only `messages`. Responses API requests carry context in `input`, with additional load in `instructions` and `tools`, so large `openai-codex` requests no longer estimate/log as `context=~0 tokens`.
- The main `codex_responses` path now preserves configured request timeouts through `_build_api_kwargs()`, `ResponsesApiTransport.build_kwargs()`, and `_preflight_codex_api_kwargs()`.

This keeps Chat Completions behavior compatible while making timeout sizing/logging work for Responses API payloads.

## Related issues / prior reports

- Addresses #21644: Codex Responses main agent path drops configured timeout.
- Helps diagnose / reduce the failure mode in #21444: `openai-codex` / `gpt-5.5` stale timeout hangs on long sessions.
- Related prior timeout architecture work: #15811.
- Not a duplicate of #22046: that PR surfaces a better user-facing error for one silent-reject path; this PR fixes timeout propagation and request-size estimation.

## Changes made

- Added `_estimate_non_stream_request_context_tokens()` in `run_agent.py`.
- Changed `_interruptible_api_call()` to compute stale timeout and warning context from full `api_kwargs`.
- Included `input`, `instructions`, and `tools` for Responses API estimates.
- Preserved positive numeric `timeout` in Codex Responses transport and preflight.
- Added regression coverage for:
  - large Responses payload stale-timeout scaling,
  - legacy Chat Completions message estimation,
  - Codex transport timeout preservation,
  - Codex preflight timeout preservation/invalid-timeout omission,
  - `AIAgent._build_api_kwargs()` including timeout for `openai-codex`.

## Test plan

```bash
git diff --check
python3 -m compileall -q run_agent.py agent/transports/codex.py agent/codex_responses_adapter.py
HERMES_HOME=/private/tmp/hermes-agent-test-home venv/bin/python -m pytest \
  tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_run_agent.py::TestBuildApiKwargs \
  tests/hermes_cli/test_timeouts.py \
  -q -o addopts=
HERMES_HOME=/private/tmp/hermes-agent-test-home venv/bin/python -m pytest \
  tests/run_agent/test_interrupt_propagation.py \
  tests/run_agent/test_openai_client_lifecycle.py \
  -q -o addopts=
```

Results:

- `git diff --check`: passed
- `compileall`: passed
- targeted timeout/Codex tests: `143 passed`
- interrupt/client lifecycle tests: `11 passed`
