### PR TITLE
[security] fix(api-server): scope idempotency cache by session context

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -551,26 +551,26 @@ class _IdempotencyCache:
 
     async def get_or_set(self, key: str, fingerprint: str, compute_coro):
         self._purge()
-        item = self._store.get(key)
-        if item and item["fp"] == fingerprint:
+        cache_key = (key, fingerprint)
+        item = self._store.get(cache_key)
+        if item:
             return item["resp"]
 
-        inflight_key = (key, fingerprint)
-        task = self._inflight.get(inflight_key)
+        task = self._inflight.get(cache_key)
         if task is None:
             async def _compute_and_store():
                 resp = await compute_coro()
                 import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+                self._store[cache_key] = {"resp": resp, "ts": _t.time()}
                 self._purge()
                 return resp
 
             task = asyncio.create_task(_compute_and_store())
-            self._inflight[inflight_key] = task
+            self._inflight[cache_key] = task
 
             def _clear_inflight(done_task: "asyncio.Task[Any]") -> None:
-                if self._inflight.get(inflight_key) is done_task:
-                    self._inflight.pop(inflight_key, None)
+                if self._inflight.get(cache_key) is done_task:
+                    self._inflight.pop(cache_key, None)
 
             task.add_done_callback(_clear_inflight)
 
@@ -580,9 +580,15 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    context: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
+    if context:
+        subset["__context__"] = context
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
@@ -1243,7 +1249,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body,
+                keys=["model", "messages", "tools", "tool_choice", "stream"],
+                context={
+                    "session_id": session_id,
+                    "gateway_session_key": gateway_session_key,
+                },
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -27,6 +27,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _idem_cache,
     _CORS_HEADERS,
     _derive_chat_session_id,
     check_api_server_requirements,
@@ -1288,6 +1289,115 @@ class TestChatCompletionsEndpoint:
                     session_ids.append(mock_run.call_args.kwargs["session_id"])
 
         assert session_ids[0] != session_ids[1]
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_is_scoped_by_session_id(self, auth_adapter):
+        """Same Idempotency-Key/body must not replay across session-continuity scopes."""
+        _idem_cache._store.clear()
+        _idem_cache._inflight.clear()
+
+        class FakeSessionDB:
+            def get_messages_as_conversation(self, session_id):
+                return [{"role": "user", "content": f"PRIVATE_HISTORY_FOR_{session_id}"}]
+
+        async def _mock_run_agent(**kwargs):
+            history = kwargs["conversation_history"]
+            session_id = kwargs["session_id"]
+            return (
+                {
+                    "final_response": f"computed_for={session_id}; history={history}",
+                    "messages": [],
+                    "api_calls": 1,
+                },
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        app = _create_app(auth_adapter)
+        body = {
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "summarize my previous conversation"}],
+        }
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(auth_adapter, "_ensure_session_db", return_value=FakeSessionDB()),
+                patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run,
+            ):
+                victim_resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "same-key",
+                        "X-Hermes-Session-Id": "victim",
+                    },
+                )
+                attacker_resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "same-key",
+                        "X-Hermes-Session-Id": "attacker",
+                    },
+                )
+                attacker_data = await attacker_resp.json()
+
+        assert victim_resp.status == 200
+        assert attacker_resp.status == 200
+        assert mock_run.call_count == 2
+        attacker_content = attacker_data["choices"][0]["message"]["content"]
+        assert "computed_for=attacker" in attacker_content
+        assert "PRIVATE_HISTORY_FOR_attacker" in attacker_content
+        assert "PRIVATE_HISTORY_FOR_victim" not in attacker_content
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_is_scoped_by_session_key(self, auth_adapter):
+        """Same Idempotency-Key/body must not replay across memory/session-key scopes."""
+        _idem_cache._store.clear()
+        _idem_cache._inflight.clear()
+
+        async def _mock_run_agent(**kwargs):
+            gateway_session_key = kwargs["gateway_session_key"]
+            return (
+                {
+                    "final_response": f"computed_for_key={gateway_session_key}",
+                    "messages": [],
+                    "api_calls": 1,
+                },
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        app = _create_app(auth_adapter)
+        body = {
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "use my memory"}],
+        }
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                first_resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "same-key",
+                        "X-Hermes-Session-Key": "memory-a",
+                    },
+                )
+                second_resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=body,
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "Idempotency-Key": "same-key",
+                        "X-Hermes-Session-Key": "memory-b",
+                    },
+                )
+                second_data = await second_resp.json()
+
+        assert first_resp.status == 200
+        assert second_resp.status == 200
+        assert mock_run.call_count == 2
+        assert second_data["choices"][0]["message"]["content"] == "computed_for_key=memory-b"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR hardens the OpenAI-compatible API server's non-streaming chat-completions idempotency cache so cached responses cannot be replayed across different Hermes session or memory scopes.

