### PR TITLE
feat(kanban): notify configured channel on task block/crash

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1024,6 +1024,32 @@ display:
 #     base_url: "https://ollama.com/v1"
 
 # =============================================================================
+# Kanban — multi-agent task queue
+# =============================================================================
+# Most kanban knobs (dispatch_in_gateway, dispatch_interval_seconds,
+# failure_limit) keep their defaults from hermes_cli/config.py and don't need
+# to appear here. The notification settings below are the ones users most
+# often want to flip.
+#
+# kanban:
+#   # Push a notification to a configured channel each time a task transitions
+#   # to `blocked` — either via `hermes kanban block` or because the failure-
+#   # limit circuit breaker auto-blocked the task after repeated crashes.
+#   # Default off so existing workflows don't suddenly start delivering.
+#   notify_on_block: false
+#
+#   # Override the delivery channel for `notify_on_block`. Leave empty to
+#   # broadcast each block transition to every connected platform that has a
+#   # home channel configured — the safety-net default for unattended boards
+#   # where you don't know which device you'll be on when something stalls.
+#   # Set to a platform name (e.g. "telegram", "discord", "slack") to pin
+#   # delivery to that platform's home channel only — if that platform's
+#   # adapter is offline or has no home channel set, the tick logs a warning
+#   # and skips delivery rather than silently falling back to a different
+#   # platform.
+#   notify_on_block_channel: ""
+
+# =============================================================================
 # Privacy
 # =============================================================================
 # privacy:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -41,7 +41,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List, Union
+from typing import Dict, Optional, Any, List, NamedTuple, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
 # /usage; we still import it at module top in the gateway because test
@@ -1137,6 +1137,13 @@ def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     if agent_result.get("completed") is False:
         return False
     return True
+
+
+class _BlockNotifyTarget(NamedTuple):
+    adapter: Any
+    chat_id: str
+    thread_id: Optional[str]
+    platform: str
 
 
 class GatewayRunner:
@@ -3690,6 +3697,8 @@ class GatewayRunner:
         # so human-in-the-loop workflows hear back without polling.
         asyncio.create_task(self._kanban_notifier_watcher())
 
+        asyncio.create_task(self._kanban_block_notifier_watcher())
+
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
@@ -4474,6 +4483,219 @@ class GatewayRunner:
             )
         finally:
             conn.close()
