### PR TITLE
fix(model-switch): show user-defined providers that shadow empty canonical entries in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1473,7 +1473,25 @@ def list_authenticated_providers(
             # Skip if this slug was already emitted (e.g. canonical provider
             # with the same name) or will be picked up by section 4.
             if ep_name.lower() in seen_slugs:
-                continue
+                # Exception: if the existing canonical entry has no models but
+                # user_providers has models/api_url for this slug, replace the
+                # canonical entry so the picker can surface it.  This fixes
+                # local providers (e.g. unsloth) that are registered as
+                # CANONICAL_PROVIDERS with an empty curated model list.
+                existing_idx = next(
+                    (i for i, r in enumerate(results) if r.get("slug") == ep_name),
+                    None,
+                )
+                if existing_idx is not None:
+                    existing = results[existing_idx]
+                    if not existing.get("models") and not existing.get("is_user_defined"):
+                        # Re-build with user config data (fall through to normal build below)
+                        results.pop(existing_idx)
+                        seen_slugs.discard(ep_name.lower())
+                    else:
+                        continue
+                else:
+                    continue
             display_name = ep_cfg.get("name", "") or ep_name
             # ``base_url`` is Hermes's canonical write key (matches
             # custom_providers and _save_custom_provider); ``api`` / ``url``


### PR DESCRIPTION
## Problem

Providers registered as `CANONICAL_PROVIDERS` with no curated model list (e.g. local inference servers like Unsloth Studio) were silently dropped from the interactive `/model` picker.

## Root Cause

Section 2b adds the canonical entry to `results` with `models: []` and `is_user_defined: False`, then marks the slug as seen. Section 3 then skips the matching `providers:` config entry because the slug is already in `seen_slugs` — so the user's `api_url`, `api_key` and model list never make it into the picker. `list_picker_providers` then filters out the empty canonical row (`has_models=False`, `is_custom_endpoint=False`), making the provider invisible.

## Fix

In section 3, when the slug is already in `seen_slugs`, check whether the existing result entry has no models and is not user-defined. If so, pop it and let the normal section-3 path rebuild it from the user's config (with correct models, `api_url`, and `is_user_defined=True`). Entries that already have models are left untouched.

## Testing

- Unsloth Studio (`providers: unsloth:` in config.yaml) now appears in the `/model` picker
- Providers with curated model lists (xai, anthropic, etc.) are unaffected
- `user_providers=None` does not crash
- `is_current: True` correctly shown when unsloth is the active provider