### PR TITLE
fix(mcp): parse quoted media attachment paths

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -173,13 +173,21 @@ def _extract_attachments(msg: dict) -> List[dict]:
                 # Unknown non-text content type
                 attachments.append({"type": ptype, "data": part})
 
-    # MEDIA: tags in text content
+    # MEDIA: tags in text content. Keep this in sync with the gateway parser's
+    # user-facing behavior for quoted/backticked paths while preserving the
+    # existing unquoted-token behavior used by MCP clients.
     text = _extract_message_content(msg)
     if text:
-        media_pattern = re.compile(r'MEDIA:\s*(\S+)')
+        media_pattern = re.compile(
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?'''
+        )
         for match in media_pattern.finditer(text):
-            path = match.group(1)
-            attachments.append({"type": "media", "path": path})
+            path = match.group("path").strip()
+            if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
+                path = path[1:-1].strip()
+            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            if path:
+                attachments.append({"type": "media", "path": path})
 
     return attachments
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -348,6 +348,13 @@ class TestAttachmentExtraction:
         msg = {"content": "MEDIA: /a.png and MEDIA: /b.mp3"}
         assert len(_extract_attachments(msg)) == 2
 
+    def test_media_tag_with_quoted_path_containing_spaces(self):
+        from mcp_serve import _extract_attachments
+        msg = {"content": "Here is the file\nMEDIA: '/tmp/my image.png'\nDone"}
+        assert _extract_attachments(msg) == [
+            {"type": "media", "path": "/tmp/my image.png"}
+        ]
+
     def test_no_attachments(self):
         from mcp_serve import _extract_attachments
         assert _extract_attachments({"content": "plain text"}) == []


### PR DESCRIPTION
## Summary
- handle quoted/backticked `MEDIA:` paths in MCP attachment extraction
- preserve the existing unquoted token behavior for MCP clients
- add a regression test for quoted paths containing spaces

## Test Plan
- RED: `pytest tests/test_mcp_serve.py::TestAttachmentExtraction::test_media_tag_with_quoted_path_containing_spaces -q` failed before the fix with `path: "'/tmp/my"`
- GREEN: `python -m pytest tests/test_mcp_serve.py -q` → 86 passed, 11 warnings
- `git diff --check origin/main...HEAD`