### PR TITLE
skills_hub: add clockless-org/html-anything tap

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -332,6 +332,7 @@ class GitHubSource(SkillSource):
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
         {"repo": "MiniMax-AI/cli", "path": "skill/"},
+        {"repo": "clockless-org/html-anything", "path": ""},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):


### PR DESCRIPTION
Adds [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) to `GitHubSource.DEFAULT_TAPS`, making it discoverable via `hermes skills browse` / `hermes skills install` and the [Skills Hub directory](https://hermes-agent.nousresearch.com/docs/skills).

> **Install once. Your agent answers as polished web pages whenever the content is actually a page, not a chat message.**

[`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) turns rich agent answers — and any file, folder, URL, or service export — into a polished single-file HTML page. The skill auto-routes to one of 16 design systems (`teaching`, `relationship`, `timeline-story`, `map-atlas`, `network-map`, `document`, `dashboard`, `developer`, `living-essay`, `editorial-carousel`, `paper-trail`, `kinetic-scoreboard`, `soft-saas`, `digital-eguide`, `interactive-learning`, `default`), builds the HTML, verifies it in a browser, and hands it back. Short chats stay short.

**Install:** `npx skills add clockless-org/html-anything`

**Live gallery (22 demos):** https://clockless-org.github.io/html-anything/examples/

Sample outputs across the catalog:
- [Kindle highlights → `living-essay`](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html)
- [Solar system brief → `teaching`](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html)
- [WhatsApp / WeChat → `relationship`](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html)
- [Google Maps saved places → `map-atlas`](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)
- [LinkedIn connections → `network-map`](https://clockless-org.github.io/html-anything/examples/linkedin-connections/output.html)
- [PR review → `developer`](https://clockless-org.github.io/html-anything/examples/pr-review/output.html)

Apache 2.0 · cross-agent (Claude Code, Codex, Cursor, Cline, Windsurf via the open `npx skills` CLI) · already on [skills.sh](https://skills.sh/clockless-org/html-anything) · active maintenance (22 demos, 16 design systems, 34 source parsers).

### Tap entry

```python
{"repo": "clockless-org/html-anything", "path": ""},
```

Matches the existing `garrytan/gstack` pattern (`path: ""`) since our `SKILL.md` lives at repo root.

### Per Hermes CONTRIBUTING.md

> "If your skill is specialized, community-contributed, or niche, it's better suited for a Skills Hub — upload it to a skills registry and share it in the Nous Research Discord."

Already on [skills.sh](https://skills.sh/clockless-org/html-anything). Happy to also share in your Discord — wanted to land the tap PR first so users can find it via Hermes once merged.

Happy to adjust naming or path layout to match Hermes conventions.