### PR TITLE
fix: recompute copilot api mode from target model for subagents

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -146,22 +146,31 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    *,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+    if (
+        configured_mode
+        and _provider_supports_explicit_api_mode("copilot", configured_provider)
+        and not target_model
+    ):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
-        return "chat_completions"
+        return configured_mode or "chat_completions"
 
     try:
         from hermes_cli.models import copilot_model_api_mode
 
         return copilot_model_api_mode(model_name, api_key=api_key)
     except Exception:
-        return "chat_completions"
+        return configured_mode or "chat_completions"
 
 
 _VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}
@@ -227,7 +236,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=target_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -882,7 +895,11 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                api_key,
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1304,7 +1321,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -226,6 +226,78 @@ def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
     assert resolved["provider"] != "qwen-oauth"
 
 
+def test_resolve_runtime_provider_copilot_target_model_recomputes_api_mode(monkeypatch):
+    """target_model must override stale persisted api_mode for Copilot GPT-5 children."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "default": "claude-sonnet-4.6",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": "copilot",
+            "api_key": "ghu_test_token",
+            "base_url": "https://api.githubcopilot.com",
+            "source": "env",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="gpt-5.4-mini",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.githubcopilot.com"
+
+
+def test_resolve_runtime_provider_copilot_without_target_model_keeps_explicit_mode(monkeypatch):
+    """Without target_model, explicit Copilot api_mode in config still wins."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "default": "gpt-5.4-mini",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": "copilot",
+            "api_key": "ghu_test_token",
+            "base_url": "https://api.githubcopilot.com",
+            "source": "env",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_resolve_runtime_provider_ai_gateway(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "ai-gateway")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -963,6 +963,43 @@ class TestDelegationProviderIntegration(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_copilot_gpt5_delegation_target_model_recomputes_api_mode(self, mock_creds, mock_cfg):
+        """Delegated Copilot GPT-5 child should use codex_responses even if parent does not."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "gpt-5.4-mini",
+            "provider": "copilot",
+        }
+        mock_creds.return_value = {
+            "model": "gpt-5.4-mini",
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "ghu_test_token",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.provider = "nous"
+        parent.base_url = "https://inference-api.nousresearch.com/v1"
+        parent.api_mode = "chat_completions"
+        parent.model = "qwen/qwen3.6-plus"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Copilot GPT-5 child", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "gpt-5.4-mini")
+            self.assertEqual(kwargs["provider"], "copilot")
+            self.assertEqual(kwargs["base_url"], "https://api.githubcopilot.com")
+            self.assertEqual(kwargs["api_mode"], "codex_responses")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_config_provider_credentials_reach_child_agent(self, mock_creds, mock_cfg):
         """When delegation.provider is configured, child agent gets resolved credentials."""
         mock_cfg.return_value = {


### PR DESCRIPTION
## Summary
- fix delegated Copilot child agents using stale or persisted api_mode instead of recomputing from the child target model
- specifically fixes Copilot GPT-5 subagents being routed to chat_completions instead of codex_responses
- add regression tests for runtime-provider target_model handling and delegated Copilot GPT-5 child construction

## Problem
Direct Copilot GPT-5 calls could work while `delegate_task` children failed with:
`model "gpt-5.4-mini" is not accessible via the /chat/completions endpoint`

The root cause was that Copilot runtime resolution preserved configured `api_mode` too aggressively, even when a child `target_model` was explicitly known and needed a different transport.

## Fix
- add `target_model` support to `_copilot_runtime_api_mode(...)`
- when `target_model` is provided, recompute Copilot api_mode from that model instead of blindly trusting persisted config api_mode
- thread `target_model` through the Copilot runtime resolution call sites

## Verification
- targeted Copilot regression tests pass
- live delegation smoke now succeeds with a Copilot GPT-5 child
