### PR TITLE
fix(tui): reload config when file metadata changes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -105,7 +105,7 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
 
     try:
         server._cfg_cache = None
-        server._cfg_mtime = None
+        server._cfg_stat_key = None
         server._cfg_path = None
         _clear_server_sessions()
         monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
@@ -139,7 +139,7 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
     finally:
         _clear_server_sessions()
         server._cfg_cache = None
-        server._cfg_mtime = None
+        server._cfg_stat_key = None
         server._cfg_path = None
         reset_hermes_home_override(token)
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import os
 import sys
 import threading
 import time
@@ -342,6 +343,23 @@ def test_config_roundtrip(server, tmp_path):
     server._hermes_home = tmp_path
     server._save_cfg({"model": "test/model"})
     assert server._load_cfg()["model"] == "test/model"
+
+
+def test_config_reload_when_size_changes_without_mtime_change(server, tmp_path):
+    server._hermes_home = tmp_path
+    cfg_path = tmp_path / "config.yaml"
+
+    cfg_path.write_text("model: old\n", encoding="utf-8")
+    assert server._load_cfg()["model"] == "old"
+
+    before = cfg_path.stat()
+    cfg_path.write_text("model: new-model\ndisplay:\n  skin: mono\n", encoding="utf-8")
+    os.utime(cfg_path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    after = cfg_path.stat()
+
+    assert after.st_mtime_ns == before.st_mtime_ns
+    assert after.st_size != before.st_size
+    assert server._load_cfg()["model"] == "new-model"
 
 
 # ── _cli_exec_blocked ────────────────────────────────────────────────

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1226,7 +1226,7 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
     monkeypatch.setattr(skin_engine, "get_hermes_home", lambda: tmp_path)
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     monkeypatch.setattr(server, "_last_skin_sig", None, raising=False)
-    server._cfg_cache = server._cfg_mtime = server._cfg_path = None
+    server._cfg_cache = server._cfg_stat_key = server._cfg_path = None
 
     emitted = []
     monkeypatch.setattr(server, "_emit", lambda ev, sid, payload=None: emitted.append((ev, payload)))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -124,7 +124,7 @@ _db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
-_cfg_mtime: float | None = None
+_cfg_stat_key: tuple[int, int] | None = None
 _cfg_path = None
 try:
     _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
@@ -650,14 +650,18 @@ _INDICATOR_DEFAULT = "kaomoji"
 
 
 def _load_cfg() -> dict:
-    global _cfg_cache, _cfg_mtime, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_path
     try:
         import yaml
 
         p = _hermes_home / "config.yaml"
-        mtime = p.stat().st_mtime if p.exists() else None
+        try:
+            st = p.stat()
+            stat_key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            stat_key = None
         with _cfg_lock:
-            if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
+            if _cfg_cache is not None and _cfg_stat_key == stat_key and _cfg_path == p:
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
             with open(p, encoding="utf-8") as f:
@@ -666,7 +670,7 @@ def _load_cfg() -> dict:
             data = {}
         with _cfg_lock:
             _cfg_cache = copy.deepcopy(data)
-            _cfg_mtime = mtime
+            _cfg_stat_key = stat_key
             _cfg_path = p
         return data
     except Exception:
@@ -675,7 +679,7 @@ def _load_cfg() -> dict:
 
 
 def _save_cfg(cfg: dict):
-    global _cfg_cache, _cfg_mtime, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_path
     import yaml
 
     path = _hermes_home / "config.yaml"
@@ -685,9 +689,10 @@ def _save_cfg(cfg: dict):
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path
         try:
-            _cfg_mtime = path.stat().st_mtime
-        except Exception:
-            _cfg_mtime = None
+            st = path.stat()
+            _cfg_stat_key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            _cfg_stat_key = None
 
 
 def _set_session_context(session_key: str) -> list:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -161,7 +161,7 @@ _profile_ui_meta_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
-_cfg_mtime: float | None = None
+_cfg_stat_key: tuple[int, int] | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
 try:
@@ -3836,7 +3836,7 @@ def _load_cfg_raw() -> dict:
     save. Behavioral reads must use :func:`_load_cfg`, which layers the
     managed overlay + env expansion on top of this raw read.
     """
-    global _cfg_cache, _cfg_mtime, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_path
     try:
         # Honor a per-session profile override (see session.resume) so a resumed
         # remote profile loads ITS config (model, skills, prompt); otherwise the
@@ -3845,9 +3845,13 @@ def _load_cfg_raw() -> dict:
         override = get_hermes_home_override()
         home = override if isinstance(override, str) and override else _hermes_home
         p = Path(home) / "config.yaml"
-        mtime = p.stat().st_mtime if p.exists() else None
+        try:
+            st = p.stat()
+            stat_key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            stat_key = None
         with _cfg_lock:
-            if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
+            if _cfg_cache is not None and _cfg_stat_key == stat_key and _cfg_path == p:
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
             from hermes_cli.config import read_user_config_raw
@@ -3860,7 +3864,7 @@ def _load_cfg_raw() -> dict:
             # the user's file. The managed overlay is applied on every return
             # path instead (read-side only).
             _cfg_cache = copy.deepcopy(data)
-            _cfg_mtime = mtime
+            _cfg_stat_key = stat_key
             _cfg_path = p
         return data
     except Exception:
@@ -3910,7 +3914,7 @@ def _apply_managed(cfg: dict) -> dict:
 
 
 def _save_cfg(cfg: dict):
-    global _cfg_cache, _cfg_mtime, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_path
 
     from utils import atomic_roundtrip_yaml_save
 
@@ -3928,9 +3932,10 @@ def _save_cfg(cfg: dict):
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path
         try:
-            _cfg_mtime = path.stat().st_mtime
-        except Exception:
-            _cfg_mtime = None
+            st = path.stat()
+            _cfg_stat_key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            _cfg_stat_key = None
 
 
 def _cwd_for_session_key(session_key: str) -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -162,6 +162,9 @@ _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run un
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_stat_key: tuple[int, int] | None = None
+# Legacy test/integration invalidation knob; the nanosecond+size key is
+# authoritative, but keeping this alias avoids breaking existing reset hooks.
+_cfg_mtime: float | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
 try:
@@ -3836,7 +3839,7 @@ def _load_cfg_raw() -> dict:
     save. Behavioral reads must use :func:`_load_cfg`, which layers the
     managed overlay + env expansion on top of this raw read.
     """
-    global _cfg_cache, _cfg_stat_key, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_mtime, _cfg_path
     try:
         # Honor a per-session profile override (see session.resume) so a resumed
         # remote profile loads ITS config (model, skills, prompt); otherwise the
@@ -3848,10 +3851,17 @@ def _load_cfg_raw() -> dict:
         try:
             st = p.stat()
             stat_key = (st.st_mtime_ns, st.st_size)
+            legacy_mtime = st.st_mtime
         except OSError:
             stat_key = None
+            legacy_mtime = None
         with _cfg_lock:
-            if _cfg_cache is not None and _cfg_stat_key == stat_key and _cfg_path == p:
+            if (
+                _cfg_cache is not None
+                and _cfg_stat_key == stat_key
+                and _cfg_mtime == legacy_mtime
+                and _cfg_path == p
+            ):
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
             from hermes_cli.config import read_user_config_raw
@@ -3865,6 +3875,7 @@ def _load_cfg_raw() -> dict:
             # path instead (read-side only).
             _cfg_cache = copy.deepcopy(data)
             _cfg_stat_key = stat_key
+            _cfg_mtime = legacy_mtime
             _cfg_path = p
         return data
     except Exception:
@@ -3914,7 +3925,7 @@ def _apply_managed(cfg: dict) -> dict:
 
 
 def _save_cfg(cfg: dict):
-    global _cfg_cache, _cfg_stat_key, _cfg_path
+    global _cfg_cache, _cfg_stat_key, _cfg_mtime, _cfg_path
 
     from utils import atomic_roundtrip_yaml_save
 
@@ -3934,8 +3945,10 @@ def _save_cfg(cfg: dict):
         try:
             st = path.stat()
             _cfg_stat_key = (st.st_mtime_ns, st.st_size)
+            _cfg_mtime = st.st_mtime
         except OSError:
             _cfg_stat_key = None
+            _cfg_mtime = None
 
 
 def _cwd_for_session_key(session_key: str) -> str:


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-config bug in the TUI gateway. `tui_gateway.server._load_cfg()`
cached `config.yaml` using only `st_mtime`, so same-timestamp rewrites could
keep serving stale config from memory. This switches the cache key to
`(st_mtime_ns, st_size)` so the TUI reloads config when file metadata changes
without requiring a restart.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [tui_gateway/server.py](/mnt/d/hermes-agent/.worktrees/tui-config-cache-reload/tui_gateway/server.py:124) to cache TUI config by `(st_mtime_ns, st_size)` instead of float `st_mtime`
- Kept the existing deepcopy-based cache behavior and path guard intact
- Added a regression test in [tests/tui_gateway/test_protocol.py](/mnt/d/hermes-agent/.worktrees/tui-config-cache-reload/tests/tui_gateway/test_protocol.py:348) covering same-mtime config rewrites with changed file size

## How to Test

1. Run `PYTHONPATH=. uv run --no-project --with pytest --with pytest-xdist python -m pytest tests/tui_gateway/test_protocol.py -q -n0 -p no:cacheprovider`
2. Confirm `test_config_reload_when_size_changes_without_mtime_change` passes
3. Optionally reproduce manually by rewriting `~/.hermes/config.yaml` within the same timestamp window and verifying the TUI sees the updated value without restart

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Reproduced before the fix with a focused regression test: `_load_cfg()` returned the old `model` value after a same-`mtime_ns` rewrite
- Verified after the fix: `tests/tui_gateway/test_protocol.py` passes (`54 passed`)
