### PR TITLE
fix(pty-bridge): terminate PTY process groups on teardown

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -211,13 +211,23 @@ class PtyBridge:
             return
         self._closed = True
 
+        try:
+            pgid = os.getpgid(self._proc.pid)
+        except Exception:
+            pgid = None
+
         # SIGHUP is the conventional "your terminal went away" signal.
-        # We escalate if the child ignores it.
+        # Send it to the whole foreground process group, not just the PTY
+        # leader: the dashboard TUI starts helper children such as the Python
+        # slash worker, and killing only the leader can strand those helpers.
         for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
             if not self._proc.isalive():
                 break
             try:
-                self._proc.kill(sig)
+                if pgid is not None:
+                    os.killpg(pgid, sig)
+                else:
+                    self._proc.kill(sig)
             except Exception:
                 pass
             deadline = time.monotonic() + 0.5

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -7,6 +7,7 @@ printf) to verify it behaves like a PTY you can read/write/resize/close.
 from __future__ import annotations
 
 import os
+import signal
 import sys
 import time
 
@@ -143,6 +144,75 @@ class TestPtyBridgeClose:
                 reaped = True
                 break
         assert reaped, f"pid {pid} still running after close()"
+
+    def test_close_signals_child_process_group(self, monkeypatch):
+        sent: list[tuple[int, signal.Signals]] = []
+
+        class _FakeProc:
+            pid = 12345
+            fd = -1
+
+            def __init__(self):
+                self.alive = True
+
+            def isalive(self):
+                return self.alive
+
+            def kill(self, sig):
+                raise AssertionError(f"single-process kill used: {sig}")
+
+            def close(self, force=False):
+                self.closed = force
+
+        fake = _FakeProc()
+
+        def fake_killpg(pgid, sig):
+            sent.append((pgid, sig))
+            fake.alive = False
+
+        monkeypatch.setattr(os, "getpgid", lambda pid: 67890)
+        monkeypatch.setattr(os, "killpg", fake_killpg)
+
+        bridge = PtyBridge.__new__(PtyBridge)
+        bridge._proc = fake
+        bridge._fd = -1
+        bridge._closed = False
+
+        bridge.close()
+
+        assert sent == [(67890, signal.SIGHUP)]
+        assert bridge._closed is True
+
+    def test_close_falls_back_to_single_process_signal_when_group_unknown(self, monkeypatch):
+        sent: list[signal.Signals] = []
+
+        class _FakeProc:
+            pid = 12345
+            fd = -1
+
+            def __init__(self):
+                self.alive = True
+
+            def isalive(self):
+                return self.alive
+
+            def kill(self, sig):
+                sent.append(sig)
+                self.alive = False
+
+            def close(self, force=False):
+                self.closed = force
+
+        monkeypatch.setattr(os, "getpgid", lambda pid: (_ for _ in ()).throw(OSError()))
+
+        bridge = PtyBridge.__new__(PtyBridge)
+        bridge._proc = _FakeProc()
+        bridge._fd = -1
+        bridge._closed = False
+
+        bridge.close()
+
+        assert sent == [signal.SIGHUP]
 
 
 @skip_on_windows


### PR DESCRIPTION
## Problem statement

The dashboard chat runs the real TUI through `PtyBridge`. After extended dashboard use, child helper processes such as `tui_gateway.slash_worker` can survive chat teardown. Those orphaned helpers accumulate and eventually exhaust available PTY devices, causing new dashboard chats to fail with:

`Chat failed to start: out of pty devices`

This primarily affects long-running local dashboard users who open/close or reconnect chat sessions over time.

## Root cause

`PtyBridge.close()` only sent teardown signals to the PTY leader process via `self._proc.kill(sig)`. The TUI can spawn helper children under the same process group, and killing only the leader does not reliably terminate those descendants. The process tree outlives the dashboard chat session, leaking PTY-backed resources.

## Fix approach

- Capture the child process group id with `os.getpgid(self._proc.pid)`.
  - Identifies the PTY subtree that should receive terminal-close signals.
- Send `SIGHUP`, then `SIGTERM`, then `SIGKILL` to the full process group with `os.killpg(pgid, sig)`.
  - Preserves the existing escalation behavior while including helper children.
- Fall back to the existing single-process kill path if the process group cannot be resolved.
  - Preserves previous behavior for races where the process is already gone or group lookup fails.
- Add focused unit coverage using fake process objects.
  - Verifies group signaling without depending on timing-sensitive real subprocess trees.

## Test coverage

Added tests in `tests/hermes_cli/test_pty_bridge.py`:

- `test_close_signals_child_process_group`
  - Verifies `close()` uses `os.killpg()` when a process group is available and does not fall back to single-process `kill()`.
- `test_close_falls_back_to_single_process_signal_when_group_unknown`
  - Verifies the existing `self._proc.kill()` path is still used if `os.getpgid()` fails.

Targeted test command:

```bash
scripts/run_tests.sh tests/hermes_cli/test_pty_bridge.py
```

## Risk assessment

Low-to-moderate risk. The PTY bridge is already POSIX-only, and process-group teardown is the correct lifecycle boundary for an embedded terminal session. The main compatibility risk is that any child process intentionally meant to survive the dashboard TUI will now be terminated; for dashboard chat teardown, that is the desired behavior because helper descendants are session-owned. Fallback preserves the previous behavior if process-group lookup is unavailable.
