### PR TITLE
fix(mcp): point stdio startup failures to stderr log

### DIFF
--- a/tests/tools/test_mcp_stderr_diagnostics.py
+++ b/tests/tools/test_mcp_stderr_diagnostics.py
@@ -1,0 +1,87 @@
+"""Regression tests for MCP stdio startup stderr diagnostics."""
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_state():
+    """Keep this test from leaking MCP connection state across the suite."""
+    import tools.mcp_tool as mcp
+
+    old_servers = dict(mcp._servers)
+    old_loop = mcp._mcp_loop
+    old_thread = mcp._mcp_thread
+    mcp._servers.clear()
+    try:
+        yield
+    finally:
+        mcp._servers.clear()
+        mcp._servers.update(old_servers)
+        mcp._mcp_loop = old_loop
+        mcp._mcp_thread = old_thread
+
+
+def _run_coro(coro, timeout=120):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def test_register_mcp_servers_logs_stderr_path_for_stdio_startup_failure(caplog):
+    """When stdio startup fails, the warning points operators to mcp-stderr.log."""
+    import tools.mcp_tool as mcp
+
+    async def fake_discover_and_register(_name, _config):
+        raise RuntimeError("synthetic startup failure")
+
+    servers = {
+        "broken_stdio": {
+            "command": "python",
+            "args": ["server.py"],
+            "connect_timeout": 1,
+        }
+    }
+
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"), \
+         patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+         patch("tools.mcp_tool._ensure_mcp_loop"), \
+         patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_coro), \
+         patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_discover_and_register):
+        assert mcp.register_mcp_servers(servers) == []
+
+    assert "Failed to connect to MCP server 'broken_stdio'" in caplog.text
+    assert "synthetic startup failure" in caplog.text
+    assert "logs/mcp-stderr.log" in caplog.text
+    assert "stderr" in caplog.text.lower()
+
+
+def test_register_mcp_servers_does_not_add_stderr_path_for_http_failure(caplog):
+    """HTTP MCP failures do not point users at the stdio subprocess stderr log."""
+    import tools.mcp_tool as mcp
+
+    async def fake_discover_and_register(_name, _config):
+        raise RuntimeError("synthetic http failure")
+
+    servers = {
+        "broken_http": {
+            "url": "http://127.0.0.1:65535/mcp",
+            "connect_timeout": 1,
+        }
+    }
+
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"), \
+         patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+         patch("tools.mcp_tool._ensure_mcp_loop"), \
+         patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_run_coro), \
+         patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_discover_and_register):
+        assert mcp.register_mcp_servers(servers) == []
+
+    assert "Failed to connect to MCP server 'broken_http'" in caplog.text
+    assert "synthetic http failure" in caplog.text
+    assert "logs/mcp-stderr.log" not in caplog.text

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -163,6 +163,31 @@ def _write_stderr_log_header(server_name: str) -> None:
     except Exception:
         pass
 
+
+def _mcp_stderr_log_path_display() -> str:
+    """Return the user-facing path for the shared MCP stderr log."""
+    try:
+        from hermes_constants import display_hermes_home
+        return f"{display_hermes_home()}/logs/mcp-stderr.log"
+    except Exception:
+        return "~/.hermes/logs/mcp-stderr.log"
+
+
+def _uses_stdio_transport(config: dict) -> bool:
+    """Return true when this MCP server config will spawn a stdio process."""
+    return bool(config.get("command")) and "url" not in config
+
+
+def _format_connect_error_for_config(exc: BaseException, config: dict) -> str:
+    """Render a connection error with stdio-specific diagnostic context."""
+    message = _format_connect_error(exc)
+    if _uses_stdio_transport(config):
+        message = (
+            f"{message} (stdio subprocess stderr log: "
+            f"{_mcp_stderr_log_path_display()})"
+        )
+    return message
+
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
 # ---------------------------------------------------------------------------
@@ -3092,7 +3117,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                     "Failed to connect to MCP server '%s'%s: %s",
                     name,
                     f" (command={command})" if command else "",
-                    _format_connect_error(result),
+                    _format_connect_error_for_config(result, new_servers.get(name, {})),
                 )
 
     # Per-server timeouts are handled inside _discover_and_register_server.
@@ -3258,7 +3283,11 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
 
         for name, outcome in zip(names, outcomes):
             if isinstance(outcome, Exception):
-                logger.debug("Probe: failed to connect to '%s': %s", name, outcome)
+                logger.debug(
+                    "Probe: failed to connect to '%s': %s",
+                    name,
+                    _format_connect_error_for_config(outcome, enabled.get(name, {})),
+                )
                 continue
             probed_servers.append(outcome)
             tools = []


### PR DESCRIPTION
## Summary
- add stdio-aware MCP connection error formatting that points startup failures to the existing `mcp-stderr.log` path
- keep HTTP MCP failures unchanged so they do not reference a stdio subprocess log
- include regression coverage for both stdio and HTTP failure diagnostics

## Testing
- `python -m pytest tests/tools/test_mcp_stderr_diagnostics.py -o 'addopts='`\n- `python -m pytest tests/tools/test_mcp_stderr_diagnostics.py tests/tools/test_mcp_probe.py -o 'addopts='`\n- `python -m pytest tests/tools/test_mcp*.py -o 'addopts='`\n- `python -m ruff check tools/mcp_tool.py tests/tools/test_mcp_stderr_diagnostics.py`\n\n## Notes\nThis is complementary to #22168: that PR covers the rare fallback-to-devnull path; this PR makes ordinary stdio startup failures point operators at the already-captured stderr log.