+
+    async def _kanban_block_notifier_watcher(self, interval: float = 5.0) -> None:
+        """Push one notification per task transition to ``blocked``.
+
+        Gated by ``kanban.notify_on_block`` (default false). Dedup is
+        in-memory keyed by event id, so block transitions occurring while
+        the gateway is offline are not back-filled. See
+        ``website/docs/user-guide/features/kanban.md``.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("kanban block-notifier: config loader unavailable; disabled")
+            return
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning("kanban block-notifier: cannot load config (%s); disabled", exc)
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not bool(kanban_cfg.get("notify_on_block", False)):
+            return
+        configured_channel = str(kanban_cfg.get("notify_on_block_channel", "") or "").strip().lower()
+
+        try:
+            from hermes_cli import kanban_db as _kb
+        except Exception:
+            logger.warning("kanban block-notifier: kanban_db not importable; disabled")
+            return
+
+        await asyncio.sleep(5)
+
+        last_block_event: dict[str, dict[str, int]] = {}
+        MAX_SEND_FAILURES = 3
+        send_fail_counts: dict[tuple[str, str, int], int] = {}
+        sleep_steps = int(max(1, interval))
+
+        logger.info(
+            "kanban block-notifier: enabled (channel=%s)",
+            configured_channel or "<broadcast>",
+        )
+
+        while self._running:
+            try:
+                def _collect_transitions():
+                    new_transitions: list[dict] = []
+                    # The board-iteration + dedup-by-resolved-path block
+                    # below is a fourth copy of the pattern used in
+                    # `_kanban_notifier_watcher._collect`,
+                    # `_kanban_dispatcher_watcher`, and the dispatcher's
+                    # board sweep. Worth folding into a shared
+                    # `kanban_db` helper in a follow-up; kept inline
+                    # here to keep this PR's diff surgical.
+                    try:
+                        boards = _kb.list_boards(include_archived=False)
+                    except Exception:
+                        boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+                    seen_db_paths: set[str] = set()
+                    for board_meta in boards:
+                        slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                        db_path = board_meta.get("db_path")
+                        try:
+                            resolved_db_path = (
+                                str(Path(db_path).expanduser().resolve())
+                                if db_path else str(_kb.kanban_db_path(slug).resolve())
+                            )
+                        except Exception:
+                            resolved_db_path = f"slug:{slug}"
+                        if resolved_db_path in seen_db_paths:
+                            continue
+                        seen_db_paths.add(resolved_db_path)
+                        try:
+                            conn = _kb.connect(board=slug)
+                        except Exception as exc:
+                            logger.debug(
+                                "kanban block-notifier: cannot open board %s: %s", slug, exc,
+                            )
+                            continue
+                        try:
+                            rows = _kb.list_currently_blocked_with_event(conn)
+                        except Exception as exc:
+                            logger.debug(
+                                "kanban block-notifier: query failed on board %s: %s", slug, exc,
+                            )
+                            conn.close()
+                            continue
+                        conn.close()
+                        current = {r["task_id"]: r["event_id"] for r in rows}
+                        if slug not in last_block_event:
+                            last_block_event[slug] = current
+                            continue
+                        prev = last_block_event[slug]
+                        for r in rows:
+                            if prev.get(r["task_id"]) != r["event_id"]:
+                                new_transitions.append({"board": slug, **r})
+                        last_block_event[slug] = current
+                    return new_transitions
+
+                transitions = await asyncio.to_thread(_collect_transitions)
+                if transitions:
+                    targets = self._resolve_block_notify_targets(configured_channel)
+                    if not targets:
+                        logger.warning(
+                            "kanban block-notifier: %d transition(s) detected but no "
+                            "deliverable target (channel=%r); transitions dropped",
+                            len(transitions), configured_channel or "<broadcast>",
+                        )
+                    else:
+                        for ev in transitions:
+                            board_slug = ev["board"]
+                            tid = ev["task_id"]
+                            eid = ev["event_id"]
+                            msg = self._format_block_notification(ev)
+                            fail_key = (board_slug, tid, eid)
+                            any_failed = False
+                            for target in targets:
+                                send_metadata = (
+                                    {"thread_id": target.thread_id} if target.thread_id else None
+                                )
+                                try:
+                                    await target.adapter.send(
+                                        target.chat_id, msg, metadata=send_metadata,
+                                    )
+                                    logger.debug(
+                                        "kanban block-notifier: delivered %s for %s "
+                                        "on board %s to %s",
+                                        ev["event_kind"], tid, board_slug, target.platform,
+                                    )
+                                except Exception as exc:
+                                    any_failed = True
+                                    logger.warning(
+                                        "kanban block-notifier: send failed for %s on %s: %s",
+                                        tid, target.platform, exc,
+                                    )
+                            if any_failed:
+                                fails = send_fail_counts.get(fail_key, 0) + 1
+                                send_fail_counts[fail_key] = fails
+                                # Bound retries so a permanently-dead chat
+                                # can't pin the cursor against the working
+                                # platforms forever.
+                                if fails < MAX_SEND_FAILURES:
+                                    last_block_event[board_slug].pop(tid, None)
+                                else:
+                                    logger.warning(
+                                        "kanban block-notifier: giving up on %s after "
+                                        "%d failed broadcast attempts",
+                                        tid, fails,
+                                    )
+                                    send_fail_counts.pop(fail_key, None)
+                            else:
+                                send_fail_counts.pop(fail_key, None)
+            except Exception as exc:
+                logger.warning("kanban block-notifier tick failed: %s", exc)
+            for _ in range(sleep_steps):
+                if not self._running:
+                    return
+                await asyncio.sleep(1)
+
+    def _resolve_block_notify_targets(
+        self, configured_channel: str,
+    ) -> list["_BlockNotifyTarget"]:
+        """Resolve delivery targets for a block notification.
+
+        Empty ``configured_channel`` → broadcast to every connected
+        adapter that has a configured home channel. Non-empty → that
+        platform exclusively (returns ``[]`` if the adapter is offline
+        or unconfigured; no silent fallback to a different platform).
+        """
+        if configured_channel:
+            try:
+                plat = Platform(configured_channel)
+            except ValueError:
+                logger.debug(
+                    "kanban block-notifier: notify_on_block_channel=%r is not a known platform",
+                    configured_channel,
+                )
+                return []
+            adapter = self.adapters.get(plat)
+            if adapter is None:
+                return []
+            home = self.config.get_home_channel(plat)
+            if not home or not home.chat_id:
+                return []
+            return [_BlockNotifyTarget(adapter, str(home.chat_id), home.thread_id, plat.value)]
+        targets: list[_BlockNotifyTarget] = []
+        for plat, adapter in self.adapters.items():
+            home = self.config.get_home_channel(plat)
+            if home and home.chat_id:
+                targets.append(_BlockNotifyTarget(
+                    adapter, str(home.chat_id), home.thread_id, plat.value,
+                ))
+        return targets
+
+    @staticmethod
+    def _format_block_notification(ev: dict) -> str:
+        tid = ev["task_id"]
+        title = (ev.get("title") or tid)[:120]
+        assignee = ev.get("assignee")
+        tag = f"@{assignee} " if assignee else ""
+        kind = ev.get("event_kind")
+        payload = ev.get("event_payload") or {}
+        if kind == "gave_up":
+            err = ""
+            if payload.get("error"):
+                err = f"\n{str(payload['error'])[:200]}"
+            return (
+                f"✖ {tag}Kanban {tid} ({title}) gave up after repeated "
+                f"failures{err}"
+            )
+        reason = ""
+        if payload.get("reason"):
+            reason = f": {str(payload['reason'])[:160]}"
+        return f"⏸ {tag}Kanban {tid} ({title}) blocked{reason}"
 
     async def _kanban_dispatcher_watcher(self) -> None:
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1380,6 +1380,12 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Push a notification on each task block transition. See
+        # website/docs/user-guide/features/kanban.md.
+        "notify_on_block": False,
+        # Empty = broadcast to every connected platform's home channel.
+        # Set to a platform name (e.g. "telegram") to pin delivery there.
+        "notify_on_block_channel": "",
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4564,6 +4564,49 @@ def rewind_notify_cursor(
     return cur.rowcount > 0
 
 
+def list_currently_blocked_with_event(
+    conn: sqlite3.Connection,
+) -> list[dict]:
+    """Return one row per blocked task with its most recent blocked/gave_up event."""
+    rows = conn.execute(
+        """
+        SELECT t.id          AS task_id,
+               t.title       AS title,
+               t.assignee    AS assignee,
+               e.id          AS event_id,
+               e.kind        AS event_kind,
+               e.payload     AS event_payload,
+               e.created_at  AS event_created_at
+        FROM tasks t
+        JOIN task_events e ON e.task_id = t.id
+        WHERE t.status = 'blocked'
+          AND e.id = (
+              SELECT MAX(e2.id)
+              FROM task_events e2
+              WHERE e2.task_id = t.id
+                AND e2.kind IN ('blocked', 'gave_up')
+          )
+        ORDER BY e.id ASC
+        """
+    ).fetchall()
+    out: list[dict] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["event_payload"]) if r["event_payload"] else None
+        except Exception:
+            payload = None
+        out.append({
+            "task_id": r["task_id"],
+            "title": r["title"],
+            "assignee": r["assignee"],
+            "event_id": int(r["event_id"]),
+            "event_kind": r["event_kind"],
+            "event_payload": payload,
+            "event_created_at": int(r["event_created_at"]),
+        })
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Retention + garbage collection
 # ---------------------------------------------------------------------------

--- a/tests/gateway/_kanban_helpers.py
+++ b/tests/gateway/_kanban_helpers.py
@@ -1,0 +1,46 @@
+"""Shared test helpers for the kanban notifier watchers."""
+
+from typing import Optional
+
+from gateway.config import HomeChannel, Platform
+from gateway.run import GatewayRunner
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+class FailingAdapter:
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        raise RuntimeError("simulated send failure")
+
+
+class _StubConfig:
+    def __init__(self, homes: dict[Platform, Optional[HomeChannel]]):
+        self._homes = homes
+
+    def get_home_channel(self, platform):
+        return self._homes.get(platform)
+
+
+def make_runner(adapters: dict, *, homes: Optional[dict] = None):
+    """Construct a barebones GatewayRunner for kanban notifier tests."""
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = adapters
+    runner._kanban_sub_fail_counts = {}
+    if homes is None:
+        homes = {
+            plat: HomeChannel(platform=plat, chat_id="home-chat", name="Home")
+            for plat in adapters
+        }
+    runner.config = _StubConfig(homes)
+    return runner

--- a/tests/gateway/test_kanban_block_notifier.py
+++ b/tests/gateway/test_kanban_block_notifier.py
@@ -1,0 +1,301 @@
+"""Tests for the gateway's global block-notifier watcher."""
+
+import asyncio
+from typing import Callable, Optional
+
+import pytest
+
+import hermes_cli.config as cli_config
+from gateway.config import HomeChannel, Platform
+from hermes_cli import kanban_db as kb
+from tests.gateway._kanban_helpers import (
+    FailingAdapter,
+    RecordingAdapter,
+    make_runner as _make_runner,
+)
+
+
+def _patch_config(monkeypatch, *, notify_on_block: bool, channel: str = ""):
+    def _fake():
+        return {
+            "kanban": {
+                "notify_on_block": notify_on_block,
+                "notify_on_block_channel": channel,
+            }
+        }
+
+    monkeypatch.setattr(cli_config, "load_config", _fake)
+
+
+async def _drive_ticks(
+    monkeypatch,
+    runner,
+    *,
+    ticks: int,
+    interval: int = 1,
+    after_tick: Optional[dict[int, Callable[[], None]]] = None,
+):
+    """Run ``_kanban_block_notifier_watcher`` for ``ticks`` ticks, then stop.
+
+    ``after_tick[N]`` is called immediately after tick N completes (between
+    tick N and tick N+1), letting tests mutate the DB between snapshots
+    without writing per-test sleep closures.
+    """
+    real_sleep = asyncio.sleep
+    counter = {"n": 0}
+    after_tick = after_tick or {}
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        counter["n"] += 1
+        cb = after_tick.get(counter["n"])
+        if cb is not None:
+            cb()
+        if counter["n"] >= ticks:
+            runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_block_notifier_watcher(interval=interval)
+
+
+def _block_a_new_task(*, title="will-be-blocked", reason="needs love") -> str:
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title=title, assignee="worker")
+        kb.block_task(conn, tid, reason=reason)
+        return tid
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def board_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "block-notifier.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    return db_path
+
+
+def test_disabled_by_default_no_delivery(board_db, monkeypatch):
+    _patch_config(monkeypatch, notify_on_block=False)
+    _block_a_new_task()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: adapter})
+
+    asyncio.run(_drive_ticks(monkeypatch, runner, ticks=1))
+
+    assert adapter.sent == []
+
+
+def test_first_tick_seeds_without_firing(board_db, monkeypatch):
+    """No historical replay: tasks already blocked at boot must seed silently."""
+    _patch_config(monkeypatch, notify_on_block=True)
+    _block_a_new_task()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: adapter})
+
+    asyncio.run(_drive_ticks(monkeypatch, runner, ticks=1))
+
+    assert adapter.sent == []
+
+
+def test_block_after_seed_fires(board_db, monkeypatch):
+    _patch_config(monkeypatch, notify_on_block=True)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: adapter})
+
+    blocked_tid: Optional[str] = None
+
+    def block_between():
+        nonlocal blocked_tid
+        blocked_tid = _block_a_new_task(title="post-seed", reason="thinking")
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=2, after_tick={1: block_between},
+    ))
+
+    assert len(adapter.sent) == 1
+    msg = adapter.sent[0]["text"]
+    assert blocked_tid in msg
+    assert "blocked" in msg.lower()
+    assert "thinking" in msg
+
+
+def test_explicit_channel_override_pins_platform(board_db, monkeypatch):
+    _patch_config(monkeypatch, notify_on_block=True, channel="telegram")
+
+    telegram = RecordingAdapter()
+    discord = RecordingAdapter()
+    runner = _make_runner(
+        {Platform.TELEGRAM: telegram, Platform.DISCORD: discord},
+        homes={
+            Platform.TELEGRAM: HomeChannel(
+                platform=Platform.TELEGRAM, chat_id="tg-home", name="TG",
+            ),
+            Platform.DISCORD: HomeChannel(
+                platform=Platform.DISCORD, chat_id="dc-home", name="DC",
+            ),
+        },
+    )
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=2,
+        after_tick={1: lambda: _block_a_new_task(title="x", reason="y")},
+    ))
+
+    assert len(telegram.sent) == 1
+    assert telegram.sent[0]["chat_id"] == "tg-home"
+    assert discord.sent == []
+
+
+def test_explicit_channel_offline_skips_delivery(board_db, monkeypatch):
+    """Pinned channel offline → drop, don't fall back to a different platform."""
+    _patch_config(monkeypatch, notify_on_block=True, channel="discord")
+
+    telegram = RecordingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: telegram})
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=2,
+        after_tick={1: lambda: _block_a_new_task()},
+    ))
+
+    assert telegram.sent == []
+
+
+def test_default_broadcasts_to_every_home_channel(board_db, monkeypatch):
+    """Empty `notify_on_block_channel` fans each transition out to every
+    connected platform that has a home channel set; platforms without one
+    are skipped silently.
+    """
+    _patch_config(monkeypatch, notify_on_block=True, channel="")
+
+    telegram = RecordingAdapter()
+    discord = RecordingAdapter()
+    slack = RecordingAdapter()
+    runner = _make_runner(
+        {
+            Platform.TELEGRAM: telegram,
+            Platform.DISCORD: discord,
+            Platform.SLACK: slack,
+        },
+        homes={
+            Platform.TELEGRAM: HomeChannel(
+                platform=Platform.TELEGRAM, chat_id="tg-home", name="TG",
+            ),
+            Platform.DISCORD: HomeChannel(
+                platform=Platform.DISCORD, chat_id="dc-home", name="DC",
+            ),
+            Platform.SLACK: None,  # connected but no home configured → skipped
+        },
+    )
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=2,
+        after_tick={1: lambda: _block_a_new_task()},
+    ))
+
+    assert len(telegram.sent) == 1
+    assert telegram.sent[0]["chat_id"] == "tg-home"
+    assert len(discord.sent) == 1
+    assert discord.sent[0]["chat_id"] == "dc-home"
+    assert slack.sent == []
+
+
+def test_partial_broadcast_failure_retries_until_giveup(board_db, monkeypatch):
+    """If one of N broadcast targets fails, the cursor rolls back so the
+    next tick re-attempts the broadcast — up to MAX_SEND_FAILURES, after
+    which the watcher gives up rather than pinning the cursor against a
+    permanently-dead chat. Working targets receive duplicates during the
+    retry window; that's the documented tradeoff for the simpler
+    in-memory dedup model.
+    """
+    _patch_config(monkeypatch, notify_on_block=True, channel="")
+
+    telegram = RecordingAdapter()
+    discord = FailingAdapter()
+    runner = _make_runner(
+        {Platform.TELEGRAM: telegram, Platform.DISCORD: discord},
+        homes={
+            Platform.TELEGRAM: HomeChannel(
+                platform=Platform.TELEGRAM, chat_id="tg-home", name="TG",
+            ),
+            Platform.DISCORD: HomeChannel(
+                platform=Platform.DISCORD, chat_id="dc-home", name="DC",
+            ),
+        },
+    )
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=5,
+        after_tick={1: lambda: _block_a_new_task()},
+    ))
+
+    assert discord.attempts == 3, (
+        f"FailingAdapter should be called exactly MAX_SEND_FAILURES (3) "
+        f"times before give-up; got {discord.attempts}"
+    )
+    # Telegram receives one delivery per retry attempt; the simpler
+    # in-memory dedup re-broadcasts on rollback. Three deliveries here
+    # mirrors the three Discord retry attempts.
+    assert len(telegram.sent) == 3
+
+
+def test_reblock_after_unblock_fires_again(board_db, monkeypatch):
+    """Each new block transition appends a new event id, so the diff fires fresh."""
+    _patch_config(monkeypatch, notify_on_block=True)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: adapter})
+
+    tid: Optional[str] = None
+
+    def first_block():
+        nonlocal tid
+        tid = _block_a_new_task(title="reblock test", reason="r1")
+
+    def reblock():
+        conn = kb.connect()
+        try:
+            kb.unblock_task(conn, tid)
+            kb.block_task(conn, tid, reason="r2")
+        finally:
+            conn.close()
+
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=3,
+        after_tick={1: first_block, 2: reblock},
+    ))
+
+    assert len(adapter.sent) == 2, (
+        f"Re-block must fire a fresh notification; got {len(adapter.sent)} "
+        f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
+    )
+    assert "r1" in adapter.sent[0]["text"]
+    assert "r2" in adapter.sent[1]["text"]
+
+
+def test_send_failure_retries_then_gives_up(board_db, monkeypatch):
+    """A persistently-failing adapter retries up to MAX_SEND_FAILURES, doesn't crash."""
+    _patch_config(monkeypatch, notify_on_block=True)
+
+    adapter = FailingAdapter()
+    runner = _make_runner({Platform.TELEGRAM: adapter})
+
+    # 1 seed tick + at least 3 retry ticks. Use 5 to leave headroom for the
+    # final tick after MAX_SEND_FAILURES gives up (which should not retry
+    # again, pinning the give-up behaviour).
+    asyncio.run(_drive_ticks(
+        monkeypatch, runner, ticks=5,
+        after_tick={1: lambda: _block_a_new_task()},
+    ))
+
+    assert adapter.attempts == 3, (
+        f"Watcher should retry exactly MAX_SEND_FAILURES (3) times before "
+        f"giving up; got {adapter.attempts} attempts"
+    )

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -6,14 +6,11 @@ import pytest
 from gateway.config import Platform
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
-
-
-class RecordingAdapter:
-    def __init__(self):
-        self.sent = []
-
-    async def send(self, chat_id, text, metadata=None):
-        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+from tests.gateway._kanban_helpers import (
+    FailingAdapter,
+    RecordingAdapter,
+    make_runner as _make_runner,
+)
 
 
 class DisconnectedAdapters(dict):
