### PR TITLE
fix(agent): bound compression summary call with a wall-clock timeout

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2214,6 +2214,11 @@ def _is_unsupported_parameter_error(exc: Exception, param: str) -> bool:
         "unrecognized request argument",
         "unrecognized parameter",
         "invalid parameter",
+        # Anthropic's Opus 4.7+ phrasing — e.g.
+        # ``HTTP 400: `temperature` is deprecated for this model``
+        # — surfaced from auxiliary auto-detect against newer Claude models.
+        # See issue #24098.
+        "is deprecated",
     ))
 
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import logging
 import re
+import threading
 import time
 from typing import Any, Dict, List, Optional
 
@@ -74,6 +75,63 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+# Hard wall-clock bound on a single summary LLM call (issue #24098).  Acts
+# independently of the per-call SDK timeout (auxiliary.compression.timeout):
+# SDK-level retries, slow streaming, or a stuck connection cannot stack past
+# this budget and keep the agent response loop blocked.  When exceeded, we
+# log a warning, enter cooldown, and return None so compress() falls through
+# to its static-marker path and the response loop continues.
+_SUMMARY_WALL_CLOCK_TIMEOUT_SECONDS = 180.0
+# Shorter cooldown after a wall-clock timeout — we don't actually know
+# whether the provider is broken or just slow.  Matches the transient cooldown
+# used for other timeout-class errors below.
+_SUMMARY_WALL_CLOCK_COOLDOWN_SECONDS = 60
+
+
+class SummaryWallClockTimeout(TimeoutError):
+    """Raised when a summary LLM call exceeds the module wall-clock budget."""
+
+
+def _call_llm_with_wall_clock(call_kwargs: Dict[str, Any]) -> Any:
+    """Run ``call_llm(**call_kwargs)`` with a hard wall-clock bound.
+
+    A naked ``call_llm`` invocation is bounded only by the underlying SDK's
+    per-request timeout. SDK-level retries and stuck httpx streams can stack
+    past that budget, blocking the calling thread indefinitely — which in
+    issue #24098 stalled an agent response loop for 88 minutes before manual
+    restart.
+
+    We run the call in a daemon thread and ``join`` with a hard timeout. On
+    timeout we raise :class:`SummaryWallClockTimeout` so the caller can fall
+    back to its existing transient-failure path; the daemon thread is
+    abandoned (rather than cancelled — Python has no safe way to interrupt
+    a blocked C-level network read) and the SDK's own timeout eventually
+    reaps it. The cooldown the caller sets prevents tight retry-loops, so
+    at most one orphan thread per cooldown window can accumulate.
+    """
+    result: Dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            result["response"] = call_llm(**call_kwargs)
+        except BaseException as exc:  # noqa: BLE001 — propagate to caller thread
+            result["exc"] = exc
+
+    worker = threading.Thread(
+        target=_runner,
+        name="ctx-compress-summary",
+        daemon=True,
+    )
+    worker.start()
+    worker.join(timeout=_SUMMARY_WALL_CLOCK_TIMEOUT_SECONDS)
+    if worker.is_alive():
+        raise SummaryWallClockTimeout(
+            f"summary call exceeded {_SUMMARY_WALL_CLOCK_TIMEOUT_SECONDS:.0f}s "
+            "wall-clock timeout"
+        )
+    if "exc" in result:
+        raise result["exc"]
+    return result["response"]
 
 
 def _content_length_for_budget(raw_content: Any) -> int:
@@ -1056,7 +1114,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
-            response = call_llm(**call_kwargs)
+            response = _call_llm_with_wall_clock(call_kwargs)
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
@@ -1070,6 +1128,22 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._summary_model_fallen_back = False
             self._last_summary_error = None
             return self._with_summary_prefix(summary)
+        except SummaryWallClockTimeout as e:
+            # Hard wall-clock bound exceeded.  Don't try to fall back to main
+            # — the same provider chain is what we just abandoned — and don't
+            # bubble the exception up; the response loop must continue.  Set
+            # a short cooldown so the next preflight pass skips the call.
+            # Issue #24098.
+            self._summary_failure_cooldown_until = (
+                time.monotonic() + _SUMMARY_WALL_CLOCK_COOLDOWN_SECONDS
+            )
+            self._last_summary_error = str(e)
+            logging.warning(
+                "Context compression: %s; dropping middle turns without summary. "
+                "Further summary attempts paused for %d seconds.",
+                e, _SUMMARY_WALL_CLOCK_COOLDOWN_SECONDS,
+            )
+            return None
         except RuntimeError:
             # No provider configured — long cooldown, unlikely to self-resolve
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS

