### PR TITLE
fix(tui_gateway): register shell hooks and plugins on TUI startup

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -187,6 +187,30 @@ def _log_exit(reason: str) -> None:
 def main():
     _install_sidecar_publisher()
 
+    # Register shell hooks and Python plugins so hook events fire on
+    # TUI turns. Without this, every ``invoke_hook(...)`` call in
+    # ``tui_gateway.server`` (e.g. ``platform="tui"`` session boundary
+    # events) reaches an empty dispatcher — observability integrations,
+    # security guardrails, approval hooks, and custom transforms all
+    # silently no-op in the TUI surface.
+    #
+    # Mirrors the equivalent bootstrap in ``hermes_cli/main.py`` (CLI
+    # entry, calls ``register_from_config`` with ``--accept-hooks``) and
+    # ``gateway/run.py`` (Gateway entry, calls it with
+    # ``accept_hooks=False`` and lets env/config resolve consent). The
+    # TUI has no equivalent of ``--accept-hooks``, so we follow the
+    # gateway pattern: ``HERMES_ACCEPT_HOOKS=1`` or
+    # ``hooks_auto_accept: true`` in ``cli-config.yaml`` opts in.
+    try:
+        from agent.shell_hooks import register_from_config
+        from hermes_cli.config import load_config
+        from hermes_cli.plugins import discover_plugins
+
+        register_from_config(load_config(), accept_hooks=False)
+        discover_plugins()
+    except Exception:
+        pass
+
     # MCP tool discovery — inline is safe here: TUI entry is a plain
     # sync loop with no asyncio event loop to block.  Previously ran as
     # a model_tools.py module-level side effect; moved to explicit


### PR DESCRIPTION
tui_gateway.entry — the Python backend for `hermes --tui` — never called `register_from_config` or `discover_plugins`. The CLI (`hermes_cli/main.py:11804`) and Gateway (`gateway/run.py:3369,3377`) both bootstrap them at process startup; the TUI was missed.

The bug is silent: `tui_gateway/server.py:280` already calls `invoke_hook(event_type, ..., platform="tui")`, but the plugin manager's dispatch table is empty in this process, so every event fires into the void. Shell hooks configured under `hooks:` in `cli-config.yaml` and Python plugins discovered via the standard plugin sources both fail to fire on TUI turns — observability integrations, security guardrails, approval hooks, and custom transforms all silently no-op.

Fix by mirroring the gateway's bootstrap (`accept_hooks=False`, letting `register_from_config` resolve consent from `HERMES_ACCEPT_HOOKS` or `hooks_auto_accept: true`).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