The patch:
- includes `X-Hermes-Session-Id` and `X-Hermes-Session-Key` derived context in the idempotency fingerprint
- stores completed idempotency entries by `(Idempotency-Key, fingerprint)` instead of by `Idempotency-Key` alone
- adds regression tests for both persisted session-history scope and session-key / memory scope

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Chat-completions idempotency cache omitted session context | A client reusing another client's idempotency key/body in a shared API-server deployment could receive a response computed with the other client's session history or memory scope | High |

## Before this PR

- Non-streaming `POST /v1/chat/completions` cached responses by `Idempotency-Key` plus a request-body fingerprint.
- The fingerprint covered `model`, `messages`, `tools`, `tool_choice`, and `stream`.
- The computed response also depended on session-scoped context:
  - `X-Hermes-Session-Id`, which can load persisted conversation history
  - `X-Hermes-Session-Key`, which can scope long-term memory
- Those response-affecting headers were not part of the idempotency scope.

## After this PR

- The idempotency fingerprint includes the normalized session context used by the request:
  - effective `session_id`
  - effective `gateway_session_key`
- Two requests with the same body and same `Idempotency-Key` but different session or memory scope recompute separately.
- Regression tests lock both boundaries:
  - different `X-Hermes-Session-Id` values do not share cached responses
  - different `X-Hermes-Session-Key` values do not share cached responses

## Why this matters

`X-Hermes-Session-Id` is intentionally protected behind API-key auth because it can expose stored conversation history. Once that history is loaded, it becomes part of the response-affecting security context.

If the idempotency cache ignores that context, a shared API-server deployment can cross the session confidentiality boundary: a second client that repeats the same idempotency key and request body can receive a response originally computed for another session.

## How this differs from #13239, #7582, and #13295

The existing idempotency PRs addressed concurrent duplicate execution:

- #13239 / #13295: deduplicate concurrent requests with the same idempotency key and fingerprint
- #7582: proposed a per-key lock for the same duplicate-computation race

This PR fixes a different failure mode in the same helper family: the fingerprint itself was missing response-affecting session context. The previous fixes can correctly deduplicate duplicate work while still deduplicating across the wrong session boundary if the fingerprint omits `X-Hermes-Session-Id` / `X-Hermes-Session-Key` effects.

## Attack flow

```text
Victim request with Idempotency-Key: K and X-Hermes-Session-Id: victim
    -> API server loads victim session history
        -> response is cached under K + body-only fingerprint
            -> attacker repeats K + same body with X-Hermes-Session-Id: attacker
                -> vulnerable code returns victim-derived cached response
```

## Affected code

| Issue | Files |
|-------|-------|
| Session-unscoped idempotency cache for chat completions | `gateway/platforms/api_server.py`, `tests/gateway/test_api_server.py` |

## Root cause

