### PR TITLE
feat(gateway): add Telegram topic runtime model overrides

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1046,6 +1046,14 @@ platform_toolsets:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames
+#       dm_topics:
+#         - chat_id: "123456789"
+#           topics:
+#             - name: "Research"
+#               thread_id: 42
+#               provider: "openrouter"       # Optional topic runtime provider
+#               model: "openai/gpt-5"        # Optional; provider default is used when omitted
+#               toolsets: [web, terminal]    # Optional; falls back to Telegram defaults if unusable
 #       command_menu:
 #         # Telegram allows up to 100 BotCommands; Hermes defaults to 60 so
 #         # all built-in commands plus common skill commands stay visible

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -543,7 +543,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and toolsets.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -552,6 +552,7 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    toolsets: Optional[List[str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -561,6 +562,8 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.toolsets is not None:
+            out["toolsets"] = list(self.toolsets)
         return out
 
     @classmethod
@@ -571,6 +574,16 @@ class ChannelOverride:
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            toolsets=(
+                [str(value).strip() for value in data.get("toolsets", []) if str(value).strip()]
+                if isinstance(data.get("toolsets"), list)
+                else (
+                    [str(data["toolsets"]).strip()]
+                    if isinstance(data.get("toolsets"), str)
+                    and str(data["toolsets"]).strip()
+                    else None
+                )
+            ),
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3372,7 +3372,10 @@ def _channel_override_lookup_keys(
     """
     keys: list[str] = []
     seen: set[str] = set()
-    for key in (chat_id, thread_id, parent_id):
+    composite_thread_key = (
+        f"{chat_id}:{thread_id}" if chat_id and thread_id else None
+    )
+    for key in (composite_thread_key, thread_id, chat_id, parent_id):
         if not key:
             continue
         sk = str(key)
@@ -8295,6 +8298,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             override,
             _resolve_gateway_model(user_config),
         )
+
+    def _resolve_toolsets_for_source(
+        self,
+        user_config: dict,
+        platform_key: str,
+        source: Optional[SessionSource],
+    ) -> list[str]:
+        """Resolve per-channel toolsets without allowing an empty tool surface."""
+        from hermes_cli.tools_config import _get_platform_tools
+
+        defaults = sorted(_get_platform_tools(user_config, platform_key))
+        if source is None:
+            return defaults
+
+        config = getattr(self, "config", None)
+        if config is None:
+            return defaults
+        override = _get_channel_override(
+            config,
+            source.platform,
+            str(source.chat_id or ""),
+            thread_id=(
+                str(source.thread_id)
+                if getattr(source, "thread_id", None)
+                else None
+            ),
+            parent_id=(
+                str(source.parent_chat_id)
+                if getattr(source, "parent_chat_id", None)
+                else None
+            ),
+        )
+        if not override or not override.toolsets:
+            return defaults
+
+        topic_config = dict(user_config)
+        platform_toolsets = dict(topic_config.get("platform_toolsets") or {})
+        platform_toolsets[platform_key] = list(override.toolsets)
+        topic_config["platform_toolsets"] = platform_toolsets
+        resolved = sorted(_get_platform_tools(topic_config, platform_key))
+        return resolved or defaults
 
     def _get_system_prompt_for_channel(
         self,
@@ -20128,8 +20172,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             platform_key = _platform_config_key(source.platform)
 
-            from hermes_cli.tools_config import _get_platform_tools
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets = self._resolve_toolsets_for_source(
+                user_config, platform_key, source
+            )
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -25206,8 +25251,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        enabled_toolsets = self._resolve_toolsets_for_source(
+            user_config, platform_key, source
+        )
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -278,7 +278,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.authz_mixin import _coerce_allow_set
-from gateway.config import Platform, PlatformConfig
+from gateway.config import ChannelOverride, Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -9653,6 +9653,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     if str(chat_entry.get("chat_id")) == chat_id:
                         for t in chat_entry.get("topics", []):
                             if t.get("name") == topic_name:
+                                self._register_dm_topic_runtime_override(
+                                    chat_id, thread_id, t
+                                )
                                 return t
                 return {"name": topic_name}
 
@@ -9667,10 +9670,34 @@ class TelegramAdapter(BasePlatformAdapter):
                     if str(chat_entry.get("chat_id")) == chat_id:
                         for t in chat_entry.get("topics", []):
                             if t.get("name") == topic_name:
+                                self._register_dm_topic_runtime_override(
+                                    chat_id, thread_id, t
+                                )
                                 return t
                 return {"name": topic_name}
 
         return None
+
+    def _register_dm_topic_runtime_override(
+        self,
+        chat_id: str,
+        thread_id: str,
+        topic_info: Dict[str, Any],
+    ) -> None:
+        """Bridge a configured DM topic into the gateway channel override path."""
+        if not isinstance(topic_info, dict):
+            return
+        if not any(
+            topic_info.get(key) not in (None, "", [])
+            for key in ("model", "provider", "toolsets")
+        ):
+            return
+        key = f"{chat_id}:{thread_id}"
+        # An explicit channel_overrides entry is the canonical architecture
+        # and wins over the dm_topics compatibility bridge.
+        if key in self.config.channel_overrides:
+            return
+        self.config.channel_overrides[key] = ChannelOverride.from_dict(topic_info)
 
     def _cache_dm_topic_from_message(self, chat_id: str, thread_id: str, topic_name: str) -> None:
         """Cache a thread_id -> topic_name mapping discovered from an incoming message."""

--- a/tests/gateway/test_telegram_topic_runtime_overrides.py
+++ b/tests/gateway/test_telegram_topic_runtime_overrides.py
@@ -1,0 +1,156 @@
+"""Telegram DM topic runtime overrides on the channel-override architecture."""
+
+from types import SimpleNamespace
+
+import gateway.run as gateway_run
+from gateway.config import ChannelOverride, Platform, PlatformConfig
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="111",
+        chat_type="dm",
+        user_id="user-1",
+        thread_id="42",
+    )
+
+
+def _runner(override: ChannelOverride):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                channel_overrides={"111:42": override},
+            )
+        }
+    )
+    runner._session_model_overrides = {}
+    runner._last_resolved_model = {}
+    runner._rehydrate_session_model_override = lambda _key: None
+    runner.session_store = SimpleNamespace(
+        _generate_session_key=lambda _source: "telegram-topic-session"
+    )
+    return runner
+
+
+def test_topic_lookup_prefers_composite_chat_thread_key():
+    keys = gateway_run._channel_override_lookup_keys(
+        "111", thread_id="42", parent_id="parent"
+    )
+
+    assert keys == ["111:42", "42", "111", "parent"]
+
+
+def test_provider_only_topic_uses_provider_runtime_model(monkeypatch):
+    runner = _runner(ChannelOverride(provider="topic-provider"))
+    monkeypatch.setattr(
+        gateway_run, "_resolve_gateway_model", lambda _config=None: "global-model"
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "global-provider", "api_key": "global-key"},
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs_for_provider",
+        lambda provider: {
+            "provider": provider,
+            "model": "provider-default-model",
+            "api_key": "topic-key",
+        },
+    )
+
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=_source(), user_config={"model": {"default": "global-model"}}
+    )
+
+    assert model == "provider-default-model"
+    assert runtime["provider"] == "topic-provider"
+
+
+def test_topic_toolsets_resolve_without_erasing_default_surface(monkeypatch):
+    import hermes_cli.tools_config as tools_config
+
+    runner = _runner(ChannelOverride(toolsets=["topic-tools"]))
+
+    def fake_platform_tools(config, _platform):
+        configured = (config.get("platform_toolsets") or {}).get("telegram")
+        if configured == ["topic-tools"]:
+            return {"web"}
+        return {"terminal", "file"}
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", fake_platform_tools)
+
+    assert runner._resolve_toolsets_for_source({}, "telegram", _source()) == ["web"]
+
+    runner.config.platforms[Platform.TELEGRAM].channel_overrides[
+        "111:42"
+    ] = ChannelOverride(toolsets=["unknown"])
+
+    def empty_invalid_toolsets(config, _platform):
+        configured = (config.get("platform_toolsets") or {}).get("telegram")
+        return set() if configured == ["unknown"] else {"terminal", "file"}
+
+    monkeypatch.setattr(
+        tools_config, "_get_platform_tools", empty_invalid_toolsets
+    )
+    assert runner._resolve_toolsets_for_source({}, "telegram", _source()) == [
+        "file",
+        "terminal",
+    ]
+
+
+def test_dm_topic_info_registers_runtime_override_on_plugin_adapter():
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "dm_topics": [
+                {
+                    "chat_id": "111",
+                    "topics": [
+                        {
+                            "name": "Research",
+                            "thread_id": 42,
+                            "provider": "topic-provider",
+                            "model": "topic-model",
+                            "toolsets": ["web"],
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    adapter = TelegramAdapter(config)
+    adapter._dm_topics["111:Research"] = 42
+
+    topic = adapter._get_dm_topic_info("111", "42")
+
+    assert topic["name"] == "Research"
+    override = config.channel_overrides["111:42"]
+    assert override.provider == "topic-provider"
+    assert override.model == "topic-model"
+    assert override.toolsets == ["web"]
+
+
+def test_explicit_channel_override_wins_over_dm_topic_bridge():
+    explicit = ChannelOverride(model="explicit-model")
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        channel_overrides={"111:42": explicit},
+    )
+    adapter = TelegramAdapter(config)
+
+    adapter._register_dm_topic_runtime_override(
+        "111",
+        "42",
+        {"model": "topic-model", "provider": "topic-provider"},
+    )
+
+    assert config.channel_overrides["111:42"] is explicit


### PR DESCRIPTION
## What does this PR do?

Adds config-driven runtime overrides for Telegram private-chat topic lanes using the gateway's current `channel_overrides` architecture.

A configured `dm_topics` entry can provide `provider`, `model`, and `toolsets`. The Telegram plugin bridges the resolved `chat_id:thread_id` lane into the existing channel override path, so normal, queued, and background turns share one runtime resolution mechanism. Explicit channel overrides remain canonical and explicit session `/model` overrides retain highest precedence.

## Related issue

Fixes #24179

Related: #18327, #4321, #10143.

## Review feedback addressed

- Uses current `channel_overrides`, not the retired Telegram gateway module.
- Keeps topic discovery/runtime bridging in `plugins/platforms/telegram/adapter.py`.
- Provider-only topics adopt the provider default model.
- Invalid or empty topic toolsets fall back to the normal non-empty platform surface.
- Excludes unrelated smart-routing and topic `max_tokens` work.

## Changes

- `gateway/config.py`: optional toolsets in channel overrides.
- `gateway/run.py`: composite `chat_id:thread_id` lookup and topic toolset resolution.
- `plugins/platforms/telegram/adapter.py`: DM-topic runtime registration.
- `cli-config.yaml.example`: provider/model/toolset documentation.
- `tests/gateway/test_telegram_topic_runtime_overrides.py`: composite lookup, provider defaults, toolset safety, adapter bridging, and precedence.

## Verification

Refreshed onto frozen upstream `2cdb30a474d76cca9eb61714d889c18f493aa7fc` (2026-08-10 unreleased main), which contains Hermes Agent v0.20.0 / v2026.8.3.

- Bytecode compilation, `git diff --check`, Ruff, and lock check: passed.
- Consolidated changed-area validation: 173 passed, 0 failed, 2 platform skips.
- Telegram topic override focused test: passed.
- Full candidate run: roughly 29k passed; all 77 remaining failures reproduce on pristine frozen upstream in the identical environment, with no failed file changed by this PR/candidate.
- New-skill authoring standards after correction: 1,166 passed, 0 failed.

## Checklist

- [x] Current upstream architecture used.
- [x] Maintainer salvage feedback addressed.
- [x] No unrelated smart-routing or max-token changes.
- [x] No empty tool surface introduced.
- [x] Focused checks pass.
