### PR TITLE
fix(gateway): safely parse HERMES_MAX_ITERATIONS in runtime paths

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -663,6 +663,30 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _max_iterations_env(default: int = 90) -> int:
+    """Read ``HERMES_MAX_ITERATIONS`` safely for long-lived gateway paths.
+
+    The gateway re-reads runtime environment/config state in several places.
+    A malformed env value must not crash startup logging, background tasks,
+    or foreground message handling.
+    """
+    raw = os.environ.get("HERMES_MAX_ITERATIONS")
+    if raw is None:
+        return int(default)
+    text = str(raw).strip()
+    if not text:
+        return int(default)
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid HERMES_MAX_ITERATIONS=%r; using default %d",
+            raw,
+            int(default),
+        )
+        return int(default)
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -3231,15 +3255,12 @@ class GatewayRunner:
         # Log the resolved max_iterations budget so operators can verify the
         # config.yaml → env bridge did the right thing at a glance (instead
         # of silently running at a stale .env value for weeks).
-        try:
-            _effective_max_iter = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            logger.info(
-                "Agent budget: max_iterations=%d (agent.max_turns from config.yaml, "
-                "or HERMES_MAX_ITERATIONS from .env, or default 90)",
-                _effective_max_iter,
-            )
-        except Exception:
-            pass
+        _effective_max_iter = _max_iterations_env()
+        logger.info(
+            "Agent budget: max_iterations=%d (agent.max_turns from config.yaml, "
+            "or HERMES_MAX_ITERATIONS from .env, or default 90)",
+            _effective_max_iter,
+        )
         # Redaction status: ON by default (#17691). Surface a prominent
         # warning if an operator has explicitly opted out so they don't
         # forget the downgrade is active — the redactor snapshots its
@@ -10207,7 +10228,7 @@ class GatewayRunner:
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = _max_iterations_env()
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -14650,7 +14671,7 @@ class GatewayRunner:
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
             # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = _max_iterations_env()
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.

--- a/tests/gateway/test_runtime_env_reload_config_authority.py
+++ b/tests/gateway/test_runtime_env_reload_config_authority.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
 
@@ -51,3 +52,22 @@ def test_reload_runtime_env_keeps_env_max_iterations_when_config_omits_key(
     gateway_run._reload_runtime_env_preserving_config_authority()
 
     assert os.environ["HERMES_MAX_ITERATIONS"] == "123"
+
+
+def test_max_iterations_env_invalid_value_falls_back_to_default(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "not-a-number")
+
+    with patch.object(gateway_run.logger, "warning") as warning:
+        assert gateway_run._max_iterations_env() == 90
+
+    warning.assert_called_once()
+    assert "Invalid HERMES_MAX_ITERATIONS" in warning.call_args[0][0]
+
+
+def test_max_iterations_env_strips_whitespace_and_uses_valid_value(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", " 42 ")
+
+    with patch.object(gateway_run.logger, "warning") as warning:
+        assert gateway_run._max_iterations_env() == 42
+
+    warning.assert_not_called()


### PR DESCRIPTION
## Summary

This fixes a gateway crash when `HERMES_MAX_ITERATIONS` contains an invalid value.

The gateway still had a few runtime paths using raw `int(os.getenv(...))` parsing for `HERMES_MAX_ITERATIONS`. If the env var was malformed, startup logging, background-task execution, or normal message handling could fail with `ValueError` instead of falling back safely.

This patch aligns those gateway paths with the already-hardened behavior used elsewhere in the repo.

## What Changed

- added a small `_max_iterations_env()` helper in `gateway/run.py`
- switched the remaining gateway runtime call-sites to use the helper
- invalid, empty, or whitespace-only values now fall back to the default `90`
- malformed values now emit a warning instead of crashing the gateway

## Validation

| Scenario | Before | After |
| --- | --- | --- |
| `HERMES_MAX_ITERATIONS=not-a-number` during gateway runtime | `ValueError` could break startup log path or turn execution | falls back to `90` and logs a warning |
| `HERMES_MAX_ITERATIONS=" 42 "` | behavior depended on raw parsing at each call-site | consistently resolves to `42` |
| Gateway startup budget log | could silently skip logging on parse failure | always logs resolved budget using safe fallback |
| Background task / normal turn agent creation | could crash on malformed env | uses shared safe parser |

## Files Changed

- `gateway/run.py`
- `tests/gateway/test_runtime_env_reload_config_authority.py`

## Tests

Added regression coverage for:

- invalid `HERMES_MAX_ITERATIONS` values falling back to `90`
- valid whitespace-wrapped values still parsing correctly

## Verification

```bash
pytest tests/gateway/test_runtime_env_reload_config_authority.py -q
4 passed in 3.55s
