### PR TITLE
fix(plugins): clean up standalone sender ty warnings

### DIFF
--- a/docs/plans/2026-07-13-001-fix-pr-24210-review-followup-plan.md
+++ b/docs/plans/2026-07-13-001-fix-pr-24210-review-followup-plan.md
@@ -1,0 +1,104 @@
+---
+title: PR 24210 Review Follow-up - Plan
+type: fix
+date: 2026-07-13
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# PR 24210 Review Follow-up - Plan
+
+## Goal Capsule
+
+- **Objective:** Refresh PR #24210 onto current upstream `main`, preserve its three type-warning cleanups, address the remaining Google Chat optional-module narrowing reported in review, and return the PR to a reviewed, mergeable, freshly verified state.
+- **Authority:** The current upstream code and repo instructions take precedence, followed by the review request and this plan.
+- **Execution profile:** One bounded code-and-test unit followed by verification and GitHub review closure.
+- **Stop conditions:** Stop if rebasing reveals a behavioural conflict that cannot preserve both current upstream intent and the PR's narrow typing scope, or if fresh failures appear to be introduced by the branch and cannot be resolved without broadening scope.
+- **Tail ownership:** The executor owns the safe push, review reply and resolution, and CI follow-through until checks are terminal.
+
+## Product Contract
+
+### Summary
+
+PR #24210 remains relevant but is stale and conflicting. The review identifies one missed sibling pattern in the Google Chat refresh-success test: it dereferences the optional `_gc_mod.service_account` module without first narrowing it to a non-`None` local binding.
+
+### Problem Frame
+
+The PR already narrows the same optional module in the API-failure test and contains two other type-warning cleanups. Rebasing must preserve those intended changes while integrating current upstream test structure, then apply the same narrowing pattern consistently to the preceding refresh-success test.
+
+### Requirements
+
+- R1. Rebase the PR branch onto current upstream `main` while preserving the intended type-warning cleanups in `plugins/platforms/google_chat/adapter.py`, `tests/gateway/test_google_chat.py`, and `tests/hermes_cli/test_setup_irc.py`.
+- R2. In the Google Chat refresh-success test, bind `_gc_mod.service_account` locally, assert that it is not `None`, and use the narrowed binding for credential replacement and restoration.
+- R3. Keep the change limited to typing correctness and test scaffolding; do not alter Google Chat runtime behaviour or broaden into unrelated CI cleanup.
+- R4. Return PR #24210 to a clean, mergeable state with the targeted review thread answered and resolved and fresh CI results verified.
+
+### Scope Boundaries
+
+- **In scope:** Conflict resolution required by the rebase, the requested sibling-test narrowing, focused tests and static checks, safe force-push with an exact lease, review-thread closure, and CI follow-through.
+- **Out of scope:** Unrelated test failures, broad Google Chat refactors, and type-warning cleanup outside the three files already owned by the PR.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Rebase rather than merge current `main` so the existing contributor commit remains a focused, reviewable change; resolve conflicts by preserving both upstream behaviour and the PR's three typing fixes.
+- KTD2. Mirror the already accepted local-binding pattern from the API-failure test in the refresh-success test, avoiding a new helper or broader test refactor.
+- KTD3. Treat focused local checks as the implementation proof, then use the PR status rollup as the final integration proof; distinguish inherited failures from branch-introduced failures with current-main evidence.
+
+### Assumptions
+
+- The review request is authoritative and technically valid because current `main` still contains the direct optional-module dereferences in the refresh-success test.
+- The branch head remains the reviewed commit until the exact-lease push; if it changes remotely, the executor must stop and reassess rather than overwrite it.
+
+## Implementation Units
+
+### U1. Refresh the branch and complete optional-module narrowing
+
+- **Goal:** Rebase the PR onto current `main`, reconcile all three touched files, and apply the requested Google Chat test narrowing without changing runtime behaviour.
+- **Requirements:** R1, R2, R3.
+- **Dependencies:** None.
+- **Files:** `plugins/platforms/google_chat/adapter.py`, `tests/gateway/test_google_chat.py`, `tests/hermes_cli/test_setup_irc.py`.
+- **Approach:** Capture the current remote head for lease protection, rebase onto fresh upstream `main`, inspect every conflict against upstream intent, preserve the original optional `aiohttp` and `PlatformEntry` typing fixes, then use the existing API-failure test's local `service_account` binding pattern in the refresh-success test.
+- **Execution note:** Verify the pre-change type-narrowing gap against current `main`, then keep the implementation mechanical and local.
+- **Patterns to follow:** The local `service_account` binding and non-`None` assertion already present in `TestGoogleChatStandaloneSend.test_standalone_send_propagates_api_failure`.
+- **Test scenarios:**
+  1. The refresh-success test replaces `Credentials.from_service_account_info`, completes a successful standalone send, and restores the original credential factory through the narrowed local binding.
+  2. The API-failure sibling test still returns the expected 403 error path and restores the credential factory.
+  3. IRC setup tests continue to construct heterogeneous `PlatformEntry` defaults without new type diagnostics.
+  4. Google Chat adapter paths still behave identically when optional `aiohttp` support is present or absent; only static narrowing changes.
+- **Verification:** The rebased diff contains only the plan and the intended narrow typing changes, has no conflict markers or whitespace errors, and the focused tests and static checks pass.
+
+### U2. Publish and close the review loop
+
+- **Goal:** Update the fork branch safely, respond to the requested review change, resolve the thread, and verify fresh PR health.
+- **Requirements:** R4.
+- **Dependencies:** U1.
+- **Files:** `docs/plans/2026-07-13-001-fix-pr-24210-review-followup-plan.md`.
+- **Approach:** Commit with the configured GodsBoy identity, push using an exact force-with-lease tied to the previously captured remote head, confirm GitHub reflects the new head, reply with the concrete change and verification evidence, resolve the review thread, and watch all relevant PR checks to terminal state.
+- **Patterns to follow:** Existing upstream fork-PR refresh discipline: exact lease, head-OID read-back, both workflow and PR-rollup verification, and factual documentation of any inherited failure.
+- **Test scenarios:**
+  1. A changed remote head causes the lease-protected push to fail instead of overwriting new work.
+  2. GitHub reports the pushed head OID before mergeability and check conclusions are trusted.
+  3. The targeted review thread is replied to and resolved only after the requested code change is present on the remote branch.
+  4. Any failing check is compared against current `main`; branch-introduced failures are fixed, while inherited or flaky failures are documented with evidence.
+- **Verification:** The PR head matches the local branch, mergeability is clean, the targeted thread is resolved, and the PR check rollup is terminal with all branch-relevant checks passing or any inherited exception explicitly evidenced.
+
+## Verification Contract
+
+- `scripts/run_tests.sh tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` proves the touched test surfaces.
+- `ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` proves focused lint correctness.
+- `ty check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` proves the targeted type diagnostics are absent.
+- `python -m compileall -q plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` proves syntax validity.
+- `git diff --check origin/main...HEAD` and conflict-marker inspection prove patch hygiene after rebase.
+- The GitHub PR head OID, mergeability, unresolved-thread query, and full check rollup provide final remote verification.
+
+## Definition of Done
+
+- R1 through R4 are satisfied without unrelated code changes.
+- U1's focused test and static-analysis scenarios pass on the rebased branch.
+- U2's lease-protected push, remote head read-back, review reply, thread resolution, and CI follow-through are complete.
+- PR #24210 is open, clean, mergeable, and no targeted review feedback remains unresolved.
+- Any abandoned conflict-resolution attempt or temporary code is removed from the final diff.

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -38,6 +38,7 @@ CARD_CLICKED is ACK'd only in v1 (follow-up PR implements interactivity).
 from __future__ import annotations
 
 import asyncio
