### PR TITLE
feat(browser): add guarded Mac CDP config tools

### DIFF
--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -409,6 +409,19 @@ def test_mac_cdp_fill_config_requires_session_and_blocks_secrets(tmp_path):
     assert "error" in secret
     assert "secret" in secret["error"].lower()
 
+    validation_js = json.loads(
+        browser_cdp_tool.browser_mac_cdp_fill_config(
+            url="https://example.com/form",
+            allowed_domains=["example.com"],
+            fields=[{"selector": "#title", "value": "ok"}],
+            session_id="fill-001",
+            validation_expression="document.querySelector('form').submit()",
+            shared_root=str(tmp_path),
+        )
+    )
+    assert "error" in validation_js
+    assert "validationExpression" in validation_js["error"]
+
 
 def test_mac_cdp_fill_config_writes_non_submitting_config(tmp_path):
     raw = browser_cdp_tool.browser_mac_cdp_fill_config(
@@ -417,7 +430,6 @@ def test_mac_cdp_fill_config_writes_non_submitting_config(tmp_path):
         fields=[{"selector": "#title", "kind": "value", "value": "hello"}],
         session_id="fill-001",
         output_prefix="flow",
-        validation_expression="({ok:true})",
         shared_root=str(tmp_path),
         write_local_config=True,
     )

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -376,6 +376,7 @@ def test_mac_cdp_inventory_config_writes_readonly_config(tmp_path):
     assert result["readOnly"] is True
     assert result["allowSubmit"] is False
     assert result["url"] == "https://example.com/form?sessionId=inv-001"
+    assert result["sideEffectPolicy"]["approvalRequiredBeforeRun"] is False
     assert '"readOnly": true' in result["config_json"]
     cfg = json.loads((tmp_path / "cdp-readonly-inventory-config.json").read_text())
     assert cfg["readOnly"] is True
@@ -426,6 +427,8 @@ def test_mac_cdp_fill_config_writes_non_submitting_config(tmp_path):
     assert result["allowSubmit"] is False
     assert result["fields_count"] == 1
     assert result["url"] == "https://example.com/form?x=1&sessionId=fill-001"
+    assert result["sideEffectPolicy"]["approvalRequiredBeforeRun"] is True
+    assert "explicit approval" in result["next_step"]
     assert '"allowSubmit": false' in result["config_json"]
     cfg = json.loads((tmp_path / "cdp-form-fill-config.json").read_text())
     assert cfg["allowSubmit"] is False

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -361,6 +361,90 @@ def test_registered_in_browser_toolset():
     assert browser_cdp_tool.CDP_DOCS_URL in entry.schema["description"]
 
 
+def test_mac_cdp_inventory_config_writes_readonly_config(tmp_path):
+    raw = browser_cdp_tool.browser_mac_cdp_inventory_config(
+        url="https://example.com/form",
+        allowed_domains=["example.com"],
+        session_id="inv-001",
+        output_prefix="flow",
+        shared_root=str(tmp_path),
+        write_local_config=True,
+    )
+    result = json.loads(raw)
+    assert result["success"] is True
+    assert result["mode"] == "inventory"
+    assert result["readOnly"] is True
+    assert result["allowSubmit"] is False
+    assert result["url"] == "https://example.com/form?sessionId=inv-001"
+    assert '"readOnly": true' in result["config_json"]
+    cfg = json.loads((tmp_path / "cdp-readonly-inventory-config.json").read_text())
+    assert cfg["readOnly"] is True
+    assert cfg["allowSubmit"] is False
+    assert cfg["outputPath"] == str(tmp_path / "flow-readonly-inventory-result.json")
+
+
+def test_mac_cdp_fill_config_requires_session_and_blocks_secrets(tmp_path):
+    missing_session = json.loads(
+        browser_cdp_tool.browser_mac_cdp_fill_config(
+            url="https://example.com/form",
+            allowed_domains=["example.com"],
+            fields=[{"selector": "#title", "value": "ok"}],
+            session_id="",
+            shared_root=str(tmp_path),
+        )
+    )
+    assert "error" in missing_session
+    assert "sessionId" in missing_session["error"]
+
+    secret = json.loads(
+        browser_cdp_tool.browser_mac_cdp_fill_config(
+            url="https://example.com/form",
+            allowed_domains=["example.com"],
+            fields=[{"selector": "#title", "value": "token=abc"}],
+            session_id="fill-001",
+            shared_root=str(tmp_path),
+        )
+    )
+    assert "error" in secret
+    assert "secret" in secret["error"].lower()
+
+
+def test_mac_cdp_fill_config_writes_non_submitting_config(tmp_path):
+    raw = browser_cdp_tool.browser_mac_cdp_fill_config(
+        url="https://example.com/form?x=1",
+        allowed_domains=["example.com"],
+        fields=[{"selector": "#title", "kind": "value", "value": "hello"}],
+        session_id="fill-001",
+        output_prefix="flow",
+        validation_expression="({ok:true})",
+        shared_root=str(tmp_path),
+        write_local_config=True,
+    )
+    result = json.loads(raw)
+    assert result["success"] is True
+    assert result["mode"] == "fill"
+    assert result["allowSubmit"] is False
+    assert result["fields_count"] == 1
+    assert result["url"] == "https://example.com/form?x=1&sessionId=fill-001"
+    assert '"allowSubmit": false' in result["config_json"]
+    cfg = json.loads((tmp_path / "cdp-form-fill-config.json").read_text())
+    assert cfg["allowSubmit"] is False
+    assert "readOnly" not in cfg
+    assert cfg["fields"][0]["value"] == "hello"
+
+
+def test_mac_cdp_config_tools_registered():
+    from tools.registry import registry
+
+    inventory = registry.get_entry("browser_mac_cdp_inventory_config")
+    fill = registry.get_entry("browser_mac_cdp_fill_config")
+    assert inventory is not None
+    assert fill is not None
+    assert inventory.toolset == "browser-cdp"
+    assert fill.toolset == "browser-cdp"
+    assert fill.schema["parameters"]["required"] == ["url", "allowed_domains", "fields", "session_id"]
+
+
 def test_dispatch_through_registry(cdp_server):
     from tools.registry import registry
 

