### PR TITLE
fix: sanitize MCP array schemas for Codex

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -18,6 +18,8 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from tools.schema_sanitizer import sanitize_tool_schemas
+
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
@@ -246,8 +248,9 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
     if not tools:
         return None
 
+    sanitized_tools = sanitize_tool_schemas(tools)
     converted: List[Dict[str, Any]] = []
-    for item in tools:
+    for item in sanitized_tools:
         fn = item.get("function", {}) if isinstance(item, dict) else {}
         name = fn.get("name")
         if not isinstance(name, str) or not name.strip():

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+from tools.schema_sanitizer import sanitize_tool_schemas
 
 
 class ResponsesApiTransport(ProviderTransport):
@@ -55,7 +56,8 @@ class ResponsesApiTransport(ProviderTransport):
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
-        return _responses_tools(tools)
+        sanitized_tools = sanitize_tool_schemas(tools)
+        return _responses_tools(sanitized_tools)
 
     def build_kwargs(
         self,

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -144,6 +144,11 @@ How the built-in MCP client connects servers (stdio/HTTP), auto-discovers
 their tools, and exposes them as first-class tools, plus catalog install
 (`hermes mcp install <name>`): `skill_view(name="hermes-agent", file_path="references/native-mcp.md")`.
 
+Codex strictness note:
+- If `openai-codex` fails at startup with `Invalid schema for function 'mcp_<server>_<tool>'` or `array schema missing items`, first update to a Hermes build whose `tools/schema_sanitizer.py` repairs array schemas by adding permissive `items: {}` for bare `"array"` nodes and dict nodes like `{"type": "array"}` that omit both `items` and `prefixItems`.
+- If you cannot patch/update Hermes immediately, exclude the offending server-native MCP tool under `mcp_servers.<name>.tools.exclude` so Hermes does not register it for that profile. Verify with `hermes -p <profile> mcp list` (`-N excluded`).
+
+
 ### Gateway (Messaging Platforms)
 
 ```

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1183,6 +1183,31 @@ def test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids(monkeypatch):
     assert function_output["call_id"] == "call_pair123"
 
 
+def test_codex_transport_sanitizes_array_tool_schema(monkeypatch):
+    _build_agent(monkeypatch)
+    from agent.transports.codex import ResponsesApiTransport
+
+    transport = ResponsesApiTransport()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "broken_tool",
+                "description": "broken",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "bag": {"type": "array"},
+                    },
+                },
+            },
+        }
+    ]
+
+    converted = transport.convert_tools(tools)
+    assert converted[0]["parameters"]["properties"]["bag"]["items"] == {}
+
+
 def test_preflight_codex_api_kwargs_strips_optional_function_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _preflight_codex_api_kwargs

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -67,6 +67,15 @@ def test_bare_string_primitive_value_replaced_with_schema_dict():
     assert out[0]["function"]["parameters"]["properties"]["name"] == {"type": "string"}
 
 
+def test_bare_string_array_value_gets_items_schema():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"bag": "array"},
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["properties"]["bag"] == {"type": "array", "items": {}}
+
+
 def test_nullable_type_array_collapsed_to_single_string():
     tools = [_tool("t", {
         "type": "object",
@@ -265,6 +274,42 @@ def test_ref_description_preserved():
     payload = out[0]["function"]["parameters"]["properties"]["payload"]
     assert payload["description"] == "The payload"
     assert payload["$ref"] == "#/$defs/Payload"
+
+
+def test_array_without_items_gets_permissive_items_schema():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "bag": {
+                "type": "array",
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    bag = out[0]["function"]["parameters"]["properties"]["bag"]
+    assert bag["type"] == "array"
+    assert bag["items"] == {}
+
+
+def test_array_without_items_inside_allof_gets_items_schema():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "defaultFilter": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {"type": "array"},
+                        },
+                    }
+                ]
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    node = out[0]["function"]["parameters"]["properties"]["defaultFilter"]["allOf"][0]["properties"]["type"]
+    assert node == {"type": "array", "items": {}}
 
 
 def test_empty_tools_list_returns_empty():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -247,10 +247,17 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 "with {'type': %r}",
                 path, node, node,
             )
-            return {"type": node} if node != "object" else {
-                "type": "object",
-                "properties": {},
-            }
+            if node == "object":
+                return {
+                    "type": "object",
+                    "properties": {},
+                }
+            if node == "array":
+                return {
+                    "type": "array",
+                    "items": {},
+                }
+            return {"type": node}
         # Any other stray string is not a schema — drop it by replacing with
         # a permissive object schema rather than propagate something the
         # backend will reject.
@@ -321,6 +328,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Some MCP / Pydantic emitters produce ``{"type": "array"}`` with no
+    # ``items`` / ``prefixItems``. OpenAI Codex rejects that schema outright
+    # ("array schema missing items"). Preserve the permissive intent by using
+    # an unconstrained item schema rather than over-constraining the array.
+    if out.get("type") == "array" and "items" not in out and "prefixItems" not in out:
+        out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -90,6 +90,10 @@ tools:
   exclude: [delete_customer]
 ```
 
+OpenAI Codex note:
+- Current Hermes builds sanitize MCP array schemas more aggressively, adding permissive `items: {}` when a schema node expresses `type: array` but omits both `items` and `prefixItems`. This fixes strict `openai-codex` startup failures like `array schema missing items` for some MCP/Pydantic/NocoBase tools.
+- On older Hermes builds, `tools.exclude` is still the fastest containment for one or two broken server-native MCP tools until Hermes or the upstream MCP schema is patched.
+
 ### Precedence
 
 If both are set, `include` wins.


### PR DESCRIPTION
## Summary
- fix Hermes schema sanitization for MCP/Pydantic array nodes that omit `items`
- sanitize tool schemas again at the Codex Responses conversion path so repaired schemas survive transport conversion in CLI and gateway flows
- add regression tests for nested `allOf` array cases and for Responses transport conversion
- document Codex strictness and the temporary `tools.exclude` containment path

## Problem
`openai-codex` rejects some MCP tool schemas at startup with:

```text
Invalid schema for function 'mcp_<server>_<tool>': ... array schema missing items
```

The original sanitizer fix repaired the base schema walker, but Codex Responses conversion still needed coverage because CLI/gateway tool conversion can hit `_responses_tools(...)` / `ResponsesApiTransport.convert_tools(...)` before request dispatch.

## Root cause
Some MCP schemas carried array intent as either:
- bare string `"array"`
- dict schema `{ "type": "array" }` with no `items`

Hermes sanitized these into still-invalid Codex schemas in nested paths such as NocoBase `defaultFilter...properties.type`.

Separately, the Codex Responses conversion path needed to sanitize tool schemas before converting them to Responses-format function definitions, otherwise repaired schemas could regress in CLI/gateway transport flows.

## Fix
- inject permissive `items: {}` during schema sanitization when a schema node expresses `type: array` but omits both `items` and `prefixItems`
- sanitize tool schemas before `_responses_tools(...)` conversion in:
  - `agent/codex_responses_adapter.py`
  - `agent/transports/codex.py`

## Validation
- `/root/.hermes/hermes-agent/.venv/bin/python -m pytest tests/tools/test_schema_sanitizer.py -q`
- `/root/.hermes/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
- verified `openai-codex` init succeeds with previously failing NocoBase MCP tools enabled
- verified Responses transport now preserves injected `items: {}` for repaired array schemas
