### PR TITLE
fix(computer_use): two bugs blocking cua-driver integration

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9545,9 +9545,14 @@ class AIAgent:
             if _ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None
 
+            # Strip image parts for non-vision models so that providers
+            # with a profile also get the vision_analyze text-fallback
+            # instead of raw image_url parts that the model rejects.
+            _msgs_for_chat = self._prepare_messages_for_non_vision_model(api_messages)
+
             return _ct.build_kwargs(
                 model=self.model,
-                messages=api_messages,
+                messages=_msgs_for_chat,
                 tools=tools_for_api,
                 base_url=self.base_url,
                 timeout=self._resolved_api_call_timeout(),

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -529,10 +529,10 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is None:
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
-        # Safari WebKit AXTextField does not accept AX attribute writes (type_text),
-        # so use type_text_chars which synthesises individual key events instead.
-        # This works universally across all macOS apps in background mode.
-        return self._action("type_text_chars", {"pid": pid, "text": text})
+        # cua-driver's type_text tries AXSetAttribute first (fast, works in
+        # background), then falls back to CGEvent character synthesis for
+        # apps that don't support AX text insertion (e.g. Safari WebKit).
+        return self._action("type_text", {"pid": pid, "text": text})
 
     def key(self, keys: str) -> ActionResult:
         pid = self._active_pid


### PR DESCRIPTION
## Summary

Two bugs prevent the `computer_use` tool from working correctly with cua-driver v0.1.6+.

### Bug 1: `type_text_chars` tool does not exist

`cua_backend.py` line 535 calls `self._action("type_text_chars", ...)`, but cua-driver exposes `type_text` (not `type_text_chars`). Every `computer_use(action="type")` call fails with:

```
McpError: Invalid params: Unknown tool: type_text_chars
```

cua-driver's `type_text` already handles both AXSetAttribute (fast, background-safe) and CGEvent fallback (for apps like Safari WebKit that reject AX text insertion). The old `type_text_chars` name appears to have been written against an earlier or hypothetical cua-driver API.

**Fix:** Change `"type_text_chars"` → `"type_text"`.

### Bug 2: Provider-profile path skips image→text fallback

When the active model lacks vision (`supports_vision=False`, e.g. GLM-5.1) but the provider has a registered profile, `_prepare_messages_for_non_vision_model()` is never called. The raw `image_url` parts in multimodal tool results reach the model, which rejects them → `_vision_supported=False` → screenshots stripped entirely.

The image→text fallback (which calls `vision_analyze` via the auxiliary vision model to produce text descriptions) only ran on the legacy no-profile path. Models behind a provider profile got no fallback.

**Fix:** Call `_prepare_messages_for_non_vision_model(api_messages)` in the provider-profile path too, before building kwargs.

## Testing

- Verified cua-driver v0.1.6 tool list: `type_text` exists, `type_text_chars` does not
- Confirmed `_model_supports_vision()` returns `False` for GLM-5.1
- After fix, `type_text` works: `cua-driver call type_text '{...}'` succeeds
- After fix, non-vision models with provider profiles get vision_analyze text descriptions for screenshots instead of raw image_url parts

## Files changed

- `tools/computer_use/cua_backend.py` — fix tool name
- `run_agent.py` — add `_prepare_messages_for_non_vision_model` call in provider-profile path