### PR TITLE
fix: harden honcho memory and dashboard terminal

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -191,6 +191,12 @@ ALL_TOOL_SCHEMAS = [PROFILE_SCHEMA, SEARCH_SCHEMA, REASONING_SCHEMA, CONTEXT_SCH
 class HonchoMemoryProvider(MemoryProvider):
     """Honcho AI-native memory with dialectic Q&A and persistent user modeling."""
 
+    # First-turn dialectic is opportunistic context enrichment, not a hard
+    # dependency for answering the user. Keep it tightly bounded so a broad
+    # Honcho HTTP timeout (e.g. 300s for explicit tool calls) cannot stall
+    # Hermes before the first model request.
+    _FIRST_TURN_DIALECTIC_TIMEOUT = 8.0
+
     def __init__(self):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
@@ -616,9 +622,7 @@ class HonchoMemoryProvider(MemoryProvider):
             self._last_dialectic_turn = self._turn_count
 
         if self._last_dialectic_turn == -999 and query:
-            _first_turn_timeout = (
-                self._config.timeout if self._config and self._config.timeout else 8.0
-            )
+            _first_turn_timeout = self._first_turn_dialectic_timeout()
             _fired_at = self._turn_count
 
             def _run_first_turn() -> None:
@@ -993,9 +997,28 @@ class HonchoMemoryProvider(MemoryProvider):
     # stale user-model context from derailing one-word replies.
     _TRIVIAL_PROMPT_RE = re.compile(
         r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
+        r'hi|hallo|moin|hoi|salut|ciao|yo|'
         r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$',
         re.IGNORECASE,
     )
+
+    def _first_turn_dialectic_timeout(self) -> float:
+        """Return bounded wait for first-turn dialectic prefetch.
+
+        Honcho's configured HTTP timeout applies to explicit Honcho tools and
+        backend calls, where a long wait can be intentional. The first-turn
+        dialectic prefetch is different: it runs before Hermes sends the first
+        model request, so letting a 300s backend timeout through makes the CLI
+        look frozen. Use the lower of the configured timeout and a small cap.
+        """
+        configured = None
+        if self._config is not None:
+            configured = getattr(self._config, "timeout", None)
+        try:
+            configured_timeout = float(configured) if configured else self._FIRST_TURN_DIALECTIC_TIMEOUT
+        except (TypeError, ValueError):
+            configured_timeout = self._FIRST_TURN_DIALECTIC_TIMEOUT
+        return max(0.1, min(configured_timeout, self._FIRST_TURN_DIALECTIC_TIMEOUT))
 
     @classmethod
     def _is_trivial_prompt(cls, text: str) -> bool:
@@ -1014,6 +1037,27 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
         """Track turn count for cadence and injection_frequency logic."""
         self._turn_count = turn_number
+
+    @staticmethod
+    def _coerce_content_for_memory(content: Any) -> str:
+        """Normalize provider turn content to text before sanitization.
+
+        Some model/gateway paths represent multimodal user content as OpenAI-style
+        content parts (a list of text/image dicts). sanitize_context expects a
+        string, so coerce structured content here instead of letting a background
+        memory sync thread fail with "expected string or bytes-like object, got
+        'list'".
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, (list, dict)):
+            try:
+                return json.dumps(content, ensure_ascii=False, default=str)
+            except (TypeError, ValueError):
+                return str(content)
+        return str(content)
 
     @staticmethod
     def _chunk_message(content: str, limit: int) -> list[str]:
@@ -1129,8 +1173,12 @@ class HonchoMemoryProvider(MemoryProvider):
             return
 
         msg_limit = self._config.message_max_chars if self._config else 25000
-        clean_user_content = sanitize_context(user_content or "").strip()
-        clean_assistant_content = sanitize_context(assistant_content or "").strip()
+        clean_user_content = sanitize_context(
+            self._coerce_content_for_memory(user_content)
+        ).strip()
+        clean_assistant_content = sanitize_context(
+            self._coerce_content_for_memory(assistant_content)
+        ).strip()
 
         def _sync():
             try:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -805,6 +805,23 @@ class TestMemoryContextFencing:
         assert "Alice" in combined[fence_start:fence_end]
         assert combined.index("weather") < fence_start
 
+    def test_honcho_provider_coerces_structured_content_before_sanitize(self):
+        from agent.memory_manager import sanitize_context
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        content = [
+            {"type": "text", "text": "hello</memory-context>"},
+            {"type": "image_url", "image_url": {"url": "file:///tmp/example.png"}},
+        ]
+
+        coerced = HonchoMemoryProvider._coerce_content_for_memory(content)
+        sanitized = sanitize_context(coerced)
+
+        assert isinstance(coerced, str)
+        assert "example.png" in coerced
+        assert "hello" in sanitized
+        assert "</memory-context>" not in sanitized
+
 
 # ---------------------------------------------------------------------------
 # AIAgent.commit_memory_session — routes to MemoryManager.on_session_end

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -569,6 +569,25 @@ class TestConcludeToolDispatch:
 # ---------------------------------------------------------------------------
 
 
+class TestHonchoPrefetchGuardrails:
+    def test_first_turn_dialectic_timeout_is_capped_below_global_timeout(self):
+        provider = HonchoMemoryProvider()
+        provider._config = SimpleNamespace(timeout=300)
+
+        assert provider._first_turn_dialectic_timeout() == 8.0
+
+    def test_first_turn_dialectic_timeout_respects_smaller_global_timeout(self):
+        provider = HonchoMemoryProvider()
+        provider._config = SimpleNamespace(timeout=2)
+
+        assert provider._first_turn_dialectic_timeout() == 2.0
+
+    def test_greeting_prompts_are_trivial_and_skip_prefetch(self):
+        for prompt in ("hi", "hallo", "moin", "hoi", "salut", "ciao", "yo"):
+            assert HonchoMemoryProvider._is_trivial_prompt(prompt)
+            assert HonchoMemoryProvider._is_trivial_prompt(prompt.upper())
+
+
 class TestToolsModeInitBehavior:
     """Verify initOnSessionStart controls session init timing in tools mode."""
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -49,11 +49,11 @@ export function Banner({ t }: { t: Theme }) {
         <ArtLines lines={logoLines} />
       ) : (
         <Text bold color={t.color.primary}>
-          {t.brand.icon} NOUS HERMES
+          {t.brand.icon} {t.brand.name}
         </Text>
       )}
 
-      <Text color={t.color.muted}>{t.brand.icon} Nous Research · Messenger of the Digital Gods</Text>
+      <Text color={t.color.muted}>{t.brand.icon} {t.brand.name}</Text>
     </Box>
   )
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,6 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2869,12 +2868,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
       "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
-      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,6 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4,7 +4,7 @@
  *   <div host> (dashboard chrome)                                         .
  *     └─ <div wrapper> (rounded, dark bg, padded — the "terminal window"  .
  *         look that gives the page a distinct visual identity)            .
- *         └─ @xterm/xterm Terminal (WebGL renderer, Unicode 11 widths)    .
+ *         └─ @xterm/xterm Terminal (DOM/canvas renderer, Unicode 11 widths).
  *              │ onData      keystrokes → WebSocket → PTY master          .
  *              │ onResize    terminal resize → `\x1b[RESIZE:cols;rows]`   .
  *              │ write(data) PTY output bytes → VT100 parser              .
@@ -19,7 +19,6 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -35,6 +34,7 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
+import { useTheme } from "@/themes";
 
 function buildWsUrl(
   token: string,
@@ -58,17 +58,48 @@ function generateChannelId(): string {
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 }
 
-// Colors for the terminal body.  Matches the dashboard's dark teal canvas
-// with cream foreground — we intentionally don't pick monokai or a loud
-// theme, because the TUI's skin engine already paints the content; the
-// terminal chrome just needs to sit quietly inside the dashboard.
-const TERMINAL_THEME = {
-  background: "#0d2626",
-  foreground: "#f0e6d2",
-  cursor: "#f0e6d2",
-  cursorAccent: "#0d2626",
-  selectionBackground: "#f0e6d244",
-};
+interface XtermTheme {
+  background: string;
+  foreground: string;
+  cursor: string;
+  cursorAccent: string;
+  selectionBackground: string;
+}
+
+function terminalThemeForDashboardTheme(
+  themeName: string,
+  theme: ReturnType<typeof useTheme>["theme"],
+): XtermTheme {
+  if (themeName === "chaos-goblin") {
+    return {
+      background: "#05070a",
+      foreground: "#d9ffb7",
+      cursor: "#ff4fd8",
+      cursorAccent: "#05070a",
+      selectionBackground: "#b8ff2f33",
+    };
+  }
+
+  const background = theme.colorOverrides?.card ?? theme.palette.background.hex;
+  const foreground =
+    theme.colorOverrides?.cardForeground ?? theme.palette.midground.hex;
+
+  return {
+    background,
+    foreground,
+    cursor: foreground,
+    cursorAccent: background,
+    selectionBackground: `${foreground}44`,
+  };
+}
+
+// Keep JetBrains Mono for ordinary terminal text, but explicitly include
+// browser/OS emoji and symbol fonts. Without these fallbacks, glyphs like 🔘,
+// ✓, →, box-drawing, and other "TUI spice" can render as tofu/black boxes in
+// the dashboard embed — especially when the renderer builds a narrow font
+// atlas from the bundled JetBrains font only.
+const TERMINAL_FONT_FAMILY =
+  "'JetBrains Mono', 'Symbols Nerd Font Mono', 'Symbols Nerd Font', 'Noto Sans Mono', 'Noto Sans Symbols 2', 'Noto Sans Symbols', 'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', 'Twemoji Mozilla', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace";
 
 /**
  * CSS width for xterm font tiers.
@@ -133,6 +164,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const [mobilePanelOpenRaw, setMobilePanelOpenRaw] = useState(false);
   const mobilePanelOpen = isActive && mobilePanelOpenRaw;
   const { setEnd } = usePageHeader();
+  const { theme, themeName } = useTheme();
+  const terminalTheme = useMemo(
+    () => terminalThemeForDashboardTheme(themeName, theme),
+    [themeName, theme],
+  );
+  const terminalThemeRef = useRef<XtermTheme>(terminalTheme);
   const { t } = useI18n();
   const closeMobilePanel = useCallback(() => setMobilePanelOpenRaw(false), []);
   const modelToolsLabel = useMemo(
@@ -148,6 +185,20 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       : false,
   );
 
+  useEffect(() => {
+    terminalThemeRef.current = terminalTheme;
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = terminalTheme;
+    if (term.rows > 0) {
+      try {
+        term.refresh(0, term.rows - 1);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [terminalTheme]);
+
   // The dashboard keeps ChatPage mounted persistently so the PTY survives tab
   // switches. That is great for ordinary /chat navigation, but it means query
   // param changes do NOT remount the component. Resume-in-chat from the
@@ -155,7 +206,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const channel = useMemo(() => {
+    const resumeScope = resumeParam ?? "new";
+    return `${resumeScope}-${generateChannelId()}`;
+  }, [resumeParam]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -278,8 +332,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const term = new Terminal({
       allowProposedApi: true,
       cursorBlink: true,
-      fontFamily:
-        "'JetBrains Mono', 'Cascadia Mono', 'Fira Code', 'MesloLGS NF', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+      fontFamily: TERMINAL_FONT_FAMILY,
       fontSize: terminalFontSizeForWidth(tierW0),
       lineHeight: terminalLineHeightForWidth(tierW0),
       letterSpacing: 0,
@@ -290,7 +343,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // let the inner Hermes TUI own transcript history/scroll behavior.
       // The outer browser xterm should act as a display/input bridge only.
       scrollback: 0,
-      theme: TERMINAL_THEME,
+      theme: terminalThemeRef.current,
     });
     termRef.current = term;
 
@@ -333,7 +386,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // original keydown event's activation. Log to aid debugging.
           console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
         });
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -434,24 +487,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     term.open(host);
 
-    // WebGL draws from a texture atlas sized with device pixels. On phones and
-    // in DevTools device mode that often produces *visually* much larger cells
-    // than `fontSize` suggests — users see "huge" text even at 7–9px settings.
-    // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
-    // hosts.  Wide layouts still get WebGL for crisp box-drawing.
-    const useWebgl = terminalTierWidthPx(host) >= 768;
-    if (useWebgl) {
-      try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
-        term.loadAddon(webgl);
-      } catch (err) {
-        console.warn(
-          "[hermes-chat] WebGL renderer unavailable; falling back to default",
-          err,
-        );
-      }
-    }
+    // Do NOT enable @xterm/addon-webgl here.
+    //
+    // The dashboard chat is glyph-heavy because the Ink TUI uses status
+    // symbols, arrows, checkmarks, the Max 🔘 motif, and occasionally emoji.
+    // The WebGL renderer is fast, but its texture-atlas path is much less
+    // forgiving with font fallback; missing glyphs commonly show up as solid
+    // black tofu boxes in Chrome/Edge. The default renderer is plenty fast for
+    // this chat surface and respects browser font fallback much better.
+    // Crisp boxes are nice. Legible text is nicer. Revolutionary, I know.
 
     // Initial fit + resize observer.  fit.fit() reads the container's
     // current bounding box and resizes the terminal grid to match.
@@ -813,7 +857,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "p-2 sm:p-3",
           )}
           style={{
-            backgroundColor: TERMINAL_THEME.background,
+            backgroundColor: terminalTheme.background,
             boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
           }}
         >
@@ -836,7 +880,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "bottom-2 right-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
               "lg:bottom-4 lg:right-4",
             )}
-            style={{ color: TERMINAL_THEME.foreground }}
+            style={{ color: terminalTheme.foreground }}
           >
             <span className="inline-flex items-center gap-1.5">
               <Copy className="h-3 w-3 shrink-0" />


### PR DESCRIPTION
## Summary
- cap first-turn Honcho dialectic prefetch timeout and skip greeting-only prompts
- coerce structured/multimodal turn content before Honcho memory sanitization
- align dashboard/TUI branding with configured theme names
- improve dashboard terminal theme/font fallback, disable WebGL glyph atlas path, and remove unused WebGL addon dependency

## Test Plan
- pytest tests/agent/test_memory_provider.py tests/honcho_plugin/test_session.py -q
- python -m ruff check plugins/memory/honcho/__init__.py tests/agent/test_memory_provider.py tests/honcho_plugin/test_session.py
- npm run build (web)
- npx eslint src/pages/ChatPage.tsx (web)
- npm run type-check (ui-tui)
- npx eslint src/components/branding.tsx (ui-tui)

Note: direct push to NousResearch/hermes-agent:main was denied for florianaebi, so this branch was pushed to the fork.