### PR TITLE
fix(supermemory): honor auto_capture during session-end flush

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -593,7 +593,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._sync_thread.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._active or not self._write_enabled or not self._client or not self._session_id:
+        if not self._active or not self._auto_capture or not self._write_enabled or not self._client or not self._session_id:
             return
         cleaned = []
         for message in messages or []:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -169,6 +169,21 @@ def test_on_session_end_ingests_clean_messages(provider):
     ]
 
 
+def test_on_session_end_respects_auto_capture_false(monkeypatch, tmp_path):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "test-key")
+    monkeypatch.setattr("plugins.memory.supermemory._SupermemoryClient", FakeClient)
+    _save_supermemory_config({"auto_capture": False}, str(tmp_path))
+    p = SupermemoryMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    p.on_session_end([
+        {"role": "user", "content": "please keep this out of automatic capture"},
+        {"role": "assistant", "content": "this should not be ingested either"},
+    ])
+
+    assert p._client.ingest_calls == []
+
+
 def test_on_memory_write_tracks_thread(provider):
     provider.on_memory_write("add", "memory", "Jordan likes concise docs")
     assert provider._write_thread is not None


### PR DESCRIPTION
## Problem statement

When Supermemory is enabled but `auto_capture` is disabled, Hermes should not automatically persist conversation content. Turn-level capture already respects this setting, but the session-end flush path still ingests the full cleaned conversation.

In practice, this can persist private session context even when the user explicitly disabled automatic capture. That stored context can later be recalled and included in outbound chat replies, creating an unexpected privacy leak.

## Root cause

`SupermemoryMemoryProvider.sync_turn()` correctly checks `_auto_capture` before writing conversation turns. `SupermemoryMemoryProvider.on_session_end()` did not. It only checked active/write/client/session state, so disabling `auto_capture` stopped per-turn capture but did not stop end-of-session ingestion.

## Fix approach

- Add `_auto_capture` to the early-return guard in `on_session_end()`.
  - Makes full-session ingestion obey the same capture toggle as turn-level ingestion.
- Add a regression test with `auto_capture: False`.
  - Locks the expected behavior: no `ingest_conversation()` call when automatic capture is disabled.

## Test coverage

Added test in `tests/plugins/memory/test_supermemory_provider.py`:

- `test_on_session_end_respects_auto_capture_false`
  - Configures Supermemory with `auto_capture: False`, calls `on_session_end()` with user/assistant messages, and verifies the fake client receives no ingestion call.

Existing coverage still verifies the enabled path:

- `test_on_session_end_ingests_clean_messages`
  - Confirms session-end ingestion still works when auto-capture is enabled.

Targeted test command:

```bash
scripts/run_tests.sh tests/plugins/memory/test_supermemory_provider.py
```

## Risk assessment

Low risk. This only changes behavior when `auto_capture` is disabled, aligning the session-end path with the documented meaning of that setting and with the existing `sync_turn()` behavior. Explicit memory writes are unaffected. Auto-recall is unaffected. Users who intentionally disabled turn capture but still expected whole-session capture would see less automatic persistence, but that split behavior is surprising and privacy-hostile.
