### PR TITLE
fix(dashboard): show correct platform status when running multiple profiles

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -517,9 +517,17 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
-def read_runtime_status() -> Optional[dict[str, Any]]:
-    """Read the persisted gateway runtime health/status information."""
-    return _read_json_file(_get_runtime_status_path())
+def read_runtime_status(status_path: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Read the persisted gateway runtime health/status information.
+
+    Parameters
+    ----------
+    status_path:
+        Optional path to a specific runtime status file. When omitted, reads
+        from the current HERMES_HOME.
+    """
+    path = status_path if status_path is not None else _get_runtime_status_path()
+    return _read_json_file(path)
 
 
 def remove_pid_file() -> None:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -412,6 +412,9 @@ class ProfileInfo:
     distribution_name: Optional[str] = None
     distribution_version: Optional[str] = None
     distribution_source: Optional[str] = None
+    gateway_state: Optional[str] = None
+    gateway_platforms: Optional[dict] = None
+    gateway_updated_at: Optional[str] = None
 
 
 def _read_distribution_meta(profile_dir: Path) -> tuple:
@@ -483,6 +486,28 @@ def _count_skills(profile_dir: Path) -> int:
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+def _read_profile_runtime_status(profile_dir: Path) -> tuple[Optional[str], Optional[dict], Optional[str]]:
+    """Read gateway runtime status for a specific profile directory.
+
+    Returns (gateway_state, gateway_platforms, gateway_updated_at).
+    """
+    try:
+        from gateway.status import read_runtime_status
+        status_path = profile_dir / "gateway_state.json"
+        if not status_path.exists():
+            return None, None, None
+        runtime = read_runtime_status(status_path)
+        if not runtime:
+            return None, None, None
+        return (
+            runtime.get("gateway_state"),
+            runtime.get("platforms") or {},
+            runtime.get("updated_at"),
+        )
+    except Exception:
+        return None, None, None
+
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
@@ -493,6 +518,7 @@ def list_profiles() -> List[ProfileInfo]:
     if default_home.is_dir():
         model, provider = _read_config_model(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
+        gateway_state, gateway_platforms, gateway_updated_at = _read_profile_runtime_status(default_home)
         profiles.append(ProfileInfo(
             name="default",
             path=default_home,
@@ -505,6 +531,9 @@ def list_profiles() -> List[ProfileInfo]:
             distribution_name=dist_name,
             distribution_version=dist_version,
             distribution_source=dist_source,
+            gateway_state=gateway_state,
+            gateway_platforms=gateway_platforms,
+            gateway_updated_at=gateway_updated_at,
         ))
 
     # Named profiles
@@ -519,6 +548,7 @@ def list_profiles() -> List[ProfileInfo]:
             model, provider = _read_config_model(entry)
             alias_path = wrapper_dir / name
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)
+            gateway_state, gateway_platforms, gateway_updated_at = _read_profile_runtime_status(entry)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -532,6 +562,9 @@ def list_profiles() -> List[ProfileInfo]:
                 distribution_name=dist_name,
                 distribution_version=dist_version,
                 distribution_source=dist_source,
+                gateway_state=gateway_state,
+                gateway_platforms=gateway_platforms,
+                gateway_updated_at=gateway_updated_at,
             ))
 
     return profiles

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -590,6 +590,22 @@ async def get_status():
     if gateway_running and gateway_state is None and remote_health_body is not None:
         gateway_state = "running"
 
+    # Aggregate platform states from all profiles (multi-profile support).
+    # Each profile may run its own gateway with different platforms; merge them
+    # so the dashboard shows the full picture.
+    try:
+        from hermes_cli import profiles as profiles_mod
+        for profile in profiles_mod.list_profiles():
+            if profile.is_default:
+                continue
+            if not profile.gateway_running or not profile.gateway_platforms:
+                continue
+            for platform_name, platform_info in profile.gateway_platforms.items():
+                if platform_name not in gateway_platforms:
+                    gateway_platforms[platform_name] = platform_info
+    except Exception:
+        pass
+
     active_sessions = 0
     try:
         from hermes_state import SessionDB
@@ -2649,6 +2665,9 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "provider": _profile_attr(info, "provider"),
         "has_env": bool(_profile_attr(info, "has_env", False)),
         "skill_count": int(_profile_attr(info, "skill_count", 0) or 0),
+        "gateway_state": _profile_attr(info, "gateway_state"),
+        "gateway_platforms": _profile_attr(info, "gateway_platforms") or {},
+        "gateway_updated_at": _profile_attr(info, "gateway_updated_at"),
     }
 
 


### PR DESCRIPTION
## Problem

When running multiple profiles simultaneously (e.g. default + wecom-agent), the dashboard status page only displays platform states from the default profile's `gateway_state.json`. Platforms running in non-default profiles appear as "disconnected" even though they are actively connected and functioning.

## Root Cause

The `/api/status` endpoint in `web_server.py` only reads `gateway_state.json` from the current (default) profile directory. Each profile has its own independent gateway process and state file, so the dashboard was completely unaware of platforms running in other profiles.

## Changes

- `gateway/status.py`: `read_runtime_status()` now accepts an optional `status_path` parameter to read state from arbitrary profile directories.
- `hermes_cli/profiles.py`: `ProfileInfo` gains `gateway_state`, `gateway_platforms`, and `gateway_updated_at` fields. `list_profiles()` reads each profile's runtime status.
- `hermes_cli/web_server.py`: `/api/status` aggregates platform states across all active profiles. Platforms from non-default profiles are merged into the response.

## Testing

- Started gateways for both default and wecom-agent profiles
- Verified `/api/status` returns both Weixin (default) and WeCom (wecom-agent) as `connected`
- Confirmed timestamps and error messages are preserved correctly

Fixes incorrect "disconnected" display for multi-profile setups.