### PR TITLE
fix(cli): allow goal controls while busy

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7371,6 +7371,56 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             return False
 
+    def _should_handle_goal_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True for /goal status/control commands that must work mid-run.
+
+        The normal slash-command path goes through ``_pending_input`` and is
+        consumed by ``process_loop``.  While an agent turn is running,
+        ``process_loop`` is blocked in ``self.chat()``, so queued goal controls
+        cannot run until the current turn ends.  That is especially bad for
+        ``/goal`` because it can intentionally start long autonomous turns.
+        Status/control subcommands are safe to dispatch on the UI thread; new
+        goal text still waits behind the current turn.
+        """
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        if not getattr(self, "_agent_running", False):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            parts = text.strip().split(None, 1)
+            base = parts[0].lower().lstrip('/') if parts else ""
+            cmd = resolve_command(base)
+            if not cmd or cmd.name != "goal":
+                return False
+            arg = parts[1].strip().lower() if len(parts) > 1 else ""
+            return (not arg) or arg in ("status", "pause", "resume", "clear", "stop", "done")
+        except Exception:
+            return False
+
+    def _handle_goal_command_inline(self, text: str) -> bool:
+        """Dispatch a safe /goal command immediately while the agent is busy.
+
+        ``pause`` and ``clear``-style controls also interrupt the current turn;
+        otherwise the goal is paused in storage but the long-running agent turn
+        continues and the CLI still appears frozen.
+        """
+        if not self._should_handle_goal_command_inline(text):
+            return False
+        parts = text.strip().split(None, 1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else ""
+        should_interrupt = arg in ("pause", "clear", "stop", "done")
+        ok = self.process_command(text)
+        if ok and should_interrupt and getattr(self, "_agent_running", False):
+            agent = getattr(self, "agent", None)
+            if agent is not None and hasattr(agent, "interrupt"):
+                reason = "goal paused by user" if arg == "pause" else "goal cleared by user"
+                try:
+                    agent.interrupt(reason)
+                except Exception as exc:
+                    logging.debug("goal inline interrupt failed: %s", exc)
+        return ok
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -12160,6 +12210,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     # linger in the input area (looking unsent) and invite an
                     # accidental re-submit. See issue #34569.
                     event.app.invalidate()
+                    return
+
+                # Handle /goal status/pause/clear while the agent is running
+                # immediately too.  /goal can intentionally create long
+                # autonomous turns; if controls wait behind _pending_input,
+                # the user has no slash-command escape hatch until that turn
+                # completes.
+                if self._should_handle_goal_command_inline(text, has_images=has_images):
+                    if not self._handle_goal_command_inline(text):
+                        self._should_exit = True
+                        if event.app.is_running:
+                            event.app.exit()
+                    event.app.current_buffer.reset(append_to_history=True)
                     return
 
                 # Snapshot and clear attached images

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -175,6 +175,43 @@ class TestBusyInputMode:
         assert cli._interrupt_queue.get_nowait() == "redirect"
         assert cli._pending_input.empty()
 
+    def test_goal_status_and_control_commands_are_inline_while_busy(self):
+        """Goal controls must not wait behind a running goal turn."""
+        cli = _make_cli()
+        cli._agent_running = True
+
+        for command in (
+            "/goal",
+            "/goal status",
+            "/goal pause",
+            "/goal resume",
+            "/goal clear",
+            "/goal stop",
+            "/goal done",
+        ):
+            assert cli._should_handle_goal_command_inline(command) is True
+
+    def test_goal_new_text_is_not_inline_while_busy(self):
+        """Setting a different goal mid-turn should still wait for the current turn."""
+        cli = _make_cli()
+        cli._agent_running = True
+
+        assert cli._should_handle_goal_command_inline("/goal follow plan") is False
+
+    def test_inline_goal_pause_interrupts_running_agent(self):
+        """Pausing a busy goal should also interrupt the current turn."""
+        cli = _make_cli()
+        cli._agent_running = True
+        calls = []
+        interrupts = []
+        cli.process_command = lambda command: calls.append(command) or True
+        cli.agent = SimpleNamespace(interrupt=lambda message=None: interrupts.append(message))
+
+        assert cli._handle_goal_command_inline("/goal pause") is True
+
+        assert calls == ["/goal pause"]
+        assert interrupts == ["goal paused by user"]
+
 
 class TestPromptToolkitTerminalCompatibility:
     def test_lf_enter_binds_to_submit_handler_posix(self):


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI freeze/control-path issue for long-running `/goal` turns. The normal slash-command path queues input into `_pending_input`, but `process_loop` is blocked inside `self.chat()` while an agent turn is running. That meant `/goal`, `/goal status`, `/goal pause`, and `/goal clear` could not run until the current goal turn finished.

This PR dispatches safe `/goal` status/control commands inline on the UI thread while the agent is busy. New goal text still waits behind the current turn. Pause, clear, stop, and done also interrupt the current running turn so the CLI does not appear frozen after the stored goal state changes.

## Related Issue

No linked issue found. I searched open issues and PRs for `/goal`, `goal controls`, `goal busy`, `allow goal controls while busy`, `test_cli_goal_interrupt`, `test_cli_init`, and `cli.py goal`; only adjacent goal work appeared, not a duplicate of this busy-control fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: add inline detection/dispatch for safe `/goal` status and control subcommands while the agent is running.
- `cli.py`: interrupt the active agent turn when inline `/goal pause`, `/goal clear`, `/goal stop`, or `/goal done` succeeds.
- `tests/cli/test_cli_init.py`: add regression coverage for inline goal controls, non-inline new goal text, and pause-triggered interruption.

## How to Test

1. Run the targeted regression suite:
   ```bash
   source venv/bin/activate
   python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/cli/test_cli_goal_interrupt.py tests/cli/test_cli_init.py -q
   ```
   Result: `84 passed, 4 warnings in 3.77s`.
2. Run the cross-platform footgun check on touched files:
   ```bash
   python scripts/check-windows-footguns.py cli.py tests/cli/test_cli_init.py
   ```
   Result: `✓ No Windows footguns found (2 file(s) scanned).`
3. Verify diff scope:
   ```bash
   git diff --name-only origin/main...HEAD
   ```
   Result: only `cli.py` and `tests/cli/test_cli_init.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run locally, targeted goal/CLI regression suite passed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, kernel 7.0.3-arch1-2, x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A. N/A, behavior is covered by tests.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A. N/A, no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A. N/A, no architecture or workflow docs changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A. No OS/process/file APIs added; footgun check passed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A. N/A, no tool schemas changed.

## For New Skills

N/A, this PR does not add or modify a skill.

## Screenshots / Logs

```text
$ python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/cli/test_cli_goal_interrupt.py tests/cli/test_cli_init.py -q
84 passed, 4 warnings in 3.77s

$ python scripts/check-windows-footguns.py cli.py tests/cli/test_cli_init.py
✓ No Windows footguns found (2 file(s) scanned).
```
