### PR TITLE
fix(security): close SSRF/IMDS, command-approval, sandbox-toolset, and OAuth credential gaps

### DIFF
--- a/agent/secure_file_io.py
+++ b/agent/secure_file_io.py
@@ -1,0 +1,107 @@
+"""Hardened JSON writer for OAuth credentials and similar local secrets.
+
+OAuth credential files (Google Workspace ``client_secret.json``,
+``google_token.json``, the Google Chat per-user tokens, etc.) must never
+live at world-readable mode, even briefly. ``Path.write_text`` opens at
+the process umask — typically ``0o644`` — and never chmods the result,
+so token files briefly exist at world-readable mode while OAuth refresh
+tokens are inside. Refresh tokens are long-lived secrets; on a shared
+host any local user can ``cat`` them before the writing process tightens
+the mode (TOCTOU window).
+
+This module exposes a single helper that the matching call sites are
+expected to migrate to:
+
+    from agent.secure_file_io import write_secret_json
+    write_secret_json(path, payload)
+
+Contract pinned by ``tests/agent/test_secure_file_io.py``:
+  * The final file lands at mode ``0o600`` (owner read+write, no
+    group/other).
+  * The parent directory ends at mode ``0o700``.
+  * The write is atomic: ``O_EXCL`` tmp file + ``fsync`` + ``os.replace``.
+    A partial-write crash leaves either the previous contents or no
+    file at all — never a half-written secret.
+  * On Windows (and exotic FUSE / Samba mounts that don't honor POSIX
+    mode bits) the chmod operations are best-effort no-ops, suppressed
+    via ``(OSError, NotImplementedError)``.
+
+Mirrors the existing safe idiom around ``agent.google_oauth.save_credentials``;
+that helper is updated to use the same ``(OSError, NotImplementedError)``
+guard so the two share one Windows-no-op contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import stat
+from pathlib import Path
+from typing import Any, Mapping
+
+__all__ = ["write_secret_json"]
+
+
+# Wrapping permission-sensitive ops in ``(OSError, NotImplementedError)``
+# keeps Windows (and FUSE / Samba mounts that don't honor POSIX mode bits)
+# as a silent no-op rather than spuriously raising at the call site. Some
+# Python stdlib paths (``os.fchmod`` on certain platforms) raise
+# ``NotImplementedError`` rather than ``OSError``, so we catch both.
+_PERM_ERRORS = (OSError, NotImplementedError)
+
+
+def _silent_chmod(path: Path, mode: int) -> None:
+    """Best-effort chmod — silently ignored on non-POSIX platforms."""
+    try:
+        os.chmod(path, mode)
+    except _PERM_ERRORS:
+        pass
+
+
+def write_secret_json(path: Path, payload: Mapping[str, Any]) -> Path:
+    """Atomically write *payload* as JSON to *path* with secret-safe perms.
+
+    Order of operations:
+      1. ``mkdir(parents=True, exist_ok=True)`` the parent dir.
+      2. Tighten the parent dir to ``0o700`` (best-effort; no-op on Windows).
+      3. ``os.open`` an ``O_EXCL`` sibling tmp file with mode ``0o600`` so
+         the secret never exists at the umask-derived ``0o644``.
+      4. Write the JSON payload, ``flush`` + ``fsync``.
+      5. ``os.replace`` the tmp file onto *path* (atomic on POSIX/Windows).
+      6. ``chmod`` the final path back to ``0o600`` in case ``os.replace``
+         lost mode bits across an inode swap or a symlink target.
+
+    On any failure mid-write the tmp sibling is unlinked, so a partial-
+    write crash leaves either the previous contents or no file at all.
+    """
+    path = Path(path)
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    _silent_chmod(parent, 0o700)
+
+    body = json.dumps(dict(payload), indent=2, sort_keys=True) + "\n"
+    tmp_path = path.with_suffix(
+        f"{path.suffix}.tmp.{os.getpid()}.{secrets.token_hex(4)}"
+    )
+
+    try:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(body)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(str(tmp_path), str(path))
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+
+    _silent_chmod(path, 0o600)
+    return path

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -134,6 +134,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_image_from_url,
     cache_audio_from_bytes,
@@ -3088,7 +3089,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
         import httpx
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
             response = await client.get(
                 file_url,
                 headers={

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -43,6 +43,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
+    _ssrf_redirect_guard,
     is_host_excluded_by_no_proxy,
     resolve_proxy_url,
     safe_url_for_log,
@@ -1058,7 +1059,11 @@ class SlackAdapter(BasePlatformAdapter):
             file_uploads: List[Dict[str, Any]] = []
             initial_comment_parts: List[str] = []
             try:
-                async with _httpx.AsyncClient(timeout=30.0, follow_redirects=True) as http_client:
+                async with _httpx.AsyncClient(
+                    timeout=30.0,
+                    follow_redirects=True,
+                    event_hooks={"response": [_ssrf_redirect_guard]},
+                ) as http_client:
                     for image_url, alt_text in chunk:
                         if alt_text:
                             initial_comment_parts.append(alt_text)

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
@@ -1051,7 +1052,11 @@ class WeComAdapter(BasePlatformAdapter):
         if not HTTPX_AVAILABLE:
             raise RuntimeError("httpx is required for WeCom media download")
 
-        client = self._http_client or httpx.AsyncClient(timeout=30.0, follow_redirects=True)
+        client = self._http_client or httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        )
         created_client = client is not self._http_client
         try:
             async with client.stream(

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -29,6 +29,8 @@ from typing import Optional, Any
 
 import httpx
 
+from gateway.platforms.base import _ssrf_redirect_guard
+
 logger = logging.getLogger(__name__)
 
 # ============ 常量 ============
@@ -218,7 +220,14 @@ async def download_url(
         httpx.HTTPError: 网络/HTTP 错误
     """
     max_bytes = max_size_mb * 1024 * 1024
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+    from tools.url_safety import is_safe_url
+    if not is_safe_url(url):
+        raise ValueError("Blocked unsafe URL (SSRF protection)")
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
         # 先 HEAD 检查大小
         try:
             head = await client.head(url)

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -66,6 +66,8 @@ import sys
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+from agent.secure_file_io import write_secret_json
+
 # Pin the legacy logger name so operator-side log filters keep matching
 # after the in-tree → plugin migration. See adapter.py for context.
 logger = logging.getLogger("gateway.platforms.google_chat_user_oauth")
@@ -296,14 +298,11 @@ def list_authorized_emails() -> List[str]:
 
 
 def _persist_credentials(creds: Any, token_path: Path) -> None:
-    """Atomic-ish JSON write of refreshed credentials."""
+    """Atomic JSON write of refreshed credentials at 0o600 / parent 0o700."""
     try:
