### PR TITLE
fix(cli): use display-width for response box header label to support CJK

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3669,7 +3669,7 @@ class HermesCLI:
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime('%H:%M')}"
             w = shutil.get_terminal_size().columns
-            fill = w - 2 - len(label)
+            fill = w - 2 - HermesCLI._status_bar_display_width(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
         self._stream_buf += text
@@ -10368,7 +10368,7 @@ class HermesCLI:
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
                             label = f"{label}{datetime.now().strftime('%H:%M')} "
-                        fill = w - 2 - len(label)
+                        fill = w - 2 - HermesCLI._status_bar_display_width(label)
                         _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
 


### PR DESCRIPTION
## Problem

When using a skin with CJK (Chinese/Japanese/Korean) characters in `response_label`, the response box top border renders wider than the bottom border:

```
╭─ 静光 ────────────────────────────────────╮   ← 2 cols wider
│ response text...                            │
╰─────────────────────────────────────────────╯
```

## Root Cause

`cli.py` line 3672 (and 10371) uses `len(label)` which counts characters, not terminal display columns. CJK characters like `静` and `光` each occupy 2 columns in a terminal, so `len(" 静光 ")` = 5 but the actual display width is 7.

## Fix

Replace `len(label)` with `HermesCLI._status_bar_display_width(label)` in both locations. This helper already exists at line 2881 and uses `prompt_toolkit.utils.get_cwidth` for proper CJK width calculation.

## Changes

- Line 3672: `fill = w - 2 - len(label)` → `fill = w - 2 - HermesCLI._status_bar_display_width(label)`
- Line 10371: same fix in the non-streaming code path

## Testing

Tested with a skin using `response_label: " 静光 "` (CJK characters). Before fix: top border 2 columns too wide. After fix: top and bottom borders align correctly.