### PR TITLE
fix(dashboard): verify process existence before reporting PIDs on macOS

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9012,6 +9012,90 @@ def _render_distribution_plan(plan) -> None:
         )
 
 
+def _is_process_alive(pid: int) -> bool:
+    """Check if a process with the given PID is still alive.
+
+    On Linux, checks /proc/<pid>.  On macOS and other Unix, uses
+    ``ps -p <pid>`` which exits non-zero if the process does not exist.
+    Returns False on any error (permission denied, etc.).
+    """
+    if sys.platform == "win32":
+        # Windows: use tasklist to check if PID exists.
+        try:
+            result = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            # tasklist output contains the PID in its lines if the process exists.
+            return str(pid) in result.stdout
+        except Exception:
+            return False
+    elif sys.platform == "darwin" or sys.platform.startswith("freebsd"):
+        # macOS / FreeBSD: ps -p exits 1 if PID not found.
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid)],
+                capture_output=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+    else:
+        # Linux: check /proc/<pid> existence.
+        return os.path.exists(f"/proc/{pid}")
+
+
+def _get_process_cmdline(pid: int) -> str:
+    """Get the command line of a process by PID.
+
+    On Linux, reads /proc/<pid>/cmdline.  On macOS and other Unix,
+    uses ``ps -p <pid> -o command=``.  Returns an empty string on any error.
+    """
+    try:
+        if sys.platform == "win32":
+            # Windows: use wmic to get command line.
+            result = subprocess.run(
+                ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine", "/FORMAT:LIST"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                encoding="utf-8",
+                errors="ignore",
+            )
+            for line in result.stdout.split("\n"):
+                if line.startswith("CommandLine="):
+                    return line[len("CommandLine="):].strip()
+            return ""
+        elif sys.platform == "darwin" or sys.platform.startswith("freebsd"):
+            # macOS / FreeBSD: use ps.
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+            return ""
+        else:
+            # Linux: read /proc/<pid>/cmdline.
+            cmdline_path = f"/proc/{pid}/cmdline"
+            if os.path.exists(cmdline_path):
+                with open(cmdline_path, "rb") as f:
+                    return (
+                        f.read()
+                        .replace(b"\x00", b" ")
+                        .decode("utf-8", errors="replace")
+                        .strip()
+                    )
+            return ""
+    except Exception:
+        return ""
+
+
 def _report_dashboard_status() -> int:
     """Print ``hermes dashboard`` PIDs and return the count.
 
@@ -9025,28 +9109,29 @@ def _report_dashboard_status() -> int:
         print("No hermes dashboard processes running.")
         return 0
 
-    print(f"{len(pids)} hermes dashboard process(es) running:")
+    # Re-verify each PID to filter out any stale entries (e.g. zombie
+    # processes, reused PIDs on macOS).  _find_stale_dashboard_pids() already
+    # does a fresh scan via ps, but a PID may disappear between that scan and
+    # this display loop — especially on macOS where /proc/ does not exist and
+    # we cannot fall back to cmdline reads.  Skipping verification would show
+    # phantom PIDs that no longer exist (#24150).
+    alive_pids: list[int] = []
     for pid in pids:
-        # Best-effort: show the full cmdline so users can tell profiles apart.
-        cmdline = ""
-        try:
-            if sys.platform != "win32":
-                cmdline_path = f"/proc/{pid}/cmdline"
-                if os.path.exists(cmdline_path):
-                    with open(cmdline_path, "rb") as f:
-                        cmdline = (
-                            f.read()
-                            .replace(b"\x00", b" ")
-                            .decode("utf-8", errors="replace")
-                            .strip()
-                        )
-        except (OSError, ValueError):
-            pass
+        if _is_process_alive(pid):
+            alive_pids.append(pid)
+
+    if not alive_pids:
+        print("No hermes dashboard processes running.")
+        return 0
+
+    print(f"{len(alive_pids)} hermes dashboard process(es) running:")
+    for pid in alive_pids:
+        cmdline = _get_process_cmdline(pid)
         if cmdline:
             print(f"    PID {pid}: {cmdline}")
         else:
             print(f"    PID {pid}")
-    return len(pids)
+    return len(alive_pids)
 
 
 def cmd_dashboard(args):

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -41,6 +41,10 @@ class TestDashboardStatus:
     def test_status_with_processes(self, capsys):
         with patch("hermes_cli.main._find_stale_dashboard_pids",
                    return_value=[12345, 12346]), \
+             patch("hermes_cli.main._is_process_alive", return_value=True), \
+             patch("hermes_cli.main._get_process_cmdline",
+                   side_effect=["/usr/bin/hermes dashboard --port 9119",
+                                "/usr/bin/hermes dashboard --port 9120"]), \
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(status=True))
         # Status is informational — always exits 0.
@@ -49,6 +53,25 @@ class TestDashboardStatus:
         assert "2 hermes dashboard process(es) running" in out
         assert "PID 12345" in out
         assert "PID 12346" in out
+
+    def test_status_filters_stale_pids(self, capsys):
+        """Stale PIDs (processes that vanished between scan and display) are
+        silently dropped from the report instead of shown as phantom entries
+        (#24150 on macOS where /proc/ does not exist)."""
+        with patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[12345, 99999]), \
+             patch("hermes_cli.main._is_process_alive",
+                   side_effect=lambda pid: pid == 12345), \
+             patch("hermes_cli.main._get_process_cmdline",
+                   return_value="/usr/bin/hermes dashboard --port 9119"), \
+             pytest.raises(SystemExit) as exc:
+            cmd_dashboard(_ns(status=True))
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        # Only the alive PID (12345) should appear; 99999 is dropped.
+        assert "1 hermes dashboard process(es) running" in out
+        assert "PID 12345" in out
+        assert "99999" not in out
 
     def test_status_does_not_try_to_import_fastapi(self):
         """`--status` must not require dashboard runtime deps — it's a
@@ -179,3 +202,115 @@ class TestArgparseWiring:
              pytest.raises(SystemExit) as exc:
             mod.cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+
+class TestIsProcessAlive:
+    """Tests for _is_process_alive() cross-platform verification."""
+
+    def test_linux_proc_exists(self):
+        """On Linux, return True when /proc/<pid> exists."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "linux"):
+            with patch("os.path.exists", return_value=True):
+                assert _is_process_alive(1) is True
+
+    def test_linux_proc_missing(self):
+        """On Linux, return False when /proc/<pid> does not exist."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "linux"):
+            with patch("os.path.exists", return_value=False):
+                assert _is_process_alive(99999) is False
+
+    def test_macos_ps_returns_alive(self):
+        """On macOS, return True when ps -p returns 0."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "darwin"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                assert _is_process_alive(1) is True
+                mock_run.assert_called_once()
+                args = mock_run.call_args[0][0]
+                assert args[0] == "ps" and args[1] == "-p"
+
+    def test_macos_ps_returns_dead(self):
+        """On macOS, return False when ps -p returns non-zero."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "darwin"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1)
+                assert _is_process_alive(99999) is False
+
+    def test_windows_tasklist_found(self):
+        """On Windows, return True when tasklist output contains the PID."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "win32"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=" 1234\n 5678\n",
+                )
+                assert _is_process_alive(1234) is True
+
+    def test_windows_tasklist_not_found(self):
+        """On Windows, return False when tasklist output does not contain the PID."""
+        from hermes_cli.main import _is_process_alive
+        with patch("sys.platform", "win32"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=" 1234\n 5678\n",
+                )
+                assert _is_process_alive(99999) is False
+
+
+class TestGetProcessCmdline:
+    """Tests for _get_process_cmdline() cross-platform retrieval."""
+
+    def test_linux_proc_cmdline(self):
+        """On Linux, read /proc/<pid>/cmdline and decode it."""
+        from hermes_cli.main import _get_process_cmdline
+        with patch("sys.platform", "linux"):
+            with patch("os.path.exists", return_value=True):
+                with patch("builtins.open", MagicMock()) as mock_open:
+                    mock_open.return_value.__enter__.return_value.read.return_value = (
+                        b"hermes\x00dashboard\x00--port\x009119"
+                    )
+                    result = _get_process_cmdline(12345)
+                    assert "hermes" in result
+                    assert "dashboard" in result
+
+    def test_macos_ps_command(self):
+        """On macOS, use ps -p <pid> -o command=."""
+        from hermes_cli.main import _get_process_cmdline
+        with patch("sys.platform", "darwin"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout=" /usr/bin/hermes dashboard --port 9119\n",
+                )
+                result = _get_process_cmdline(12345)
+                assert "hermes" in result
+                mock_run.assert_called_once()
+                args = mock_run.call_args[0][0]
+                assert "-p" in args and "-o" in args and "command=" in args
+
+    def test_macos_ps_returns_empty_on_error(self):
+        """On macOS, return empty string when ps fails."""
+        from hermes_cli.main import _get_process_cmdline
+        with patch("sys.platform", "darwin"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stdout="")
+                assert _get_process_cmdline(99999) == ""
+
+    def test_windows_wmic_commandline(self):
+        """On Windows, use wmic to get command line."""
+        from hermes_cli.main import _get_process_cmdline
+        with patch("sys.platform", "win32"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0,
+                    stdout="CommandLine=C:\\hermes.exe dashboard --port 9119\n",
+                )
+                result = _get_process_cmdline(12345)
+                assert "hermes" in result.lower()
+


