### PR TITLE
feat(gateway): add opt-in startup online notification

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -604,6 +604,15 @@ max_concurrent_sessions: null
 # explicitly want one shared "room brain" per group/channel.
 group_sessions_per_user: true
 
+# Gateway-only runtime settings. Use the nested shape produced by
+# `hermes config set gateway.<key> <value>`.
+gateway:
+  # Send the home-channel "Gateway online" notification after ordinary gateway
+  # cold starts too (Docker/systemd/reboot), not only after /restart. Disabled by
+  # default to avoid noisy boot pings; enable for operator back-channels where an
+  # explicit up-and-running signal is useful.
+  gateway_startup_notification: false
+
 # ─────────────────────────────────────────────────────────────────────────────
 # API Server — per-client model routing
 # ─────────────────────────────────────────────────────────────────────────────

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -711,6 +711,12 @@ class GatewayConfig:
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
+    # Optional cold-start notification. The existing /restart completion path
+    # is marker-gated to avoid noisy ordinary boots; this opt-in flag covers
+    # operators who also want a home-channel "gateway is online" signal after
+    # process starts caused by Docker/systemd/reboots rather than /restart.
+    gateway_startup_notification: bool = False
+
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
 
@@ -825,6 +831,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
+            "gateway_startup_notification": self.gateway_startup_notification,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
         }
@@ -881,7 +888,7 @@ class GatewayConfig:
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
-        nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        nested_gateway: Dict[str, Any] = _coerce_dict(data.get("gateway"))
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -912,6 +919,20 @@ class GatewayConfig:
             data.get("unauthorized_dm_behavior"),
             "pair",
         )
+        if "gateway_startup_notification" in nested_gateway:
+            gateway_startup_notification_raw = nested_gateway.get(
+                "gateway_startup_notification"
+            )
+        elif "gateway_startup_notification" in data:
+            gateway_startup_notification_raw = data.get(
+                "gateway_startup_notification"
+            )
+        else:
+            gateway_startup_notification_raw = None
+        gateway_startup_notification = _coerce_bool(
+            gateway_startup_notification_raw,
+            False,
+        )
 
         try:
             session_store_max_age_days = int(data.get("session_store_max_age_days", 90))
@@ -939,6 +960,7 @@ class GatewayConfig:
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
+            gateway_startup_notification=gateway_startup_notification,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
         )
@@ -1063,6 +1085,21 @@ def load_gateway_config() -> GatewayConfig:
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]
+
+            if (
+                isinstance(gateway_section, dict)
+                and "gateway_startup_notification" in gateway_section
+            ):
+                gw_data["gateway_startup_notification"] = gateway_section[
+                    "gateway_startup_notification"
+                ]
+            elif "gateway_startup_notification" in yaml_cfg:
+                # Backward compatibility for the original top-level preview
+                # shape. The canonical runtime location is now
+                # gateway.gateway_startup_notification.
+                gw_data["gateway_startup_notification"] = yaml_cfg[
+                    "gateway_startup_notification"
+                ]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if not isinstance(streaming_cfg, dict):
@@ -1466,6 +1503,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if not platform_config.enabled and not enabled_was_explicit:
             platform_config.enabled = True
         return platform_config
+
+    startup_notify = getenv("GATEWAY_STARTUP_NOTIFICATION", "")
+    if startup_notify.strip():
+        # _getenv_str() is profile-secret-scope aware. Preserve the YAML value
+        # for blank or unrecognized tokens instead of silently forcing False.
+        config.gateway_startup_notification = _coerce_bool(
+            startup_notify,
+            config.gateway_startup_notification,
+        )
     
     # Telegram
     telegram_token = getenv("TELEGRAM_BOT_TOKEN")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7365,27 +7365,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             await asyncio.sleep(1.0)
 
         # Notify the chat that initiated /restart that the gateway is back.
