### PR TITLE
test: pyproject.toml dep gate (KEEP OPEN)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,3 +235,4 @@ select = ["PLW1514"]
 "skills/**" = ["PLW1514"]
 "optional-skills/**" = ["PLW1514"]
 "plugins/**" = ["PLW1514"]
+# dep gate test


### PR DESCRIPTION
Touches pyproject.toml → should be BLOCKED requiring 2 approvals from All of Nous. Don't close.