### PR TITLE
fix(feishu): improve inbound message reliability diagnostics

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1319,9 +1319,10 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
     try:
+        logger.info("[Feishu] Websocket client thread starting")
         ws_client.start()
     except Exception:
-        pass
+        logger.exception("[Feishu] Websocket client thread crashed")
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
@@ -1340,6 +1341,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             pass
         adapter._ws_thread_loop = None
+        logger.info("[Feishu] Websocket client thread exiting")
 
 
 def check_feishu_requirements() -> bool:
@@ -2206,6 +2208,15 @@ class FeishuAdapter(BasePlatformAdapter):
         during startup/restart or network-flap reconnect), the event is queued
         for replay instead of dropped.
         """
+        message_id = "unknown"
+        try:
+            event = getattr(data, "event", None)
+            message = getattr(event, "message", None)
+            message_id = str(getattr(message, "message_id", "") or "unknown")
+        except Exception:
+            message_id = "unknown"
+        logger.info("[Feishu] Raw inbound message callback: id=%s", message_id)
+
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
             start_drainer = self._enqueue_pending_inbound_event(data)
@@ -2216,6 +2227,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     daemon=True,
                 ).start()
             return
+        logger.info("[Feishu] Scheduling inbound message on adapter loop: id=%s", message_id)
         future = asyncio.run_coroutine_threadsafe(
             self._handle_message_event_data(data),
             loop,
@@ -2251,8 +2263,15 @@ class FeishuAdapter(BasePlatformAdapter):
             should_start = not self._pending_drain_scheduled
             if should_start:
                 self._pending_drain_scheduled = True
+        try:
+            event = getattr(data, "event", None)
+            message = getattr(event, "message", None)
+            message_id = str(getattr(message, "message_id", "") or "unknown")
+        except Exception:
+            message_id = "unknown"
         logger.warning(
-            "[Feishu] Queued inbound event for replay (loop not ready, queue depth=%d)",
+            "[Feishu] Queued inbound event for replay (loop not ready, id=%s, queue depth=%d)",
+            message_id,
             depth,
         )
         return should_start
@@ -2346,17 +2365,23 @@ class FeishuAdapter(BasePlatformAdapter):
         message = getattr(event, "message", None)
         sender = getattr(event, "sender", None)
         if not message or not sender or not getattr(sender, "sender_id", None):
-            logger.debug("[Feishu] Dropping malformed inbound event: missing message/sender")
+            logger.info("[Feishu] Dropping malformed inbound event: missing message/sender")
             return
 
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):
-            logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
+            logger.info("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
             return
+
+        logger.info(
+            "[Feishu] Received raw message type=%s message_id=%s",
+            getattr(message, "message_type", None) or getattr(message, "msg_type", None) or "unknown",
+            message_id,
+        )
 
         reason = self._admit(sender, message)
         if reason is not None:
-            logger.debug("[Feishu] dropping inbound event: %s", reason)
+            logger.info("[Feishu] Dropping inbound event: id=%s reason=%s", message_id, reason)
             return
 
         chat_type = getattr(message, "chat_type", "p2p")
@@ -2745,6 +2770,12 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", "") or "" if event.source else ""
         chat_lock = self._get_chat_lock(chat_id)
         async with chat_lock:
+            logger.info(
+                "[Feishu] Dispatching inbound event to agent: id=%s chat_id=%s type=%s",
+                event.message_id,
+                chat_id,
+                event.message_type.value,
+            )
             await self.handle_message(event)
 
     # =========================================================================
@@ -2777,8 +2808,15 @@ class FeishuAdapter(BasePlatformAdapter):
             response = await asyncio.to_thread(self._client.im.v1.message_reaction.create, request)
             if response and getattr(response, "success", lambda: False)():
                 data = getattr(response, "data", None)
-                return getattr(data, "reaction_id", None)
-            logger.debug(
+                reaction_id = getattr(data, "reaction_id", None)
+                logger.info(
+                    "[Feishu] Added reaction %s on %s reaction_id=%s",
+                    emoji_type,
+                    message_id,
+                    reaction_id,
+                )
+                return reaction_id
+            logger.info(
                 "[Feishu] Add reaction %s on %s rejected: code=%s msg=%s",
                 emoji_type,
                 message_id,
@@ -2807,8 +2845,9 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             response = await asyncio.to_thread(self._client.im.v1.message_reaction.delete, request)
             if response and getattr(response, "success", lambda: False)():
+                logger.info("[Feishu] Removed reaction %s on %s", reaction_id, message_id)
                 return True
-            logger.debug(
+            logger.info(
                 "[Feishu] Remove reaction %s on %s rejected: code=%s msg=%s",
                 reaction_id,
                 message_id,

--- a/scripts/feishu_inbound_backfill_watchdog.py
+++ b/scripts/feishu_inbound_backfill_watchdog.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Read-only Feishu/Lark inbound backfill watchdog.
+
+Polls recent Feishu/Lark chat history and compares message_id values with local
+Hermes evidence (gateway logs + Feishu dedup state). This intentionally reports
+or queues suspected websocket misses but does not replay messages into the
+agent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+MESSAGE_ID_RE = re.compile(r"\bom_[A-Za-z0-9_\-]+")
+DEFAULT_WINDOW_SECONDS = 15 * 60
+DEFAULT_GRACE_SECONDS = 45
+DEFAULT_PAGE_SIZE = 50
+RECALLED_PREVIEWS = {"this message was recalled", "message was recalled", "消息已撤回"}
+
+
+def hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+
+
+def _load_env(path: Path | None = None) -> None:
+    path = path or hermes_home() / ".env"
+    if not path.exists():
+        return
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _domain_base() -> str:
+    return (
+        "https://open.larksuite.com"
+        if os.getenv("FEISHU_DOMAIN", "feishu").strip().lower() == "lark"
+        else "https://open.feishu.cn"
+    )
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    token: str | None = None,
+    body: dict[str, Any] | None = None,
+    timeout: int = 20,
+) -> dict[str, Any]:
+    data = None
+    headers = {"Content-Type": "application/json; charset=utf-8"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+    req = Request(url, data=data, headers=headers, method=method)
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _tenant_token() -> str:
+    app_id = os.getenv("FEISHU_APP_ID", "").strip()
+    app_secret = os.getenv("FEISHU_APP_SECRET", "").strip()
+    if not app_id or not app_secret:
+        raise RuntimeError("FEISHU_APP_ID/FEISHU_APP_SECRET missing")
+    payload = _request_json(
+        "POST",
+        f"{_domain_base()}/open-apis/auth/v3/tenant_access_token/internal",
+        body={"app_id": app_id, "app_secret": app_secret},
+    )
+    if payload.get("code") != 0 or not payload.get("tenant_access_token"):
+        raise RuntimeError(
+            f"tenant token request failed: code={payload.get('code')} msg={payload.get('msg')}"
+        )
+    return str(payload["tenant_access_token"])
+
+
+def _load_log_ids(home: Path) -> set[str]:
+    ids: set[str] = set()
+    for path in home.glob("logs/gateway.log*"):
+        if not path.is_file():
+            continue
+        with path.open("rb") as fh:
+            try:
+                fh.seek(-5 * 1024 * 1024, os.SEEK_END)
+            except OSError:
+                fh.seek(0)
+            text = fh.read().decode("utf-8", errors="replace")
+        ids.update(MESSAGE_ID_RE.findall(text))
+    return ids
+
+
+def _load_dedup_ids(path: Path) -> set[str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return set()
+    data = payload.get("message_ids", {}) if isinstance(payload, dict) else {}
+    if isinstance(data, dict):
+        return {str(k) for k in data if str(k).startswith("om_")}
+    if isinstance(data, list):
+        return {str(k) for k in data if str(k).startswith("om_")}
+    return set()
+
+
+def _load_state(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"reported": {}}
+
+
+def _save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _list_messages(
+    token: str,
+    chat_id: str,
+    start_time: int,
+    end_time: int,
+    page_size: int,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page_token = ""
+    while True:
+        query = {
+            "container_id_type": "chat",
+            "container_id": chat_id,
+            "start_time": str(start_time),
+            "end_time": str(end_time),
+            "page_size": str(page_size),
+        }
+        if page_token:
+            query["page_token"] = page_token
+        payload = _request_json(
+            "GET",
+            f"{_domain_base()}/open-apis/im/v1/messages?{urlencode(query)}",
+            token=token,
+        )
+        if payload.get("code") != 0:
+            raise RuntimeError(f"list messages failed: code={payload.get('code')} msg={payload.get('msg')}")
+        data = payload.get("data") or {}
+        batch = data.get("items") or []
+        if isinstance(batch, list):
+            items.extend(x for x in batch if isinstance(x, dict))
+        if not data.get("has_more"):
+            break
+        page_token = str(data.get("page_token") or "")
+        if not page_token:
+            break
+    return items
+
+
+def _message_id(item: dict[str, Any]) -> str:
+    return str(item.get("message_id") or item.get("messageId") or "")
+
+
+def _sender_type(item: dict[str, Any]) -> str:
+    sender = item.get("sender") or {}
+    return str(sender.get("sender_type") or sender.get("type") or "")
+
+
+def _message_create_time(item: dict[str, Any]) -> int:
+    raw = item.get("create_time") or item.get("update_time") or 0
+    try:
+        val = int(str(raw))
+        return val // 1000 if val > 10_000_000_000 else val
+    except (TypeError, ValueError):
+        return 0
+
+
+def _preview(item: dict[str, Any], limit: int = 80) -> str:
+    content = item.get("body", {}).get("content") or item.get("content") or ""
+    text = ""
+    try:
+        parsed = json.loads(content) if isinstance(content, str) else content
+        if isinstance(parsed, dict):
+            text = parsed.get("text") or parsed.get("title") or json.dumps(parsed, ensure_ascii=False)
+        else:
+            text = str(parsed)
+    except Exception:
+        text = str(content)
+    text = " ".join(text.split())
+    return text[:limit]
+
+
+def _is_recalled_message(item: dict[str, Any]) -> bool:
+    msg_type = str(item.get("msg_type") or item.get("message_type") or "").lower()
+    if "recall" in msg_type or "withdraw" in msg_type:
+        return True
+    preview = _preview(item, limit=120).strip().lower()
+    return preview in RECALLED_PREVIEWS
+
+
+def _queue_record(item: dict[str, Any], *, chat_id: str, detected_at: int) -> dict[str, Any]:
+    return {
+        "detected_at": detected_at,
+        "chat_id": chat_id,
+        "message_id": _message_id(item),
+        "create_time": _message_create_time(item),
+        "sender_type": _sender_type(item) or "<unknown>",
+        "msg_type": str(item.get("msg_type") or item.get("message_type") or ""),
+        "preview": _preview(item, limit=240),
+    }
+
+
+def _append_queue(records: list[dict[str, Any]], path: Path) -> None:
+    if not records:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only Feishu/Lark inbound backfill watchdog")
+    parser.add_argument("--chat-id", default=os.getenv("FEISHU_HOME_CHANNEL", ""), help="Feishu chat/container id")
+    parser.add_argument("--window-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS)))
+    parser.add_argument("--grace-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_GRACE_SECONDS", DEFAULT_GRACE_SECONDS)))
+    parser.add_argument("--page-size", type=int, default=DEFAULT_PAGE_SIZE)
+    parser.add_argument("--include-bots", action="store_true", help="Also check app/bot-originated messages")
+    parser.add_argument("--include-recalled", action="store_true", help="Also report recalled/withdrawn messages")
+    parser.add_argument("--no-queue", action="store_true", help="Do not append suspected misses to the local review queue")
+    parser.add_argument("--dry-run", action="store_true", help="Print OK summary even when no misses are found")
+    return parser
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    home = hermes_home()
+    _load_env(home / ".env")
+    chat_id = (args.chat_id or os.getenv("FEISHU_HOME_CHANNEL", "")).strip()
+    if not chat_id:
+        raise RuntimeError("chat id missing; set FEISHU_HOME_CHANNEL or pass --chat-id")
+
+    now = int(time.time())
+    start_time = now - max(args.window_seconds, 60)
+    end_time = now - max(args.grace_seconds, 0)
+    if end_time <= start_time:
+        raise RuntimeError("window too small after grace period")
+
+    state_path = home / "state" / "feishu_inbound_backfill_watchdog.json"
+    queue_path = home / "state" / "feishu_inbound_backfill_queue.jsonl"
+    token = _tenant_token()
+    messages = _list_messages(token, chat_id, start_time, end_time, max(1, min(args.page_size, 50)))
+    seen_ids = _load_log_ids(home) | _load_dedup_ids(home / "feishu_seen_message_ids.json")
+
+    state = _load_state(state_path)
+    reported = state.setdefault("reported", {})
+    cutoff = now - 24 * 60 * 60
+    state["reported"] = {
+        mid: ts for mid, ts in reported.items()
+        if isinstance(ts, int) and ts >= cutoff
+    }
+    reported = state["reported"]
+
+    checked = 0
+    missing: list[dict[str, Any]] = []
+    for item in messages:
+        mid = _message_id(item)
+        if not mid:
+            continue
+        stype = _sender_type(item).lower()
+        if not args.include_bots and stype in {"app", "bot"}:
+            continue
+        if not args.include_recalled and _is_recalled_message(item):
+            continue
+        checked += 1
+        if mid not in seen_ids and mid not in reported:
+            missing.append(item)
+            reported[mid] = now
+
+    state["last_run"] = now
+    state["last_window"] = {
+        "chat_id": chat_id,
+        "start_time": start_time,
+        "end_time": end_time,
+        "checked": checked,
+        "fetched": len(messages),
+    }
+    _save_state(state_path, state)
+
+    queue_records = [_queue_record(item, chat_id=chat_id, detected_at=now) for item in missing]
+    if not args.no_queue:
+        _append_queue(queue_records, queue_path)
+
+    if missing:
+        print("Feishu inbound watchdog: suspected missed message(s)")
+        queue_note = " disabled" if args.no_queue else f" appended={len(queue_records)} path={queue_path}"
+        print(
+            f"chat_id={chat_id} window={start_time}..{end_time} "
+            f"fetched={len(messages)} checked={checked} missing={len(missing)} queue{queue_note}"
+        )
+        for record in queue_records[:10]:
+            print(
+                f"- id={record['message_id']} create_time={record['create_time']} "
+                f"sender_type={record['sender_type']} preview={record['preview']!r}"
+            )
+        if len(missing) > 10:
+            print(f"... {len(missing) - 10} more")
+        return 2
+
+    if args.dry_run:
+        print(f"Feishu inbound watchdog OK: chat_id={chat_id} fetched={len(messages)} checked={checked} window={start_time}..{end_time}")
+    return 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except (HTTPError, URLError, TimeoutError, RuntimeError) as exc:
+        print(f"Feishu inbound watchdog ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/feishu_inbound_backfill_watchdog.py
+++ b/scripts/feishu_inbound_backfill_watchdog.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Read-only Feishu/Lark inbound backfill watchdog.
+"""Feishu inbound backfill watchdog.
 
