### PR TITLE
feat: add prompt caching mode override

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -85,6 +85,9 @@ model:
 #   ollama-local:
 #     request_timeout_seconds: 300   # Longer timeout for local cold-starts
 #     stale_timeout_seconds: 900     # Explicitly re-enable stale detection on local endpoints
+#   custom:
+#     prompt_caching:
+#       mode: force                  # auto | force | off; applies to this provider route only
 #   anthropic:
 #     request_timeout_seconds: 30    # Fast-fail cloud requests
 #     models:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -679,13 +679,10 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
-    # mode controls cache_control marker injection:
-    #   "auto"  - enable only for known-compatible provider/model combinations
-    #   "force" - always inject cache_control markers (use with compatible gateways)
-    #   "off"   - never inject cache_control markers
+    # Provider-level marker injection overrides live under:
+    # providers.<provider_id>.prompt_caching.mode: auto | force | off
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
-        "mode": "auto",
         "cache_ttl": "5m",
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -679,8 +679,13 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
+    # mode controls cache_control marker injection:
+    #   "auto"  - enable only for known-compatible provider/model combinations
+    #   "force" - always inject cache_control markers (use with compatible gateways)
+    #   "off"   - never inject cache_control markers
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
     "prompt_caching": {
+        "mode": "auto",
         "cache_ttl": "5m",
     },
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1380,23 +1380,37 @@ class AIAgent:
         # input costs by ~75% on multi-turn conversations. Uses system_and_3
         # strategy (4 breakpoints). See ``_anthropic_prompt_cache_policy``
         # for the layout-vs-transport decision. Users can override marker
-        # injection with config.yaml ``prompt_caching.mode`` (auto|force|off).
+        # injection per provider with
+        # ``providers.<provider_id>.prompt_caching.mode`` (auto|force|off).
         # Anthropic supports "5m" (default) and "1h" cache TTL tiers. Read from
         # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
         # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
         # sessions with >5-minute pauses between turns (#14971).
-        self._prompt_caching_mode = "auto"
+        self._prompt_caching_provider_modes = {}
         self._cache_ttl = "5m"
         try:
             from hermes_cli.config import load_config as _load_pc_cfg
 
-            _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-            _mode = str(_pc_cfg.get("mode", "auto") or "auto").strip().lower()
-            if _mode in ("auto", "force", "off"):
-                self._prompt_caching_mode = _mode
+            _cfg = _load_pc_cfg() or {}
+            _pc_cfg = _cfg.get("prompt_caching", {}) or {}
             _ttl = _pc_cfg.get("cache_ttl", "5m")
             if _ttl in ("5m", "1h"):
                 self._cache_ttl = _ttl
