### PR TITLE
fix(cli): guard interactive chat startup without TTY

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1288,6 +1288,7 @@ def _pin_kanban_board_env() -> None:
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1"
+    is_interactive_chat = not (getattr(args, "query", None) or getattr(args, "image", None))
 
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
@@ -1355,6 +1356,12 @@ def cmd_chat(args):
         print("You can run 'hermes setup' at any time to configure.")
         sys.exit(1)
 
+    # Guard prompt_toolkit/curses chat mode from non-interactive stdin.
+    # `curl ... | bash` installs run with stdin wired to a pipe; launching
+    # `hermes` from that context crashes inside asyncio/prompt_toolkit on macOS.
+    # Query/image one-shot mode is intentionally exempt and remains headless-safe.
+    if is_interactive_chat:
+        _require_tty("chat")
     # Start update check in background (runs while other init happens)
     try:
         from hermes_cli.banner import prefetch_update_check

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -1,6 +1,7 @@
 """Tests for non-interactive setup and first-run headless behavior."""
 
 from argparse import Namespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -143,6 +144,41 @@ class TestNonInteractiveSetup:
         mock_setup.assert_not_called()
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
+
+    def test_chat_requires_tty_in_interactive_mode(self, capsys):
+        """Interactive `hermes chat` should fail fast when stdin is not a TTY."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args()
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(SystemExit) as exc:
+                cmd_chat(args)
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "requires an interactive terminal" in err
+
+    def test_chat_query_mode_allows_headless_stdin(self):
+        """One-shot query mode must remain usable without an interactive TTY."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args(query="ping")
+        fake_cli_main = MagicMock()
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch.dict("sys.modules", {"cli": SimpleNamespace(main=fake_cli_main)}),
+            patch("sys.stdin") as mock_stdin,
+        ):
+            mock_stdin.isatty.return_value = False
+            cmd_chat(args)
+
+        fake_cli_main.assert_called_once()
 
     def test_main_accepts_tts_setup_section(self, monkeypatch):
         """`hermes setup tts` should parse and dispatch like other setup sections."""


### PR DESCRIPTION
## Summary
- Guard interactive CLI chat startup when stdin is not a TTY
- Add regression coverage for non-interactive setup/chat startup behavior

## Test Plan
- venv/bin/python -m pytest tests/hermes_cli/test_setup_noninteractive.py
- git diff --check upstream/main..HEAD