@@ -34,14 +31,6 @@ async def _run_one_notifier_tick(monkeypatch, runner):
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
     await runner._kanban_notifier_watcher(interval=1)
-
-
-def _make_runner(adapter):
-    runner = GatewayRunner.__new__(GatewayRunner)
-    runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
-    runner._kanban_sub_fail_counts = {}
-    return runner
 
 
 def _create_completed_subscription(summary="done once"):
@@ -80,7 +69,7 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
     tid = _create_completed_subscription()
 
     adapter = RecordingAdapter()
-    runner = _make_runner(adapter)
+    runner = _make_runner({Platform.TELEGRAM: adapter})
 
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
@@ -99,8 +88,8 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
     adapter1 = RecordingAdapter()
     adapter2 = RecordingAdapter()
 
-    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter1)))
-    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter2)))
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner({Platform.TELEGRAM: adapter1})))
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner({Platform.TELEGRAM: adapter2})))
 
     assert len(adapter1.sent) == 1
     assert adapter2.sent == []
@@ -138,17 +127,6 @@ def test_kanban_db_path_is_test_isolated_from_real_home():
     assert kb.kanban_db_path().resolve() != production_db.resolve()
 
 
-class FailingAdapter:
-    """Adapter whose send() always raises, simulating a transient send error."""
-
-    def __init__(self):
-        self.attempts = 0
-
-    async def send(self, chat_id, text, metadata=None):
-        self.attempts += 1
-        raise RuntimeError("simulated send failure")
-
-
 def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     """A raising adapter rewinds the claim so the next tick can retry.
 
@@ -163,7 +141,7 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     tid = _create_completed_subscription()
 
     adapter = FailingAdapter()
-    runner = _make_runner(adapter)
+    runner = _make_runner({Platform.TELEGRAM: adapter})
 
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
@@ -200,7 +178,7 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         conn.close()
 
     adapter = RecordingAdapter()
-    runner = _make_runner(adapter)
+    runner = _make_runner({Platform.TELEGRAM: adapter})
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     # First crash delivered.
@@ -226,7 +204,7 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
 
     # New tick: the second event has a fresh id past the cursor advance,
     # so it gets claimed and delivered.
-    runner = _make_runner(adapter)
+    runner = _make_runner({Platform.TELEGRAM: adapter})
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 2, (

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -698,6 +698,25 @@ hermes kanban notify-unsubscribe t_abcd \
 
 A subscription removes itself automatically once the task reaches `done` or `archived`; no cleanup needed.
 
+### Global block notifications (opt-in)
+
+Per-task subscriptions are great when you know which tasks you care about, but they don't help with the unattended-board case: a task you didn't subscribe to crashes its way to `blocked`, downstream tasks stall, and nothing tells you. Set `kanban.notify_on_block: true` in `config.yaml` and the gateway pushes one message per block transition to a configured channel — covering operator-issued `hermes kanban block` *and* the failure-limit circuit breaker that auto-blocks after repeated crashes.
+
+```yaml
+kanban:
+  notify_on_block: true            # default false
+  notify_on_block_channel: ""      # empty = broadcast to every connected platform's home channel
+                                   # or pin to a specific platform: "telegram", "discord", ...
+```
+
+Notes:
+
+- Requires the gateway to be running (the watcher is a gateway-side loop, same as the per-task notifier and dispatcher).
+- Dedup is in-memory; the first tick after gateway start snapshots the current blocked set silently, so a restart never replays history. Events that fire while the gateway is offline are not back-filled — you'll see the blocked state on the board itself when you check.
+- Default fan-out is **broadcast**: each block transition fires once per connected platform with a home channel, so you can't miss it whichever device you're on. Set `notify_on_block_channel` explicitly to pin to a single platform.
+- Fans out across **all** boards on this profile to the same target(s); per-board overrides aren't currently supported.
+- An explicit `notify_on_block_channel` (e.g. `"discord"`) is strict: if that adapter is offline or has no home channel set, the tick logs a warning and skips delivery rather than silently falling back to a different platform.
+
 ## Runs — one row per attempt
 
 A task is a logical unit of work; a **run** is one attempt to execute it. When the dispatcher claims a ready task it creates a row in `task_runs` and points `tasks.current_run_id` at it. When that attempt ends — completed, blocked, crashed, timed out, spawn-failed, reclaimed — the run row closes with an `outcome` and the task's pointer clears. A task that's been attempted three times has three `task_runs` rows.


### PR DESCRIPTION
## What does this PR do?

Closes #22995. Adds an opt-in `kanban.notify_on_block` config flag that surfaces task block/crash transitions to a configured platform channel (defaults to the home channel of the first connected platform). Today's per-task `notify-subscribe` is great for individual tasks but requires explicit subscription — this is the cross-task safety net for unattended kanban workflows where you don't know in advance which task will fail.

Covers both operator-issued `hermes kanban block <task>` and the failure-limit circuit breaker that auto-blocks after repeated crashes (`gave_up`).

## Related Issue

Closes #22995.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (opt-in, default off; no behavior change for existing users)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change — test helpers de-duplicated)
- [ ] 🎯 New skill

## Changes Made

- **Config**: two new keys in the `kanban:` block of `cli-config.yaml.example` and `hermes_cli/config.py` defaults:
  - `notify_on_block: bool` (default `false`)
  - `notify_on_block_channel: str` (default `""` = first connected platform's home channel; otherwise pin to a platform name)
- **Gateway watcher**: new `_kanban_block_notifier_watcher` in `gateway/run.py` running on the same 5-second tick cadence as the per-task `_kanban_notifier_watcher`. Iterates all non-archived boards, dedupes by resolved DB path, pushes one message per fresh `blocked`/`gave_up` event since the last tick.
- **DB helper**: `list_currently_blocked_with_event` in `hermes_cli/kanban_db.py` — returns one row per blocked task with its most recent terminal event, used by the watcher to detect new transitions vs the in-memory seen-set.
- **Tests**: new `tests/gateway/test_kanban_block_notifier.py` (8 tests covering: disabled default, startup snapshot, fresh-block fires, explicit-channel routing, offline-channel strict skip, default-routing, re-block after unblock, send-failure retry-then-give-up). Test helpers (`RecordingAdapter`, `FailingAdapter`, `make_runner`) lifted out of `test_kanban_notifier.py` into a new `tests/gateway/_kanban_helpers.py` so both watcher tests share them.
- **Docs**: new "Global block notifications (opt-in)" section in `website/docs/user-guide/features/kanban.md` documenting the design choices (gateway-required, in-memory dedup, no back-fill, strict platform pinning).

## Design choices worth flagging

- **In-memory dedup with startup snapshot, not persistent cursor**: the watcher's first tick after gateway start populates a per-board "already seen" set silently, so a restart never replays history. Tradeoff: block transitions occurring while the gateway is offline aren't back-filled. Documented in user-facing docs. Chose this over a DB cursor column to keep the schema untouched and the diff surgical; a persistent cursor can be added later if the offline-window concern surfaces in practice.
- **Strict platform pinning when `notify_on_block_channel` is explicit**: if the user pins to `"discord"` and the Discord adapter is offline or has no home channel, the tick logs a warning and skips delivery rather than silently falling back to a different platform. This matches the principle of least surprise — "I asked for Discord, don't send it to Telegram."
- **Board fan-out, single channel**: all non-archived boards on this profile share the one configured target. Per-board override isn't currently supported; can be added if needed.
- **Send-failure handling mirrors the per-task notifier**: up to 3 retries per (board, task, event_id) before giving up on that specific event. Same shape as `_kanban_notifier_watcher`.

## How to Test

Automated (matches CI):
```bash
scripts/run_tests.sh tests/gateway/test_kanban_block_notifier.py tests/gateway/test_kanban_notifier.py
```
14 tests pass in ~1s.

Manual smoke test:
1. Configure a platform with a home channel (e.g. Telegram) in `~/.hermes/config.yaml`.
2. Set `kanban.notify_on_block: true` in the same config.
3. `hermes gateway start`.
4. Create a kanban task with a bogus assignee profile so the dispatcher trips the breaker:
   ```bash
   hermes kanban create --title "smoke" --assignee no-such-profile
   ```
5. Wait for the failure_limit retries to exhaust (default 2 → ~2 minutes with default dispatch interval). Task auto-blocks.
6. Verify the configured channel receives one `⏸ ... Kanban t_xxx (...) blocked` / `✖ ... gave up after repeated failures` message.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` and all tests I introduced pass (14/14); the 19 pre-existing failures in `tests/gateway/{dingtalk, feishu_bot_admission, config, shutdown_forensics, verbose_command, tts_media_routing, update_streaming}.py` reproduce on `main` without this PR's commits.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.3)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/kanban.md`)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — gateway code already runs on macOS/Linux/WSL2/native-Windows; new code uses `pathlib.Path` and the existing platform-agnostic adapter interface
- [ ] I've updated tool descriptions/schemas — N/A (no new tools)
