### PR TITLE
feat(deepseek): plumb V4 thinking + reasoning_effort via provider profile

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,9 +1,64 @@
 """DeepSeek provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-deepseek = ProviderProfile(
+
+class DeepSeekProfile(ProviderProfile):
+    """DeepSeek native API — V4 thinking + reasoning_effort plumbing.
+
+    Reference: https://api-docs.deepseek.com/guides/thinking_mode
+
+    The V4 API exposes thinking mode as an explicit request contract:
+      - ``extra_body.thinking = {"type": "enabled" | "disabled"}``
+        (default: ``enabled``)
+      - top-level ``reasoning_effort = "high" | "max"``
+        (DeepSeek accepts only those two values; ``low`` / ``medium``
+        compatibility-map to ``"high"``, ``xhigh`` maps to ``"max"``)
+
+    Without this override the registered profile inherits the no-op
+    default and ``reasoning_effort`` is silently dropped before the
+    request leaves Hermes.
+    """
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        # No reasoning_config supplied → server defaults (thinking enabled,
+        # effort=high). Be explicit so the payload is self-describing in logs.
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            extra_body["thinking"] = {"type": "enabled"}
+            top_level["reasoning_effort"] = "high"
+            return extra_body, top_level
+
+        if reasoning_config.get("enabled") is False:
+            extra_body["thinking"] = {"type": "disabled"}
+            # Per DeepSeek docs reasoning_effort is meaningless when
+            # thinking is off — omit entirely (mirrors KimiProfile).
+            return extra_body, top_level
+
+        extra_body["thinking"] = {"type": "enabled"}
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if effort in ("max", "xhigh"):
+            top_level["reasoning_effort"] = "max"
+        else:
+            # low / medium / high / unknown → "high" (DeepSeek's documented
+            # compatibility mapping for clients that still emit the wider
+            # OpenAI-style vocabulary).
+            top_level["reasoning_effort"] = "high"
+
+        return extra_body, top_level
+
+
+deepseek = DeepSeekProfile(
     name="deepseek",
     aliases=("deepseek-chat",),
     env_vars=("DEEPSEEK_API_KEY",),
@@ -11,6 +66,10 @@ deepseek = ProviderProfile(
     description="DeepSeek — native DeepSeek API",
     signup_url="https://platform.deepseek.com/",
     fallback_models=(
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        # Legacy aliases — server-side mapped to deepseek-v4-flash
+        # non-thinking / thinking modes, retained until DeepSeek removes them.
         "deepseek-chat",
         "deepseek-reasoner",
     ),

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -88,6 +88,58 @@ class TestKimiProfile:
         assert tl["reasoning_effort"] == "medium"
 
 
+class TestDeepSeekProfile:
+    """DeepSeek native API — V4 thinking + reasoning_effort plumbing.
+
+    Reference: https://api-docs.deepseek.com/guides/thinking_mode
+    """
+
+    def test_registered(self):
+        p = get_provider_profile("deepseek")
+        assert p is not None
+        assert p.name == "deepseek"
+        assert "deepseek.com" in p.base_url
+
+    def test_fallback_models_include_v4(self):
+        p = get_provider_profile("deepseek")
+        assert "deepseek-v4-pro" in p.fallback_models
+        assert "deepseek-v4-flash" in p.fallback_models
+        # Legacy aliases retained until DeepSeek removes them server-side
+        assert "deepseek-chat" in p.fallback_models
+        assert "deepseek-reasoner" in p.fallback_models
+
+    def test_no_config_defaults(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config=None)
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_thinking_disabled(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": False})
+        assert eb["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in tl
+
+    @pytest.mark.parametrize("input_effort,expected", [
+        ("low", "high"),
+        ("medium", "high"),
+        ("high", "high"),
+        ("xhigh", "max"),
+        ("max", "max"),
+        ("MEDIUM", "high"),       # case insensitive
+        ("  high  ", "high"),     # whitespace tolerant
+        ("banana", "high"),       # unknown → safe fallback
+        ("", "high"),             # empty → default
+    ])
+    def test_effort_mapping(self, input_effort, expected):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": input_effort}
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == expected
+
+
 class TestOpenRouterProfile:
     def test_extra_body_with_prefs(self):
         p = get_provider_profile("openrouter")


### PR DESCRIPTION
## Summary

The DeepSeek provider profile registered in [plugins/model-providers/deepseek/\_\_init\_\_.py](plugins/model-providers/deepseek/__init__.py) was a bare-bones `ProviderProfile` — no `build_api_kwargs_extras` override — so on the post-refactor profile path `reasoning_effort` is silently dropped before the request leaves Hermes, and there's no way to explicitly toggle V4 thinking mode from config. Kimi's profile already implements this pattern; this PR adds the symmetric override for DeepSeek.

### Official V4 contract

DeepSeek V4 exposes thinking mode as an explicit API contract (<https://api-docs.deepseek.com/guides/thinking_mode>):

| Signal          | Location                     | Values                                         | Default                                  |
| --------------- | ---------------------------- | ---------------------------------------------- | ---------------------------------------- |
| Thinking toggle | `extra_body.thinking`        | `{"type": "enabled"}` / `{"type": "disabled"}` | `enabled`                                |
| Effort level    | top-level `reasoning_effort` | `"high"` / `"max"`                             | `"high"` (auto `"max"` for complex agents) |

### Hermes → DeepSeek effort mapping

DeepSeek accepts only two effort values, so the wider Hermes vocabulary compatibility-maps:

| Hermes `reasoning_effort` | → DeepSeek `reasoning_effort` |
| ------------------------- | ----------------------------- |
| `low`                     | `high`                        |
| `medium`                  | `high`                        |
| `high`                    | `high`                        |
| `xhigh`                   | `max`                         |
| `max`                     | `max`                         |
| _(thinking disabled)_     | _omitted_                     |

### Changes

- **[plugins/model-providers/deepseek/\_\_init\_\_.py](plugins/model-providers/deepseek/__init__.py)** — subclass `ProviderProfile` as `DeepSeekProfile`, override `build_api_kwargs_extras` (mirrors `KimiProfile`); refresh `fallback_models` to the first-class V4 ids with legacy aliases retained for the deprecation window
- **[tests/providers/test_provider_profiles.py](tests/providers/test_provider_profiles.py)** — new `TestDeepSeekProfile` covering registration, V4 fallback models, default-enabled thinking, explicit disable, full effort mapping (`low`/`medium`/`high`/`xhigh`/`max`/case/whitespace/unknown/empty)

### Note for reviewers

This supersedes #14958 (closed), which added `is_deepseek` as a transport-level boolean flag — pre-dating the `provider_profile` migration. The contract emitted by both PRs is identical and was verified live against `api.deepseek.com` (request returns HTTP 200 with `reasoning_content` populated when thinking is enabled, empty when disabled). This rewrite simply lands the fix on the architecture `main` is using now.

## Test plan

- [x] `pytest tests/providers/test_provider_profiles.py::TestDeepSeekProfile tests/providers/test_provider_profiles.py::TestKimiProfile` — 21 passed (13 new + 8 Kimi regression)
- [x] Live contract verified in #14958: `extra_body.thinking.type=enabled` + top-level `reasoning_effort=max` produces a 200 response with populated `reasoning_content`; `thinking.type=disabled` produces a 200 with empty `reasoning_content`