### PR TITLE
fix: inject base_url into system prompt volatile metadata

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -262,6 +262,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nModel: {agent.model}"
     if agent.provider:
         timestamp_line += f"\nProvider: {agent.provider}"
+    if agent.base_url:
+        timestamp_line += f"\nBase URL: {agent.base_url}"
     volatile_parts.append(timestamp_line)
 
     return {


### PR DESCRIPTION
## Problem

When using `custom_providers`, the system prompt only injects `Model` and `Provider` names from `config.yaml` which may not reflect the runtime-resolved endpoint. This causes the LLM to see incorrect metadata about which API it is actually using.

For example, with a Volcengine custom provider:
- System prompt shows `Provider: openai-codex` (from config)
- Runtime actually routes to `custom:火山方舟` with a completely different `base_url`
- The LLM has no way to determine the actual endpoint

## Fix

Add `base_url` to the volatile metadata section of the system prompt:

```python
if self.model:
    timestamp_line += f"\nModel: {self.model}"
if self.provider:
    timestamp_line += f"\nProvider: {self.provider}"
if self.base_url:
    timestamp_line += f"\nBase URL: {self.base_url}"
```

This gives the LLM a reliable signal about the actual API endpoint, regardless of whether the provider name matches. The `base_url` is always the truth — it is the URL that API requests are actually sent to.

The `base_url` is placed in the `volatile_parts` section of the prompt (alongside Model and Provider), so it is rebuilt each turn and reflects any runtime changes from `switch_model()`.

## Why not also fix Model/Provider values?

After `switch_model()`, `self.model` and `self.provider` ARE updated to the resolved values, and the system prompt cache IS invalidated (`self._cached_system_prompt = None`). So after a `/model` switch, the next turn already gets the correct model/provider names.

The remaining ambiguity is at **session init time** — when `model.provider` in config differs from the custom_providers entry that actually handles the request. `base_url` resolves this ambiguity without needing to change the init-time resolution logic, which has broader implications.

Fixes #24215