### PR TITLE
feat: add long task policy rollout controls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -718,8 +718,11 @@ class _CodexCompletionsAdapter:
                 logger.debug("Codex auxiliary: cache eviction on timeout failed", exc_info=True)
 
         def _check_cancelled() -> None:
+            if timed_out.is_set():
+                raise TimeoutError(_timeout_message())
             if deadline is not None and time.monotonic() >= deadline:
-                timed_out.set()
+                if not timed_out.is_set():
+                    _close_client_on_timeout()
                 raise TimeoutError(_timeout_message())
             try:
                 from tools.interrupt import is_interrupted
@@ -4078,6 +4081,7 @@ def call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    allow_provider_fallback: bool = True,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -4096,6 +4100,10 @@ def call_llm(
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
         extra_body: Additional request body fields.
+        allow_provider_fallback: When False, do not route auto-mode payment,
+            timeout, connection, or rate-limit failures to a secondary provider.
+            This is used by context compression so the primary model remains
+            the only implicit model unless a task-specific override is set.
 
     Returns:
         Response object with .choices[0].message.content
@@ -4360,7 +4368,7 @@ def call_llm(
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
         is_auto = resolved_provider in {"auto", "", None}
-        if should_fallback and is_auto:
+        if should_fallback and is_auto and allow_provider_fallback:
             if _is_payment_error(first_err):
                 reason = "payment error"
                 # Resolve the actual provider label (resolved_provider may be

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -944,6 +944,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": int(summary_budget * 1.3),
+                # Compression is continuity-critical. In auto mode, use the
+                # main/primary runtime only; do not silently fall through to
+                # generic auxiliary fallbacks (OpenRouter/Gemini/etc.) on a
+                # primary timeout. Explicit summary_model still gets one
+                # compressor-managed retry on main below.
+                "allow_provider_fallback": False,
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
             }
             if self.summary_model:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from agent.skill_utils import (
     extract_skill_conditions,
@@ -366,7 +366,9 @@ LONG_TASK_POLICY_DEFAULTS = {
     "default_log_dir": "reports/_run_logs",
     "status_filename": "status.json",
     "manifest_filename": "manifest.json",
+    "fail_fast_markers": ["FATAL", "AUTH_FAILED", "NEEDS_USER_DECISION", "BLOCKED"],
     "notify_on_completion": True,
+    "watch_patterns_default": [],
 }
 
 
@@ -378,27 +380,75 @@ def _policy_int(policy: Mapping[str, Any], key: str) -> int:
     return max(1, value)
 
 
-def build_long_task_policy_guidance(policy: Mapping[str, Any] | None) -> str:
+def _policy_bool(policy: Mapping[str, Any], key: str) -> bool:
+    value = policy.get(key, LONG_TASK_POLICY_DEFAULTS[key])
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"false", "0", "no", "off", "never"}
+    return bool(value)
+
+
+def build_long_task_policy_guidance(
+    policy: Mapping[str, Any] | None,
+    available_tools: Iterable[str] | None = None,
+) -> str:
     """Render concise system-prompt guidance for Hermes long-task handling."""
     if not isinstance(policy, Mapping):
         return ""
-    if policy.get("enabled", LONG_TASK_POLICY_DEFAULTS["enabled"]) is False:
+    if not _policy_bool(policy, "enabled"):
         return ""
 
     foreground_limit = _policy_int(policy, "foreground_soft_limit_seconds")
+    staged_limit = _policy_int(policy, "staged_task_soft_limit_seconds")
     background_limit = _policy_int(policy, "require_background_after_seconds")
     log_dir = str(policy.get("default_log_dir") or LONG_TASK_POLICY_DEFAULTS["default_log_dir"])
     status_name = str(policy.get("status_filename") or LONG_TASK_POLICY_DEFAULTS["status_filename"])
     manifest_name = str(policy.get("manifest_filename") or LONG_TASK_POLICY_DEFAULTS["manifest_filename"])
+    require_artifacts = _policy_bool(policy, "require_progress_artifacts")
+    notify_on_completion = _policy_bool(policy, "notify_on_completion")
+    tool_names = set(available_tools or [])
+    terminal_available = available_tools is None or "terminal" in tool_names
+    artifact_tools_available = available_tools is None or bool({"terminal", "write_file", "patch"} & tool_names)
+    durable_artifacts_available = require_artifacts and artifact_tools_available
+
+    stage_clause = (
+        f"For work expected to run longer than {foreground_limit} seconds, "
+        f"break it into stages with checkpoints before {staged_limit} seconds."
+    )
+    if durable_artifacts_available:
+        artifact_clause = f" save logs/status/manifest under {log_dir} using {status_name} and {manifest_name}."
+    elif require_artifacts:
+        artifact_clause = " keep concise progress notes in your response because artifact-writing tools are unavailable."
+    else:
+        artifact_clause = " keep recoverable progress notes when practical."
+
+    if terminal_available:
+        notify_arg = ", notify_on_complete=true" if notify_on_completion else ""
+        background_clause = (
+            f"For finite work expected to run longer than {background_limit} seconds, "
+            f"use terminal(background=true{notify_arg}) and{artifact_clause}"
+        )
+    else:
+        background_clause = (
+            f"For finite work expected to run longer than {background_limit} seconds, "
+            "do not invent unavailable background tool calls; use shorter verified stages "
+            "or explain the missing durable-execution path and"
+            f"{artifact_clause}"
+        )
+    if durable_artifacts_available:
+        final_clause = "Before finalizing, verify artifacts and report exact paths."
+    elif require_artifacts:
+        final_clause = "Before finalizing, verify the latest progress state and avoid inventing artifact paths."
+    else:
+        final_clause = "Before finalizing, verify the progress state and summarize any recoverable notes."
 
     return (
-        "Hermes long-task policy: For work expected to run longer than "
-        f"{foreground_limit} seconds, break it into stages with saved artifacts. "
-        "For finite work expected to run longer than "
-        f"{background_limit} seconds, use terminal(background=true, notify_on_complete=true) "
-        f"and save logs/status/manifest under {log_dir} using {status_name} and {manifest_name}. "
+        "Hermes long-task policy: "
+        f"{stage_clause} "
+        f"{background_clause} "
         "Do not use noisy watch_patterns; reserve them for rare blocker/readiness markers. "
-        "Before finalizing, verify artifacts and report exact paths."
+        f"{final_clause}"
     )
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from agent.skill_utils import (
     extract_skill_conditions,
@@ -333,6 +333,74 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- If you must proceed with incomplete information, label assumptions explicitly.\n"
     "</missing_context>"
 )
+
+GPT55_PROMPT_GUIDANCE = (
+    "# GPT-5.5 prompt guidance\n"
+    "Apply these model-specific prompting preferences when interpreting the "
+    "system prompt, loaded skills, project instructions, and user requests.\n"
+    "\n"
+    "<gpt55_prompting>\n"
+    "- Optimize for outcome-oriented work: identify the desired result, hard "
+    "constraints, available evidence, and final answer shape; choose the most "
+    "efficient path yourself.\n"
+    "- Avoid becoming mechanical from stacked instructions. Treat legacy ALWAYS/NEVER "
+    "rules as guardrails, but do not over-narrate internal process or add ceremony.\n"
+    "- Separate voice from workflow: preserve the configured personality and user "
+    "preferences while applying collaboration rules for assumptions, tools, "
+    "uncertainty, and verification.\n"
+    "- Prefer progress over broad clarification. Ask only narrow questions when "
+    "missing information materially changes the action or creates meaningful risk.\n"
+    "- Use brief preambles before long tool workflows so the user knows what is "
+    "happening, then act. Keep final answers direct and grounded in results.\n"
+    "- Stop when the task is complete and verified. If evidence is missing or weak, "
+    "say so plainly and provide the best safe fallback rather than inventing details.\n"
+    "</gpt55_prompting>"
+)
+
+LONG_TASK_POLICY_DEFAULTS = {
+    "enabled": True,
+    "foreground_soft_limit_seconds": 120,
+    "staged_task_soft_limit_seconds": 600,
+    "require_background_after_seconds": 600,
+    "require_progress_artifacts": True,
+    "default_log_dir": "reports/_run_logs",
+    "status_filename": "status.json",
+    "manifest_filename": "manifest.json",
+    "notify_on_completion": True,
+}
+
+
+def _policy_int(policy: Mapping[str, Any], key: str) -> int:
+    try:
+        value = int(policy.get(key, LONG_TASK_POLICY_DEFAULTS[key]))
+    except (TypeError, ValueError):
+        value = int(LONG_TASK_POLICY_DEFAULTS[key])
+    return max(1, value)
+
+
+def build_long_task_policy_guidance(policy: Mapping[str, Any] | None) -> str:
+    """Render concise system-prompt guidance for Hermes long-task handling."""
+    if not isinstance(policy, Mapping):
+        return ""
+    if policy.get("enabled", LONG_TASK_POLICY_DEFAULTS["enabled"]) is False:
+        return ""
+
+    foreground_limit = _policy_int(policy, "foreground_soft_limit_seconds")
+    background_limit = _policy_int(policy, "require_background_after_seconds")
+    log_dir = str(policy.get("default_log_dir") or LONG_TASK_POLICY_DEFAULTS["default_log_dir"])
+    status_name = str(policy.get("status_filename") or LONG_TASK_POLICY_DEFAULTS["status_filename"])
+    manifest_name = str(policy.get("manifest_filename") or LONG_TASK_POLICY_DEFAULTS["manifest_filename"])
+
+    return (
+        "Hermes long-task policy: For work expected to run longer than "
+        f"{foreground_limit} seconds, break it into stages with saved artifacts. "
+        "For finite work expected to run longer than "
+        f"{background_limit} seconds, use terminal(background=true, notify_on_complete=true) "
+        f"and save logs/status/manifest under {log_dir} using {status_name} and {manifest_name}. "
+        "Do not use noisy watch_patterns; reserve them for rare blocker/readiness markers. "
+        "Before finalizing, verify artifacts and report exact paths."
+    )
+
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
 # Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -103,17 +103,20 @@ class ResponsesApiTransport(ProviderTransport):
         if not is_github_responses and session_id:
             kwargs["prompt_cache_key"] = session_id
 
-        if reasoning_enabled and is_xai_responses:
+        if is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort
 
             kwargs["include"] = ["reasoning.encrypted_content"]
-            # xAI rejects `reasoning.effort` on grok-4 / grok-4-fast / grok-3
-            # / grok-code-fast / grok-4.20-0309-* with HTTP 400 even though
-            # those models reason natively. Only send the effort dial when
-            # the target model is on the allowlist; otherwise send no
-            # `reasoning` key at all and let the model reason on its own.
+            # Curtis/Engine Brands policy: whenever Hermes uses Grok, prefer
+            # the highest reasoning setting. This is intentionally independent
+            # of the generic reasoning_config so a later `/reasoning low` or
+            # config drift cannot silently downgrade Grok. xAI rejects
+            # `reasoning.effort` on grok-4 / grok-4-fast / grok-3 /
+            # grok-code-fast / grok-4.20-0309-* with HTTP 400 even though
+            # those models reason natively, so only send the effort dial when
+            # the target model is on the verified allowlist.
             if grok_supports_reasoning_effort(model):
-                kwargs["reasoning"] = {"effort": reasoning_effort}
+                kwargs["reasoning"] = {"effort": "high"}
         elif reasoning_enabled:
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -20,6 +20,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
+from types import SimpleNamespace
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
@@ -2861,7 +2862,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         await interaction.response.defer(ephemeral=True)
-        event = self._build_slash_event(interaction, command_text)
+        event = await self._build_simple_slash_event(interaction, command_text)
         await self.handle_message(event)
         try:
             if followup_msg:
@@ -3374,48 +3375,151 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         return (len(self._skill_entries), self._skill_group_hidden_count)
 
-    def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
+    def _slash_goal_auto_thread_seed(self, text: str) -> str | None:
+        """Return a slash /goal seed string when the command should auto-thread.
+
+        Only a new goal starts agent work and should get the same isolated
+        conversation treatment as a channel @mention. Status/control subcommands
+        stay in the invoking channel/thread so they remain lightweight.
+        """
+        stripped = (text or "").strip()
+        if not stripped.startswith("/"):
+            return None
+        command, _, args = stripped[1:].partition(" ")
+        if command.lower() != "goal":
+            return None
+        goal_text = args.strip()
+        if not goal_text:
+            return None
+        if goal_text.lower() in ("status", "pause", "resume", "clear", "stop", "done"):
+            return None
+        return goal_text
+
+    async def _maybe_auto_thread_slash_goal(
+        self,
+        interaction: discord.Interaction,
+        text: str,
+    ) -> Any | None:
+        """Auto-create a Discord thread for native /goal starts when enabled.
+
+        Normal Discord messages pass through _handle_message(), which auto-
+        creates a thread before building the MessageEvent source. Native slash
+        commands bypass that path, so a /goal started from a profile channel
+        would otherwise queue its kickoff and continuations against the parent
+        channel session. This helper mirrors the same auto_thread/no_thread
+        gates for goal-start slash commands and returns the new thread target.
+        """
+        seed = self._slash_goal_auto_thread_seed(text)
+        if seed is None:
+            return None
+
+        channel = getattr(interaction, "channel", None)
+        if channel is None or isinstance(channel, discord.DMChannel) or isinstance(channel, discord.Thread):
+            return None
+
+        auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+        if not auto_thread:
+            return None
+
+        channel_id = str(getattr(channel, "id", None) or getattr(interaction, "channel_id", "") or "")
+        no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
+        no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+        if channel_id and channel_id in no_thread_channels:
+            return None
+
+        voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
+        if channel_id and channel_id in voice_linked_ids:
+            return None
+
+        pseudo_message = SimpleNamespace(
+            content=seed,
+            create_thread=getattr(channel, "create_thread", None),
+            channel=channel,
+            author=getattr(interaction, "user", None),
+        )
+        thread = await self._auto_create_thread(pseudo_message)
+        if thread is not None:
+            self._threads.mark(str(getattr(thread, "id", "")))
+        return thread
+
+    async def _build_simple_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
+        """Build a simple slash event, applying /goal auto-thread routing first."""
+        original_channel = getattr(interaction, "channel", None)
+        parent_channel_id = str(getattr(original_channel, "id", None) or getattr(interaction, "channel_id", "") or "")
+        thread = await self._maybe_auto_thread_slash_goal(interaction, text)
+        if thread is not None:
+            return self._build_slash_event(
+                interaction,
+                text,
+                channel_override=thread,
+                parent_channel_id=parent_channel_id or None,
+            )
+        return self._build_slash_event(interaction, text)
+
+    def _build_slash_event(
+        self,
+        interaction: discord.Interaction,
+        text: str,
+        *,
+        channel_override: Any | None = None,
+        parent_channel_id: str | None = None,
+    ) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
-        is_dm = isinstance(interaction.channel, discord.DMChannel)
-        is_thread = isinstance(interaction.channel, discord.Thread)
+        channel = channel_override or interaction.channel
+        channel_id_value = getattr(channel, "id", None) or getattr(interaction, "channel_id", None)
+        is_dm = isinstance(channel, discord.DMChannel)
+        is_thread = isinstance(channel, discord.Thread)
         thread_id = None
 
         if is_dm:
             chat_type = "dm"
         elif is_thread:
             chat_type = "thread"
-            thread_id = str(interaction.channel_id)
+            thread_id = str(channel_id_value)
         else:
             chat_type = "group"
 
         chat_name = ""
-        if not is_dm and hasattr(interaction.channel, "name"):
-            chat_name = interaction.channel.name
-            if hasattr(interaction.channel, "guild") and interaction.channel.guild:
-                chat_name = f"{interaction.channel.guild.name} / #{chat_name}"
+        if not is_dm and hasattr(channel, "name"):
+            if is_thread:
+                chat_name = self._format_thread_chat_name(channel)
+            else:
+                chat_name = channel.name
+                if hasattr(channel, "guild") and channel.guild:
+                    chat_name = f"{channel.guild.name} / #{chat_name}"
 
         # Get channel topic (if available).
         # For forum threads, inherit the parent forum's topic.
-        chat_topic = self._get_effective_topic(interaction.channel, is_thread=is_thread)
+        chat_topic = self._get_effective_topic(channel, is_thread=is_thread)
+
+        effective_parent_id = parent_channel_id
+        if effective_parent_id is None and is_thread:
+            effective_parent_id = self._get_parent_channel_id(channel)
+
+        guild = getattr(interaction, "guild", None) or getattr(channel, "guild", None)
+        guild_id = getattr(interaction, "guild_id", None) or getattr(guild, "id", None)
 
         source = self.build_source(
-            chat_id=str(interaction.channel_id),
+            chat_id=str(channel_id_value),
             chat_name=chat_name,
             chat_type=chat_type,
             user_id=str(interaction.user.id),
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=str(guild_id) if guild_id else None,
+            parent_chat_id=effective_parent_id,
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
-        channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        channel_id = str(channel_id_value)
+        parent_id = str(effective_parent_id or getattr(channel, "parent_id", "") or "")
         return MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=interaction,
+            auto_skill=self._resolve_channel_skills(channel_id, parent_id or None),
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8924,10 +8924,15 @@ class GatewayRunner:
                         # Store model note + session override
                         if not hasattr(_self, "_pending_model_notes"):
                             _self._pending_model_notes = {}
+                        _from_model = _cur_model or "unknown model"
+                        _from_provider = _cur_provider or "unknown provider"
+                        _to_provider = result.provider_label or result.target_provider or "unknown provider"
                         _self._pending_model_notes[_session_key] = (
-                            f"[Note: model was just switched from {_cur_model} to {result.new_model} "
-                            f"via {result.provider_label or result.target_provider}. "
-                            f"Adjust your self-identification accordingly.]"
+                            f"[System note: The user explicitly switched the active model/provider "
+                            f"for this session from {_from_model} via {_from_provider} to "
+                            f"{result.new_model} via {_to_provider}. This is session model/provider "
+                            f"context only; no credentials are included. Adjust your "
+                            f"self-identification to the active model/provider for this turn.]"
                         )
                         _self._session_model_overrides[_session_key] = {
                             "model": result.new_model,
@@ -9062,10 +9067,15 @@ class GatewayRunner:
         # knows about the switch (avoids system messages mid-history).
         if not hasattr(self, "_pending_model_notes"):
             self._pending_model_notes = {}
+        _from_model = current_model or "unknown model"
+        _from_provider = current_provider or "unknown provider"
+        _to_provider = result.provider_label or result.target_provider or "unknown provider"
         self._pending_model_notes[session_key] = (
-            f"[Note: model was just switched from {current_model} to {result.new_model} "
-            f"via {result.provider_label or result.target_provider}. "
-            f"Adjust your self-identification accordingly.]"
+            f"[System note: The user explicitly switched the active model/provider "
+            f"for this session from {_from_model} via {_from_provider} to "
+            f"{result.new_model} via {_to_provider}. This is session model/provider "
+            f"context only; no credentials are included. Adjust your "
+            f"self-identification to the active model/provider for this turn.]"
         )
 
         # Store session override so next agent creation uses the new model

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -473,6 +473,27 @@ DEFAULT_CONFIG = {
         # (force on/off for all models), or a list of model-name substrings
         # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
         "tool_use_enforcement": "auto",
+        # Long-task policy: concise prompt guidance that pushes agents toward
+        # staged checkpoints and durable background execution for finite work
+        # that is too long for a foreground tool call.
+        "long_task_policy": {
+            "enabled": True,
+            "foreground_soft_limit_seconds": 120,
+            "staged_task_soft_limit_seconds": 600,
+            "require_background_after_seconds": 600,
+            "require_progress_artifacts": True,
+            "default_log_dir": "reports/_run_logs",
+            "status_filename": "status.json",
+            "manifest_filename": "manifest.json",
+            "fail_fast_markers": [
+                "FATAL",
+                "AUTH_FAILED",
+                "NEEDS_USER_DECISION",
+                "BLOCKED",
+            ],
+            "notify_on_completion": True,
+            "watch_patterns_default": [],
+        },
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/plugins/model-providers/xai/__init__.py
+++ b/plugins/model-providers/xai/__init__.py
@@ -1,9 +1,41 @@
 """xAI (Grok) provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xai = ProviderProfile(
+
+class XAIProviderProfile(ProviderProfile):
+    """xAI/Grok request-time quirks."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Force highest Grok reasoning on OpenAI chat-completions wire.
+
+        The Responses transport handles xAI separately via ``reasoning.effort``.
+        This hook protects the alternate chat-completions path, where xAI accepts
+        top-level ``reasoning_effort`` for the verified effort-capable Grok models.
+        """
+        model = str(context.get("model") or "").strip().lower()
+        if not model:
+            return {}, {}
+
+        try:
+            from agent.model_metadata import grok_supports_reasoning_effort
+        except Exception:
+            return {}, {}
+
+        if grok_supports_reasoning_effort(model):
+            return {}, {"reasoning_effort": "high"}
+        return {}, {}
+
+
+xai = XAIProviderProfile(
     name="xai",
     aliases=("grok", "x-ai", "x.ai"),
     api_mode="codex_responses",

--- a/run_agent.py
+++ b/run_agent.py
@@ -160,7 +160,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, build_long_task_policy_guidance, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, GPT55_PROMPT_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -1489,10 +1489,15 @@ class AIAgent:
         # (e.g. CLI voice mode adds a temporary prefix for the live call only).
         self._persist_user_message_idx = None
         self._persist_user_message_override = None
+        # One-shot provider/model switch context for the next user turn.
+        # Used for automatic fallback notes so the next model understands
+        # whether it is currently on a fallback or has restored the preferred
+        # primary.  Stores only provider/model labels — never credentials.
+        self._pending_model_switch_event = None
 
         # Cache anthropic image-to-text fallbacks per image payload/URL so a
         # single tool loop does not repeatedly re-run auxiliary vision on the
-        # same image history.
+        # same image when the main model lacks native vision support.
         self._anthropic_image_fallback_cache: Dict[str, str] = {}
 
         # Initialize LLM client via centralized provider router.
@@ -2032,6 +2037,8 @@ class AIAgent:
         if not isinstance(_agent_section, dict):
             _agent_section = {}
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+        _long_task_policy = _agent_section.get("long_task_policy", {})
+        self._long_task_policy = _long_task_policy if isinstance(_long_task_policy, dict) else {}
 
         # App-level API retry count (wraps each model API call).  Default 3,
         # overridable via agent.api_max_retries in config.yaml.  See #11616.
@@ -2859,6 +2866,68 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
 
+    @staticmethod
+    def _runtime_label(model: Any, provider: Any) -> str:
+        """Return a safe provider/model label with no credential-bearing fields."""
+        model_s = str(model or "").strip() or "unknown model"
+        provider_s = str(provider or "").strip() or "unknown provider"
+        return f"{model_s} via {provider_s}"
+
+    @classmethod
+    def _format_model_switch_context_note(
+        cls,
+        event: Dict[str, Any],
+        *,
+        restored_primary: bool = False,
+    ) -> str:
+        """Build the one-shot model-visible note for provider/model switches.
+
+        The note intentionally includes only provider/model labels and a reason;
+        never include API keys, base URLs, headers, or other secrets here.
+        """
+        from_label = cls._runtime_label(event.get("from_model"), event.get("from_provider"))
+        to_label = cls._runtime_label(event.get("to_model"), event.get("to_provider"))
+        reason = str(event.get("reason") or "automatic fallback").replace("_", " ")
+
+        if event.get("type") == "fallback" and restored_primary:
+            return (
+                f"[System note: During the previous turn, Hermes automatically switched "
+                f"from the configured/preferred primary {from_label} to fallback {to_label} "
+                f"because of {reason}. At the start of this turn, Hermes restored/retried "
+                f"the configured/preferred primary {from_label}. Do not infer that the "
+                f"user's provider preference changed; if the primary provider is private/local, "
+                f"preserve that context. Adjust your self-identification to the active "
+                f"model/provider for this turn.]"
+            )
+
+        if event.get("type") == "fallback":
+            return (
+                f"[System note: Hermes automatically switched the active model/provider "
+                f"for this session from the configured/preferred primary {from_label} "
+                f"to fallback {to_label} because of {reason}. This is operational failover, "
+                f"not a user preference change; if the primary provider is private/local, "
+                f"preserve that context. Adjust your self-identification to the active "
+                f"fallback model/provider for this turn.]"
+            )
+
+        return (
+            f"[System note: Hermes changed the active model/provider for this session "
+            f"from {from_label} to {to_label} because of {reason}. Adjust your "
+            f"self-identification to the active model/provider for this turn.]"
+        )
+
+    def _consume_pending_model_switch_note(self, *, restored_primary: bool = False) -> Optional[str]:
+        """Return and clear the one-shot model switch note, if any."""
+        event = getattr(self, "_pending_model_switch_event", None)
+        if not event:
+            return None
+        self._pending_model_switch_event = None
+        try:
+            return self._format_model_switch_context_note(event, restored_primary=restored_primary)
+        except Exception:
+            logger.debug("failed to format pending model switch note", exc_info=True)
+            return None
+
     # Headers we capture from the dying stream's HTTP response so post-mortem
     # diagnosis can answer "which CF edge / which OpenRouter downstream
     # provider / which request id".  Lowercased; httpx returns CIMultiDict.
@@ -3594,6 +3663,14 @@ class AIAgent:
         if "/" in m:
             m = m.rsplit("/", 1)[-1]
         return m.startswith("gpt-5")
+
+    @staticmethod
+    def _model_is_gpt55(model: str) -> bool:
+        """Return True for GPT-5.5 model names, including provider-prefixed names."""
+        m = (model or "").strip().lower()
+        if "/" in m:
+            m = m.rsplit("/", 1)[-1]
+        return m == "gpt-5.5" or m.startswith("gpt-5.5-")
 
     @staticmethod
     def _provider_model_requires_responses_api(
@@ -5771,6 +5848,16 @@ class AIAgent:
 
         # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
         stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+
+        # GPT-5.5-specific prompting preferences from OpenAI's guidance.
+        # Keep this separate from tool-use enforcement so it applies to
+        # GPT-5.5 sessions across CLI/gateway/profiles, but not other models.
+        if self._model_is_gpt55(self.model):
+            stable_parts.append(GPT55_PROMPT_GUIDANCE)
+
+        long_task_guidance = build_long_task_policy_guidance(getattr(self, "_long_task_policy", None))
+        if long_task_guidance:
+            stable_parts.append(long_task_guidance)
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
@@ -8654,6 +8741,7 @@ class AIAgent:
                 fb_api_mode = "bedrock_converse"
 
             old_model = self.model
+            old_provider = self.provider
             self.model = fb_model
             self.provider = fb_provider
             self.base_url = fb_base_url
@@ -8750,6 +8838,16 @@ class AIAgent:
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
                 )
+
+            _reason_label = getattr(reason, "value", None) or str(reason or "automatic fallback")
+            self._pending_model_switch_event = {
+                "type": "fallback",
+                "from_model": old_model,
+                "from_provider": old_provider,
+                "to_model": fb_model,
+                "to_provider": fb_provider,
+                "reason": _reason_label,
+            }
 
             self._emit_status(
                 f"🔄 Primary model failed — switching to fallback: "
@@ -11675,7 +11773,16 @@ class AIAgent:
         # If the previous turn activated fallback, restore the primary
         # runtime so this turn gets a fresh attempt with the preferred model.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
-        self._restore_primary_runtime()
+        _restored_primary_runtime = self._restore_primary_runtime()
+        if _restored_primary_runtime:
+            try:
+                from agent.auxiliary_client import set_runtime_main
+                set_runtime_main(
+                    getattr(self, "provider", "") or "",
+                    getattr(self, "model", "") or "",
+                )
+            except Exception:
+                pass
 
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates
@@ -11684,6 +11791,16 @@ class AIAgent:
             user_message = _sanitize_surrogates(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = _sanitize_surrogates(persist_user_message)
+
+        _switch_note = self._consume_pending_model_switch_note(
+            restored_primary=_restored_primary_runtime
+        )
+        if _switch_note:
+            # The note is API-facing context, not user-authored content; keep
+            # persisted transcripts clean by storing the original user text.
+            if persist_user_message is None:
+                persist_user_message = user_message
+            user_message = f"{_switch_note}\n\n{user_message}"
 
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback

--- a/run_agent.py
+++ b/run_agent.py
@@ -5855,7 +5855,10 @@ class AIAgent:
         if self._model_is_gpt55(self.model):
             stable_parts.append(GPT55_PROMPT_GUIDANCE)
 
-        long_task_guidance = build_long_task_policy_guidance(getattr(self, "_long_task_policy", None))
+        long_task_guidance = build_long_task_policy_guidance(
+            getattr(self, "_long_task_policy", None),
+            available_tools=self.valid_tool_names,
+        )
         if long_task_guidance:
             stable_parts.append(long_task_guidance)
 

--- a/scripts/hermes-supervised-run.py
+++ b/scripts/hermes-supervised-run.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Run finite long-running commands with Hermes-friendly artifacts.
+
+Writes a redacted combined log, status.json during execution, and manifest.json
+on completion. Intended for local finite jobs that need resumable evidence.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+SECRET_PATTERNS = [
+    re.compile(r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASSWD)[A-Z0-9_]*)\s*=\s*([^\s]+)"),
+    re.compile(r"(?i)\b(token)\s*=\s*([^\s]+)"),
+    re.compile(r"(?i)(Authorization\s*:\s*Bearer\s+)([^\s]+)"),
+    re.compile(r"\b(xox[baprs]-)[A-Za-z0-9-]+"),
+    re.compile(r"\b(gh[pousr]_[A-Za-z0-9_]{8,})"),
+    re.compile(r"\b(sk-[A-Za-z0-9_-]{12,})"),
+    re.compile(r"\b(shpat_[A-Za-z0-9_]{8,})"),
+]
+
+MARKER_RE = re.compile(r"^\s*(STAGE|BLOCKED|NEEDS_USER_DECISION|AUTH_FAILED|FATAL)\s*:\s*(.+?)\s*$", re.IGNORECASE)
+BLOCKER_MARKERS = {"BLOCKED", "NEEDS_USER_DECISION", "AUTH_FAILED", "FATAL"}
+TAIL_CHARS = 4000
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def redact_text(text: str) -> str:
+    """Redact obvious secret-bearing command/output fragments."""
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        def repl(match: re.Match[str]) -> str:
+            if match.lastindex and match.lastindex >= 2:
+                return f"{match.group(1)}[REDACTED]"
+            if match.lastindex == 1:
+                prefix = match.group(1)
+                if prefix.startswith(("xox", "gh", "sk-", "shpat_")):
+                    return "[REDACTED]"
+                return f"{prefix}[REDACTED]"
+            return "[REDACTED]"
+
+        redacted = pattern.sub(repl, redacted)
+    return redacted
+
+
+@dataclass
+class RunState:
+    name: str
+    started_at: str
+    status: str = "running"
+    updated_at: str = ""
+    exit_code: Optional[int] = None
+    current_stage: str = ""
+    last_output_tail: str = ""
+    artifacts: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "started_at": self.started_at,
+            "updated_at": self.updated_at or utc_now(),
+            "exit_code": self.exit_code,
+            "current_stage": self.current_stage,
+            "last_output_tail": self.last_output_tail,
+            "artifacts": self.artifacts,
+            "blockers": self.blockers,
+        }
+
+
+def atomic_json_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def update_markers(text: str, state: RunState) -> None:
+    for line in text.splitlines():
+        match = MARKER_RE.match(line)
+        if not match:
+            continue
+        marker = match.group(1).upper()
+        value = match.group(2).strip()
+        if marker == "STAGE":
+            state.current_stage = value
+        elif marker in BLOCKER_MARKERS and value not in state.blockers:
+            state.blockers.append(value)
+
+
+def snapshot_files(workdir: Path) -> dict[str, tuple[int, int]]:
+    snapshot: dict[str, tuple[int, int]] = {}
+    if not workdir.exists():
+        return snapshot
+    for path in workdir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            rel = str(path.relative_to(workdir))
+            stat = path.stat()
+        except OSError:
+            continue
+        snapshot[rel] = (stat.st_mtime_ns, stat.st_size)
+    return snapshot
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def changed_files(workdir: Path, before: dict[str, tuple[int, int]], exclude: Iterable[Path]) -> tuple[list[str], dict[str, str]]:
+    excluded = {p.resolve() for p in exclude}
+    files: list[str] = []
+    hashes: dict[str, str] = {}
+    for path in workdir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            resolved = path.resolve()
+            if resolved in excluded:
+                continue
+            rel = str(path.relative_to(workdir))
+            stat = path.stat()
+        except OSError:
+            continue
+        fingerprint = (stat.st_mtime_ns, stat.st_size)
+        if rel not in before or before[rel] != fingerprint:
+            files.append(rel)
+            try:
+                hashes[rel] = sha256_file(path)
+            except OSError:
+                pass
+    files.sort()
+    return files, hashes
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a command with durable Hermes status/log/manifest artifacts.")
+    parser.add_argument("--name", required=True, help="Human-readable run name")
+    parser.add_argument("--workdir", required=True, help="Directory to run in and scan for artifacts")
+    parser.add_argument("--log", default="run.log", help="Log file path, relative to workdir unless absolute")
+    parser.add_argument("--status", default="status.json", help="Status JSON path, relative to workdir unless absolute")
+    parser.add_argument("--manifest", default="manifest.json", help="Manifest JSON path, relative to workdir unless absolute")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command after --")
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("command is required after --")
+    return args
+
+
+def resolve_artifact_path(workdir: Path, value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else workdir / path
+
+
+def run(argv: list[str]) -> int:
+    args = parse_args(argv)
+    workdir = Path(args.workdir).expanduser().resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    log_path = resolve_artifact_path(workdir, args.log)
+    status_path = resolve_artifact_path(workdir, args.status)
+    manifest_path = resolve_artifact_path(workdir, args.manifest)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    started_at = utc_now()
+    safe_command = redact_text(" ".join(subprocess.list2cmdline([part]) for part in args.command))
+    state = RunState(name=args.name, started_at=started_at, updated_at=started_at)
+    atomic_json_write(status_path, state.to_json())
+
+    before = snapshot_files(workdir)
+    exit_code = 1
+    tail = ""
+
+    with log_path.open("a", encoding="utf-8", buffering=1) as log:
+        log.write(f"# hermes-supervised-run {args.name}\n")
+        log.write(f"# started_at={started_at}\n")
+        log.write(f"# command={safe_command}\n")
+        process = subprocess.Popen(
+            args.command,
+            cwd=str(workdir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for raw_line in process.stdout:
+            line = redact_text(raw_line)
+            log.write(line)
+            try:
+                sys.stdout.write(line)
+                sys.stdout.flush()
+            except BrokenPipeError:
+                pass
+            tail = (tail + line)[-TAIL_CHARS:]
+            state.last_output_tail = tail
+            update_markers(line, state)
+            state.updated_at = utc_now()
+            atomic_json_write(status_path, state.to_json())
+        exit_code = process.wait()
+
+    files, hashes = changed_files(workdir, before, exclude=[log_path, status_path, manifest_path])
+    completed_at = utc_now()
+    state.exit_code = exit_code
+    state.artifacts = files
+    if state.blockers:
+        state.status = "blocked"
+    else:
+        state.status = "completed" if exit_code == 0 else "failed"
+    state.updated_at = completed_at
+    atomic_json_write(status_path, state.to_json())
+
+    manifest = {
+        "run_name": args.name,
+        "command": safe_command,
+        "workdir": str(workdir),
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "exit_code": exit_code,
+        "files_created_or_updated": files,
+        "sha256": hashes,
+        "notes": [
+            "Command and output are redacted for obvious secret-like values before saving.",
+            f"Status file: {status_path}",
+            f"Log file: {log_path}",
+        ],
+    }
+    atomic_json_write(manifest_path, manifest)
+    return exit_code
+
+
+def main() -> None:
+    raise SystemExit(run(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -659,6 +659,7 @@ class TestAuxiliaryPoolAwareness:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="google/gemini-3-flash-preview"),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
             from agent.auxiliary_client import _try_nous
@@ -1037,6 +1038,27 @@ class TestCallLlmPaymentFallback:
             )
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
+
+    def test_allow_provider_fallback_false_raises_primary_error(self):
+        """Compression can opt out of generic OpenRouter/secondary fallback."""
+        primary_client = MagicMock()
+        timeout_err = Exception("Codex auxiliary Responses stream exceeded 120.0s total timeout")
+        primary_client.chat.completions.create.side_effect = timeout_err
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback, \
+             patch("agent.auxiliary_client._evict_cached_client_instance"):
+            with pytest.raises(Exception, match="120.0s total timeout"):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hello"}],
+                    allow_provider_fallback=False,
+                )
+
+        mock_fallback.assert_not_called()
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
@@ -2085,6 +2107,8 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
+        emitted = {"count": 0}
+
         class SlowAliveStream:
             def __enter__(self):
                 return self
@@ -2095,6 +2119,7 @@ class TestCodexAuxiliaryAdapterTimeout:
             def __iter__(self):
                 for _ in range(5):
                     time.sleep(0.03)
+                    emitted["count"] += 1
                     yield SimpleNamespace(type="response.in_progress")
 
             def get_final_response(self):
@@ -2113,14 +2138,13 @@ class TestCodexAuxiliaryAdapterTimeout:
         fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
         adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
 
-        started = time.monotonic()
         with pytest.raises(TimeoutError):
             adapter.create(
                 messages=[{"role": "user", "content": "summarize this"}],
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        assert emitted["count"] < 5, "timeout must abort before draining the full stream"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -245,6 +245,7 @@ class TestNonStringContent:
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         }
+        assert mock_call.call_args.kwargs["allow_provider_fallback"] is False
 
 
 class TestSummaryFailureCooldown:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -160,25 +160,25 @@ class TestCodexBuildKwargs:
         assert kw.get("reasoning") == {"effort": "high"}
         assert "reasoning.encrypted_content" in kw.get("include", [])
 
-    def test_xai_reasoning_disabled_no_reasoning_key(self, transport):
+    def test_xai_reasoning_disabled_still_forces_high_for_grok(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="grok-4.3", messages=messages, tools=[],
             is_xai_responses=True,
             reasoning_config={"enabled": False},
         )
-        # When reasoning is disabled, do not send the reasoning key at all
-        assert "reasoning" not in kw
+        # EB policy: generic reasoning-disable must not downgrade Grok.
+        assert kw.get("reasoning") == {"effort": "high"}
 
-    def test_xai_minimal_effort_clamped(self, transport):
+    def test_xai_low_or_minimal_effort_forces_high_for_grok(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
-        kw = transport.build_kwargs(
-            model="grok-4.3", messages=messages, tools=[],
-            is_xai_responses=True,
-            reasoning_config={"effort": "minimal"},
-        )
-        # "minimal" should be clamped to "low" for xAI as well
-        assert kw.get("reasoning", {}).get("effort") == "low"
+        for requested_effort in ("minimal", "low", "medium"):
+            kw = transport.build_kwargs(
+                model="grok-4.3", messages=messages, tools=[],
+                is_xai_responses=True,
+                reasoning_config={"effort": requested_effort},
+            )
+            assert kw.get("reasoning", {}).get("effort") == "high"
 
     # --- Grok reasoning-effort capability allowlist ---
     # api.x.ai 400s with "Model X does not support parameter reasoningEffort"
@@ -263,7 +263,7 @@ class TestCodexBuildKwargs:
             is_xai_responses=True,
             reasoning_config={"effort": "low"},
         )
-        assert kw.get("reasoning") == {"effort": "low"}
+        assert kw.get("reasoning") == {"effort": "high"}
 
     def test_xai_grok_code_fast_omits_reasoning_effort(self, transport):
         """grok-code-fast-1 rejects reasoning.effort."""

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -705,6 +705,81 @@ async def test_auto_thread_enabled_by_default_slash_commands(adapter, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_run_simple_slash_goal_auto_threads_channel(adapter, monkeypatch):
+    """Native /goal starts should route like channel mentions when auto-thread is on."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    channel = _FakeTextChannel(channel_id=123, name="profile")
+    thread = _FakeThreadChannel(channel_id=999, name="Build the thing", parent_id=123)
+    thread.parent = channel
+    channel.create_thread = AsyncMock(return_value=thread)
+    channel.send = AsyncMock()
+
+    interaction = SimpleNamespace(
+        channel=channel,
+        channel_id=123,
+        guild_id=1,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        response=SimpleNamespace(defer=AsyncMock()),
+        delete_original_response=AsyncMock(),
+    )
+
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+
+    await adapter._run_simple_slash(interaction, "/goal Build the thing")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    channel.create_thread.assert_awaited_once()
+    assert channel.create_thread.await_args.kwargs["name"] == "Build the thing"
+    assert len(captured_events) == 1
+    event = captured_events[0]
+    assert event.text == "/goal Build the thing"
+    assert event.source.chat_id == "999"
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
+    assert event.source.parent_chat_id == "123"
+    assert "999" in adapter._threads
+
+
+@pytest.mark.asyncio
+async def test_run_simple_slash_goal_status_does_not_auto_thread(adapter, monkeypatch):
+    """Goal status/control commands stay in the channel instead of spawning threads."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    channel = _FakeTextChannel(channel_id=123, name="profile")
+    channel.create_thread = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=channel,
+        channel_id=123,
+        guild_id=1,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        response=SimpleNamespace(defer=AsyncMock()),
+        delete_original_response=AsyncMock(),
+    )
+
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+
+    await adapter._run_simple_slash(interaction, "/goal status")
+
+    channel.create_thread.assert_not_awaited()
+    assert len(captured_events) == 1
+    assert captured_events[0].source.chat_id == "123"
+    assert captured_events[0].source.chat_type == "group"
+    assert captured_events[0].source.thread_id is None
+
+
+@pytest.mark.asyncio
 async def test_auto_thread_can_be_disabled(adapter, monkeypatch):
     """Setting DISCORD_AUTO_THREAD=false keeps messages in the channel."""
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -122,6 +122,30 @@ class TestKimiParity:
         assert kw.get("reasoning_effort") == "medium"
 
 
+class TestXAIParity:
+    """xAI/Grok: force highest reasoning effort on the chat-completions wire."""
+
+    def test_grok_4_3_forces_reasoning_effort_high(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("xai"),
+            reasoning_config={"enabled": False, "effort": "low"},
+        )
+        assert kw.get("reasoning_effort") == "high"
+
+    def test_effort_incapable_grok_omits_reasoning_effort(self, transport):
+        kw = transport.build_kwargs(
+            model="grok-4",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("xai"),
+            reasoning_config={"effort": "high"},
+        )
+        assert "reasoning_effort" not in kw
+
+
 class TestOpenRouterParity:
     """OpenRouter: provider preferences, reasoning in extra_body."""
 

--- a/tests/run_agent/test_long_task_policy.py
+++ b/tests/run_agent/test_long_task_policy.py
@@ -20,13 +20,13 @@ def _make_tool_defs(*names: str) -> list[dict]:
     ]
 
 
-def _make_agent(long_task_policy: dict | None = None) -> AIAgent:
+def _make_agent(long_task_policy: dict | None = None, tools: tuple[str, ...] = ("terminal", "process")) -> AIAgent:
     agent_section = {"tool_use_enforcement": "off"}
     if long_task_policy is not None:
         agent_section["long_task_policy"] = long_task_policy
 
     with (
-        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal", "process")),
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tools)),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
         patch("hermes_cli.config.load_config", return_value={"agent": agent_section}),
@@ -63,6 +63,7 @@ def test_enabled_long_task_policy_injects_concise_prompt_guidance():
         {
             "enabled": True,
             "foreground_soft_limit_seconds": 90,
+            "staged_task_soft_limit_seconds": 240,
             "require_background_after_seconds": 480,
             "default_log_dir": "custom/logs",
             "status_filename": "state.json",
@@ -74,6 +75,7 @@ def test_enabled_long_task_policy_injects_concise_prompt_guidance():
 
     assert "Hermes long-task policy" in prompt
     assert "longer than 90 seconds" in prompt
+    assert "before 240 seconds" in prompt
     assert "longer than 480 seconds" in prompt
     assert "terminal(background=true, notify_on_complete=true)" in prompt
     assert "custom/logs" in prompt
@@ -88,3 +90,50 @@ def test_disabled_long_task_policy_suppresses_prompt_guidance():
 
     assert "Hermes long-task policy" not in prompt
     assert "terminal(background=true, notify_on_complete=true)" not in prompt
+
+
+def test_string_false_disables_long_task_policy_guidance():
+    agent = _make_agent({"enabled": "false"})
+
+    prompt = agent._build_system_prompt()
+
+    assert "Hermes long-task policy" not in prompt
+
+
+def test_long_task_policy_avoids_terminal_instruction_when_terminal_unavailable():
+    agent = _make_agent(
+        {
+            "enabled": True,
+            "foreground_soft_limit_seconds": 120,
+            "require_background_after_seconds": 600,
+        },
+        tools=("web_search",),
+    )
+
+    prompt = agent._build_system_prompt()
+
+    assert "Hermes long-task policy" in prompt
+    assert "terminal(background=true" not in prompt
+    assert "unavailable background tool calls" in prompt
+    assert "save logs/status/manifest" not in prompt
+    assert "artifact-writing tools are unavailable" in prompt
+    assert "avoid inventing artifact paths" in prompt
+
+
+def test_long_task_policy_honors_notification_and_artifact_knobs():
+    agent = _make_agent(
+        {
+            "enabled": True,
+            "notify_on_completion": False,
+            "require_progress_artifacts": False,
+        }
+    )
+
+    prompt = agent._build_system_prompt()
+
+    assert "terminal(background=true)" in prompt
+    assert "notify_on_complete=true" not in prompt
+    assert "save logs/status/manifest" not in prompt
+    assert "verify artifacts" not in prompt
+    assert "recoverable progress notes" in prompt
+    assert "verify the progress state" in prompt

--- a/tests/run_agent/test_long_task_policy.py
+++ b/tests/run_agent/test_long_task_policy.py
@@ -1,0 +1,90 @@
+"""Tests for Hermes long-task policy prompt/config behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.config import DEFAULT_CONFIG
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(long_task_policy: dict | None = None) -> AIAgent:
+    agent_section = {"tool_use_enforcement": "off"}
+    if long_task_policy is not None:
+        agent_section["long_task_policy"] = long_task_policy
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal", "process")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value={"agent": agent_section}),
+    ):
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4",
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def test_default_config_includes_long_task_policy_defaults():
+    policy = DEFAULT_CONFIG["agent"]["long_task_policy"]
+
+    assert policy["enabled"] is True
+    assert policy["foreground_soft_limit_seconds"] == 120
+    assert policy["staged_task_soft_limit_seconds"] == 600
+    assert policy["require_background_after_seconds"] == 600
+    assert policy["require_progress_artifacts"] is True
+    assert policy["default_log_dir"] == "reports/_run_logs"
+    assert policy["status_filename"] == "status.json"
+    assert policy["manifest_filename"] == "manifest.json"
+    assert policy["notify_on_completion"] is True
+    assert "FATAL" in policy["fail_fast_markers"]
+
+
+def test_enabled_long_task_policy_injects_concise_prompt_guidance():
+    agent = _make_agent(
+        {
+            "enabled": True,
+            "foreground_soft_limit_seconds": 90,
+            "require_background_after_seconds": 480,
+            "default_log_dir": "custom/logs",
+            "status_filename": "state.json",
+            "manifest_filename": "files.json",
+        }
+    )
+
+    prompt = agent._build_system_prompt()
+
+    assert "Hermes long-task policy" in prompt
+    assert "longer than 90 seconds" in prompt
+    assert "longer than 480 seconds" in prompt
+    assert "terminal(background=true, notify_on_complete=true)" in prompt
+    assert "custom/logs" in prompt
+    assert "state.json" in prompt
+    assert "files.json" in prompt
+
+
+def test_disabled_long_task_policy_suppresses_prompt_guidance():
+    agent = _make_agent({"enabled": False})
+
+    prompt = agent._build_system_prompt()
+
+    assert "Hermes long-task policy" not in prompt
+    assert "terminal(background=true, notify_on_complete=true)" not in prompt

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1062,6 +1062,24 @@ class TestToolUseEnforcementConfig:
         prompt = agent._build_system_prompt()
         assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
 
+    def test_gpt55_prompt_guidance_injected_for_exact_model(self):
+        from agent.prompt_builder import GPT55_PROMPT_GUIDANCE
+        agent = self._make_agent(model="gpt-5.5", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert GPT55_PROMPT_GUIDANCE in prompt
+
+    def test_gpt55_prompt_guidance_injected_for_provider_prefixed_model(self):
+        from agent.prompt_builder import GPT55_PROMPT_GUIDANCE
+        agent = self._make_agent(model="openai/gpt-5.5", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert GPT55_PROMPT_GUIDANCE in prompt
+
+    def test_gpt55_prompt_guidance_skips_other_gpt_models(self):
+        from agent.prompt_builder import GPT55_PROMPT_GUIDANCE
+        agent = self._make_agent(model="openai/gpt-5.4", tool_use_enforcement="auto")
+        prompt = agent._build_system_prompt()
+        assert GPT55_PROMPT_GUIDANCE not in prompt
+
     def test_auto_injects_for_codex(self):
         from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
         agent = self._make_agent(model="openai/codex-mini", tool_use_enforcement="auto")
@@ -2475,6 +2493,72 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_pending_model_switch_note_prepended_once_and_not_persisted(self, agent):
+        self._setup_agent(agent)
+        agent._pending_model_switch_event = {
+            "type": "fallback",
+            "from_model": "local-llm",
+            "from_provider": "custom:local",
+            "to_model": "openrouter/fallback",
+            "to_provider": "openrouter",
+            "reason": "rate_limit",
+        }
+        captured_api_messages = []
+
+        def _capture(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="Final answer", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue")
+
+        api_user_msg = [m for m in captured_api_messages[0] if m.get("role") == "user"][-1]["content"]
+        assert api_user_msg.startswith("[System note: Hermes automatically switched")
+        assert "local-llm via custom:local" in api_user_msg
+        assert "openrouter/fallback via openrouter" in api_user_msg
+        assert "private/local" in api_user_msg
+        assert api_user_msg.endswith("continue")
+        assert result["messages"][-2]["content"] == "continue"
+        assert agent._pending_model_switch_event is None
+
+    def test_pending_model_switch_note_consumed_only_once(self, agent):
+        self._setup_agent(agent)
+        agent._pending_model_switch_event = {
+            "type": "fallback",
+            "from_model": "primary",
+            "from_provider": "local",
+            "to_model": "fallback",
+            "to_provider": "openrouter",
+            "reason": "rate_limit",
+        }
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        captured = []
+
+        def _capture(api_kwargs):
+            captured.append(api_kwargs["messages"])
+            return resp
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_flush_messages_to_session_db"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("first")
+            agent.run_conversation("second", conversation_history=[])
+
+        first_user = [m for m in captured[0] if m.get("role") == "user"][-1]["content"]
+        second_user = [m for m in captured[1] if m.get("role") == "user"][-1]["content"]
+        assert first_user.startswith("[System note:")
+        assert second_user == "second"
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)
@@ -5182,6 +5266,31 @@ class TestFallbackSetsOAuthFlag:
 
         assert result is True
         assert agent._is_anthropic_oauth is False
+
+    def test_fallback_records_model_switch_note_without_credentials(self, agent):
+        agent.model = "local-primary"
+        agent.provider = "custom:local"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "openrouter", "model": "openrouter/fallback"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://openrouter.ai/api/v1"
+        mock_client.api_key = "sk-secret-should-not-appear"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback(FailoverReason.rate_limit)
+
+        assert result is True
+        note = agent._consume_pending_model_switch_note(restored_primary=False)
+        assert "local-primary via custom:local" in note
+        assert "openrouter/fallback via openrouter" in note
+        assert "operational failover" in note
+        assert "private/local" in note
+        assert "sk-secret-should-not-appear" not in note
+        assert "openrouter.ai" not in note
 
 
 class TestMemoryNudgeCounterPersistence:

--- a/tests/tools/test_hermes_supervised_run.py
+++ b/tests/tools/test_hermes_supervised_run.py
@@ -1,0 +1,92 @@
+"""Tests for the hermes-supervised-run helper script."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "hermes-supervised-run.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("hermes_supervised_run", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_helper(workdir: Path, *command: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--name",
+            "pytest-supervised-run",
+            "--workdir",
+            str(workdir),
+            "--log",
+            "run.log",
+            "--status",
+            "status.json",
+            "--manifest",
+            "manifest.json",
+            "--",
+            *command,
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_supervised_run_success_writes_status_manifest_and_log(tmp_path):
+    result = _run_helper(
+        tmp_path,
+        sys.executable,
+        "-c",
+        "from pathlib import Path; print('STAGE: start'); Path('artifact.txt').write_text('ok')",
+    )
+
+    assert result.returncode == 0
+    log = (tmp_path / "run.log").read_text()
+    status = json.loads((tmp_path / "status.json").read_text())
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+
+    assert "STAGE: start" in log
+    assert status["status"] == "completed"
+    assert status["exit_code"] == 0
+    assert status["current_stage"] == "start"
+    assert manifest["run_name"] == "pytest-supervised-run"
+    assert manifest["exit_code"] == 0
+    assert "artifact.txt" in manifest["files_created_or_updated"]
+    assert "artifact.txt" in manifest["sha256"]
+
+
+def test_supervised_run_failure_exits_with_underlying_code(tmp_path):
+    result = _run_helper(tmp_path, sys.executable, "-c", "print('about to fail'); raise SystemExit(7)")
+
+    assert result.returncode == 7
+    status = json.loads((tmp_path / "status.json").read_text())
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+
+    assert status["status"] == "failed"
+    assert status["exit_code"] == 7
+    assert manifest["exit_code"] == 7
+
+
+def test_stage_blocker_and_redaction_helpers(tmp_path):
+    module = _load_module()
+
+    state = module.RunState(name="unit", started_at="2026-01-01T00:00:00Z")
+    redacted = module.redact_text("SHOPIFY_API_KEY=shpat_123456 token=abc123456789 Authorization: Bearer secret-token")
+    module.update_markers("STAGE: crawl\nBLOCKED: login required", state)
+
+    assert "shpat_123456" not in redacted
+    assert "abc123456789" not in redacted
+    assert "secret-token" not in redacted
+    assert state.current_stage == "crawl"
+    assert "login required" in state.blockers


### PR DESCRIPTION
## Summary
- Add configurable Hermes long-task policy defaults and prompt guidance
- Add supervised-run helper for durable logs/status/manifest artifacts
- Make long-task guidance aware of available tools so it does not instruct unavailable background/file artifact actions
- Add focused coverage for prompt injection behavior and supervised-run helper behavior

## Test Plan
- `python -m pytest tests/tools/test_hermes_supervised_run.py tests/run_agent/test_long_task_policy.py -o 'addopts=' -q`
- `python -m py_compile agent/prompt_builder.py run_agent.py tests/run_agent/test_long_task_policy.py`
- `python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_context_compressor.py tests/agent/transports/test_codex_transport.py tests/gateway/test_discord_slash_commands.py tests/providers/test_transport_parity.py tests/run_agent/test_long_task_policy.py tests/run_agent/test_run_agent.py tests/tools/test_hermes_supervised_run.py -o 'addopts=' -q`

## Notes
- Local Engine Brands profile rollout artifacts/backups were intentionally not committed.