+        restart_notification_pending = _restart_notification_pending()
         planned_restart_notification_pending = _planned_restart_notification_pending()
         # Capture, before _send_restart_notification() unlinks the marker,
         # whether this process booted from a chat-originated /restart. Used as
         # a one-shot signal by the /restart redelivery guard so a missing
         # dedup marker only suppresses a /restart when we KNOW we just came out
         # of a restart cycle (see _is_stale_restart_redelivery).
-        if _restart_notification_pending() or planned_restart_notification_pending:
+        if restart_notification_pending or planned_restart_notification_pending:
             self._booted_from_restart = True
         await self._send_restart_notification()
 
         # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
-        # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
-            try:
+        # channels for non-chat planned restarts and explicit cold-start opt-in
+        # only. Chat-originated /restart already has a precise reply target in
+        # .restart_notify.json, so keep that lifecycle in the originating
+        # chat/topic rather than also leaking it to the configured home channel.
+        should_send_home_startup_notification = (
+            self._should_send_home_channel_startup_notifications(
+                planned_restart_notification_pending=planned_restart_notification_pending,
+                restart_notification_pending=restart_notification_pending,
+            )
+        )
+        try:
+            if should_send_home_startup_notification:
                 await self._send_home_channel_startup_notifications(
                     skip_targets=None,
                 )
-            finally:
+        finally:
+            # A stale planned-restart marker may coexist with a more precise
+            # chat /restart marker. The chat route wins, but both one-shot
+            # markers belong to this boot and must be consumed.
+            if planned_restart_notification_pending:
                 _clear_planned_restart_notification()
 
         # Automatically continue fresh sessions that were interrupted by the
