### PR TITLE
fix: preserve ansi output history on resize replay

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1415,9 +1415,6 @@ _OUTPUT_HISTORY_REPLAYING = False
 _OUTPUT_HISTORY_SUPPRESSED = False
 _OUTPUT_HISTORY_MAX_LINES = 200
 _OUTPUT_HISTORY = deque(maxlen=_OUTPUT_HISTORY_MAX_LINES)
-_ANSI_CONTROL_RE = re.compile(
-    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))"
-)
 
 
 def _coerce_output_history_limit(value) -> int:
@@ -1459,10 +1456,10 @@ def _record_output_history_entry(entry) -> None:
 def _record_output_history(text: str) -> None:
     if not _OUTPUT_HISTORY_ENABLED or _OUTPUT_HISTORY_REPLAYING or _OUTPUT_HISTORY_SUPPRESSED:
         return
-    clean = _ANSI_CONTROL_RE.sub("", str(text)).replace("\r", "").rstrip("\n")
-    if not clean:
+    normalized = str(text).replace("\r", "").rstrip("\n")
+    if not normalized:
         return
-    for line in clean.splitlines():
+    for line in normalized.splitlines():
         _record_output_history_entry(line)
 
 

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -215,13 +215,15 @@ def test_cprint_swallows_prompt_toolkit_import_error(monkeypatch):
     assert direct_prints == ["fallback2"]
 
 
-def test_output_history_strips_ansi_and_keeps_recent_lines():
+def test_output_history_preserves_ansi_and_keeps_recent_lines():
     cli._configure_output_history(True, 10)
 
     for idx in range(12):
         cli._record_output_history(f"\x1b[31mline-{idx}\x1b[0m")
 
-    assert list(cli._OUTPUT_HISTORY) == [f"line-{idx}" for idx in range(2, 12)]
+    assert list(cli._OUTPUT_HISTORY) == [
+        f"\x1b[31mline-{idx}\x1b[0m" for idx in range(2, 12)
+    ]
 
 
 def test_replay_output_history_does_not_record_replayed_lines(monkeypatch):
@@ -260,6 +262,16 @@ def test_replay_output_history_rerenders_callable_entries(monkeypatch):
     assert widths_seen == ["called"]
     assert printed == ["top border", "body"]
     assert list(cli._OUTPUT_HISTORY) == [_render_current_width]
+
+
+def test_chat_console_records_rich_ansi_for_resize_replay(monkeypatch):
+    cli._configure_output_history(True, 10)
+    monkeypatch.setattr(cli, "_pt_print", lambda *_args, **_kwargs: None)
+
+    cli.ChatConsole().print("[bold red]Hello[/]")
+
+    assert cli._OUTPUT_HISTORY
+    assert any("\x1b[" in line for line in cli._OUTPUT_HISTORY)
 
 
 def test_suspend_output_history_blocks_recording():


### PR DESCRIPTION
## What does this PR do?

Preserves ANSI/Rich formatting in the CLI output history that is replayed after terminal redraws. The previous history recorder stripped ANSI control sequences before storing lines, so rich console output could lose styling when persistent output was replayed after a resize.

## Related Issue

Fixes #24017

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `cli.py` so output history keeps ANSI formatting while still normalizing carriage returns and trailing newlines.
- Updated the existing output-history replay test to assert ANSI preservation.
- Added coverage for `ChatConsole.print()` recording Rich-rendered ANSI output for replay.

## How to Test

1. Run `scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/cli/test_cli_force_redraw.py`.
2. Run `git diff --check`.
3. Run `uv sync --frozen --extra all` and `uv run --frozen ruff check .`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Local verification:

```text
scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/cli/test_cli_force_redraw.py
# passed

git diff --check
# passed

uv sync --frozen --extra all
# passed

uv run --frozen ruff check .
# passed
```