### PR TITLE
fix(memory): skip symlinked files in OpenViking directory uploads

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -336,10 +336,17 @@ ADD_RESOURCE_SCHEMA = {
 
 def _zip_directory(dir_path: Path) -> Path:
     """Create a temporary zip file containing a directory tree."""
+    root = dir_path.resolve()
     zip_path = Path(tempfile.gettempdir()) / f"openviking_upload_{uuid.uuid4().hex}.zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         for file_path in dir_path.rglob("*"):
+            if file_path.is_symlink():
+                continue
             if file_path.is_file():
+                try:
+                    file_path.resolve().relative_to(root)
+                except ValueError:
+                    continue
                 arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
                 zipf.write(file_path, arcname=arcname)
     return zip_path

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,4 +1,5 @@
 import json
+import zipfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -154,6 +155,43 @@ def test_tool_add_resource_uploads_existing_local_directory_and_cleans_zip(tmp_p
     })
     assert result["status"] == "added"
     assert result["root_uri"] == "viking://resources/docs"
+
+
+def test_tool_add_resource_directory_zip_skips_symlink_escape(tmp_path):
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("do not upload\n", encoding="utf-8")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    link = docs / "leak.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    archive_entries = {}
+
+    def inspect_upload(path):
+        with zipfile.ZipFile(path) as archive:
+            archive_entries["names"] = archive.namelist()
+            archive_entries["payloads"] = {
+                name: archive.read(name)
+                for name in archive.namelist()
+            }
+        return "upload_docs.zip"
+
+    provider._client.upload_temp_file.side_effect = inspect_upload
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/docs"},
+    }
+
+    json.loads(provider._tool_add_resource({"url": str(docs)}))
+
+    assert archive_entries["names"] == ["guide.md"]
+    assert b"do not upload" not in b"".join(archive_entries["payloads"].values())
 
 
 def test_tool_add_resource_cleans_local_directory_zip_when_add_fails(tmp_path):


### PR DESCRIPTION
## Summary

- prevent `viking_add_resource` directory uploads from following symlinked files while building the temporary zip
- keep uploaded archive entries constrained to files that resolve under the selected directory root
- add a regression test that proves a symlink inside the selected directory does not upload the target file's contents

## Root cause

OpenViking local directory ingestion zips every `Path.rglob("*")` entry where `Path.is_file()` returns true. `is_file()` follows symlinks, so a selected directory containing `leak.txt -> /path/outside-secret.txt` would archive the outside file contents under `leak.txt` and upload them through `temp_upload`.

## Impact

A directory chosen for OpenViking resource ingestion could include readable files outside that directory when it contains symlinks. This is a privacy boundary issue for local knowledge-base imports: users expect the selected directory tree to define the upload scope.

## Validation

- RED: `python3 -m pytest -q tests/plugins/memory/test_openviking_provider.py::test_tool_add_resource_directory_zip_skips_symlink_escape` failed before the fix because the zip contained `leak.txt`
- GREEN: `python3 -m pytest -q tests/plugins/memory/test_openviking_provider.py::test_tool_add_resource_directory_zip_skips_symlink_escape`
- `pytest tests/plugins/memory/test_openviking_provider.py -q` (`21 passed`) after rebasing onto `upstream/main` `1e01b25e7`
- `ruff check plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
- `python3 -m py_compile plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
- `git diff --check upstream/main...HEAD`

CI note: after syncing to `b497d4fc4`, `e2e`, build amd64/arm64, nix macOS/Ubuntu, supply-chain, attribution, Windows footguns, ruff enforcement, and `ruff + ty diff` pass. The full `test` job still fails in unrelated baseline areas; no OpenViking tests fail in CI.