--- a/tests/agent/test_compression_wall_clock.py
+++ b/tests/agent/test_compression_wall_clock.py
@@ -1,0 +1,139 @@
+"""Regression tests for the compression wall-clock timeout (issue #24098).
+
+When the auxiliary compression worker fails or hangs (e.g. HTTP 400 from a
+provider that rejects the hardcoded ``temperature`` parameter, or a stuck
+httpx stream), the agent response loop must not block indefinitely. The
+fix wraps the summary LLM call in a hard wall-clock guard and degrades to
+the static-marker fallback when it expires.
+"""
+
+import threading
+import time
+
+from unittest.mock import patch
+
+import pytest
+
+from agent import context_compressor
+from agent.context_compressor import (
+    ContextCompressor,
+    SummaryWallClockTimeout,
+    _call_llm_with_wall_clock,
+)
+
+
+def _short_timeout(monkeypatch, seconds: float = 0.05) -> None:
+    monkeypatch.setattr(
+        context_compressor,
+        "_SUMMARY_WALL_CLOCK_TIMEOUT_SECONDS",
+        seconds,
+    )
+
+
+def _msgs():
+    return [
+        {"role": "user", "content": "do something"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+
+class TestCallLLMWithWallClock:
+    """Direct coverage of the helper that bounds a single call_llm invocation."""
+
+    def test_returns_result_when_call_completes_in_time(self):
+        sentinel = object()
+
+        def _fast_call(**_):
+            return sentinel
+
+        with patch("agent.context_compressor.call_llm", side_effect=_fast_call):
+            assert _call_llm_with_wall_clock({}) is sentinel
+
+    def test_propagates_call_llm_exception(self):
+        def _boom(**_):
+            raise RuntimeError("provider rejected request")
+
+        with patch("agent.context_compressor.call_llm", side_effect=_boom):
+            with pytest.raises(RuntimeError, match="provider rejected"):
+                _call_llm_with_wall_clock({})
+
+    def test_raises_timeout_when_call_hangs(self, monkeypatch):
+        _short_timeout(monkeypatch, seconds=0.05)
+        # Use an event the test can set to release the worker thread, so
+        # the daemon doesn't sit blocked for the rest of the suite.
+        release = threading.Event()
+
+        def _hang(**_):
+            release.wait(timeout=5)  # released by the test cleanup below
+            return None
+
+        try:
+            with patch("agent.context_compressor.call_llm", side_effect=_hang):
+                with pytest.raises(SummaryWallClockTimeout):
+                    _call_llm_with_wall_clock({})
+        finally:
+            release.set()
+
+
+class TestGenerateSummaryWallClock:
+    """End-to-end: a hung summary call must surface as a transient failure,
+    not a hang that bubbles up into the response loop."""
+
+    def test_timeout_returns_none_and_sets_cooldown(self, monkeypatch):
+        _short_timeout(monkeypatch, seconds=0.05)
+        release = threading.Event()
+
+        def _hang(**_):
+            release.wait(timeout=5)
+            return None
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(model="anthropic/claude-opus-4-7", quiet_mode=True)
+
+        try:
+            with patch("agent.context_compressor.call_llm", side_effect=_hang):
+                start = time.monotonic()
+                result = c._generate_summary(_msgs())
+                elapsed = time.monotonic() - start
+        finally:
+            release.set()
+
+        assert result is None
+        # Must return promptly — within a small multiple of the wall-clock
+        # bound, not the 5s safety release above.
+        assert elapsed < 2.0
+        # Cooldown set so the next preflight pass skips the call rather
+        # than re-arming a fresh hang.
+        assert c._summary_failure_cooldown_until > time.monotonic()
+        # Error message surfaced for the gateway-level warning emitter.
+        assert c._last_summary_error is not None
+        assert "wall-clock" in c._last_summary_error
+
+    def test_timeout_does_not_attempt_fallback_to_main(self, monkeypatch):
+        """If the call hangs, retrying on the main provider would just hang
+        again (it's the same chain).  Don't fall through to that path."""
+        _short_timeout(monkeypatch, seconds=0.05)
+        release = threading.Event()
+        call_count = {"n": 0}
+
+        def _hang(**_):
+            call_count["n"] += 1
+            release.wait(timeout=5)
+            return None
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="main-model",
+                summary_model_override="broken-aux-model",
+                quiet_mode=True,
+            )
+
+        try:
+            with patch("agent.context_compressor.call_llm", side_effect=_hang):
+                result = c._generate_summary(_msgs())
+        finally:
+            release.set()
+
+        assert result is None
+        assert call_count["n"] == 1
+        assert getattr(c, "_summary_model_fallen_back", False) is False

--- a/tests/agent/test_unsupported_parameter_retry.py
+++ b/tests/agent/test_unsupported_parameter_retry.py
@@ -36,6 +36,12 @@ class TestIsUnsupportedParameterError:
         ("temperature", "HTTP 400: Unsupported parameter: temperature"),
         ("temperature", "Error code: 400 - {'error': {'code': 'unsupported_parameter', 'param': 'temperature'}}"),
         ("temperature", "this model does not support temperature"),
+        # Opus 4.7-style deprecation wording surfaced by issue #24098 —
+        # ``\`temperature\` is deprecated for this model`` — must drive the
+        # same temperature-stripped retry instead of bubbling up as an
+        # unrecoverable error.
+        ("temperature", "HTTP 400: `temperature` is deprecated for this model."),
+        ("temperature", "temperature is deprecated for this model"),
         # max_tokens phrasings
         ("max_tokens", "HTTP 400: Unsupported parameter: max_tokens"),
         ("max_tokens", "Unknown parameter: max_tokens — use max_completion_tokens"),


### PR DESCRIPTION
Bound the auxiliary compression summary call with a hard wall-clock so a stuck httpx stream or stacked SDK retries cannot stall the agent response loop. Also broaden the unsupported-parameter detector so Opus 4.7's `temperature is deprecated` wording triggers the existing parameter-stripped retry.

## What changed and why
- `agent/context_compressor.py`: introduce `_call_llm_with_wall_clock` and `SummaryWallClockTimeout`. `_generate_summary` now runs `call_llm` in a daemon thread joined with `_SUMMARY_WALL_CLOCK_TIMEOUT_SECONDS` (180s). On timeout we set a 60s cooldown, record `_last_summary_error`, log a warning, and return `None` so `compress()` falls through to its existing static-marker fallback and the response loop continues. The timeout path explicitly bypasses the retry-on-main fallback — same provider chain, so retrying would just hang again. Fixes the 88-min silent stall reported in the issue.
- `agent/auxiliary_client.py`: add `"is deprecated"` to the marker list in `_is_unsupported_parameter_error` so the Opus 4.7 message ``HTTP 400: `temperature` is deprecated for this model`` drives the same temperature-stripped retry as ``Unsupported parameter: temperature``. The detector still requires the param name to appear in the error, so generic deprecation notices don't match.
- `tests/agent/test_compression_wall_clock.py` (new): covers the helper (passthrough, exception propagation, timeout), and `_generate_summary`'s timeout-to-cooldown path including the no-fallback-to-main invariant.
- `tests/agent/test_unsupported_parameter_retry.py`: parametrise the new ``is deprecated for this model`` phrasings.

The daemon thread is abandoned (not cancelled — Python can't safely interrupt a blocked C-level read) when the wall-clock expires; the SDK's per-call timeout eventually reaps it, and the 60s cooldown on the caller bounds orphan-thread accumulation to one per minute under sustained failure.

Departure from the 'no broad gating' rejection rule: not applicable here — the rule was about SSH env vars and key bindings; this change is scoped to a single auxiliary call site.

## How to test
- `pytest tests/agent/test_compression_wall_clock.py tests/agent/test_unsupported_parameter_retry.py tests/agent/test_context_compressor.py -q --timeout=60` — passes (99/99).
- Pre-existing failures in `test_auxiliary_client.py`, `test_anthropic_adapter.py`, and `test_skill_commands.py` reproduce on `main` without this branch — unrelated.
- Manual repro: pin `auxiliary.compression.provider: auto` against a main model whose API rejects `temperature` (e.g. `claude-opus-4-7`), build a session past the compression threshold, and confirm the response loop no longer stalls — instead, a fallback context marker is inserted and the user gets a reply.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #24098

<!-- autocontrib:worker-id=issue-new-ac95e0df kind=pr-open -->