-        token_path.parent.mkdir(parents=True, exist_ok=True)
-        token_path.write_text(
-            json.dumps(
-                _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                indent=2,
-            )
+        write_secret_json(
+            token_path,
+            _normalize_authorized_user_payload(json.loads(creds.to_json())),
         )
     except Exception:
         logger.debug(
@@ -402,25 +401,21 @@ def store_client_secret(path: str) -> None:
         sys.exit(1)
 
     target = _client_secret_path()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(data, indent=2))
+    write_secret_json(target, data)
     print(f"OK: Client secret saved to {target}")
 
 
 def _save_pending_auth(*, state: str, code_verifier: str,
                       email: Optional[str] = None) -> None:
     pending = _pending_auth_path(email)
-    pending.parent.mkdir(parents=True, exist_ok=True)
-    pending.write_text(
-        json.dumps(
-            {
-                "state": state,
-                "code_verifier": code_verifier,
-                "redirect_uri": _REDIRECT_URI,
-                "email": email or "",
-            },
-            indent=2,
-        )
+    write_secret_json(
+        pending,
+        {
+            "state": state,
+            "code_verifier": code_verifier,
+            "redirect_uri": _REDIRECT_URI,
+            "email": email or "",
+        },
     )
 
 

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -10,12 +10,18 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Ensure sibling modules (_hermes_home) are importable when run standalone.
-_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
-if _SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPTS_DIR)
+# Ensure sibling modules (_hermes_home) AND project-root modules
+# (agent.secure_file_io) are importable when run standalone — this bridge
+# is invoked from gws CLI wrappers where only the script directory is on
+# sys.path by default.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parents[3]
+for _p in (str(_SCRIPTS_DIR), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from _hermes_home import get_hermes_home
+from agent.secure_file_io import write_secret_json
 
 
 def get_token_path() -> Path:
@@ -65,8 +71,9 @@ def refresh_token(token_data: dict) -> dict:
         tz=timezone.utc,
     ).isoformat()
 
-    get_token_path().write_text(
-        json.dumps(_normalize_authorized_user_payload(token_data), indent=2)
+    write_secret_json(
+        get_token_path(),
+        _normalize_authorized_user_payload(token_data),
     )
     return token_data
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -30,12 +30,18 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Ensure sibling modules (_hermes_home) are importable when run standalone.
-_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
-if _SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, _SCRIPTS_DIR)
+# Ensure sibling modules (_hermes_home) AND project-root modules
+# (agent.secure_file_io) are importable when run standalone — this script
+# can be invoked outside the Hermes process (cron, nix env, CI) where
+# only the script directory is on sys.path by default.
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPTS_DIR.parents[3]
+for _p in (str(_SCRIPTS_DIR), str(_REPO_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from _hermes_home import display_hermes_home, get_hermes_home
+from agent.secure_file_io import write_secret_json
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
@@ -190,11 +196,9 @@ def check_auth(quiet: bool = False):
     if creds.expired and creds.refresh_token:
         try:
             creds.refresh(Request())
-            TOKEN_PATH.write_text(
-                json.dumps(
-                    _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                    indent=2,
-                )
+            write_secret_json(
+                TOKEN_PATH,
+                _normalize_authorized_user_payload(json.loads(creds.to_json())),
             )
             missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
             if missing_scopes:
@@ -244,21 +248,19 @@ def store_client_secret(path: str):
         print("Download the correct file from: https://console.cloud.google.com/apis/credentials")
         sys.exit(1)
 
-    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2))
+    write_secret_json(CLIENT_SECRET_PATH, data)
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
 def _save_pending_auth(*, state: str, code_verifier: str):
     """Persist the OAuth session bits needed for a later token exchange."""
-    PENDING_AUTH_PATH.write_text(
-        json.dumps(
-            {
-                "state": state,
-                "code_verifier": code_verifier,
-                "redirect_uri": REDIRECT_URI,
-            },
-            indent=2,
-        )
+    write_secret_json(
+        PENDING_AUTH_PATH,
+        {
+            "state": state,
+            "code_verifier": code_verifier,
+            "redirect_uri": REDIRECT_URI,
+        },
     )
 
 
@@ -384,7 +386,7 @@ def exchange_auth_code(code: str):
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
         print("Some services may not be available.")
 
-    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
+    write_secret_json(TOKEN_PATH, token_payload)
     PENDING_AUTH_PATH.unlink(missing_ok=True)
     print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
     print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")

--- a/tests/agent/test_secure_file_io.py
+++ b/tests/agent/test_secure_file_io.py
@@ -1,0 +1,237 @@
+"""RED tests for ``agent.secure_file_io.write_secret_json``.
+
+Background
+==========
+OAuth credential files (Google Workspace ``client_secret.json``,
+``google_token.json``, the Google Chat per-user tokens, etc.) are
+currently written with ``Path.write_text`` from a handful of scattered
+sites. ``Path.write_text`` opens at the process umask — typically
+``0o644`` — and never chmods the result, so the token files briefly
+exist at world-readable mode while OAuth refresh tokens are inside.
+Refresh tokens are long-lived secrets; on a shared host, any local user
+can ``cat`` them before the writing process tightens the mode.
+
+We're consolidating the fix behind a single helper that the matching
+GREEN commit will introduce:
+
+    from agent.secure_file_io import write_secret_json
+    write_secret_json(path, payload)
+
+The contract these tests pin:
+  * The file ends at mode ``0o600`` (owner read+write, no group/other).
+  * The parent directory ends at mode ``0o700``.
+  * The write is atomic: a partial-write failure must leave either the
+    previous contents or no file — never a half-written secret on disk.
+
+The module ``agent/secure_file_io.py`` does NOT exist yet — these
+tests are deliberately RED until the GREEN commit lands both the
+helper and the call-site migrations. The failure mode is ``ImportError``
+inside each test body (kept out of module scope so collection still
+succeeds and readable diagnostics survive).
+
+POSIX-only — Windows does not enforce POSIX mode bits.
+
+Mirrors:
+  * ``tests/cron/test_file_permissions.py``
+  * ``tests/hermes_cli/test_auth_toctou_file_modes.py``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+
+
+# ---------------------------------------------------------------------------
+# File mode: 0o600
+# ---------------------------------------------------------------------------
+
+
+def test_write_secret_json_writes_file_at_0o600(tmp_path):
+    """``write_secret_json`` must land the file at ``0o600`` under any umask."""
+    # Force a permissive umask that would otherwise leave the file at 0o644.
+    old_umask = os.umask(0o022)
+    try:
+        from agent.secure_file_io import write_secret_json
+
+        target = tmp_path / "secrets" / "token.json"
+        write_secret_json(target, {"refresh_token": "rt-xyz", "access_token": "at-xyz"})
+    finally:
+        os.umask(old_umask)
+
+    assert target.exists(), "write_secret_json must create the target file"
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, (
+        f"secret file mode 0o{mode:o} != 0o600 — umask would expose tokens"
+    )
+
+    # Content preserved.
+    payload = json.loads(target.read_text())
+    assert payload["refresh_token"] == "rt-xyz"
+    assert payload["access_token"] == "at-xyz"
+
+
+# ---------------------------------------------------------------------------
+# Parent directory mode: 0o700
+# ---------------------------------------------------------------------------
+
+
+def test_write_secret_json_tightens_parent_dir_to_0o700(tmp_path):
+    """The parent dir must end at ``0o700`` so siblings can't traverse to it."""
+    old_umask = os.umask(0o022)
+    try:
+        from agent.secure_file_io import write_secret_json
+
+        # Parent dir does not exist yet; helper must create it at 0o700.
+        target = tmp_path / "creds_dir" / "token.json"
+        write_secret_json(target, {"k": "v"})
+    finally:
+        os.umask(old_umask)
+
+    parent_mode = stat.S_IMODE(target.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"parent dir mode 0o{parent_mode:o} != 0o700 — other users can traverse"
+    )
+
+
+def test_write_secret_json_retightens_existing_parent_dir(tmp_path):
+    """If parent dir already exists at a looser mode, the helper must tighten it."""
+    parent = tmp_path / "loose_parent"
+    parent.mkdir(mode=0o755)
+    os.chmod(parent, 0o755)  # ensure 0o755 regardless of umask
+
+    old_umask = os.umask(0o022)
+    try:
+        from agent.secure_file_io import write_secret_json
+
+        target = parent / "token.json"
+        write_secret_json(target, {"k": "v"})
+    finally:
+        os.umask(old_umask)
+
+    parent_mode = stat.S_IMODE(parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"existing parent dir was not retightened: mode 0o{parent_mode:o} != 0o700"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Atomicity: partial-write must not corrupt the on-disk file
+# ---------------------------------------------------------------------------
+
+
+def test_write_secret_json_is_atomic_under_partial_write(tmp_path):
+    """A failure mid-write must leave the previous contents intact.
+
+    Atomic writers use ``os.open(O_EXCL, 0o600)`` + ``fsync`` + ``os.replace``
+    so the target file is either the previous version or the complete new
+    version — never a half-written secret. We simulate a partial-write
+    crash by making ``os.fsync`` raise; the previous file contents must
+    survive untouched.
+    """
+    target = tmp_path / "token.json"
+    target.write_text(json.dumps({"refresh_token": "prior-secret"}))
+    os.chmod(target, 0o600)
+
+    real_fsync = os.fsync
+
+    def exploding_fsync(fd):
+        # Raise BEFORE the atomic replace lands so a non-atomic writer
+        # would either truncate the target or leave a tmp file behind.
+        raise OSError("simulated partial-write failure (disk full)")
+
+    old_umask = os.umask(0o022)
+    try:
+        from agent.secure_file_io import write_secret_json
+
+        with patch.object(os, "fsync", exploding_fsync):
+            with pytest.raises(OSError):
+                write_secret_json(target, {"refresh_token": "new-secret-NEVER-LANDED"})
+    finally:
+        os.umask(old_umask)
+        # Restore in case the patch leaked.
+        os.fsync = real_fsync
+
+    # The previous content must survive — no corruption.
+    surviving = json.loads(target.read_text())
+    assert surviving["refresh_token"] == "prior-secret", (
+        "partial-write failure clobbered the previously-written secret — "
+        "the writer is not atomic"
+    )
+
+    # And no orphan tmp files should be left around the target.
+    tmp_siblings = [
+        p for p in target.parent.iterdir()
+        if p != target and "token.json" in p.name
+    ]
+    assert tmp_siblings == [], (
+        f"atomic writer left tmp files behind after a partial-write crash: "
+        f"{tmp_siblings!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# os.open contract: O_EXCL + explicit 0o600 (closes TOCTOU window)
+# ---------------------------------------------------------------------------
+
+
+def test_write_secret_json_opens_with_o_excl_and_explicit_0o600(tmp_path):
+    """The helper must call ``os.open`` with ``O_CREAT|O_EXCL`` and an
+    explicit ``0o600`` mode so the file is created at 0o600 atomically —
+    not at the umask-derived 0o644 with a post-write chmod (which leaves
+    a TOCTOU window where other users can read the secret).
+    """
+    observed_opens: list[tuple[str, int, int]] = []
+    real_os_open = os.open
+
+    def spying_os_open(path, flags, mode=0o777, *args, **kwargs):
+        observed_opens.append((str(path), flags, mode))
+        return real_os_open(path, flags, mode, *args, **kwargs)
+
+    target = tmp_path / "token.json"
+
+    old_umask = os.umask(0o022)
+    try:
+        from agent.secure_file_io import write_secret_json
+
+        with patch.object(os, "open", spying_os_open):
+            write_secret_json(target, {"k": "v"})
+    finally:
+        os.umask(old_umask)
+
+    # Look for an open() against either the target or a sibling tmp file
+    # that includes the basename — atomic writers typically open
+    # ``<target>.tmp.<pid>`` and rename onto the target.
+    target_opens = [
+        (p, fl, m) for (p, fl, m) in observed_opens
+        if Path(p).name == target.name or target.name in Path(p).name
+    ]
+    assert target_opens, (
+        f"os.open was never called for the secret file or its tmp sibling; "
+        f"observed={observed_opens!r}"
+    )
+    for path, flags, mode in target_opens:
+        assert flags & os.O_CREAT, (
+            f"secret open missing O_CREAT: path={path}"
+        )
+        assert flags & os.O_EXCL, (
+            f"secret open missing O_EXCL — TOCTOU-safe pattern not used: "
+            f"path={path}, flags={flags}"
+        )
+        expected = stat.S_IRUSR | stat.S_IWUSR
+        assert mode == expected, (
+            f"secret open mode 0o{mode:o} != 0o{expected:o} (S_IRUSR|S_IWUSR) — "
+            f"umask would briefly expose the secret"
+        )

--- a/tests/gateway/test_feishu_media_ssrf_redirect.py
+++ b/tests/gateway/test_feishu_media_ssrf_redirect.py
@@ -1,0 +1,244 @@
+"""RED test: Feishu media download must re-validate redirects.
+
+``FeishuAdapter._download_remote_document`` (gateway/platforms/feishu.py)
+is the entry point for fetching remote document/animation media before
+re-uploading to the Lark/Feishu APIs. It performs an ``is_safe_url``
+pre-flight check, then builds an
+``httpx.AsyncClient(timeout=30.0, follow_redirects=True)`` *without*
+the shared ``_ssrf_redirect_guard`` event hook.
+
+Consequence: a public-looking URL that 302-redirects to
+``http://169.254.169.254/latest/meta-data/`` is silently followed and
+the cloud-metadata bytes get cached + re-uploaded.
+
+The desired behavior — re-validating each redirect target via
+``event_hooks={'response': [_ssrf_redirect_guard]}`` — raises
+``ValueError('Blocked redirect to private/internal address: ...')``.
+
+This RED test asserts:
+  1. The ``httpx.AsyncClient`` used by ``_download_remote_document``
+     is configured with a response event hook (the redirect guard).
+  2. Invoking that hook against a redirect-to-metadata response raises
+     a ``ValueError`` whose message mentions ``Blocked redirect`` or
+     ``Blocked unsafe URL``.
+
+We additionally exercise the public-facing call path so a future
+``_download_remote_bytes`` helper that other Feishu code might call
+remains covered. Today both assertions fail because no hook is
+installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Local fake httpx pieces — no real network.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Mimic the parts of an httpx response that the Feishu code touches."""
+
+    def __init__(
+        self,
+        *,
+        headers: Dict[str, str] | None = None,
+        content: bytes = b"",
+    ) -> None:
+        self.headers = headers or {"Content-Type": "application/octet-stream"}
+        self.content = content
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class _FakeAsyncClient:
+    """Capture kwargs at construction time so the test can assert that
+    ``event_hooks={"response": [_ssrf_redirect_guard]}`` was passed."""
+
+    def __init__(self, *_args: Any, **kwargs: Any) -> None:
+        _FakeAsyncClient.captured_kwargs = kwargs  # type: ignore[attr-defined]
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    async def get(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+        return _FakeResponse(
+            headers={"Content-Type": "application/octet-stream"},
+            content=b"public-doc-bytes",
+        )
+
+
+class _RedirectResponse:
+    def __init__(self, target_url: str) -> None:
+        self.is_redirect = True
+        self.next_request = MagicMock(url=target_url)
+        self.headers = {"location": target_url}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFeishuDownloadRemoteDocumentRedirect:
+    """``_download_remote_document`` must re-validate redirects."""
+
+    def test_async_client_uses_redirect_guard_hook(self):
+        """The ``httpx.AsyncClient`` built inside
+        ``_download_remote_document`` must register a response event
+        hook so each redirect target is re-checked. Today the call
+        passes only ``timeout`` + ``follow_redirects`` — no hook — so
+        this fails for the right RED reason."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        # Reset captured state — each test instance gets a fresh slate.
+        _FakeAsyncClient.captured_kwargs = {}  # type: ignore[attr-defined]
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", return_value=True), \
+                 patch("httpx.AsyncClient", _FakeAsyncClient), \
+                 patch(
+                     "gateway.platforms.feishu.cache_document_from_bytes",
+                     return_value="/tmp/cached-doc.bin",
+                 ):
+                return await adapter._download_remote_document(
+                    "https://public.example.com/document.pdf",
+                    default_ext=".pdf",
+                    preferred_name="document",
+                )
+
+        asyncio.run(run())
+
+        captured = getattr(_FakeAsyncClient, "captured_kwargs", {})
+        assert captured.get("follow_redirects") is True
+        event_hooks = captured.get("event_hooks") or {}
+        response_hooks = event_hooks.get("response") or []
+        assert response_hooks, (
+            "FeishuAdapter._download_remote_document must build httpx.AsyncClient "
+            "with event_hooks={'response': [_ssrf_redirect_guard]} to prevent "
+            "redirect-based SSRF; today the hook is absent."
+        )
+
+    def test_redirect_to_metadata_raises_blocked_message(self):
+        """The redirect hook registered by ``_download_remote_document``
+        must reject a 302 → 169.254.169.254 with a ``ValueError`` whose
+        message mentions ``Blocked redirect`` or ``Blocked unsafe URL``."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        _FakeAsyncClient.captured_kwargs = {}  # type: ignore[attr-defined]
+
+        public_url = "https://public.example.com/document.pdf"
+        metadata_url = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", _FakeAsyncClient), \
+                 patch(
+                     "gateway.platforms.feishu.cache_document_from_bytes",
+                     return_value="/tmp/cached-doc.bin",
+                 ):
+                await adapter._download_remote_document(
+                    public_url,
+                    default_ext=".pdf",
+                    preferred_name="document",
+                )
+
+        asyncio.run(run())
+
+        captured = getattr(_FakeAsyncClient, "captured_kwargs", {})
+        hooks = (captured.get("event_hooks") or {}).get("response") or []
+        assert hooks, (
+            "Feishu _download_remote_document did not install a redirect "
+            "guard hook on httpx.AsyncClient — SSRF redirect protection "
+            "is missing."
+        )
+
+        async def drive_hook():
+            redirect_resp = _RedirectResponse(metadata_url)
+            for hook in hooks:
+                await hook(redirect_resp)
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(drive_hook())
+
+        msg = str(exc_info.value)
+        assert ("Blocked redirect" in msg) or ("Blocked unsafe URL" in msg), (
+            f"Feishu redirect guard exception must mention 'Blocked redirect' "
+            f"or 'Blocked unsafe URL'; got: {msg!r}"
+        )
+
+
+class TestFeishuDownloadRemoteBytesRedirect:
+    """When Feishu acquires a generic ``_download_remote_bytes`` (parity with
+    WeCom) it must also install the redirect guard. Today the helper does
+    not exist on FeishuAdapter; until it does, this test guards against any
+    refactor that re-introduces ``follow_redirects=True`` without the hook.
+
+    Implementation note: the FeishuAdapter currently funnels every remote
+    fetch through ``_download_remote_document`` (and ``cache_image_from_url``
+    in base.py, which is already guarded). The test below uses
+    ``_download_remote_document`` as the canonical bytes-fetching entry
+    point and asserts the same redirect-guard contract — so any future
+    rename to ``_download_remote_bytes`` continues to be covered by name.
+    """
+
+    def test_remote_document_bytes_path_blocks_redirect_to_imds(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        _FakeAsyncClient.captured_kwargs = {}  # type: ignore[attr-defined]
+
+        public_url = "https://public.example.com/data.bin"
+        metadata_url = "http://169.254.169.254/latest/meta-data/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", _FakeAsyncClient), \
+                 patch(
+                     "gateway.platforms.feishu.cache_document_from_bytes",
+                     return_value="/tmp/cached-doc.bin",
+                 ):
+                await adapter._download_remote_document(
+                    public_url,
+                    default_ext=".bin",
+                    preferred_name="data",
+                )
+
+        asyncio.run(run())
+
+        captured = getattr(_FakeAsyncClient, "captured_kwargs", {})
+        hooks = (captured.get("event_hooks") or {}).get("response") or []
+        assert hooks, (
+            "Feishu remote-bytes fetch must build httpx.AsyncClient with a "
+            "redirect re-validation hook."
+        )
+
+        async def drive_hook():
+            redirect_resp = _RedirectResponse(metadata_url)
+            for hook in hooks:
+                await hook(redirect_resp)
+
+        with pytest.raises(ValueError, match=r"Blocked (redirect|unsafe URL)"):
+            asyncio.run(drive_hook())

--- a/tests/gateway/test_slack_media_ssrf_redirect.py
+++ b/tests/gateway/test_slack_media_ssrf_redirect.py
@@ -1,0 +1,264 @@
+"""RED test: Slack multi-image upload must re-validate redirects.
+
+``SlackAdapter.send_multiple_images`` downloads each remote image via an
+``httpx.AsyncClient`` built with ``follow_redirects=True``. Today that
+client is constructed *without* the shared ``_ssrf_redirect_guard``
+event hook, so a public-looking initial URL that responds with a 302
+to ``http://169.254.169.254/latest/meta-data/`` is silently followed
+and the cloud-metadata bytes get attached to the Slack message.
+
+The desired behavior, mirroring ``cache_image_from_url`` /
+``SlackAdapter.send_image``, is to either install an ``event_hooks``
+redirect guard or otherwise verify the redirect target so the
+attempted upload is dropped (``file_uploads`` stays empty) and the
+Slack ``files_upload_v2`` API is never called with metadata content.
+
+This test is expected to FAIL today because the production code path
+does not register a redirect guard and would proxy IMDS bytes into the
+multi-image batch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock the slack-bolt + slack-sdk packages so importing the adapter works
+# without the real third-party dependencies installed.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_slack_mock() -> None:
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    slack_sdk = MagicMock()
+    slack_sdk.web.async_client.AsyncWebClient = MagicMock
+    for name, mod in [
+        ("slack_bolt", slack_bolt),
+        ("slack_bolt.async_app", slack_bolt.async_app),
+        ("slack_bolt.adapter", slack_bolt.adapter),
+        ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
+        ("slack_sdk", slack_sdk),
+        ("slack_sdk.web", slack_sdk.web),
+        ("slack_sdk.web.async_client", slack_sdk.web.async_client),
+    ]:
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("aiohttp", MagicMock())
+
+
+_ensure_slack_mock()
+
+import gateway.platforms.slack as _slack_mod  # noqa: E402
+_slack_mod.SLACK_AVAILABLE = True
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.slack import SlackAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_slack_adapter() -> SlackAdapter:
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    adapter._app = MagicMock()
+    adapter._app.client = AsyncMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._running = True
+    return adapter
+
+
+def _make_redirect_response(target_url: str) -> MagicMock:
+    """Mock an httpx response that *would* be followed as a redirect."""
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.next_request = MagicMock(url=target_url)
+    resp.headers = {"content-type": "text/plain"}
+    # If the production code follows the redirect without guarding, it will
+    # ultimately treat the metadata payload as image bytes.
+    resp.content = b"AKIA-FAKE-IAM-CREDENTIAL-FROM-IMDS"
+
+    def _raise_for_status() -> None:
+        return None
+
+    resp.raise_for_status = _raise_for_status
+    return resp
+
+
+def _capture_async_client():
+    """Return (mock_client, captured_kwargs, factory)."""
+    captured: dict = {}
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    def factory(*args, **kwargs):
+        captured.update(kwargs)
+        return mock_client
+
+    return mock_client, captured, factory
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+class TestSlackMultiImageSsrfRedirect:
+    """``send_multiple_images`` must drop uploads whose downloads redirect
+    into a private/internal IP (e.g. cloud metadata)."""
+
+    def test_multi_image_blocks_redirect_to_imds(self, monkeypatch):
+        """Public initial URL → 302 → IMDS must NOT result in a
+        ``files_upload_v2`` call carrying metadata bytes.
+
+        The guard mechanism mirrors the pattern in
+        ``SlackAdapter.send_image`` and ``cache_image_from_url``: the
+        ``httpx.AsyncClient`` is constructed with
+        ``event_hooks={"response": [_ssrf_redirect_guard]}`` and the
+        guard raises ``ValueError`` on a redirect to a private host.
+        """
+        adapter = _make_slack_adapter()
+
+        # is_safe_url is True only for the *initial* public URL — a private
+        # IP / metadata host must report False.
+        public_url = "https://public.example.com/cute-cat.png"
+        metadata_url = "http://169.254.169.254/latest/meta-data/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        redirect_resp = _make_redirect_response(metadata_url)
+        mock_client, captured, factory = _capture_async_client()
+
+        async def fake_get(_url, **_kwargs):
+            # If the production code installed the guard, invoking it on a
+            # redirect-to-metadata response would raise ValueError before any
+            # bytes were attached to the upload payload.
+            hooks = (captured.get("event_hooks") or {}).get("response") or []
+            for hook in hooks:
+                await hook(redirect_resp)
+            return redirect_resp
+
+        mock_client.get = AsyncMock(side_effect=fake_get)
+
+        # files_upload_v2 is the API that would carry the unsafe payload —
+        # capture every call so we can assert nothing leaked.
+        upload_mock = AsyncMock(return_value={"ok": True})
+        adapter._app.client.files_upload_v2 = upload_mock
+        adapter._get_client = MagicMock(return_value=adapter._app.client)
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", side_effect=factory):
+                await adapter.send_multiple_images(
+                    chat_id="C123",
+                    images=[(public_url, "alt text")],
+                    metadata=None,
+                    human_delay=0.0,
+                )
+
+        asyncio.run(run())
+
+        # 1) The httpx.AsyncClient *must* be configured with a redirect
+        #    re-validation hook. The slack send_image path uses event_hooks
+        #    for exactly this; send_multiple_images currently omits it.
+        event_hooks = captured.get("event_hooks") or {}
+        response_hooks = event_hooks.get("response") or []
+        assert response_hooks, (
+            "Slack send_multiple_images must build httpx.AsyncClient with "
+            "event_hooks={'response': [_ssrf_redirect_guard]} to prevent "
+            "redirect-based SSRF; today the hook is absent."
+        )
+
+        # 2) The metadata payload must never be uploaded. If the guard is
+        #    installed, the download will raise, the upload list stays
+        #    empty, and files_upload_v2 is not called at all.
+        if upload_mock.await_count > 0:
+            for call in upload_mock.await_args_list:
+                file_uploads = call.kwargs.get("file_uploads") or []
+                for entry in file_uploads:
+                    content = entry.get("content") or b""
+                    assert b"IMDS" not in content and b"AKIA" not in content, (
+                        "files_upload_v2 was called with metadata bytes from "
+                        "169.254.169.254 — redirect was followed without "
+                        "SSRF revalidation."
+                    )
+
+    def test_multi_image_redirect_guard_message_blocked(self, monkeypatch):
+        """The redirect guard error must mention 'Blocked redirect' or
+        'Blocked unsafe URL' so log audits / warning paths can match it.
+
+        The slack path swallows download exceptions and continues, but the
+        guard's *message* is still observable: tests in test_media_download_retry
+        use ``pytest.raises(ValueError, match='Blocked redirect')`` against
+        the production hook installed on the AsyncClient.
+
+        Here we directly invoke whatever response hook send_multiple_images
+        registered and verify it raises with the expected message — today
+        no hook is registered, so the test fails the right way.
+        """
+        adapter = _make_slack_adapter()
+        public_url = "https://public.example.com/img.png"
+        metadata_url = "http://169.254.169.254/latest/meta-data/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        redirect_resp = _make_redirect_response(metadata_url)
+        mock_client, captured, factory = _capture_async_client()
+
+        # Make .get a no-op so we just observe how AsyncClient was built.
+        async def fake_get(_url, **_kwargs):
+            return redirect_resp
+
+        mock_client.get = AsyncMock(side_effect=fake_get)
+
+        # Stop before doing any real Slack API call.
+        adapter._get_client = MagicMock(return_value=MagicMock(
+            files_upload_v2=AsyncMock(return_value={"ok": True})
+        ))
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", side_effect=factory):
+                await adapter.send_multiple_images(
+                    chat_id="C123",
+                    images=[(public_url, "alt")],
+                    metadata=None,
+                    human_delay=0.0,
+                )
+
+        asyncio.run(run())
+
+        hooks = (captured.get("event_hooks") or {}).get("response") or []
+        assert hooks, (
+            "send_multiple_images did not install a response event hook on "
+            "httpx.AsyncClient — redirect-based SSRF is not prevented."
+        )
+
+        async def _drive_hook():
+            for hook in hooks:
+                await hook(redirect_resp)
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(_drive_hook())
+
+        msg = str(exc_info.value)
+        assert ("Blocked redirect" in msg) or ("Blocked unsafe URL" in msg), (
+            f"Redirect guard exception must mention 'Blocked redirect' or "
+            f"'Blocked unsafe URL'; got: {msg!r}"
+        )

--- a/tests/gateway/test_wecom_media_ssrf_redirect.py
+++ b/tests/gateway/test_wecom_media_ssrf_redirect.py
@@ -1,0 +1,187 @@
+"""RED test: WeCom media download must re-validate redirects.
+
+``WeComAdapter._download_remote_bytes`` (gateway/platforms/wecom.py) is
+the single entry point for fetching outbound media and inbound
+attachments from a remote HTTP(S) URL. It performs an
+``is_safe_url`` pre-flight check, then builds an
+``httpx.AsyncClient(timeout=30.0, follow_redirects=True)`` *without*
+the shared ``_ssrf_redirect_guard`` event hook.
+
+Consequence: a public-looking URL that 302-redirects to
+``http://169.254.169.254/latest/meta-data/`` is silently followed and
+returns cloud-metadata bytes that get uploaded to WeCom servers.
+
+The desired behavior — re-validating each redirect target via
+``event_hooks={'response': [_ssrf_redirect_guard]}`` — raises
+``ValueError('Blocked redirect to private/internal address: ...')``.
+
+This RED test asserts:
+  1. The ``httpx.AsyncClient`` used by ``_download_remote_bytes`` is
+     configured with a response event hook (the redirect guard).
+  2. Invoking that hook against a redirect-to-metadata response raises
+     a ``ValueError`` whose message mentions ``Blocked redirect`` or
+     ``Blocked unsafe URL``.
+
+Today both assertions fail because no hook is installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Local fake httpx pieces — no real network.
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamResponse:
+    """Mimic the parts of an httpx streaming response that
+    ``_download_remote_bytes`` touches."""
+
+    def __init__(self, *, headers: Dict[str, str], chunks: List[bytes]):
+        self.headers = headers
+        self._chunks = chunks
+
+    async def __aenter__(self) -> "_FakeStreamResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _RedirectResponse:
+    """An httpx-shaped redirect response used to drive the guard."""
+
+    def __init__(self, target_url: str) -> None:
+        self.is_redirect = True
+        self.next_request = MagicMock(url=target_url)
+        self.headers = {"location": target_url}
+
+
+def _capture_async_client():
+    """Return (mock_client, captured_kwargs, factory)."""
+    captured: Dict[str, Any] = {}
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    def factory(*args, **kwargs):
+        captured.update(kwargs)
+        return mock_client
+
+    return mock_client, captured, factory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWeComDownloadRemoteBytesRedirect:
+    """``_download_remote_bytes`` must re-validate redirects."""
+
+    def test_async_client_uses_redirect_guard_hook(self):
+        """``httpx.AsyncClient(...)`` constructed inside
+        ``_download_remote_bytes`` must register a response event hook
+        so each redirect target is re-checked. Today the call passes
+        only ``timeout`` + ``follow_redirects`` — no hook — so this
+        fails for the right RED reason."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = None  # force the per-call client path
+
+        mock_client, captured, factory = _capture_async_client()
+
+        # The stream context returns immediately with empty bytes — we
+        # only care about what was passed to httpx.AsyncClient(...).
+        mock_client.stream = MagicMock(
+            return_value=_FakeStreamResponse(
+                headers={"content-length": "0", "content-type": "image/png"},
+                chunks=[],
+            )
+        )
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", return_value=True), \
+                 patch("gateway.platforms.wecom.httpx.AsyncClient", side_effect=factory):
+                await adapter._download_remote_bytes(
+                    "https://public.example.com/image.png",
+                    max_bytes=4096,
+                )
+
+        asyncio.run(run())
+
+        # ``follow_redirects=True`` without an event hook is the bug.
+        assert captured.get("follow_redirects") is True
+        event_hooks = captured.get("event_hooks") or {}
+        response_hooks = event_hooks.get("response") or []
+        assert response_hooks, (
+            "WeComAdapter._download_remote_bytes must build httpx.AsyncClient "
+            "with event_hooks={'response': [_ssrf_redirect_guard]} to prevent "
+            "redirect-based SSRF; today the hook is absent."
+        )
+
+    def test_redirect_to_metadata_raises_blocked_message(self):
+        """The redirect hook registered by ``_download_remote_bytes``
+        must reject a 302 → 169.254.169.254 with a ``ValueError`` whose
+        message mentions ``Blocked redirect`` or ``Blocked unsafe URL``."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = None
+
+        mock_client, captured, factory = _capture_async_client()
+        mock_client.stream = MagicMock(
+            return_value=_FakeStreamResponse(
+                headers={"content-length": "0"},
+                chunks=[],
+            )
+        )
+
+        public_url = "https://public.example.com/file.bin"
+        metadata_url = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("gateway.platforms.wecom.httpx.AsyncClient", side_effect=factory):
+                await adapter._download_remote_bytes(public_url, max_bytes=4096)
+
+        asyncio.run(run())
+
+        hooks = (captured.get("event_hooks") or {}).get("response") or []
+        assert hooks, (
+            "WeCom _download_remote_bytes did not install a redirect guard "
+            "hook on httpx.AsyncClient — SSRF redirect protection is missing."
+        )
+
+        async def drive_hook():
+            redirect_resp = _RedirectResponse(metadata_url)
+            for hook in hooks:
+                await hook(redirect_resp)
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(drive_hook())
+
+        msg = str(exc_info.value)
+        assert ("Blocked redirect" in msg) or ("Blocked unsafe URL" in msg), (
+            f"WeCom redirect guard exception must mention 'Blocked redirect' "
+            f"or 'Blocked unsafe URL'; got: {msg!r}"
+        )

--- a/tests/gateway/test_yuanbao_media_ssrf.py
+++ b/tests/gateway/test_yuanbao_media_ssrf.py
@@ -1,0 +1,208 @@
+"""RED test: gateway.platforms.yuanbao_media.download_url SSRF safety.
+
+``download_url`` in ``gateway/platforms/yuanbao_media.py`` fetches an
+arbitrary HTTP(S) URL to upload it through Yuanbao's COS pipeline. The
+current implementation:
+
+* calls ``httpx.AsyncClient(timeout=30.0, follow_redirects=True)`` on
+  the bare URL with no ``is_safe_url`` pre-flight, and
+* installs no ``_ssrf_redirect_guard`` event hook on the AsyncClient.
+
+That makes both initial-URL SSRF and redirect-bounce SSRF possible:
+
+  1. A directly-private URL (``http://127.0.0.1/internal``,
+     ``http://169.254.169.254/latest/meta-data/``) is fetched as-is.
+  2. A public-looking URL that 302-redirects to the IMDS host is
+     followed all the way to cloud-metadata bytes.
+
+The desired behavior is:
+
+  1. ``download_url`` calls ``tools.url_safety.is_safe_url`` on the
+     input URL and refuses (``ValueError`` mentioning
+     ``Blocked unsafe URL``) when it returns False.
+  2. The ``httpx.AsyncClient`` is constructed with an event hook
+     mirroring ``_ssrf_redirect_guard`` so any redirect into a
+     private/internal host raises ``ValueError`` mentioning
+     ``Blocked redirect``.
+
+Both tests below are expected to FAIL today because neither check is
+implemented in ``yuanbao_media.download_url``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Local fake httpx pieces — no real network.
+# ---------------------------------------------------------------------------
+
+
+class _RedirectResponse:
+    def __init__(self, target_url: str) -> None:
+        self.is_redirect = True
+        self.next_request = MagicMock(url=target_url)
+        self.headers = {"location": target_url}
+
+
+class _StreamResponse:
+    """Mimic the parts of an httpx streaming response that
+    ``download_url`` touches."""
+
+    def __init__(self, *, headers: Dict[str, str], chunks: list[bytes]) -> None:
+        self.headers = headers
+        self._chunks = chunks
+
+    async def __aenter__(self) -> "_StreamResponse":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    async def aiter_bytes(self, _chunk_size: int = 65536):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _capture_async_client(stream_response: _StreamResponse):
+    """Return (mock_client, captured_kwargs, factory).
+
+    The factory records every kwarg that was passed to
+    ``httpx.AsyncClient(...)`` so the test can assert on the presence
+    of ``event_hooks``."""
+    captured: Dict[str, Any] = {}
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    # HEAD is optional — yuanbao_media uses it for an early size probe
+    # and swallows HTTPStatusError. Return a permissive head response.
+    head_resp = MagicMock()
+    head_resp.headers = {"content-length": "0"}
+    mock_client.head = AsyncMock(return_value=head_resp)
+    mock_client.stream = MagicMock(return_value=stream_response)
+
+    def factory(*args, **kwargs):
+        captured.update(kwargs)
+        return mock_client
+
+    return mock_client, captured, factory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestYuanbaoDownloadUrlPrivateInitial:
+    """The initial URL must be checked against ``is_safe_url``."""
+
+    def test_refuses_private_initial_url(self):
+        """``download_url('http://127.0.0.1/...')`` must invoke
+        ``is_safe_url`` and refuse with a ``ValueError`` containing
+        ``Blocked unsafe URL`` — today the production code skips the
+        check entirely and would attempt the request."""
+        from gateway.platforms import yuanbao_media
+
+        private_url = "http://127.0.0.1/internal/secret.bin"
+        safe_calls: list[str] = []
+
+        def fake_safe(url: str) -> bool:
+            safe_calls.append(url)
+            return False  # simulate private/internal
+
+        stream_resp = _StreamResponse(
+            headers={"content-type": "application/octet-stream"},
+            chunks=[b"should-never-be-read"],
+        )
+        _client, _captured, factory = _capture_async_client(stream_resp)
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", side_effect=factory):
+                await yuanbao_media.download_url(private_url, max_size_mb=1)
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(run())
+
+        # The error must come from the SSRF check, not from a downstream
+        # mock-side failure that happens to raise ValueError.
+        assert "Blocked unsafe URL" in str(exc_info.value), (
+            f"Expected SSRF refusal with 'Blocked unsafe URL' marker; "
+            f"got: {exc_info.value!r}"
+        )
+        assert safe_calls and safe_calls[0] == private_url, (
+            "yuanbao_media.download_url must call tools.url_safety.is_safe_url "
+            "on the input URL before issuing any HTTP request; today it does "
+            "not, so safe_calls stays empty."
+        )
+
+
+class TestYuanbaoDownloadUrlRedirectGuard:
+    """Public initial URL → 302 → IMDS must be blocked."""
+
+    def test_blocks_redirect_to_metadata(self):
+        """A public-looking URL that 302-redirects into
+        ``http://169.254.169.254/...`` must surface a ``ValueError``
+        whose message mentions ``Blocked redirect`` or
+        ``Blocked unsafe URL``. Today no event hook is installed on
+        the ``httpx.AsyncClient`` inside ``download_url``, so the
+        test fails for the right RED reason."""
+        from gateway.platforms import yuanbao_media
+
+        public_url = "https://public.example.com/cute.png"
+        metadata_url = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+
+        def fake_safe(url: str) -> bool:
+            return url == public_url
+
+        stream_resp = _StreamResponse(
+            headers={"content-type": "image/png"},
+            chunks=[b"public-image-bytes"],
+        )
+        _client, captured, factory = _capture_async_client(stream_resp)
+
+        async def run():
+            with patch("tools.url_safety.is_safe_url", side_effect=fake_safe), \
+                 patch("httpx.AsyncClient", side_effect=factory):
+                await yuanbao_media.download_url(public_url, max_size_mb=1)
+
+        # First: drive the call so AsyncClient(...) is invoked and the
+        # kwargs are captured.
+        asyncio.run(run())
+
+        # The client must be created with both follow_redirects=True
+        # (existing behavior) and an SSRF redirect guard hook.
+        assert captured.get("follow_redirects") is True, (
+            "download_url should call httpx.AsyncClient with "
+            "follow_redirects=True (current behavior)."
+        )
+        hooks = (captured.get("event_hooks") or {}).get("response") or []
+        assert hooks, (
+            "yuanbao_media.download_url must build httpx.AsyncClient with "
+            "event_hooks={'response': [_ssrf_redirect_guard]} to prevent "
+            "redirect-based SSRF; today the hook is absent."
+        )
+
+        # Drive the registered hook against a metadata-redirect response.
+        async def drive_hook():
+            redirect_resp = _RedirectResponse(metadata_url)
+            for hook in hooks:
+                await hook(redirect_resp)
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(drive_hook())
+
+        msg = str(exc_info.value)
+        assert ("Blocked redirect" in msg) or ("Blocked unsafe URL" in msg), (
+            f"Yuanbao redirect guard exception must mention 'Blocked redirect' "
+            f"or 'Blocked unsafe URL'; got: {msg!r}"
+        )

--- a/tests/plugins/test_google_chat_oauth_modes.py
+++ b/tests/plugins/test_google_chat_oauth_modes.py
@@ -1,0 +1,272 @@
+"""RED file-mode tests for ``plugins/platforms/google_chat/oauth.py``.
+
+Background
+==========
+The Google Chat user-OAuth helper persists three secret-bearing files
+under ``$HERMES_HOME``:
+
+  * ``_client_secret_path()``  → ``google_chat_user_client_secret.json``
+  * ``_token_path(email)``     → per-user OAuth refresh token JSON
+  * ``_pending_auth_path()``   → PKCE state + code_verifier for in-flight
+                                  ``/setup-files`` exchanges
+
+Today all three are written with ``Path.write_text``, which inherits
+the process ``umask`` (typically ``0o022``) and never chmods the file
+afterward. On shared hosts that leaves long-lived OAuth refresh tokens
+at ``0o644`` — readable by every local user. Same TOCTOU class as
+#19673 (``agent/google_oauth.py``) and #21148 (``tools/mcp_oauth.py``);
+this helper is the last big writer that hasn't been migrated.
+
+The matching GREEN commit will route all three writes through
+``agent.secure_file_io.write_secret_json`` (or an inline
+``os.open(O_EXCL, 0o600) + fsync + atomic_replace`` pattern).
+
+POSIX-only — Windows does not enforce POSIX mode bits.
+
+Everything is local to ``tmp_path``: ``HERMES_HOME`` is redirected via
+monkeypatch and the ``hermes_constants.get_hermes_home`` import is
+shadowed so no real OAuth dance and no real ``~/.hermes`` writes can
+happen.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME to a tmp dir and reset module cache.
+
+    Both ``get_hermes_home`` (resolved at call time inside oauth.py) and
+    ``HERMES_HOME`` env var are routed at ``tmp_path``, so no real
+    ``~/.hermes`` writes can leak.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # The module reads HERMES_HOME late (via _hermes_home() → get_hermes_home())
+    # so just setting the env var is enough. Force-reload to be safe in case
+    # an earlier test imported the module with a different env.
+    if "plugins.platforms.google_chat.oauth" in sys.modules:
+        del sys.modules["plugins.platforms.google_chat.oauth"]
+    return home
+
+
+@pytest.fixture
+def client_secret_src(tmp_path):
+    """A valid client_secret.json on disk that ``store_client_secret`` will accept."""
+    src = tmp_path / "src_client_secret.json"
+    src.write_text(json.dumps({
+        "installed": {
+            "client_id": "fake-chat-client-id",
+            "client_secret": "fake-chat-client-secret",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    }))
+    return src
+
+
+class _FakeChatCredentials:
+    """Stand-in for ``google.oauth2.credentials.Credentials`` (just ``.to_json``)."""
+
+    def to_json(self):
+        return json.dumps({
+            "token": "chat-access-token",
+            "refresh_token": "chat-refresh-token-XXX",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "fake-chat-client-id",
+            "client_secret": "fake-chat-client-secret",
+            "scopes": ["https://www.googleapis.com/auth/chat.messages.create"],
+        })
+
+
+# ---------------------------------------------------------------------------
+# _persist_credentials → token file 0o600 / parent dir 0o700
+# ---------------------------------------------------------------------------
+
+
+def test_persist_credentials_writes_token_at_0o600_with_0o700_parent(
+    isolated_hermes_home, monkeypatch
+):
+    """``_persist_credentials`` must land the per-user token at 0o600 / parent 0o700."""
+    from plugins.platforms.google_chat import oauth as oauth_mod
+
+    target = oauth_mod._token_path("user@example.com")
+    creds = _FakeChatCredentials()
+
+    old_umask = os.umask(0o022)
+    try:
+        oauth_mod._persist_credentials(creds, target)
+    finally:
+        os.umask(old_umask)
+
+    assert target.exists(), "_persist_credentials did not write the token file"
+
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, (
+        f"per-user token file mode 0o{mode:o} != 0o600 — "
+        f"umask leaked refresh token to other local users"
+    )
+
+    parent_mode = stat.S_IMODE(target.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"per-user tokens dir mode 0o{parent_mode:o} != 0o700 — "
+        f"other users can list per-user token filenames (PII leak)"
+    )
+
+    # Content survived.
+    data = json.loads(target.read_text())
+    assert data["refresh_token"] == "chat-refresh-token-XXX"
+
+
+def test_persist_credentials_legacy_path_is_0o600(
+    isolated_hermes_home, monkeypatch
+):
+    """The legacy single-user token path must also land at 0o600."""
+    from plugins.platforms.google_chat import oauth as oauth_mod
+
+    legacy = oauth_mod._legacy_token_path()
+    creds = _FakeChatCredentials()
+
+    old_umask = os.umask(0o022)
+    try:
+        oauth_mod._persist_credentials(creds, legacy)
+    finally:
+        os.umask(old_umask)
+
+    assert legacy.exists(), "_persist_credentials did not write the legacy token"
+
+    mode = stat.S_IMODE(legacy.stat().st_mode)
+    assert mode == 0o600, (
+        f"legacy token mode 0o{mode:o} != 0o600 — "
+        f"umask leaked refresh token to other local users"
+    )
+
+    parent_mode = stat.S_IMODE(legacy.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"HERMES_HOME mode 0o{parent_mode:o} != 0o700"
+    )
+
+
+# ---------------------------------------------------------------------------
+# store_client_secret → client secret 0o600 / parent dir 0o700
+# ---------------------------------------------------------------------------
+
+
+def test_store_client_secret_writes_0o600_with_0o700_parent(
+    isolated_hermes_home, client_secret_src, monkeypatch
+):
+    """``store_client_secret`` must land the client_secret.json at 0o600."""
+    from plugins.platforms.google_chat import oauth as oauth_mod
+
+    old_umask = os.umask(0o022)
+    try:
+        oauth_mod.store_client_secret(str(client_secret_src))
+    finally:
+        os.umask(old_umask)
+
+    target = oauth_mod._client_secret_path()
+    assert target.exists(), "store_client_secret did not write the client_secret.json"
+
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, (
+        f"client_secret.json mode 0o{mode:o} != 0o600 — "
+        f"umask leaked Google OAuth client_secret to other local users"
+    )
+
+    parent_mode = stat.S_IMODE(target.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"client_secret parent dir mode 0o{parent_mode:o} != 0o700"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _save_pending_auth → pending file 0o600 / parent dir 0o700
+# ---------------------------------------------------------------------------
+
+
+def test_save_pending_auth_writes_0o600_with_0o700_parent_per_user(
+    isolated_hermes_home, monkeypatch
+):
+    """Per-user pending OAuth state must land at 0o600 / parent 0o700.
+
+    The pending file holds the PKCE ``code_verifier``; with umask 0o022
+    the current writer leaves it at 0o644, exposing the verifier to
+    every local user mid-flow.
+    """
+    from plugins.platforms.google_chat import oauth as oauth_mod
+
+    old_umask = os.umask(0o022)
+    try:
+        oauth_mod._save_pending_auth(
+            state="fake-chat-state",
+            code_verifier="fake-chat-code-verifier",
+            email="user@example.com",
+        )
+    finally:
+        os.umask(old_umask)
+
+    pending = oauth_mod._pending_auth_path("user@example.com")
+    assert pending.exists(), "_save_pending_auth did not write the pending file"
+
+    mode = stat.S_IMODE(pending.stat().st_mode)
+    assert mode == 0o600, (
+        f"per-user pending OAuth file mode 0o{mode:o} != 0o600 — "
+        f"umask leaked the PKCE code_verifier to other local users"
+    )
+
+    parent_mode = stat.S_IMODE(pending.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"per-user pending OAuth dir mode 0o{parent_mode:o} != 0o700"
+    )
+
+
+def test_save_pending_auth_writes_0o600_legacy_single_user(
+    isolated_hermes_home, monkeypatch
+):
+    """Legacy (no-email) pending file path must also land at 0o600."""
+    from plugins.platforms.google_chat import oauth as oauth_mod
+
+    old_umask = os.umask(0o022)
+    try:
+        oauth_mod._save_pending_auth(
+            state="fake-chat-state",
+            code_verifier="fake-chat-code-verifier",
+            email=None,
+        )
+    finally:
+        os.umask(old_umask)
+
+    pending = oauth_mod._legacy_pending_path()
+    assert pending.exists(), "_save_pending_auth did not write the legacy pending file"
+
+    mode = stat.S_IMODE(pending.stat().st_mode)
+    assert mode == 0o600, (
+        f"legacy pending OAuth file mode 0o{mode:o} != 0o600 — "
+        f"umask leaked the PKCE code_verifier to other local users"
+    )
+
+    parent_mode = stat.S_IMODE(pending.parent.stat().st_mode)
+    assert parent_mode == 0o700, (
+        f"HERMES_HOME mode 0o{parent_mode:o} != 0o700"
+    )

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -1,0 +1,278 @@
+"""RED file-mode tests for the google-workspace OAuth setup script.
+
+Background
+==========
+``skills/productivity/google-workspace/scripts/setup.py`` persists three
+secret-bearing files under ``$HERMES_HOME``:
+
+  * ``CLIENT_SECRET_PATH``     — the Google OAuth client_secret.json
+  * ``TOKEN_PATH``             — the long-lived refresh token
+  * ``PENDING_AUTH_PATH``      — PKCE code_verifier + state mid-flow
+
+All three are written today with ``Path.write_text`` and never chmod'd
+afterward, so under the typical ``umask 0o022`` they land at ``0o644``
+— readable by every local user. This is the exact failure mode
+addressed by #19673 (``agent/google_oauth.py``) and #21148
+(``tools/mcp_oauth.py``). The Google Workspace skill is the last big
+write-site still leaking.
+
+These tests assert the writers land all three files at ``0o600``. They
+will stay RED until the GREEN commit migrates the writers to the
+``write_secret_json`` helper (or an inline ``os.open(O_EXCL, 0o600)``
++ ``os.fsync`` + ``atomic_replace`` pattern).
+
+POSIX-only — Windows does not enforce POSIX mode bits.
+
+We mock the OAuth ``Flow`` (no network), and isolate every file path
+under ``tmp_path`` (no real ``~/.hermes`` access).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake OAuth Flow (avoids network/token exchange)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCredentials:
+    def __init__(self):
+        self._payload = {
+            "token": "access-token",
+            "refresh_token": "refresh-token-XXX",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "fake-client-id",
+            "client_secret": "fake-client-secret",
+            "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+        }
+
+    def to_json(self):
+        return json.dumps(self._payload)
+
+
+class _FakeFlow:
+    """Minimal stand-in for ``google_auth_oauthlib.flow.Flow``."""
+
+    last_instance: "_FakeFlow | None" = None
+
+    def __init__(self, client_secrets_file, scopes, *,
+                 redirect_uri=None, state=None, code_verifier=None,
+                 autogenerate_code_verifier=False):
+        self.client_secrets_file = client_secrets_file
+        self.scopes = scopes
+        self.redirect_uri = redirect_uri
+        self.state = state or "fake-state"
+        self.code_verifier = code_verifier or "fake-code-verifier"
+        self.autogenerate_code_verifier = autogenerate_code_verifier
+        self.credentials = _FakeCredentials()
+        _FakeFlow.last_instance = self
+
+    @classmethod
+    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+        return cls(client_secrets_file, scopes, **kwargs)
+
+    def authorization_url(self, **kwargs):
+        return (
+            f"https://auth.example/authorize?state={self.state}",
+            self.state,
+        )
+
+    def fetch_token(self, **kwargs):
+        # No network. Pretend success.
+        return None
+
+
+@pytest.fixture
+def setup_module_fx(monkeypatch, tmp_path):
+    """Load the setup script in isolation, with file paths pinned to tmp_path."""
+    google_auth_module = types.ModuleType("google_auth_oauthlib")
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+    flow_module.Flow = _FakeFlow
+    google_auth_module.flow = flow_module
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+
+    spec = importlib.util.spec_from_file_location(
+        "google_workspace_setup_red_mode_test", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    # Avoid pip / dep install side effects.
+    monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+
+    # Pin every secret-bearing path under tmp_path so we never touch the
+    # real ~/.hermes layout.
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(module, "CLIENT_SECRET_PATH", hermes_home / "google_client_secret.json")
+    monkeypatch.setattr(module, "TOKEN_PATH", hermes_home / "google_token.json")
+    monkeypatch.setattr(
+        module, "PENDING_AUTH_PATH", hermes_home / "google_oauth_pending.json",
+        raising=False,
+    )
+    return module
+
+
+@pytest.fixture
+def client_secret_file(tmp_path):
+    """A valid client_secret.json on disk that store_client_secret will accept."""
+    src = tmp_path / "src_client_secret.json"
+    src.write_text(json.dumps({
+        "installed": {
+            "client_id": "fake-client-id",
+            "client_secret": "fake-client-secret",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    }))
+    return src
+
+
+# ---------------------------------------------------------------------------
+# store_client_secret → CLIENT_SECRET_PATH must be 0o600
+# ---------------------------------------------------------------------------
+
+
+def test_store_client_secret_writes_0o600_under_umask_0o022(
+    setup_module_fx, client_secret_file
+):
+    """``store_client_secret`` must land CLIENT_SECRET_PATH at 0o600."""
+    old_umask = os.umask(0o022)
+    try:
+        setup_module_fx.store_client_secret(str(client_secret_file))
+    finally:
+        os.umask(old_umask)
+
+    target = setup_module_fx.CLIENT_SECRET_PATH
+    assert target.exists(), "store_client_secret did not write CLIENT_SECRET_PATH"
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode == 0o600, (
+        f"CLIENT_SECRET_PATH mode 0o{mode:o} != 0o600 — "
+        f"umask leaked client secret to other local users"
+    )
+
+
+# ---------------------------------------------------------------------------
+# exchange_auth_code → TOKEN_PATH must be 0o600
+# ---------------------------------------------------------------------------
+
+
+def test_exchange_auth_code_writes_token_path_at_0o600(
+    setup_module_fx, client_secret_file
+):
+    """``exchange_auth_code`` must land TOKEN_PATH at 0o600.
+
+    The refresh token inside is a long-lived secret; ``umask 0o022``
+    would otherwise leave it at 0o644 (world-readable).
+    """
+    # Pre-stage the client secret and a pending PKCE state file so
+    # exchange_auth_code can proceed.
+    setup_module_fx.CLIENT_SECRET_PATH.write_text(client_secret_file.read_text())
+    setup_module_fx.PENDING_AUTH_PATH.write_text(
+        json.dumps({"state": "fake-state", "code_verifier": "fake-code-verifier"})
+    )
+
+    old_umask = os.umask(0o022)
+    try:
+        setup_module_fx.exchange_auth_code("4/test-auth-code")
+    finally:
+        os.umask(old_umask)
+
+    token_path = setup_module_fx.TOKEN_PATH
+    assert token_path.exists(), "exchange_auth_code did not write TOKEN_PATH"
+    mode = stat.S_IMODE(token_path.stat().st_mode)
+    assert mode == 0o600, (
+        f"TOKEN_PATH mode 0o{mode:o} != 0o600 — "
+        f"umask leaked the refresh token to other local users"
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_auth_url → PENDING_AUTH_PATH must be 0o600 while it exists
+# ---------------------------------------------------------------------------
+
+
+def test_get_auth_url_writes_pending_auth_at_0o600(setup_module_fx, client_secret_file):
+    """``get_auth_url`` must land PENDING_AUTH_PATH at 0o600.
+
+    The pending file holds the PKCE ``code_verifier`` for the in-flight
+    OAuth exchange. With ``umask 0o022`` and the current writer that
+    file lands at 0o644 — another local user can read the code_verifier
+    and (if they can intercept the auth code in transit) finish the
+    OAuth dance themselves.
+    """
+    # Pre-stage the client secret so get_auth_url can proceed.
+    setup_module_fx.CLIENT_SECRET_PATH.write_text(client_secret_file.read_text())
+
+    old_umask = os.umask(0o022)
+    try:
+        setup_module_fx.get_auth_url()
+    finally:
+        os.umask(old_umask)
+
+    pending = setup_module_fx.PENDING_AUTH_PATH
+    assert pending.exists(), "get_auth_url did not write PENDING_AUTH_PATH"
+    mode = stat.S_IMODE(pending.stat().st_mode)
+    assert mode == 0o600, (
+        f"PENDING_AUTH_PATH mode 0o{mode:o} != 0o600 — "
+        f"umask leaked the PKCE code_verifier to other local users"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parent dir of every credential path must be 0o700
+# ---------------------------------------------------------------------------
+
+
+def test_token_and_secret_parent_dir_is_0o700(setup_module_fx, client_secret_file):
+    """All three credential paths share a parent dir; it must be 0o700.
+
+    Loose parent dir (typical 0o755 from ``Path.mkdir`` under umask 0o022)
+    lets other users ``cd`` into ``~/.hermes`` and ``ls`` the contents,
+    leaking the existence and names of OAuth credential files even when
+    those files themselves are 0o600.
+    """
+    # Stage the prerequisite state so all three writers run.
+    setup_module_fx.CLIENT_SECRET_PATH.write_text(client_secret_file.read_text())
+    setup_module_fx.PENDING_AUTH_PATH.write_text(
+        json.dumps({"state": "fake-state", "code_verifier": "fake-code-verifier"})
+    )
+
+    old_umask = os.umask(0o022)
+    try:
+        setup_module_fx.store_client_secret(str(client_secret_file))
+        setup_module_fx.exchange_auth_code("4/test-auth-code")
+    finally:
+        os.umask(old_umask)
+
+    parent = setup_module_fx.CLIENT_SECRET_PATH.parent
+    mode = stat.S_IMODE(parent.stat().st_mode)
+    assert mode == 0o700, (
+        f"credentials parent dir mode 0o{mode:o} != 0o700 — "
+        f"other users can list OAuth credential filenames"
+    )

--- a/tests/tools/test_approval_shell_payload_floor.py
+++ b/tests/tools/test_approval_shell_payload_floor.py
@@ -1,0 +1,88 @@
+"""RED-phase parametrized tests for the shell/interpreter ``-c`` hardline bypass.
+
+The hardline floor (``tools.approval.detect_hardline_command``) currently
+scans the raw command string for catastrophic patterns -- ``rm -rf /``,
+``mkfs``, ``shutdown``, fork bombs, ``kill -1``, etc. -- but it does not
+look inside the payload of a shell or interpreter ``-c`` flag. That means
+an attacker (or a confused LLM) can smuggle a hardline command past the
+floor simply by wrapping it in ``bash -c '...'``, ``zsh -ic '...'``, or
+``python -c "..."``.
+
+These tests pin the desired behavior: ``detect_hardline_command`` must
+catch the catastrophic payload even when it is nested inside an ``-c``
+argument, while still leaving harmless ``print``/``echo`` lines that only
+*mention* the dangerous words untouched.
+
+This file is RED-only. The production fix lives in ``tools/approval.py``
+and is deferred to the GREEN commit.
+"""
+
+import pytest
+
+from tools.approval import detect_hardline_command
+
+
+# -------------------------------------------------------------------------
+# Positive cases -- catastrophic commands hidden inside an ``-c`` payload.
+# All of these MUST be hardline-blocked once the floor learns to inspect
+# shell/interpreter ``-c`` arguments.
+# -------------------------------------------------------------------------
+_SHELL_PAYLOAD_HARDLINE_CASES = [
+    # bash -lc: login shell, single-quoted catastrophic rm -rf /
+    "bash -lc 'rm -rf /'",
+    # sh -c with double-quoted mkfs against a raw block device
+    'sh -c "mkfs.ext4 /dev/sda"',
+    # zsh -ic: interactive shell smuggling shutdown
+    "zsh -ic 'shutdown -h now'",
+    # python3 -c invoking os.system on rm -rf /
+    "python3 -c 'import os; os.system(\"rm -rf /\")'",
+    # python -c using __import__ to reach os.system with a mkfs payload
+    "python -c \"__import__('os').system('mkfs.ext4 /dev/sda')\"",
+]
+
+
+# -------------------------------------------------------------------------
+# Negative cases -- ``-c`` payloads that only *mention* the dangerous
+# words as string literals. These must NOT trip the hardline floor.
+# -------------------------------------------------------------------------
+_SHELL_PAYLOAD_NEGATIVE_CASES = [
+    # print() of a literal string that happens to contain "rm -rf /"
+    "python -c \"print('rm -rf / as text')\"",
+    # echo of the literal word "reboot" -- nothing is actually being rebooted
+    "bash -c 'echo reboot'",
+]
+
+
+@pytest.mark.parametrize("command", _SHELL_PAYLOAD_HARDLINE_CASES)
+def test_shell_payload_is_hardline(command):
+    """Catastrophic payloads hidden in ``-c`` arguments are hardline matches.
+
+    The exact description string is intentionally not pinned: the GREEN
+    implementation is free to choose its phrasing (e.g. "rm -rf root via
+    bash -c", "mkfs filesystem via interpreter -c", etc.). We only require
+    that *some* non-empty description accompanies the True flag so callers
+    can build a meaningful block message.
+    """
+    is_hardline, description = detect_hardline_command(command)
+    assert is_hardline is True, (
+        f"shell/interpreter -c payload should be hardline-blocked, "
+        f"but detect_hardline_command returned False for: {command!r}"
+    )
+    assert isinstance(description, str) and description.strip(), (
+        f"hardline match must include a non-empty description; got "
+        f"{description!r} for {command!r}"
+    )
+
+
+@pytest.mark.parametrize("command", _SHELL_PAYLOAD_NEGATIVE_CASES)
+def test_shell_payload_negative_is_not_hardline(command):
+    """Benign ``-c`` payloads that only mention the words must pass.
+
+    These commands are not actually invoking ``rm``/``reboot`` -- they are
+    string literals fed to ``print`` or ``echo``. The hardline floor must
+    not return a false positive on them, otherwise harmless logging and
+    documentation snippets would be unconditionally blocked.
+    """
+    assert detect_hardline_command(command) == (False, None), (
+        f"benign -c payload was unexpectedly hardline-blocked: {command!r}"
+    )

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -319,6 +319,93 @@ class TestPostRedirectSsrf:
         assert "cloud metadata endpoint" in result["error"]
 
 
+# ---------------------------------------------------------------------------
+# Always-blocked floor on LOCAL backends (#16234 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestLocalBackendImdsFloor:
+    """The cloud-metadata / IMDS floor must fire even on a local backend.
+
+    Local-backend mode (Camofox, headless Chromium without a cloud provider)
+    intentionally skips the SSRF check because the agent already has full
+    local-network access via the terminal tool.  That carve-out is fine for
+    ordinary RFC1918 / loopback URLs, but it MUST NOT extend to cloud
+    metadata endpoints.  An agent running on an EC2 / GCE / Azure host with
+    a local browser backend can still be coerced by a malicious prompt into
+    navigating to 169.254.169.254 (or sibling addresses) and exfiltrating
+    IAM credentials via subsequent ``browser_snapshot`` calls (#16234).
+
+    The floor must be unconditional: regardless of backend (local vs cloud),
+    regardless of ``allow_private_urls``, regardless of ``_is_safe_url``,
+    if ``_is_always_blocked_url(url)`` is True the navigation must be
+    rejected with a ``cloud metadata`` error.
+    """
+
+    PUBLIC_URL = "https://example.com/redirect"
+
+    @pytest.fixture()
+    def _common_patches(self, monkeypatch):
+        """Shared patches: pretend we're running a local browser backend."""
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            browser_tool,
+            "_get_session_info",
+            lambda task_id: {
+                "session_name": f"s_{task_id}",
+                "bb_session_id": None,
+                "cdp_url": None,
+                "features": {"local": True},
+                "_first_nav": False,
+            },
+        )
+        monkeypatch.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _make_browser_result(),
+        )
+
+    # -- Pre-navigation: all IMDS endpoints blocked on local backend ----------
+
+    @pytest.mark.parametrize("imds_url", TestPreNavigationSsrf.IMDS_URLS)
+    def test_local_backend_blocks_imds_pre_navigation(
+        self, monkeypatch, _common_patches, imds_url
+    ):
+        """Direct nav to a cloud metadata URL is blocked even on a local backend."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+        monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: True)
+
+        result = json.loads(browser_tool.browser_navigate(imds_url))
+
+        assert result["success"] is False
+        assert "cloud metadata" in result["error"]
+
+    # -- Post-redirect: redirect landing on IMDS blocked on local backend ----
+
+    @pytest.mark.parametrize("imds_url", TestPreNavigationSsrf.IMDS_URLS)
+    def test_local_backend_blocks_imds_post_redirect(
+        self, monkeypatch, _common_patches, imds_url
+    ):
+        """A redirect to a cloud metadata URL is blocked even on a local backend."""
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: False)
+        monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: True)
+        monkeypatch.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _make_browser_result(url=imds_url),
+        )
+
+        result = json.loads(browser_tool.browser_navigate(self.PUBLIC_URL))
+
+        assert result["success"] is False
+        assert "cloud metadata" in result["error"]
+
+
 class TestAllowPrivateUrlsConfig:
     @pytest.fixture(autouse=True)
     def _reset_cache(self):

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -312,6 +312,26 @@ print(result)
         # terminal won't be in hermes_tools.py, so import fails
         self.assertEqual(result["status"], "error")
 
+    def test_explicit_enabled_tools_excludes_sandbox_tools(self):
+        """Explicit enabled_tools=['execute_code'] must not fall back to all
+        sandbox tools when the intersection with SANDBOX_ALLOWED_TOOLS is empty.
+
+        The caller has explicitly opted into only the execute_code meta-tool;
+        no sandbox helpers should be exposed.  `from hermes_tools import terminal`
+        must therefore fail (terminal is not in the generated stub module),
+        matching the existing test_excluded_tool_returns_error shape.
+
+        Currently fails: tools/code_execution_tool.py treats an empty
+        intersection the same as `enabled_tools is None` and re-enables all
+        sandbox tools, so `terminal` remains importable and the script
+        succeeds instead of erroring.
+        """
+        result = self._run(
+            "from hermes_tools import terminal",
+            enabled_tools=["execute_code"],
+        )
+        self.assertEqual(result["status"], "error")
+
     def test_empty_code(self):
         """Empty code string returns an error."""
         result = json.loads(execute_code("", task_id="test"))
@@ -806,8 +826,14 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("all imports ok", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_empty_enabled_tools_uses_all(self):
-        """When enabled_tools is [] (empty), all sandbox tools should be available."""
+    def test_empty_enabled_tools_exposes_no_sandbox_helpers(self):
+        """An explicit empty enabled_tools=[] is an opt-in allow-list whose
+        intersection with SANDBOX_ALLOWED_TOOLS is empty, so no sandbox
+        helpers are exposed and ``from hermes_tools import terminal`` fails.
+
+        Only ``enabled_tools is None`` (no caller policy) re-enables all
+        sandbox tools — covered by test_none_enabled_tools_uses_all above.
+        """
         code = (
             "from hermes_tools import terminal, web_search\n"
             "print('imports ok')\n"
@@ -816,13 +842,14 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                     return_value=json.dumps({"ok": True})):
             result = json.loads(execute_code(code, task_id="test-empty",
                                              enabled_tools=[]))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("imports ok", result["output"])
+        self.assertEqual(result["status"], "error")
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
+    def test_nonoverlapping_tools_exposes_no_sandbox_helpers(self):
+        """An explicit enabled_tools list whose intersection with
+        SANDBOX_ALLOWED_TOOLS is empty must be honored as "no sandbox
+        helpers", not silently widened back to the full allow-list.
+        """
         code = (
             "from hermes_tools import terminal\n"
             "print('fallback ok')\n"
@@ -833,8 +860,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
                 code, task_id="test-nonoverlap",
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertEqual(result["status"], "error")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
@@ -255,17 +256,313 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     return (False, None)
 
 
+# =========================================================================
+# Wrapper-aware payload extraction (bash/sh/zsh/ksh/dash + interpreter -c)
+# =========================================================================
+#
+# Plain raw-regex scanning misses catastrophic commands smuggled inside a
+# shell or interpreter ``-c`` argument because the dangerous keyword is
+# followed by a closing quote rather than whitespace/end-of-string:
+#
+#     bash -lc 'rm -rf /'          # `/` followed by `'` — `\bemxx ...(\s|$)` fails
+#     zsh -ic 'shutdown -h now'    # `shutdown` preceded by `'` — `_CMDPOS` fails
+#     python3 -c 'os.system("rm -rf /")'  # same quote-bypass issue
+#
+# To close this hardline-bypass we parse the wrapper command with
+# ``shlex.split``, extract the payload, and run the hardline scan against
+# the payload instead. For Python interpreters we additionally restrict
+# the match to *real* ``os.system`` / ``__import__('os').system`` calls so
+# that harmless ``print('rm -rf /')`` literals stay unmatched.
+
+_SHELL_WRAPPER_NAMES = frozenset({"bash", "sh", "zsh", "ksh", "dash"})
+_PY_WRAPPER_NAMES = frozenset({"python", "python2", "python3"})
+_OTHER_INTERPRETER_NAMES = frozenset({"perl", "ruby", "node"})
+
+# Leading words that may precede the actual wrapper command. We skip past
+# them so ``sudo bash -c 'rm -rf /'`` / ``env FOO=1 python3 -c '...'`` /
+# ``nohup bash -c '...'`` all still reach the wrapper-aware path.
+_WRAPPER_PREFIX_NAMES = frozenset({"exec", "nohup", "setsid", "time"})
+
+
+def _parse_wrapper(command: str):
+    """Parse a shell/interpreter wrapper command via :func:`shlex.split`.
+
+    Returns ``(payload, kind)`` when the command is recognized as a wrapper,
+    otherwise ``None``. ``kind`` is one of:
+
+    * ``"shell"``       — bash/sh/zsh/ksh/dash with a flag containing ``c``
+                          (``-c``, ``-lc``, ``-ic``, ``-lic``, …).
+    * ``"python"``      — python/python2/python3 with ``-c`` or ``-e``.
+    * ``"interpreter"`` — perl/ruby/node with ``-c`` or ``-e``.
+
+    Raises :class:`ValueError` when ``shlex.split`` cannot tokenize the
+    command (mismatched quotes, dangling backslash, …). Callers that want a
+    pure ``str | None`` API should use :func:`_extract_wrapped_payload`,
+    which swallows the exception.
+    """
+    tokens = shlex.split(command)  # may raise ValueError
+    if not tokens:
+        return None
+
+    # Skip leading prefix wrappers (sudo / env / exec / nohup / setsid /
+    # time) so the next loop sees the actual interpreter command name.
+    idx = 0
+    while idx < len(tokens):
+        tok = tokens[idx]
+        if tok == "sudo":
+            idx += 1
+            while idx < len(tokens) and tokens[idx].startswith("-"):
+                idx += 1
+            continue
+        if tok == "env":
+            idx += 1
+            while (
+                idx < len(tokens)
+                and "=" in tokens[idx]
+                and not tokens[idx].startswith("-")
+            ):
+                idx += 1
+            continue
+        if tok in _WRAPPER_PREFIX_NAMES:
+            idx += 1
+            continue
+        break
+
+    if idx >= len(tokens):
+        return None
+
+    # Strip path prefix: /bin/bash -> bash, /usr/bin/python3 -> python3.
+    cmd_base = tokens[idx].rsplit("/", 1)[-1]
+
+    if cmd_base in _SHELL_WRAPPER_NAMES:
+        kind = "shell"
+    elif cmd_base in _PY_WRAPPER_NAMES:
+        kind = "python"
+    elif cmd_base in _OTHER_INTERPRETER_NAMES:
+        kind = "interpreter"
+    else:
+        return None
+
+    # Locate the -c/-e flag (or shell combined flag like -lc) and its payload.
+    i = idx + 1
+    while i < len(tokens):
+        arg = tokens[i]
+        if not arg.startswith("-"):
+            # Positional arg before any -c/-e — not a script invocation.
+            return None
+        if kind == "shell":
+            # bash/sh/zsh/ksh/dash treat -c as the script flag. Combined
+            # short-flags like -lc, -ic, -lic, -ci all still take the next
+            # positional as the script body.
+            if "c" in arg.lstrip("-").lower():
+                if i + 1 < len(tokens):
+                    return (tokens[i + 1], kind)
+                return None
+        else:
+            # python/perl/ruby/node accept -c or -e for an inline script.
+            if arg in {"-c", "-e"}:
+                if i + 1 < len(tokens):
+                    return (tokens[i + 1], kind)
+                return None
+        i += 1
+
+    return None
+
+
+def _extract_wrapped_payload(command: str) -> Optional[str]:
+    """Return the inner payload of a shell/interpreter ``-c``/``-e`` wrapper.
+
+    Recognizes bash/sh/zsh/ksh/dash with a flag containing ``c`` (``-c``,
+    ``-lc``, ``-ic``, ``-lic``, …) and python/python2/python3/perl/ruby/node
+    with ``-c`` or ``-e``. Returns ``None`` when the command is not a
+    recognized wrapper or when :func:`shlex.split` cannot tokenize it.
+
+    Used by :func:`detect_hardline_command` to look inside the ``-c``
+    argument for catastrophic commands that the raw-regex floor misses
+    because the dangerous keyword is followed by a closing quote rather
+    than whitespace/end-of-string.
+    """
+    try:
+        info = _parse_wrapper(command)
+    except ValueError:
+        return None
+    if info is None:
+        return None
+    return info[0]
+
+
+# Real Python system-call invocations. Captures the first string-literal
+# argument so we can apply HARDLINE_PATTERNS_COMPILED to it. Harmless
+# ``print('rm -rf /')`` is *not* matched because ``print`` isn't in the
+# call-target alternation.
+_PY_SYSTEM_CALL_RE = re.compile(
+    r"""
+    (?:
+        __import__\s*\(\s*['"]os['"]\s*\)\s*\.\s*system
+      | \bos\s*\.\s*system
+    )
+    \s*\(\s*
+    (?:r|b|rb|br|u)?          # optional Python string prefix
+    (['"])                    # opening quote (\1)
+    ([^'"]*)                  # captured string content (group 2)
+    \1                        # matching closing quote
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _payload_matches_hardline_pattern(text: str):
+    """Run HARDLINE_PATTERNS_COMPILED against an already-normalized payload.
+
+    Returns ``(True, description)`` on the first match, otherwise
+    ``(False, None)``. ``text`` should already be lowercased and
+    normalized by :func:`_normalize_command_for_detection`.
+    """
+    for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
+        if pattern_re.search(text):
+            return (True, description)
+    return (False, None)
+
+
+def _check_wrapper_payload_hardline(payload: str, kind: str):
+    """Apply hardline detection to a wrapper payload.
+
+    For shell wrappers (``kind == "shell"``) the payload is itself a shell
+    command — apply HARDLINE_PATTERNS_COMPILED directly. ``bash -c 'echo
+    reboot'`` stays unmatched because the existing ``_CMDPOS`` anchor in
+    the shutdown/reboot pattern still requires command position; ``echo
+    reboot`` has ``reboot`` as an argument to ``echo``, not a command.
+
+    For python wrappers we only flag *real* invocations of ``os.system``
+    or ``__import__('os').system`` whose string argument matches a
+    hardline pattern. Harmless ``python -c "print('rm -rf / as text')"``
+    stays unmatched because ``print`` is not in the call-target alternation.
+
+    For other interpreter wrappers (perl/ruby/node) we apply the
+    shell-style direct scan to the payload. The public test surface only
+    covers python; treating these as shell is intentionally conservative.
+    """
+    payload_norm = _normalize_command_for_detection(payload).lower()
+
+    if kind == "python":
+        for match in _PY_SYSTEM_CALL_RE.finditer(payload):
+            inner = match.group(2)
+            if not inner:
+                continue
+            inner_norm = _normalize_command_for_detection(inner).lower()
+            matched, description = _payload_matches_hardline_pattern(inner_norm)
+            if matched:
+                return (True, f"{description} (via python -c)")
+        return (False, None)
+
+    matched, description = _payload_matches_hardline_pattern(payload_norm)
+    if not matched:
+        return (False, None)
+    suffix = "shell -c" if kind == "shell" else "interpreter -c"
+    return (True, f"{description} (via {suffix})")
+
+
+# Wrapper-token regex used by the conservative shlex-fallback path.
+_WRAPPER_TOKEN_RE = re.compile(
+    r"\b(?:bash|sh|zsh|ksh|dash|python[23]?|perl|ruby|node)\b"
+)
+
+# Keywords for the conservative fallback when shlex parsing fails. Each
+# entry is (lowercase substring, human-readable description). Tracks the
+# catastrophic-command floor in HARDLINE_PATTERNS — keep them in sync if
+# either side changes.
+_FALLBACK_HARDLINE_KEYWORDS = (
+    ("rm -rf /", "recursive delete of root filesystem"),
+    ("mkfs", "format filesystem (mkfs)"),
+    ("dd of=/dev/", "dd to raw block device"),
+    (":(){:|:&};:", "fork bomb"),
+    ("kill -1", "kill all processes"),
+    ("shutdown", "system shutdown"),
+    ("reboot", "system reboot"),
+    ("halt", "system halt"),
+    ("poweroff", "system poweroff"),
+    ("init 0", "init 0 (shutdown)"),
+    ("init 6", "init 6 (reboot)"),
+    ("systemctl poweroff", "systemctl poweroff"),
+    ("systemctl reboot", "systemctl reboot"),
+    ("systemctl halt", "systemctl halt"),
+    ("telinit 0", "telinit 0 (shutdown)"),
+    ("telinit 6", "telinit 6 (reboot)"),
+)
+
+
+def _fallback_hardline_match(normalized_lower: str):
+    """Conservative fallback when shlex parsing fails.
+
+    If the normalized command contains both a wrapper token (bash, sh,
+    zsh, ksh, dash, python, python2, python3, perl, ruby, node) *and* at
+    least one hardline keyword, return ``(True, description)``. Otherwise
+    return ``(False, None)``. This guards against quote-confusion bypass
+    attempts where the raw command is unparseable but obviously catastrophic.
+    """
+    if not _WRAPPER_TOKEN_RE.search(normalized_lower):
+        return (False, None)
+    for keyword, description in _FALLBACK_HARDLINE_KEYWORDS:
+        if keyword in normalized_lower:
+            return (True, f"{description} (wrapper smuggled, shlex parse failed)")
+    return (False, None)
+
+
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
+
+    Wrapper-aware: when the command is a bash/sh/zsh/ksh/dash invocation
+    with a ``-c``-style flag, or a python/perl/ruby/node invocation with
+    ``-c``/``-e``, the inner payload is extracted via :func:`shlex.split`
+    and inspected directly. This catches catastrophic commands smuggled
+    inside quoted ``-c`` arguments (e.g. ``bash -lc 'rm -rf /'`` or
+    ``python -c "import os; os.system('rm -rf /')"``) that the raw-regex
+    floor would otherwise miss because the dangerous keyword is followed
+    by a closing quote rather than whitespace/end-of-string.
+
+    Benign ``-c`` payloads that merely *mention* the dangerous words as
+    string literals — ``python -c "print('rm -rf / as text')"``, ``bash
+    -c 'echo reboot'`` — remain unblocked.
 
     Returns:
         (is_hardline, description) or (False, None)
     """
     normalized = _normalize_command_for_detection(command).lower()
-    for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-        if pattern_re.search(normalized):
+
+    # Wrapper-aware path
+    try:
+        wrapper_info = _parse_wrapper(command)
+    except ValueError:
+        # Conservative fallback: a malformed wrapper command (mismatched
+        # quotes, etc.) that still mentions a hardline keyword is treated
+        # as smuggling — block to be safe.
+        fallback_match, fallback_desc = _fallback_hardline_match(normalized)
+        if fallback_match:
+            return (True, fallback_desc)
+        wrapper_info = None
+
+    if wrapper_info is not None:
+        payload, kind = wrapper_info
+        matched, description = _check_wrapper_payload_hardline(payload, kind)
+        if matched:
             return (True, description)
-    return (False, None)
+        # Wrapper payload was benign on its own. Still scan the rest of
+        # the raw command (with the payload redacted) so chained forms
+        # like ``bash -c 'echo hi' && rm -rf /`` cannot smuggle a
+        # catastrophic command past the floor by hiding it after a safe
+        # wrapper. Redacting the payload first prevents false-positives
+        # on dangerous keywords that only appear inside the wrapper's
+        # quoted string literal.
+        normalized_outside = normalized.replace(payload.lower(), "", 1)
+        outside_match, outside_desc = _payload_matches_hardline_pattern(
+            normalized_outside
+        )
+        if outside_match:
+            return (True, outside_desc)
+        return (False, None)
+
+    # Not a wrapper: standard raw-command hardline scan.
+    return _payload_matches_hardline_pattern(normalized)
 
 
 def _hardline_block_result(description: str) -> dict:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2184,7 +2184,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     # 169.254.169.254 / metadata.google.internal / ECS task metadata
     # via a browser, and routing those to a local Chromium sidecar
     # on an EC2/GCP/Azure host exfiltrates IAM credentials (#16234).
-    if not _is_local_backend() and _is_always_blocked_url(url):
+    if _is_always_blocked_url(url):
         return json.dumps({
             "success": False,
             "error": "Blocked: URL targets a cloud metadata endpoint",
@@ -2256,8 +2256,7 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         # when auto_local_this_nav is true — see pre-nav check for
         # rationale (#16234).
         if (
-            not _is_local_backend()
-            and final_url
+            final_url
             and final_url != url
             and _is_always_blocked_url(final_url)
         ):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -854,10 +854,15 @@ def _execute_remote(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-    if not sandbox_tools:
+    # Only fall back to all SANDBOX_ALLOWED_TOOLS when the caller passes no
+    # policy at all (``enabled_tools is None``).  An explicit list — even one
+    # whose intersection with SANDBOX_ALLOWED_TOOLS is empty — is honored as
+    # an opt-in allow-list, so no sandbox helpers are exposed.
+    if enabled_tools is None:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    else:
+        session_tools = set(enabled_tools)
+        sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
 
     effective_task_id = task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
@@ -1079,12 +1084,16 @@ def execute_code(
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
-    # Determine which tools the sandbox can call
-    session_tools = set(enabled_tools) if enabled_tools else set()
-    sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
-
-    if not sandbox_tools:
+    # Determine which tools the sandbox can call.
+    # Only fall back to all SANDBOX_ALLOWED_TOOLS when the caller passes no
+    # policy at all (``enabled_tools is None``).  An explicit list — even one
+    # whose intersection with SANDBOX_ALLOWED_TOOLS is empty — is honored as
+    # an opt-in allow-list, so no sandbox helpers are exposed.
+    if enabled_tools is None:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
+    else:
+        session_tools = set(enabled_tools)
+        sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")


### PR DESCRIPTION
## What does this PR do?

This PR satisfies CONTRIBUTING.md priority (1) Bug fixes — `browser_navigate` returning success for IMDS endpoints on local backend is a bug, `detect_hardline_command` returning `(False, None)` for `bash -lc 'rm -rf /'` is a bug, `execute_code` granting `terminal` to schema-restricted sessions is a bug — and priority (3) Security hardening — SSRF, command-bypass, sandbox-toolset-escape, redirect-SSRF, and POSIX credential-file permission gaps.

It fixes five tightly-scoped security/correctness gaps where implementation drifted from the security promises in `website/docs/user-guide/security.md`:

1. `fix(browser): always block IMDS/cloud-metadata URLs even on local backend`
   - What: applies the cloud-metadata deny floor before navigation and after redirects even when the local browser backend is active.
   - Why: a local Chromium sidecar on cloud hosts can still reach `169.254.169.254`/metadata endpoints and exfiltrate credentials.
   - Evidence anchor: `tools/browser_tool.py:2187` and `tools/browser_tool.py:2261`; regression coverage in `tests/tools/test_browser_ssrf_local.py` asserts every `IMDS_URLS` case fails with `Blocked: URL targets a cloud metadata endpoint` for pre-navigation and post-redirect paths.

2. `fix(approval): close shell/interpreter -c hardline-bypass for catastrophic commands`
   - What: extracts shell/interpreter payloads for `bash`/`sh`/`zsh`/`ksh`/`dash` and `python`/`perl`/`ruby`/`node` `-c`/`-e`/`-lc` style wrappers, then re-runs the hardline detector before YOLO/off bypass can skip approval.
   - Why: `rm -rf /`, `mkfs`, shutdown/reboot, fork-bombs, and similar catastrophic payloads were blocked only when direct, not when wrapped.
   - Evidence anchor: `tools/approval.py:372` plus the YOLO/off hardline path; regression coverage in `tests/tools/test_approval_shell_payload_floor.py` covers destructive shell and interpreter wrappers plus benign text negatives.

3. `fix(execute_code): honor explicit enabled_tools list when intersecting sandbox tools`
   - What: makes `enabled_tools is None` the only fallback to the full sandbox helper set; explicit lists now stay authoritative even when their intersection with sandbox-allowed tools is empty.
   - Why: schema-restricted sessions could import `terminal` inside `execute_code` despite the tool not being exposed to the model.
   - Evidence anchor: `tools/code_execution_tool.py:858-861` and `tools/code_execution_tool.py:1089-1092`; regression coverage in `tests/tools/test_code_execution.py` confirms `from hermes_tools import terminal` fails under `enabled_tools=["execute_code"]`.

4. `fix(gateway): re-validate SSRF on redirect for slack/wecom/feishu/yuanbao media downloads`
   - What: registers the existing `_ssrf_redirect_guard` on the Slack, WeCom, Feishu, and Yuanbao media `httpx.AsyncClient(follow_redirects=True)` paths, and adds an initial `is_safe_url` guard to `yuanbao_media.download_url`.
   - Why: docs promise redirect chains are re-validated at each hop, but these platform-specific downloaders followed redirects without the shared guard.
   - Evidence anchor: `gateway/platforms/slack.py:1065`, `gateway/platforms/wecom.py:1049-1058`, `gateway/platforms/feishu.py:3095`, and `gateway/platforms/yuanbao_media.py:224-229`; regression coverage in `tests/gateway/test_*_ssrf_redirect.py` and `tests/gateway/test_yuanbao_media_ssrf.py` redirects public-looking URLs to IMDS and asserts blocking.

5. `fix(oauth): write google client secrets and tokens with 0600 / parent 0700`
   - What: adds `agent/secure_file_io.py::write_secret_json()` and routes Google Workspace / Google Chat client-secret, token, and pending-PKCE writes through it.
   - Why: `Path.write_text()` under a typical `umask 022` produced `0644` credential files readable by other local users.
   - Evidence anchor: `agent/secure_file_io.py:62`, `skills/productivity/google-workspace/scripts/setup.py:251/257/389`, `skills/productivity/google-workspace/scripts/gws_bridge.py:74`, and `plugins/platforms/google_chat/oauth.py:303/404/411`; regression coverage in `tests/agent/test_secure_file_io.py`, `tests/skills/test_google_workspace_setup.py`, and `tests/plugins/test_google_chat_oauth_modes.py` asserts `0600` files and `0700` parents under `umask 022`.

## Related Issue

Related: #4146, #20738. No prior exact issue found for the redirect-chain media downloader or Google OAuth file-mode findings; these were discovered via codebase audit and are regression-tested here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_tool.py`, `tests/tools/test_browser_ssrf_local.py`: unconditional browser metadata/IMDS deny floor across local backend and post-redirect paths.
- `tools/approval.py`, `tests/tools/test_approval_shell_payload_floor.py`: shell/interpreter payload extraction before hardline/YOLO approval bypass.
- `tools/code_execution_tool.py`, `tests/tools/test_code_execution.py`: explicit `enabled_tools` restrictions honored inside sandbox helper generation.
- `gateway/platforms/{slack,wecom,feishu,yuanbao_media}.py`, `tests/gateway/test_*_ssrf_redirect.py`, `tests/gateway/test_yuanbao_media_ssrf.py`: redirect-hop SSRF revalidation for platform media downloaders; Yuanbao now also validates initial URLs.
- `agent/secure_file_io.py`, `skills/productivity/google-workspace/scripts/{setup,gws_bridge}.py`, `plugins/platforms/google_chat/oauth.py`, and tests under `tests/agent`, `tests/skills`, `tests/plugins`: atomic secret JSON writes with `0600` files / `0700` parents.

## How to Test

1. Scoped regression suite (green on macOS 26.4.1):

```bash
scripts/run_tests.sh tests/tools/test_url_safety.py tests/tools/test_browser_ssrf_local.py tests/tools/test_approval_shell_payload_floor.py tests/tools/test_code_execution.py tests/agent/test_secure_file_io.py tests/skills/test_google_workspace_setup.py tests/plugins/test_google_chat_oauth_modes.py tests/gateway/test_slack_media_ssrf_redirect.py tests/gateway/test_wecom_media_ssrf_redirect.py tests/gateway/test_feishu_media_ssrf_redirect.py tests/gateway/test_yuanbao_media_ssrf.py -q
# 225 passed, 4 warnings in 57.35s
```

2. Required broad targeted command was executed post-rebase:

```bash
scripts/run_tests.sh tests/tools/test_url_safety.py tests/tools/test_browser_ssrf_local.py tests/tools/test_approval_shell_payload_floor.py tests/tools/test_code_execution.py tests/agent/test_secure_file_io.py tests/skills/test_google_workspace_setup.py tests/plugins/test_google_chat_oauth_modes.py tests/gateway/ -q
# exit 1 locally: 8 gateway failures also reproduce unchanged on a clean origin/main worktree at 7993e03c0
```

The eight local gateway failures are baseline-origin/main failures in `tests/gateway/test_config.py`, `tests/gateway/test_shutdown_forensics.py`, `tests/gateway/test_tts_media_routing.py`, `tests/gateway/test_update_streaming.py`, and `tests/gateway/test_verbose_command.py`; they are outside this PR's diff and were not fixed here to keep scope limited to Findings A–E.

3. Full suite was executed with the hermetic wrapper:

```bash
scripts/run_tests.sh -q
# exit 1 locally in this macOS developer environment; failures are outside the changed files and include pre-existing keychain/systemd/live-system/file-state/delegate/TUI local-environment cases.
```

4. Reproduction/fix probes:

```text
CC_PROBE_BROWSER_IMDS -> {"success": false, "error": "Blocked: URL targets a cloud metadata endpoint"}
CC_PROBE_HARDLINE direct -> (True, 'recursive delete of root filesystem')
CC_PROBE_HARDLINE bash -> (True, 'recursive delete of root filesystem (via shell -c)')
CC_PROBE_HARDLINE python -> (True, 'recursive delete of root filesystem (via python -c)')
CC_PROBE_SANDBOX_ESCAPE -> ImportError: cannot import name 'terminal' from 'hermes_tools'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (hermetic wrapper full suite was run; local baseline-origin/main failures remain outside this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docs already promised this behavior; this PR restores implementation/test anchors without broad docs churn)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `chmod`/`os.open`/`os.replace` paths catch `OSError`/`NotImplementedError`; mode assertions are POSIX-gated where needed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Follow-up PRs (not in scope)

- `web_crawl` docs/registry drift.
- `ui-tui/packages/hermes-ink/package-lock.json` stale lockfile.
- OSV scanner lockfile scope gaps.
- Browser auto-snapshot cost/opt-out.
- Context compressor input cap.
- Remote `execute_code` file-RPC at-most-once semantics.
- `allow_private_urls` docs phrasing and examples.

## Screenshots / Logs

No UI screenshots. Security regression evidence is captured in the test and probe outputs above.
