### PR TITLE
feat: render markdown tables for Slack

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -77,6 +77,86 @@ def check_slack_requirements() -> bool:
     return SLACK_AVAILABLE
 
 
+_TABLE_SEPARATOR_RE = re.compile(
+    r'^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$'
+)
+
+
+def _split_markdown_table_row(line: str) -> list[str]:
+    """Split a simple GFM pipe-table row into stripped cell values."""
+    stripped = line.strip()
+    if stripped.startswith('|'):
+        stripped = stripped[1:]
+    if stripped.endswith('|'):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split('|')]
+
+
+def _render_table_block_for_slack(table_block: list[str]) -> str:
+    """Render a GFM table as an aligned Slack-friendly code block."""
+    if len(table_block) < 3:
+        return '\n'.join(table_block)
+
+    headers = _split_markdown_table_row(table_block[0])
+    rows = [_split_markdown_table_row(row) for row in table_block[2:]]
+    if len(headers) < 2 or not rows:
+        return '\n'.join(table_block)
+
+    width = len(headers)
+    normalized_rows: list[list[str]] = []
+    for row in rows:
+        if len(row) < width:
+            row = row + [''] * (width - len(row))
+        normalized_rows.append(row[:width])
+
+    widths = [len(header) for header in headers]
+    for row in normalized_rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def fmt(row: list[str]) -> str:
+        return '  '.join(cell.ljust(widths[idx]) for idx, cell in enumerate(row)).rstrip()
+
+    rendered = [fmt(headers), fmt(['-' * width for width in widths])]
+    rendered.extend(fmt(row) for row in normalized_rows)
+    return '```\n' + '\n'.join(rendered) + '\n```'
+
+
+def _wrap_markdown_tables_for_slack(text: str) -> str:
+    """Rewrite GFM pipe tables into aligned code blocks for Slack."""
+    if '|' not in text or '-' not in text:
+        return text
+
+    lines = text.split('\n')
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped.startswith('```'):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+        if '|' in line and i + 1 < len(lines) and _TABLE_SEPARATOR_RE.match(lines[i + 1]):
+            table_block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and lines[j].strip() and '|' in lines[j]:
+                table_block.append(lines[j])
+                j += 1
+            out.append(_render_table_block_for_slack(table_block))
+            i = j
+            continue
+        out.append(line)
+        i += 1
+    return '\n'.join(out)
+
+
 def _extract_text_from_slack_blocks(blocks: list) -> str:
     """Extract readable text from Slack Block Kit blocks, including quoted/forwarded content.
 
@@ -1139,6 +1219,10 @@ class SlackAdapter(BasePlatformAdapter):
             return key
 
         text = content
+
+        # 0) Rewrite GFM-style pipe tables before protecting code blocks. Slack
+        #    has no table markdown, but it preserves monospaced code blocks.
+        text = _wrap_markdown_tables_for_slack(text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         text = re.sub(

--- a/tests/gateway/test_slack_table_format.py
+++ b/tests/gateway/test_slack_table_format.py
@@ -1,0 +1,35 @@
+from gateway.platforms.slack import _wrap_markdown_tables_for_slack
+
+
+class TestWrapMarkdownTablesForSlack:
+    def test_basic_table_rewritten_as_aligned_code_block(self):
+        text = (
+            "Numbers:\n\n"
+            "| Keyword | Installs | Revenue |\n"
+            "|---------|---------:|--------:|\n"
+            "| clara ai | 56 | $153.97 |\n"
+            "| voicemail app | 37 | $69.99 |\n"
+            "\nDone."
+        )
+
+        out = _wrap_markdown_tables_for_slack(text)
+
+        assert out.startswith("Numbers:")
+        assert "```" in out
+        assert "Keyword        Installs  Revenue" in out
+        assert "clara ai       56        $153.97" in out
+        assert "voicemail app  37        $69.99" in out
+        assert out.endswith("Done.")
+
+    def test_bare_pipe_table_rewritten(self):
+        text = "A | B\n--- | ---\n1 | 2"
+        out = _wrap_markdown_tables_for_slack(text)
+        assert out == "```\nA  B\n-  -\n1  2\n```"
+
+    def test_plain_pipes_not_rewritten(self):
+        text = "Use a | pipe in shell commands."
+        assert _wrap_markdown_tables_for_slack(text) == text
+
+    def test_existing_code_block_left_alone(self):
+        text = "```\n| A | B |\n|---|---|\n| 1 | 2 |\n```"
+        assert _wrap_markdown_tables_for_slack(text) == text


### PR DESCRIPTION
## Summary
- Detect GFM pipe tables in Slack outbound formatting
- Render tables as aligned monospaced code blocks so numeric reports stay readable
- Leave fenced code blocks and prose with literal pipes untouched

## Test Plan
- `python -m pytest tests/gateway/test_slack_table_format.py -q -o 'addopts='`