-Polls recent Feishu/Lark chat history and compares message_id values with local
-Hermes evidence (gateway logs + Feishu dedup state). This intentionally reports
-or queues suspected websocket misses but does not replay messages into the
-agent.
+Polls recent Feishu chat history and compares message_id values with Hermes
+local evidence (gateway logs + Feishu dedup state). It is intentionally
+read-only: it reports suspected websocket misses but does not replay messages.
 """
 from __future__ import annotations
 
@@ -20,6 +19,13 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+HERMES_HOME = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+LOG_PATH = HERMES_HOME / "logs" / "gateway.log"
+DEDUP_PATH = HERMES_HOME / "feishu_seen_message_ids.json"
+ENV_PATH = HERMES_HOME / ".env"
+STATE_PATH = HERMES_HOME / "state" / "feishu_inbound_backfill_watchdog.json"
+QUEUE_PATH = HERMES_HOME / "state" / "feishu_inbound_backfill_queue.jsonl"
+
 MESSAGE_ID_RE = re.compile(r"\bom_[A-Za-z0-9_\-]+")
 DEFAULT_WINDOW_SECONDS = 15 * 60
 DEFAULT_GRACE_SECONDS = 45
@@ -27,12 +33,7 @@ DEFAULT_PAGE_SIZE = 50
 RECALLED_PREVIEWS = {"this message was recalled", "message was recalled", "消息已撤回"}
 
 
-def hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
-
-
-def _load_env(path: Path | None = None) -> None:
-    path = path or hermes_home() / ".env"
+def _load_env(path: Path = ENV_PATH) -> None:
     if not path.exists():
         return
     for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -47,21 +48,10 @@ def _load_env(path: Path | None = None) -> None:
 
 
 def _domain_base() -> str:
-    return (
-        "https://open.larksuite.com"
-        if os.getenv("FEISHU_DOMAIN", "feishu").strip().lower() == "lark"
-        else "https://open.feishu.cn"
-    )
+    return "https://open.larksuite.com" if os.getenv("FEISHU_DOMAIN", "feishu").strip().lower() == "lark" else "https://open.feishu.cn"
 
 
-def _request_json(
-    method: str,
-    url: str,
-    *,
-    token: str | None = None,
-    body: dict[str, Any] | None = None,
-    timeout: int = 20,
-) -> dict[str, Any]:
+def _request_json(method: str, url: str, *, token: str | None = None, body: dict[str, Any] | None = None, timeout: int = 20) -> dict[str, Any]:
     data = None
     headers = {"Content-Type": "application/json; charset=utf-8"}
     if token:
@@ -84,17 +74,16 @@ def _tenant_token() -> str:
         body={"app_id": app_id, "app_secret": app_secret},
     )
     if payload.get("code") != 0 or not payload.get("tenant_access_token"):
-        raise RuntimeError(
-            f"tenant token request failed: code={payload.get('code')} msg={payload.get('msg')}"
-        )
+        raise RuntimeError(f"tenant token request failed: code={payload.get('code')} msg={payload.get('msg')}")
     return str(payload["tenant_access_token"])
 
 
-def _load_log_ids(home: Path) -> set[str]:
+def _load_log_ids() -> set[str]:
     ids: set[str] = set()
-    for path in home.glob("logs/gateway.log*"):
+    for path in HERMES_HOME.glob("logs/gateway.log*"):
         if not path.is_file():
             continue
+        # Bound read volume per file. Rotated gateway logs may hold the relevant window.
         with path.open("rb") as fh:
             try:
                 fh.seek(-5 * 1024 * 1024, os.SEEK_END)
@@ -105,40 +94,34 @@ def _load_log_ids(home: Path) -> set[str]:
     return ids
 
 
-def _load_dedup_ids(path: Path) -> set[str]:
+def _load_dedup_ids(path: Path = DEDUP_PATH) -> set[str]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return set()
     data = payload.get("message_ids", {}) if isinstance(payload, dict) else {}
     if isinstance(data, dict):
-        return {str(k) for k in data if str(k).startswith("om_")}
+        return {str(k) for k in data.keys() if str(k).startswith("om_")}
     if isinstance(data, list):
         return {str(k) for k in data if str(k).startswith("om_")}
     return set()
 
 
-def _load_state(path: Path) -> dict[str, Any]:
+def _load_state() -> dict[str, Any]:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {"reported": {}}
 
 
-def _save_state(path: Path, state: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".tmp")
     tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(path)
+    tmp.replace(STATE_PATH)
 
 
-def _list_messages(
-    token: str,
-    chat_id: str,
-    start_time: int,
-    end_time: int,
-    page_size: int,
-) -> list[dict[str, Any]]:
+def _list_messages(token: str, chat_id: str, start_time: int, end_time: int, page_size: int) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     page_token = ""
     while True:
@@ -182,6 +165,7 @@ def _sender_type(item: dict[str, Any]) -> str:
 def _message_create_time(item: dict[str, Any]) -> int:
     raw = item.get("create_time") or item.get("update_time") or 0
     try:
+        # Feishu often returns milliseconds as a string.
         val = int(str(raw))
         return val // 1000 if val > 10_000_000_000 else val
     except (TypeError, ValueError):
@@ -223,7 +207,7 @@ def _queue_record(item: dict[str, Any], *, chat_id: str, detected_at: int) -> di
     }
 
 
-def _append_queue(records: list[dict[str, Any]], path: Path) -> None:
+def _append_queue(records: list[dict[str, Any]], path: Path = QUEUE_PATH) -> None:
     if not records:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -232,8 +216,8 @@ def _append_queue(records: list[dict[str, Any]], path: Path) -> None:
             fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Read-only Feishu/Lark inbound backfill watchdog")
+def run() -> int:
+    parser = argparse.ArgumentParser(description="Read-only Feishu inbound backfill watchdog")
     parser.add_argument("--chat-id", default=os.getenv("FEISHU_HOME_CHANNEL", ""), help="Feishu chat/container id")
     parser.add_argument("--window-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS)))
     parser.add_argument("--grace-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_GRACE_SECONDS", DEFAULT_GRACE_SECONDS)))
@@ -242,15 +226,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--include-recalled", action="store_true", help="Also report recalled/withdrawn messages")
     parser.add_argument("--no-queue", action="store_true", help="Do not append suspected misses to the local review queue")
     parser.add_argument("--dry-run", action="store_true", help="Print OK summary even when no misses are found")
-    return parser
+    args = parser.parse_args()
 
-
-def run(argv: list[str] | None = None) -> int:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    home = hermes_home()
-    _load_env(home / ".env")
+    _load_env()
     chat_id = (args.chat_id or os.getenv("FEISHU_HOME_CHANNEL", "")).strip()
     if not chat_id:
         raise RuntimeError("chat id missing; set FEISHU_HOME_CHANNEL or pass --chat-id")
@@ -261,14 +239,15 @@ def run(argv: list[str] | None = None) -> int:
     if end_time <= start_time:
         raise RuntimeError("window too small after grace period")
 
-    state_path = home / "state" / "feishu_inbound_backfill_watchdog.json"
-    queue_path = home / "state" / "feishu_inbound_backfill_queue.jsonl"
     token = _tenant_token()
     messages = _list_messages(token, chat_id, start_time, end_time, max(1, min(args.page_size, 50)))
-    seen_ids = _load_log_ids(home) | _load_dedup_ids(home / "feishu_seen_message_ids.json")
+    log_ids = _load_log_ids()
+    dedup_ids = _load_dedup_ids()
+    seen_ids = log_ids | dedup_ids
 
-    state = _load_state(state_path)
+    state = _load_state()
     reported = state.setdefault("reported", {})
+    # Prune old report suppression entries.
     cutoff = now - 24 * 60 * 60
     state["reported"] = {
         mid: ts for mid, ts in reported.items()
@@ -293,26 +272,17 @@ def run(argv: list[str] | None = None) -> int:
             reported[mid] = now
 
     state["last_run"] = now
-    state["last_window"] = {
-        "chat_id": chat_id,
-        "start_time": start_time,
-        "end_time": end_time,
-        "checked": checked,
-        "fetched": len(messages),
-    }
-    _save_state(state_path, state)
+    state["last_window"] = {"chat_id": chat_id, "start_time": start_time, "end_time": end_time, "checked": checked, "fetched": len(messages)}
+    _save_state(state)
 
     queue_records = [_queue_record(item, chat_id=chat_id, detected_at=now) for item in missing]
     if not args.no_queue:
-        _append_queue(queue_records, queue_path)
+        _append_queue(queue_records)
 
     if missing:
         print("Feishu inbound watchdog: suspected missed message(s)")
-        queue_note = " disabled" if args.no_queue else f" appended={len(queue_records)} path={queue_path}"
-        print(
-            f"chat_id={chat_id} window={start_time}..{end_time} "
-            f"fetched={len(messages)} checked={checked} missing={len(missing)} queue{queue_note}"
-        )
+        queue_note = " disabled" if args.no_queue else f" appended={len(queue_records)} path={QUEUE_PATH}"
+        print(f"chat_id={chat_id} window={start_time}..{end_time} fetched={len(messages)} checked={checked} missing={len(missing)} queue{queue_note}")
         for record in queue_records[:10]:
             print(
                 f"- id={record['message_id']} create_time={record['create_time']} "
@@ -320,20 +290,19 @@ def run(argv: list[str] | None = None) -> int:
             )
         if len(missing) > 10:
             print(f"... {len(missing) - 10} more")
-        return 2
+        # Cron semantics: suspected misses are an alert condition, not a script
+        # failure. Keep stdout non-empty so no_agent cron delivers the alert,
+        # but reserve non-zero exit codes for API/config/runtime failures.
+        return 0
 
     if args.dry_run:
         print(f"Feishu inbound watchdog OK: chat_id={chat_id} fetched={len(messages)} checked={checked} window={start_time}..{end_time}")
     return 0
 
 
-def main() -> int:
+if __name__ == "__main__":
     try:
-        return run()
+        raise SystemExit(run())
     except (HTTPError, URLError, TimeoutError, RuntimeError) as exc:
         print(f"Feishu inbound watchdog ERROR: {exc}", file=sys.stderr)
-        return 1
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+        raise SystemExit(1)

--- a/scripts/feishu_inbound_backfill_watchdog.py
+++ b/scripts/feishu_inbound_backfill_watchdog.py
@@ -19,12 +19,20 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-HERMES_HOME = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
-LOG_PATH = HERMES_HOME / "logs" / "gateway.log"
-DEDUP_PATH = HERMES_HOME / "feishu_seen_message_ids.json"
-ENV_PATH = HERMES_HOME / ".env"
-STATE_PATH = HERMES_HOME / "state" / "feishu_inbound_backfill_watchdog.json"
-QUEUE_PATH = HERMES_HOME / "state" / "feishu_inbound_backfill_queue.jsonl"
+def _home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+
+def _dedup_path() -> Path:
+    return _home() / "feishu_seen_message_ids.json"
+
+def _env_path() -> Path:
+    return _home() / ".env"
+
+def _state_path() -> Path:
+    return _home() / "state" / "feishu_inbound_backfill_watchdog.json"
+
+def _queue_path() -> Path:
+    return _home() / "state" / "feishu_inbound_backfill_queue.jsonl"
 
 MESSAGE_ID_RE = re.compile(r"\bom_[A-Za-z0-9_\-]+")
 DEFAULT_WINDOW_SECONDS = 15 * 60
@@ -33,7 +41,8 @@ DEFAULT_PAGE_SIZE = 50
 RECALLED_PREVIEWS = {"this message was recalled", "message was recalled", "消息已撤回"}
 
 
-def _load_env(path: Path = ENV_PATH) -> None:
+def _load_env(path: Path | None = None) -> None:
+    path = path or _env_path()
     if not path.exists():
         return
     for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -80,7 +89,7 @@ def _tenant_token() -> str:
 
 def _load_log_ids() -> set[str]:
     ids: set[str] = set()
-    for path in HERMES_HOME.glob("logs/gateway.log*"):
+    for path in _home().glob("logs/gateway.log*"):
         if not path.is_file():
             continue
         # Bound read volume per file. Rotated gateway logs may hold the relevant window.
@@ -94,7 +103,8 @@ def _load_log_ids() -> set[str]:
     return ids
 
 
-def _load_dedup_ids(path: Path = DEDUP_PATH) -> set[str]:
+def _load_dedup_ids(path: Path | None = None) -> set[str]:
+    path = path or _dedup_path()
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
@@ -109,16 +119,17 @@ def _load_dedup_ids(path: Path = DEDUP_PATH) -> set[str]:
 
 def _load_state() -> dict[str, Any]:
     try:
-        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        return json.loads(_state_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {"reported": {}}
 
 
 def _save_state(state: dict[str, Any]) -> None:
-    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = STATE_PATH.with_suffix(".tmp")
+    state_path = _state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_path.with_suffix(".tmp")
     tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(STATE_PATH)
+    tmp.replace(state_path)
 
 
 def _list_messages(token: str, chat_id: str, start_time: int, end_time: int, page_size: int) -> list[dict[str, Any]]:
@@ -207,7 +218,8 @@ def _queue_record(item: dict[str, Any], *, chat_id: str, detected_at: int) -> di
     }
 
 
-def _append_queue(records: list[dict[str, Any]], path: Path = QUEUE_PATH) -> None:
+def _append_queue(records: list[dict[str, Any]], path: Path | None = None) -> None:
+    path = path or _queue_path()
     if not records:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -216,8 +228,8 @@ def _append_queue(records: list[dict[str, Any]], path: Path = QUEUE_PATH) -> Non
             fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def run() -> int:
-    parser = argparse.ArgumentParser(description="Read-only Feishu inbound backfill watchdog")
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read-only Feishu/Lark inbound backfill watchdog")
     parser.add_argument("--chat-id", default=os.getenv("FEISHU_HOME_CHANNEL", ""), help="Feishu chat/container id")
     parser.add_argument("--window-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS)))
     parser.add_argument("--grace-seconds", type=int, default=int(os.getenv("FEISHU_BACKFILL_GRACE_SECONDS", DEFAULT_GRACE_SECONDS)))
@@ -226,7 +238,12 @@ def run() -> int:
     parser.add_argument("--include-recalled", action="store_true", help="Also report recalled/withdrawn messages")
     parser.add_argument("--no-queue", action="store_true", help="Do not append suspected misses to the local review queue")
     parser.add_argument("--dry-run", action="store_true", help="Print OK summary even when no misses are found")
-    args = parser.parse_args()
+    return parser
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
     _load_env()
     chat_id = (args.chat_id or os.getenv("FEISHU_HOME_CHANNEL", "")).strip()
@@ -281,7 +298,7 @@ def run() -> int:
 
     if missing:
         print("Feishu inbound watchdog: suspected missed message(s)")
-        queue_note = " disabled" if args.no_queue else f" appended={len(queue_records)} path={QUEUE_PATH}"
+        queue_note = " disabled" if args.no_queue else f" appended={len(queue_records)} path={_queue_path()}"
         print(f"chat_id={chat_id} window={start_time}..{end_time} fetched={len(messages)} checked={checked} missing={len(missing)} queue{queue_note}")
         for record in queue_records[:10]:
             print(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -547,7 +547,8 @@ class TestAdapterModule(unittest.TestCase):
         try:
             from gateway.platforms.feishu import _run_official_feishu_ws_client
 
-            _run_official_feishu_ws_client(fake_client, fake_adapter)
+            with self.assertLogs("gateway.platforms.feishu", level="INFO") as logs:
+                _run_official_feishu_ws_client(fake_client, fake_adapter)
         finally:
             sys.modules.clear()
             sys.modules.update(original_modules)
@@ -556,6 +557,9 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._reconnect_nonce, 2)
         self.assertEqual(fake_client._reconnect_interval, 3)
         self.assertEqual(fake_client._ping_interval, 4)
+        joined = "\n".join(logs.output)
+        self.assertIn("Websocket client thread crashed", joined)
+        self.assertIn("Websocket client thread exiting", joined)
 
 
 def _admits_group(adapter, message, sender_id, chat_id=""):

--- a/tests/scripts/test_feishu_inbound_backfill_watchdog.py
+++ b/tests/scripts/test_feishu_inbound_backfill_watchdog.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import feishu_inbound_backfill_watchdog as watchdog
+
+
+def _write_log(home: Path, text: str) -> None:
+    log_dir = home / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "gateway.log").write_text(text, encoding="utf-8")
+
+
+def _message(mid: str, text: str, *, sender_type: str = "user", create_time: str = "1700000000000") -> dict:
+    return {
+        "message_id": mid,
+        "create_time": create_time,
+        "msg_type": "text",
+        "sender": {"sender_type": sender_type},
+        "body": {"content": json.dumps({"text": text})},
+    }
+
+
+def test_reports_missing_user_message_and_appends_queue(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_test")
+    monkeypatch.setattr(watchdog.time, "time", lambda: 1_700_000_100)
+    monkeypatch.setattr(watchdog, "_tenant_token", lambda: "token")
+    monkeypatch.setattr(
+        watchdog,
+        "_list_messages",
+        lambda *args, **kwargs: [_message("om_missing", "hello from feishu")],
+    )
+    _write_log(tmp_path, "")
+
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 2
+    output = capsys.readouterr().out
+    assert "suspected missed message" in output
+    assert "om_missing" in output
+
+    queue = tmp_path / "state" / "feishu_inbound_backfill_queue.jsonl"
+    records = [json.loads(line) for line in queue.read_text(encoding="utf-8").splitlines()]
+    assert records == [
+        {
+            "chat_id": "oc_test",
+            "create_time": 1_700_000_000,
+            "detected_at": 1_700_000_100,
+            "message_id": "om_missing",
+            "msg_type": "text",
+            "preview": "hello from feishu",
+            "sender_type": "user",
+        }
+    ]
+
+
+def test_ignores_messages_seen_in_rotated_gateway_logs(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_test")
+    monkeypatch.setattr(watchdog.time, "time", lambda: 1_700_000_100)
+    monkeypatch.setattr(watchdog, "_tenant_token", lambda: "token")
+    monkeypatch.setattr(
+        watchdog,
+        "_list_messages",
+        lambda *args, **kwargs: [_message("om_seen", "already processed")],
+    )
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "gateway.log.1").write_text("Received raw message type=text message_id=om_seen", encoding="utf-8")
+
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10", "--dry-run"]) == 0
+    assert "OK" in capsys.readouterr().out
+    assert not (tmp_path / "state" / "feishu_inbound_backfill_queue.jsonl").exists()
+
+
+def test_filters_recalled_and_bot_messages_by_default(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_test")
+    monkeypatch.setattr(watchdog.time, "time", lambda: 1_700_000_100)
+    monkeypatch.setattr(watchdog, "_tenant_token", lambda: "token")
+    recalled = _message("om_recalled", "This message was recalled")
+    bot = _message("om_bot", "bot echo", sender_type="app")
+    monkeypatch.setattr(watchdog, "_list_messages", lambda *args, **kwargs: [recalled, bot])
+    _write_log(tmp_path, "")
+
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10", "--dry-run"]) == 0
+    output = capsys.readouterr().out
+    assert "checked=0" in output
+    assert not (tmp_path / "state" / "feishu_inbound_backfill_queue.jsonl").exists()
+
+
+def test_suppresses_repeated_alerts_with_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_test")
+    monkeypatch.setattr(watchdog.time, "time", lambda: 1_700_000_100)
+    monkeypatch.setattr(watchdog, "_tenant_token", lambda: "token")
+    monkeypatch.setattr(
+        watchdog,
+        "_list_messages",
+        lambda *args, **kwargs: [_message("om_once", "only alert once")],
+    )
+    _write_log(tmp_path, "")
+
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 2
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10", "--dry-run"]) == 0
+    queue = tmp_path / "state" / "feishu_inbound_backfill_queue.jsonl"
+    assert len(queue.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_validates_required_chat_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("FEISHU_HOME_CHANNEL", raising=False)
+    with pytest.raises(RuntimeError, match="chat id missing"):
+        watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"])

--- a/tests/scripts/test_feishu_inbound_backfill_watchdog.py
+++ b/tests/scripts/test_feishu_inbound_backfill_watchdog.py
@@ -34,7 +34,7 @@ def test_reports_missing_user_message_and_appends_queue(tmp_path, monkeypatch, c
     )
     _write_log(tmp_path, "")
 
-    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 2
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 0
     output = capsys.readouterr().out
     assert "suspected missed message" in output
     assert "om_missing" in output
@@ -101,7 +101,7 @@ def test_suppresses_repeated_alerts_with_state(tmp_path, monkeypatch):
     )
     _write_log(tmp_path, "")
 
-    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 2
+    assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10"]) == 0
     assert watchdog.run(["--window-seconds", "300", "--grace-seconds", "10", "--dry-run"]) == 0
     queue = tmp_path / "state" / "feishu_inbound_backfill_queue.jsonl"
     assert len(queue.read_text(encoding="utf-8").splitlines()) == 1


### PR DESCRIPTION
## Summary

Improve Feishu/Lark inbound message reliability and observability.

This PR addresses a class of failures where the Feishu message history API contains a user message, but Hermes never receives a websocket callback for it. In that state the user sees no typing reaction and no response, while the adapter/agent pipeline may still be healthy for adjacent messages.

Changes:
- Make the Feishu websocket path observable enough to distinguish these states:
  - message never reached the websocket callback
  - callback reached Hermes but was not scheduled onto the adapter loop
  - message was dropped by malformed/duplicate/admission logic
  - message reached the agent dispatch path
  - reaction add/remove succeeded or was rejected
- Stop silently swallowing official `lark-oapi` websocket client thread crashes; log start/crash/exit instead.
- Add a read-only inbound reconciliation helper for operators:
  - polls Feishu/Lark `/im/v1/messages`
  - compares recent user messages against Hermes local evidence (`gateway.log*` + `feishu_seen_message_ids.json`)
  - filters recalled/withdrawn messages by default
  - suppresses repeated reports for 24h
  - writes suspected misses to a local JSONL review queue

The reconciliation helper is not meant as the product fix by itself; it is a safe reliability guardrail and diagnostic path for websocket delivery gaps. It intentionally does **not** replay missed messages into the agent.

## Why this improves message stability

Without this patch, a websocket delivery gap can look identical to a downstream processing issue: no visible reaction, no response, and no high-level error. The adapter also swallowed websocket client thread exceptions, making the root cause hard to see.

With this patch:
- Hermes can prove whether an inbound message crossed each critical boundary.
- Operators can detect history-vs-websocket gaps soon after they happen.
- Suspected misses become reviewable records instead of silent losses.
- Automatic replay is avoided until duplicate, recalled-message, ordering, batching, and user-intent semantics are explicitly designed.

## Context

Observed in production:
- A Feishu user message was returned by `/im/v1/messages`.
- The same `message_id` was absent from all local Hermes evidence:
  - no raw callback log
  - no adapter scheduling log
  - no normalized inbound message log
  - no `inbound message: platform=feishu`
  - no typing reaction
  - no response
- A nearby earlier Feishu message in the same chat completed normally, so the adapter and agent pipeline were not generally broken.
- Recent logs showed websocket reconnect/DNS instability.

This points to a websocket delivery gap or SDK reconnect edge case, not a normal reaction/output failure.

## Test Plan

```bash
python -m pytest tests/scripts/test_feishu_inbound_backfill_watchdog.py tests/gateway/test_feishu.py -o 'addopts=' -q
```

Local result:

```text
203 passed, 7 warnings in 3.81s
```

## Operational usage

Example diagnostic run:

```bash
scripts/feishu_inbound_backfill_watchdog.py \
  --chat-id <oc_chat_id> \
  --window-seconds 1800 \
  --grace-seconds 60 \
  --dry-run
```

Exit behavior:
- `0`: no suspected misses, or suspected misses were reported/queued successfully
- `1`: configuration/API/runtime error

The script sources credentials from `HERMES_HOME/.env` and does not print app secrets or tenant tokens.