### PR DESCRIPTION
## Problem

On macOS, `hermes dashboard --status` could report phanton PIDs that no longer exist (#24150).

The old code in `_report_dashboard_status()` tried to read `/proc/<pid>/cmdline` to get the command line and verify the process exists, but `/proc/` does not exist on macOS, so verification was skipped entirely. This led to stale phantom PIDs being displayed.

## Root Cause

1. macOS: `/proc/<pid>/cmdline` does not exist → verification skipped → phantom PIDs shown  
2. `-find_stale_dashboard_pids()` already uses `ps -A -o pid=,command=` (not `pgrep -f` as described in the issue—that was fixed in 9048fd02), but `_report_dashboard_status()` was not cross-platform

## Solution

1. **Add `_is_process_alive(pid)` helper** with cross-platform support:
   - Linux: check `/proc/<pid>` existence
   - macOs/FreeBSD: `ps -p <pid>` (exits 1 if PID not found)
   - Windows: `tasklist /FI "PID eq <pid>"`

2. **Add `_get_process_cmdline(pid)` helper** with cross-platform support:
   - Linux: read `/proc/<pid>/cmdline`
   - macOS/FreeBSD: `ps -p <pid> -o command=`
   - Windows: `wmic process where "ProcessId=<pid>" get CommandLine`

3. **Update `_report_dashboard_status()`** to:
   - Re-verify each PID with `_is_process_alive()` before displaying
   - Use `_get_process_cmdline()` to retrieve the command line
   - Filter out stale/phantom entries → no more false positives

## Testing

- All 21 tests in `test_dashboard_lifecycle_flags.py` pass
- All 19 tests in `test_update_stale_dashboard.py` pass
- Added new tests for `_is_process_alive()` and `_get_process_cmdline()`

## Related Issues

Fixes #24150

---

**Checklist**
- [x] Changes are consistent with the codebase style  
- [x] Unit tests added/updated  
- [x] All tests pass  
- [x] Commit message follows convention  