### PR TITLE
fix(agent): prevent silent data loss when message repair shortens history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4664,6 +4664,21 @@ class AIAgent:
             if not self._session_db_created:
                 self._ensure_db_session()
             start_idx = len(conversation_history) if conversation_history else 0
+            # Guard: if _repair_message_sequence() or
+            # _drop_trailing_empty_response_scaffolding() mutated ``messages``
+            # in-place (dropping orphan tool results, merging consecutive user
+            # messages), the list may now be shorter than the original
+            # conversation_history.  Cap both persistence cursors so the
+            # current turn is never silently skipped.
+            if self._last_flushed_db_idx > len(messages):
+                self._last_flushed_db_idx = len(messages)
+            if start_idx > len(messages):
+                logger.warning(
+                    "start_idx=%d > len(messages)=%d — repair removed %d messages; "
+                    "adjusting persistence boundary to last-flushed cursor",
+                    start_idx, len(messages), start_idx - len(messages),
+                )
+                start_idx = self._last_flushed_db_idx
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:
                 role = msg.get("role", "unknown")

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -102,7 +102,13 @@ class TestFlushAfterCompression:
             )
 
     def test_flush_with_stale_history_loses_messages(self):
-        """Demonstrates the bug condition: stale conversation_history causes data loss."""
+        """Regression: stale conversation_history no longer silently drops messages.
+
+        Before the fix, a stale conversation_history longer than the compressed
+        messages list caused flush_from to exceed len(messages), silently
+        skipping the current turn.  Now _flush_messages_to_session_db detects
+        this and adjusts the persistence boundary.
+        """
         from hermes_state import SessionDB
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -126,11 +132,12 @@ class TestFlushAfterCompression:
             agent._flush_messages_to_session_db(compressed, stale_history)
 
             rows = db.get_messages("new-session")