+            _providers_cfg = _cfg.get("providers", {}) or {}
+            if isinstance(_providers_cfg, dict):
+                for _provider_id, _provider_cfg in _providers_cfg.items():
+                    if not isinstance(_provider_cfg, dict):
+                        continue
+                    _provider_pc = _provider_cfg.get("prompt_caching", {}) or {}
+                    if not isinstance(_provider_pc, dict):
+                        continue
+                    _mode = self._normalize_prompt_caching_mode(
+                        _provider_pc.get("mode")
+                    )
+                    if _mode != "auto":
+                        _provider_key = str(_provider_id).strip().lower()
+                        if _provider_key:
+                            self._prompt_caching_provider_modes[_provider_key] = _mode
         except Exception:
             pass
         self._use_prompt_caching, self._use_native_cache_layout = (
@@ -1814,8 +1828,10 @@ class AIAgent:
                 source = "native Anthropic"
             elif self._use_native_cache_layout:
                 source = "Anthropic-compatible endpoint"
-            else:
+            elif self._is_openrouter_url():
                 source = "Claude via OpenRouter"
+            else:
+                source = f"{self.provider or 'provider'} route"
             print(f"💾 Prompt caching: ENABLED ({source}, {self._cache_ttl} TTL)")
         
         # Session logging setup - auto-save conversation trajectories for debugging
@@ -3377,6 +3393,20 @@ class AIAgent:
         """Return True when the base URL targets OpenRouter."""
         return base_url_host_matches(self._base_url_lower, "openrouter.ai")
 
+    @staticmethod
+    def _normalize_prompt_caching_mode(mode: object) -> str:
+        mode_str = str(mode or "auto").strip().lower()
+        if mode_str in {"auto", "force", "off"}:
+            return mode_str
+        return "auto"
+
+    def _prompt_caching_mode_for_provider(self, provider: str) -> str:
+        modes = getattr(self, "_prompt_caching_provider_modes", {}) or {}
+        if not isinstance(modes, dict):
+            return "auto"
+        key = str(provider or "").strip().lower()
+        return self._normalize_prompt_caching_mode(modes.get(key))
+
     def _anthropic_prompt_cache_policy(
         self,
         *,
@@ -3420,9 +3450,7 @@ class AIAgent:
         is_claude = "claude" in model_lower
         is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
         is_anthropic_wire = eff_api_mode == "anthropic_messages"
-        prompt_caching_mode = str(
-            getattr(self, "_prompt_caching_mode", "auto") or "auto"
-        ).strip().lower()
+        prompt_caching_mode = self._prompt_caching_mode_for_provider(eff_provider)
         if prompt_caching_mode == "off":
             return False, False
         if prompt_caching_mode == "force":

--- a/run_agent.py
+++ b/run_agent.py
@@ -1379,24 +1379,29 @@ class AIAgent:
         # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
         # input costs by ~75% on multi-turn conversations. Uses system_and_3
         # strategy (4 breakpoints). See ``_anthropic_prompt_cache_policy``
-        # for the layout-vs-transport decision.
-        self._use_prompt_caching, self._use_native_cache_layout = (
-            self._anthropic_prompt_cache_policy()
-        )
+        # for the layout-vs-transport decision. Users can override marker
+        # injection with config.yaml ``prompt_caching.mode`` (auto|force|off).
         # Anthropic supports "5m" (default) and "1h" cache TTL tiers. Read from
         # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
         # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
         # sessions with >5-minute pauses between turns (#14971).
+        self._prompt_caching_mode = "auto"
         self._cache_ttl = "5m"
         try:
             from hermes_cli.config import load_config as _load_pc_cfg
 
             _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+            _mode = str(_pc_cfg.get("mode", "auto") or "auto").strip().lower()
+            if _mode in ("auto", "force", "off"):
+                self._prompt_caching_mode = _mode
             _ttl = _pc_cfg.get("cache_ttl", "5m")
             if _ttl in ("5m", "1h"):
                 self._cache_ttl = _ttl
         except Exception:
             pass
+        self._use_prompt_caching, self._use_native_cache_layout = (
+            self._anthropic_prompt_cache_policy()
+        )
 
         # Iteration budget: the LLM is only notified when it actually exhausts
         # the iteration budget (api_call_count >= max_iterations).  At that
@@ -3415,6 +3420,16 @@ class AIAgent:
         is_claude = "claude" in model_lower
         is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
         is_anthropic_wire = eff_api_mode == "anthropic_messages"
+        prompt_caching_mode = str(
+            getattr(self, "_prompt_caching_mode", "auto") or "auto"
+        ).strip().lower()
+        if prompt_caching_mode == "off":
+            return False, False
+        if prompt_caching_mode == "force":
+            # Force only controls whether cache_control markers are injected;
+            # the layout still follows the active transport.
+            return True, is_anthropic_wire
+
         is_native_anthropic = (
             is_anthropic_wire
             and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -28,6 +28,7 @@ def _make_agent(
     agent._base_url_lower = (base_url or "").lower()
     agent.client = MagicMock()
     agent.quiet_mode = True
+    agent._prompt_caching_provider_modes = {}
     return agent
 
 
@@ -179,7 +180,7 @@ class TestOpenAIWireFormatOnCustomProvider:
 
 
 class TestPromptCachingModeOverride:
-    """Users may explicitly override prompt cache marker injection."""
+    """Users may explicitly override prompt cache marker injection per provider."""
 
     def test_force_enables_custom_openai_wire_with_envelope_layout(self):
         agent = _make_agent(
@@ -188,7 +189,7 @@ class TestPromptCachingModeOverride:
             api_mode="chat_completions",
             model="qwen3.6-plus",
         )
-        agent._prompt_caching_mode = "force"
+        agent._prompt_caching_provider_modes = {"custom": "force"}
         assert agent._anthropic_prompt_cache_policy() == (True, False)
 
     def test_force_enables_custom_anthropic_wire_with_native_layout(self):
@@ -198,7 +199,7 @@ class TestPromptCachingModeOverride:
             api_mode="anthropic_messages",
             model="qwen3.6-plus",
         )
-        agent._prompt_caching_mode = "force"
+        agent._prompt_caching_provider_modes = {"custom": "force"}
         assert agent._anthropic_prompt_cache_policy() == (True, True)
 
     def test_off_disables_auto_detected_cache_support(self):
@@ -208,7 +209,7 @@ class TestPromptCachingModeOverride:
             api_mode="chat_completions",
             model="anthropic/claude-sonnet-4.6",
         )
-        agent._prompt_caching_mode = "off"
+        agent._prompt_caching_provider_modes = {"openrouter": "off"}
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
     def test_invalid_mode_falls_back_to_auto(self):
@@ -218,8 +219,26 @@ class TestPromptCachingModeOverride:
             api_mode="chat_completions",
             model="anthropic/claude-sonnet-4.6",
         )
-        agent._prompt_caching_mode = "definitely-not-valid"
+        agent._prompt_caching_provider_modes = {"openrouter": "definitely-not-valid"}
         assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_initial_provider_mode_is_not_used_for_target_provider(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://proxy.example.com/v1",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+        )
+        agent._prompt_caching_provider_modes = {
+            "custom": "off",
+            "opencode-go": "force",
+        }
+        assert agent._anthropic_prompt_cache_policy(
+            provider="opencode-go",
+            base_url="https://api.opencode.ai/v1",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+        ) == (True, False)
 
 
 class TestQwenAlibabaFamily:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -178,6 +178,50 @@ class TestOpenAIWireFormatOnCustomProvider:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestPromptCachingModeOverride:
+    """Users may explicitly override prompt cache marker injection."""
+
+    def test_force_enables_custom_openai_wire_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://proxy.example.com/v1",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+        )
+        agent._prompt_caching_mode = "force"
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_force_enables_custom_anthropic_wire_with_native_layout(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://proxy.example.com/anthropic",
+            api_mode="anthropic_messages",
+            model="qwen3.6-plus",
+        )
+        agent._prompt_caching_mode = "force"
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_off_disables_auto_detected_cache_support(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        agent._prompt_caching_mode = "off"
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_invalid_mode_falls_back_to_auto(self):
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        agent._prompt_caching_mode = "definitely-not-valid"
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+
 class TestQwenAlibabaFamily:
     """Qwen on OpenCode/OpenCode-Go/Alibaba — needs cache_control even on OpenAI-wire.
 

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -271,6 +271,32 @@ class TestTryActivateFallback:
             agent._try_activate_fallback()
             assert agent._use_prompt_caching is False
 
+    def test_fallback_uses_target_provider_prompt_caching_mode(self):
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "qwen3.6-plus",
+                "base_url": "https://proxy.example/v1",
+            },
+        )
+        agent._prompt_caching_provider_modes = {
+            "openrouter": "off",
+            "custom": "force",
+        }
+        mock_client = _mock_resolve(
+            api_key="sk-custom-key",
+            base_url="https://proxy.example/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "qwen3.6-plus"),
+        ):
+            agent._try_activate_fallback()
+            assert (agent._use_prompt_caching, agent._use_native_cache_layout) == (
+                True,
+                False,
+            )
+
     def test_zai_alt_env_var(self):
         """Z.AI should also check Z_AI_API_KEY as fallback env var."""
         agent = _make_agent(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -831,6 +831,101 @@ class TestInit:
             )
             assert a._cache_ttl == "5m"
 
+    def test_provider_prompt_caching_force_enables_custom_openai_wire(self):
+        """providers.<id>.prompt_caching.mode=force enables markers for that provider."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "providers": {
+                        "custom": {"prompt_caching": {"mode": "force"}},
+                    },
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="custom",
+                model="qwen3.6-plus",
+                base_url="https://proxy.example/v1",
+                api_mode="chat_completions",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert (a._use_prompt_caching, a._use_native_cache_layout) == (True, False)
+
+    def test_provider_prompt_caching_off_disables_auto_openrouter_claude(self):
+        """providers.<id>.prompt_caching.mode=off disables an auto-enabled route."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "providers": {
+                        "openrouter": {"prompt_caching": {"mode": "off"}},
+                    },
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="openrouter",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                api_mode="chat_completions",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert (a._use_prompt_caching, a._use_native_cache_layout) == (
+                False,
+                False,
+            )
+
+    def test_switch_model_uses_target_provider_prompt_caching_mode(self):
+        """Switching providers re-evaluates cache mode from the target provider config."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "providers": {
+                        "custom": {"prompt_caching": {"mode": "off"}},
+                        "opencode-go": {"prompt_caching": {"mode": "force"}},
+                    },
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="custom",
+                model="qwen3.6-plus",
+                base_url="https://proxy.example/v1",
+                api_mode="chat_completions",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._use_prompt_caching is False
+
+            a.switch_model(
+                "qwen3.6-plus",
+                "opencode-go",
+                api_key="test-key-1234567890",
+                base_url="https://api.opencode.ai/v1",
+                api_mode="chat_completions",
+            )
+
+            assert (a._use_prompt_caching, a._use_native_cache_layout) == (True, False)
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -335,11 +335,21 @@ Prompt caching is automatically enabled when:
 # config.yaml — TTL is configurable (must be "5m" or "1h")
 prompt_caching:
   cache_ttl: "5m"
+
+# Optional per-provider marker override.
+providers:
+  custom:
+    prompt_caching:
+      mode: force # auto | force | off
 ```
+
+`force` applies only to that provider route. Use it only for gateways that
+accept Anthropic-style `cache_control`; strict OpenAI-compatible gateways may
+reject the extra fields.
 
 The CLI shows caching status at startup:
 ```
-💾 Prompt caching: ENABLED (Claude via OpenRouter, 5m TTL)
+💾 Prompt caching: ENABLED (custom route, 5m TTL)
 ```
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -77,17 +77,22 @@ For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-ho
 
 Hermes automatically injects Anthropic-style `cache_control` markers for known-compatible model/provider combinations (for example Claude on Anthropic/OpenRouter and selected compatible gateways). Custom gateways vary: some accept and forward these markers, some ignore them, and strict OpenAI-compatible gateways may reject unknown fields.
 
-Use `prompt_caching.mode` to override the automatic policy:
+Use `providers.<provider_id>.prompt_caching.mode` to override the automatic
+policy for one provider route:
 
 ```yaml
 prompt_caching:
-  mode: auto     # auto | force | off
   cache_ttl: 5m  # 5m | 1h
+
+providers:
+  custom:
+    prompt_caching:
+      mode: force # auto | force | off
 ```
 
 - `auto` (default): enable markers only for known-compatible routes.
-- `force`: always inject markers. Use this only when your provider/gateway supports Anthropic-style `cache_control`. Hermes still chooses the marker layout from the active API mode (`anthropic_messages` uses native layout; OpenAI-compatible `chat_completions` uses envelope layout).
-- `off`: never inject markers, even for routes Hermes would normally auto-detect.
+- `force`: inject markers for that provider route only. Use this only when your provider/gateway supports Anthropic-style `cache_control`; strict OpenAI-compatible gateways may reject the extra fields. Hermes still chooses the marker layout from the active API mode (`anthropic_messages` uses native layout; OpenAI-compatible `chat_completions` uses envelope layout).
+- `off`: disable markers for that provider route, even when Hermes would normally auto-detect support.
 
 `cache_ttl` controls Anthropic cache TTL when supported. Unknown values fall back to `5m`.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -73,6 +73,24 @@ Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a refer
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/docs/integrations/providers).
 
+### Prompt Caching
+
+Hermes automatically injects Anthropic-style `cache_control` markers for known-compatible model/provider combinations (for example Claude on Anthropic/OpenRouter and selected compatible gateways). Custom gateways vary: some accept and forward these markers, some ignore them, and strict OpenAI-compatible gateways may reject unknown fields.
+
+Use `prompt_caching.mode` to override the automatic policy:
+
+```yaml
+prompt_caching:
+  mode: auto     # auto | force | off
+  cache_ttl: 5m  # 5m | 1h
+```
+
+- `auto` (default): enable markers only for known-compatible routes.
+- `force`: always inject markers. Use this only when your provider/gateway supports Anthropic-style `cache_control`. Hermes still chooses the marker layout from the active API mode (`anthropic_messages` uses native layout; OpenAI-compatible `chat_completions` uses envelope layout).
+- `off`: never inject markers, even for routes Hermes would normally auto-detect.
+
+`cache_ttl` controls Anthropic cache TTL when supported. Unknown values fall back to `5m`.
+
 ### Provider Timeouts
 
 You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.


### PR DESCRIPTION
## Summary
- Add `prompt_caching.mode` with `auto`, `force`, and `off` options.
- Let users force Anthropic-style `cache_control` marker injection for compatible custom gateways, while preserving transport-specific layout selection.
- Document the new prompt caching override and add policy tests for force/off/invalid modes.

## Test Plan
- `python -m pytest tests/run_agent/test_anthropic_prompt_cache_policy.py -q`
- `git diff --check`
