### PR TITLE
chore: fix ruff E741 — rename ambiguous variable l to descriptive names

### DIFF
--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -738,7 +738,7 @@ async def _resolve_wiki_nodes(
     Mutates entries in *links* in-place: replaces ``doc_type`` and ``token``
     with the resolved values for wiki links.  Non-wiki links are unchanged.
     """
-    wiki_links = [l for l in links if l["doc_type"] == "wiki"]
+    wiki_links = [link for link in links if link["doc_type"] == "wiki"]
     if not wiki_links:
         return links
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -882,9 +882,9 @@ class SignalAdapter(BasePlatformAdapter):
             return pos - shift
 
         adjusted_prior: list = []
-        for s, l, st in styles:
+        for s, length, st in styles:
             ns = _adj(s)
-            ne = _adj(s + l)
+            ne = _adj(s + length)
             if ne > ns:
                 adjusted_prior.append((ns, ne - ns, st))
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -639,7 +639,7 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
     anchor = old_lines[0].strip()
     if not anchor:
         # Try second line if first is blank
-        candidates = [l.strip() for l in old_lines if l.strip()]
+        candidates = [line.strip() for line in old_lines if line.strip()]
         if not candidates:
             return ""
         anchor = candidates[0]

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -263,7 +263,7 @@ def _validate_operations(
 
             simulated = read_result.content
             for hunk in op.hunks:
-                search_lines = [l.content for l in hunk.lines if l.prefix in {' ', '-'}]
+                search_lines = [line.content for line in hunk.lines if line.prefix in {' ', '-'}]
                 if not search_lines:
                     # Addition-only hunk: validate context hint uniqueness
                     if hunk.context_hint:
@@ -282,7 +282,7 @@ def _validate_operations(
                     continue
 
                 search_pattern = '\n'.join(search_lines)
-                replace_lines = [l.content for l in hunk.lines if l.prefix in {' ', '+'}]
+                replace_lines = [line.content for line in hunk.lines if line.prefix in {' ', '+'}]
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1298,7 +1298,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr
-        error_lines = [l for l in stderr.splitlines() if not l.startswith("OK:")]
+        error_lines = [line for line in stderr.splitlines() if not line.startswith("OK:")]
         raise RuntimeError(f"NeuTTS synthesis failed: {chr(10).join(error_lines) or 'unknown error'}")
 
     # If the caller wanted .mp3 or .ogg, convert from WAV


### PR DESCRIPTION
## Summary
Rename the ambiguous variable name `l` (easily confused with the digit `1`) to descriptive, context-appropriate names across 5 files. This fixes the remaining E741 warnings flagged by ruff.

## Changes
- `gateway/platforms/feishu_comment.py`: `l` → `link` in wiki-links list comprehension
- `gateway/platforms/signal.py`: `l` → `length` in style-adjustment loop
- `tools/fuzzy_match.py`: `l` → `line` in closest-lines candidate filter
- `tools/patch_parser.py`: `l` → `line` in hunk search/replace line extraction (2 instances)
- `tools/tts_tool.py`: `l` → `line` in NeuTTS stderr filter

## Test Plan
- [x] `ruff check --select=E741` passes (0 errors, was 6)
- [x] `py_compile` passes for all 5 modified files
- [x] Zero logic changes — only variable names renamed

Follows the same pattern as previously merged ruff cleanup PRs (#23940, #23937, #23926).