### PR TITLE
feat(deepseek): add reasoning_effort and thinking toggle support

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,9 +1,69 @@
-"""DeepSeek provider profile."""
+"""DeepSeek provider profile.
+
+DeepSeek V4 models support thinking mode with two independent controls:
+- Thinking toggle: ``{"thinking": {"type": "enabled/disabled"}}`` in extra_body
+- Effort control: ``{"reasoning_effort": "high/max"}`` as a top-level parameter
+
+See: https://api-docs.deepseek.com/guides/thinking_mode
+"""
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-deepseek = ProviderProfile(
+
+class DeepSeekProfile(ProviderProfile):
+    """DeepSeek — thinking toggle via extra_body + reasoning_effort as top-level."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit extra_body.thinking + top-level reasoning_effort.
+
+        Per DeepSeek API docs:
+        - Default: thinking enabled, reasoning_effort = "high"
+        - Valid effort values: "high", "max"
+        - low/medium → high, xhigh → max (server-side mapping, but we
+          normalize here for predictability)
+        - When thinking is disabled, reasoning_effort is omitted.
+        """
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            # No config → thinking enabled, default effort
+            extra_body["thinking"] = {"type": "enabled"}
+            top_level["reasoning_effort"] = "high"
+            return extra_body, top_level
+
+        enabled = reasoning_config.get("enabled", True)
+        if enabled is False:
+            extra_body["thinking"] = {"type": "disabled"}
+            # No reasoning_effort when thinking is off
+            return extra_body, top_level
+
+        # Thinking enabled
+        extra_body["thinking"] = {"type": "enabled"}
+
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        # DeepSeek only natively supports "high" and "max".
+        # Map the OpenRouter-style effort levels for compatibility:
+        #   low/medium → high
+        #   high       → high
+        #   xhigh      → max
+        #   max        → max
+        if effort in ("high", "max"):
+            top_level["reasoning_effort"] = effort
+        elif effort == "xhigh":
+            top_level["reasoning_effort"] = "max"
+        else:
+            top_level["reasoning_effort"] = "high"
+
+        return extra_body, top_level
+
+
+deepseek = DeepSeekProfile(
     name="deepseek",
     aliases=("deepseek-chat",),
     env_vars=("DEEPSEEK_API_KEY",),

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -287,3 +287,91 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+
+class TestDeepSeekProfile:
+    """DeepSeek V4 profile — thinking toggle + reasoning_effort."""
+
+    def test_profile_registered(self):
+        p = get_provider_profile("deepseek")
+        assert p is not None
+        assert p.name == "deepseek"
+        assert "api.deepseek.com" in p.base_url
+
+    def test_alias_lookup(self):
+        p = get_provider_profile("deepseek-chat")
+        assert p.name == "deepseek"
+
+    def test_no_config_defaults(self):
+        """Default: thinking enabled, effort high."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config=None)
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_thinking_disabled(self):
+        """When disabled, no reasoning_effort is emitted."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": False})
+        assert eb["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in tl
+
+    def test_effort_high(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_effort_max(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"}
+        )
+        assert tl["reasoning_effort"] == "max"
+
+    def test_effort_xhigh_maps_to_max(self):
+        """xhigh (OpenRouter-style) maps to max."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"}
+        )
+        assert tl["reasoning_effort"] == "max"
+
+    def test_effort_medium_maps_to_high(self):
+        """medium maps to high (DeepSeek's minimum effort)."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"}
+        )
+        assert tl["reasoning_effort"] == "high"
+
+    def test_effort_low_maps_to_high(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "low"}
+        )
+        assert tl["reasoning_effort"] == "high"
+
+    def test_effort_minimal_maps_to_high(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "minimal"}
+        )
+        assert tl["reasoning_effort"] == "high"
+
+    def test_unknown_effort_falls_back_to_high(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "garbage"}
+        )
+        assert tl["reasoning_effort"] == "high"
+
+    def test_missing_effort_defaults_to_high(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True}
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == "high"


### PR DESCRIPTION
## What does this PR do?

Add `reasoning_effort` (intensity control) and `thinking` toggle support for the native DeepSeek provider (`api.deepseek.com`).

DeepSeek V4 models (Flash / Pro) expose two independent thinking controls through their OpenAI-compatible API:

- **Thinking toggle**: `{"thinking": {"type": "enabled/disabled"}}` in `extra_body`
- **Effort control**: `"reasoning_effort": "high"` / `"max"` at top level

The server maps `low` / `medium` → `high` and `xhigh` → `max` for compatibility with OpenRouter-style effort levels. This PR mirrors that mapping client-side.

Previously, the deepseek provider profile was a bare `ProviderProfile` that emitted neither parameter — the native API path had no way to toggle thinking or control reasoning intensity. The OpenRouter path sent a generic `extra_body.reasoning` block that does not match DeepSeek's native format.

This PR introduces a `DeepSeekProfile` subclass implementing `build_api_kwargs_extras()` that emits both parameters, following the same pattern already used by `KimiProfile` for Kimi / Moonshot.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/model-providers/deepseek/__init__.py` — Replace bare `ProviderProfile` with `DeepSeekProfile` subclass that implements `build_api_kwargs_extras()`, emitting `extra_body.thinking` (toggle) and top-level `reasoning_effort` (intensity). Effort mapping: `low`/`medium`/`minimal` → `high`, `xhigh` → `max`, `high` → `high`, `max` → `max`, unknown → `high`.
- `tests/providers/test_provider_profiles.py` — Add `TestDeepSeekProfile` class with 12 test cases covering all effort mappings (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, unknown, missing), alias lookup, profile registration, and thinking toggle behavior.

## How to Test

1. Run `pytest tests/providers/test_provider_profiles.py -v -n 0` — all 53 tests should pass (41 existing + 12 new).
2. Start a Hermes session with `provider: deepseek` and a DeepSeek V4 model.
3. Use `/reasoning none` to disable thinking — the API request should include `extra_body.thinking = {"type": "disabled"}` with no `reasoning_effort`.
4. Use `/reasoning xhigh` — the API request should include `reasoning_effort: "max"` and `extra_body.thinking = {"type": "enabled"}`.
5. Verify default behavior (no `/reasoning` set) sends `thinking: enabled` + `reasoning_effort: high`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL (Ubuntu) / Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring on `build_api_kwargs_extras` updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (provider profile is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
tests/providers/test_provider_profiles.py ................................
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_profile_registered PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_alias_lookup PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_no_config_defaults PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_thinking_disabled PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_high PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_max PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_xhigh_maps_to_max PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_medium_maps_to_high PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_low_maps_to_high PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_effort_minimal_maps_to_high PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_unknown_effort_falls_back_to_high PASSED
tests/providers/test_provider_profiles.py::TestDeepSeekProfile::test_missing_effort_defaults_to_high PASSED

============================== 53 passed in 1.10s ==============================
```

Ref: https://api-docs.deepseek.com/guides/thinking_mode