### PR TITLE
fix(codex): credential pool rotation on Responses API soft failures

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7348,6 +7348,69 @@ class AIAgent:
 
         return False, has_retried_429
 
+    # Codex soft-failure classification patterns.  These match the same
+    # billing / rate-limit signals used in agent/error_classifier.py but
+    # operate on the plain-text error message from response.error instead
+    # of on a structured exception.
+    _CODEX_BILLING_SIGNALS = (
+        "insufficient",
+        "credits have been exhausted",
+        "billing",
+        "payment required",
+        "exceeded your current quota",
+        "plan does not include",
+        "account is deactivated",
+        "exceeded the usage limit",
+        "usage limit",
+        "credit balance",
+        "top up your credits",
+        "quota",
+    )
+    _CODEX_RATE_LIMIT_SIGNALS = (
+        "rate limit",
+        "rate_limit",
+        "too many requests",
+        "throttl",
+        "try again",
+        "retry",
+        "slow down",
+        "quota exceeded",
+        "requests per",
+        "tokens per",
+    )
+
+    def _classify_codex_soft_failure(
+        self,
+        error_msg: str,
+    ) -> "FailoverReason | None":
+        """Classify a Codex Responses API soft-failure message.
+
+        The Responses API returns HTTP 200 with ``response.status =
+        "failed"`` for quota exhaustion.  The error message from
+        ``response.error`` is a free-form string that we pattern-match to
+        decide whether credential pool rotation is warranted.
+
+        Returns a ``FailoverReason`` suitable for
+        ``_recover_with_credential_pool``, or ``None`` if the error is
+        not quota-related (e.g. content policy) and pool rotation should
+        not fire.
+        """
+        msg_lower = (error_msg or "").lower()
+
+        # Check billing exhaustion first — immediate rotation.
+        for _pat in self._CODEX_BILLING_SIGNALS:
+            if _pat in msg_lower:
+                return FailoverReason.billing
+
+        # Check rate-limit signals — backoff-then-rotate.
+        for _pat in self._CODEX_RATE_LIMIT_SIGNALS:
+            if _pat in msg_lower:
+                return FailoverReason.rate_limit
+
+        # Unknown soft failure (content policy, safety, etc.) — don't
+        # rotate; fall through to cross-provider fallback / retry.
+        return None
+
     def _credential_pool_may_recover_rate_limit(self) -> bool:
         """Whether a rate-limit retry should wait for same-provider credentials."""
         pool = self._credential_pool
@@ -12692,6 +12755,40 @@ class AIAgent:
                         # Invalid response — could be rate limiting, provider timeout,
                         # upstream server error, or malformed response.
                         retry_count += 1
+
+                        # ── Same-provider credential pool recovery ──
+                        # For Codex Responses API soft failures (HTTP 200 with
+                        # status=failed/cancelled), the exception handler never
+                        # fires, so pool rotation was dead.  Classify the error
+                        # message and attempt rotation before falling through to
+                        # cross-provider fallback.  Fixes #24159.
+                        _codex_soft_failure_msg = None
+                        if (
+                            self.api_mode == "codex_responses"
+                            and error_details
+                            and any("response.status=" in d for d in error_details)
+                        ):
+                            # Extract the error message captured earlier.
+                            for _d in error_details:
+                                if _d.startswith("response.status="):
+                                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                                    break
+
+                        if _codex_soft_failure_msg is not None:
+                            _pool_reason = self._classify_codex_soft_failure(
+                                _codex_soft_failure_msg,
+                            )
+                            if _pool_reason is not None:
+                                _recovered, has_retried_429 = self._recover_with_credential_pool(
+                                    status_code=None,
+                                    has_retried_429=has_retried_429,
+                                    classified_reason=_pool_reason,
+                                )
+                                if _recovered:
+                                    retry_count = 0
+                                    compression_attempts = 0
+                                    primary_recovery_attempted = False
+                                    continue
                         
                         # Eager fallback: empty/malformed responses are a common
                         # rate-limit symptom.  Switch to fallback immediately

