### PR TITLE
fix(mcp): honor per-server connect_timeout + raise default for OAuth probes

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -164,10 +164,46 @@ def _apply_mcp_preset(
 
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
 
+# OAuth probes shell out to the user's browser, so the connect step can
+# block on a human typing credentials. Anything below ~5 minutes regularly
+# times out on first-time logins (the user has to sign in, click Authorize,
+# and bounce back to the loopback callback). 30s is fine for stdio and
+# pre-authenticated transports where the connect is purely automated.
+_OAUTH_PROBE_TIMEOUT = 300.0
+_DEFAULT_PROBE_TIMEOUT = 30.0
+
+
+def _resolve_probe_timeout(config: dict) -> float:
+    """Pick the connect timeout for ``_probe_single_server``.
+
+    Honors a per-server ``connect_timeout`` field in ``mcp_servers.<name>``
+    when present and numeric; otherwise selects a default based on whether
+    the server uses OAuth (browser-mediated, slow) or any other transport.
+    """
+    configured = config.get("connect_timeout")
+    if configured is not None:
+        try:
+            value = float(configured)
+        except (TypeError, ValueError):
+            value = None
+        if value is not None and value > 0:
+            return value
+    if config.get("auth") == "oauth":
+        return _OAUTH_PROBE_TIMEOUT
+    return _DEFAULT_PROBE_TIMEOUT
+
+
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30
+    name: str, config: dict, connect_timeout: Optional[float] = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
+
+    When ``connect_timeout`` is ``None`` (the normal call path), the
+    timeout is resolved from the server config: a ``connect_timeout``
+    field in ``mcp_servers.<name>`` wins, otherwise it falls back to
+    300s for OAuth-based servers (whose probe runs a browser-mediated
+    handshake) and 30s for everything else. Explicit callers may pass
+    a value to override.
 
     Returns list of ``(tool_name, description)`` tuples.
     Raises on connection failure.
@@ -178,6 +214,9 @@ def _probe_single_server(
         _connect_server,
         _stop_mcp_loop,
     )
+
+    if connect_timeout is None:
+        connect_timeout = _resolve_probe_timeout(config)
 
     _ensure_mcp_loop()
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -650,3 +650,143 @@ class TestMcpLogin:
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
 
+
+# ---------------------------------------------------------------------------
+# Tests: _probe_single_server honors per-server connect_timeout + picks
+# OAuth-appropriate defaults (issue #24097).
+# ---------------------------------------------------------------------------
+
+
+class TestProbeConnectTimeout:
+    def test_resolve_uses_configured_value_when_present(self):
+        from hermes_cli.mcp_config import _resolve_probe_timeout
+
+        assert _resolve_probe_timeout(
+            {"url": "https://x", "auth": "oauth", "connect_timeout": 600}
+        ) == 600.0
+        # Even non-OAuth servers honor the field.
+        assert _resolve_probe_timeout(
+            {"command": "npx", "connect_timeout": 5}
+        ) == 5.0
+        # Stringy YAML values (yaml.safe_load returns ints, but users
+        # occasionally quote numbers in config) must still coerce.
+        assert _resolve_probe_timeout(
+            {"url": "https://x", "auth": "oauth", "connect_timeout": "120"}
+        ) == 120.0
+
+    def test_resolve_falls_back_to_oauth_default_when_unset(self):
+        from hermes_cli.mcp_config import (
+            _resolve_probe_timeout,
+            _OAUTH_PROBE_TIMEOUT,
+        )
+
+        # OAuth-based remote server, no connect_timeout in config.
+        assert _resolve_probe_timeout(
+            {"url": "https://x", "auth": "oauth"}
+        ) == _OAUTH_PROBE_TIMEOUT
+        # 40s (current bug) is well below the OAuth ceiling; sanity check
+        # the default lives above the historical 40s cutoff from #24097.
+        assert _OAUTH_PROBE_TIMEOUT > 40.0
+
+    def test_resolve_falls_back_to_short_default_for_non_oauth(self):
+        from hermes_cli.mcp_config import (
+            _resolve_probe_timeout,
+            _DEFAULT_PROBE_TIMEOUT,
+        )
+
+        # Stdio server — fast, automated connect.
+        assert _resolve_probe_timeout(
+            {"command": "npx", "args": ["some-server"]}
+        ) == _DEFAULT_PROBE_TIMEOUT
+        # Header-auth remote server — still automated, no browser.
+        assert _resolve_probe_timeout(
+            {"url": "https://x", "auth": "header"}
+        ) == _DEFAULT_PROBE_TIMEOUT
+
+    def test_resolve_ignores_invalid_configured_value(self):
+        from hermes_cli.mcp_config import (
+            _resolve_probe_timeout,
+            _OAUTH_PROBE_TIMEOUT,
+            _DEFAULT_PROBE_TIMEOUT,
+        )
+
+        # Non-numeric strings, None, negatives, and zero are all bad data
+        # — fall back to the auth-appropriate default rather than passing
+        # a broken value into asyncio.wait_for.
+        for bad in ("forever", None, 0, -5, ""):
+            assert _resolve_probe_timeout(
+                {"url": "https://x", "auth": "oauth", "connect_timeout": bad}
+            ) == _OAUTH_PROBE_TIMEOUT
+            assert _resolve_probe_timeout(
+                {"command": "npx", "connect_timeout": bad}
+            ) == _DEFAULT_PROBE_TIMEOUT
+
+    def test_probe_passes_resolved_timeout_to_run_on_mcp_loop(
+        self, monkeypatch
+    ):
+        """End-to-end: when called with no explicit timeout, the resolved
+        per-server value flows through to ``_run_on_mcp_loop`` (and thus,
+        by construction, to the inner ``asyncio.wait_for``)."""
+        from hermes_cli import mcp_config
+
+        captured: Dict[str, Any] = {}
+
+        def _fake_run_on_mcp_loop(coro, timeout):
+            captured["run_timeout"] = timeout
+            # Cancel the unstarted coroutine so the Python warning
+            # "coroutine was never awaited" doesn't fire under -W error.
+            coro.close()
+
+        monkeypatch.setattr(
+            "tools.mcp_tool._ensure_mcp_loop", lambda: None
+        )
+        monkeypatch.setattr(
+            "tools.mcp_tool._stop_mcp_loop", lambda: None
+        )
+        monkeypatch.setattr(
+            "tools.mcp_tool._connect_server",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("connect_server should not run")
+            ),
+        )
+        monkeypatch.setattr(
+            "tools.mcp_tool._run_on_mcp_loop", _fake_run_on_mcp_loop
+        )
+
+        # Configured value wins over the OAuth default.
+        captured.clear()
+        mcp_config._probe_single_server(
+            "srv",
+            {"url": "https://x", "auth": "oauth", "connect_timeout": 250},
+        )
+        assert captured["run_timeout"] == 250.0 + 10
+
+        # No configured value + OAuth → OAuth default, not the historical 30.
+        captured.clear()
+        mcp_config._probe_single_server(
+            "srv", {"url": "https://x", "auth": "oauth"}
+        )
+        assert (
+            captured["run_timeout"]
+            == mcp_config._OAUTH_PROBE_TIMEOUT + 10
+        )
+
+        # Stdio with no config → short default.
+        captured.clear()
+        mcp_config._probe_single_server(
+            "srv", {"command": "npx", "args": ["x"]}
+        )
+        assert (
+            captured["run_timeout"]
+            == mcp_config._DEFAULT_PROBE_TIMEOUT + 10
+        )
+
+        # Explicit timeout from the caller wins over both config and defaults.
+        captured.clear()
+        mcp_config._probe_single_server(
+            "srv",
+            {"url": "https://x", "auth": "oauth", "connect_timeout": 250},
+            connect_timeout=15.0,
+        )
+        assert captured["run_timeout"] == 15.0 + 10
+


