### PR TITLE
fix: only send reasoning.encrypted_content include for supported models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -666,7 +666,12 @@ class _CodexCompletionsAdapter:
                         "effort": effort,
                         "summary": "auto",
                     }
-                    resp_kwargs["include"] = ["reasoning.encrypted_content"]
+                    # Only send include=["reasoning.encrypted_content"] for models
+                    # that support it. GPT-4o, GPT-4o-mini, and older models reject
+                    # this parameter with HTTP 400.
+                    from agent.model_metadata import openai_supports_encrypted_content
+                    if openai_supports_encrypted_content(final_model):
+                        resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -282,6 +282,39 @@ def grok_supports_reasoning_effort(model: str) -> bool:
     return any(name.startswith(prefix) for prefix in _GROK_EFFORT_CAPABLE_PREFIXES)
 
 
+# OpenAI models that ACCEPT the ``reasoning.encrypted_content`` include
+# parameter on the Responses API.
+#
+# Models NOT on this list will return HTTP 400 with "Encrypted content is
+# not supported with this model" when the include parameter is sent.
+#
+# Currently supported models: o-series (o1, o3), gpt-5 series.
+# Not supported: gpt-4o, gpt-4o-mini, gpt-4, gpt-3.5-turbo.
+_OPENAI_ENCRYPTED_CONTENT_CAPABLE_PREFIXES = (
+    "o1",
+    "o3",
+    "gpt-5",
+)
+
+
+def openai_supports_encrypted_content(model: str) -> bool:
+    """Return True when an OpenAI model accepts ``reasoning.encrypted_content``.
+
+    Allowlist by substring (matches both bare ``gpt-5`` and
+    aggregator-prefixed ``openai/gpt-5``). Conservative by design:
+    if a future model isn't listed, we send no include parameter rather
+    than 400.
+    """
+    name = (model or "").strip().lower()
+    if not name:
+        return False
+    # Strip common aggregator prefixes (openai/, openrouter/openai/, ...)
+    for sep in ("/",):
+        if sep in name:
+            name = name.rsplit(sep, 1)[-1]
+    return any(name.startswith(prefix) for prefix in _OPENAI_ENCRYPTED_CONTENT_CAPABLE_PREFIXES)
+
+
 _CONTEXT_LENGTH_KEYS = (
     "context_length",
     "context_window",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -120,10 +120,19 @@ class ResponsesApiTransport(ProviderTransport):
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
             else:
+                from agent.model_metadata import openai_supports_encrypted_content
+
                 kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
-                kwargs["include"] = ["reasoning.encrypted_content"]
+                # Only send include=["reasoning.encrypted_content"] for models
+                # that support it. GPT-4o, GPT-4o-mini, and older models reject
+                # this parameter with HTTP 400 "Encrypted content is not
+                # supported with this model".
+                if openai_supports_encrypted_content(model):
+                    kwargs["include"] = ["reasoning.encrypted_content"]
         elif not is_github_responses and not is_xai_responses:
-            kwargs["include"] = []
+            # Don't send include parameter at all when reasoning is disabled.
+            # Sending include=[] can also cause issues with some models.
+            pass
 
         request_overrides = params.get("request_overrides")
         if request_overrides:

--- a/tests/agent/test_encrypted_content_support.py
+++ b/tests/agent/test_encrypted_content_support.py
@@ -1,0 +1,57 @@
+"""Test for OpenAI encrypted_content support check.
+
+Verifies that openai_supports_encrypted_content() correctly identifies
+models that support the `reasoning.encrypted_content` include parameter
+on the Responses API.
+"""
+
+import pytest
+
+from agent.model_metadata import openai_supports_encrypted_content
+
+
+class TestOpenAIEncryptedContentSupport:
+    """Test openai_supports_encrypted_content function."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5",
+            "gpt-5.4",
+            "gpt-5.5-preview",
+            "o1",
+            "o1-preview",
+            "o1-mini",
+            "o3",
+            "o3-mini",
+            "openai/gpt-5",
+            "openai/o3",
+            "openrouter/openai/gpt-5.4",
+        ],
+    )
+    def test_supported_models(self, model: str) -> None:
+        """Models that should support encrypted_content."""
+        assert openai_supports_encrypted_content(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4o-2024-08-06",
+            "gpt-4",
+            "gpt-4-turbo",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-0125",
+            "openai/gpt-4o",
+            "openai/gpt-4o-mini",
+            "openrouter/openai/gpt-4o",
+            "claude-sonnet-4.6",
+            "grok-4.3",
+            "",
+            None,
+        ],
+    )
+    def test_unsupported_models(self, model: str) -> None:
+        """Models that should NOT support encrypted_content."""
+        assert openai_supports_encrypted_content(model) is False


### PR DESCRIPTION
### Description

Prevent HTTP 400 errors when using OpenAI models that don't support encrypted reasoning content (e.g., gpt-4o, gpt-4o-mini) with the Responses API.

The codex transport and auxiliary client previously sent `include=["reasoning.encrypted_content"]` unconditionally for all non-xAI, non-GitHub models. However, only o-series (o1, o3) and gpt-5 models support this parameter. GPT-4o, GPT-4o-mini, and older models reject it with:
> Encrypted content is not supported with this model

### Changes Made

1. **agent/model_metadata.py**: Added `openai_supports_encrypted_content()` function to check if a model supports the encrypted reasoning content parameter. Uses an allowlist approach (conservative - only known-supported models get the parameter).

2. **agent/transports/codex.py**: Updated to only send the `include` parameter for models that support encrypted content. Also removed `include=[]` when reasoning is disabled to avoid potential issues with some models.

3. **agent/auxiliary_client.py**: Updated the auxiliary client's codex completions adapter with the same check.

4. **tests/agent/test_encrypted_content_support.py**: Added test coverage for the new function.

### Fixes

#23450

### Testing

- All unit tests for `openai_supports_encrypted_content()` pass
- Verified the function correctly identifies supported models (gpt-5, o1, o3) and unsupported models (gpt-4o, gpt-4o-mini, etc.)
- The allowlist approach ensures future models that don't support this parameter won't break

### Checklist

- [x] Code follows the project style guidelines
- [x] Tests have been added or updated
- [x] Documentation has been updated if needed
- [x] All existing tests pass