Chat-completions idempotency cache omitted session context:
- Direct cause: `_make_request_fingerprint()` only hashed selected request-body fields for non-streaming chat completions.
- Boundary failure: `_handle_chat_completions()` also passes loaded `conversation_history`, `session_id`, and `gateway_session_key` into `_run_agent()`, so those values affect the response and must be part of the idempotency scope.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Session-unscoped chat-completions idempotency cache | 8.5 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N` |

Rationale:
- Network-reachable API clients with a valid shared API credential can trigger the cache behavior.
- The impact is confidentiality-only and bounded to shared API-server deployments where idempotency keys/bodies can collide or be reused.
- Scope is treated as changed because one authenticated client/session can receive response content derived from another session's stored history or memory scope.

## Safe reproduction steps

1. Configure the API server with an API key.
2. Send a non-streaming `POST /v1/chat/completions` request with:
   - `Authorization: Bearer <api-key>`
   - `Idempotency-Key: same-key`
   - `X-Hermes-Session-Id: victim`
   - a body such as `summarize my previous conversation`
3. Send the same body and same idempotency key with:
   - `X-Hermes-Session-Id: attacker`
4. On vulnerable code, the second request can receive the first request's cached response instead of recomputing under the attacker session.

The regression test uses a safe local mock session database that returns `PRIVATE_HISTORY_FOR_victim` and `PRIVATE_HISTORY_FOR_attacker` for different session IDs, then verifies the attacker response is recomputed for `attacker` rather than replaying `victim`.

## Expected vulnerable behavior

On vulnerable code:
- `_run_agent()` is called only once for the victim request.
- The second request receives content derived from the victim session despite sending `X-Hermes-Session-Id: attacker`.

## Changes in this PR

- Adds an optional `context` parameter to `_make_request_fingerprint()`.
- Includes effective `session_id` and `gateway_session_key` in the non-streaming chat-completions idempotency fingerprint.
- Stores `_IdempotencyCache` entries by `(Idempotency-Key, fingerprint)` so different fingerprints for the same idempotency key do not overwrite each other.
- Adds focused regression tests for session ID and session key isolation.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API server hardening | `gateway/platforms/api_server.py` | Scope idempotency cache entries and fingerprints to response-affecting session context |
| Regression tests | `tests/gateway/test_api_server.py` | Add session ID and session key cache-isolation tests |

## Maintainer impact

- Existing duplicate-request behavior is preserved for identical body and identical session context.
- Streaming chat completions are unchanged; the affected cache is only used for non-streaming responses.
- The patch is narrow to the API-server idempotency path and does not change dashboard, gateway platform, or provider behavior.

## Fix rationale

Idempotency should only reuse a response when every response-affecting security context matches. The request body alone is not sufficient for Hermes API-server chat completions because session-continuity headers can load stored history and memory context before the agent runs.

Including the effective session context in the fingerprint keeps useful retry deduplication while preventing cache reuse across session boundaries.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused idempotency/session regressions passed
- [x] Full `tests/gateway/test_api_server.py` passed
- [x] Syntax, whitespace, and ruff checks passed for touched files
- [ ] Full `tests/gateway/` is not green on this local checkout; unrelated current-main failures remain outside this patch scope
- [ ] Remote `test` / `e2e` currently fail during dependency installation before tests run because `uv pip install -e ".[all,dev]"` cannot resolve `mistralai>=2.3.0,<3`; this appears unrelated to the touched API-server files
- [ ] Remote `Windows footguns (blocking)` currently reports pre-existing `tools/process_registry.py` findings outside this patch scope

Executed with:

```bash
scripts/run_tests.sh \
  tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_idempotency_key_is_scoped_by_session_id \
  tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_idempotency_key_is_scoped_by_session_key \
  tests/gateway/test_api_server.py::TestIdempotencyCache -q
```

Result: `5 passed, 2 warnings`

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py -q
```

Result: `143 passed, 94 warnings`

```bash
python3.11 -m compileall -q gateway/platforms/api_server.py tests/gateway/test_api_server.py
git diff --check
uv run ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py
```

Result: all passed.

Broader gateway suite note:

```bash
ulimit -n 4096 && scripts/run_tests.sh tests/gateway/ -q
```

This still shows unrelated current-main failures in Dingtalk/Google Chat/TTS media routing/update/verbose tests. The focused API-server suite and touched-file checks above pass.


## Disclosure notes

- This PR is bounded to shared API-server deployments and the non-streaming `/v1/chat/completions` idempotency cache.
- It does not claim unauthenticated access; an API credential is required when session-continuity headers are used.
- No unrelated files were changed.
