### PR TITLE
fix(anthropic): override SDK User-Agent for third-party endpoints (#24293)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -327,6 +327,27 @@ def _get_claude_code_version() -> str:
     return _claude_code_version_cache
 
 
+_HERMES_AGENT_VERSION_FALLBACK = "0.0.0"
+_hermes_agent_version_cache: Optional[str] = None
+
+
+def _get_hermes_agent_version() -> str:
+    """Lazily resolve the installed hermes-agent version for User-Agent headers.
+
+    Used when overriding the Anthropic SDK's default ``Anthropic/Python <ver>``
+    user-agent on third-party endpoints; self-hosted proxies behind Cloudflare
+    bot-detection 403 the SDK fingerprint, but accept any non-SDK UA.
+    """
+    global _hermes_agent_version_cache
+    if _hermes_agent_version_cache is None:
+        try:
+            from hermes_cli import __version__ as _v
+            _hermes_agent_version_cache = str(_v) if _v else _HERMES_AGENT_VERSION_FALLBACK
+        except Exception:
+            _hermes_agent_version_cache = _HERMES_AGENT_VERSION_FALLBACK
+    return _hermes_agent_version_cache
+
+
 def _is_oauth_token(key: str) -> bool:
     """Check if the key is an Anthropic OAuth/setup token.
 
@@ -734,13 +755,20 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _is_third_party_anthropic_endpoint(base_url):
-        # Third-party proxies (Microsoft Foundry, AWS Bedrock, etc.) use their
-        # own API keys with x-api-key auth. Skip OAuth detection — their keys
-        # don't follow Anthropic's sk-ant-* prefix convention and would be
-        # misclassified as OAuth tokens.
+        # Third-party proxies (Microsoft Foundry, AWS Bedrock, self-hosted
+        # relays, GLM proxies, etc.) use their own API keys with x-api-key
+        # auth. Skip OAuth detection — their keys don't follow Anthropic's
+        # sk-ant-* prefix convention and would be misclassified as OAuth
+        # tokens.
+        #
+        # Override the SDK's default ``Anthropic/Python <ver>`` user-agent
+        # because Cloudflare-style WAF bot detection on self-hosted proxies
+        # 403s the SDK fingerprint by default. (#24293)
         kwargs["api_key"] = api_key
+        headers = {"User-Agent": f"hermes-agent/{_get_hermes_agent_version()}"}
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            headers["anthropic-beta"] = ",".join(common_betas)
+        kwargs["default_headers"] = headers
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -109,9 +109,40 @@ class TestBuildAnthropicClient:
             build_anthropic_client("sk-ant-api03-x", base_url="https://custom.api.com")
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
-            assert kwargs["default_headers"] == {
-                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
-            }
+            headers = kwargs["default_headers"]
+            assert headers["anthropic-beta"] == (
+                "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+            )
+            # Third-party endpoints override the SDK's default User-Agent so
+            # Cloudflare-style WAF bot detection doesn't 403 the SDK fingerprint.
+            assert headers["User-Agent"].startswith("hermes-agent/")
+
+    def test_third_party_endpoint_overrides_sdk_user_agent(self):
+        """Custom-provider endpoints get a hermes-agent UA instead of the
+        Anthropic SDK's default ``Anthropic/Python <ver>``, which Cloudflare
+        WAF rules block on self-hosted proxies (#24293)."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "proxy-key-xyz",
+                base_url="https://proxy.example.com/v1",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["api_key"] == "proxy-key-xyz"
+            ua = kwargs["default_headers"]["User-Agent"]
+            assert ua.startswith("hermes-agent/"), ua
+            # The Anthropic SDK default fingerprint must NOT leak through.
+            assert "Anthropic/Python" not in ua
+
+    def test_native_anthropic_endpoint_does_not_override_user_agent(self):
+        """Direct anthropic.com requests must NOT carry the third-party UA
+        override — the SDK's default ``Anthropic/Python`` UA is expected by
+        Anthropic's own infrastructure and routing."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-direct")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            headers = kwargs.get("default_headers", {}) or {}
+            assert "User-Agent" not in headers
+            assert "user-agent" not in headers
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:


### PR DESCRIPTION
## What does this PR do?

Override the Anthropic Python SDK's default `User-Agent: Anthropic/Python <ver>` with `User-Agent: hermes-agent/<version>` whenever `build_anthropic_client` constructs a client for a third-party (non-`anthropic.com`) endpoint. Direct `anthropic.com` traffic is unchanged — the SDK's native UA is preserved there.

Self-hosted Anthropic-compatible proxies (e.g. GLM relays, custom gateways) commonly sit behind Cloudflare with bot-detection rules that 403 the Anthropic SDK fingerprint. Reproduced in #24293:

```
# Without SDK User-Agent → 200 OK
# With "User-Agent: Anthropic/Python 0.101.0" → 403 Forbidden
```

In `agent/anthropic_adapter.py`, the `_is_third_party_anthropic_endpoint` branch of `build_anthropic_client` only set `anthropic-beta` in `default_headers`; the SDK's default UA flowed through untouched, so every request from Hermes to such a proxy was rejected with `HTTP 403: Your request was blocked.` Pattern mirrors the existing OAuth (`claude-cli/...`) and Kimi-coding (`claude-code/0.1.0`) branches in the same function — both already override the SDK UA for routing reasons. Version resolution lazily imports `hermes_cli.__version__` and caches it; falls back to `"0.0.0"` if unavailable (mirrors `acp_adapter/server.py` and `gateway/platforms/yuanbao.py` conventions).

## Related Issue

Fixes #24293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py` — in the third-party branch of `build_anthropic_client`, populate `default_headers["User-Agent"]` with `hermes-agent/<resolved-version>` before constructing the SDK client. Native-Anthropic branch untouched.
- `tests/agent/test_anthropic_adapter.py` — new cases: `test_third_party_endpoint_overrides_sdk_user_agent` asserts UA starts with `hermes-agent/` and `Anthropic/Python` never appears; `test_native_anthropic_endpoint_does_not_override_user_agent` asserts no UA override for direct `anthropic.com` calls. Updates `test_custom_base_url` to assert both `anthropic-beta` and the new `User-Agent` are present together.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/agent/test_anthropic_adapter.py::TestBuildAnthropicClient tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs -v`
2. Expected: 10 + 23 = 33 passed.
3. Regression guard: revert the fix — both new assertions fail with `KeyError: 'User-Agent'`. Restore — all 10 `TestBuildAnthropicClient` cases pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (33/33)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — UA header is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #24293.
- Mirrors the existing OAuth (`claude-cli/...`) and Kimi-coding (`claude-code/0.1.0`) UA-override branches in the same function.
- The user-proposed `custom_providers.user_agent` config knob is deliberately not included here — the default-override pattern matches how the existing OAuth/Kimi branches handle SDK UA overrides and unblocks affected users without requiring per-provider config awareness. A config-knob follow-up can layer on top if maintainers want explicit per-provider control.

> Sibling code paths that may need the same fix: the OpenAI client construction sites in `agent/auxiliary_client.py` (around 15 `OpenAI(...)` callsites) likely 403 in the same Cloudflare scenario when `custom_providers` use the OpenAI wire format. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.
