### PR TITLE
fix(agent): skip external memory providers in background review agent

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -281,10 +281,12 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         try:
             # ----- Port #4053: cron guard -----
+            # Also covers background_review and subagent contexts to prevent
+            # non-user-facing agents from polluting peer representations.
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
-            if agent_context in ("cron", "flush") or platform == "cron":
-                logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
+            if agent_context in ("cron", "flush", "background_review", "subagent") or platform == "cron":
+                logger.debug("Honcho skipped: non-primary context (agent_context=%s, platform=%s)",
                              agent_context, platform)
                 self._cron_skipped = True
                 return

--- a/run_agent.py
+++ b/run_agent.py
@@ -4297,6 +4297,7 @@ class AIAgent:
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                         enabled_toolsets=["memory", "skills"],
+                        skip_memory=True,
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"


### PR DESCRIPTION
Reopened from #21511 (auto-closed during fork sync).

The background review agent was inadvertently calling external memory providers (Honcho, etc.) during its review cycles, which:
- Wasted API calls and tokens on non-user-facing background work
- Could trigger unintended side effects in external memory systems
- Created noise in observability/monitoring

This fix adds a check to skip external memory provider calls when the agent is running in background review mode.