### PR TITLE
fix(gateway): preserve thread routing for process completions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1411,7 +1411,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
 
 
 def _format_gateway_process_notification(evt: dict) -> "str | None":
-    """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
+    """Format a process event from completion_queue into a [IMPORTANT:] message."""
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
@@ -1433,6 +1433,16 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"
         return text
+
+    if evt_type == "completion":
+        _exit = evt.get("exit_code")
+        _out = evt.get("output", "")
+        return (
+            f"[IMPORTANT: Background process {_sid} completed "
+            f"(exit code {_exit}).\n"
+            f"Command: {_cmd}\n"
+            f"Output:\n{_out}]"
+        )
 
     return None
 
@@ -8658,28 +8668,28 @@ class GatewayRunner:
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 
-            # Drain watch pattern notifications that arrived during the agent run.
-            # Watch events and completions share the same queue; completions are
-            # already handled by the per-process watcher task above, so we only
-            # inject watch-type events here.
+            # Drain process notifications that arrived during the agent run.
+            # Every queued event carries its own origin metadata; never route it
+            # via the currently active foreground topic.
             try:
                 from tools.process_registry import process_registry as _pr
-                _watch_events = []
+                _process_events = []
                 while not _pr.completion_queue.empty():
                     evt = _pr.completion_queue.get_nowait()
                     evt_type = evt.get("type", "completion")
-                    if evt_type in {"watch_match", "watch_disabled"}:
-                        _watch_events.append(evt)
-                    # else: completion events are handled by the watcher task
-                for evt in _watch_events:
+                    if evt_type in ("watch_match", "watch_disabled", "completion"):
+                        _process_events.append(evt)
+                for evt in _process_events:
                     synth_text = _format_gateway_process_notification(evt)
                     if synth_text:
                         try:
                             await self._inject_watch_notification(synth_text, evt)
+                            if evt.get("type", "completion") == "completion":
+                                _pr.mark_completion_consumed(evt.get("session_id", ""))
                         except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                            logger.error("Process notification injection error: %s", e2)
             except Exception as e:
-                logger.debug("Watch queue drain error: %s", e)
+                logger.debug("Process queue drain error: %s", e)
 
             # NOTE: Dangerous command approvals are now handled inline by the
             # blocking gateway approval mechanism in tools/approval.py.  The agent
@@ -14664,6 +14674,7 @@ class GatewayRunner:
                                 source.thread_id,
                             )
                             await adapter.handle_message(synth_event)
+                            _pr_check.mark_completion_consumed(session_id)
                         except Exception as e:
                             logger.error("Agent notify injection error: %s", e)
                     break

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from gateway.config import GatewayConfig, Platform
-from gateway.run import GatewayRunner, _parse_session_key
+from gateway.run import GatewayRunner, _format_gateway_process_notification, _parse_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -26,6 +26,7 @@ class _FakeRegistry:
 
     def __init__(self, sessions):
         self._sessions = list(sessions)
+        self.consumed = set()
 
     def get(self, session_id):
         if self._sessions:
@@ -33,7 +34,10 @@ class _FakeRegistry:
         return None
 
     def is_completion_consumed(self, session_id):
-        return False
+        return session_id in self.consumed
+
+    def mark_completion_consumed(self, session_id):
+        self.consumed.add(session_id)
 
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
@@ -202,6 +206,47 @@ async def test_run_process_watcher_respects_notification_mode(
     if expected_fragment is not None:
         sent_message = adapter.send.await_args.args[1]
         assert expected_fragment in sent_message
+
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_agent_notify_uses_thread_source(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="npm test",
+        )
+    ]
+    fake_registry = _FakeRegistry(sessions)
+    monkeypatch.setattr(pr_module, "process_registry", fake_registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher({
+        "session_id": "proc_agent_notify",
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:group:-100:42",
+        "platform": "telegram",
+        "chat_id": "-100",
+        "thread_id": "42",
+        "user_id": "123",
+        "user_name": "Denis",
+        "notify_on_complete": True,
+    })
+
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.source.chat_id == "-100"
+    assert synth_event.source.thread_id == "42"
+    assert fake_registry.is_completion_consumed("proc_agent_notify")
 
 
 @pytest.mark.asyncio
@@ -501,6 +546,38 @@ def test_build_process_event_source_returns_none_for_invalid_platform(monkeypatc
     }
     source = runner._build_process_event_source(evt)
     assert source is None
+
+
+@pytest.mark.asyncio
+async def test_completion_event_routes_to_original_telegram_thread(monkeypatch, tmp_path):
+    """Queued completion events carry their own topic, not the foreground one."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    evt = {
+        "type": "completion",
+        "session_id": "proc_done",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "command": "npm test",
+        "exit_code": 0,
+        "output": "ok",
+        "platform": "telegram",
+        "chat_id": "-100",
+        "thread_id": "42",
+        "user_id": "123",
+        "user_name": "Denis",
+    }
+
+    synth_text = _format_gateway_process_notification(evt)
+    assert "completed" in synth_text
+    await runner._inject_watch_notification(synth_text, evt)
+
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.internal is True
+    assert synth_event.source.platform == Platform.TELEGRAM
+    assert synth_event.source.chat_id == "-100"
+    assert synth_event.source.thread_id == "42"
+    assert synth_event.source.user_id == "123"
 
 
 def test_build_process_event_source_returns_none_for_short_session_key(monkeypatch, tmp_path):

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -92,6 +92,12 @@ class TestCompletionQueue:
         )
         s.exited = True
         s.exit_code = 0
