### PR TITLE
feat(pricing): add deepseek-v4-pro to docs pricing snapshot

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -370,6 +370,18 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-03-16",
     ),
+    # Standard list prices (excludes 75% promo through 2026-05-31).
+    (
+        "deepseek",
+        "deepseek-v4-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.74"),
+        output_cost_per_million=Decimal("3.48"),
+        cache_read_cost_per_million=Decimal("0.0145"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-12",
+    ),
     # Google Gemini
     (
         "google",

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -370,7 +370,6 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-03-16",
     ),
-    # Standard list prices (excludes 75% promo through 2026-05-31).
     (
         "deepseek",
         "deepseek-v4-pro",


### PR DESCRIPTION
## What does this PR do?

Adds an `official_docs_snapshot` pricing entry for `deepseek/deepseek-v4-pro` in `agent/usage_pricing.py`. Without it, sessions on this model show as `unknown` cost in `hermes insights` and the gateway `/usage` output, even though `deepseek-v4-pro` has been a first-class model id since v0.12.

Numbers come from DeepSeek's published list price ([api-docs.deepseek.com/quick_start/pricing](https://api-docs.deepseek.com/quick_start/pricing)). They deliberately exclude the 75% promo that expires **2026-05-31** — encoding the discounted rate would silently understate cost once the promo lapses.

## Related Issue

Fixes #24218

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/usage_pricing.py`: new entry `("deepseek", "deepseek-v4-pro")` → `input $1.74 / output $3.48 / cache_read $0.0145` per 1M tokens, tagged `pricing_version="deepseek-pricing-2026-05-12"`.

## How to Test

1. `uv run --no-sync python -c "from agent.usage_pricing import get_pricing_entry; print(get_pricing_entry('deepseek-v4-pro', provider='deepseek'))"` → returns the new `PricingEntry`, not `None`.
2. `uv run --no-sync python -c "from agent.usage_pricing import estimate_usage_cost, CanonicalUsage; print(estimate_usage_cost('deepseek-v4-pro', CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000, cache_read_tokens=2_000_000), provider='deepseek'))"` → cost `$3.5090`, status `estimated`, source `official_docs_snapshot` (matches `1.74 + 1.74 + 0.029`).
3. Run a DeepSeek session against `deepseek-v4-pro`, then `hermes insights` — overview / per-model cost is computed instead of dropping into `unknown_cost_sessions`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(pricing): …`, `chore(pricing): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — *ran the focused pricing/insights/usage suites only (`tests/agent/test_usage_pricing.py`, `tests/agent/test_insights.py`, `tests/test_account_usage.py`, `tests/gateway/test_usage_command.py`, `tests/gateway/test_insights_unicode_flags.py`): 89 passed*
- [ ] I've added tests for my changes — *the existing `_OFFICIAL_DOCS_PRICING` table is data, not behavior; no existing entry has a dedicated test. Happy to add one if maintainers want it.*
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (pricing data only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
>>> from agent.usage_pricing import get_pricing_entry, estimate_usage_cost, CanonicalUsage
>>> get_pricing_entry("deepseek-v4-pro", provider="deepseek")
PricingEntry(input_cost_per_million=Decimal('1.74'),
             output_cost_per_million=Decimal('3.48'),
             cache_read_cost_per_million=Decimal('0.0145'),
             cache_write_cost_per_million=None,
             ...
             source='official_docs_snapshot',
             source_url='https://api-docs.deepseek.com/quick_start/pricing',
             pricing_version='deepseek-pricing-2026-05-12', ...)
>>> estimate_usage_cost("deepseek-v4-pro",
...     CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000, cache_read_tokens=2_000_000),
...     provider="deepseek").amount_usd
Decimal('3.5090')
```