### PR TITLE
fix(gateway): preserve spaced MEDIA file paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2062,9 +2062,18 @@ class BasePlatformAdapter(ABC):
         cleaned = cleaned.replace("[[as_document]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
+        # and quoted/backticked paths for LLM-formatted outputs.  Unquoted
+        # absolute paths may contain spaces, including Windows drive paths
+        # (``C:\\Users\\Foo Bar\\file.pdf``), so match through a known media/file
+        # extension instead of stopping at the first whitespace.
+        media_exts = (
+            "png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|"
+            "epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|kmz|kml|geojson|gpx|json|xml|html?"
+        )
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:[A-Za-z]:[\\/]|~/|/)[^\n`"']*?\.(?:'''
+            + media_exts
+            + r''')(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,27 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_unquoted_windows_paths_with_spaces(self):
+        content = r"MEDIA:C:\Users\Confera\OneDrive\Nusa Alam Kreasindo\Project\Foo\report.pdf"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            (r"C:\Users\Confera\OneDrive\Nusa Alam Kreasindo\Project\Foo\report.pdf", False)
+        ]
+        assert cleaned == ""
+
+    def test_media_tag_supports_unquoted_spaced_gis_paths(self):
+        content = "Map attached\nMEDIA:/tmp/Client Project/site boundary.geojson\nDone"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/Client Project/site boundary.geojson", False)]
+        assert "Map attached" in cleaned
+        assert "Done" in cleaned
+
+    def test_media_tag_supports_unquoted_windows_gis_paths_with_spaces(self):
+        content = r"MEDIA:C:\Users\Confera\GIS Files\site boundary.kmz"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(r"C:\Users\Confera\GIS Files\site boundary.kmz", False)]
+        assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## Summary
- Preserve unquoted `MEDIA:` paths with spaces, including Windows drive paths.
- Add GIS / structured-data extensions (`kmz`, `kml`, `geojson`, `gpx`, `json`, `xml`, `html`) to the spaced-path matcher.
- Add regression coverage for Windows spaced PDF paths and spaced GIS paths.

Closes #24032

## Test Plan
- `python -m pytest tests/gateway/test_platform_base.py::TestExtractMedia -q -o addopts=`
- `python -m pytest tests/gateway/test_send_image_file.py tests/gateway/test_signal.py::TestSignalMediaExtraction::test_extract_media_finds_image_tag tests/gateway/test_signal.py::TestSignalMediaExtraction::test_extract_media_finds_audio_tag -q -o addopts=`
- `python -m pytest tests/gateway/test_platform_base.py -q -o addopts=`
