### PR TITLE
test: dep-version-gate demo (close after viewing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,3 +235,4 @@ select = ["PLW1514"]
 "skills/**" = ["PLW1514"]
 "optional-skills/**" = ["PLW1514"]
 "plugins/**" = ["PLW1514"]
+# dep gate demo


### PR DESCRIPTION
Demonstrating that the dep-version-gate ruleset blocks merge without 2 approvals from all-of-nous when pyproject.toml is touched. **Close after verifying the gate in the UI.**