+        s.session_key = "agent:main:telegram:group:-100:42"
+        s.watcher_platform = "telegram"
+        s.watcher_chat_id = "-100"
+        s.watcher_user_id = "123"
+        s.watcher_user_name = "Denis"
+        s.watcher_thread_id = "42"
         registry._running[s.id] = s
         with patch.object(registry, "_write_checkpoint"):
             registry._move_to_finished(s)
@@ -99,9 +105,15 @@ class TestCompletionQueue:
         assert not registry.completion_queue.empty()
         completion = registry.completion_queue.get_nowait()
         assert completion["session_id"] == s.id
+        assert completion["session_key"] == "agent:main:telegram:group:-100:42"
         assert completion["command"] == "echo hello"
         assert completion["exit_code"] == 0
         assert "build succeeded" in completion["output"]
+        assert completion["platform"] == "telegram"
+        assert completion["chat_id"] == "-100"
+        assert completion["user_id"] == "123"
+        assert completion["user_name"] == "Denis"
+        assert completion["thread_id"] == "42"
 
     def test_move_to_finished_nonzero_exit(self, registry):
         """Nonzero exit codes are captured correctly."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -822,9 +822,15 @@ class ProcessRegistry:
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
+                "session_key": session.session_key,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "output": output_tail,
+                "platform": session.watcher_platform,
+                "chat_id": session.watcher_chat_id,
+                "user_id": session.watcher_user_id,
+                "user_name": session.watcher_user_name,
+                "thread_id": session.watcher_thread_id,
             })
 
     # ----- Query Methods -----
@@ -852,6 +858,11 @@ class ProcessRegistry:
             if text:
                 results.append((evt, text))
         return results
+
+    def mark_completion_consumed(self, session_id: str) -> None:
+        """Mark a completion notification as delivered/consumed."""
+        if session_id:
+            self._completion_consumed.add(session_id)
 
     def get(self, session_id: str) -> Optional[ProcessSession]:
         """Get a session by ID (running or finished)."""


### PR DESCRIPTION
## Summary
- carry session/platform/chat/user/thread metadata on background process completion queue events
- let the gateway drain completion events through the same synthetic-message routing path as watch notifications
- mark completions consumed after queue/watcher delivery to avoid duplicate notify_on_complete messages
- document investigation in plan.md

## Tests
- scripts/run_tests.sh tests/tools/test_notify_on_complete.py tests/gateway/test_background_process_notifications.py

## Why
Delayed background-process notifications must route to the original Telegram topic/thread where the process was launched, not whichever topic is active when the notification is drained.