### PR DESCRIPTION
## Summary

- `hermes mcp login` and `hermes mcp add --auth oauth` both hit a 40s wall during the browser-mediated OAuth handshake — well below the time a realistic OAuth flow takes (sign in, click Authorize, bounce back to the loopback callback).
- The per-server `connect_timeout` field in `mcp_servers.<name>` was silently ignored — setting it to 300 produced no change in behaviour.
- Both are fixed in `_probe_single_server`: config wins when set; otherwise a 300s OAuth default vs. 30s for everything else.

## The bug

`hermes_cli/mcp_config.py:_probe_single_server` previously hard-coded the timeout:

```python
def _probe_single_server(
    name: str, config: dict, connect_timeout: float = 30
) -> List[Tuple[str, str]]:
    ...
    async def _probe():
        server = await asyncio.wait_for(
            _connect_server(name, config), timeout=connect_timeout   # 30s
        )
    ...
    _run_on_mcp_loop(_probe(), timeout=connect_timeout + 10)   # 40s total
```

`config.get(\"connect_timeout\")` was never consulted, so the user-visible config field for tuning per-server timeouts had no effect on the login path. From the issue:

> ```sh
> hermes mcp login supabase
> ✗ Authentication failed: MCP call timed out after 40.0s (configured timeout: 40.0s)
> ```

