### PR TITLE
fix: validate Gemini API keys with native header

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -248,8 +248,9 @@ def _build_apikey_providers_list() -> list:
     # Providers that already have a dedicated health check above the generic
     # API-key loop (with custom headers/auth). Skip their pluggable profiles
     # here so the generic Bearer-auth loop doesn't run a duplicate, broken
-    # check (e.g. Anthropic native API requires x-api-key, not Bearer).
-    _dedicated_canonical = {"anthropic", "openrouter", "bedrock"}
+    # check (e.g. Anthropic native API requires x-api-key, not Bearer; Gemini
+    # accepts API keys via query param or x-goog-api-key, not Bearer).
+    _dedicated_canonical = {"anthropic", "openrouter", "bedrock", "gemini"}
     _known_canonical.update(_dedicated_canonical)
     try:
         from providers import list_providers
@@ -1326,6 +1327,49 @@ def run_doctor(args):
                 [],
             )
 
+    def _probe_gemini() -> _ConnectivityResult:
+        key = os.getenv("GOOGLE_API_KEY", "") or os.getenv("GEMINI_API_KEY", "")
+        key = key.strip().strip('\"').strip("'")
+        if not key:
+            return _ConnectivityResult("gemini", [], [])
+        label = "gemini".ljust(20)
+        try:
+            import httpx
+            r = httpx.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                headers={
+                    "x-goog-api-key": key,
+                    "User-Agent": _HERMES_USER_AGENT,
+                },
+                timeout=10,
+            )
+            if r.status_code == 200:
+                return _ConnectivityResult(
+                    "gemini",
+                    [(color("✓", Colors.GREEN), label, "")],
+                    [],
+                )
+            if r.status_code in {400, 401, 403}:
+                return _ConnectivityResult(
+                    "gemini",
+                    [(color("✗", Colors.RED), label,
+                      color("(invalid API key)", Colors.DIM))],
+                    ["Check GOOGLE_API_KEY in .env"],
+                )
+            return _ConnectivityResult(
+                "gemini",
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"(HTTP {r.status_code})", Colors.DIM))],
+                [],
+            )
+        except Exception as e:
+            return _ConnectivityResult(
+                "gemini",
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"({e})", Colors.DIM))],
+                [],
+            )
+
     def _probe_apikey_provider(pname, env_vars, default_url, base_env,
                                supports_health_check) -> _ConnectivityResult:
         key = ""
@@ -1456,6 +1500,7 @@ def run_doctor(args):
     # Build the probe submission list in display order
     _probes.append(("OpenRouter API", _probe_openrouter))
     _probes.append(("Anthropic API", _probe_anthropic))
+    _probes.append(("gemini", _probe_gemini))
 
     global _APIKEY_PROVIDERS_CACHE
     if _APIKEY_PROVIDERS_CACHE is None:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -711,6 +711,59 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
     )
 
 
+def test_run_doctor_gemini_uses_google_api_key_header_not_bearer(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("GOOGLE_API_KEY=AIza-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIza-test")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers or {}, timeout))
+        if url == "https://generativelanguage.googleapis.com/v1beta/models":
+            assert headers["x-goog-api-key"] == "AIza-test"
+            assert "Authorization" not in headers
+            return types.SimpleNamespace(status_code=200)
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "gemini" in out
+    assert "Check GOOGLE_API_KEY" not in out
+    assert any(
+        url == "https://generativelanguage.googleapis.com/v1beta/models"
+        for url, _, _ in calls
+    )
+
+
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
 def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- add a dedicated hermes doctor Gemini connectivity probe using x-goog-api-key
- exclude Gemini from the generic Bearer-token API-key probe
- cover the behavior with a doctor regression test

## Test Plan
- ./venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts='