### PR TITLE
fix(security): Apply secret redaction to all outbound platform messages

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3440,7 +3440,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._app = None
         logger.info("[%s] API server stopped", self.name)
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -21,6 +21,8 @@ from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
 
+from agent.redact import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 
 # Audio file extensions Hermes recognizes for native audio delivery.
@@ -1543,7 +1545,6 @@ class BasePlatformAdapter(ABC):
         """Disconnect from the platform."""
         pass
     
-    @abstractmethod
     async def send(
         self,
         chat_id: str,
@@ -1557,6 +1558,30 @@ class BasePlatformAdapter(ABC):
         Args:
             chat_id: The chat/channel ID to send to
             content: Message content (may be markdown)
+            reply_to: Optional message ID to reply to
+            metadata: Additional platform-specific options
+        
+        Returns:
+            SendResult with success status and message ID
+        """
+        # Redact sensitive text from outbound messages before platform-specific formatting and delivery
+        redacted_content = redact_sensitive_text(content)
+        return await self._send(chat_id, redacted_content, reply_to, metadata)
+    
+    @abstractmethod
+    async def _send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> SendResult:
+        """
+        Platform-specific message send implementation.
+        
+        Args:
+            chat_id: The chat/channel ID to send to
+            content: Message content (already redacted)
             reply_to: Optional message ID to reply to
             metadata: Additional platform-specific options
         

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -401,7 +401,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chunks = BasePlatformAdapter.truncate_message(content, max_length)
         return [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -774,7 +774,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     # -- Outbound messaging -------------------------------------------------
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1363,7 +1363,7 @@ class DiscordAdapter(BasePlatformAdapter):
             elif outcome == ProcessingOutcome.FAILURE:
                 await self._add_reaction(message, "❌")
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -500,7 +500,7 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1697,7 +1697,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -383,7 +383,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
     # Outbound messaging
     # ------------------------------------------------------------------
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -901,7 +901,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         logger.info("Matrix: disconnected")
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -249,7 +249,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         logger.info("Mattermost: disconnected")
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -157,7 +157,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             self._runner = None
         self._mark_disconnected()
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -929,7 +929,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Sending
     # ------------------------------------------------------------------
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -734,7 +734,7 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -149,7 +149,7 @@ class SmsAdapter(BasePlatformAdapter):
         self._running = False
         logger.info("[sms] Disconnected")
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1485,7 +1485,7 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -210,7 +210,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[webhook] Disconnected")
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1332,7 +1332,7 @@ class WeComAdapter(BasePlatformAdapter):
             },
         )
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -177,7 +177,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # Outbound: proactive send via access-token API
     # ------------------------------------------------------------------
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1665,7 +1665,7 @@ class WeixinAdapter(BasePlatformAdapter):
         assert last_error is not None
         raise last_error
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -803,7 +803,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
         return result
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4541,7 +4541,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
 
         logger.info("[%s] Disconnected", self.name)
 
-    async def send(
+    async def _send(
         self,
         chat_id: str,
         content: str,


### PR DESCRIPTION
Fixes #23810: Outbound chat messages were not being passed through `redact_sensitive_text` before delivery to messaging platforms, despite the gateway startup banner claiming they were.

## Changes
- Adds `redact_sensitive_text` call in the base `BasePlatformAdapter.send()` method, before passing content to platform-specific implementation
- Uses template method pattern: `send()` handles cross-cutting concerns (redaction) and delegates to `_send()` for platform-specific delivery
- Redaction happens **before** platform-specific formatting to ensure regex patterns match raw secret strings before any escaping/formatting modifies them
- Updated all built-in platform adapters to implement `_send()` instead of `send()`

## Rationale
Redacting before formatting is safer than redacting after:
1. Secret regex patterns match the original raw secret strings exactly
2. Formatting steps (Markdown escaping, etc.) can modify special characters in secrets, causing regex patterns to fail to match
3. Redacted output has no special Markdown characters that would break formatting when applied later

## Breaking Change
Custom third-party platform adapters that implement `send()` directly will need to rename their method to `_send()` to work with this change.

## Testing
- Verified syntax correctness across all modified platform files
- Redaction logic already has existing test coverage in `tests/hermes_cli/test_redact*.py`
- Matches the existing redaction behavior already applied to tool output and log records