### PR TITLE
feat(cron): add toolsets flag to cron create

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -32,6 +32,20 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
     return normalized
 
 
+def _normalize_toolsets(toolsets=None) -> Optional[List[str]]:
+    if not toolsets:
+        return None
+    raw_items = [toolsets] if isinstance(toolsets, str) else list(toolsets)
+
+    normalized: List[str] = []
+    for item in raw_items:
+        for part in str(item or "").split(","):
+            text = part.strip()
+            if text and text not in normalized:
+                normalized.append(text)
+    return normalized or None
+
+
 def _cron_api(**kwargs):
     from tools.cronjob_tools import cronjob as cronjob_tool
 
@@ -73,6 +87,7 @@ def cron_list(show_all: bool = False):
         deliver_str = ", ".join(deliver)
 
         skills = job.get("skills") or ([job["skill"]] if job.get("skill") else [])
+        toolsets = job.get("enabled_toolsets") or []
         if state == "paused":
             status = color("[paused]", Colors.YELLOW)
         elif state == "completed":
@@ -90,6 +105,8 @@ def cron_list(show_all: bool = False):
         print(f"    Deliver:   {deliver_str}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
+        if toolsets:
+            print(f"    Toolsets:  {', '.join(toolsets)}")
         script = job.get("script")
         if script:
             print(f"    Script:    {script}")
@@ -172,6 +189,7 @@ def cron_create(args):
         repeat=getattr(args, "repeat", None),
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
+        enabled_toolsets=_normalize_toolsets(getattr(args, "toolsets", None)),
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
@@ -185,6 +203,8 @@ def cron_create(args):
     if result.get("skills"):
         print(f"  Skills: {', '.join(result['skills'])}")
     job_data = result.get("job", {})
+    if job_data.get("enabled_toolsets"):
+        print(f"  Toolsets: {', '.join(job_data['enabled_toolsets'])}")
     if job_data.get("script"):
         print(f"  Script: {job_data['script']}")
     if job_data.get("no_agent"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9820,6 +9820,13 @@ def main():
         help="Attach a skill. Repeat to add multiple skills.",
     )
     cron_create.add_argument(
+        "--toolsets",
+        help=(
+            "Comma-separated toolsets to enable for this job "
+            "(for example: terminal,file,tdx-custom)."
+        ),
+    )
+    cron_create.add_argument(
         "--script",
         help=(
             "Path to a script under ~/.hermes/scripts/. Default mode: "

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -1,11 +1,24 @@
 """Tests for hermes_cli.cron command handling."""
 
+import subprocess
+import sys
 from argparse import Namespace
 
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
 from hermes_cli.cron import cron_command
+
+
+def test_cron_create_help_includes_toolsets_flag():
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "cron", "create", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0
+    assert "--toolsets" in result.stdout
 
 
 @pytest.fixture()
@@ -96,6 +109,7 @@ class TestCronCommandLifecycle:
                 repeat=None,
                 skill=None,
                 skills=["blogwatcher", "maps"],
+                toolsets=None,
             )
         )
         out = capsys.readouterr().out
@@ -105,3 +119,26 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+    def test_create_with_toolsets(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Run with scoped tools",
+                name="Scoped tools",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                toolsets="terminal,file, terminal",
+            )
+        )
+        out = capsys.readouterr().out
+        assert "Created job" in out
+        assert "Toolsets: terminal, file" in out
+
+        jobs = list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["enabled_toolsets"] == ["terminal", "file"]
+        assert jobs[0]["name"] == "Scoped tools"


### PR DESCRIPTION
## Summary
- add `hermes cron create --toolsets` so scheduled jobs can opt into specific toolsets
- pass the CLI value through as per-job `enabled_toolsets`, which the cron scheduler already honors
- show configured toolsets in `cron create` output and `cron list`

Closes #24134

## Tests
- `python3 -m py_compile contrib3/hermes_cli/cron.py contrib3/hermes_cli/main.py contrib3/tests_test_cron.py`
- direct stubbed `cron_create` check for `terminal,file, terminal` -> `["terminal", "file"]`

Note: I verified the changed files from an API-minimal workspace rather than a full repository clone, so I could not run the full pytest suite locally here.
