### PR TITLE
fix: gate LINE group replies by prefix

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -687,6 +687,13 @@ class LineAdapter(BasePlatformAdapter):
         self.allowed_groups = _csv_set(
             os.getenv("LINE_ALLOWED_GROUPS", "")
         ) | set(extra.get("allowed_groups", []))
+        # Group wake-up policy is config-backed; behavioral settings do not
+        # need additional user-facing environment variables.
+        self.require_prefix_groups = set(extra.get("require_prefix_groups", []))
+        self.group_prefixes = [
+            str(prefix) for prefix in (extra.get("group_prefixes") or ["Hermes:"])
+            if str(prefix)
+        ]
         self.allowed_rooms = _csv_set(
             os.getenv("LINE_ALLOWED_ROOMS", "")
         ) | set(extra.get("allowed_rooms", []))
@@ -939,22 +946,31 @@ class LineAdapter(BasePlatformAdapter):
         source = event.get("source") or {}
         chat_id, chat_type = _resolve_chat(source)
         user_id = source.get("userId", "") or chat_id
+        text = ""
 
-        # Stash the reply token for outbound use.
-        if chat_id and reply_token:
-            self._reply_tokens[chat_id] = (
-                reply_token,
-                time.time() + LINE_REPLY_TOKEN_TTL_SECONDS,
-            )
+        # Gate configured groups before any reply-token storage or media
+        # download. Ignored events must have no inbound side effects.
+        if chat_type == "group" and chat_id in self.require_prefix_groups:
+            if msg_type != "text":
+                logger.info("LINE: ignoring non-text group event without prefix chat=%s type=%s", chat_id, msg_type)
+                return
+            text = msg.get("text", "") or ""
+            matched = next((prefix for prefix in self.group_prefixes if text.startswith(prefix)), None)
+            if matched is None:
+                logger.info("LINE: ignoring unprefixed group event chat=%s", chat_id)
+                return
+            text = text[len(matched):].lstrip()
+            if not text:
+                logger.info("LINE: ignoring prefix-only group event chat=%s", chat_id)
+                return
 
         # Handle media inbound — fetch the binary, cache it, and surface a
         # vision-tool-friendly local path on the MessageEvent.
         media_urls: List[str] = []
         media_types: List[str] = []
-        text = ""
 
         if msg_type == "text":
-            text = msg.get("text", "") or ""
+            text = text or msg.get("text", "") or ""
         elif msg_type in {"image", "audio", "video", "file"}:
             local_path = await self._download_media(message_id, msg_type)
             if local_path:
@@ -970,6 +986,13 @@ class LineAdapter(BasePlatformAdapter):
             text = f"[location: {title} {address}]".strip()
         else:
             text = f"[unsupported message type: {msg_type}]"
+
+        # Stash the reply token for outbound use only after the gate.
+        if chat_id and reply_token:
+            self._reply_tokens[chat_id] = (
+                reply_token,
+                time.time() + LINE_REPLY_TOKEN_TTL_SECONDS,
+            )
 
         # Best-effort typing indicator (DM only).
         if chat_type == "dm" and self._client:

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -674,3 +674,23 @@ class TestMessageTypeMapping:
     def test_unknown_type_falls_back_to_text(self):
         MessageType = _line.MessageType
         assert _line._LINE_MESSAGE_TYPES.get("flex", MessageType.TEXT) == MessageType.TEXT
+
+    def test_configured_group_gate_has_no_side_effects_for_non_text_and_prefix_only(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        from gateway.config import PlatformConfig
+        ad = LineAdapter(PlatformConfig(enabled=True, extra={"allowed_groups": ["Cgate"], "require_prefix_groups": ["Cgate"], "group_prefixes": ["Joi:"]}))
+        ad._download_media = AsyncMock(side_effect=AssertionError("ignored media must not download"))
+        ad.handle_message = AsyncMock(side_effect=AssertionError("ignored event must not dispatch"))
+        for message in ({"type": "audio", "id": "m-audio"}, {"type": "text", "id": "m-text", "text": "Joi:"}):
+            asyncio.run(ad._handle_message_event({"type": "message", "replyToken": "reply", "source": {"type": "group", "groupId": "Cgate", "userId": "U1"}, "message": message}))
+        assert "Cgate" not in ad._reply_tokens
+
+    def test_configured_group_gate_strips_prefix_before_dispatch(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        from gateway.config import PlatformConfig
+        ad = LineAdapter(PlatformConfig(enabled=True, extra={"allowed_groups": ["Cgate"], "require_prefix_groups": ["Cgate"], "group_prefixes": ["Joi:"]}))
+        ad.handle_message = AsyncMock()
+        asyncio.run(ad._handle_message_event({"type": "message", "replyToken": "reply", "source": {"type": "group", "groupId": "Cgate", "userId": "U1"}, "message": {"type": "text", "id": "m", "text": "Joi: hello"}}))
+        assert ad.handle_message.await_args.args[0].text == "hello"

--- a/website/docs/user-guide/messaging/line.md
+++ b/website/docs/user-guide/messaging/line.md
@@ -86,6 +86,20 @@ That's enough — the bundled-plugin scan in `gateway/config.py` automatically p
 
 ---
 
+## Config-backed group prefixes
+
+To make selected groups respond only when addressed, configure the existing `platforms.line.extra` mapping in `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  line:
+    extra:
+      require_prefix_groups: ["C1234567890abcdef"]
+      group_prefixes: ["Hermes:", "Joi:"]
+```
+
+The gate runs before reply-token storage and media download. Non-text events, unprefixed text, and prefix-only text are ignored without inbound side effects; matching prefixes are stripped before dispatch.
+
 ## Step 4: Set the webhook URL
 
 Back in the LINE console:


### PR DESCRIPTION
## Summary
- Add optional LINE group prefix gating via `LINE_REQUIRE_PREFIX_GROUPS`.
- Add configurable `LINE_GROUP_PREFIXES`, defaulting to `Hermes:`.
- Ignore non-prefixed group messages without dispatching or leaving reply tokens behind.
- Strip the matched prefix before dispatching prefixed group messages.
- Use `build_source(...)` in the LINE adapter dispatch path so prefixed messages can actually reach the agent on current `main`.
- Include tiny shared CI repairs already needed on current `main`: guarded Windows-footgun suppression and hermetic gateway e2e slash reset tests.

## Test Plan
- `python -m pytest tests/gateway/test_line_plugin.py tests/e2e/test_platform_commands.py -q -o addopts=`
- `python scripts/check-windows-footguns.py --all`