### PR TITLE
fix(line): implement create_source for dispatch

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -915,6 +915,29 @@ class LineAdapter(BasePlatformAdapter):
         else:
             logger.debug("LINE: ignoring event type %r", event_type)
 
+    def create_source(
+        self,
+        *,
+        chat_id: str,
+        chat_name: Optional[str] = None,
+        chat_type: str = "dm",
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> SessionSource:
+        """Build a SessionSource for LINE webhook dispatch."""
+        return SessionSource(
+            platform=Platform("line"),
+            chat_id=str(chat_id),
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=str(user_id) if user_id else None,
+            user_name=user_name,
+            thread_id=str(thread_id) if thread_id else None,
+            message_id=str(message_id) if message_id else None,
+        )
+
     async def _handle_message_event(self, event: Dict[str, Any]) -> None:
         msg = event.get("message") or {}
         msg_type = msg.get("type", "")
@@ -965,6 +988,7 @@ class LineAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_id,
             chat_name=chat_id,
+            message_id=message_id,
         )
 
         event_obj = MessageEvent(

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -642,3 +642,53 @@ class TestAdapterInit:
         assert asyncio.run(ad.get_chat_info("U123"))["type"] == "dm"
         assert asyncio.run(ad.get_chat_info("C123"))["type"] == "group"
         assert asyncio.run(ad.get_chat_info("R123"))["type"] == "channel"
+
+    def test_create_source_returns_line_session_source(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+
+        from gateway.config import PlatformConfig
+
+        ad = LineAdapter(PlatformConfig(enabled=True))
+        source = ad.create_source(
+            chat_id="U123",
+            chat_type="dm",
+            user_id="U123",
+            user_name="Line User",
+            chat_name="Direct LINE chat",
+            message_id="m1",
+        )
+
+        assert source.platform.name == "line"
+        assert source.chat_id == "U123"
+        assert source.chat_type == "dm"
+        assert source.user_id == "U123"
+        assert source.user_name == "Line User"
+        assert source.chat_name == "Direct LINE chat"
+        assert source.message_id == "m1"
+
+    def test_message_event_dispatches_with_line_source(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+
+        from gateway.config import PlatformConfig
+
+        ad = LineAdapter(PlatformConfig(enabled=True))
+        ad.handle_message = AsyncMock()
+
+        event = {
+            "type": "message",
+            "replyToken": "reply-token",
+            "source": {"type": "user", "userId": "U123"},
+            "message": {"id": "m1", "type": "text", "text": "hello"},
+        }
+
+        asyncio.run(ad._handle_message_event(event))
+
+        ad.handle_message.assert_awaited_once()
+        message_event = ad.handle_message.await_args.args[0]
+        assert message_event.text == "hello"
+        assert message_event.source.platform.name == "line"
+        assert message_event.source.chat_id == "U123"
+        assert message_event.source.user_id == "U123"
+        assert message_event.source.message_id == "m1"


### PR DESCRIPTION
## Summary
- implement `LineAdapter.create_source()` directly in the native LINE platform plugin
- pass the inbound LINE `message_id` into the generated `SessionSource`
- add regression coverage for LINE `SessionSource` creation and message dispatch

## Context
Hermes Agent v0.13.0 includes the native LINE platform plugin, but LINE webhook dispatch can fail when the gateway calls the adapter source-construction contract and the LINE adapter does not provide an explicit `create_source()` implementation.

In production this showed up after signed LINE webhook events reached the adapter, then failed before dispatch with:

```text
AttributeError: 'LineAdapter' object has no attribute 'create_source'
```

This patch makes the LINE adapter's dispatch contract explicit instead of relying on surrounding gateway/base behavior, so LINE webhook events consistently produce a `SessionSource` with `platform=line`, chat/user metadata, and the triggering message id.

## Testing
- `python -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_plugin.py`
- Could not run `python -m pytest tests/gateway/test_line_plugin.py -q` locally because `pytest` is not installed in this Windows Python environment.
- Could not run `uv run pytest tests/gateway/test_line_plugin.py -q` locally because `uv` is not installed in this Windows shell.