### PR TITLE
feat: add getxapi skill — X/Twitter via getxapi.com third-party API

### DIFF
--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -113,7 +113,7 @@ Overly specific terms like `exampleKeyword2%20tip` often return zero Top results
 
 ## Posting
 
-Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
+Posting requires BOTH the API key (Bearer header) AND an X `auth_token` value (passed in the JSON body). The auth_token is typically extracted from browser cookies — it is httpOnly and should not be extracted programmatically at runtime. Alternatively, `POST /twitter/user_login` (see the endpoint reference) can retrieve fresh tokens, but this endpoint accepts highly sensitive credentials and must only be used locally with credentials stored in `~/.hermes/.env`.
 
 **Cron prompt compatibility:** The Hermes cron scanner (`_CRON_EXFIL_COMMAND_PATTERNS` + `_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references — in Authorization headers, embedded in URLs, and in POST/form data — for all curl/wget invocations targeting non-GitHub domains. The only allowlist exemption is `Authorization: token $VAR` targeting `https://api.github.com`. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned.
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -73,9 +73,9 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
 
 getxapi uses **non-standard field names**. Do NOT use official X API v2 field names — they silently produce zero results.
 
-| getxapi field | X API v2 equivalent | Usage |
+| getxapi field | NOT these (official X API fields — won't work) | Usage |
 |---------------|---------------------|-------|
-| `author.userName` | NOT `screen_name` or `author.username` (those are X API v2 names — using them returns zero results) | Author handle |
+| `author.userName` | `screen_name` (v1.1), `username` (v2 user objects), `author.username` — using any of these returns zero results | Author handle |
 | `author.followers` | `public_metrics.followers_count` | Follower count |
 | `isReply` | `in_reply_to_user_id` (check if set) | Is it a reply? |
 | `id` | `id` (same) | Tweet ID |

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -43,7 +43,7 @@ Critical rules when operating inside an agent/LLM session:
 - The user must store credentials in `~/.hermes/.env` via `hermes setup` or manual editing.
 - **Never** execute `curl` commands with inline `Authorization: Bearer <real-key>` in agent sessions — it may be logged or exposed.
 - Treat the X `auth_token` like a password — it grants posting access to the account. Rotate immediately if exposed.
-- To verify API key validity, only use: `curl -s -H "Authorization: Bearer $GETXAPI_API_KEY" "https://api.getxapi.com/account/me"` after confirming the env var is set (never echo the value).
+- To verify API key validity, run: `curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/me"` (use the placeholder — the user supplies their real key locally, outside agent context)
 
 ## Quick Reference
 
@@ -111,12 +111,7 @@ Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net t
 
 Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
 
-**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references (e.g. `$GETXAPI_API_KEY`) in Authorization headers targeting non-GitHub domains. Two approaches work:
-
-1. **Hardcode the literal key in the cron prompt.** The scanner pattern requires a `$` prefix — a literal key like `get-x-api-...` does not match and passes the scan. Store the key in the cron prompt directly (NOT recommended for shared prompts, but works for personal use).
-2. **Use a helper script.** Reference a script in the cron job that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call. The script itself is not scanned for `$VAR` patterns.
-
-All curl examples in this skill use `<your-api-key>` and `<your-auth-token>` placeholders to avoid false-positive scanner matches in documentation.
+**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references (e.g. `$GETXAPI_API_KEY`) in Authorization headers targeting non-GitHub domains. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned for `$VAR` patterns.
 
 **Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -111,7 +111,7 @@ Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net t
 
 Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
 
-**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references (e.g. `$GETXAPI_API_KEY`) in Authorization headers targeting non-GitHub domains. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned for `$VAR` patterns.
+**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references in curl Authorization headers. The only allowlist exemption is `Authorization: token $VAR` targeting `https://api.github.com` — `Bearer` auth and all other domains (including `api.getxapi.com`) are blocked. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned for `$VAR` patterns.
 
 **Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -105,7 +105,7 @@ getxapi uses **non-standard field names**. Do NOT use official X API v2 field na
 
 Broad niche keywords work best (examples: `exampleKeyword1`, `exampleKeyword2`). Multi-word queries must be URL-encoded (e.g. `exampleKeyword1%20modifier`) — unencoded spaces cause truncated or failed requests.
 
-Overly specific terms like `exampleKeyword2 tip` often return zero Top results. Cast a wide net then filter.
+Overly specific terms like `exampleKeyword2%20tip` often return zero Top results. Cast a wide net then filter.
 
 ## Posting
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -7,7 +7,6 @@ license: MIT
 metadata:
   hermes:
     tags: [twitter, x, social-media, getxapi, api]
-    related_skills: [xurl]
 required_environment_variables:
   - name: GETXAPI_API_KEY
     prompt: getxapi API key (Bearer token)
@@ -138,7 +137,7 @@ Check `GET /account/me` before bulk operations. If credits drop below $1.00, red
 # Verify API key works
 curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/account/me"
-# Should return: {"email":"...","credits":"...","requests":"..."}
+# Should return account details with email, credit balance, and request counts.
 
 # Verify posting works
 curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -56,7 +56,7 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
 
 # Search tweets (always use product=Top)
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/tweet/advanced_search?q=homelab&product=Top&count=20"
+  "https://api.getxapi.com/twitter/tweet/advanced_search?q=exampleKeyword1&product=Top&count=20"
 
 # Post a tweet
 curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
@@ -103,9 +103,9 @@ getxapi uses **non-standard field names**. Do NOT use official X API v2 field na
 
 **Always use `product=Top`.** `product=Latest` returns 0-50 follower accounts and bot spam.
 
-Broad niche keywords work best: `homelab`, `self-hosting`, `Ollama`, `Hackintosh`, `HomeAssistant`, `Proxmox`, `Docker`, `TrueNAS`. Multi-word queries must be URL-encoded (e.g. `Ollama%20local`, `Docker%20self-hosted`) — unencoded spaces cause truncated or failed requests.
+Broad niche keywords work best (examples: `exampleKeyword1`, `exampleKeyword2`). Multi-word queries must be URL-encoded (e.g. `exampleKeyword1%20modifier`) — unencoded spaces cause truncated or failed requests.
 
-Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net then filter.
+Overly specific terms like `exampleKeyword2 tip` often return zero Top results. Cast a wide net then filter.
 
 ## Posting
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -16,7 +16,7 @@ required_environment_variables:
     required_for: all API access (search, post, user lookup)
   - name: GETXAPI_AUTH_TOKEN
     prompt: X auth_token for posting (32+ hex chars)
-    help: Extract from browser cookies (x.com → Storage → Cookies → auth_token). Required for tweet create/delete.
+    help: Extract from browser cookies (x.com → Storage → Cookies → auth_token). Required for posting tweets and replies.
     required_for: posting tweets and replies
 ---
 
@@ -76,7 +76,7 @@ getxapi uses **non-standard field names**. Do NOT use official X API v2 field na
 
 | getxapi field | X API v2 equivalent | Usage |
 |---------------|---------------------|-------|
-| `author.userName` | `author.username` / `screen_name` | Author handle |
+| `author.userName` | NOT `screen_name` or `author.username` (those are X API v2 names — using them returns zero results) | Author handle |
 | `author.followers` | `public_metrics.followers_count` | Follower count |
 | `isReply` | `in_reply_to_user_id` (check if set) | Is it a reply? |
 | `id` | `id` (same) | Tweet ID |
@@ -102,7 +102,7 @@ Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net t
 
 Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
 
-**Never put inline Bearer tokens in cron prompts.** The Hermes cron scanner blocks `$VAR` patterns in Authorization headers targeting non-GitHub domains. Hardcode the literal key or use `<your-api-key>` placeholder in documentation.
+**Cron prompt compatibility:** The Hermes cron scanner blocks `$VAR`-style environment variable references in Authorization headers for non-GitHub domains. When using getxapi in cron job prompts, reference the stored credential from `~/.hermes/.env` at runtime rather than embedding variable expansions. For curl examples in this skill, `<your-api-key>` and `<your-auth-token>` placeholders are used throughout to avoid false-positive scanner matches.
 
 **Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
 
@@ -112,7 +112,7 @@ Check `GET /account/me` before bulk operations. If credits drop below $1.00, red
 
 ## Gotchas
 
-- **No delete endpoint.** `POST /twitter/tweet/delete` returns 404. Contradictory tweets must be deleted manually on x.com.
+- **No delete endpoint.** `/twitter/tweet/delete` is not implemented (returns 404). Contradictory tweets must be deleted manually on x.com.
 - **`inReplyToId` is the field to check for original tweet** when deduplicating — use this, not `conversationId`.
 - **Transient "Daily tweet limit reached" errors** — retry once. Account still in warmup may hit X platform caps.
 - **Image-only tweets:** If text < 30 chars with media, analyze image OR skip — never reply blind.

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -25,9 +25,14 @@ Third-party X/Twitter API at `https://api.getxapi.com`. Credits-based ($0.001/re
 
 Use this skill for:
 - searching tweets by keyword with `product=Top` (actual engagement) vs `product=Latest` (bot spam)
-- posting standalone tweets and replies
-- fetching user timelines
-- checking account credits
+- posting standalone tweets, replies, and quote tweets with media attachments
+- liking, retweeting, and fetching tweet replies and articles
+- fetching user profiles, timelines, media, mentions, and liked tweets
+- searching users, checking follow relationships, listing followers/following
+- managing profile (avatar, banner, display name, bio)
+- sending and listing direct messages
+- checking account credits and payment history
+- bookmark search and home timeline
 
 Do NOT use for:
 - deleting tweets (no delete endpoint — must delete manually on x.com)
@@ -143,4 +148,4 @@ curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
 # Should return tweet object with id
 ```
 
-For detailed endpoint documentation, field maps, and response schemas, see `references/getxapi-endpoints.md`.
+For detailed endpoint documentation covering all 35 endpoints, field maps, response schemas, pagination, and error codes, see `references/getxapi-endpoints.md`.

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -88,7 +88,7 @@ getxapi uses **non-standard field names**. Do NOT use official X API v2 field na
 | `author.userName` | `screen_name` (v1.1), `username` (v2 user objects), `author.username` — using any of these returns zero results | Author handle |
 | `author.followers` | `public_metrics.followers_count` | Follower count |
 | `isReply` | `in_reply_to_user_id` (check if set) | Is it a reply? |
-| `id` | `id` (same) | Tweet ID |
+| `id` | (same — no difference from official API) | Tweet ID |
 | `inReplyToId` | `referenced_tweets[].id` | Original tweet being replied to |
 | `createdAt` | `created_at` | Timestamp |
 | `viewCount` | `public_metrics.impression_count` | Views |
@@ -103,7 +103,7 @@ getxapi uses **non-standard field names**. Do NOT use official X API v2 field na
 
 **Always use `product=Top`.** `product=Latest` returns 0-50 follower accounts and bot spam.
 
-Broad niche keywords work best: `homelab`, `self-hosting`, `Ollama local`, `Hackintosh`, `HomeAssistant`, `Proxmox`, `Docker self-hosted`, `local LLM`, `unRAID`, `TrueNAS`.
+Broad niche keywords work best: `homelab`, `self-hosting`, `Ollama`, `Hackintosh`, `HomeAssistant`, `Proxmox`, `Docker`, `TrueNAS`. Multi-word queries must be URL-encoded (e.g. `Ollama%20local`, `Docker%20self-hosted`) — unencoded spaces cause truncated or failed requests.
 
 Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net then filter.
 
@@ -111,7 +111,7 @@ Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net t
 
 Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
 
-**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references in curl Authorization headers. The only allowlist exemption is `Authorization: token $VAR` targeting `https://api.github.com` — `Bearer` auth and all other domains (including `api.getxapi.com`) are blocked. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned for `$VAR` patterns.
+**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_EXFIL_COMMAND_PATTERNS` + `_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references — in Authorization headers, embedded in URLs, and in POST/form data — for all curl/wget invocations targeting non-GitHub domains. The only allowlist exemption is `Authorization: token $VAR` targeting `https://api.github.com`. To use getxapi in cron jobs, reference a helper script that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call — scripts are not scanned.
 
 **Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -4,7 +4,6 @@ description: X/Twitter via getxapi.com third-party API — search, post, reply, 
 version: 1.0.0
 author: Ayush Sahay Chaudhary
 license: MIT
-platforms: [macos, linux]
 metadata:
   hermes:
     tags: [twitter, x, social-media, getxapi, api]
@@ -34,6 +33,17 @@ Do NOT use for:
 - deleting tweets (no delete endpoint — must delete manually on x.com)
 - creating Articles (GET only, read-only)
 - OAuth flows or official v2 endpoints (use `xurl` instead)
+
+## Secret Safety (MANDATORY)
+
+Critical rules when operating inside an agent/LLM session:
+
+- **Never** read, print, parse, summarize, upload, or send the getxapi API key or X `auth_token` to LLM context.
+- **Never** ask the user to paste credentials or tokens into chat.
+- The user must store credentials in `~/.hermes/.env` via `hermes setup` or manual editing.
+- **Never** execute `curl` commands with inline `Authorization: Bearer <real-key>` in agent sessions — it may be logged or exposed.
+- Treat the X `auth_token` like a password — it grants posting access to the account. Rotate immediately if exposed.
+- To verify API key validity, only use: `curl -s -H "Authorization: Bearer $GETXAPI_API_KEY" "https://api.getxapi.com/account/me"` after confirming the env var is set (never echo the value).
 
 ## Quick Reference
 
@@ -101,7 +111,12 @@ Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net t
 
 Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
 
-**Cron prompt compatibility:** The Hermes cron scanner blocks `$VAR`-style environment variable references in Authorization headers for non-GitHub domains. When using getxapi in cron job prompts, reference the stored credential from `~/.hermes/.env` at runtime rather than embedding variable expansions. For curl examples in this skill, `<your-api-key>` and `<your-auth-token>` placeholders are used throughout to avoid false-positive scanner matches.
+**Cron prompt compatibility:** The Hermes cron scanner (`_CRON_SECRET_VAR_RE`) blocks `$VAR`-style environment variable references (e.g. `$GETXAPI_API_KEY`) in Authorization headers targeting non-GitHub domains. Two approaches work:
+
+1. **Hardcode the literal key in the cron prompt.** The scanner pattern requires a `$` prefix — a literal key like `get-x-api-...` does not match and passes the scan. Store the key in the cron prompt directly (NOT recommended for shared prompts, but works for personal use).
+2. **Use a helper script.** Reference a script in the cron job that reads credentials from `~/.hermes/.env` at runtime and makes the authenticated call. The script itself is not scanned for `$VAR` patterns.
+
+All curl examples in this skill use `<your-api-key>` and `<your-auth-token>` placeholders to avoid false-positive scanner matches in documentation.
 
 **Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
 

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: getxapi
+description: X/Twitter via getxapi.com third-party API — search, post, reply, user lookup, media. Simpler than official v2.
+version: 1.0.0
+author: Ayush Sahay Chaudhary
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [twitter, x, social-media, getxapi, api]
+    related_skills: [xurl]
+required_environment_variables:
+  - name: GETXAPI_API_KEY
+    prompt: getxapi API key (Bearer token)
+    help: Get your key at https://getxapi.com — sign up, go to dashboard, copy API key
+    required_for: all API access (search, post, user lookup)
+  - name: GETXAPI_AUTH_TOKEN
+    prompt: X auth_token for posting (32+ hex chars)
+    help: Extract from browser cookies (x.com → Storage → Cookies → auth_token). Required for tweet create/delete.
+    required_for: posting tweets and replies
+---
+
+# getxapi — X (Twitter) via getxapi.com
+
+Third-party X/Twitter API at `https://api.getxapi.com`. Credits-based ($0.001/read, $0.002/write). Simpler than official v2 — no OAuth, no PKCE. Authenticate with a Bearer API key. Post with an X `auth_token` cookie.
+
+Use this skill for:
+- searching tweets by keyword with `product=Top` (actual engagement) vs `product=Latest` (bot spam)
+- posting standalone tweets and replies
+- fetching user timelines
+- checking account credits
+- image analysis workflows (pair with mmx vision)
+
+Do NOT use for:
+- deleting tweets (no delete endpoint — must delete manually on x.com)
+- creating Articles (GET only, read-only)
+- OAuth flows or official v2 endpoints (use `xurl` instead)
+
+## Quick Reference
+
+All requests use `Authorization: Bearer <your-api-key>`. Posting also requires `auth_token` in the JSON body.
+
+```bash
+# Check credits
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/account/me"
+
+# Search tweets (always use product=Top)
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/advanced_search?q=homelab&product=Top&count=20"
+
+# Post a tweet
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","text":"hello world"}'
+
+# Reply to a tweet
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","text":"good take","reply_to_tweet_id":"1234567890"}'
+
+# User timeline
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/tweets?userName=kextcache&count=10"
+
+# Single tweet detail
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/detail?id=1234567890"
+```
+
+## Field Name Mapping — CRITICAL
+
+getxapi uses **non-standard field names**. Do NOT use official X API v2 field names — they silently produce zero results.
+
+| getxapi field | X API v2 equivalent | Usage |
+|---------------|---------------------|-------|
+| `author.userName` | `author.username` / `screen_name` | Author handle |
+| `author.followers` | `public_metrics.followers_count` | Follower count |
+| `isReply` | `in_reply_to_user_id` (check if set) | Is it a reply? |
+| `id` | `id` (same) | Tweet ID |
+| `inReplyToId` | `referenced_tweets[].id` | Original tweet being replied to |
+| `createdAt` | `created_at` | Timestamp |
+| `viewCount` | `public_metrics.impression_count` | Views |
+
+**Filtering rules using these fields:**
+- Skip `isReply: true` (don't reply to replies)
+- Skip `author.followers < 500` (low reach)
+- Skip `author.followers > 500000` (too big, reply gets buried)
+- Check `createdAt` before replying — skip tweets older than 7 days
+
+## Search Strategy
+
+**Always use `product=Top`.** `product=Latest` returns 0-50 follower accounts and bot spam.
+
+Broad niche keywords work best: `homelab`, `self-hosting`, `Ollama local`, `Hackintosh`, `HomeAssistant`, `Proxmox`, `Docker self-hosted`, `local LLM`, `unRAID`, `TrueNAS`.
+
+Narrow terms like `Proxmox tip` often return zero Top results. Cast a wide net then filter.
+
+## Posting
+
+Posting requires BOTH the API key (Bearer header) AND an X `auth_token` cookie (in JSON body). The auth_token must be extracted from browser cookies — it is httpOnly and cannot be extracted programmatically at runtime.
+
+**Never put inline Bearer tokens in cron prompts.** The Hermes cron scanner blocks `$VAR` patterns in Authorization headers targeting non-GitHub domains. Hardcode the literal key or use `<your-api-key>` placeholder in documentation.
+
+**Shell quoting:** When reply text contains apostrophes (`'`), embedding JSON in `-d '{...}'` breaks. Write JSON to a temp file and use `-d @file` instead.
+
+## Account & Credits
+
+Check `GET /account/me` before bulk operations. If credits drop below $1.00, reduce volume or alert. Each search costs ~$0.001, each post costs $0.002.
+
+## Gotchas
+
+- **No delete endpoint.** `POST /twitter/tweet/delete` returns 404. Contradictory tweets must be deleted manually on x.com.
+- **`inReplyToId` is the field to check for original tweet** when deduplicating — use this, not `conversationId`.
+- **Transient "Daily tweet limit reached" errors** — retry once. Account still in warmup may hit X platform caps.
+- **Image-only tweets:** If text < 30 chars with media, analyze image OR skip — never reply blind.
+- **Detail endpoint param:** Use `?id=` not `?tweet_id=` — wrong param name returns "Missing required query param" error.
+
+## Verification
+
+```bash
+# Verify API key works
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/account/me"
+# Should return: {"email":"...","credits":"...","requests":"..."}
+
+# Verify posting works
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","text":"api test"}'
+# Should return tweet object with id
+```
+
+For detailed endpoint documentation, field maps, and response schemas, see `references/getxapi-endpoints.md`.

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -29,7 +29,6 @@ Use this skill for:
 - posting standalone tweets and replies
 - fetching user timelines
 - checking account credits
-- image analysis workflows (pair with mmx vision)
 
 Do NOT use for:
 - deleting tweets (no delete endpoint — must delete manually on x.com)

--- a/skills/social-media/getxapi/SKILL.md
+++ b/skills/social-media/getxapi/SKILL.md
@@ -72,7 +72,7 @@ curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
 
 # User timeline
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/user/tweets?userName=kextcache&count=10"
+  "https://api.getxapi.com/twitter/user/tweets?userName=someuser&count=10"
 
 # Single tweet detail
 curl -s -H "Authorization: Bearer <your-api-key>" \

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -35,6 +35,7 @@ Cost: $0.001. ~20 tweets/page. Cursor pagination.
 |-------|----------|-------|
 | `q` | Yes | Search query. Supports operators: `from:user`, `to:user`, `has:media`, `-filter:retweets`, `min_faves:N`, `since:YYYY-MM-DD` |
 | `product` | No | `Latest` (default) or `Top` |
+| `count` | No | Results per page (default 20, max ~20) |
 | `cursor` | No | Pagination cursor |
 
 ```bash
@@ -208,6 +209,7 @@ Cost: $0.001. ~20 tweets/page. User's profile "Posts" tab.
 |-------|----------|-------|
 | `userName` | Conditional | Screen name. Required if `userId` not provided |
 | `userId` | Conditional | Numeric ID. Faster — skips username lookup |
+| `count` | No | Results per page (default 20) |
 | `cursor` | No | Pagination cursor |
 
 ```bash
@@ -351,6 +353,8 @@ Cost: $0.001. ~20 users/page. Affiliated accounts of a verified organization.
 
 ### POST /twitter/user_login
 Cost: $0.001. Returns fresh auth tokens (auth_token, ct0, twid).
+
+**⚠️ SECURITY:** This endpoint accepts highly sensitive credentials — `username`, `password`, and optionally `totp_secret`. Never paste these into chat or agent context. Only use this endpoint locally with credentials stored in `~/.hermes/.env`.
 
 | Field | Required | Notes |
 |-------|----------|-------|

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -1,7 +1,7 @@
 # getxapi Endpoint Reference
 
 Base URL: `https://api.getxapi.com`
-Auth: `Authorization: Bearer <api-key>` (all endpoints)
+Auth: `Authorization: Bearer <your-api-key>` (all endpoints)
 Post auth: value of the X `auth_token` cookie, passed as an `auth_token` field in the JSON body
 
 ## Account
@@ -22,7 +22,7 @@ Free. Rate limit: 30 req/min. Returns payment history.
 curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/payments"
 ```
 
-Response: `{"payments": [{"amount", "credits_added", "status", "created_at"}]}`
+Response fields: `{"payments": [{"amount", "credits_added", "status", "created_at"}]}`
 
 ---
 
@@ -43,9 +43,9 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/twitter/tweet/advanced_search?q=from:elonmusk&product=Top"
 ```
 
-Response: `{"query", "tweet_count", "has_more", "next_cursor", "tweets": [...]}`
+Response fields: `query`, `tweet_count`, `has_more`, `next_cursor`, `tweets` (array of tweet objects).
 
-Each tweet: `type`, `id`, `url`, `twitterUrl`, `text`, `source`, `retweetCount`, `replyCount`, `likeCount`, `quoteCount`, `viewCount`, `createdAt`, `lang`, `bookmarkCount`, `isReply`, `inReplyToId`, `conversationId`, `media[]`, `inReplyToUserId`, `author{...}`, `quoted_tweet`.
+Response fields: `type`, `id`, `url`, `twitterUrl`, `text`, `source`, like/reply/quote/view counts, `createdAt`, `isReply`, `inReplyToId`, `media[]`, `author{...}`.
 
 ### GET /twitter/tweet/detail
 Cost: $0.001. Returns a single tweet with full author and media.
@@ -74,7 +74,7 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/twitter/tweet/replies?id=1234567890123456789"
 ```
 
-Response: `{"tweetId", "reply_count", "has_more", "next_cursor", "replies": [...]}`
+Response fields: `{"tweetId", "reply_count", "has_more", "next_cursor", "replies": [...]}`
 
 ### GET /twitter/tweet/article
 Cost: $0.001. Returns full article/note content. Tweet must be an article tweet.
@@ -88,7 +88,7 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/twitter/tweet/article?id=1234567890123456789"
 ```
 
-Response: `article` with `title`, `preview_text`, `cover_media_img_url`, `contents` (rich text blocks).
+Response fields: `article` with `title`, `preview_text`, `cover_media_img_url`, `contents` (rich text blocks).
 
 ### POST /twitter/tweet/create
 Cost: $0.002. Creates a tweet or reply.
@@ -176,7 +176,7 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/twitter/user/info?userName=someuser"
 ```
 
-Response: `id`, `name`, `userName`, `location`, `description`, `protected`, `isVerified`, `isBlueVerified`, `followers`, `following`, `favouritesCount`, `statusesCount`, `mediaCount`, `createdAt`, `profilePicture`, `coverPicture`, `canDm`, `pinnedTweetIds`.
+Response fields: `id`, `name`, `userName`, `location`, `description`, `protected`, `isVerified`, `isBlueVerified`, `followers`, `following`, `favouritesCount`, `statusesCount`, `mediaCount`, `createdAt`, `profilePicture`, `coverPicture`, `canDm`, `pinnedTweetIds`.
 
 ### GET /twitter/user/info_by_id
 Cost: $0.001. Same as `/user/info` but by numeric user ID.
@@ -324,7 +324,7 @@ Cost: $0.001. Checks follow/block/mute relationship between two users.
 | `source_user_name` | Yes | Source screen name |
 | `target_user_name` | Yes | Target screen name |
 
-Response: `sourceFollowsTarget`, `targetFollowsSource`, `canDm`, `blocking`, `blockedBy`, `muting`.
+Response fields: `sourceFollowsTarget`, `targetFollowsSource`, `canDm`, `blocking`, `blockedBy`, `muting`.
 
 ### POST /twitter/user/home_timeline
 Cost: $0.001. ~20 tweets/page. Home timeline feed.

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -37,7 +37,7 @@ curl -s -H "Authorization: Bearer <your-api-key>" \
 Response: `{"tweets": [...]}` or `{"data": {"tweets": [...]}}`. Each tweet has `id`, `text`, `author.userName`, `author.followers`, `isReply`, `createdAt`, `viewCount`, `media[]`.
 
 **Field mapping gotchas:**
-- `author.userName` — NOT `screen_name` or `author.username`
+- `author.userName` — NOT `screen_name` (v1.1), `username` (v2 user objects), or `author.username`
 - `author.followers` — NOT `public_metrics.followers_count`
 - `isReply` (boolean) — NOT `in_reply_to_user_id`
 - `createdAt` — NOT `created_at`
@@ -61,10 +61,11 @@ Body (JSON):
 ```json
 {
   "auth_token": "<your-auth-token>",
-  "text": "tweet content here",
-  "reply_to_tweet_id": "1234567890"  // optional, for replies
+  "text": "tweet content here"
 }
 ```
+
+Add `"reply_to_tweet_id": "1234567890"` to the body to post a reply instead of a standalone tweet.
 
 ```bash
 curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -31,7 +31,7 @@ Search tweets by keyword.
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/tweet/advanced_search?q=homelab&product=Top&count=20"
+  "https://api.getxapi.com/twitter/tweet/advanced_search?q=exampleKeyword1&product=Top&count=20"
 ```
 
 Response: `{"tweets": [...]}` or `{"data": {"tweets": [...]}}`. Each tweet has `id`, `text`, `author.userName`, `author.followers`, `isReply`, `createdAt`, `viewCount`, `media[]`.
@@ -48,7 +48,7 @@ Response: `{"tweets": [...]}` or `{"data": {"tweets": [...]}}`. Each tweet has `
 - `from:username` — from specific user
 - `-filter:retweets` — exclude retweets
 - `-filter:replies` — exclude replies
-- Combine: `q=homelab%20has:media%20-filter:retweets`
+- Combine: `q=exampleKeyword1%20has:media%20-filter:retweets`
 
 ---
 

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -2,7 +2,7 @@
 
 Base URL: `https://api.getxapi.com`
 Auth: `Authorization: Bearer <api-key>` (all endpoints)
-Post auth: `auth_token` cookie in JSON body (create/delete endpoints)
+Post auth: `auth_token` cookie in JSON body (create endpoint)
 
 ## Account
 
@@ -86,8 +86,8 @@ curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
   -d @/tmp/post.json
 ```
 
-### DELETE /twitter/tweet/delete
-**DOES NOT EXIST.** Returns 404. Tweets must be deleted manually on x.com. There is no programmatic undelete.
+### /twitter/tweet/delete (not implemented)
+**DOES NOT EXIST.** Returns 404. Tweets must be deleted manually on x.com. There is no programmatic undo.
 
 ---
 

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -2,166 +2,452 @@
 
 Base URL: `https://api.getxapi.com`
 Auth: `Authorization: Bearer <api-key>` (all endpoints)
-Post auth: value of the X `auth_token` cookie, passed as an `auth_token` field in the JSON body (create endpoint)
+Post auth: value of the X `auth_token` cookie, passed as an `auth_token` field in the JSON body
 
 ## Account
 
 ### GET /account/me
-Check credits, email, request count.
+Free. Rate limit: 30 req/min. Returns account details, credit balance, usage.
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/me"
 ```
 
-Response fields: `email`, `credits` (string, e.g. `"$X.XX"`), `requests` (integer).
+Response fields: `email`, `name`, `credits_remaining`, `credits_used`, `total_requests`, `created_at`.
 
----
-
-## Search
-
-### GET /twitter/tweet/advanced_search
-Search tweets by keyword.
-
-| Param | Required | Notes |
-|-------|----------|-------|
-| `q` | Yes | Search query. Single-word queries work best. Use URL encoding for multi-word (`docker%20compose`) |
-| `product` | No | `Top` (real engagement) or `Latest` (chronological, mostly bot spam). Always use `Top`. |
-| `count` | No | Results per page, max ~20 |
-| `cursor` | No | Pagination cursor from previous response |
+### GET /account/payments
+Free. Rate limit: 30 req/min. Returns payment history.
 
 ```bash
-curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/tweet/advanced_search?q=exampleKeyword1&product=Top&count=20"
+curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/payments"
 ```
 
-Response: `{"tweets": [...]}` or `{"data": {"tweets": [...]}}`. Each tweet has `id`, `text`, `author.userName`, `author.followers`, `isReply`, `createdAt`, `viewCount`, `media[]`.
-
-**Field mapping gotchas:**
-- `author.userName` — NOT `screen_name` (v1.1), `username` (v2 user objects), or `author.username`
-- `author.followers` — NOT `public_metrics.followers_count`
-- `isReply` (boolean) — NOT `in_reply_to_user_id`
-- `createdAt` — NOT `created_at`
-- `inReplyToId` — original tweet ID this is replying to
-
-**Search operators (limited support):**
-- `has:media` — tweets with images/video
-- `from:username` — from specific user
-- `-filter:retweets` — exclude retweets
-- `-filter:replies` — exclude replies
-- Combine: `q=exampleKeyword1%20has:media%20-filter:retweets`
+Response: `{"payments": [{"amount", "credits_added", "status", "created_at"}]}`
 
 ---
 
 ## Tweets
 
-### POST /twitter/tweet/create
-Post a new tweet or reply.
-
-Body (JSON):
-```json
-{
-  "auth_token": "<your-auth-token>",
-  "text": "tweet content here"
-}
-```
-
-Add `"reply_to_tweet_id": "1234567890"` to the body to post a reply instead of a standalone tweet.
-
-```bash
-curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
-  -H "Authorization: Bearer <your-api-key>" \
-  -H "Content-Type: application/json" \
-  -d '{"auth_token":"<your-auth-token>","text":"hello"}'
-```
-
-Response: tweet object with `id`, `text`, `createdAt`, `author`, `url`.
-
-**Shell quoting:** If text contains apostrophes, write JSON to temp file:
-```bash
-cat > /tmp/post.json << 'EOF'
-{"auth_token":"<your-auth-token>","text":"don't use inline quotes"}
-EOF
-curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
-  -H "Authorization: Bearer <your-api-key>" \
-  -H "Content-Type: application/json" \
-  -d @/tmp/post.json
-```
-
-### /twitter/tweet/delete (not implemented)
-**DOES NOT EXIST.** Returns 404. Tweets must be deleted manually on x.com. There is no programmatic undo.
-
----
-
-## User
-
-### GET /twitter/user/tweets
-Fetch user's timeline.
+### GET /twitter/tweet/advanced_search
+Cost: $0.001. ~20 tweets/page. Cursor pagination.
 
 | Param | Required | Notes |
 |-------|----------|-------|
-| `userName` | Yes* | Username (e.g. `someuser`) |
-| `userId` | Yes* | User ID alternative to userName |
-| `count` | No | Results per page |
-
-*One of `userName` or `userId` is required.
+| `q` | Yes | Search query. Supports operators: `from:user`, `to:user`, `has:media`, `-filter:retweets`, `min_faves:N`, `since:YYYY-MM-DD` |
+| `product` | No | `Latest` (default) or `Top` |
+| `cursor` | No | Pagination cursor |
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/user/tweets?userName=someuser&count=20"
+  "https://api.getxapi.com/twitter/tweet/advanced_search?q=from:elonmusk&product=Top"
 ```
 
-Response: `{"userName": "...", "userId": "...", "tweet_count": N, "has_more": bool, "next_cursor": "...", "tweets": [...]}`
+Response: `{"query", "tweet_count", "has_more", "next_cursor", "tweets": [...]}`
 
----
-
-## Tweet Detail
+Each tweet: `type`, `id`, `url`, `twitterUrl`, `text`, `source`, `retweetCount`, `replyCount`, `likeCount`, `quoteCount`, `viewCount`, `createdAt`, `lang`, `bookmarkCount`, `isReply`, `inReplyToId`, `conversationId`, `media[]`, `inReplyToUserId`, `author{...}`, `quoted_tweet`.
 
 ### GET /twitter/tweet/detail
-Get single tweet by ID.
+Cost: $0.001. Returns a single tweet with full author and media.
 
 | Param | Required | Notes |
 |-------|----------|-------|
-| `id` | Yes | Tweet ID. Use `id=` NOT `tweet_id=` — wrong param returns error. |
+| `id` | Yes | Tweet ID |
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" \
   "https://api.getxapi.com/twitter/tweet/detail?id=1234567890123456789"
 ```
 
-Response: `{"data": {"type": "tweet", "id": "...", "text": "...", "author": {...}, "inReplyToId": "...", "createdAt": "...", "media": [...], ...}}`
+Response wrapped in `data` field: `type`, `id`, `text`, `author{...}`, `inReplyToId`, `createdAt`, `media[]`, `quoted_tweet`.
 
-Key fields in response:
-- `data.id` — tweet ID
-- `data.text` — full text
-- `data.inReplyToId` — original tweet being replied to (empty/null for standalone)
-- `data.author.userName` — author handle
-- `data.createdAt` — timestamp (format: `Tue May 12 01:42:53 +0000 2026`)
-- `data.isReply` — boolean
-- `data.viewCount` — impression count
-- `data.media` — array of media objects with `media_url_https`
+### GET /twitter/tweet/replies
+Cost: $0.001. ~20 replies/page. Cursor pagination.
 
----
-
-## Rate Limits & Credits
-
-| Action | Cost | Rate limit |
-|--------|------|------------|
-| Search | ~$0.001/req | Per-account X limits apply |
-| Post/Reply | $0.002/post | X daily post cap (varies by account age/activity) |
-| User timeline | ~$0.001/req | Standard |
-| Tweet detail | ~$0.001/req | Standard |
-| Account check | Free | Unlimited |
-
-Accounts in warmup (new or low-activity) hit X's daily post cap aggressively. Start at 3-4 posts per run window, scale up over 2-3 weeks.
-
----
-
-## Image Download for Vision Analysis
-
-Tweet images are at `https://pbs.twimg.com/media/<media_id>?format=jpg&name=small` (or `medium`, `large`). Download before analyzing with vision tools:
+| Param | Required | Notes |
+|-------|----------|-------|
+| `id` | Yes | Tweet ID |
+| `cursor` | No | Pagination cursor |
 
 ```bash
-curl -s -o /tmp/tweet_img.jpg \
-  "https://pbs.twimg.com/media/HH8jjRZXIAQ7dlA.jpg?format=jpg&name=small"
-file /tmp/tweet_img.jpg  # verify it's JPEG, not HTML error page
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/replies?id=1234567890123456789"
 ```
+
+Response: `{"tweetId", "reply_count", "has_more", "next_cursor", "replies": [...]}`
+
+### GET /twitter/tweet/article
+Cost: $0.001. Returns full article/note content. Tweet must be an article tweet.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `id` | Yes | Tweet ID of the article |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/article?id=1234567890123456789"
+```
+
+Response: `article` with `title`, `preview_text`, `cover_media_img_url`, `contents` (rich text blocks).
+
+### POST /twitter/tweet/create
+Cost: $0.002. Creates a tweet or reply.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token cookie value |
+| `text` | Yes | Tweet text |
+| `reply_to_tweet_id` | No | Tweet ID to reply to |
+| `quote_tweet_url` | No | Full URL of tweet to quote |
+| `quote_tweet_id` | No | Tweet ID to quote (resolved to URL) |
+| `media_urls` | No | Array of image/video URLs |
+| `media_ids` | No | Pre-uploaded Twitter media IDs |
+| `media` | No | Array of `{data: base64, type: mime/type}` |
+| `proxy` | No | Custom proxy URL |
+
+```bash
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","text":"Hello world"}'
+```
+
+Add `"reply_to_tweet_id": "1234567890"` to the body for replies.
+
+### POST /twitter/tweet/favorite
+Cost: $0.001. Likes a tweet.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `tweet_id` | Yes | Tweet ID to like |
+
+```bash
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/favorite" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","tweet_id":"1234567890123456789"}'
+```
+
+### POST /twitter/tweet/retweet
+Cost: $0.001. Retweets a tweet.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `tweet_id` | Yes | Tweet ID to retweet |
+
+```bash
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/retweet" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","tweet_id":"1234567890123456789"}'
+```
+
+### /twitter/tweet/delete (not implemented)
+Does not exist. Returns 404. Tweets must be deleted manually on x.com.
+
+---
+
+## Users
+
+### GET /twitter/user/search
+Cost: $0.001. ~20 users/page. Searches for users (equivalent to "People" tab).
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `q` | Yes | Search query (username, keyword, topic) |
+| `cursor` | No | Pagination cursor |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/search?q=exampleKeyword1"
+```
+
+### GET /twitter/user/info
+Cost: $0.001. Returns full profile for a user.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/info?userName=someuser"
+```
+
+Response: `id`, `name`, `userName`, `location`, `description`, `protected`, `isVerified`, `isBlueVerified`, `followers`, `following`, `favouritesCount`, `statusesCount`, `mediaCount`, `createdAt`, `profilePicture`, `coverPicture`, `canDm`, `pinnedTweetIds`.
+
+### GET /twitter/user/info_by_id
+Cost: $0.001. Same as `/user/info` but by numeric user ID.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userId` | Yes | Numeric user ID |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/info_by_id?userId=44196397"
+```
+
+### GET /twitter/user/user_about
+Cost: $0.001. Returns account metadata: creation location, signup source, username change history.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/user_about?userName=someuser"
+```
+
+### GET /twitter/user/tweets
+Cost: $0.001. ~20 tweets/page. User's profile "Posts" tab.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Conditional | Screen name. Required if `userId` not provided |
+| `userId` | Conditional | Numeric ID. Faster — skips username lookup |
+| `cursor` | No | Pagination cursor |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/tweets?userName=someuser&count=20"
+```
+
+### GET /twitter/user/tweets_and_replies
+Cost: $0.001. ~20 results/page. User's profile "Replies" tab.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/tweets_and_replies?userName=someuser"
+```
+
+### GET /twitter/user/media
+Cost: $0.001. ~20 results/page. User's tweets containing media.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/media?userName=someuser"
+```
+
+### GET /twitter/user/mentions
+Cost: $0.001. ~20 tweets/page. Tweets mentioning the user.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### POST /twitter/user/likes
+Cost: $0.001. ~20 tweets/page. User's liked tweets.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `cursor` | No | Pagination cursor |
+
+```bash
+curl -s -X POST "https://api.getxapi.com/twitter/user/likes" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>"}'
+```
+
+### GET /twitter/user/followers
+Cost: $0.001. ~200 users/page. REST v1 endpoint — no total cap, full follower list accessible.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/followers_v2
+Cost: $0.001. ~70 users/page. Higher fidelity, capped at ~800 total (matches x.com UI).
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/following
+Cost: $0.001. ~200 users/page. REST v1 — no total cap.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/following_v2
+Cost: $0.001. ~70 users/page. Capped at ~800 total.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/verified_followers
+Cost: $0.001. ~20 verified (blue check) followers/page.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Screen name (without @) |
+| `cursor` | No | Pagination cursor |
+
+### POST /twitter/user/followers_you_know
+Cost: $0.001. ~20 users/page. Returns followers you know for a target user.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `user_id` | Conditional | Target user ID |
+| `user_name` | Conditional | Target username |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/check_follow_relationship
+Cost: $0.001. Checks follow/block/mute relationship between two users.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `source_user_name` | Yes | Source screen name |
+| `target_user_name` | Yes | Target screen name |
+
+Response: `sourceFollowsTarget`, `targetFollowsSource`, `canDm`, `blocking`, `blockedBy`, `muting`.
+
+### POST /twitter/user/home_timeline
+Cost: $0.001. ~20 tweets/page. Home timeline feed.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `cursor` | No | Pagination cursor |
+
+### POST /twitter/user/bookmark_search
+Cost: $0.001. ~20 results/page. Searches user's bookmarks.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `q` | Yes | Search query |
+| `cursor` | No | Pagination cursor |
+
+### GET /twitter/user/affiliates
+Cost: $0.001. ~20 users/page. Affiliated accounts of a verified organization.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes | Organization username |
+| `cursor` | No | Pagination cursor |
+
+### POST /twitter/user_login
+Cost: $0.001. Returns fresh auth tokens (auth_token, ct0, twid).
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `username` | Yes | X username |
+| `password` | Yes | Account password |
+| `email` | Yes | Email for verification |
+| `totp_secret` | Conditional | TOTP secret for 2FA accounts |
+| `proxy` | No | Custom proxy URL |
+
+### POST /twitter/user/update_avatar
+Cost: $0.001. Updates profile picture. Provide `image_url` or `image_base64` (not both).
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `image_url` | Conditional | Public image URL |
+| `image_base64` | Conditional | Base64-encoded image |
+
+### POST /twitter/user/update_banner
+Cost: $0.001. Updates profile banner. Same params as update_avatar.
+
+### POST /twitter/user/update_profile
+Cost: $0.001. Updates profile fields (name, description, location, url, colors, birthdate).
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `name` | No | Display name |
+| `description` | No | Bio |
+| `location` | No | Location |
+| `url` | No | Website URL |
+| `birthdate_year/month/day` | No | Birthdate |
+| `birthdate_visibility` | No | `self`, `mutualfollow`, `followers`, `following`, `public` |
+
+---
+
+## Lists
+
+### GET /twitter/list/members
+Cost: $0.001. ~20 users/page. Members of a list.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `listId` | Yes | List ID |
+| `cursor` | No | Pagination cursor |
+
+---
+
+## Direct Messages
+
+### POST /twitter/dm/list
+Cost: $0.002. ~50 messages/page.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `cursor` | No | Pagination cursor |
+| `count` | No | Messages per page (default 50) |
+
+### POST /twitter/dm/send
+Cost: $0.002. Sends a DM.
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `auth_token` | Yes | X auth_token |
+| `recipient_id` | Conditional | Recipient user ID |
+| `recipient_username` | Conditional | Recipient username |
+| `text` | Yes | Message text |
+
+---
+
+## Pagination
+
+All list endpoints use cursor-based pagination:
+- Omit `cursor` for the first page
+- Pass `next_cursor` from the response for subsequent pages
+- ~20 items/page (followers/following v1: ~200; v2 variants: ~70; DMs: ~50)
+- Paginate until `has_more` is `false`
+- Followers/following v2 capped at ~800 results; v1 has no cap
+
+## Error Codes
+
+| Status | Meaning | Common Cause |
+|--------|---------|-------------|
+| 400 | Bad Request | Missing required parameter |
+| 401 | Unauthorized | Invalid/missing API key or auth_token |
+| 404 | Not Found | User or tweet does not exist |
+| 429 | Rate Limited | Account endpoints: exceeded 30 req/min |
+| 502 | Bad Gateway | X rejected the mutation |
+
+All errors return JSON: `{"error": "description"}`
+
+## Pricing
+
+| Category | Cost |
+|----------|------|
+| All read endpoints | $0.001/req |
+| Create tweet | $0.002/req |
+| DM endpoints | $0.002/req |
+| Account endpoints | Free (30 req/min limit) |

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -1,0 +1,166 @@
+# getxapi Endpoint Reference
+
+Base URL: `https://api.getxapi.com`
+Auth: `Authorization: Bearer <api-key>` (all endpoints)
+Post auth: `auth_token` cookie in JSON body (create/delete endpoints)
+
+## Account
+
+### GET /account/me
+Check credits, email, request count.
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/me"
+```
+
+Response fields: `email`, `credits` (string, e.g. "$7.53"), `requests` (integer).
+
+---
+
+## Search
+
+### GET /twitter/tweet/advanced_search
+Search tweets by keyword.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `q` | Yes | Search query. Single-word queries work best. Use URL encoding for multi-word (`docker%20compose`) |
+| `product` | No | `Top` (real engagement) or `Latest` (chronological, mostly bot spam). Always use `Top`. |
+| `count` | No | Results per page, max ~20 |
+| `cursor` | No | Pagination cursor from previous response |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/advanced_search?q=homelab&product=Top&count=20"
+```
+
+Response: `{"tweets": [...]}` or `{"data": {"tweets": [...]}}`. Each tweet has `id`, `text`, `author.userName`, `author.followers`, `isReply`, `createdAt`, `viewCount`, `media[]`.
+
+**Field mapping gotchas:**
+- `author.userName` — NOT `screen_name` or `author.username`
+- `author.followers` — NOT `public_metrics.followers_count`
+- `isReply` (boolean) — NOT `in_reply_to_user_id`
+- `createdAt` — NOT `created_at`
+- `inReplyToId` — original tweet ID this is replying to
+
+**Search operators (limited support):**
+- `has:media` — tweets with images/video
+- `from:username` — from specific user
+- `-filter:retweets` — exclude retweets
+- `-filter:replies` — exclude replies
+- Combine: `q=homelab%20has:media%20-filter:retweets`
+
+---
+
+## Tweets
+
+### POST /twitter/tweet/create
+Post a new tweet or reply.
+
+Body (JSON):
+```json
+{
+  "auth_token": "<your-auth-token>",
+  "text": "tweet content here",
+  "reply_to_tweet_id": "1234567890"  // optional, for replies
+}
+```
+
+```bash
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_token":"<your-auth-token>","text":"hello"}'
+```
+
+Response: tweet object with `id`, `text`, `createdAt`, `author`, `url`.
+
+**Shell quoting:** If text contains apostrophes, write JSON to temp file:
+```bash
+cat > /tmp/post.json << 'EOF'
+{"auth_token":"<your-auth-token>","text":"don't use inline quotes"}
+EOF
+curl -s -X POST "https://api.getxapi.com/twitter/tweet/create" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/post.json
+```
+
+### DELETE /twitter/tweet/delete
+**DOES NOT EXIST.** Returns 404. Tweets must be deleted manually on x.com. There is no programmatic undelete.
+
+---
+
+## User
+
+### GET /twitter/user/tweets
+Fetch user's timeline.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `userName` | Yes* | Username (e.g. `kextcache`) |
+| `userId` | Yes* | User ID alternative to userName |
+| `count` | No | Results per page |
+
+*One of `userName` or `userId` is required.
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/user/tweets?userName=kextcache&count=20"
+```
+
+Response: `{"userName": "...", "userId": "...", "tweet_count": N, "has_more": bool, "next_cursor": "...", "tweets": [...]}`
+
+---
+
+## Tweet Detail
+
+### GET /twitter/tweet/detail
+Get single tweet by ID.
+
+| Param | Required | Notes |
+|-------|----------|-------|
+| `id` | Yes | Tweet ID. Use `id=` NOT `tweet_id=` — wrong param returns error. |
+
+```bash
+curl -s -H "Authorization: Bearer <your-api-key>" \
+  "https://api.getxapi.com/twitter/tweet/detail?id=2054014418455839156"
+```
+
+Response: `{"data": {"type": "tweet", "id": "...", "text": "...", "author": {...}, "inReplyToId": "...", "createdAt": "...", "media": [...], ...}}`
+
+Key fields in response:
+- `data.id` — tweet ID
+- `data.text` — full text
+- `data.inReplyToId` — original tweet being replied to (empty/null for standalone)
+- `data.author.userName` — author handle
+- `data.createdAt` — timestamp (format: `Tue May 12 01:42:53 +0000 2026`)
+- `data.isReply` — boolean
+- `data.viewCount` — impression count
+- `data.media` — array of media objects with `media_url_https`
+
+---
+
+## Rate Limits & Credits
+
+| Action | Cost | Rate limit |
+|--------|------|------------|
+| Search | ~$0.001/req | Per-account X limits apply |
+| Post/Reply | $0.002/post | X daily post cap (varies by account age/activity) |
+| User timeline | ~$0.001/req | Standard |
+| Tweet detail | ~$0.001/req | Standard |
+| Account check | Free | Unlimited |
+
+Accounts in warmup (new or low-activity) hit X's daily post cap aggressively. Start at 3-4 posts per run window, scale up over 2-3 weeks.
+
+---
+
+## Image Download for Vision Analysis
+
+Tweet images are at `https://pbs.twimg.com/media/<media_id>?format=jpg&name=small` (or `medium`, `large`). Download before analyzing with vision tools:
+
+```bash
+curl -s -o /tmp/tweet_img.jpg \
+  "https://pbs.twimg.com/media/HH8jjRZXIAQ7dlA.jpg?format=jpg&name=small"
+file /tmp/tweet_img.jpg  # verify it's JPEG, not HTML error page
+```

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -2,7 +2,7 @@
 
 Base URL: `https://api.getxapi.com`
 Auth: `Authorization: Bearer <api-key>` (all endpoints)
-Post auth: `auth_token` cookie in JSON body (create endpoint)
+Post auth: value of the X `auth_token` cookie, passed as an `auth_token` field in the JSON body (create endpoint)
 
 ## Account
 

--- a/skills/social-media/getxapi/references/getxapi-endpoints.md
+++ b/skills/social-media/getxapi/references/getxapi-endpoints.md
@@ -13,7 +13,7 @@ Check credits, email, request count.
 curl -s -H "Authorization: Bearer <your-api-key>" "https://api.getxapi.com/account/me"
 ```
 
-Response fields: `email`, `credits` (string, e.g. "$7.53"), `requests` (integer).
+Response fields: `email`, `credits` (string, e.g. `"$X.XX"`), `requests` (integer).
 
 ---
 
@@ -99,7 +99,7 @@ Fetch user's timeline.
 
 | Param | Required | Notes |
 |-------|----------|-------|
-| `userName` | Yes* | Username (e.g. `kextcache`) |
+| `userName` | Yes* | Username (e.g. `someuser`) |
 | `userId` | Yes* | User ID alternative to userName |
 | `count` | No | Results per page |
 
@@ -107,7 +107,7 @@ Fetch user's timeline.
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/user/tweets?userName=kextcache&count=20"
+  "https://api.getxapi.com/twitter/user/tweets?userName=someuser&count=20"
 ```
 
 Response: `{"userName": "...", "userId": "...", "tweet_count": N, "has_more": bool, "next_cursor": "...", "tweets": [...]}`
@@ -125,7 +125,7 @@ Get single tweet by ID.
 
 ```bash
 curl -s -H "Authorization: Bearer <your-api-key>" \
-  "https://api.getxapi.com/twitter/tweet/detail?id=2054014418455839156"
+  "https://api.getxapi.com/twitter/tweet/detail?id=1234567890123456789"
 ```
 
 Response: `{"data": {"type": "tweet", "id": "...", "text": "...", "author": {...}, "inReplyToId": "...", "createdAt": "...", "media": [...], ...}}`


### PR DESCRIPTION
## Summary
New built-in skill documenting the getxapi.com third-party X/Twitter API — all 35 endpoints.

## What this skill provides
- **Correct field names** that differ from official X API: `author.userName` (not `screen_name`), `author.followers` (not `public_metrics.followers_count`), `isReply` (boolean), `inReplyToId`
- **Search strategy**: `product=Top` vs `product=Latest` and why Top is the only viable option for engagement
- **Posting workflow**: Bearer API key + X auth_token cookie value, shell quoting workarounds, media attachments
- **Full endpoint coverage**: tweets, users, DMs, lists, account — all 35 endpoints with params, costs, and pagination
- **Credit tracking**: `GET /account/me` with cost reference ($0.001/read, $0.002/write)
- **Secret Safety section**: modeled on repo conventions, warns against pasting credentials
- **Cron scanner guidance**: explains `_CRON_EXFIL_COMMAND_PATTERNS` behavior and helper-script workaround

## Scanner safety
All curl examples use `<your-api-key>` and `<your-auth-token>` placeholders. No `$VAR` references that trigger cron scanner patterns.

## Category
`skills/social-media/getxapi/`