@@ -15058,6 +15069,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         return delivered
+
+    def _should_send_home_channel_startup_notifications(
+        self,
+        *,
+        planned_restart_notification_pending: bool,
+        restart_notification_pending: bool = False,
+    ) -> bool:
+        """Return whether this startup should emit home-channel online pings.
+
+        #19271 salvaged #18440 and intentionally tied the generic
+        home-channel "gateway online" message to restart lifecycle markers so
+        ordinary cold starts would stay quiet. Operators can now opt in to the
+        same thread-aware online ping for Docker/systemd/reboot starts via
+        ``gateway.gateway_startup_notification`` while keeping chat-originated
+        /restart behavior unchanged. A chat restart marker deliberately takes
+        priority over a simultaneous planned-restart marker: the precise chat
+        reply is the only online notification, while ``start()`` still consumes
+        both one-shot markers.
+        """
+        if restart_notification_pending:
+            return False
+
+        if planned_restart_notification_pending:
+            return True
+
+        return bool(getattr(self.config, "gateway_startup_notification", False))
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -103,6 +103,11 @@ def make_restart_runner(
     runner._send_home_channel_startup_notifications = (
         GatewayRunner._send_home_channel_startup_notifications.__get__(runner, GatewayRunner)
     )
+    runner._should_send_home_channel_startup_notifications = (
+        GatewayRunner._should_send_home_channel_startup_notifications.__get__(
+            runner, GatewayRunner
+        )
+    )
     runner._status_action_label = GatewayRunner._status_action_label.__get__(
         runner, GatewayRunner
     )

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -412,6 +412,35 @@ class TestGatewayConfigRoundtrip:
         assert restored.reset_by_platform == {}
         assert restored.streaming.transport == "auto"
 
+    def test_startup_notification_defaults_to_false(self):
+        config = GatewayConfig.from_dict({})
+
+        assert config.gateway_startup_notification is False
+
+    def test_roundtrip_preserves_startup_notification_flag(self):
+        config = GatewayConfig(gateway_startup_notification=True)
+
+        restored = GatewayConfig.from_dict(config.to_dict())
+
+        assert restored.gateway_startup_notification is True
+
+    def test_from_dict_accepts_nested_startup_notification_flag(self):
+        config = GatewayConfig.from_dict(
+            {"gateway": {"gateway_startup_notification": True}}
+        )
+
+        assert config.gateway_startup_notification is True
+
+    def test_from_dict_nested_startup_notification_overrides_legacy_top_level(self):
+        config = GatewayConfig.from_dict(
+            {
+                "gateway_startup_notification": False,
+                "gateway": {"gateway_startup_notification": True},
+            }
+        )
+
+        assert config.gateway_startup_notification is True
+
     def test_get_notice_delivery_defaults_to_public(self):
         config = GatewayConfig(
             platforms={Platform.SLACK: PlatformConfig(enabled=True, token="***")}
@@ -550,6 +579,118 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.thread_sessions_per_user is True
+
+    def test_bridges_gateway_startup_notification_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("gateway_startup_notification: true\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GATEWAY_STARTUP_NOTIFICATION", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.gateway_startup_notification is True
+
+    def test_bridges_nested_gateway_startup_notification_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n"
+            "  gateway_startup_notification: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GATEWAY_STARTUP_NOTIFICATION", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.gateway_startup_notification is True
+
+    def test_nested_gateway_startup_notification_overrides_legacy_top_level(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway_startup_notification: false\n"
+            "gateway:\n"
+            "  gateway_startup_notification: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("GATEWAY_STARTUP_NOTIFICATION", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.gateway_startup_notification is True
+
+    def test_gateway_startup_notification_env_overrides_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("gateway_startup_notification: false\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("GATEWAY_STARTUP_NOTIFICATION", "true")
+
+        config = load_gateway_config()
+
+        assert config.gateway_startup_notification is True
+
+    def test_gateway_startup_notification_uses_profile_scoped_env_override(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n"
+            "  gateway_startup_notification: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("GATEWAY_STARTUP_NOTIFICATION", "false")
+        token = secret_scope.set_secret_scope(
+            {"GATEWAY_STARTUP_NOTIFICATION": "true"}
+        )
+        try:
+            config = load_gateway_config()
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert config.gateway_startup_notification is True
+
+    def test_blank_profile_scoped_startup_notification_env_keeps_yaml_value(
+        self, tmp_path, monkeypatch
+    ):
+        from agent import secret_scope
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n"
+            "  gateway_startup_notification: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        token = secret_scope.set_secret_scope(
+            {"GATEWAY_STARTUP_NOTIFICATION": "  "}
+        )
+        try:
+            config = load_gateway_config()
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert config.gateway_startup_notification is True
 
     def test_thread_sessions_per_user_defaults_to_false(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -43,6 +43,218 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     gateway_run._clear_planned_restart_notification()
 
     assert gateway_run._planned_restart_notification_pending() is False
+
+
+async def _start_gateway_for_lifecycle_test(
+    tmp_path,
+    monkeypatch,
+    *,
+    startup_notification: bool,
+    planned_restart_pending: bool,
+    chat_restart_pending: bool,
+):
+    """Exercise GatewayRunner.start() while isolating external platform/runtime I/O."""
+    runner, adapter = make_restart_runner()
+    runner.config.sessions_dir = tmp_path / "sessions"
+    runner.config.gateway_startup_notification = startup_notification
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-123",
+        name="Home",
+        thread_id="topic-456",
+    )
+    runner._running = False
+    runner._exit_with_failure = False
+    runner._exit_cleanly = False
+    runner._failed_platforms = {}
+    setattr(runner, "_honcho_managers", {})
+    setattr(runner, "_honcho_configs", {})
+    setattr(runner, "_create_adapter", MagicMock(return_value=adapter))
+    setattr(
+        runner,
+        "_connect_adapter_with_timeout",
+        AsyncMock(return_value=True),
+    )
+    setattr(runner, "_update_platform_runtime_status", MagicMock())
+    setattr(runner, "_sync_voice_mode_state_to_adapter", MagicMock())
+    setattr(
+        runner,
+        "_start_secondary_profile_adapters",
+        AsyncMock(return_value=0),
+    )
+    setattr(runner, "_suspend_stuck_loop_sessions", MagicMock(return_value=0))
+    setattr(runner, "_send_update_notification", AsyncMock(return_value=True))
+    setattr(runner, "_schedule_resume_pending_sessions", MagicMock())
+    setattr(runner, "_finish_startup_restore", AsyncMock())
+    setattr(runner, "_wire_teams_pipeline_runtime", MagicMock())
+    runner.hooks = MagicMock()
+    runner.hooks.loaded_hooks = []
+    runner.hooks.emit = AsyncMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    if planned_restart_pending:
+        (tmp_path / ".restart_pending.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
+    if chat_restart_pending:
+        (tmp_path / ".restart_notify.json").write_text(
+            json.dumps(
+                {
+                    "platform": "telegram",
+                    "chat_id": "origin-999",
+                    "chat_type": "group",
+                    "thread_id": "thread-888",
+                    "message_id": "message-777",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    # Avoid touching the real session DB/process checkpoint and avoid spawning
+    # long-lived watcher tasks. Closing each coroutine keeps asyncio warning-free.
+    (tmp_path / ".clean_shutdown").write_text("", encoding="utf-8")
+
+    def fake_create_task(coro):
+        coro.close()
+        return MagicMock()
+
+    with patch("gateway.status.write_runtime_status"):
+        with patch("gateway.shutdown_forensics.check_systemd_timing_alignment", return_value=None):
+            with patch("hermes_cli.plugins.discover_plugins"):
+                with patch(
+                    "gateway.platform_registry.platform_registry.plugin_entries",
+                    return_value=[],
+                ):
+                    with patch("hermes_cli.config.load_config", return_value={}):
+                        with patch("agent.shell_hooks.register_from_config"):
+                            with patch(
+                                "tools.process_registry.process_registry.recover_from_checkpoint",
+                                return_value=0,
+                            ):
+                                with patch(
+                                    "gateway.channel_directory.build_channel_directory",
+                                    new=AsyncMock(return_value={"platforms": {}}),
+                                ):
+                                    with patch(
+                                        "gateway.run.asyncio.create_task",
+                                        side_effect=fake_create_task,
+                                    ):
+                                        with patch(
+                                            "gateway.run.asyncio.sleep",
+                                            new=AsyncMock(),
+                                        ):
+                                            assert await runner.start() is True
+
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "startup_notification",
+        "planned_restart_pending",
+        "chat_restart_pending",
+        "expected_home_calls",
+    ),
+    [
+        pytest.param(False, False, False, 0, id="ordinary-start-default-off"),
+        pytest.param(True, False, False, 1, id="ordinary-start-opted-in"),
+        pytest.param(False, True, False, 1, id="planned-restart"),
+        pytest.param(True, False, True, 0, id="chat-restart-target-only"),
+        pytest.param(
+            True,
+            True,
+            True,
+            0,
+            id="chat-restart-wins-over-stale-planned-marker",
+        ),
+    ],
+)
+async def test_start_lifecycle_routes_online_notifications_without_duplicates(
+    tmp_path,
+    monkeypatch,
+    startup_notification,
+    planned_restart_pending,
+    chat_restart_pending,
+    expected_home_calls,
+):
+    _runner, adapter = await _start_gateway_for_lifecycle_test(
+        tmp_path,
+        monkeypatch,
+        startup_notification=startup_notification,
+        planned_restart_pending=planned_restart_pending,
+        chat_restart_pending=chat_restart_pending,
+    )
+
+    sent_calls = getattr(adapter, "sent_calls")
+    if expected_home_calls:
+        assert len(sent_calls) == 1
+        chat_id, content, metadata = sent_calls[0]
+        assert chat_id == "home-123"
+        assert content == "♻️ Gateway online — Hermes is back and ready."
+        assert metadata["thread_id"] == "topic-456"
+    elif chat_restart_pending:
+        # A chat-originated /restart gets exactly one targeted reply and no
+        # duplicate online ping in the configured home channel.
+        assert len(sent_calls) == 1
+        chat_id, content, metadata = sent_calls[0]
+        assert chat_id == "origin-999"
+        assert "Gateway restarted successfully" in content
+        assert metadata["thread_id"] == "thread-888"
+    else:
+        assert sent_calls == []
+
+    assert not (tmp_path / ".restart_notify.json").exists()
+    assert not (tmp_path / ".restart_pending.json").exists()
+
+
+def test_home_channel_startup_notification_skipped_on_cold_start_by_default():
+    runner, _adapter = make_restart_runner()
+
+    assert runner._should_send_home_channel_startup_notifications(
+        planned_restart_notification_pending=False,
+        restart_notification_pending=False,
+    ) is False
+
+
+def test_home_channel_startup_notification_runs_on_planned_restart_marker():
+    runner, _adapter = make_restart_runner()
+
+    assert runner._should_send_home_channel_startup_notifications(
+        planned_restart_notification_pending=True,
+        restart_notification_pending=False,
+    ) is True
+
+
+def test_home_channel_startup_notification_keeps_chat_restart_quiet_even_when_opted_in():
+    runner, _adapter = make_restart_runner()
+    runner.config.gateway_startup_notification = True
+
+    assert runner._should_send_home_channel_startup_notifications(
+        planned_restart_notification_pending=False,
+        restart_notification_pending=True,
+    ) is False
+
+
+def test_chat_restart_marker_takes_priority_over_planned_restart_marker():
+    runner, _adapter = make_restart_runner()
+    runner.config.gateway_startup_notification = True
+
+    assert runner._should_send_home_channel_startup_notifications(
+        planned_restart_notification_pending=True,
+        restart_notification_pending=True,
+    ) is False
+
+
+def test_home_channel_startup_notification_runs_on_opt_in_cold_start():
+    runner, _adapter = make_restart_runner()
+    runner.config.gateway_startup_notification = True
+
+    assert runner._should_send_home_channel_startup_notifications(
+        planned_restart_notification_pending=False,
+        restart_notification_pending=False,
+    ) is True
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
@@ -100,9 +312,20 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 @pytest.mark.asyncio
 async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+    """Without systemd or a container runtime, /restart uses the detached subprocess approach."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    import gateway.slash_commands as slash_commands
+
+    real_exists = slash_commands.os.path.exists
+
+    def fake_exists(path):
+        if path in {"/.dockerenv", "/run/.containerenv"}:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(slash_commands.os.path, "exists", fake_exists)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Why

Hermes already emits a completion notification after `/restart`, but ordinary cold starts caused by Docker, systemd, or a host reboot remain silent. Operators with a dedicated home/back-channel need an explicit opt-in online signal without making startup pings noisy by default.

## What changed

- adds the global `gateway_startup_notification` runtime flag, defaulting to `false`;
- reads the canonical nested configuration shape while preserving the original top-level form for backward compatibility;
- keeps `GATEWAY_STARTUP_NOTIFICATION` as an override and resolves it through Hermes' profile-scoped secret environment;
- reuses the existing thread-aware home-channel sender;
- preserves planned-restart notifications;
- keeps chat-originated `/restart` replies targeted to the original chat/topic and suppresses duplicate home-channel broadcasts;
- gives a chat `/restart` marker priority when it coexists with a stale planned-restart marker, while consuming both one-shot markers on that boot;
- documents the opt-in setting in `cli-config.yaml.example`.

## Configuration

Canonical YAML:

```yaml
gateway:
  gateway_startup_notification: true
```

Environment override:

```bash
GATEWAY_STARTUP_NOTIFICATION=true
```

The compatibility top-level YAML key remains accepted for existing users:

```yaml
gateway_startup_notification: true
```

## Validation

- `186 passed`: gateway config, restart notification, platform reconnect, and home-target environment suites;
- `37 passed`: complete restart-notification suite after the final rebase;
- `ruff check .` passed;
- Windows footgun scan passed across 757 files;
- Python compilation and `git diff --check` passed;
- isolated runtime smoke test passed with a dedicated worktree, virtualenv, and `HERMES_HOME`: nested config loaded, `GatewayRunner.start()` returned `true`, and `GatewayRunner.stop()` completed cleanly;
- lifecycle tests call the real `GatewayRunner.start()` path and assert real adapter sends for default cold start, opted-in cold start, planned restart, chat `/restart`, and simultaneous chat/planned markers without duplicates or residual markers.
