### PR TITLE
fix(gateway/weixin): add media burst-batching to prevent session lockup on rapid file uploads

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1223,6 +1223,14 @@ class WeixinAdapter(BasePlatformAdapter):
         self._text_batch_split_delay_seconds = self._coerce_float_extra(
             "text_batch_split_delay_seconds", 5.0
         )
+        # Media/file bursts (docx, images, ...) arrive as separate iLink
+        # messages too. They flow through the same session-scoped batcher as
+        # text so a mixed burst dispatches as one turn, but use their own quiet
+        # window since file uploads are slower-paced than typed text. Set to 0
+        # to disable media batching (each file dispatches immediately).
+        self._media_batch_delay_seconds = self._coerce_float_extra(
+            "media_batch_delay_seconds", 2.0
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
@@ -1312,9 +1320,15 @@ class WeixinAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         _LIVE_ADAPTERS.pop(self._token, None)
         self._running = False
+        # Cancel and await in-flight batch flushes (text + media) so a timer
+        # armed here cannot fire handle_message() after shutdown has begun.
         for task in self._pending_text_batch_tasks.values():
             if not task.done():
                 task.cancel()
+        if self._pending_text_batch_tasks:
+            await asyncio.gather(
+                *self._pending_text_batch_tasks.values(), return_exceptions=True
+            )
         self._pending_text_batches.clear()
         self._pending_text_batch_tasks.clear()
         if self._poll_task and not self._poll_task.done():
@@ -1469,6 +1483,11 @@ class WeixinAdapter(BasePlatformAdapter):
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
         if event.message_type == MessageType.TEXT:
             self._enqueue_text_event(event)
+        elif self._should_batch_media(event):
+            # Burst-batch rapid file/photo uploads so N of them become one turn,
+            # avoiding the gateway's interrupt-recursion guard. Shares the text
+            # batcher's pending state so a caption + files coalesce together.
+            self._enqueue_text_event(event)
         else:
             await self.handle_message(event)
 
@@ -1503,10 +1522,23 @@ class WeixinAdapter(BasePlatformAdapter):
         return True
 
     # ------------------------------------------------------------------
-    # Text debounce batching
+    # Message debounce batching (text + media/file bursts)
     # ------------------------------------------------------------------
 
     _SPLIT_THRESHOLD = 1800  # iLink chunks at ~2048 chars
+
+    # Media types that are debounced. Only file/photo bursts (which trigger the
+    # interrupt-recursion lockup) are batched. Voice/audio/video are left to
+    # dispatch immediately: they are latency-sensitive and their downstream
+    # handling (STT, voice-reply routing) is keyed on message_type, which the
+    # batch merge would flatten.
+    _BATCHABLE_MEDIA_TYPES = (MessageType.DOCUMENT, MessageType.PHOTO)
+
+    def _should_batch_media(self, event: MessageEvent) -> bool:
+        return (
+            self._media_batch_delay_seconds > 0
+            and event.message_type in self._BATCHABLE_MEDIA_TYPES
+        )
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
@@ -1518,12 +1550,13 @@ class WeixinAdapter(BasePlatformAdapter):
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
-        """Buffer a text event and reset the flush timer.
+        """Buffer a text or media event and reset the flush timer.
 
-        When users forward multiple messages or send rapid-fire texts
-        via WeChat, each arrives as a separate iLink message. This
-        concatenates them and waits for a short quiet period before
-        dispatching the combined message.
+        When users forward multiple messages, send rapid-fire texts, or
+        upload several files via WeChat, each arrives as a separate iLink
+        message. This concatenates their text and merges their media into a
+        single pending event, then waits for a short quiet period before
+        dispatching one combined ``handle_message`` call.
         """
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
@@ -1538,6 +1571,13 @@ class WeixinAdapter(BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+                # Re-derive the type so a batch that absorbs media (e.g. a photo
+                # merging into a pending text event) still classifies as media
+                # downstream — otherwise it stays TEXT and media-specific
+                # handling (photo/STT/voice-reply) is skipped.
+                existing.message_type = _message_type_from_media(
+                    existing.media_types, existing.text or ""
+                )
 
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():
@@ -1551,18 +1591,27 @@ class WeixinAdapter(BasePlatformAdapter):
         current_task = asyncio.current_task()
         try:
             pending = self._pending_text_batches.get(key)
-            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
-                delay = self._text_batch_split_delay_seconds
+            if pending is not None and pending.media_urls:
+                # A file/media burst is in flight; give it the media window.
+                delay = self._media_batch_delay_seconds
             else:
-                delay = self._text_batch_delay_seconds
+                last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+                if last_len >= self._SPLIT_THRESHOLD:
+                    delay = self._text_batch_split_delay_seconds
+                else:
+                    delay = self._text_batch_delay_seconds
             await asyncio.sleep(delay)
             if self._pending_text_batch_tasks.get(key) is not current_task:
                 return
             event = self._pending_text_batches.pop(key, None)
             if not event:
                 return
-            await self.handle_message(event)
+            # Shield the dispatch: a follow-up message/file arriving mid-turn
+            # cancels this flush task (see _enqueue_text_event), which must not
+            # abort the agent response already in flight. Matches the Discord/
+            # Telegram adapters. Especially important for file bursts, whose
+            # turns run long and widen the cancellation window.
+            await asyncio.shield(self.handle_message(event))
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/tests/gateway/test_weixin_media_batching.py
+++ b/tests/gateway/test_weixin_media_batching.py
@@ -1,0 +1,346 @@
+"""Tests for WeixinAdapter media/file burst batching.
+
+When a Weixin user sends multiple files (docx, images, ...) in rapid
+succession, each arrives as an independent inbound iLink event. Dispatching
+every one immediately hits the gateway's interrupt-recursion guard and the
+session locks up.
+
+Media events are routed through the same session-scoped debounce batcher as
+text (``_enqueue_text_event`` / ``_flush_text_batch``), so a whole burst — and
+any accompanying caption — coalesces into a single ``handle_message`` call.
+This module covers the media-specific behaviour, config parsing via
+``_coerce_float_extra`` (config.yaml-driven, no env var), shutdown cleanup in
+``disconnect()``, and the shield guard that keeps a follow-up file from
+cancelling an in-flight dispatch.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.platforms.weixin import WeixinAdapter
+
+
+def _make_adapter(media_delay: float = 0.1, text_delay: float = 5.0) -> WeixinAdapter:
+    """Minimal WeixinAdapter wired for batching tests.
+
+    ``text_delay`` is deliberately long so that when a media batch is pending
+    the test only completes if the media window (``media_delay``) is the one
+    actually used by ``_flush_text_batch``.
+    """
+    adapter = object.__new__(WeixinAdapter)
+    adapter.platform = Platform.WEIXIN
+    adapter.config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = text_delay
+    adapter._text_batch_split_delay_seconds = text_delay
+    adapter._media_batch_delay_seconds = media_delay
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _media_event(path: str, chat_id: str = "weixin-dm", text: str = "") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.DOCUMENT,
+        source=SessionSource(platform=Platform.WEIXIN, chat_id=chat_id, chat_type="dm"),
+        media_urls=[path],
+        media_types=["application/octet-stream"],
+    )
+
+
+def _text_event(text: str, chat_id: str = "weixin-dm") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.WEIXIN, chat_id=chat_id, chat_type="dm"),
+    )
+
+
+def _photo_event(path: str, chat_id: str = "weixin-dm", text: str = "") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.PHOTO,
+        source=SessionSource(platform=Platform.WEIXIN, chat_id=chat_id, chat_type="dm"),
+        media_urls=[path],
+        media_types=["image/jpeg"],
+    )
+
+
+def _typed_event(message_type: MessageType) -> MessageEvent:
+    return MessageEvent(
+        text="",
+        message_type=message_type,
+        source=SessionSource(platform=Platform.WEIXIN, chat_id="c", chat_type="dm"),
+    )
+
+
+class TestWeixinMediaBurstBatching:
+    @pytest.mark.asyncio
+    async def test_single_file_dispatches_once_after_window(self):
+        adapter = _make_adapter()
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+
+        adapter.handle_message.assert_not_called()  # debounced
+        await asyncio.sleep(0.25)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.media_urls == ["/tmp/a.docx"]
+
+    @pytest.mark.asyncio
+    async def test_rapid_files_merge_into_single_dispatch(self):
+        """8 files sent within the window become one handle_message call."""
+        adapter = _make_adapter()
+
+        for i in range(8):
+            adapter._enqueue_text_event(_media_event(f"/tmp/file-{i}.docx"))
+            await asyncio.sleep(0.01)  # within the 0.1s media window
+
+        adapter.handle_message.assert_not_called()
+        await asyncio.sleep(0.25)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert len(dispatched.media_urls) == 8
+        assert dispatched.media_urls[0] == "/tmp/file-0.docx"
+        assert dispatched.media_urls[-1] == "/tmp/file-7.docx"
+
+    @pytest.mark.asyncio
+    async def test_caption_and_files_coalesce_into_one_turn(self):
+        """A text caption + a file burst in the same session dispatch together.
+
+        This is the point of routing media through the text batcher: the
+        caption is not split off into its own separate turn.
+        """
+        adapter = _make_adapter()
+
+        adapter._enqueue_text_event(_text_event("here are the files"))
+        await asyncio.sleep(0.01)
+        for i in range(3):
+            adapter._enqueue_text_event(_media_event(f"/tmp/f{i}.docx"))
+            await asyncio.sleep(0.01)
+
+        await asyncio.sleep(0.25)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert "here are the files" in dispatched.text
+        assert len(dispatched.media_urls) == 3
+
+    @pytest.mark.asyncio
+    async def test_media_window_used_not_text_window(self):
+        """With a pending media batch, the flush must use the media delay.
+
+        text_delay is 5s; if the flush wrongly used it, this would time out
+        rather than flush inside 0.25s.
+        """
+        adapter = _make_adapter(media_delay=0.1, text_delay=5.0)
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+
+        await asyncio.sleep(0.25)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_different_sessions_dispatch_separately(self):
+        adapter = _make_adapter()
+
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx", chat_id="chat-a"))
+        adapter._enqueue_text_event(_media_event("/tmp/b.docx", chat_id="chat-b"))
+
+        await asyncio.sleep(0.25)
+        assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_state_cleaned_up_after_flush(self):
+        adapter = _make_adapter()
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+        await asyncio.sleep(0.25)
+
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_text_batch_tasks == {}
+
+
+class TestWeixinMediaBatchShutdown:
+    """Regression for review comment: pending flush timers must be torn down
+    in ``disconnect()`` so none can fire ``handle_message`` after shutdown."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pending_batch(self):
+        # Long media window so the batch is still pending at disconnect.
+        adapter = _make_adapter(media_delay=30.0)
+        adapter._token = "test-token"
+        adapter._running = True
+        adapter._poll_task = None
+        adapter._poll_session = None
+        adapter._send_session = None
+        adapter._release_platform_lock = MagicMock()
+        adapter._mark_disconnected = MagicMock()
+
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+        assert adapter._pending_text_batch_tasks  # armed
+
+        await adapter.disconnect()
+
+        adapter.handle_message.assert_not_called()
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_text_batch_tasks == {}
+        adapter._mark_disconnected.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_followup_file_does_not_cancel_inflight_dispatch(self):
+        """A file arriving while handle_message is mid-flight must not abort it.
+
+        ``_enqueue_text_event`` cancels the prior flush task on every new
+        event; without ``asyncio.shield`` around handle_message that cancel
+        would propagate into the running agent turn. File turns run long, so
+        this window is wide in practice.
+        """
+        adapter = _make_adapter()
+
+        handle_started = asyncio.Event()
+        release_handle = asyncio.Event()
+        first_cancelled = asyncio.Event()
+        first_completed = asyncio.Event()
+        calls = [0]
+
+        async def slow_handle(event):
+            calls[0] += 1
+            if calls[0] == 1:
+                handle_started.set()
+                try:
+                    await release_handle.wait()
+                    first_completed.set()
+                except asyncio.CancelledError:
+                    first_cancelled.set()
+                    raise
+
+        adapter.handle_message = slow_handle
+
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+        await asyncio.wait_for(handle_started.wait(), timeout=1.0)
+
+        # Follow-up file cancels batch 1's flush task, which is awaiting
+        # inside handle_message.
+        adapter._enqueue_text_event(_media_event("/tmp/b.docx"))
+        await asyncio.sleep(0.05)
+
+        assert not first_cancelled.is_set(), (
+            "in-flight handle_message was cancelled by a follow-up file — "
+            "asyncio.shield is missing"
+        )
+
+        release_handle.set()
+        await asyncio.wait_for(first_completed.wait(), timeout=1.0)
+
+        for task in list(adapter._pending_text_batch_tasks.values()):
+            task.cancel()
+        await asyncio.sleep(0.01)
+
+
+class TestWeixinMediaRoutingDecision:
+    """Only file/photo bursts are debounced. Voice/audio/video dispatch
+    immediately so their message_type-keyed downstream handling (STT,
+    voice-reply routing) is preserved and they incur no debounce latency."""
+
+    @pytest.mark.parametrize(
+        "mtype,expected",
+        [
+            (MessageType.DOCUMENT, True),
+            (MessageType.PHOTO, True),
+            (MessageType.VOICE, False),
+            (MessageType.AUDIO, False),
+            (MessageType.VIDEO, False),
+            (MessageType.TEXT, False),
+        ],
+    )
+    def test_should_batch_media_by_type(self, mtype, expected):
+        adapter = _make_adapter(media_delay=2.0)
+        assert adapter._should_batch_media(_typed_event(mtype)) is expected
+
+    def test_zero_delay_never_batches(self):
+        adapter = _make_adapter(media_delay=0.0)
+        assert adapter._should_batch_media(_typed_event(MessageType.DOCUMENT)) is False
+
+
+class TestWeixinMediaMergeReclassifies:
+    """When media merges into a pending text batch, the merged event's
+    message_type must reflect the media so downstream handling runs."""
+
+    @pytest.mark.asyncio
+    async def test_photo_merged_into_text_batch_becomes_photo(self):
+        adapter = _make_adapter()
+        adapter._enqueue_text_event(_text_event("look at this"))
+        await asyncio.sleep(0.01)
+        adapter._enqueue_text_event(_photo_event("/tmp/p.jpg"))
+
+        await asyncio.sleep(0.25)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.message_type == MessageType.PHOTO
+        assert "look at this" in dispatched.text
+        assert dispatched.media_urls == ["/tmp/p.jpg"]
+
+    @pytest.mark.asyncio
+    async def test_document_merged_into_text_batch_becomes_document(self):
+        adapter = _make_adapter()
+        adapter._enqueue_text_event(_text_event("here"))
+        await asyncio.sleep(0.01)
+        adapter._enqueue_text_event(_media_event("/tmp/a.docx"))
+
+        await asyncio.sleep(0.25)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.message_type == MessageType.DOCUMENT
+
+
+class TestWeixinMediaBatchConfig:
+    """``media_batch_delay_seconds`` is parsed via ``_coerce_float_extra``:
+    config.yaml-driven, and invalid/non-finite/negative values fall back to
+    the default instead of breaking adapter construction."""
+
+    def test_zero_disables_media_batching(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account", "media_batch_delay_seconds": 0},
+            )
+        )
+        assert adapter._media_batch_delay_seconds == 0.0
+
+    def test_invalid_value_falls_back_to_default(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account", "media_batch_delay_seconds": "abc"},
+            )
+        )
+        assert adapter._media_batch_delay_seconds == 2.0
+
+    def test_negative_value_falls_back_to_default(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account", "media_batch_delay_seconds": -1},
+            )
+        )
+        assert adapter._media_batch_delay_seconds == 2.0
+
+    def test_default_when_unset(self):
+        adapter = WeixinAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"account_id": "test-account"},
+            )
+        )
+        assert adapter._media_batch_delay_seconds == 2.0


### PR DESCRIPTION
## Problem

When a Weixin/WeChat user sends multiple files (docx, images, etc.) in rapid succession, each file arrives as an independent inbound iLink event. On `main`, `_process_message` dispatches every **non-text** event immediately via `handle_message()`:

```python
if event.message_type == MessageType.TEXT:
    self._enqueue_text_event(event)
else:
    await self.handle_message(event)   # ← every file, right away
```

With 8 files arriving within ~4 seconds this triggers 8 nested agent invocations and the session hits the `_MAX_INTERRUPT_DEPTH=3` guard:

```
WARNING gateway.run: Interrupt recursion depth 3 reached for session
agent:main:weixin:dm:... — queueing message instead of recursing.
```

After that point all responses return `response=0 chars` and the session is effectively dead until the gateway restarts.

## Fix

`main` already has a session-scoped **text** debounce batcher (`_enqueue_text_event` / `_flush_text_batch`) whose merge path already extends `media_urls`. Rather than add a *second*, parallel media batcher, this routes media/file bursts through the **same** batcher:

```python
if event.message_type == MessageType.TEXT:
    self._enqueue_text_event(event)
elif self._should_batch_media(event):     # DOCUMENT / PHOTO only
    self._enqueue_text_event(event)       # coalesce files with any caption
else:
    await self.handle_message(event)      # voice/video, or batching disabled
```

Reusing one batcher (one pending map, one task registry) means:

- **N files → one `handle_message()`** — the interrupt-recursion trigger is gone.
- **A caption + its files dispatch as one turn**, not two out-of-order turns.
- **Shutdown teardown is shared** — `disconnect()` already tears these tasks down (see below), so there's no second code path to keep in sync.

### Details

- **Only `DOCUMENT` and `PHOTO` bursts are batched** (`_should_batch_media`). Voice/audio/video keep dispatching immediately — they're latency-sensitive and their downstream handling (STT, voice-reply routing) is keyed on `message_type`.
- **`message_type` is re-derived on merge** (`_message_type_from_media`): a photo merged into a pending text event still classifies as `PHOTO` downstream instead of being flattened to `TEXT` and skipping media-specific handling.
- **`media_batch_delay_seconds`** (default **2.0s**) is read via `_coerce_float_extra`, so it is config.yaml-driven and invalid / non-finite / negative values fall back to the default instead of breaking adapter construction. **`0` disables** media batching (each file dispatches immediately).
- **`_flush_text_batch`** uses the media window when the pending batch carries files; the text and split-continuation windows are unchanged for text-only batches.
- **`disconnect()`** now **cancels *and awaits*** the pending flush tasks before clearing state, so a timer armed here cannot fire `handle_message()` after shutdown has begun.
- The dispatch is wrapped in **`asyncio.shield`** (matching the Discord/Telegram adapters) so a follow-up file can't cancel an agent turn that is already in flight — the cancellation window is wide for long-running file turns.

## Configuration

| Setting (under `gateway.platforms.weixin.extra`) | Default | Description |
|---|---|---|
| `media_batch_delay_seconds` | `2.0` | Quiet window for file/media bursts, in seconds. `0` disables (restore per-file dispatch). |

Config-only (consistent with the existing `text_batch_delay_seconds`); there is no environment variable.

## Testing

`tests/gateway/test_weixin_media_batching.py` covers: single-file dispatch, 8-file burst coalescing, caption+files coalescing into one turn, media-window selection, per-session isolation, state cleanup, `disconnect()` cancels a pending batch, the shield guard (a follow-up file does not cancel an in-flight dispatch), the routing decision (document/photo batched vs voice/video immediate), merge re-classification of `message_type`, and `_coerce_float_extra` parsing (zero / invalid / negative / default).

```
tests/gateway/test_weixin_media_batching.py .............  21 passed
tests/gateway/test_text_batching.py + test_weixin.py + …   106 passed (regression)
```

## Related

Closes #22602.
