### PR TITLE
fix(feishu): keep topic replies out of main chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -47,8 +47,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     value. Telegram private-chat topics created through Hermes' DM-topic helper
     are exposed in updates as ``message_thread_id`` plus a reply anchor, but
     outbound sends only render in the correct Telegram lane when the adapter
-    supplies both ``message_thread_id`` and ``reply_to_message_id``. Mark those
-    lanes so the Telegram adapter can avoid the known-bad partial routes.
+    supplies both ``message_thread_id`` and ``reply_to_message_id``. Feishu
+    topics likewise must be routed through message.reply with
+    reply_in_thread=true; metadata carries that reply anchor to non-text send
+    paths that do not receive an explicit ``reply_to``.
     """
     thread_id = getattr(source, "thread_id", None)
     if thread_id is None:
@@ -59,6 +61,10 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
         anchor = reply_to_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)
+    if _platform_name(getattr(source, "platform", None)) == "feishu":
+        anchor = reply_to_message_id or getattr(source, "message_id", None) or thread_id
+        if anchor is not None:
+            metadata["reply_to_message_id"] = str(anchor)
     return metadata
 
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2930,11 +2930,17 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu can report the same topic as root_id (om_...) on the first
+        # reply and thread_id (omt_...) on later messages. Use the root message
+        # id when available so one Feishu topic maps to one Hermes session key
+        # instead of splitting across om_/omt_ variants.
+        root_id = getattr(message, "root_id", None) or None
+        platform_thread_id = getattr(message, "thread_id", None) or None
+        thread_id = root_id or platform_thread_id or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
-            or getattr(message, "root_id", None)
+            or root_id
             or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
@@ -2969,6 +2975,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text,
@@ -4261,7 +4268,11 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> Any:
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
-            effective_reply_to = metadata.get("reply_to_message_id")
+            # Feishu topics must be sent through message.reply with
+            # reply_in_thread=true. If a caller only has the canonical topic
+            # root id, use it as the reply target instead of falling back to
+            # message.create, which would post into the main DM.
+            effective_reply_to = metadata.get("reply_to_message_id") or metadata.get("thread_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
         if effective_reply_to:
             body = self._build_reply_message_body(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12123,6 +12123,10 @@ class GatewayRunner:
             anchor = reply_to_message_id or getattr(source, "message_id", None)
             if anchor is not None:
                 metadata["telegram_reply_to_message_id"] = str(anchor)
+        if getattr(source, "platform", None) == Platform.FEISHU:
+            anchor = reply_to_message_id or getattr(source, "message_id", None) or thread_id
+            if anchor is not None:
+                metadata["reply_to_message_id"] = str(anchor)
         return metadata
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1922,6 +1922,47 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_message_uses_root_id_as_canonical_topic_id(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="omt_topic",
+            root_id="om_topic_root",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"reply in topic"}',
+            message_id="om_current",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_current",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(event.source.thread_id, "om_topic_root")
+        self.assertEqual(event.source.message_id, "om_current")
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -2000,6 +2041,68 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(captured["request"].message_id, "om_trigger")
         self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_thread_id_as_reply_anchor_when_reply_target_missing(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+            def create(self, request):
+                raise AssertionError("Feishu topic sends must not fall back to message.create")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="status update",
+                    metadata={"thread_id": "om_topic_root"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].message_id, "om_topic_root")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    def test_thread_metadata_for_source_includes_feishu_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _thread_metadata_for_source
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="dm",
+            thread_id="om_topic_root",
+            message_id="om_current",
+        )
+
+        metadata = _thread_metadata_for_source(source)
+
+        self.assertEqual(
+            metadata,
+            {
+                "thread_id": "om_topic_root",
+                "reply_to_message_id": "om_current",
+            },
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1051,4 +1051,3 @@ async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
 
 
 
-


### PR DESCRIPTION
## Summary
- canonicalize Feishu topic session keys on root message IDs so one topic does not split between `om_` and `omt_` variants
- carry Feishu reply anchors through the shared thread metadata used by normal gateway sends
- make Feishu topic sends use `message.reply` with `reply_in_thread=true` even when callers only pass `thread_id`, avoiding accidental top-level DM posts

## Tests
- `/Users/hywl/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/gateway/test_feishu.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_reply_to_injection.py tests/gateway/test_session_race_guard.py`