### PR TITLE
AIF-196: Add Telnyx STT provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1018,7 +1018,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "telnyx" | "xai"
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -1028,6 +1028,11 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "telnyx": {
+            "model": "openai/whisper-large-v3-turbo",
+            "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+            # "base_url": "https://api.telnyx.com/v2/ai",
         },
     },
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -275,7 +275,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "openai"],
+        "options": ["local", "openai", "telnyx"],
     },
     "display.skin": {
         "type": "select",

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -22,6 +22,8 @@ def isolate_env(monkeypatch):
     for key in (
         "GROQ_API_KEY",
         "MISTRAL_API_KEY",
+        "TELNYX_API_KEY",
+        "TELNYX_STT_BASE_URL",
         "XAI_API_KEY",
         "XAI_STT_BASE_URL",
     ):
@@ -92,6 +94,15 @@ class TestProviderSelectionGate:
              patch("hermes_cli.config.load_env",
                    return_value={"XAI_API_KEY": "dotenv-secret"}):
             assert tt._get_provider({"enabled": True, "provider": "xai"}) == "xai"
+
+    def test_explicit_telnyx_sees_dotenv(self):
+        from tools import transcription_tools as tt
+
+        with patch.object(tt, "_HAS_FASTER_WHISPER", False), \
+             patch.object(tt, "_has_local_command", return_value=False), \
+             patch("hermes_cli.config.load_env",
+                   return_value={"TELNYX_API_KEY": "dotenv-secret"}):
+            assert tt._get_provider({"enabled": True, "provider": "telnyx"}) == "telnyx"
 
     def test_auto_detect_sees_dotenv_groq(self):
         """No local backend, no explicit provider — auto-detect should fall
@@ -198,6 +209,34 @@ class TestTranscribeCallSitesReadDotenv:
 
         assert result["success"] is True
         assert captured["headers"]["Authorization"] == "Bearer xai-dotenv-key"
+
+    def test_transcribe_telnyx_forwards_dotenv_key(self):
+        from tools import transcription_tools as tt
+
+        captured: dict = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["data"] = kwargs.get("data", {})
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = {"text": "hello"}
+            return response
+
+        def fake_get_env_value(name, default=None):
+            if name == "TELNYX_API_KEY":
+                return "telnyx-dotenv-key"
+            return None
+
+        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+             patch("requests.post", side_effect=fake_post), \
+             patch("builtins.open", MagicMock()):
+            result = tt._transcribe_telnyx("/tmp/fake.mp3", "openai/whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        assert captured["headers"]["Authorization"] == "Bearer telnyx-dotenv-key"
+        assert captured["data"]["model"] == "openai/whisper-large-v3-turbo"
 
 
 class TestEndToEndRegressionGuard:

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1102,6 +1102,137 @@ class TestTranscribeAudioMistralDispatch:
 
 
 # ============================================================================
+# _transcribe_telnyx
+# ============================================================================
+
+class TestTranscribeTelnyx:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("TELNYX_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_telnyx
+        result = _transcribe_telnyx("/tmp/test.ogg", "openai/whisper-large-v3-turbo")
+        assert result["success"] is False
+        assert "TELNYX_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("TELNYX_API_KEY", "KEYtest")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "hello from telnyx"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_telnyx
+            result = _transcribe_telnyx(sample_ogg, "openai/whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello from telnyx"
+        assert result["provider"] == "telnyx"
+        data = mock_post.call_args.kwargs.get("data", mock_post.call_args[1].get("data", {}))
+        assert data["model"] == "openai/whisper-large-v3-turbo"
+
+    def test_sends_configured_language(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("TELNYX_API_KEY", "KEYtest")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "hola"}
+
+        config = {"telnyx": {"language": "es"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_telnyx
+            _transcribe_telnyx(sample_ogg, "openai/whisper-large-v3-turbo")
+
+        data = mock_post.call_args.kwargs.get("data", mock_post.call_args[1].get("data", {}))
+        assert data["language"] == "es"
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("TELNYX_API_KEY", "KEYtest")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"errors": [{"detail": "Authentication failed"}]}
+        mock_response.text = '{"errors":[{"detail":"Authentication failed"}]}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_telnyx
+            result = _transcribe_telnyx(sample_ogg, "openai/whisper-large-v3-turbo")
+
+        assert result["success"] is False
+        assert "HTTP 401" in result["error"]
+        assert "Authentication failed" in result["error"]
+
+
+# ============================================================================
+# _get_provider — Telnyx
+# ============================================================================
+
+class TestGetProviderTelnyx:
+    def test_telnyx_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TELNYX_API_KEY", "KEYtest")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "telnyx"}) == "telnyx"
+
+    def test_telnyx_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("TELNYX_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "telnyx"}) == "none"
+
+    def test_auto_detect_does_not_pick_telnyx_implicitly(self, monkeypatch):
+        monkeypatch.setenv("TELNYX_API_KEY", "KEYtest")
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "none"
+
+
+# ============================================================================
+# transcribe_audio — Telnyx dispatch
+# ============================================================================
+
+class TestTranscribeAudioTelnyxDispatch:
+    def test_dispatches_to_telnyx(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "telnyx"}), \
+             patch("tools.transcription_tools._get_provider", return_value="telnyx"), \
+             patch("tools.transcription_tools._transcribe_telnyx",
+                   return_value={"success": True, "transcript": "hi", "provider": "telnyx"}) as mock_telnyx:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "telnyx"
+        mock_telnyx.assert_called_once()
+
+    def test_config_telnyx_model_used(self, sample_ogg):
+        config = {"provider": "telnyx", "telnyx": {"model": "custom/telnyx-stt"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="telnyx"), \
+             patch("tools.transcription_tools._transcribe_telnyx",
+                   return_value={"success": True, "transcript": "hi"}) as mock_telnyx:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_telnyx.call_args[0][1] == "custom/telnyx-stt"
+
+    def test_model_override_passed_to_telnyx(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="telnyx"), \
+             patch("tools.transcription_tools._transcribe_telnyx",
+                   return_value={"success": True, "transcript": "hi"}) as mock_telnyx:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="override-model")
+
+        assert mock_telnyx.call_args[0][1] == "override-model"
+
+
+# ============================================================================
 # _transcribe_xai
 # ============================================================================
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -9,6 +9,7 @@ Provides speech-to-text transcription with six providers:
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
+  - **telnyx** — Telnyx AI Speech-to-Text API, requires ``TELNYX_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
 
@@ -84,13 +85,16 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_TELNYX_STT_MODEL = os.getenv("STT_TELNYX_MODEL", "openai/whisper-large-v3-turbo")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
+TELNYX_STT_LANGUAGE_ENV = "TELNYX_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+TELNYX_STT_BASE_URL = os.getenv("TELNYX_STT_BASE_URL", "https://api.telnyx.com/v2/ai")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -265,6 +269,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "telnyx":
+            if get_env_value("TELNYX_API_KEY"):
+                return "telnyx"
+            logger.warning(
+                "STT provider 'telnyx' configured but TELNYX_API_KEY not set"
+            )
+            return "none"
+
         if provider == "xai":
             if get_env_value("XAI_API_KEY"):
                 return "xai"
@@ -289,6 +301,8 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
+    # Telnyx keys are commonly present in Telnyx deployments for non-STT tools,
+    # so do not auto-select Telnyx implicitly. Use ``stt.provider: telnyx``.
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
@@ -687,6 +701,93 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: telnyx (AI Speech-to-Text API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_telnyx(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using the Telnyx AI Speech-to-Text API.
+
+    Uses ``POST /v2/ai/audio/transcriptions`` with multipart/form-data.
+    Requires ``TELNYX_API_KEY``. Optional language can be set with
+    ``stt.telnyx.language`` or ``TELNYX_STT_LANGUAGE``.
+    """
+    api_key = get_env_value("TELNYX_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "TELNYX_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    telnyx_config = stt_config.get("telnyx", {})
+    base_url = str(
+        telnyx_config.get("base_url")
+        or get_env_value("TELNYX_STT_BASE_URL")
+        or TELNYX_STT_BASE_URL
+    ).strip().rstrip("/")
+    language = str(
+        telnyx_config.get("language")
+        or os.getenv(TELNYX_STT_LANGUAGE_ENV)
+        or ""
+    ).strip()
+
+    try:
+        import requests
+
+        data: Dict[str, str] = {"model": model_name}
+        if language:
+            data["language"] = language
+
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                f"{base_url}/audio/transcriptions",
+                headers={"Authorization": f"Bearer {api_key}"},
+                files={"file": (Path(file_path).name, audio_file)},
+                data=data,
+                timeout=120,
+            )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                errors = err_body.get("errors")
+                if isinstance(errors, list) and errors:
+                    detail = errors[0].get("detail") or errors[0].get("title") or ""
+                if not detail:
+                    detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Telnyx STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = _extract_transcript_text(result)
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Telnyx STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via Telnyx STT (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "telnyx"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Telnyx STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Telnyx STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Provider: xAI (Grok STT API)
 # ---------------------------------------------------------------------------
 
@@ -853,6 +954,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
 
+    if provider == "telnyx":
+        telnyx_cfg = stt_config.get("telnyx", {})
+        model_name = model or telnyx_cfg.get("model", DEFAULT_TELNYX_STT_MODEL)
+        return _transcribe_telnyx(file_path, model_name)
+
     if provider == "xai":
         # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
@@ -866,7 +972,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set TELNYX_API_KEY with stt.provider: telnyx for Telnyx STT, "
+            "set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }


### PR DESCRIPTION
## Summary
- adds a first-class `telnyx` STT provider to Hermes' real `tools/transcription_tools.py` dispatch path
- wires `stt.provider: telnyx` config defaults and web settings option
- adds unit and dotenv regression coverage for provider selection, request payloads, errors, language config, and `transcribe_audio()` dispatch

## Validation
- `PYTHONPATH=. /tmp/hermes-aif196-py311/bin/python -m pytest -o addopts='' tests/tools/test_transcription.py tests/tools/test_transcription_tools.py tests/tools/test_transcription_dotenv_fallback.py -q` → `139 passed`
- Live Telnyx API smoke test with local `TELNYX_API_KEY` against `POST /v2/ai/audio/transcriptions` → success, provider `telnyx`, non-empty transcript returned

## Notes
- This replaces the previous standalone plugin approach for AIF-196. Current Hermes does not expose a `plugins/transcription-providers/*` registry, so the working integration is implemented directly in the existing STT provider dispatch module.

Closes AIF-196
