### PR TITLE
fix(slack): clear assistant status per thread

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1285,6 +1285,7 @@ class BasePlatformAdapter(ABC):
         # Without the owner-task map, an old task's finally block could delete
         # a newer task's guard, leaving stale busy state.
         self._active_sessions: Dict[str, asyncio.Event] = {}
+        self._active_session_metadata: Dict[str, Optional[Dict[str, Any]]] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
         # Background message-processing tasks spawned by handle_message().
@@ -2226,7 +2227,7 @@ class BasePlatformAdapter(ABC):
             # Cancelling _keep_typing alone won't clean that up.
             if hasattr(self, "stop_typing"):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self._stop_typing_with_metadata(chat_id, metadata=metadata)
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
@@ -2243,6 +2244,26 @@ class BasePlatformAdapter(ABC):
         """Resume typing indicator for a chat after approval resolves."""
         self._typing_paused.discard(chat_id)
 
+    async def _stop_typing_with_metadata(self, chat_id: str, metadata=None) -> None:
+        """Call stop_typing, passing metadata only for adapters that accept it."""
+        if not hasattr(self, "stop_typing"):
+            return
+        stop_typing = self.stop_typing
+        try:
+            sig = inspect.signature(stop_typing)
+        except (TypeError, ValueError):
+            sig = None
+        params = sig.parameters if sig is not None else {}
+        accepts_metadata = (
+            sig is None
+            or "metadata" in params
+            or any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
+        )
+        if accepts_metadata:
+            await stop_typing(chat_id, metadata=metadata)
+        else:
+            await stop_typing(chat_id)
+
     async def interrupt_session_activity(self, session_key: str, chat_id: str) -> None:
         """Signal the active session loop to stop and clear typing immediately."""
         if session_key:
@@ -2250,7 +2271,7 @@ class BasePlatformAdapter(ABC):
             if interrupt_event is not None:
                 interrupt_event.set()
         try:
-            await self.stop_typing(chat_id)
+            await self._stop_typing_with_metadata(chat_id, metadata=self._active_session_metadata.get(session_key))
         except Exception:
             pass
 
@@ -2526,6 +2547,7 @@ class BasePlatformAdapter(ABC):
         if guard is not None and current_guard is not guard:
             return
         del self._active_sessions[session_key]
+        self._active_session_metadata.pop(session_key, None)
 
     def _session_task_is_stale(self, session_key: str) -> bool:
         """Return True if the owner task for ``session_key`` is done/cancelled.
@@ -2566,6 +2588,7 @@ class BasePlatformAdapter(ABC):
             session_key,
         )
         self._active_sessions.pop(session_key, None)
+        self._active_session_metadata.pop(session_key, None)
         self._pending_messages.pop(session_key, None)
         self._session_tasks.pop(session_key, None)
         return True
@@ -2586,6 +2609,10 @@ class BasePlatformAdapter(ABC):
         """
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
+        self._active_session_metadata[session_key] = _thread_metadata_for_source(
+            event.source,
+            _reply_anchor_for_event(event),
+        )
 
         task = asyncio.create_task(self._process_message_background(event, session_key))
         self._session_tasks[session_key] = task
@@ -2911,6 +2938,7 @@ class BasePlatformAdapter(ABC):
         
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        self._active_session_metadata[session_key] = _thread_metadata
         _keep_typing_kwargs = {"metadata": _thread_metadata}
         try:
             _keep_typing_sig = inspect.signature(self._keep_typing)
@@ -3292,7 +3320,7 @@ class BasePlatformAdapter(ABC):
             # that may have been recreated by _keep_typing after the last stop_typing()
             try:
                 if hasattr(self, "stop_typing"):
-                    await self.stop_typing(event.source.chat_id)
+                    await self._stop_typing_with_metadata(event.source.chat_id, metadata=_thread_metadata)
             except Exception:
                 pass
             # Late-arrival drain: a message may have arrived during the
@@ -3363,6 +3391,7 @@ class BasePlatformAdapter(ABC):
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
                     del self._session_tasks[session_key]
                     self._release_session_guard(session_key, guard=interrupt_event)
