### PR TITLE
[security] fix(api-server): scope run approvals by run id

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2939,7 +2939,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
-        approval_session_key = gateway_session_key or session_id or run_id
+        # Approval queues gate host-side tool execution and must be isolated
+        # per API run.  Client-provided session IDs and memory session keys are
+        # conversation/memory scopes, not authorization namespaces: multiple
+        # concurrent runs can intentionally share them, and resolving an
+        # approval for one run must not unblock another run's dangerous command.
+        approval_session_key = run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -24,6 +24,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from tools import approval as approval_mod
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +357,77 @@ class TestRunEvents:
             "once",
             resolve_all=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
+        """Same client session_id must not let one run approve another run's queue."""
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                victim_agent, victim_ready, victim_interrupted = _make_slow_agent()
+                attacker_agent, attacker_ready, attacker_interrupted = _make_slow_agent()
+                mock_create.side_effect = [victim_agent, attacker_agent]
+
+                victim_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "victim", "session_id": "shared-project"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                attacker_resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "attacker", "session_id": "shared-project"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert victim_resp.status == 202
+                assert attacker_resp.status == 202
+                victim_run = (await victim_resp.json())["run_id"]
+                attacker_run = (await attacker_resp.json())["run_id"]
+
+                victim_ready.wait(timeout=3.0)
+                attacker_ready.wait(timeout=3.0)
+                assert auth_adapter._run_approval_sessions[victim_run] == victim_run
+                assert auth_adapter._run_approval_sessions[attacker_run] == attacker_run
+                assert auth_adapter._run_approval_sessions[victim_run] != auth_adapter._run_approval_sessions[attacker_run]
+
+                victim_entry = approval_mod._ApprovalEntry({
+                    "command": "bash -c victim-danger",
+                    "description": "victim approval",
+                    "pattern_keys": ["shell-c"],
+                })
+                attacker_entry = approval_mod._ApprovalEntry({
+                    "command": "bash -c attacker-danger",
+                    "description": "attacker approval",
+                    "pattern_keys": ["shell-c"],
+                })
+                with approval_mod._lock:
+                    approval_mod._gateway_queues[victim_run] = [victim_entry]
+                    approval_mod._gateway_queues[attacker_run] = [attacker_entry]
+
+                approval_resp = await cli.post(
+                    f"/v1/runs/{attacker_run}/approval",
+                    json={"choice": "always", "resolve_all": True},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                approval_data = await approval_resp.json()
+
+                assert approval_resp.status == 200
+                assert approval_data["resolved"] == 1
+                assert attacker_entry.result == "always"
+                assert attacker_entry.event.is_set()
+                assert victim_entry.result is None
+                assert not victim_entry.event.is_set()
+                with approval_mod._lock:
+                    assert approval_mod._gateway_queues[victim_run] == [victim_entry]
+                    assert victim_run in approval_mod._gateway_queues
+                    assert attacker_run not in approval_mod._gateway_queues
+
+                # Clean up the synthetic pending victim approval and unblock the
+                # slow test agents so their background run tasks can finish.
+                with approval_mod._lock:
+                    approval_mod._gateway_queues.pop(victim_run, None)
+                victim_interrupted.set()
+                attacker_interrupted.set()
+
 
     @pytest.mark.asyncio
     async def test_events_not_found_returns_404(self, adapter):


### PR DESCRIPTION
## Summary

This PR hardens the API server's `/v1/runs` dangerous-command approval path so one API run cannot resolve another run's pending approval when both runs share the same client-provided session scope.

The patch:
- scopes API-server approval queues to the generated `run_id`
- keeps request-body `session_id` for conversation/task continuity without reusing it as an approval authorization namespace
- adds a regression proving `resolve_all` on one run does not approve another run with the same `session_id`

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| API run approvals were scoped by shared `session_id` / gateway session key | An authenticated API client could start a run with the same `session_id` as another concurrent run and use `resolve_all` to resolve the other run's dangerous-command approval | High |

## Before this PR

- `POST /v1/runs` accepted caller-controlled `session_id` for run continuity.
- The API server reused that value as the approval session key:
  - `approval_session_key = gateway_session_key or session_id or run_id`
- `POST /v1/runs/{run_id}/approval` looked up the run's approval session key and called `resolve_gateway_approval(..., resolve_all=...)`.
- The underlying gateway approval queue is keyed by session key, so multiple concurrent runs sharing the same `session_id` could share one approval queue.
- `resolve_all=true` on one run could therefore resolve pending approvals from another run in the same shared key.

## After this PR

- API-server approval queues are scoped to the generated `run_id`.
- Client-provided `session_id` and `X-Hermes-Session-Key` continue to represent conversation/memory scope, but no longer act as the approval authorization namespace.
- `resolve_all=true` only resolves approvals queued for the target API run.
- A regression test locks this boundary in place.

## Why this matters

Dangerous-command approvals are a host-side safety boundary. An API client approving its own run should not be able to unblock another user's or another client's pending dangerous command just because both runs reuse a shared project/session identifier.

The bug is especially relevant for shared API-server or WebUI deployments where multiple authenticated clients can submit runs and choose `session_id` values for continuity.

## How this differs from #21899, #20311, #15802, and #6059

- #15802 reported that API-server/WebUI runs could not surface dangerous-command approvals.
- #20311 and #21899 added structured approval events and `POST /v1/runs/{run_id}/approval`.
- #6059 is an earlier open feature PR for API-server approval events and says `all: true` should resolve approvals for the run.

This PR fixes a distinct security boundary in the current implementation: the approval endpoint was route-scoped by `run_id`, but the queue it resolved was scoped by caller-controlled session context. The result was a cross-run approval-resolution primitive that the feature PRs did not describe or test.

## Attack flow

```text
Victim starts /v1/runs with session_id = shared-project
    -> victim run reaches a dangerous command
        -> approval is queued under shared-project
Attacker starts /v1/runs with the same session_id = shared-project
    -> attacker receives their own run_id
        -> attacker POSTs /v1/runs/{attacker_run_id}/approval with resolve_all=true
            -> vulnerable code resolves all queued approvals under shared-project
                -> victim's pending dangerous-command approval is unblocked
```

## Affected code

| Issue | Files |
|-------|-------|
| API run approval queue reused caller-controlled session scope | `gateway/platforms/api_server.py`, `tests/gateway/test_api_server_runs.py` |

## Root cause

- Direct cause: API-server runs used conversation/memory session scope as the approval queue key.
- Boundary failure: `session_id` is attacker-controllable continuity metadata and can be intentionally shared by multiple runs; it should not authorize approval resolution for host-side tool execution.
- Missing regression: existing API-server run approval tests did not cover two concurrent runs with the same `session_id` and `resolve_all=true`.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Cross-run API approval resolution | 8.0 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:N` |

Rationale:
- A valid API credential is required when the API server is configured with a key.
- The attack is network-reachable to authenticated API clients.
- The main impact is integrity over dangerous-command approval decisions, with possible confidentiality impact depending on the command that gets approved.
- Scope is treated as changed because one API run/client can affect another run's host-side approval boundary.

## Safe reproduction steps

1. Start an API run with `session_id` set to a shared value and have it reach a dangerous-command approval.
2. Start a second API run with the same `session_id`.
3. Send approval only to the second run:

```http
POST /v1/runs/{attacker_run_id}/approval
Authorization: Bearer <api-key>
Content-Type: application/json

{"choice":"always","resolve_all":true}
```

4. On vulnerable code, approvals queued under the shared session key can be resolved together, including the first run's pending approval.

The regression test uses two runs with the same `session_id`, seeds separate pending approvals, and verifies approving the attacker run resolves exactly one approval and leaves the victim entry untouched.

## Expected vulnerable behavior

On vulnerable code, the proof harness showed:

```text
status 200
response {'object': 'hermes.run.approval_response', 'run_id': 'run_attacker', 'choice': 'always', 'resolved': 2}
victim_result always
attacker_result always
victim_event_set True
attacker_event_set True
bypass_signal True
```

The key signal is `resolved: 2` plus `victim_result always` even though the request targeted only the attacker run.

## Changes in this PR

- Changes the API-server approval session key for `/v1/runs` to the generated `run_id`.
- Leaves `session_id` as the task/conversation continuity identifier.
- Adds a regression proving two runs with the same `session_id` have distinct approval scopes.
- Verifies `resolve_all` on the attacker run resolves only the attacker's pending approval entry.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API-server hardening | `gateway/platforms/api_server.py` | Scope run approval queues by `run_id` instead of shared caller-controlled session context |
| Regression tests | `tests/gateway/test_api_server_runs.py` | Add same-`session_id` cross-run approval isolation coverage |

## Maintainer impact

- The change is narrow to the API-server `/v1/runs` approval path.
- Conversation continuity remains unchanged: `session_id` is still passed as the run task/conversation identifier.
- Approval choices such as `once`, `session`, `always`, and `deny` remain available.
- For API-server runs, `session` approval now scopes to the target run's approval queue rather than every concurrent run sharing the same client-provided `session_id`.

## Fix rationale

Host-side command approvals should be tied to the specific run or approval request that surfaced the prompt. Client-supplied session continuity values are useful for conversation state, but they are not an authorization boundary for approving dangerous local tool execution.

Using the generated `run_id` keeps approval resolution aligned with the `/v1/runs/{run_id}/approval` route and preserves `resolve_all` semantics within the target run only.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused approval regression passed
- [x] Full API-server run endpoint suite passed
- [x] API-server + API-server run suites passed together
- [x] Syntax compile, whitespace, and ruff checks passed for touched files

Executed:

```bash
scripts/run_tests.sh \
  tests/gateway/test_api_server_runs.py::TestRunEvents::test_approval_response_without_pending_returns_409 \
  tests/gateway/test_api_server_runs.py::TestRunEvents::test_approval_resolve_all_is_scoped_to_target_run -q
```

Result: `2 passed, 2 warnings`

```bash
scripts/run_tests.sh tests/gateway/test_api_server_runs.py -q
```

Result: `22 passed, 22 warnings`

```bash
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py -q
```

Result: `163 passed, 114 warnings`

```bash
python3.11 -m compileall -q gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py
git diff --check
.venv/bin/ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py
```

Result: all passed.

Note: `uv run ruff check ...` currently fails during dependency resolution before ruff runs because the project still resolves the `mistralai>=2.3.0,<3` extra for future Python markers. Running the already-installed project ruff binary directly succeeds on the touched files.

## Disclosure notes

- This PR does not claim unauthenticated access; the affected route still requires API-server authentication when an API key is configured.
- The issue is bounded to the API-server `/v1/runs` dangerous-command approval control plane.
- Hardline-blocked commands remain blocked by the existing hardline guard.
- No unrelated files were changed.