-            # With the stale history, flush_from = max(100, 0) = 100
-            # But compressed only has 2 entries → messages[100:] = empty
-            assert len(rows) == 0, (
-                "Expected 0 messages with stale conversation_history "
-                "(this test verifies the bug condition exists)"
+            # With the fix, stale history is detected and the boundary is
+            # adjusted to _last_flushed_db_idx (0), so all compressed
+            # messages are persisted.
+            assert len(rows) == 2, (
+                f"Expected 2 messages persisted after stale-history adjustment, got {len(rows)}. "
+                f"Fix for #24187 should prevent silent data loss."
             )
 
 

--- a/tests/run_agent/test_flush_from_overflow.py
+++ b/tests/run_agent/test_flush_from_overflow.py
@@ -1,0 +1,134 @@
+"""Regression test for SessionDB flush_from overflow after message repair.
+
+When _repair_message_sequence() or _drop_trailing_empty_response_scaffolding()
+shortens ``messages`` below the original ``conversation_history`` length,
+``flush_from`` can exceed ``len(messages)``.  The fix caps ``flush_from`` so
+the current turn is always persisted rather than silently skipped.
+
+See: https://github.com/NousResearch/hermes-agent/issues/24187
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestFlushFromOverflow:
+    """Verify _flush_messages_to_session_db handles shortened messages."""
+
+    def _make_agent(self, session_db):
+        """Create a minimal AIAgent with a real session DB."""
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="test-session-repair-overflow",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent._ensure_db_session()
+        return agent
+
+    def test_flush_persists_current_turn_after_repair_shortens_messages(self):
+        """Current turn must be persisted even when repair removes historical entries.
+
+        Scenario:
+          - conversation_history has 6 entries (loaded from DB)
+          - messages starts as 8 (history + user + assistant reply)
+          - _repair_message_sequence removes 4 orphan tool messages
+          - messages shrinks to 4
+          - flush_from = len(conversation_history) = 6 > 4 = len(messages)
+          - Without the fix, messages[6:] == [] and the turn is lost.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            session_db = SessionDB(db_path)
+            agent = self._make_agent(session_db)
+
+            # Simulate a conversation history loaded from DB (6 entries).
+            conversation_history = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+                {"role": "user", "content": "ask"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "tc1", "type": "function", "function": {"name": "x", "arguments": "{}"}}]},
+                {"role": "tool", "content": "result", "tool_call_id": "tc1"},
+                {"role": "assistant", "content": "answer"},
+            ]
+
+            # Build messages = history + current turn + some orphan tool msgs
+            # that _repair_message_sequence would drop.
+            messages = list(conversation_history) + [
+                {"role": "user", "content": "current question"},
+                {"role": "assistant", "content": "current answer"},
+                # Orphan tool messages (no matching assistant tool_call in this scope)
+                {"role": "tool", "content": "stale1", "tool_call_id": "orphan-1"},
+                {"role": "tool", "content": "stale2", "tool_call_id": "orphan-2"},
+            ]
+            # Simulate _repair_message_sequence dropping the 2 orphan tool msgs
+            # (in reality it also merges consecutive user messages, but this
+            # captures the core overflow scenario).
+            messages_before = len(messages)  # 10
+            messages = [m for m in messages if not (m.get("role") == "tool" and m.get("tool_call_id", "").startswith("orphan"))]
+            messages_after = len(messages)  # 8
+
+            # The original conversation_history length is still 6.
+            # messages is now 8.  flush_from = 6, which is fine here.
+            # But let's also simulate the more extreme case where repair
+            # removes entries FROM the history (not just the current turn),
+            # making messages shorter than conversation_history.
+            messages_extreme = list(conversation_history[:2]) + [
+                {"role": "user", "content": "current question"},
+                {"role": "assistant", "content": "current answer"},
+            ]
+            # conversation_history len = 6, messages len = 4
+            # flush_from = 6 > 4 = len(messages) → overflow!
+
+            # Write the current turn using the agent's flush method.
+            # We need to manually set messages to simulate the overflow.
+            agent._last_flushed_db_idx = 0
+            agent._flush_messages_to_session_db(messages_extreme, conversation_history)
+
+            # Verify the current turn was persisted.
+            rows = session_db.get_messages("test-session-repair-overflow")
+            persisted_contents = [r["content"] for r in rows if r.get("content")]
+            assert "current question" in persisted_contents, (
+                f"Current user turn not persisted! Contents: {persisted_contents}"
+            )
+            assert "current answer" in persisted_contents, (
+                f"Current assistant turn not persisted! Contents: {persisted_contents}"
+            )
+
+    def test_flush_no_warning_when_messages_longer_than_history(self):
+        """Normal case: no warning when messages >= conversation_history."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            session_db = SessionDB(db_path)
+            agent = self._make_agent(session_db)
+
+            conversation_history = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ]
+            messages = list(conversation_history) + [
+                {"role": "user", "content": "follow up"},
+                {"role": "assistant", "content": "reply"},
+            ]
+
+            agent._last_flushed_db_idx = 0
+            agent._flush_messages_to_session_db(messages, conversation_history)
+
+            rows = session_db.get_messages("test-session-repair-overflow")
+            persisted_contents = [r["content"] for r in rows if r.get("content")]
+            assert "follow up" in persisted_contents
+            assert "reply" in persisted_contents


### PR DESCRIPTION
## What does this PR do?

`_flush_messages_to_session_db()` silently skips persisting the current turn when `_repair_message_sequence()` or `_drop_trailing_empty_response_scaffolding()` shortens `messages` below the original `conversation_history` length.


### Root Cause

`_flush_messages_to_session_db()` computes:
```python
start_idx = len(conversation_history)  # e.g. 120
flush_from = max(start_idx, self._last_flushed_db_idx)
for msg in messages[flush_from:]:
```

When in-place repair (dropping orphan tool messages, merging consecutive user messages) shortens `messages` from 122 to 116, `flush_from = 120 > 116 = len(messages)`, so `messages[120:]` returns `[]`. The current user turn and assistant response are silently not persisted.

Gateway integrations that create a fresh `AIAgent` per inbound message rely on SessionDB for continuity. Once this happens, the session loads stale history and follow-up messages resolve against old context.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A