+                    self._active_session_metadata.pop(session_key, None)
     
     async def cancel_background_tasks(self) -> None:
         """Cancel any in-flight background message-processing tasks.

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -16,7 +16,7 @@ import os
 import re
 import time
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Any, Tuple, List
+from typing import Dict, Optional, Any, Tuple, List, Set
 
 try:
     from slack_bolt.async_app import AsyncApp
@@ -320,8 +320,15 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them.  Key by (chat_id, thread_ts) rather than chat_id only:
+        # Slack channels can have multiple Hermes threads running concurrently,
+        # and a single chat_id → thread_ts slot lets one thread overwrite
+        # another, leaving Slack's "is thinking..." status stuck forever.
+        self._active_status_threads: Set[Tuple[str, str]] = set()
+        # Map bot reply message ts → parent thread ts so streaming final edits
+        # can clear the exact Slack Assistant status even if the caller only
+        # provides the edited message id. Bounded with _BOT_TS_MAX below.
+        self._message_thread_ts: Dict[str, str] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -745,6 +752,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        thread_ts = None
         try:
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
@@ -786,7 +794,14 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                try:
+                    await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
+                except Exception as clear_error:  # pragma: no cover - defensive logging
+                    logger.warning(
+                        "[Slack] Failed to clear assistant status for thread %s: %s",
+                        thread_ts,
+                        clear_error,
+                    )
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -796,10 +811,12 @@ class SlackAdapter(BasePlatformAdapter):
                 # Also register the thread root so replies-to-my-replies work
                 if thread_ts:
                     self._bot_message_ts.add(thread_ts)
+                    self._message_thread_ts[sent_ts] = thread_ts
                 if len(self._bot_message_ts) > self._BOT_TS_MAX:
                     excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
                     for old_ts in list(self._bot_message_ts)[:excess]:
                         self._bot_message_ts.discard(old_ts)
+                        self._message_thread_ts.pop(old_ts, None)
 
             return SendResult(
                 success=True,
@@ -808,6 +825,15 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
+            if thread_ts:
+                try:
+                    await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
+                except Exception as clear_error:
+                    logger.warning(
+                        "[Slack] Failed to clear assistant status after send error for thread %s: %s",
+                        thread_ts,
+                        clear_error,
+                    )
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
@@ -866,7 +892,16 @@ class SlackAdapter(BasePlatformAdapter):
                 text=formatted,
             )
             if finalize:
-                await self.stop_typing(chat_id)
+                thread_ts = self._message_thread_ts.get(message_id)
+                if thread_ts:
+                    try:
+                        await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
+                    except Exception as clear_error:  # pragma: no cover - defensive logging
+                        logger.warning(
+                            "[Slack] Failed to clear assistant status after edit finalize for thread %s: %s",
+                            thread_ts,
+                            clear_error,
+                        )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -895,13 +930,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
                 status="is thinking...",
             )
+            self._active_status_threads.add((chat_id, thread_ts))
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
@@ -911,17 +946,32 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
-        if not thread_ts:
+        thread_ts = None
+        if metadata:
+            thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+
+        if thread_ts:
+            targets = [(chat_id, thread_ts)] if (chat_id, thread_ts) in self._active_status_threads else []
+        elif metadata and metadata.get("clear_all_threads"):
+            # Explicit administrative/shutdown escape hatch. Normal lifecycle
+            # cleanup must pass thread metadata so finishing one Slack session
+            # cannot clear sibling thread indicators in the same channel.
+            targets = [key for key in self._active_status_threads if key[0] == chat_id]
+        else:
             return
-        try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status="",
-            )
-        except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+
+        if not targets:
+            return
+        for target_chat_id, target_thread_ts in targets:
+            self._active_status_threads.discard((target_chat_id, target_thread_ts))
+            try:
+                await self._get_client(target_chat_id).assistant_threads_setStatus(
+                    channel_id=target_chat_id,
+                    thread_ts=target_thread_ts,
+                    status="",
+                )
+            except Exception as e:
+                logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1189,8 +1189,9 @@ class TestSendTyping:
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
-        # Should not raise
+        # Should not raise or track a status that Slack did not set.
         await adapter.send_typing("C123", metadata={"thread_id": "ts1"})
+        assert ("C123", "ts1") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_uses_thread_ts_fallback(self, adapter):
@@ -1214,7 +1215,7 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_stop_typing_noop_without_tracked_thread(self, adapter):
@@ -1226,25 +1227,25 @@ class TestSendTyping:
 
     @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads.add(("C123", "parent_ts"))
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
 
-        await adapter.stop_typing("C123")
+        await adapter.stop_typing("C123", metadata={"clear_all_threads": True})
 
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_send_clears_status_after_final_post(self, adapter):
         adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads.add(("C123", "parent_ts"))
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -1255,13 +1256,14 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads.add(("C123", "parent_ts"))
+        adapter._message_thread_ts["reply_ts"] = "parent_ts"
 
         result = await adapter.edit_message(
             "C123",
@@ -1281,13 +1283,13 @@ class TestSendTyping:
             thread_ts="parent_ts",
             status="",
         )
-        assert "C123" not in adapter._active_status_threads
+        assert ("C123", "parent_ts") not in adapter._active_status_threads
 
     @pytest.mark.asyncio
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads.add(("C123", "parent_ts"))
 
         result = await adapter.edit_message(
             "C123",
@@ -1298,7 +1300,57 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert ("C123", "parent_ts") in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_clearing_one_thread_keeps_sibling_status(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads.update({("C123", "t1"), ("C123", "t2")})
+        adapter._message_thread_ts["reply_t1"] = "t1"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_t1",
+            "done",
+            finalize=True,
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="t1",
+            status="",
+        )
+        assert ("C123", "t1") not in adapter._active_status_threads
+        assert ("C123", "t2") in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_without_metadata_does_not_clear_siblings(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads.update({("C123", "t1"), ("C123", "t2")})
+
+        await adapter.stop_typing("C123")
+
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+        assert adapter._active_status_threads == {("C123", "t1"), ("C123", "t2")}
+
+    @pytest.mark.asyncio
+    async def test_send_failure_clears_exact_status(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=Exception("boom"))
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads.update({("C123", "t1"), ("C123", "t2")})
+
+        result = await adapter.send("C123", "done", metadata={"thread_id": "t1"})
+
+        assert not result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="t1",
+            status="",
+        )
+        assert ("C123", "t1") not in adapter._active_status_threads
+        assert ("C123", "t2") in adapter._active_status_threads
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Slack Assistant status messages are tracked per channel/thread, but the previous cleanup path could treat all in-flight status indicators in a channel as the same thing. That meant concurrent runs in different Slack threads could clear each other’s status indicator, or leave one stuck behind. This change makes Slack’s status tracking thread-aware so each run cleans up only its own indicator, while keeping the fix scoped to the Slack adapter and its lifecycle hook.