### PR TITLE
fix(bluebubbles): drop participant-address fallback in _resolve_chat_guid

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -432,8 +432,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         If *target* already contains a semicolon (raw GUID format like
         ``iMessage;-;user@example.com``), it is returned as-is.  Otherwise
-        the adapter queries the BlueBubbles chat list and matches on
-        ``chatIdentifier`` or participant address.
+        the adapter queries the BlueBubbles chat list and matches strictly
+        on ``chatIdentifier`` / ``identifier``.
+
+        Participant membership is intentionally NOT used as a fallback:
+        the same contact can appear in a 1:1 DM and in any number of group
+        chats, so a participant match would let an outbound DM reply leak
+        into a group thread (see #24157). When no exact chat identity
+        matches, return ``None`` and let the caller create a fresh DM
+        explicitly via ``_create_chat_for_handle``.
         """
         target = (target or "").strip()
         if not target:
@@ -458,12 +465,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                         while len(self._guid_cache) > _GUID_CACHE_SIZE:
                             self._guid_cache.popitem(last=False)
                     return guid
-                for part in chat.get("participants", []) or []:
-                    if (part.get("address") or "").strip() == target and guid:
-                        self._guid_cache[target] = guid
-                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
-                            self._guid_cache.popitem(last=False)
-                        return guid
         except Exception:
             pass
         return None

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -454,7 +454,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         try:
             payload = await self._api_post(
                 "/api/v1/chat/query",
-                {"limit": 100, "offset": 0, "with": ["participants"]},
+                {"limit": 100, "offset": 0},
             )
             for chat in payload.get("data", []) or []:
                 guid = chat.get("guid") or chat.get("chatGuid")

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -426,6 +426,110 @@ class TestBlueBubblesGuidResolution:
         )
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_exact_chat_identifier_match_returns_dm_guid(self, monkeypatch):
+        """A 1:1 DM whose chatIdentifier equals the target resolves to its guid."""
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                        "participants": [{"address": "user@example.com"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result == "iMessage;-;user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_participant_only_match_does_not_resolve_to_group(self, monkeypatch):
+        """Regression for #24157: contact appearing as a participant in a group
+        chat must NOT be selected when no DM with that exact chatIdentifier exists.
+
+        Otherwise an outbound DM reply leaks into the group thread.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [
+                            {"address": "user@example.com"},
+                            {"address": "+15555550100"},
+                        ],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result is None, (
+            "participant-only match must not resolve to a group GUID — DM "
+            "replies would leak into the group thread"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dm_chosen_over_group_when_both_contain_contact(self, monkeypatch):
+        """Even when a group chat is returned BEFORE a DM in the query result,
+        the resolver must lock onto the DM by chatIdentifier and not the
+        group via participant fallback.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [{"address": "user@example.com"}],
+                    },
+                    {
+                        "guid": "iMessage;-;user@example.com",
+                        "chatIdentifier": "user@example.com",
+                        "participants": [{"address": "user@example.com"}],
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._resolve_chat_guid("user@example.com")
+        assert result == "iMessage;-;user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_unresolved_target_is_not_cached(self, monkeypatch):
+        """When no exact match is found, the resolver must NOT cache anything.
+
+        Otherwise a later attempt — after the DM has been created — would
+        keep returning the stale ``None`` from cache. Also guards against a
+        latent variant of #24157 where a group GUID could be cached under a
+        bare address key and persist across calls.
+        """
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(path, payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;chat0000000000-family-group",
+                        "chatIdentifier": "chat0000000000",
+                        "participants": [{"address": "user@example.com"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        await adapter._resolve_chat_guid("user@example.com")
+        assert "user@example.com" not in adapter._guid_cache
+
 
 class TestBlueBubblesAttachmentDownload:
     """Verify _download_attachment routes to the correct cache helper."""


### PR DESCRIPTION
## Summary
- Outbound 1:1 BlueBubbles replies could be misrouted into a group chat when the same contact appeared in both a DM and a group thread — a real privacy leak (issue #24157).
- Restricts `_resolve_chat_guid` to raw GUID passthrough and exact `chatIdentifier` / `identifier` match. Removes the participant-address fallback that was the root cause.

## The bug
`gateway/platforms/bluebubbles.py:_resolve_chat_guid` iterates the chat list returned by `POST /api/v1/chat/query` and, for each chat, first compares `chatIdentifier == target` and then falls back to scanning that chat's `participants[].address` for a match.

If the same contact (e.g. `user@example.com`) appears as a participant in a group thread, and the group chat happens to be returned before the DM, the participant fallback fires on the group's iteration before the DM is even examined. The resolver returns the group's GUID, the GUID is cached under the bare address, and every subsequent DM reply continues to land in the group thread.

This is a delivery-layer bug: inbound session isolation, agent selection, and chat-to-agent routing can all be correct upstream, but the final `_resolve_chat_guid` step still rewrites the outbound destination.

alt-glitch's note on the issue confirms this is the uncovered residual of the BlueBubbles routing family — #9806 fixed inbound group-vs-DM separation, but the outbound participant-matching fallback was never closed.

## The fix
Resolution order is now:
1. Raw GUID passthrough (target contains `;`)
2. Exact `chatIdentifier` / `identifier` match

If neither matches, return `None`. The callers already handle this safely:
- `BlueBubblesAdapter.send()` checks for an address-shaped target (`@` or `+digit`) and creates a fresh DM via `_create_chat_for_handle` instead of guessing.
- `BlueBubblesAdapter._send_attachment()` returns `SendResult(success=False, error=\"Chat not found: ...\")` instead of silently sending to a group.

Both behaviors are strictly preferable to misrouting a DM into a group.

## Test plan
- [x] Focused regression: `pytest tests/gateway/test_bluebubbles.py::TestBlueBubblesGuidResolution -v` — 6/6 pass.
- [x] Adjacent suite: `pytest tests/gateway/test_bluebubbles.py -v` — 52/52 pass.
- [x] Regression guard: before the fix, `test_participant_only_match_does_not_resolve_to_group` and `test_dm_chosen_over_group_when_both_contain_contact` both fail (the resolver returns the group GUID); after the fix both pass.

New tests under `TestBlueBubblesGuidResolution`:
- `test_exact_chat_identifier_match_returns_dm_guid` — 1:1 DM still resolves.
- `test_participant_only_match_does_not_resolve_to_group` — contact appearing only as a group participant must not resolve to the group GUID.
- `test_dm_chosen_over_group_when_both_contain_contact` — even when the group is returned first in the query response, the DM wins because it matches by `chatIdentifier`.
- `test_unresolved_target_is_not_cached` — guards against the latent cache-poisoning variant where a wrong GUID could persist across calls.

## Related
- Fixes #24157.
- Related: #9806 (merged) — closed the inbound group-vs-DM session separation; this PR closes the matching outbound resolution gap.