### PR TITLE
fix(agent): persist repaired current turn history

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1489,6 +1489,7 @@ class AIAgent:
         # (e.g. CLI voice mode adds a temporary prefix for the live call only).
         self._persist_user_message_idx = None
         self._persist_user_message_override = None
+        self._session_db_needs_rewrite = False
 
         # Cache anthropic image-to-text fallbacks per image payload/URL so a
         # single tool loop does not repeatedly re-run auxiliary vision on the
@@ -4559,6 +4560,14 @@ class AIAgent:
             # Rewrite in place so downstream paths (persistence, return
             # value, session DB flush) see the repaired sequence.
             messages[:] = merged
+            # The repair may have merged the current user turn into a message
+            # that was already flushed to SQLite, so append-only persistence can
+            # silently skip the new text. Force the next DB flush to resync the
+            # stored transcript from the repaired in-memory history.
+            try:
+                self._session_db_needs_rewrite = True
+            except Exception:
+                pass
 
         return repairs
 
@@ -4576,6 +4585,11 @@ class AIAgent:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
                 self._ensure_db_session()
+            if getattr(self, "_session_db_needs_rewrite", False):
+                self._session_db.replace_messages(self.session_id, messages)
+                self._last_flushed_db_idx = len(messages)
+                self._session_db_needs_rewrite = False
+                return
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -91,6 +91,47 @@ def test_repair_merges_consecutive_user_messages():
     assert len(messages) == 1
     assert messages[0]["role"] == "user"
     assert messages[0]["content"] == "first\n\nsecond"
