### PR TITLE
fix(dashboard): rescan plugins when cached directory is removed

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4021,6 +4021,10 @@ def _get_dashboard_plugins(force_rescan: bool = False) -> list:
     global _dashboard_plugins_cache
     if _dashboard_plugins_cache is None or force_rescan:
         _dashboard_plugins_cache = _discover_dashboard_plugins()
+    elif _dashboard_plugins_cache:
+        from pathlib import Path as _Path
+        if any(not _Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
+            _dashboard_plugins_cache = _discover_dashboard_plugins()
     return _dashboard_plugins_cache
 
 


### PR DESCRIPTION
## Summary

When a dashboard plugin directory is removed from disk (e.g. after `git pull` removes a bundled plugin from the repo), the in-process `_dashboard_plugins_cache` in `web_server.py` still holds stale metadata. The frontend then tries to load the plugin JS bundle from a path that no longer exists, resulting in a 404 on the script load.

## Root Cause

`_get_dashboard_plugins()` returns the cached plugin list without validating that each plugin's directory still exists on disk. The only way to refresh is the explicit `/api/dashboard/plugins/rescan` endpoint, which users don't know about.

## Fix

Add a staleness check in `_get_dashboard_plugins()`: if the cache is non-empty and any cached plugin's `_dir` no longer exists on disk, trigger a full rescan automatically. This is a single `Path.is_dir()` check per cached plugin on each call — negligible overhead.

## Regression Coverage

New test `test_stale_cache_pruned_on_missing_directory`:
1. Creates two plugins, populates the cache
2. Removes one plugin's directory from disk
3. Calls `_get_dashboard_plugins()` without `force_rescan`
4. Asserts the removed plugin is no longer returned while the surviving plugin persists

## Testing

```
scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions -xvs
# 5 passed in 1.00s
```

Fixes Stale dashboard plugin cache persists after plugin directory is removed from disk #24116
