### PR TITLE
fix(mem0): redact outbound memory payloads

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -25,6 +25,12 @@ from typing import Any, Dict, List
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
+try:
+    from agent.redact import redact_sensitive_text
+except Exception:  # pragma: no cover - defensive fallback during partial imports
+    def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
+        return text
+
 logger = logging.getLogger(__name__)
 
 # Circuit breaker: after this many consecutive failures, pause API calls
@@ -218,6 +224,11 @@ class Mem0MemoryProvider(MemoryProvider):
         return {"user_id": self._user_id, "agent_id": self._agent_id}
 
     @staticmethod
+    def _redact_for_mem0(text: Any) -> str:
+        """Redact secrets before sending user/assistant text to Mem0's API."""
+        return redact_sensitive_text("" if text is None else str(text), force=True)
+
+    @staticmethod
     def _unwrap_results(response: Any) -> list:
         """Normalize Mem0 API response — v2 wraps results in {"results": [...]}."""
         if isinstance(response, dict):
@@ -251,8 +262,9 @@ class Mem0MemoryProvider(MemoryProvider):
         def _run():
             try:
                 client = self._get_client()
+                safe_query = self._redact_for_mem0(query)
                 results = self._unwrap_results(client.search(
-                    query=query,
+                    query=safe_query,
                     filters=self._read_filters(),
                     rerank=self._rerank,
                     top_k=5,
@@ -278,8 +290,8 @@ class Mem0MemoryProvider(MemoryProvider):
             try:
                 client = self._get_client()
                 messages = [
-                    {"role": "user", "content": user_content},
-                    {"role": "assistant", "content": assistant_content},
+                    {"role": "user", "content": self._redact_for_mem0(user_content)},
+                    {"role": "assistant", "content": self._redact_for_mem0(assistant_content)},
                 ]
                 client.add(messages, **self._write_filters())
                 self._record_success()
@@ -321,7 +333,7 @@ class Mem0MemoryProvider(MemoryProvider):
                 return tool_error(f"Failed to fetch profile: {e}")
 
         elif tool_name == "mem0_search":
-            query = args.get("query", "")
+            query = self._redact_for_mem0(args.get("query", ""))
             if not query:
                 return tool_error("Missing required parameter: query")
             rerank = args.get("rerank", False)
@@ -343,7 +355,7 @@ class Mem0MemoryProvider(MemoryProvider):
                 return tool_error(f"Search failed: {e}")
 
         elif tool_name == "mem0_conclude":
-            conclusion = args.get("conclusion", "")
+            conclusion = self._redact_for_mem0(args.get("conclusion", ""))
             if not conclusion:
                 return tool_error("Missing required parameter: conclusion")
             try:

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -199,6 +199,67 @@ class TestMem0ResponseUnwrapping:
 
 
 # ---------------------------------------------------------------------------
+# Outbound redaction
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OutboundRedaction:
+    """Sensitive text should be redacted before any Mem0 API call leaves Hermes."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_sync_turn_redacts_messages_before_add(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+        raw_token = "tok_" + "a" * 40
+
+        provider.sync_turn(
+            f"Authorization: Bearer {raw_token}",
+            f"I saw Authorization: Bearer {raw_token}",
+            session_id="s1",
+        )
+        provider._sync_thread.join(timeout=2)
+
+        sent = json.dumps(client.captured_add[0]["messages"])
+        assert raw_token not in sent
+
+    def test_search_redacts_query_before_api_call(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+        raw_token = "tok_" + "b" * 40
+
+        provider.handle_tool_call("mem0_search", {"query": f"Authorization: Bearer {raw_token}"})
+
+        assert raw_token not in client.captured_search["query"]
+
+    def test_prefetch_redacts_query_before_api_call(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+        raw_token = "tok_" + "d" * 40
+
+        provider.queue_prefetch(f"Authorization: Bearer {raw_token}")
+        provider._prefetch_thread.join(timeout=2)
+
+        assert raw_token not in client.captured_search["query"]
+
+    def test_conclude_redacts_fact_before_add(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+        raw_token = "tok_" + "c" * 40
+
+        provider.handle_tool_call("mem0_conclude", {"conclusion": f"Authorization: Bearer {raw_token}"})
+
+        sent = json.dumps(client.captured_add[0]["messages"])
+        assert raw_token not in sent
+
+
+# ---------------------------------------------------------------------------
 # Default preservation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- redact user/assistant turn content before automatic Mem0 sync
- redact Mem0 search and prefetch queries before they leave Hermes
- redact explicit `mem0_conclude` content before storing it in Mem0
- add regression coverage for outbound redaction behavior

## Why
Mem0's hosted/API backend receives raw payloads from Hermes for server-side memory extraction and retrieval. Hermes already has central secret redaction utilities; the Mem0 provider should apply them before sending outbound memory payloads so accidental tokens, bearer headers, or other sensitive strings are not forwarded to the memory provider.

## Test Plan
- `./venv/bin/python -m py_compile plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v2.py`
- `./venv/bin/python -m pytest tests/plugins/memory/test_mem0_v2.py tests/agent/test_memory_user_id.py -q`
- `git diff --check -- plugins/memory/mem0/__init__.py tests/plugins/memory/test_mem0_v2.py`
