### PR TITLE
fix(tui): block private link title redirects

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -585,7 +585,7 @@ class ProcessRegistry:
             try:
                 if not _IS_WINDOWS:
                     try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)  # windows-footgun: ok - gated by _IS_WINDOWS
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:

--- a/ui-tui/src/__tests__/externalLink.test.ts
+++ b/ui-tui/src/__tests__/externalLink.test.ts
@@ -135,4 +135,25 @@ describe('external link helpers', () => {
     await expect(fetchLinkTitle('file:///tmp/demo.html')).resolves.toBe('')
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  it('does not follow title redirects to private hosts', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.redirect === 'manual') {
+        return new Response('', {
+          headers: { location: 'http://169.254.169.254/latest/meta-data' },
+          status: 302
+        })
+      }
+
+      return new Response('<html><head><title>Instance Metadata</title></head></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200
+      })
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchLinkTitle('https://example.com/redirect')).resolves.toBe('')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/ui-tui/src/lib/externalLink.ts
+++ b/ui-tui/src/lib/externalLink.ts
@@ -9,6 +9,7 @@ const titleSubs = new Map<string, Set<(value: string) => void>>()
 const TITLE_CACHE_LIMIT = 500
 const TITLE_MAX_LENGTH = 240
 const TITLE_BYTE_BUDGET = 96 * 1024
+const TITLE_MAX_REDIRECTS = 5
 const TITLE_TIMEOUT_MS = 5000
 
 const TITLE_USER_AGENT =
@@ -321,34 +322,71 @@ function usableTitle(value: string): string {
   return clean && !TITLE_ERROR_RE.test(clean) ? clean : ''
 }
 
+function redirectTarget(currentUrl: string, location: null | string): string {
+  if (!location) {
+    return ''
+  }
+
+  try {
+    return new URL(location, currentUrl).toString()
+  } catch {
+    return ''
+  }
+}
+
 async function fetchHtmlTitle(normalizedUrl: string): Promise<string> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), TITLE_TIMEOUT_MS)
+  let currentUrl = normalizedUrl
 
   try {
-    const response = await fetch(normalizedUrl, {
-      headers: {
-        Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
-        'Accept-Language': 'en-US,en;q=0.7',
-        'User-Agent': TITLE_USER_AGENT
-      },
-      redirect: 'follow',
-      signal: controller.signal
-    })
+    for (let redirects = 0; redirects <= TITLE_MAX_REDIRECTS; redirects++) {
+      if (!isTitleFetchable(currentUrl)) {
+        return ''
+      }
 
-    if (!response.ok) {
-      return ''
+      const response = await fetch(currentUrl, {
+        headers: {
+          Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.5',
+          'Accept-Language': 'en-US,en;q=0.7',
+          'User-Agent': TITLE_USER_AGENT
+        },
+        redirect: 'manual',
+        signal: controller.signal
+      })
+
+      if (response.status >= 300 && response.status < 400) {
+        const nextUrl = redirectTarget(currentUrl, response.headers.get('location'))
+
+        if (!nextUrl || !isTitleFetchable(nextUrl)) {
+          return ''
+        }
+
+        currentUrl = nextUrl
+
+        continue
+      }
+
+      if (response.url && !isTitleFetchable(response.url)) {
+        return ''
+      }
+
+      if (!response.ok) {
+        return ''
+      }
+
+      const contentType = response.headers.get('content-type')
+
+      if (contentType && !/(?:html|xml|text\/html)/i.test(contentType)) {
+        return ''
+      }
+
+      const html = await readResponseSnippet(response)
+
+      return parseHtmlTitle(html).slice(0, TITLE_MAX_LENGTH)
     }
 
-    const contentType = response.headers.get('content-type')
-
-    if (contentType && !/(?:html|xml|text\/html)/i.test(contentType)) {
-      return ''
-    }
-
-    const html = await readResponseSnippet(response)
-
-    return parseHtmlTitle(html).slice(0, TITLE_MAX_LENGTH)
+    return ''
   } catch {
     return ''
   } finally {


### PR DESCRIPTION
## Summary
- fetch TUI markdown link titles with manual redirects instead of automatic follow
- validate every redirect target with the existing public-HTTP host guard before fetching it
- add regression coverage for a public URL redirecting to 169.254.169.254
- add an inline Windows-footgun suppression for an existing POSIX-gated process_registry false positive because the blocking CI scan checks the whole repo

## Impact
Assistant or user-rendered markdown links can no longer make the TUI title resolver follow redirects to local/private hosts while trying to display a readable title.

## Tests
- npm test -- src/__tests__/externalLink.test.ts
- npm test -- src/__tests__/externalLink.test.ts src/__tests__/markdown.test.ts
- env -u SSH_CONNECTION -u SSH_CLIENT -u SSH_TTY npm test
- npm run type-check
- ./node_modules/.bin/eslint src/lib/externalLink.ts src/__tests__/externalLink.test.ts
- python3 scripts/check-windows-footguns.py tools/process_registry.py
- python3 scripts/check-windows-footguns.py --all
- python3 -m py_compile tools/process_registry.py
- git diff --check