+import importlib
 import json
 import logging
 import os
@@ -3247,7 +3248,7 @@ async def _standalone_send(
 
     url = f"https://chat.googleapis.com/v1/{chat_id}/messages"
     try:
-        import aiohttp as _aiohttp
+        _aiohttp = importlib.import_module("aiohttp")
     except ImportError:
         return {"error": "Google Chat standalone send: aiohttp not installed"}
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2855,8 +2855,10 @@ class TestGoogleChatStandaloneSend:
         fake_creds.token = "the-token"
         fake_creds.refresh = MagicMock(return_value=None)
 
-        original = _gc_mod.service_account.Credentials.from_service_account_info
-        _gc_mod.service_account.Credentials.from_service_account_info = MagicMock(
+        service_account = _gc_mod.service_account
+        assert service_account is not None
+        original = service_account.Credentials.from_service_account_info
+        service_account.Credentials.from_service_account_info = MagicMock(
             return_value=fake_creds
         )
         try:
@@ -2871,7 +2873,7 @@ class TestGoogleChatStandaloneSend:
                 "hello cron",
             )
         finally:
-            _gc_mod.service_account.Credentials.from_service_account_info = original
+            service_account.Credentials.from_service_account_info = original
 
         assert result == {
             "success": True,

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2910,8 +2910,10 @@ class TestGoogleChatStandaloneSend:
         fake_creds.token = "the-token"
         fake_creds.refresh = MagicMock(return_value=None)
 
-        original = _gc_mod.service_account.Credentials.from_service_account_info
-        _gc_mod.service_account.Credentials.from_service_account_info = MagicMock(
+        service_account = _gc_mod.service_account
+        assert service_account is not None
+        original = service_account.Credentials.from_service_account_info
+        service_account.Credentials.from_service_account_info = MagicMock(
             return_value=fake_creds
         )
         try:
@@ -2930,7 +2932,7 @@ class TestGoogleChatStandaloneSend:
                 "hi",
             )
         finally:
-            _gc_mod.service_account.Credentials.from_service_account_info = original
+            service_account.Credentials.from_service_account_info = original
 
         assert "error" in result
         assert "403" in result["error"]

--- a/tests/hermes_cli/test_setup_irc.py
+++ b/tests/hermes_cli/test_setup_irc.py
@@ -6,6 +6,7 @@ interactive setup menus.
 """
 
 import os
+from typing import Any
 
 from gateway.platform_registry import PlatformEntry, platform_registry
 
@@ -16,7 +17,7 @@ def _register_irc_platform(**overrides):
     Tests run outside the normal plugin-discovery path, so we inject the entry
     directly into the singleton registry and yield its dict shape.
     """
-    defaults = dict(
+    defaults: dict[str, Any] = dict(
         name="irc",
         label="IRC",
         adapter_factory=lambda cfg: None,


### PR DESCRIPTION
## Summary
- Rebase the stale fork branch onto current `main` while preserving the original focused typing cleanups
- Use `importlib` for the optional `aiohttp` import in Google Chat standalone send without changing its runtime behaviour
- Narrow the optional Google Chat `service_account` module in both standalone-send credential mock tests
- Annotate IRC setup defaults so `ty` does not infer a heterogeneous value union for `PlatformEntry` keyword arguments
- Record the review follow-up and verification contract in `docs/plans/2026-07-13-001-fix-pr-24210-review-followup-plan.md`

## Verification
- `scripts/run_tests.sh tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` - 168 passed
- `ruff check .` - passed
- `python scripts/check-windows-footguns.py --all` - passed
- `python -m compileall -q plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py tests/hermes_cli/test_setup_irc.py` - passed
- CI-style Ruff and ty diff against the rebased `origin/main` - no new Ruff issues and 22 fewer ty diagnostics
- Full local suite - 40,402 passed and 23 failed in unrelated, unchanged areas; the corresponding failure set reproduced on current `main`, apart from one timing-sensitive cache invalidation test in unchanged code

Addresses the advisory ty diff reported on #22461: https://github.com/NousResearch/hermes-agent/pull/22461#issuecomment-4412204236