+    assert agent._session_db_needs_rewrite is True
+
+
+def test_repaired_shorter_history_rewrites_session_db_current_turn(tmp_path):
+    """If repair shortens history, persistence must not skip the current turn."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "repair-current-turn"
+    db.create_session(session_id=session_id, source="test")
+    db.append_message(session_id, role="assistant", content="prior answer")
+    db.append_message(session_id, role="user", content="stale user tail")
+
+    agent = _bare_agent()
+    agent.session_id = session_id
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._ensure_db_session = lambda: None
+
+    conversation_history = [
+        {"role": "assistant", "content": "prior answer"},
+        {"role": "user", "content": "stale user tail"},
+    ]
+    messages = list(conversation_history) + [
+        {"role": "user", "content": "CURRENT TURN SHOULD PERSIST"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+    AIAgent._flush_messages_to_session_db(agent, messages, conversation_history)
+
+    rows = db.get_messages(session_id)
+    assert repairs == 1
+    assert len(messages) == len(conversation_history)
+    assert len(rows) == 2
+    assert rows[1]["role"] == "user"
+    assert rows[1]["content"] == "stale user tail\n\nCURRENT TURN SHOULD PERSIST"
+    assert agent._last_flushed_db_idx == 2
+    assert agent._session_db_needs_rewrite is False
 
 
 def test_repair_preserves_user_content_when_one_side_empty():


### PR DESCRIPTION
## What does this PR do?

Fixes a SessionDB persistence bug where the current turn can be silently skipped after message-sequence repair shortens the live conversation history.

`AIAgent._repair_message_sequence()` mutates the live `messages` list in place before the API call. That repair can drop orphan tool messages or merge consecutive user messages. `_flush_messages_to_session_db()` then used the original `len(conversation_history)` and `_last_flushed_db_idx` as append-only boundaries. If repair shortened the list, persistence could slice from the old boundary and write nothing.

The important edge case is consecutive user-message repair: the current user turn can be merged into a prior user message that was already persisted in SQLite. In that case, appending from a later index is not enough because the existing DB row needs to be rewritten.

This PR marks the SessionDB transcript for rewrite when `_repair_message_sequence()` changes the live history. The next flush uses the existing `SessionDB.replace_messages()` path to atomically resync the stored transcript from the repaired in-memory history, then updates `_last_flushed_db_idx`.

## Related Issue

Fixes #24187

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `run_agent.py` to track when message-sequence repair requires a SessionDB transcript rewrite
- updated `_repair_message_sequence()` to set the rewrite flag after it mutates `messages`
- updated `_flush_messages_to_session_db()` to call `SessionDB.replace_messages()` when the repaired live transcript must replace the stored transcript
- added regression coverage in `tests/run_agent/test_message_sequence_repair.py` for the case where repair merges the current user turn into an already persisted user message

## How to Test

1. Run the focused regression and flush-dedup tests:
   ```bash
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_860_dedup.py -q
   ```
2. Run adjacent persistence coverage:
   ```bash
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_compression_persistence.py -q
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k 'PersistUserMessageOverride or repair'
   ```
3. Reproduce the original failure shape with consecutive user-message repair and confirm the DB row contains the current turn after flush.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu / local Linux `pytest` via `/home/cyt/miniconda3/envs/meta_workflow_py312/bin/python`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix, local minimal reproduction showed that repair merged the current user turn into the live message list, but SessionDB append was skipped:

```text
repairs= 1
len_history= 2
len_messages_after_repair= 2
messages_after_repair= [{'role': 'assistant', 'content': 'prior answer'}, {'role': 'user', 'content': 'stale user tail\n\nCURRENT TURN SHOULD PERSIST'}]
append_calls= 0
last_flushed_idx= 2
```

After fix, the same reproduction rewrites the stored SessionDB transcript and preserves the current turn:

```text
Could not import tool module tools.browser_dialog_tool: No module named 'websockets'
repairs= 1
len_history= 2
len_messages_after_repair= 2
db_rows= [('assistant', 'prior answer'), ('user', 'stale user tail\n\nCURRENT TURN SHOULD PERSIST')]
last_flushed_idx= 2
```

Real local pytest results:

```bash
$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_860_dedup.py -q
.....................                                                    [100%]
21 passed in 20.42s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_compression_persistence.py -q
......                                                                   [100%]
6 passed in 8.87s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k 'PersistUserMessageOverride or repair'
.                                                                        [100%]
1 passed, 324 deselected in 7.06s
```
## What does this PR do?

Fixes a SessionDB persistence bug where the current turn can be silently skipped after message-sequence repair shortens the live conversation history.

`AIAgent._repair_message_sequence()` mutates the live `messages` list in place before the API call. That repair can drop orphan tool messages or merge consecutive user messages. `_flush_messages_to_session_db()` then used the original `len(conversation_history)` and `_last_flushed_db_idx` as append-only boundaries. If repair shortened the list, persistence could slice from the old boundary and write nothing.

The important edge case is consecutive user-message repair: the current user turn can be merged into a prior user message that was already persisted in SQLite. In that case, appending from a later index is not enough because the existing DB row needs to be rewritten.

This PR marks the SessionDB transcript for rewrite when `_repair_message_sequence()` changes the live history. The next flush uses the existing `SessionDB.replace_messages()` path to atomically resync the stored transcript from the repaired in-memory history, then updates `_last_flushed_db_idx`.

## Related Issue

Fixes #24187

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `run_agent.py` to track when message-sequence repair requires a SessionDB transcript rewrite
- updated `_repair_message_sequence()` to set the rewrite flag after it mutates `messages`
- updated `_flush_messages_to_session_db()` to call `SessionDB.replace_messages()` when the repaired live transcript must replace the stored transcript
- added regression coverage in `tests/run_agent/test_message_sequence_repair.py` for the case where repair merges the current user turn into an already persisted user message

## How to Test

1. Run the focused regression and flush-dedup tests:
   ```bash
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_860_dedup.py -q
   ```
2. Run adjacent persistence coverage:
   ```bash
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_compression_persistence.py -q
   HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k 'PersistUserMessageOverride or repair'
   ```
3. Reproduce the original failure shape with consecutive user-message repair and confirm the DB row contains the current turn after flush.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu / local Linux `pytest` via `/home/cyt/miniconda3/envs/meta_workflow_py312/bin/python`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix, local minimal reproduction showed that repair merged the current user turn into the live message list, but SessionDB append was skipped:

```text
repairs= 1
len_history= 2
len_messages_after_repair= 2
messages_after_repair= [{'role': 'assistant', 'content': 'prior answer'}, {'role': 'user', 'content': 'stale user tail\n\nCURRENT TURN SHOULD PERSIST'}]
append_calls= 0
last_flushed_idx= 2
```

After fix, the same reproduction rewrites the stored SessionDB transcript and preserves the current turn:

```text
Could not import tool module tools.browser_dialog_tool: No module named 'websockets'
repairs= 1
len_history= 2
len_messages_after_repair= 2
db_rows= [('assistant', 'prior answer'), ('user', 'stale user tail\n\nCURRENT TURN SHOULD PERSIST')]
last_flushed_idx= 2
```

Real local pytest results:

```bash
$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_860_dedup.py -q
.....................                                                    [100%]
21 passed in 20.42s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_compression_persistence.py -q
......                                                                   [100%]
6 passed in 8.87s

$ HOME=/tmp/hermes-agent-pytest HERMES_HOME=/tmp/hermes-agent-pytest/.hermes XDG_CACHE_HOME=/tmp/hermes-agent-pytest/.cache PYTHONPATH=. /home/cyt/miniconda3/envs/meta_workflow_py312/bin/python -m pytest --override-ini=addopts='' -p no:cacheprovider tests/run_agent/test_run_agent.py -q -k 'PersistUserMessageOverride or repair'
.                                                                        [100%]
1 passed, 324 deselected in 7.06s
```
