### PR TITLE
fix(dashboard): skip browser-open on headless Linux to prevent process exit

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4415,11 +4415,33 @@ def start_server(
     if open_browser:
         import webbrowser
 
-        def _open():
-            time.sleep(1.0)
-            webbrowser.open(f"http://{host}:{port}")
+        # On headless Linux (no DISPLAY or WAYLAND_DISPLAY) some registered
+        # browsers are TUI programs (links, lynx, www-browser) that try to
+        # take over the terminal.  That can send SIGHUP to the server process
+        # and cause an immediate exit even though uvicorn bound successfully.
+        # Skip the auto-open attempt on headless systems and let the user
+        # open the URL manually.  macOS and Windows are always considered
+        # display-capable.
+        _has_display = (
+            sys.platform != "linux"
+            or bool(os.environ.get("DISPLAY"))
+            or bool(os.environ.get("WAYLAND_DISPLAY"))
+        )
 
-        threading.Thread(target=_open, daemon=True).start()
+        if _has_display:
+            def _open():
+                try:
+                    time.sleep(1.0)
+                    webbrowser.open(f"http://{host}:{port}")
+                except Exception:
+                    pass
+
+            threading.Thread(target=_open, daemon=True).start()
+        else:
+            _log.debug(
+                "Skipping browser-open: no DISPLAY or WAYLAND_DISPLAY detected "
+                "(headless Linux). Pass --no-open to suppress this detection."
+            )
 
     print(f"  Hermes Web UI → http://{host}:{port}")
     uvicorn.run(app, host=host, port=port, log_level="warning")


### PR DESCRIPTION
## Summary

Fixes #24127

## Root Cause

On headless Linux VPS (no `DISPLAY` or `WAYLAND_DISPLAY`), Python's `webbrowser` module may register TUI programs such as **`links`**, **`lynx`**, or **`www-browser`** as the available browser. `GenericBrowser.open()` spawns these programs via `subprocess.Popen` **without redirecting stdin/stdout**, which lets them attempt to take over the terminal. This can cause the server process to receive **`SIGHUP`** and exit immediately, even though `uvicorn` bound the port successfully — producing a misleading success message followed by an empty `--status`.

This is why `--no-open` works correctly: it skips the `webbrowser.open()` call entirely, so no TUI browser is spawned.

## Fix

**`hermes_cli/web_server.py` — `start_server()`**

1. **Detect headless Linux** at startup using `DISPLAY` / `WAYLAND_DISPLAY` environment variables.
2. **Skip the auto-open** on headless Linux — the URL is still printed so the user can open it manually or via an SSH tunnel.
3. **Wrap `webbrowser.open()` in try/except** to silently absorb any unexpected failure on display-capable systems.

```python
# Before
def _open():
    time.sleep(1.0)
    webbrowser.open(f"http://{host}:{port}")
threading.Thread(target=_open, daemon=True).start()

# After
_has_display = (
    sys.platform != "linux"
    or bool(os.environ.get("DISPLAY"))
    or bool(os.environ.get("WAYLAND_DISPLAY"))
)
if _has_display:
    def _open():
        try:
            time.sleep(1.0)
            webbrowser.open(f"http://{host}:{port}")
        except Exception:
            pass
    threading.Thread(target=_open, daemon=True).start()
else:
    _log.debug("Skipping browser-open: headless Linux detected")
```

## Behavior After Fix

| Scenario | Before | After |
|----------|--------|-------|
| Headless Linux VPS | Process exits immediately | Server stays running; URL printed for manual open |
| Linux with `DISPLAY` set | Works | Works (unchanged) |
| macOS / Windows | Works | Works (unchanged) |
| Any platform with `--no-open` | Works | Works (unchanged) |