### PR TITLE
fix(runtime): detach concurrent tool batches on interrupt

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -123,9 +123,10 @@ def _budget_for_agent(agent) -> BudgetConfig:
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
 _DEFAULT_IMAGE_PARALLEL_REQUESTS = 4
-# Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
-# guard does not preempt a slow-but-valid summarization attempt.
+# Generous ceiling for slow-but-valid tool work (large page fetches, slow
+# remote backends) so the batch guard does not preempt a legitimate attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
+_CONCURRENT_TOOL_POLL_INTERVAL_S = 0.2
 # Upper bound a concurrent worker will wait at the start-order gate for all
 # earlier-ordered tools to advance before proceeding out of order. Long enough
 # to cover slow-but-legitimate authorization (e.g. an approval round-trip),
@@ -1409,6 +1410,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 return
             except KeyboardInterrupt:
+                if batch_abandoned.is_set():
+                    return
                 try:
                     agent.interrupt("keyboard interrupt")
                 except Exception:
@@ -1438,6 +1441,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
+            if batch_abandoned.is_set():
+                logger.info(
+                    "discarding late completion from abandoned concurrent tool "
+                    "batch (tool=%s, %.2fs)",
+                    function_name,
+                    duration,
+                )
+                return
             if not blocked and not dispatched:
                 _emit_terminal_post_tool_call(
                     agent,
@@ -1454,6 +1465,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
             else:
                 logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
+            if batch_abandoned.is_set():
+                logger.info(
+                    "discarding completion that raced batch abandonment (tool=%s)",
+                    function_name,
+                )
+                return
             results[index] = (
                 function_name,
                 function_args,
@@ -1574,7 +1591,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _conc_start = time.time()
                 _interrupt_logged = False
                 while True:
-                    wait_timeout = 5.0
+                    wait_timeout = _CONCURRENT_TOOL_POLL_INTERVAL_S
                     if deadline is not None:
                         effective_deadline = (
                             deadline + authorization_gate.excluded_seconds()
@@ -1654,7 +1671,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         _abandon_batch()
                         # Give already-running tools a moment to notice the
                         # per-thread interrupt signal and exit gracefully.
-                        concurrent.futures.wait(not_done, timeout=3.0)
+                        concurrent.futures.wait(
+                            not_done, timeout=_CONCURRENT_TOOL_POLL_INTERVAL_S
+                        )
                         break
 
                     _conc_elapsed = int(time.time() - _conc_start)

--- a/run_agent.py
+++ b/run_agent.py
@@ -372,6 +372,7 @@ _DESTRUCTIVE_PATTERNS = re.compile(
 )
 # Output redirects that overwrite files (> but not >>)
 _REDIRECT_OVERWRITE = re.compile(r'[^>]>[^>]|^>[^>]')
+_CONCURRENT_TOOL_POLL_INTERVAL_S = 0.2
 
 
 def _is_destructive_command(cmd: str) -> bool:
@@ -427,6 +428,82 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
             return False
 
     return True
+
+
+def _ensure_concurrent_batch_state(agent) -> None:
+    """Lazily initialize concurrent-tool batch state on *agent*."""
+    if getattr(agent, "_active_concurrent_batch_lock", None) is None:
+        agent._active_concurrent_batch_lock = threading.Lock()
+    if not hasattr(agent, "_active_concurrent_batch"):
+        agent._active_concurrent_batch = None
+    if not hasattr(agent, "_concurrent_batch_seq"):
+        agent._concurrent_batch_seq = 0
+
+
+def _begin_concurrent_tool_batch(agent) -> dict[str, Any]:
+    """Register a new live concurrent-tool batch on *agent*."""
+    _ensure_concurrent_batch_state(agent)
+    with agent._active_concurrent_batch_lock:
+        agent._concurrent_batch_seq += 1
+        batch = {
+            "id": agent._concurrent_batch_seq,
+            "detached": False,
+            "executor": None,
+        }
+        agent._active_concurrent_batch = batch
+    return batch
+
+
+def _attach_concurrent_batch_executor(agent, batch: dict[str, Any], executor) -> bool:
+    """Attach *executor* to *batch*. Return True when the batch is still live."""
+    _ensure_concurrent_batch_state(agent)
+    with agent._active_concurrent_batch_lock:
+        batch["executor"] = executor
+        return agent._active_concurrent_batch is batch and not batch.get("detached", False)
+
+
+def _concurrent_batch_accepts_late_delivery(agent, batch: Optional[dict[str, Any]]) -> bool:
+    """Return True while *batch* is still the live batch for *agent*."""
+    if batch is None:
+        return False
+    _ensure_concurrent_batch_state(agent)
+    with agent._active_concurrent_batch_lock:
+        return agent._active_concurrent_batch is batch and not batch.get("detached", False)
+
+
+def _detach_concurrent_tool_batch(agent, batch: Optional[dict[str, Any]] = None) -> bool:
+    """Detach a concurrent-tool batch so the current turn can move on."""
+    _ensure_concurrent_batch_state(agent)
+    executor = None
+    with agent._active_concurrent_batch_lock:
+        current = batch if batch is not None else agent._active_concurrent_batch
+        if current is None:
+            return False
+        if current.get("detached", False):
+            return True
+        current["detached"] = True
+        executor = current.get("executor")
+        current["executor"] = None
+        if agent._active_concurrent_batch is current:
+            agent._active_concurrent_batch = None
+    if executor is not None:
+        try:
+            executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            pass
+    return True
+
+
+def _finish_concurrent_tool_batch(agent, batch: Optional[dict[str, Any]]) -> None:
+    """Retire *batch* from *agent* after the concurrent executor path exits."""
+    if batch is None:
+        return
+    _ensure_concurrent_batch_state(agent)
+    with agent._active_concurrent_batch_lock:
+        batch["detached"] = True
+        batch["executor"] = None
+        if agent._active_concurrent_batch is batch:
+            agent._active_concurrent_batch = None
 
 
 def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Path | None:
@@ -1347,6 +1424,9 @@ class AIAgent:
         # their tids explicitly.
         self._tool_worker_threads: set[int] = set()
         self._tool_worker_threads_lock = threading.Lock()
+        self._active_concurrent_batch: Optional[dict[str, Any]] = None
+        self._active_concurrent_batch_lock = threading.Lock()
+        self._concurrent_batch_seq = 0
         
         # Subagent delegation state
         self._delegate_depth = 0        # 0 = top-level agent, incremented for children
@@ -5229,6 +5309,13 @@ class AIAgent:
                     _set_interrupt(True, _wtid)
                 except Exception:
                     pass
+        # Detach any in-flight concurrent tool batch so the current turn can
+        # return immediately instead of blocking on slow, non-interruptible
+        # worker threads inside ThreadPoolExecutor.__exit__().
+        try:
+            _detach_concurrent_tool_batch(self)
+        except Exception:
+            pass
         # Propagate interrupt to any running child agents (subagent delegation)
         with self._active_children_lock:
             children_copy = list(self._active_children)
@@ -10672,6 +10759,26 @@ class AIAgent:
         # deadlocks against prompt_toolkit's raw terminal mode (#13617).
         _parent_approval_cb = _get_approval_callback()
         _parent_sudo_cb = _get_sudo_password_callback()
+        _batch = None
+
+        def _batch_accepts_callbacks() -> bool:
+            return _concurrent_batch_accepts_late_delivery(self, _batch)
+
+        def _batch_touch_activity(desc: str) -> None:
+            if _batch_accepts_callbacks():
+                self._touch_activity(desc)
+
+        def _batch_approval_callback(command, description, *, allow_permanent=True):
+            if not _batch_accepts_callbacks():
+                return "deny"
+            return _parent_approval_cb(
+                command, description, allow_permanent=allow_permanent
+            )
+
+        def _batch_sudo_callback():
+            if not _batch_accepts_callbacks():
+                return ""
+            return _parent_sudo_cb() or ""
 
         def _run_tool(index, tool_call, function_name, function_args):
             """Worker function executed in a thread."""
@@ -10696,35 +10803,60 @@ class AIAgent:
             # is invisible to worker threads.
             try:
                 from tools.environments.base import set_activity_callback
-                set_activity_callback(self._touch_activity)
+                set_activity_callback(_batch_touch_activity)
             except Exception:
                 pass
             # Propagate approval/sudo callbacks to this worker thread.
             # Mirrors cli.py run_agent() pattern (GHSA-qg5c-hvr5-hjgr).
             if _parent_approval_cb is not None:
                 try:
-                    _set_approval_callback(_parent_approval_cb)
+                    _set_approval_callback(_batch_approval_callback)
                 except Exception:
                     pass
             if _parent_sudo_cb is not None:
                 try:
-                    _set_sudo_password_callback(_parent_sudo_cb)
+                    _set_sudo_password_callback(_batch_sudo_callback)
                 except Exception:
                     pass
             start = time.time()
             try:
-                result = self._invoke_tool(
-                    function_name,
-                    function_args,
-                    effective_task_id,
-                    tool_call.id,
-                    messages=messages,
-                    pre_tool_block_checked=True,
-                )
+                if not _batch_accepts_callbacks():
+                    result = (
+                        f"[Tool execution cancelled — {function_name} was skipped "
+                        "due to user interrupt]"
+                    )
+                else:
+                    result = self._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                        pre_tool_block_checked=True,
+                    )
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
+            if not _batch_accepts_callbacks():
+                logger.info(
+                    "discarding late tool completion from detached concurrent "
+                    "batch (tool=%s, %.2fs)",
+                    function_name,
+                    duration,
+                )
+                with self._tool_worker_threads_lock:
+                    self._tool_worker_threads.discard(_worker_tid)
+                try:
+                    _set_interrupt(False, _worker_tid)
+                except Exception:
+                    pass
+                try:
+                    _set_approval_callback(None)
+                    _set_sudo_password_callback(None)
+                except Exception:
+                    pass
+                return
             is_error, _ = _detect_tool_failure(function_name, result)
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -10764,59 +10896,101 @@ class AIAgent:
             futures = []
             if runnable_calls:
                 max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
-                with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-                    for i, tc, name, args in runnable_calls:
-                        # Propagate ContextVars (e.g. _approval_session_key); mirrors asyncio.to_thread.
-                        ctx = contextvars.copy_context()
-                        f = executor.submit(ctx.run, _run_tool, i, tc, name, args)
-                        futures.append(f)
-
-                    # Wait for all to complete with periodic heartbeats so the
-                    # gateway's inactivity monitor doesn't kill us during long
-                    # concurrent tool batches. Also check for user interrupts
-                    # so we don't block indefinitely when the user sends /stop
-                    # or a new message during concurrent tool execution.
-                    _conc_start = time.time()
-                    _interrupt_logged = False
-                    while True:
-                        done, not_done = concurrent.futures.wait(
-                            futures, timeout=5.0,
-                        )
-                        if not not_done:
-                            break
-
-                        # Check for interrupt — the per-thread interrupt signal
-                        # already causes individual tools (terminal, execute_code)
-                        # to abort, but tools without interrupt checks (web_search,
-                        # read_file) will run to completion. Cancel any futures
-                        # that haven't started yet so we don't block on them.
-                        if self._interrupt_requested:
-                            if not _interrupt_logged:
-                                _interrupt_logged = True
-                                self._vprint(
-                                    f"{self.log_prefix}⚡ Interrupt: cancelling "
-                                    f"{len(not_done)} pending concurrent tool(s)",
-                                    force=True,
+                _batch = _begin_concurrent_tool_batch(self)
+                executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+                try:
+                    if _attach_concurrent_batch_executor(self, _batch, executor):
+                        submitted_calls = []
+                        for i, tc, name, args in runnable_calls:
+                            if not _concurrent_batch_accepts_late_delivery(self, _batch):
+                                logger.info(
+                                    "concurrent batch detached during submission; "
+                                    "skipping remaining tool launches"
                                 )
-                            for f in not_done:
-                                f.cancel()
-                            # Give already-running tools a moment to notice the
-                            # per-thread interrupt signal and exit gracefully.
-                            concurrent.futures.wait(not_done, timeout=3.0)
-                            break
+                                break
+                            # Propagate ContextVars (e.g. _approval_session_key); mirrors asyncio.to_thread.
+                            ctx = contextvars.copy_context()
+                            try:
+                                f = executor.submit(ctx.run, _run_tool, i, tc, name, args)
+                            except RuntimeError:
+                                if not _concurrent_batch_accepts_late_delivery(self, _batch):
+                                    logger.info(
+                                        "executor shut down while detaching concurrent "
+                                        "batch; skipping remaining tool launches"
+                                    )
+                                    break
+                                raise
+                            futures.append(f)
+                            submitted_calls.append((i, tc, name, args))
 
-                        _conc_elapsed = int(time.time() - _conc_start)
-                        # Heartbeat every ~30s (6 × 5s poll intervals)
-                        if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
-                            _still_running = [
-                                parsed_calls[futures.index(f)][1]
-                                for f in not_done
-                                if f in futures
-                            ]
-                            self._touch_activity(
-                                f"concurrent tools running ({_conc_elapsed}s, "
-                                f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"
+                        # Wait for all to complete with periodic heartbeats so the
+                        # gateway's inactivity monitor doesn't kill us during long
+                        # concurrent tool batches. Also check for user interrupts
+                        # so we don't block indefinitely when the user sends /stop
+                        # or a new message during concurrent tool execution.
+                        _conc_start = time.time()
+                        _interrupt_logged = False
+                        _last_heartbeat_second = -1
+                        _future_to_name = {
+                            future: name
+                            for future, (_i, _tc, name, _args) in zip(futures, submitted_calls)
+                        }
+                        while True:
+                            done, not_done = concurrent.futures.wait(
+                                futures, timeout=_CONCURRENT_TOOL_POLL_INTERVAL_S,
                             )
+                            if not not_done:
+                                break
+
+                            # Check for interrupt — the per-thread interrupt signal
+                            # already causes individual tools (terminal, execute_code)
+                            # to abort, but tools without interrupt checks (web_search,
+                            # read_file) will run to completion. Detach the batch so the
+                            # current turn can return immediately instead of waiting for
+                            # the executor to drain those threads.
+                            if self._interrupt_requested:
+                                if not _interrupt_logged:
+                                    _interrupt_logged = True
+                                    self._vprint(
+                                        f"{self.log_prefix}⚡ Interrupt: cancelling "
+                                        f"{len(not_done)} pending concurrent tool(s)",
+                                        force=True,
+                                    )
+                                for f in not_done:
+                                    f.cancel()
+                                _detach_concurrent_tool_batch(self, _batch)
+                                # Give already-running tools a brief chance to
+                                # notice the per-thread interrupt signal without
+                                # keeping the interrupted turn on the hook.
+                                concurrent.futures.wait(not_done, timeout=0.2)
+                                break
+
+                            _conc_elapsed = int(time.time() - _conc_start)
+                            # Heartbeat every ~30s while using a short poll
+                            # interval so interrupts can detach promptly.
+                            if (
+                                _conc_elapsed > 0
+                                and _conc_elapsed % 30 == 0
+                                and _conc_elapsed != _last_heartbeat_second
+                            ):
+                                _last_heartbeat_second = _conc_elapsed
+                                _still_running = [
+                                    _future_to_name.get(f, "?")
+                                    for f in not_done
+                                ]
+                                self._touch_activity(
+                                    f"concurrent tools running ({_conc_elapsed}s, "
+                                    f"{len(not_done)} remaining: {', '.join(_still_running[:3])})"
+                                )
+                finally:
+                    try:
+                        if _concurrent_batch_accepts_late_delivery(self, _batch):
+                            executor.shutdown(wait=True)
+                        else:
+                            executor.shutdown(wait=False, cancel_futures=True)
+                    except Exception:
+                        pass
+                    _finish_concurrent_tool_batch(self, _batch)
         finally:
             if spinner:
                 # Build a summary message for the spinner stop

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -3,6 +3,7 @@
 import concurrent.futures
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,7 +33,7 @@ def _make_agent(monkeypatch):
         verbose_logging = False
         log_prefix_chars = 200
         _checkpoint_mgr = MagicMock(enabled=False)
-        _subdirectory_hints = MagicMock()
+        _subdirectory_hints = MagicMock(check_tool_call=MagicMock(return_value=""))
         tool_progress_callback = None
         tool_start_callback = None
         tool_complete_callback = None
@@ -44,6 +45,11 @@ def _make_agent(monkeypatch):
         _current_tool = None
         _last_activity = 0
         _print_fn = print
+        _tool_guardrails = MagicMock(
+            before_call=MagicMock(
+                return_value=SimpleNamespace(allows_execution=True)
+            )
+        )
         # Worker-thread tracking state mirrored from AIAgent.__init__ so the
         # real interrupt() method can fan out to concurrent-tool workers.
         _active_children: list = []
@@ -53,6 +59,9 @@ def _make_agent(monkeypatch):
             self._tool_worker_threads: set = set()
             self._tool_worker_threads_lock = threading.Lock()
             self._active_children_lock = threading.Lock()
+            self._active_concurrent_batch = None
+            self._active_concurrent_batch_lock = threading.Lock()
+            self._concurrent_batch_seq = 0
 
         def _touch_activity(self, desc):
             self._last_activity = time.time()
@@ -71,6 +80,12 @@ def _make_agent(monkeypatch):
 
         def _has_stream_consumers(self):
             return False
+
+        def _guardrail_block_result(self, decision):
+            raise AssertionError("guardrail block path should not be used in this test")
+
+        def _append_guardrail_observation(self, function_name, function_args, function_result, failed=False):
+            return function_result
 
     stub = _Stub()
     # Bind the real methods under test
@@ -144,3 +159,78 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "worker tid — stale interrupt can leak into the next turn"
     )
 
+
+def test_concurrent_interrupt_detaches_running_workers_and_returns_fast(monkeypatch):
+    """Interrupting a running concurrent batch must return promptly.
+
+    Regression target: ``_execute_tool_calls_concurrent`` used a ``with
+    ThreadPoolExecutor(...)`` block, so even after cancelling pending futures it
+    still waited for already-running workers when ``__exit__`` called
+    ``shutdown(wait=True)``. That made /stop look successful while the turn was
+    still blocked on non-interruptible tools.
+    """
+    agent = _make_agent(monkeypatch)
+    started = threading.Event()
+    release = threading.Event()
+    shutdown_calls: list[tuple[bool, bool]] = []
+
+    real_shutdown = concurrent.futures.ThreadPoolExecutor.shutdown
+
+    def tracking_shutdown(self, wait=True, cancel_futures=False):
+        shutdown_calls.append((wait, cancel_futures))
+        return real_shutdown(self, wait=wait, cancel_futures=cancel_futures)
+
+    monkeypatch.setattr(
+        concurrent.futures.ThreadPoolExecutor,
+        "shutdown",
+        tracking_shutdown,
+    )
+
+    def _slow_tool(*args, **kwargs):
+        started.set()
+        release.wait(timeout=5.0)
+        return '{"ok": true, "late": true}'
+
+    agent._invoke_tool = MagicMock(side_effect=_slow_tool)
+
+    tc1 = _FakeToolCall("tool_a", call_id="tc_a")
+    tc2 = _FakeToolCall("tool_b", call_id="tc_b")
+    msg = _FakeAssistantMsg([tc1, tc2])
+    messages = []
+
+    runner = threading.Thread(
+        target=agent._execute_tool_calls_concurrent,
+        args=(msg, messages, "test_task"),
+    )
+    t0 = time.time()
+    runner.start()
+
+    assert started.wait(timeout=1.0), "concurrent worker never started"
+    agent.interrupt("stop")
+    runner.join(timeout=1.0)
+    elapsed = time.time() - t0
+
+    assert not runner.is_alive(), (
+        f"concurrent interrupt path blocked for {elapsed:.2f}s waiting on a "
+        "running worker; it should detach the batch and return promptly"
+    )
+    assert elapsed < 1.0, (
+        f"interrupt path took {elapsed:.2f}s — expected prompt return after "
+        "detaching the concurrent batch"
+    )
+    assert len(messages) == 2
+    contents = [m["content"] for m in messages]
+    assert all("skipped due to user interrupt" in content for content in contents)
+    assert any(
+        wait is False and cancel_futures is True
+        for wait, cancel_futures in shutdown_calls
+    ), (
+        "interrupt never triggered a non-blocking executor shutdown; a live "
+        "worker can still hold the turn open if shutdown(wait=True) wins"
+    )
+
+    # Let the detached worker threads unwind. Their late results must not
+    # replace the interrupt placeholders already emitted to the model.
+    release.set()
+    time.sleep(0.05)
+    assert [m["content"] for m in messages] == contents

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -71,6 +71,15 @@ def _make_agent(monkeypatch):
         def _has_stream_consumers(self):
             return False
 
+        def _tool_result_content_for_active_model(self, _name, result):
+            return result
+
+        def _append_guardrail_observation(self, _name, _args, result, **_kwargs):
+            return result
+
+        def _record_file_mutation_result(self, *_args, **_kwargs):
+            pass
+
     stub = _Stub()
     # Bind the real methods under test
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
@@ -80,6 +89,8 @@ def _make_agent(monkeypatch):
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.
     stub._apply_pending_steer_to_tool_results = lambda *a, **kw: None
+    stub._subdirectory_hints.check_tool_call.return_value = ""
+    stub._flush_messages_to_session_db = lambda *a, **kw: True
     stub._invoke_tool = MagicMock(side_effect=lambda *a, **kw: '{"ok": true}')
     return stub
 
@@ -142,4 +153,60 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "clear_interrupt() did not clear the interrupt bit for a tracked "
         "worker tid — stale interrupt can leak into the next turn"
     )
+
+
+def test_interrupt_detaches_noncooperative_concurrent_batch(monkeypatch):
+    """An interrupted batch returns promptly and suppresses late completions."""
+    import agent.tool_executor as tool_executor
+    from agent.tool_executor import _ManagedToolResult
+
+    agent = _make_agent(monkeypatch)
+    started = threading.Event()
+    release = threading.Event()
+
+    def _blocking_middleware(agent_arg, **kwargs):
+        started.set()
+        release.wait(timeout=10)
+        return _ManagedToolResult(
+            result='{"late": true}',
+            args=kwargs.get("function_args", {}),
+            middleware_trace=[],
+            blocked=False,
+            dispatched=True,
+        )
+
+    monkeypatch.setattr(
+        tool_executor,
+        "_run_agent_tool_execution_middleware",
+        _blocking_middleware,
+    )
+    monkeypatch.setattr(tool_executor, "_resolve_concurrent_tool_timeout", lambda: None)
+
+    messages = []
+    worker = threading.Thread(
+        target=agent._execute_tool_calls_concurrent,
+        args=(_FakeAssistantMsg([
+            _FakeToolCall("tool_a", call_id="tc_a"),
+            _FakeToolCall("tool_b", call_id="tc_b"),
+        ]), messages, "test_task"),
+        daemon=True,
+    )
+    worker.start()
+    assert started.wait(timeout=2.0)
+
+    started_at = time.monotonic()
+    agent.interrupt("user stop")
+    worker.join(timeout=2.0)
+    elapsed = time.monotonic() - started_at
+
+    assert not worker.is_alive()
+    assert elapsed < 1.5
+    assert messages
+    assert all("cancelled" in str(message.get("content", "")) for message in messages)
+
+    # Let the abandoned daemon workers finish. Their result must not be
+    # appended or projected after the interrupted turn has moved on.
+    release.set()
+    time.sleep(0.1)
+    assert all("late" not in str(message) for message in messages)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a runtime bug where interrupting a concurrent tool batch did not actually release the current turn promptly.

Before this change, `_execute_tool_calls_concurrent()` used `with ThreadPoolExecutor(...)`. On interrupt, Hermes cancelled futures that had not started yet, but `ThreadPoolExecutor.__exit__()` still called `shutdown(wait=True)`. In practice, `/stop` or a new user message could appear to succeed while the current turn was still blocked on already-running tools like `web_search`, file reads, or custom plugins that do not actively poll for interrupts.

This approach keeps the normal concurrent path intact, but makes interrupted concurrent batches detachable so the current turn can return promptly.

## Related Issue

NA

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `run_agent.py` to track the active concurrent tool batch on the agent
- replaced the implicit `ThreadPoolExecutor` lifetime with explicit attach/detach/shutdown handling
- detach the active concurrent batch during `interrupt()` so the current turn does not wait for long-running workers to drain
- added a short poll interval in the concurrent wait loop so interrupts are noticed promptly
- reject late callback delivery and discard late tool results after a batch has been detached
- handled the submit-time race where the executor can be shut down while a concurrent batch is being detached
- added a regression test in `tests/run_agent/test_concurrent_interrupt.py` covering prompt interrupt return and late-result suppression

## How to Test

1. Run:
   ```bash
   PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_concurrent_interrupt.py -q
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k concurrent
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_tool_call_guardrail_runtime.py -q
   ```
2. Confirm the results are:
   - `tests/run_agent/test_concurrent_interrupt.py`: `3 passed`
   - `tests/run_agent/test_run_agent.py -k concurrent`: `22 passed, 303 deselected`
   - `tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_tool_call_guardrail_runtime.py`: `19 passed`
3. Optionally reproduce the original issue by interrupting a concurrent tool batch with a slow non-cooperative tool and confirm the turn returns promptly instead of waiting for executor drain.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu / local Linux `pytest` via `/home/cyt/miniconda3/envs/meta_workflow_py312/bin/python`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual reproduction harness against `upstream/main` and this branch, forcing `_MAX_TOOL_WORKERS = 1` so one tool is running while the batch is interrupted:

```bash
$ # upstream/main baseline
$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python repro_concurrent_interrupt.py
Could not import tool module tools.browser_dialog_tool: No module named 'websockets'
{'phase': 'before_fix', 'started_wait': True, 'alive_after_1s': True, 'elapsed_after_1s': 1.0, 'total_elapsed': 1.0, 'message_count': 2, 'messages': ['{"ok": true, "late": true}', '{"ok": true, "late": true}']}

$ # fix/concurrent-tool-interrupt
$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python repro_concurrent_interrupt.py
Could not import tool module tools.browser_dialog_tool: No module named 'websockets'
{'phase': 'after_fix', 'started_wait': True, 'alive_after_1s': False, 'elapsed_after_1s': 0.43, 'total_elapsed': 0.43, 'message_count': 2, 'messages': ['[Tool execution cancelled — tool_a was skipped due to user interrupt]', '[Tool execution cancelled — tool_b was skipped due to user interrupt]']}
```

The baseline reproduces the bug: one second after interrupt, the concurrent batch is still alive and the late tool result eventually lands. The fixed branch returns promptly and preserves interrupt placeholders instead of accepting late completions.

```bash
$ PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_concurrent_interrupt.py -q
...                                                                      [100%]
3 passed in 6.52s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k concurrent
......................                                                   [100%]
22 passed, 303 deselected in 19.50s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_tool_call_guardrail_runtime.py -q
...................                                                      [100%]
19 passed in 12.21s
```