--- a/tests/tools/test_mac_cdp_config_builder.py
+++ b/tests/tools/test_mac_cdp_config_builder.py
@@ -96,6 +96,9 @@ def test_fill_config_requires_fields_and_blocks_custom_validation_js(tmp_path):
     assert cfg["url"] == "https://example.com/form?x=1&sessionId=abc"
     assert cfg["allowSubmit"] is False
     assert cfg["fields"][0]["value"] == "こんにちは"
+    assert cfg["allowedDomains"] == ["example.com"]
+    assert cfg["sessionId"] == "abc"
+    assert "sideEffectApproval" not in cfg
     assert cfg["validationExpression"] == "({ok:true})"
     assert cfg["sideEffectPolicy"]["approvalRequiredBeforeRun"] is True
     assert "autosave" in " ".join(cfg["sideEffectPolicy"]["knownSideEffects"])
@@ -110,6 +113,38 @@ def test_fill_config_requires_fields_and_blocks_custom_validation_js(tmp_path):
                 "allowedDomains": ["example.com"],
                 "fields": [{"selector": "#title", "kind": "value", "value": "こんにちは"}],
                 "validationExpression": "document.querySelector('form').submit()",
+            },
+            shared_root=tmp_path,
+        )
+
+
+def test_fill_config_includes_approval_marker_only_with_matching_token(tmp_path):
+    cfg = builder.build_config(
+        {
+            "mode": "fill",
+            "url": "https://example.com/form",
+            "sessionId": "abc",
+            "allowedDomains": ["example.com"],
+            "fields": [{"selector": "#title", "value": "ok"}],
+            "approvalToken": "APPROVED:abc",
+        },
+        shared_root=tmp_path,
+    )
+    assert cfg["sideEffectApproval"] == {
+        "approved": True,
+        "token": "APPROVED:abc",
+        "scope": "url+fields+sessionId",
+    }
+
+    with pytest.raises(ValueError, match="approvalToken"):
+        builder.build_config(
+            {
+                "mode": "fill",
+                "url": "https://example.com/form",
+                "sessionId": "abc",
+                "allowedDomains": ["example.com"],
+                "fields": [{"selector": "#title", "value": "ok"}],
+                "approvalToken": "APPROVED:wrong",
             },
             shared_root=tmp_path,
         )

--- a/tests/tools/test_mac_cdp_config_builder.py
+++ b/tests/tools/test_mac_cdp_config_builder.py
@@ -82,7 +82,7 @@ def test_fill_config_rejects_submit_secret_and_missing_session(tmp_path):
         assert expected.lower() in str(exc.value).lower()
 
 
-def test_fill_config_requires_fields_and_preserves_validation(tmp_path):
+def test_fill_config_requires_fields_and_blocks_custom_validation_js(tmp_path):
     cfg = builder.build_config(
         {
             "mode": "fill",
@@ -90,17 +90,29 @@ def test_fill_config_requires_fields_and_preserves_validation(tmp_path):
             "sessionId": "abc",
             "allowedDomains": ["example.com"],
             "fields": [{"selector": "#title", "kind": "value", "value": "こんにちは"}],
-            "validationExpression": "({ok: document.querySelector(\"#title\").value.length > 0})",
         },
         shared_root=tmp_path,
     )
     assert cfg["url"] == "https://example.com/form?x=1&sessionId=abc"
     assert cfg["allowSubmit"] is False
     assert cfg["fields"][0]["value"] == "こんにちは"
-    assert cfg["validationExpression"].startswith("({ok:")
+    assert cfg["validationExpression"] == "({ok:true})"
     assert cfg["sideEffectPolicy"]["approvalRequiredBeforeRun"] is True
     assert "autosave" in " ".join(cfg["sideEffectPolicy"]["knownSideEffects"])
     assert "obtain approval" in cfg["sideEffectPolicy"]["approvalInstruction"]
+
+    with pytest.raises(ValueError, match="custom validationExpression"):
+        builder.build_config(
+            {
+                "mode": "fill",
+                "url": "https://example.com/form?x=1",
+                "sessionId": "abc",
+                "allowedDomains": ["example.com"],
+                "fields": [{"selector": "#title", "kind": "value", "value": "こんにちは"}],
+                "validationExpression": "document.querySelector('form').submit()",
+            },
+            shared_root=tmp_path,
+        )
 
 
 def test_write_config_uses_mode_specific_default_name(tmp_path):