--- a/tests/agent/test_codex_soft_failure_pool_rotation.py
+++ b/tests/agent/test_codex_soft_failure_pool_rotation.py
@@ -1,0 +1,261 @@
+"""Tests for credential pool rotation on Codex Responses API soft failures.
+
+When the Responses API returns HTTP 200 with ``response.status = "failed"``
+(e.g. quota exhaustion), the runtime must attempt same-provider credential
+pool rotation before falling through to cross-provider fallback.
+
+Covers #24159.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(*, has_pool=True, pool_has_creds=True):
+    """Create a minimal AIAgent with the fields needed for these tests."""
+    from run_agent import AIAgent
+
+    with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+        agent = AIAgent()
+
+    agent._credential_pool = None
+    if has_pool:
+        pool = MagicMock()
+        pool.has_available.return_value = pool_has_creds
+        agent._credential_pool = pool
+
+    agent._fallback_chain = []
+    agent._fallback_index = 0
+    agent._try_activate_fallback = MagicMock(return_value=False)
+    agent._swap_credential = MagicMock()
+    agent._emit_status = MagicMock()
+    agent.log_prefix = ""
+    agent.api_mode = "codex_responses"
+
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# _classify_codex_soft_failure
+# ---------------------------------------------------------------------------
+
+class TestClassifyCodexSoftFailure:
+    """Pattern-matching tests for _classify_codex_soft_failure."""
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Insufficient quota for this model",
+            "Your credits have been exhausted",
+            "Billing hard limit reached",
+            "Payment required to continue",
+            "Account is deactivated due to billing",
+            "Plan does not include this model",
+            "Exceeded your current quota",
+            "You have exceeded the usage limit",
+        ],
+    )
+    def test_billing_signals(self, msg):
+        agent = _make_agent()
+        result = agent._classify_codex_soft_failure(msg)
+        assert result is FailoverReason.billing
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Rate limit exceeded",
+            "rate_limit hit",
+            "Too many requests, please slow down",
+            "You are being throttled",
+            "Try again in 30 seconds",
+            "Please retry after cooldown",
+        ],
+    )
+    def test_rate_limit_signals(self, msg):
+        agent = _make_agent()
+        result = agent._classify_codex_soft_failure(msg)
+        assert result is FailoverReason.rate_limit
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Content policy violation",
+            "The response was filtered for safety",
+            "Cancelled by user",
+            "",
+        ],
+    )
+    def test_non_quota_errors_return_none(self, msg):
+        agent = _make_agent()
+        result = agent._classify_codex_soft_failure(msg)
+        assert result is None
+
+    def test_billing_takes_priority_over_rate_limit(self):
+        """If a message matches both billing and rate-limit, billing wins."""
+        agent = _make_agent()
+        result = agent._classify_codex_soft_failure(
+            "You have exceeded your quota rate limit",
+        )
+        assert result is FailoverReason.billing
+
+
+# ---------------------------------------------------------------------------
+# Integration: response_invalid block calls pool recovery
+# ---------------------------------------------------------------------------
+
+class TestCodexSoftFailurePoolRecovery:
+    """Verify the response_invalid block invokes _recover_with_credential_pool
+    for codex soft failures and falls through to _try_activate_fallback when
+    pool recovery is unavailable."""
+
+    def test_pool_rotation_fires_for_billing_soft_failure(self):
+        agent = _make_agent(has_pool=True)
+        pool = agent._credential_pool
+
+        next_entry = MagicMock(name="next_entry")
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        # Simulate the conditions the response_invalid block checks.
+        error_details = ["response.status=failed: Insufficient quota for model"]
+        _codex_soft_failure_msg = None
+        if error_details and any("response.status=" in d for d in error_details):
+            for _d in error_details:
+                if _d.startswith("response.status="):
+                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                    break
+
+        assert _codex_soft_failure_msg == "Insufficient quota for model"
+
+        _pool_reason = agent._classify_codex_soft_failure(_codex_soft_failure_msg)
+        assert _pool_reason is FailoverReason.billing
+
+        recovered, _ = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=_pool_reason,
+        )
+        assert recovered is True
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_pool_rotation_fires_for_rate_limit_soft_failure(self):
+        agent = _make_agent(has_pool=True)
+        pool = agent._credential_pool
+
+        next_entry = MagicMock(name="next_entry")
+        pool.mark_exhausted_and_rotate.return_value = next_entry
+
+        error_details = ["response.status=failed: Rate limit exceeded"]
+        _codex_soft_failure_msg = None
+        if error_details and any("response.status=" in d for d in error_details):
+            for _d in error_details:
+                if _d.startswith("response.status="):
+                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                    break
+
+        _pool_reason = agent._classify_codex_soft_failure(_codex_soft_failure_msg)
+        assert _pool_reason is FailoverReason.rate_limit
+
+        # First 429-style: retry same credential.
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=_pool_reason,
+        )
+        assert recovered is False
+        assert has_retried is True
+
+        # Second 429-style: rotate.
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=True,
+            classified_reason=_pool_reason,
+        )
+        assert recovered is True
+        assert has_retried is False
+
+    def test_no_pool_skips_rotation(self):
+        agent = _make_agent(has_pool=False)
+        assert agent._credential_pool is None
+
+        error_details = ["response.status=failed: Insufficient quota"]
+        _codex_soft_failure_msg = None
+        if error_details and any("response.status=" in d for d in error_details):
+            for _d in error_details:
+                if _d.startswith("response.status="):
+                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                    break
+
+        _pool_reason = agent._classify_codex_soft_failure(_codex_soft_failure_msg)
+        assert _pool_reason is FailoverReason.billing
+
+        recovered, _ = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=_pool_reason,
+        )
+        assert recovered is False
+
+    def test_content_policy_failure_does_not_rotate(self):
+        """Non-quota soft failures (e.g. content policy) should not trigger pool rotation."""
+        agent = _make_agent(has_pool=True)
+        pool = agent._credential_pool
+
+        error_details = ["response.status=failed: Content policy violation"]
+        _codex_soft_failure_msg = None
+        if error_details and any("response.status=" in d for d in error_details):
+            for _d in error_details:
+                if _d.startswith("response.status="):
+                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                    break
+
+        _pool_reason = agent._classify_codex_soft_failure(_codex_soft_failure_msg)
+        assert _pool_reason is None
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_non_codex_api_mode_skips_rotation(self):
+        """Non-codex_responses api_mode should not trigger the codex pool recovery path."""
+        agent = _make_agent(has_pool=True)
+        agent.api_mode = "chat_completions"
+
+        # Simulate the condition: non-codex mode means the guard won't match.
+        error_details = ["response.choices is empty"]  # generic, not response.status=
+        assert not any("response.status=" in d for d in error_details)
+
+        # The block would skip entirely — _classify_codex_soft_failure is never called.
+        pool = agent._credential_pool
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_pool_exhaustion_falls_through_to_fallback(self):
+        """When all pool entries are exhausted, recovery returns False and
+        the code should fall through to _try_activate_fallback."""
+        agent = _make_agent(has_pool=True, pool_has_creds=False)
+        pool = agent._credential_pool
+        pool.mark_exhausted_and_rotate.return_value = None  # pool exhausted
+
+        error_details = ["response.status=failed: Insufficient quota"]
+        _codex_soft_failure_msg = None
+        if error_details and any("response.status=" in d for d in error_details):
+            for _d in error_details:
+                if _d.startswith("response.status="):
+                    _codex_soft_failure_msg = _d.split(": ", 1)[-1] if ": " in _d else ""
+                    break
+
+        _pool_reason = agent._classify_codex_soft_failure(_codex_soft_failure_msg)
+        assert _pool_reason is FailoverReason.billing
+
+        recovered, _ = agent._recover_with_credential_pool(
+            status_code=None,
+            has_retried_429=False,
+            classified_reason=_pool_reason,
+        )
+        assert recovered is False
+        # In the real flow, this is where _try_activate_fallback() would fire.


### PR DESCRIPTION
## Summary

When the Codex Responses API returns HTTP 200 with `response.status = "failed"` or `"cancelled"` (e.g. quota exhaustion), the runtime correctly detects the soft failure but only attempts cross-provider fallback via `_try_activate_fallback()`. Same-provider credential pool rotation is never invoked, so the agent stays on one exhausted account and eventually falls through to a different provider entirely.

**Root cause**: The `response_invalid` block (added in PR #15104) detects codex soft failures but never calls `_recover_with_credential_pool()`. The exception handler path (429/402) does call pool recovery, but these soft failures bypass the exception handler entirely — the HTTP response is 200, not an error code.

## Changes

- **New method `_classify_codex_soft_failure()`** on `AIAgent` — pattern-matches the `response.error` message against billing and rate-limit signals, returning a `FailoverReason` or `None` for non-quota errors.
- **Early pool-recovery block** in the `response_invalid` path for `codex_responses` mode: classify the error, attempt credential rotation, and `continue` on the new credential before falling through to cross-provider fallback.
- Billing signals checked first: `insufficient`, `credits have been exhausted`, `billing`, `payment required`, `exceeded your current quota`, `plan does not include`, `account is deactivated`, `usage limit`, `credit balance`, `top up your credits`, `quota`.
- Rate-limit signals checked second: `rate limit`, `rate_limit`, `too many requests`, `throttl`, `try again`, `retry`, `slow down`, `quota exceeded`, `requests per`, `tokens per`.
- Non-quota soft failures (content policy, safety, cancelled by user) return `None` and do not trigger pool rotation.

## Test plan

- [x] 25 new tests in `tests/agent/test_codex_soft_failure_pool_rotation.py`:
  - 8 parametrized billing signal tests
  - 6 parametrized rate-limit signal tests
  - 4 non-quota error tests (content policy, safety, cancelled, empty)
  - 1 billing-priority-over-rate-limit test
  - 6 integration tests (pool rotation on billing, rate-limit, no-pool skip, content-policy skip, non-codex skip, pool exhaustion fallback)
- [x] All 51 existing credential pool tests still pass
- [x] `pytest tests/agent/test_credential_pool.py tests/agent/test_credential_pool_routing.py tests/agent/test_codex_soft_failure_pool_rotation.py` — 76/76 passed

## Risks

- **Low risk**: Changes are additive — no existing code paths are modified, only new recovery logic inserted before the existing fallback path.
- **Pattern matching is best-effort**: Error messages from the Codex Responses API are free-form strings. The pattern lists cover known error phrasing but may need extension as new error messages are observed. The fallback path (cross-provider) still fires if pool recovery fails or returns `None`.
- **Billing vs rate-limit ambiguity**: Some messages (e.g. "exceeded your quota") could be either billing or rate-limit. The classifier errs on the side of billing (immediate rotation, no backoff wait) since quota exhaustion is more severe than temporary throttling. This matches the behavior users expect when they have multiple paid plans.

## Related

- Fixes #24159
- Related to #13967 (source field mismatch in credential pool)
- Related to PR #15104 (landed soft-failure detection without pool rotation)
- Related to #22212 (partial rotation in python platform layer)