### PR TITLE
fix(kanban): demote ready children when a parent is reopened

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -718,6 +718,10 @@ def _set_status_direct(
                 return False
 
         was_running = prev["status"] == "running"
+        reopening_satisfied_parent = (
+            prev["status"] in {"done", "archived"}
+            and new_status not in {"done", "archived"}
+        )
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
@@ -741,6 +745,37 @@ def _set_status_direct(
             "VALUES (?, ?, 'status', ?, ?)",
             (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
         )
+        if reopening_satisfied_parent:
+            # A parent leaving done/archived invalidates any direct child that
+            # was sitting in ready solely because that parent used to satisfy
+            # the dependency gate. Demote those children immediately so the
+            # dashboard does not keep advertising stale-ready work.
+            for row in conn.execute(
+                "SELECT child_id FROM task_links WHERE parent_id = ? ORDER BY child_id",
+                (task_id,),
+            ).fetchall():
+                child_id = row["child_id"]
+                demoted = conn.execute(
+                    "UPDATE tasks SET status = 'todo' "
+                    "WHERE id = ? AND status = 'ready'",
+                    (child_id,),
+                )
+                if demoted.rowcount == 1:
+                    conn.execute(
+                        "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                        "VALUES (?, 'status', ?, ?)",
+                        (
+                            child_id,
+                            json.dumps(
+                                {
+                                    "status": "todo",
+                                    "reason": "parent_reopened",
+                                    "parent": task_id,
+                                }
+                            ),
+                            int(time.time()),
+                        ),
+                    )
     # If we re-opened something, children may have gone stale.
     if new_status in ("done", "ready"):
         kanban_db.recompute_ready(conn)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -270,6 +270,43 @@ def test_patch_drag_drop_move_todo_to_ready(client):
     assert child_after["status"] == "ready"
 
 
+def test_reopening_parent_demotes_ready_child(client):
+    """Reopening a completed parent must invalidate ready children immediately.
+
+    The dispatcher re-checks parent completion on claim, but the dashboard
+    should not keep showing a stale child as ready after an operator drags
+    its parent back out of done for more work.
+    """
+    parent = client.post("/api/plugins/kanban/tasks", json={"title": "p"}).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "c", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "todo"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "done"},
+    )
+    assert r.status_code == 200
+
+    child_after_done = client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()["task"]
+    assert child_after_done["status"] == "ready"
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}",
+        json={"status": "todo"},
+    )
+    assert r.status_code == 200
+
+    child_after_reopen = client.get(
+        f"/api/plugins/kanban/tasks/{child['id']}"
+    ).json()["task"]
+    assert child_after_reopen["status"] == "todo"
+
+
 def test_patch_reassign(client):
     t = client.post(
         "/api/plugins/kanban/tasks",


### PR DESCRIPTION
## Summary

Fix a Kanban dashboard state invalidation bug where reopening a completed parent task could leave dependent children incorrectly visible in `ready`.

When an operator moves a parent task from `done` or `archived` back into active work, any directly dependent child that was previously unblocked by that parent should stop advertising itself as ready immediately. Before this change, the dashboard could keep showing a stale `ready` child until a later claim-time guard corrected it.

## What Changed

- update the dashboard status transition helper to detect when a task leaves a satisfied dependency state (`done` / `archived`)
- immediately demote directly linked `ready` children back to `todo`
- emit a child status event with `reason: "parent_reopened"` so the transition is observable

## Why This Matters

The dispatcher already protects the invariant at claim time, but the dashboard UI was still capable of showing stale-ready work after a parent was reopened. This patch brings the visible board state back in line with the actual dependency model immediately, instead of waiting for a later recovery point.

## Tests

Passed targeted regression coverage:

- `test_patch_drag_drop_move_todo_to_ready`
- `test_reopening_parent_demotes_ready_child`
- `test_patch_status_running_rejected`