--- a/tests/tools/test_mac_cdp_config_builder.py
+++ b/tests/tools/test_mac_cdp_config_builder.py
@@ -1,0 +1,109 @@
+"""Unit tests for guarded Mac CDP sidecar config generation."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import mac_cdp_config_builder as builder
+
+
+def test_inventory_config_is_readonly_and_sessionized(tmp_path):
+    cfg = builder.build_config(
+        {
+            "mode": "inventory",
+            "url": "https://example.com/form",
+            "sessionId": "safe-01",
+            "allowedDomains": ["example.com"],
+            "outputPrefix": "dryrun",
+        },
+        shared_root=tmp_path,
+    )
+    assert cfg["url"] == "https://example.com/form?sessionId=safe-01"
+    assert cfg["allowSubmit"] is False
+    assert cfg["readOnly"] is True
+    assert cfg["minFields"] == 1
+    assert cfg["outputPath"] == str(tmp_path / "dryrun-readonly-inventory-result.json")
+    assert cfg["screenshotPath"] == str(tmp_path / "dryrun-readonly-inventory-screenshot.png")
+
+
+def test_fill_config_rejects_unlisted_domain(tmp_path):
+    with pytest.raises(ValueError, match="not in allowedDomains"):
+        builder.build_config(
+            {
+                "mode": "fill",
+                "url": "https://evil.example/form",
+                "sessionId": "safe-01",
+                "allowedDomains": ["example.com"],
+                "fields": [{"selector": "#title", "value": "x"}],
+            },
+            shared_root=tmp_path,
+        )
+
+
+def test_fill_config_rejects_submit_secret_and_missing_session(tmp_path):
+    rejected = [
+        (
+            {
+                "mode": "fill",
+                "url": "https://example.com",
+                "sessionId": "safe-01",
+                "allowedDomains": ["example.com"],
+                "allowSubmit": True,
+                "fields": [{"selector": "#x", "value": "ok"}],
+            },
+            "submit",
+        ),
+        (
+            {
+                "mode": "fill",
+                "url": "https://example.com",
+                "sessionId": "safe-01",
+                "allowedDomains": ["example.com"],
+                "fields": [{"selector": "#x", "value": "token=abc"}],
+            },
+            "secret",
+        ),
+        (
+            {
+                "mode": "fill",
+                "url": "https://example.com",
+                "allowedDomains": ["example.com"],
+                "fields": [{"selector": "#x", "value": "ok"}],
+            },
+            "sessionId",
+        ),
+    ]
+    for payload, expected in rejected:
+        with pytest.raises(ValueError) as exc:
+            builder.build_config(payload, shared_root=tmp_path)
+        assert expected.lower() in str(exc.value).lower()
+
+
+def test_fill_config_requires_fields_and_preserves_validation(tmp_path):
+    cfg = builder.build_config(
+        {
+            "mode": "fill",
+            "url": "https://example.com/form?x=1",
+            "sessionId": "abc",
+            "allowedDomains": ["example.com"],
+            "fields": [{"selector": "#title", "kind": "value", "value": "こんにちは"}],
+            "validationExpression": "({ok: document.querySelector(\"#title\").value.length > 0})",
+        },
+        shared_root=tmp_path,
+    )
+    assert cfg["url"] == "https://example.com/form?x=1&sessionId=abc"
+    assert cfg["allowSubmit"] is False
+    assert cfg["fields"][0]["value"] == "こんにちは"
+    assert cfg["validationExpression"].startswith("({ok:")
+
+
+def test_write_config_uses_mode_specific_default_name(tmp_path):
+    out = builder.write_config(
+        {"mode": "inventory", "url": "https://example.com", "allowedDomains": ["example.com"]},
+        shared_root=tmp_path,
+    )
+    assert out == tmp_path / "cdp-readonly-inventory-config.json"
+    data = json.loads(out.read_text())
+    assert data["allowSubmit"] is False
+    assert data["readOnly"] is True

--- a/tests/tools/test_mac_cdp_config_builder.py
+++ b/tests/tools/test_mac_cdp_config_builder.py
@@ -23,6 +23,8 @@ def test_inventory_config_is_readonly_and_sessionized(tmp_path):
     assert cfg["allowSubmit"] is False
     assert cfg["readOnly"] is True
     assert cfg["minFields"] == 1
+    assert cfg["sideEffectPolicy"]["approvalRequiredBeforeRun"] is False
+    assert "does not type" in " ".join(cfg["sideEffectPolicy"]["knownSideEffects"])
     assert cfg["outputPath"] == str(tmp_path / "dryrun-readonly-inventory-result.json")
     assert cfg["screenshotPath"] == str(tmp_path / "dryrun-readonly-inventory-screenshot.png")
 
@@ -96,6 +98,9 @@ def test_fill_config_requires_fields_and_preserves_validation(tmp_path):
     assert cfg["allowSubmit"] is False
     assert cfg["fields"][0]["value"] == "こんにちは"
     assert cfg["validationExpression"].startswith("({ok:")
+    assert cfg["sideEffectPolicy"]["approvalRequiredBeforeRun"] is True
+    assert "autosave" in " ".join(cfg["sideEffectPolicy"]["knownSideEffects"])
+    assert "obtain approval" in cfg["sideEffectPolicy"]["approvalInstruction"]
 
 
 def test_write_config_uses_mode_specific_default_name(tmp_path):

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -525,6 +525,7 @@ def browser_mac_cdp_fill_config(
     session_id: str,
     output_prefix: Optional[str] = None,
     validation_expression: Optional[str] = None,
+    approval_token: Optional[str] = None,
     shared_root: str = str(DEFAULT_SHARED_ROOT),
     config_path: Optional[str] = None,
     write_local_config: bool = False,
@@ -541,6 +542,8 @@ def browser_mac_cdp_fill_config(
         spec["outputPrefix"] = output_prefix
     if validation_expression:
         spec["validationExpression"] = validation_expression
+    if approval_token:
+        spec["approvalToken"] = approval_token
     return _mac_sidecar_config_payload(
         spec,
         shared_root=shared_root,
@@ -759,6 +762,10 @@ MAC_CDP_FILL_SCHEMA: Dict[str, Any] = {
                 "type": "string",
                 "description": "Deprecated/blocked for guarded fill: arbitrary JS validation is rejected because it can cause side effects.",
             },
+            "approval_token": {
+                "type": "string",
+                "description": "Optional explicit approval marker required by the runner for actual fill execution. Must equal APPROVED:<session_id> after user approval for this URL and field set.",
+            },
             "shared_root": {"type": "string", "description": "Mac shared-worker root. Defaults to Kagura local-worker shared root."},
             "config_path": {"type": "string", "description": "Optional intended output config JSON path under shared_root."},
             "write_local_config": {"type": "boolean", "description": "Advanced/testing only: also write config_path on the current Hermes host."},
@@ -795,6 +802,7 @@ registry.register(
         session_id=args.get("session_id", ""),
         output_prefix=args.get("output_prefix"),
         validation_expression=args.get("validation_expression"),
+        approval_token=args.get("approval_token"),
         shared_root=args.get("shared_root", str(DEFAULT_SHARED_ROOT)),
         config_path=args.get("config_path"),
         write_local_config=bool(args.get("write_local_config", False)),

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -424,6 +424,15 @@ MAC_CDP_INVENTORY_RUNNER = str(DEFAULT_SHARED_ROOT / "mac-cdp-readonly-dom-inven
 MAC_CDP_FILL_RUNNER = str(DEFAULT_SHARED_ROOT / "mac-cdp-form-fill-sidecar.py")
 
 
+def _mac_config_path_under_shared_root(path: str, shared_root: str) -> str:
+    """Return a normalized config path, rejecting paths outside shared_root."""
+    resolved = Path(path).expanduser().resolve()
+    root = Path(shared_root).expanduser().resolve()
+    if not (resolved == root or root in resolved.parents):
+        raise ValueError(f"config_path outside shared root: {resolved}")
+    return str(resolved)
+
+
 def _mac_sidecar_config_payload(
     spec: Dict[str, Any],
     *,
@@ -443,7 +452,7 @@ def _mac_sidecar_config_payload(
         cfg = build_config(spec, shared_root=shared_root)
         mode = "inventory" if cfg.get("readOnly") is True else "fill"
         if config_path:
-            intended_path = config_path
+            intended_path = _mac_config_path_under_shared_root(config_path, shared_root)
         else:
             name = "cdp-readonly-inventory-config.json" if mode == "inventory" else "cdp-form-fill-config.json"
             intended_path = str(DEFAULT_SHARED_ROOT / name) if shared_root == str(DEFAULT_SHARED_ROOT) else str(Path(shared_root) / name)

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -465,9 +465,13 @@ def _mac_sidecar_config_payload(
         "sideEffectPolicy": cfg.get("sideEffectPolicy"),
         "url": cfg.get("url"),
         "next_step": (
-            "Install config_json to config_path via mac_write_file, then run "
-            "runner_path via mac_run_shared_python. For fill configs, first "
-            "state sideEffectPolicy to the user and obtain explicit approval."
+            "Before running, state sideEffectPolicy to the user and obtain "
+            "explicit approval for this URL and field set; then install "
+            "config_json to config_path via mac_write_file and run runner_path "
+            "via mac_run_shared_python."
+            if mode == "fill"
+            else "Install config_json to config_path via mac_write_file, then "
+            "run runner_path via mac_run_shared_python for the read-only pass."
         ),
     }
     if cfg.get("readOnly") is True:
@@ -742,7 +746,10 @@ MAC_CDP_FILL_SCHEMA: Dict[str, Any] = {
             },
             "session_id": {"type": "string", "description": "Required correlation ID from a prior read-only inventory pass."},
             "output_prefix": {"type": "string", "description": "Optional safe filename prefix for result/screenshot artifacts."},
-            "validation_expression": {"type": "string", "description": "Optional JS expression returning validation info after fill."},
+            "validation_expression": {
+                "type": "string",
+                "description": "Deprecated/blocked for guarded fill: arbitrary JS validation is rejected because it can cause side effects.",
+            },
             "shared_root": {"type": "string", "description": "Mac shared-worker root. Defaults to Kagura local-worker shared root."},
             "config_path": {"type": "string", "description": "Optional intended output config JSON path under shared_root."},
             "write_local_config": {"type": "boolean", "description": "Advanced/testing only: also write config_path on the current Hermes host."},

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from pathlib import Path
 from typing import Any, Dict, Optional
 
+from tools.mac_cdp_config_builder import DEFAULT_SHARED_ROOT, build_config, write_config
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
@@ -414,6 +416,126 @@ def browser_cdp(
 
 
 # ---------------------------------------------------------------------------
+# Guarded Mac local-worker sidecar config entry points
+# ---------------------------------------------------------------------------
+
+
+MAC_CDP_INVENTORY_RUNNER = str(DEFAULT_SHARED_ROOT / "mac-cdp-readonly-dom-inventory.py")
+MAC_CDP_FILL_RUNNER = str(DEFAULT_SHARED_ROOT / "mac-cdp-form-fill-sidecar.py")
+
+
+def _mac_sidecar_config_payload(
+    spec: Dict[str, Any],
+    *,
+    shared_root: str = str(DEFAULT_SHARED_ROOT),
+    config_path: Optional[str] = None,
+    runner_path: str,
+    write_local_config: bool = False,
+) -> str:
+    """Build a guarded Mac CDP sidecar config.
+
+    Browser tools run on the current Hermes host, not on the Mac.  Therefore
+    the safe default is to return config JSON plus the intended Mac path; the
+    caller installs it with mac_write_file before running mac_run_shared_python.
+    Tests and local harnesses can opt into writing with write_local_config=True.
+    """
+    try:
+        cfg = build_config(spec, shared_root=shared_root)
+        mode = "inventory" if cfg.get("readOnly") is True else "fill"
+        if config_path:
+            intended_path = config_path
+        else:
+            name = "cdp-readonly-inventory-config.json" if mode == "inventory" else "cdp-form-fill-config.json"
+            intended_path = str(DEFAULT_SHARED_ROOT / name) if shared_root == str(DEFAULT_SHARED_ROOT) else str(Path(shared_root) / name)
+        if write_local_config:
+            path = write_config(spec, shared_root=shared_root, out_path=intended_path)
+            intended_path = str(path)
+    except Exception as exc:
+        return tool_error(f"Mac CDP sidecar config rejected: {exc}")
+
+    payload: Dict[str, Any] = {
+        "success": True,
+        "mode": mode,
+        "config_path": intended_path,
+        "config_json": json.dumps(cfg, ensure_ascii=False, indent=2) + "\n",
+        "runner_path": runner_path,
+        "result_path": cfg.get("outputPath"),
+        "screenshot_path": cfg.get("screenshotPath"),
+        "allowSubmit": cfg.get("allowSubmit"),
+        "url": cfg.get("url"),
+        "next_step": (
+            "Install config_json to config_path via mac_write_file, then run "
+            "runner_path via mac_run_shared_python."
+        ),
+    }
+    if cfg.get("readOnly") is True:
+        payload["readOnly"] = True
+    else:
+        payload["fields_count"] = len(cfg.get("fields", []))
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def browser_mac_cdp_inventory_config(
+    url: str,
+    allowed_domains: list[str],
+    session_id: Optional[str] = None,
+    output_prefix: Optional[str] = None,
+    shared_root: str = str(DEFAULT_SHARED_ROOT),
+    config_path: Optional[str] = None,
+    write_local_config: bool = False,
+) -> str:
+    """Create a read-only DOM inventory config for the Mac CDP sidecar."""
+    spec: Dict[str, Any] = {
+        "mode": "inventory",
+        "url": url,
+        "allowedDomains": allowed_domains,
+    }
+    if session_id:
+        spec["sessionId"] = session_id
+    if output_prefix:
+        spec["outputPrefix"] = output_prefix
+    return _mac_sidecar_config_payload(
+        spec,
+        shared_root=shared_root,
+        config_path=config_path,
+        runner_path=MAC_CDP_INVENTORY_RUNNER,
+        write_local_config=write_local_config,
+    )
+
+
+def browser_mac_cdp_fill_config(
+    url: str,
+    allowed_domains: list[str],
+    fields: list[dict[str, Any]],
+    session_id: str,
+    output_prefix: Optional[str] = None,
+    validation_expression: Optional[str] = None,
+    shared_root: str = str(DEFAULT_SHARED_ROOT),
+    config_path: Optional[str] = None,
+    write_local_config: bool = False,
+) -> str:
+    """Create a guarded, non-submitting form-fill config for the Mac sidecar."""
+    spec: Dict[str, Any] = {
+        "mode": "fill",
+        "url": url,
+        "allowedDomains": allowed_domains,
+        "fields": fields,
+        "sessionId": session_id,
+    }
+    if output_prefix:
+        spec["outputPrefix"] = output_prefix
+    if validation_expression:
+        spec["validationExpression"] = validation_expression
+    return _mac_sidecar_config_payload(
+        spec,
+        shared_root=shared_root,
+        config_path=config_path,
+        runner_path=MAC_CDP_FILL_RUNNER,
+        write_local_config=write_local_config,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -560,4 +682,104 @@ registry.register(
     ),
     check_fn=_browser_cdp_check,
     emoji="🧪",
+)
+
+
+MAC_CDP_INVENTORY_SCHEMA: Dict[str, Any] = {
+    "name": "browser_mac_cdp_inventory_config",
+    "description": (
+        "Build a guarded read-only DOM inventory config for Kagura's Mac "
+        "local-worker CDP sidecar. This returns config JSON plus the intended "
+        "Mac config path; it does not steal foreground focus and does not "
+        "execute browser actions. Install config_json with mac_write_file, then "
+        "run runner_path via mac_run_shared_python to perform the read-only pass."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string", "description": "Absolute http/https URL to inspect."},
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exact hostnames allowed for this operation; subdomains are not implied.",
+            },
+            "session_id": {"type": "string", "description": "Optional correlation ID appended as sessionId query parameter."},
+            "output_prefix": {"type": "string", "description": "Optional safe filename prefix for result/screenshot artifacts."},
+            "shared_root": {"type": "string", "description": "Mac shared-worker root. Defaults to Kagura local-worker shared root."},
+            "config_path": {"type": "string", "description": "Optional intended output config JSON path under shared_root."},
+            "write_local_config": {"type": "boolean", "description": "Advanced/testing only: also write config_path on the current Hermes host."},
+        },
+        "required": ["url", "allowed_domains"],
+    },
+}
+
+
+MAC_CDP_FILL_SCHEMA: Dict[str, Any] = {
+    "name": "browser_mac_cdp_fill_config",
+    "description": (
+        "Build a guarded non-submitting form-fill config for Kagura's Mac "
+        "local-worker CDP sidecar. Requires a session_id from the prior "
+        "inventory pass, rejects likely secrets, exact-domain mismatches, and "
+        "always enforces allowSubmit=false. Returns config JSON plus the intended "
+        "Mac config path; install config_json with mac_write_file and execute "
+        "the returned runner_path via mac_run_shared_python after review."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string", "description": "Absolute http/https URL to fill."},
+            "allowed_domains": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Exact hostnames allowed for this operation; subdomains are not implied.",
+            },
+            "fields": {
+                "type": "array",
+                "items": {"type": "object", "additionalProperties": True},
+                "description": "Field specs: selector, optional kind=value/textContent/innerText, and value.",
+            },
+            "session_id": {"type": "string", "description": "Required correlation ID from a prior read-only inventory pass."},
+            "output_prefix": {"type": "string", "description": "Optional safe filename prefix for result/screenshot artifacts."},
+            "validation_expression": {"type": "string", "description": "Optional JS expression returning validation info after fill."},
+            "shared_root": {"type": "string", "description": "Mac shared-worker root. Defaults to Kagura local-worker shared root."},
+            "config_path": {"type": "string", "description": "Optional intended output config JSON path under shared_root."},
+            "write_local_config": {"type": "boolean", "description": "Advanced/testing only: also write config_path on the current Hermes host."},
+        },
+        "required": ["url", "allowed_domains", "fields", "session_id"],
+    },
+}
+
+
+registry.register(
+    name="browser_mac_cdp_inventory_config",
+    toolset="browser-cdp",
+    schema=MAC_CDP_INVENTORY_SCHEMA,
+    handler=lambda args, **kw: browser_mac_cdp_inventory_config(
+        url=args.get("url", ""),
+        allowed_domains=args.get("allowed_domains") or [],
+        session_id=args.get("session_id"),
+        output_prefix=args.get("output_prefix"),
+        shared_root=args.get("shared_root", str(DEFAULT_SHARED_ROOT)),
+        config_path=args.get("config_path"),
+        write_local_config=bool(args.get("write_local_config", False)),
+    ),
+    emoji="🛡️",
+)
+
+registry.register(
+    name="browser_mac_cdp_fill_config",
+    toolset="browser-cdp",
+    schema=MAC_CDP_FILL_SCHEMA,
+    handler=lambda args, **kw: browser_mac_cdp_fill_config(
+        url=args.get("url", ""),
+        allowed_domains=args.get("allowed_domains") or [],
+        fields=args.get("fields") or [],
+        session_id=args.get("session_id", ""),
+        output_prefix=args.get("output_prefix"),
+        validation_expression=args.get("validation_expression"),
+        shared_root=args.get("shared_root", str(DEFAULT_SHARED_ROOT)),
+        config_path=args.get("config_path"),
+        write_local_config=bool(args.get("write_local_config", False)),
+    ),
+    emoji="🛡️",
 )

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -462,10 +462,12 @@ def _mac_sidecar_config_payload(
         "result_path": cfg.get("outputPath"),
         "screenshot_path": cfg.get("screenshotPath"),
         "allowSubmit": cfg.get("allowSubmit"),
+        "sideEffectPolicy": cfg.get("sideEffectPolicy"),
         "url": cfg.get("url"),
         "next_step": (
             "Install config_json to config_path via mac_write_file, then run "
-            "runner_path via mac_run_shared_python."
+            "runner_path via mac_run_shared_python. For fill configs, first "
+            "state sideEffectPolicy to the user and obtain explicit approval."
         ),
     }
     if cfg.get("readOnly") is True:

--- a/tools/mac_cdp_config_builder.py
+++ b/tools/mac_cdp_config_builder.py
@@ -64,6 +64,7 @@ def _side_effect_policy(mode: str) -> dict[str, Any]:
             "types supplied values into selected fields",
             "does not click submit/save buttons because allowSubmit is forced false",
             "the target site may still autosave or trigger oninput/onchange side effects",
+            "runner marks the fill unsafe if post-fill network/storage/submit activity is detected",
         ],
         "approvalInstruction": (
             "Before running this fill config, explicitly tell the user the likely "
@@ -202,6 +203,7 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
                 "sessionId": session_id,
                 "fields": _validate_fields(spec.get("fields")),
                 "postFillWaitSec": float(spec.get("postFillWaitSec", 1.0)),
+                "postFillNetworkDrainSec": float(spec.get("postFillNetworkDrainSec", 0.5)),
                 "validationExpression": FIXED_VALIDATION_EXPRESSION,
                 "outputPath": _validate_shared_output(root / f"{prefix}-form-fill-result.json", root),
                 "screenshotPath": _validate_shared_output(root / f"{prefix}-form-fill-screenshot.png", root),

--- a/tools/mac_cdp_config_builder.py
+++ b/tools/mac_cdp_config_builder.py
@@ -37,6 +37,11 @@ SECRET_PATTERNS = [
 ]
 FIELD_KINDS = {"value", "textContent", "innerText"}
 MODES = {"inventory", "fill"}
+FIXED_VALIDATION_EXPRESSION = "({ok:true})"
+
+
+def _approval_token(session_id: str) -> str:
+    return f"APPROVED:{session_id}"
 
 
 def _side_effect_policy(mode: str) -> dict[str, Any]:
@@ -179,6 +184,7 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
         "pageReadyTimeoutSec": int(spec.get("pageReadyTimeoutSec", 12)),
         "allowSubmit": False,
         "sideEffectPolicy": _side_effect_policy(mode),
+        "allowedDomains": [str(x).lower().strip().strip(".") for x in allowed if str(x).strip()],
     }
 
     if mode == "inventory":
@@ -193,13 +199,23 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
     else:
         cfg.update(
             {
+                "sessionId": session_id,
                 "fields": _validate_fields(spec.get("fields")),
                 "postFillWaitSec": float(spec.get("postFillWaitSec", 1.0)),
-                "validationExpression": "({ok:true})",
+                "validationExpression": FIXED_VALIDATION_EXPRESSION,
                 "outputPath": _validate_shared_output(root / f"{prefix}-form-fill-result.json", root),
                 "screenshotPath": _validate_shared_output(root / f"{prefix}-form-fill-screenshot.png", root),
             }
         )
+        approval_token = str(spec.get("approvalToken") or "").strip()
+        if approval_token:
+            if approval_token != _approval_token(session_id):
+                raise ValueError("approvalToken must match APPROVED:<sessionId>")
+            cfg["sideEffectApproval"] = {
+                "approved": True,
+                "token": approval_token,
+                "scope": "url+fields+sessionId",
+            }
     if _looks_like_secret({k: v for k, v in cfg.items() if k not in {"profile", "outputPath", "screenshotPath"}}):
         raise ValueError("config rejected as possible secret payload")
     return cfg

--- a/tools/mac_cdp_config_builder.py
+++ b/tools/mac_cdp_config_builder.py
@@ -161,6 +161,11 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
     session_id = str(spec.get("sessionId") or "").strip()
     if mode == "fill" and not session_id:
         raise ValueError("fill mode requires a non-empty sessionId from a prior inventory pass")
+    if mode == "fill" and spec.get("validationExpression"):
+        raise ValueError(
+            "custom validationExpression is not permitted for guarded fill configs; "
+            "arbitrary JavaScript could submit, save, or otherwise mutate the page"
+        )
 
     root = _as_path(shared_root)
     prefix = _sanitize_prefix(spec.get("outputPrefix"), mode)
@@ -190,7 +195,7 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
             {
                 "fields": _validate_fields(spec.get("fields")),
                 "postFillWaitSec": float(spec.get("postFillWaitSec", 1.0)),
-                "validationExpression": spec.get("validationExpression") or "({ok:true})",
+                "validationExpression": "({ok:true})",
                 "outputPath": _validate_shared_output(root / f"{prefix}-form-fill-result.json", root),
                 "screenshotPath": _validate_shared_output(root / f"{prefix}-form-fill-screenshot.png", root),
             }

--- a/tools/mac_cdp_config_builder.py
+++ b/tools/mac_cdp_config_builder.py
@@ -39,6 +39,34 @@ FIELD_KINDS = {"value", "textContent", "innerText"}
 MODES = {"inventory", "fill"}
 
 
+def _side_effect_policy(mode: str) -> dict[str, Any]:
+    """Return the approval policy agents should surface before execution."""
+    if mode == "inventory":
+        return {
+            "approvalRequiredBeforeRun": False,
+            "operationClass": "read-only inventory",
+            "knownSideEffects": [
+                "loads the target URL in a dedicated CDP browser profile",
+                "may create normal network access logs, analytics events, or cookies",
+                "does not type, click, submit, save, or intentionally mutate fields",
+            ],
+        }
+    return {
+        "approvalRequiredBeforeRun": True,
+        "operationClass": "guarded fill without submit",
+        "knownSideEffects": [
+            "loads the target URL in a dedicated CDP browser profile",
+            "types supplied values into selected fields",
+            "does not click submit/save buttons because allowSubmit is forced false",
+            "the target site may still autosave or trigger oninput/onchange side effects",
+        ],
+        "approvalInstruction": (
+            "Before running this fill config, explicitly tell the user the likely "
+            "side effects and obtain approval for this specific URL and field set."
+        ),
+    }
+
+
 def _as_path(path: str | Path) -> Path:
     return Path(path).expanduser().resolve()
 
@@ -145,6 +173,7 @@ def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_
         "windowSize": str(spec.get("windowSize", "1280,900")),
         "pageReadyTimeoutSec": int(spec.get("pageReadyTimeoutSec", 12)),
         "allowSubmit": False,
+        "sideEffectPolicy": _side_effect_policy(mode),
     }
 
     if mode == "inventory":

--- a/tools/mac_cdp_config_builder.py
+++ b/tools/mac_cdp_config_builder.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Build guarded Mac CDP sidecar configs for Kagura browser automation.
+
+This generator keeps production/browser form work on the non-intrusive path:
+read-only DOM inventory first, then guarded fill config with allowSubmit=false.
+It writes configs under the Mac shared-worker root by default so they can be
+executed by mac_run_shared_python without foreground GUI focus takeover.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+DEFAULT_SHARED_ROOT = Path("/Users/tora/.hermes/profiles/kagura/local-worker/shared")
+DEFAULT_PROFILE = DEFAULT_SHARED_ROOT / "kagura-chrome-cdp-profile"
+DEFAULT_PORT = 9223
+SECRET_PATTERNS = [
+    r"password",
+    r"passwd",
+    r"token\s*=",
+    r"secret\s*=",
+    r"apikey",
+    r"api_key",
+    r"authorization\s*:",
+    r"bearer\s+",
+    r"sk-[A-Za-z0-9_-]{8,}",
+    r"ghp_[A-Za-z0-9_]{8,}",
+    r"xoxb-[A-Za-z0-9-]{8,}",
+    r"\botp\b",
+    r"\btotp\b",
+    r"(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{80,}(?![A-Za-z0-9_-])",
+]
+FIELD_KINDS = {"value", "textContent", "innerText"}
+MODES = {"inventory", "fill"}
+
+
+def _as_path(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _require_http_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("url must be absolute http/https")
+    return url
+
+
+def _host_allowed(host: str, allowed: list[str]) -> bool:
+    normalized = host.lower().strip(".")
+    for domain in allowed:
+        d = str(domain).lower().strip().strip(".")
+        if not d:
+            continue
+        if normalized == d:
+            return True
+        # Deliberately do NOT allow arbitrary subdomains for production form work.
+        # If a subdomain is intended, include it explicitly in allowedDomains.
+    return False
+
+
+def _append_session_id(url: str, session_id: str | None) -> str:
+    if not session_id:
+        return url
+    parsed = urlparse(url)
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    pairs = [(k, v) for k, v in pairs if k != "sessionId"]
+    pairs.append(("sessionId", session_id))
+    return urlunparse(parsed._replace(query=urlencode(pairs)))
+
+
+def _looks_like_secret(value: Any) -> bool:
+    text = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
+    return any(re.search(pat, text, re.IGNORECASE) for pat in SECRET_PATTERNS)
+
+
+def _sanitize_prefix(raw: str | None, mode: str) -> str:
+    base = raw or ("cdp-readonly-inventory" if mode == "inventory" else "cdp-form-fill")
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", base).strip("-.")
+    return cleaned or ("cdp-readonly-inventory" if mode == "inventory" else "cdp-form-fill")
+
+
+def _validate_shared_output(path: Path, shared_root: Path) -> str:
+    resolved = path.expanduser().resolve()
+    root = shared_root.expanduser().resolve()
+    if not (resolved == root or root in resolved.parents):
+        raise ValueError(f"output path outside shared root: {resolved}")
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return str(resolved)
+
+
+def _validate_fields(fields: Any) -> list[dict[str, Any]]:
+    if not isinstance(fields, list) or not fields:
+        raise ValueError("fill mode requires at least one field")
+    checked: list[dict[str, Any]] = []
+    for idx, field in enumerate(fields):
+        if not isinstance(field, dict):
+            raise ValueError(f"field[{idx}] must be an object")
+        selector = field.get("selector")
+        if not isinstance(selector, str) or not selector.strip():
+            raise ValueError(f"field[{idx}] requires non-empty selector")
+        kind = field.get("kind", "value")
+        if kind not in FIELD_KINDS:
+            raise ValueError(f"field[{idx}] unsupported kind: {kind}")
+        if "value" not in field:
+            raise ValueError(f"field[{idx}] requires value")
+        if _looks_like_secret(field.get("value")):
+            raise ValueError(f"field[{idx}] rejected as possible secret payload")
+        checked.append({"selector": selector, "kind": kind, "value": str(field.get("value", ""))})
+    return checked
+
+
+def build_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_ROOT) -> dict[str, Any]:
+    """Return a guarded sidecar config from a compact browser-operation spec."""
+    if not isinstance(spec, dict):
+        raise ValueError("spec must be a JSON object")
+    mode = spec.get("mode", "inventory")
+    if mode not in MODES:
+        raise ValueError(f"mode must be one of {sorted(MODES)}")
+    url = _require_http_url(str(spec.get("url") or ""))
+    parsed = urlparse(url)
+    allowed = spec.get("allowedDomains") or []
+    if not isinstance(allowed, list) or not allowed:
+        raise ValueError("allowedDomains is required and must list exact hostnames")
+    if not _host_allowed(parsed.hostname or "", [str(x) for x in allowed]):
+        raise ValueError(f"host {parsed.hostname!r} not in allowedDomains")
+    if spec.get("allowSubmit") is True:
+        raise ValueError("allowSubmit=true is not permitted by this guarded generator")
+    session_id = str(spec.get("sessionId") or "").strip()
+    if mode == "fill" and not session_id:
+        raise ValueError("fill mode requires a non-empty sessionId from a prior inventory pass")
+
+    root = _as_path(shared_root)
+    prefix = _sanitize_prefix(spec.get("outputPrefix"), mode)
+    url = _append_session_id(url, session_id or None)
+
+    cfg: dict[str, Any] = {
+        "url": url,
+        "port": int(spec.get("port", DEFAULT_PORT)),
+        "profile": str(spec.get("profile") or DEFAULT_PROFILE),
+        "windowSize": str(spec.get("windowSize", "1280,900")),
+        "pageReadyTimeoutSec": int(spec.get("pageReadyTimeoutSec", 12)),
+        "allowSubmit": False,
+    }
+
+    if mode == "inventory":
+        cfg.update(
+            {
+                "readOnly": True,
+                "minFields": int(spec.get("minFields", 1)),
+                "outputPath": _validate_shared_output(root / f"{prefix}-readonly-inventory-result.json", root),
+                "screenshotPath": _validate_shared_output(root / f"{prefix}-readonly-inventory-screenshot.png", root),
+            }
+        )
+    else:
+        cfg.update(
+            {
+                "fields": _validate_fields(spec.get("fields")),
+                "postFillWaitSec": float(spec.get("postFillWaitSec", 1.0)),
+                "validationExpression": spec.get("validationExpression") or "({ok:true})",
+                "outputPath": _validate_shared_output(root / f"{prefix}-form-fill-result.json", root),
+                "screenshotPath": _validate_shared_output(root / f"{prefix}-form-fill-screenshot.png", root),
+            }
+        )
+    if _looks_like_secret({k: v for k, v in cfg.items() if k not in {"profile", "outputPath", "screenshotPath"}}):
+        raise ValueError("config rejected as possible secret payload")
+    return cfg
+
+
+def write_config(spec: dict[str, Any], shared_root: str | Path = DEFAULT_SHARED_ROOT, out_path: str | Path | None = None) -> Path:
+    cfg = build_config(spec, shared_root=shared_root)
+    root = _as_path(shared_root)
+    mode = spec.get("mode", "inventory")
+    if out_path is None:
+        name = "cdp-readonly-inventory-config.json" if mode == "inventory" else "cdp-form-fill-config.json"
+        path = root / name
+    else:
+        path = _as_path(out_path)
+    _validate_shared_output(path, root)
+    path.write_text(json.dumps(cfg, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build guarded Mac CDP sidecar config JSON")
+    parser.add_argument("spec", help="Path to compact operation spec JSON")
+    parser.add_argument("--shared-root", default=str(DEFAULT_SHARED_ROOT))
+    parser.add_argument("--out", help="Output config path under shared root")
+    parser.add_argument("--print", action="store_true", help="Print generated config to stdout")
+    args = parser.parse_args(argv)
+    spec_path = Path(args.spec).expanduser()
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    out = write_config(spec, shared_root=args.shared_root, out_path=args.out)
+    if args.print:
+        print(out.read_text(encoding="utf-8"), end="")
+    else:
+        print(str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

Mac local-worker 経由のブラウザ操作で、foreground GUI のクリック/ペーストに依存しない安全な CDP sidecar config 生成フローを追加します。

このPRでは、フォーム操作をいきなり実行するのではなく、以下の2段階に分離します。

1. 読み取り専用 DOM inventory config を生成する
2. inventory確認後、送信不可の guarded fill config を生成する

## 変更内容

- `tools/mac_cdp_config_builder.py` を追加
  - read-only inventory config を生成
  - guarded fill config を生成
  - exact hostname allowlist を強制
  - `allowSubmit=true` を拒否
  - fill mode では `sessionId` を必須化
  - password/token/API key などの秘密情報らしいpayloadを拒否
  - output/screenshot path を Mac shared-worker root 配下に制限
- `tools/browser_cdp_tool.py` に以下の tool entrypoint を追加
  - `browser_mac_cdp_inventory_config`
  - `browser_mac_cdp_fill_config`
- テストを追加
  - config builder単体テスト
  - browser_cdp registry/tool wrapperテスト

## なぜ必要か

Mac foreground GUI 操作は、toraさんが同じMacを使っているとフォーカス・マウス・キーボード・クリップボードを奪い合い、worker-level success と実DOM状態が一致しないことがあります。

この変更により、Mac側では `mac_run_shared_python` で shared root 配下の CDP sidecar を実行し、Hermes側では事前に安全なconfigだけを生成できます。

## スクリーンショット

UIの見た目変更ではないため、変更前/変更後スクリーンショットは該当しません。
代わりに、Mac local-worker上での read-only inventory と guarded fill の実行結果JSONを検証しました。

## 検証

ローカルテスト:

```bash
/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/tools/test_browser_cdp_tool.py tests/tools/test_mac_cdp_config_builder.py -q
# 28 passed
```

静的確認:

```bash
git diff --check
/usr/local/lib/hermes-agent/venv/bin/python -m py_compile \
  tools/browser_cdp_tool.py \
  tools/mac_cdp_config_builder.py \
  tests/tools/test_browser_cdp_tool.py \
  tests/tools/test_mac_cdp_config_builder.py
```

Mac local-worker proof:

- read-only inventory
  - `passed: true`
  - `readOnly: true`
  - `mutatesFields: false`
  - `uses_clipboard: false`
  - `uses_mouse_keyboard: false`
  - `allowSubmit: false`
  - 対象: `https://httpbin.org/forms/post?sessionId=kagura-proof-20260512-02`
  - 結果: formsCount=1, fieldsCount=12, riskyButtons に `Submit order` を検出
- guarded fill
  - `passed: true`
  - `validation.ok: true`
  - `validation.submitted: false`
  - `front_app_dependency: false`
  - `uses_clipboard: false`
  - `uses_mouse_keyboard: false`
  - `allowSubmit: false`

## 既知の注意点

- このPRはconfig生成とtool entrypointの追加です。Mac側 sidecar runner 自体は既存の shared-worker script を使います。
- `allowSubmit=false` はクリック/submitを行わない保証ですが、対象サイトに自動保存やoninput副作用がある場合は、別途inventory/reviewで確認が必要です。
- 実本番フォームでの投稿/保存/購入/送信は、このPRの範囲外であり、引き続き明示承認が必要です。
