### PR TITLE
fix(mcp): add missing array items schemas

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -266,6 +266,24 @@ class TestSchemaConversion:
 
         assert schema["properties"]["items"]["items"]["properties"] == {}
 
+    def test_array_missing_items_gets_permissive_items_schema(self):
+        """OpenAI/Codex reject array schemas that omit items."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "cookies": {
+                    "anyOf": [
+                        {"type": "object"},
+                        {"type": "array"},
+                    ],
+                },
+            },
+        })
+
+        assert schema["properties"]["cookies"]["anyOf"][1]["items"] == {}
+
     def test_optional_nullable_field_is_collapsed_to_non_null_schema(self):
         """Anthropic rejects MCP/Pydantic anyOf-null optional parameter schemas."""
         from tools.mcp_tool import _normalize_mcp_input_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2589,6 +2589,8 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
       nullable branches in tool input schemas, so nullable unions are collapsed
       to the non-null branch and optionality remains represented solely by the
       parent object's ``required`` list.
+    * ``array`` nodes without ``items`` get permissive ``items: {}`` because
+      OpenAI / Codex rejects array schemas that omit the items schema.
 
     All repairs are provider-agnostic and ideally produce a schema valid on
     OpenAI, Anthropic, Gemini, and Moonshot in one pass.
@@ -2638,6 +2640,11 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
             "properties" in repaired or "required" in repaired
         ):
             repaired["type"] = "object"
+
+        if repaired.get("type") == "array" and "items" not in repaired:
+            # Strict providers reject array schemas without an items schema.
+            # Empty schema is permissive and preserves the MCP server's intent.
+            repaired["items"] = {}
 
         if repaired.get("type") == "object":
             # Ensure properties exists so required can reference it safely


### PR DESCRIPTION
## Summary
- Repairs MCP tool schemas that declare arrays without an items schema
- Covers OpenAI/Codex 400s from MCP servers such as scrapling that emit anyOf branches with bare arrays
- Adds a regression test for missing array items inside nested MCP schemas

## Test Plan
- [x] venv/bin/python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_tool.py
- [x] Direct sanity import of _normalize_mcp_input_schema with object/array anyOf shape