## The fix

Add `_resolve_probe_timeout(config)` and call it when the caller passes no explicit `connect_timeout`:

1. If `config[\"connect_timeout\"]` is set to a positive numeric value, use it.
2. Otherwise, if `config[\"auth\"] == \"oauth\"`, default to **300s** (OAuth is browser-mediated; humans are slow).
3. Otherwise default to **30s** (stdio + header-auth — fully automated).
4. Invalid configured values (non-numeric, `None`, zero, negative) fall back to the auth-appropriate default rather than passing junk into `asyncio.wait_for`.

Explicit callers may still pass `connect_timeout=...` to override — the existing default-argument call shape is preserved.

## Test plan

- [x] Focused regression: \`uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_mcp_config.py -v\` — 37 passed (5 new in \`TestProbeConnectTimeout\`).
- [x] Regression guard: reverting just \`hermes_cli/mcp_config.py\` while keeping the new tests produces 5 failures (4 by behaviour-mismatch, 1 import-error on the new helper). Restoring the fix passes all 5.
- [x] The new tests cover: (a) configured value wins, (b) OAuth default = 300s, (c) non-OAuth default = 30s, (d) invalid values coerce safely, (e) end-to-end the resolved timeout flows through to \`_run_on_mcp_loop\`.

## Contract Protected

| Invariant | Known-bad input | Behaviour after fix |
|-----------|-----------------|---------------------|
| OAuth probes get enough wall-clock for a human browser flow | \`{\"url\": \"...\", \"auth\": \"oauth\"}\` (no \`connect_timeout\`) | 300s, not 30s |
| Per-server config field is load-bearing | \`{\"auth\": \"oauth\", \"connect_timeout\": 600}\` | 600s |
| Stdio/header transports keep their fast default | \`{\"command\": \"npx\", ...}\` | 30s (unchanged) |
| Garbage config doesn't crash the probe | \`{\"connect_timeout\": \"forever\"}\` | falls back to auth default |

## Related

- Fixes #24097.
- Touches the same module/function as the historical OAuth MCP work (`b7091f93b feat(cli): MCP server management CLI + OAuth 2.1 PKCE auth`) but is purely additive — the `connect_timeout=None` default preserves the existing call shape for `cmd_mcp_add`, `cmd_mcp_test`, `cmd_mcp_login`, `cmd_mcp_configure`.

> Sibling code paths that may need similar treatment: callers of `_probe_single_server` for OAuth servers in `cmd_mcp_add`, `cmd_mcp_test`, `cmd_mcp_configure` are now auto-correct via the helper. The `_run_on_mcp_loop` outer wrapper still adds a fixed +10s; intentionally left as-is to keep the diff small — happy to widen if preferred.