### PR TITLE
feat(display): diff-aware tool preview truncation

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -187,6 +187,79 @@ def _truncate_preview(text: str, max_len: int | None) -> str:
     return text
 
 
+# --- Diff-aware preview truncation (PR #24304) --------------------------
+# Presentation only: reveal what differs from the previous preview so
+# sibling tool calls read distinctly.  Deduplication keys on RAW tool
+# identity (see gateway/run.py progress_callback), NOT on this rendered
+# output, so this never needs to preserve equality across re-calls.
+_ELLIPSIS = "..."
+_TAIL_FRACTION_NUM = 2
+_TAIL_FRACTION_DEN = 5
+
+
+def truncate_middle(text: str, max_len: int, prev: str | None = None) -> str:
+    """Truncate ``text`` to at most ``max_len`` chars for display, filling
+    the budget with as much content as possible while revealing what
+    differs from ``prev``.
+
+    Resolution order (each step skipped if it doesn't apply):
+
+    1. ``text`` fits in ``max_len`` → return it unchanged.
+    2. ``prev`` provided → show ``text`` from the first differing char
+       through the end (the part the reader needs), then prepend as much
+       of the shared prefix as budget allows, joined by ``"..."``.
+    3. Otherwise → stateless head + ellipsis + short tail.
+
+    ``max_len <= 0`` produces ``""``.  Presentation only — dedup keys on
+    raw identity elsewhere, so a fallback that renders two distinct
+    inputs identically is harmless (it never merges their bubbles).
+    """
+    if max_len <= 0:
+        return ""
+    if len(text) <= max_len:
+        return text
+    if prev:
+        diff_view = _truncate_around_diff(text, prev, max_len)
+        if diff_view is not None:
+            return diff_view
+    return _head_tail_truncate(text, max_len)
+
+
+def _truncate_around_diff(text: str, prev: str, max_len: int) -> str | None:
+    """``text[:keep] + "..." + text[diff:]`` filling ``max_len`` while
+    keeping everything from the first divergence onward visible.  Returns
+    ``None`` when no useful diff-aware truncation exists (no shared prefix,
+    or the must-show tail alone overflows)."""
+    n = min(len(text), len(prev))
+    i = 0
+    while i < n and text[i] == prev[i]:
+        i += 1
+    if i == 0 or i == len(text):
+        return None
+    tail = text[i:]
+    if len(tail) > max_len:
+        return None
+    head_budget = max_len - len(tail)
+    el = len(_ELLIPSIS)
+    if head_budget >= el + 1:
+        keep = head_budget - el
+        return text[:keep] + _ELLIPSIS + tail
+    if el + len(tail) <= max_len:
+        return _ELLIPSIS + tail
+    return tail
+
+
+def _head_tail_truncate(text: str, max_len: int) -> str:
+    """Stateless: keep the head, drop the middle, keep a short tail.
+    Fallback when no ``prev`` preview is available."""
+    avail = max_len - len(_ELLIPSIS)
+    if avail < 2:
+        return text[:max_len]
+    suffix_len = max(1, avail * _TAIL_FRACTION_NUM // _TAIL_FRACTION_DEN)
+    prefix_len = avail - suffix_len
+    return text[:prefix_len] + _ELLIPSIS + text[-suffix_len:]
+
+
 _SHELL_SILENT_HEADS = {"cd", "pushd", "popd", "export", "set", "unset", "source", ".", "true", "false", ":"}
 _SHELL_PIPE_TAIL_HEADS = {"head", "tail", "wc", "sort", "uniq"}
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17373,8 +17373,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if needs_progress_queue else None
         last_tool = [None]  # Mutable container for tracking in closure
-        last_progress_msg = [None]  # Track last message for dedup
-        repeat_count = [0]  # How many times the same message repeated
+        # Deduplicate consecutive progress bubbles on RAW tool identity
+        # ((tool_name, raw preview)) rather than the rendered/truncated line.
+        # Truncation is presentation only and cannot guarantee that distinct
+        # raw calls render distinctly (teknium1 review, PR #24304).
+        last_raw_key = [None]
+        last_display_raw = [None]  # previous raw preview, for diff-aware truncate_middle
+        repeat_count = [0]  # How many times the same identity repeated
         # True when the previously enqueued progress line was a terminal
         # fenced code block — consecutive terminal calls then drop the
         # repeated "💻 terminal" header and render back-to-back blocks.
@@ -17574,10 +17579,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40
                 _lines = _cmd_full.splitlines()
-                _cmd_short = _lines[0] if _lines else _cmd_full
+                _cmd_line_raw = _lines[0] if _lines else _cmd_full
                 _multiline = len(_lines) > 1
+                _cmd_short = _cmd_line_raw
                 if len(_cmd_short) > _cap:
-                    _cmd_short = _cmd_short[:_cap - 3] + "..."
+                    from agent.display import truncate_middle
+                    # Presentation only: reveal what differs from the previous
+                    # command so back-to-back siblings read distinctly.
+                    _cmd_short = truncate_middle(_cmd_short, _cap, prev=last_display_raw[0])
                 elif _multiline:
                     _cmd_short = _cmd_short + " ..."
                 _code_block_short = f"{_block_header}```\n{_cmd_short}\n```"
@@ -17611,20 +17620,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # compact — unlike CLI spinners, these persist as permanent messages).
             # Terminal commands on markdown platforms get a single-line capped
             # fenced block (built above) instead of the truncated preview.
+            _dedup_ident = None   # raw identity for dedup (see below)
+            _this_display = None  # raw preview to diff the NEXT call against
             if _code_block_short is not None:
                 msg = _code_block_short
                 last_was_terminal_block[0] = True
+                _dedup_ident = _cmd_full        # full raw command → robust identity
+                _this_display = _cmd_line_raw    # raw first line, for the next diff
             elif preview:
                 from agent.display import (
                     get_tool_preview_max_len,
                     get_tool_verb,
                     tool_verb_connector,
+                    truncate_middle,
                     verb_drops_preview,
                 )
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40
+                _preview_raw = preview
                 if len(preview) > _cap:
-                    preview = preview[:_cap - 3] + "..."
+                    # Presentation only: reveal the part that differs from the
+                    # previous preview so distinct calls read distinctly.
+                    preview = truncate_middle(preview, _cap, prev=last_display_raw[0])
                 # Friendly labels: render a human-phrased line for built-in
                 # tools ("🔍 Searching the web for ...") by prefixing the verb
                 # onto the preview the callback already computed (so the
@@ -17639,20 +17656,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     msg = f"{emoji} {tool_name}: \"{preview}\""
                 last_was_terminal_block[0] = False
+                _dedup_ident = _preview_raw   # dedup on the RAW preview, not the truncated line
+                _this_display = _preview_raw
             else:
                 msg = f"{emoji} {tool_name}..."
                 last_was_terminal_block[0] = False
             
-            # Dedup: collapse consecutive identical progress messages.
-            # Common with execute_code where models iterate with the same
-            # code (same boilerplate imports → identical previews).
-            if msg == last_progress_msg[0]:
+            # Dedup on RAW tool identity, not the rendered line.  Truncation
+            # is presentation only: two distinct raw calls can truncate to the
+            # same text (which must NOT merge), and identical raw calls always
+            # share a key regardless of how they render (teknium1, PR #24304).
+            _raw_key = (tool_name, _dedup_ident)
+            if _raw_key == last_raw_key[0]:
                 repeat_count[0] += 1
                 # Update the last line in progress_lines with a counter
                 # via a special "dedup" queue message.
                 progress_queue.put(("__dedup__", msg, repeat_count[0]))
                 return
-            last_progress_msg[0] = msg
+            last_raw_key[0] = _raw_key
+            last_display_raw[0] = _this_display
             repeat_count[0] = 0
             
             progress_queue.put(msg)
@@ -17923,7 +17945,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # linearization regression after PR #7885.)
                         progress_msg_id = None
                         progress_lines = []
-                        last_progress_msg[0] = None
+                        last_raw_key[0] = None
+                        last_display_raw[0] = None
                         repeat_count[0] = 0
                         continue
                     else:
@@ -18047,7 +18070,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         pass
                                 progress_msg_id = None
                                 progress_lines = []
-                                last_progress_msg[0] = None
+                                last_raw_key[0] = None
+                                last_display_raw[0] = None
                                 repeat_count[0] = 0
                             else:
                                 progress_lines.append(raw)

--- a/tests/agent/test_display_truncate_middle.py
+++ b/tests/agent/test_display_truncate_middle.py
@@ -1,0 +1,225 @@
+"""Behavioural tests for ``truncate_middle`` in ``agent/display.py``.
+
+Each test is a small scenario that reads top-to-bottom like a worked
+example: the previous preview, the new preview, the budget, and the
+expected output.  Together they document what the function does and why
+the ``...`` lands where it does.
+
+``truncate_middle`` is *presentation only*: the gateway deduplicates
+consecutive progress bubbles on RAW tool identity (see
+``gateway/run.py``), so truncation never needs to preserve equality.
+"""
+
+import pytest
+
+from agent.display import truncate_middle
+
+
+# ── Use the whole budget when you can ───────────────────────────────────
+
+class TestPassThroughWhenItFits:
+    """Truncation is not a goal in itself.  When the new preview fits
+    in the budget, return it unchanged — even if it shares a long
+    prefix with the previous preview."""
+
+    def test_short_text_with_no_history_passes_through(self):
+        out = truncate_middle("git status", max_len=40)
+        assert out == "git status"
+
+    def test_short_text_with_prev_still_passes_through(self):
+        # We have a prev, but text still fits — show it in full.
+        out = truncate_middle("git diff", max_len=40, prev="git status")
+        assert out == "git diff"
+
+    def test_long_but_under_budget_passes_through(self):
+        # 39-char curr in a 40-char budget — even though the shared
+        # prefix with prev is 29 chars, the reader gets to see the whole
+        # thing.
+        prev = "cd /opt/myproject/sub/dir && git status"
+        curr = "cd /opt/myproject/sub/dir && cat README"
+        out = truncate_middle(curr, max_len=40, prev=prev)
+        assert out == "cd /opt/myproject/sub/dir && cat README"
+
+
+# ── Presentation only (dedup moved to raw identity) ─────────────────────
+
+class TestPresentationOnly:
+    """``truncate_middle`` no longer round-trips a cached truncation for
+    identical re-calls — the gateway dedups on raw identity, so an
+    identical re-call may render via the head-tail fallback.  All the
+    function must guarantee is determinism and the length budget."""
+
+    def test_identical_recall_is_deterministic_and_bounded(self):
+        t = "cd /opt/app && rake db:migrate VERSION=20251201"
+        a = truncate_middle(t, max_len=40, prev=t)
+        b = truncate_middle(t, max_len=40, prev=t)
+        assert a == b
+        assert len(a) <= 40
+
+
+# ── Diff-aware truncation when text doesn't fit ─────────────────────────
+
+class TestRevealsTheDiff:
+    """When ``text`` overflows the budget but a ``prev`` is available,
+    show everything from the first differing char to the end (mandatory),
+    then pack as much of the shared prefix in front as fits."""
+
+    def test_shows_diff_tail_plus_prefix_beginning(self):
+        # Path is the same, only the trailing action changed.
+        # 39-char curr in a 20-char budget — diff-aware truncation kicks
+        # in, showing the action in full and as much of the leading path
+        # as fits.
+        prev = "cd /opt/myproject/sub/dir && git status"
+        curr = "cd /opt/myproject/sub/dir && cat README"
+
+        out = truncate_middle(curr, max_len=20, prev=prev)
+
+        # 10 chars "cat README" + 3 chars "..." + 7 chars beginning prefix = 20
+        assert out == "cd /opt...cat README"
+        assert len(out) == 20
+
+    def test_path_grew_by_one_segment(self):
+        # Tight budget forces truncation; the new "/Y" segment is in
+        # the mandatory tail, the beginning of the path provides context.
+        prev = "cd /home/user/path/X && ls"
+        curr = "cd /home/user/path/X/Y && ls"
+
+        out = truncate_middle(curr, max_len=20, prev=prev)
+
+        # 8 chars "/Y && ls" + 3 chars "..." + 9 chars "cd /home/" = 20
+        assert out == "cd /home/.../Y && ls"
+        assert len(out) == 20
+
+    def test_action_after_long_shared_path(self):
+        # Path is identical, action is the diff; budget is just barely
+        # bigger than the diff itself.
+        prev = "cd /opt/myproject/sub/dir && git status --short"
+        curr = "cd /opt/myproject/sub/dir && cat README"
+
+        out = truncate_middle(curr, max_len=13, prev=prev)
+
+        # The 10-char "cat README" plus "..." takes 13 → no room for any
+        # prefix content, just the elision marker.
+        assert out == "...cat README"
+
+
+# ── Fallback when even the diff doesn't fit ─────────────────────────────
+
+class TestFallbackWhenDiffTooBig:
+    """If the mandatory "diff onward" tail itself exceeds ``max_len``,
+    head-tail-truncate the whole string instead."""
+
+    def test_huge_paste_after_tiny_shared_prefix(self):
+        prev = "ab"
+        curr = "ab" + ("x" * 100)
+        out = truncate_middle(curr, max_len=20, prev=prev)
+        assert len(out) == 20
+        assert "..." in out
+
+    def test_completely_unrelated_strings(self):
+        # No common prefix → no diff-aware path possible.
+        prev = "alpha"
+        curr = "completely-different-very-long-string-here"
+        out = truncate_middle(curr, max_len=15, prev=prev)
+        assert len(out) == 15
+        assert "..." in out
+
+
+# ── Defensive edge cases ────────────────────────────────────────────────
+
+class TestEdgeCases:
+
+    def test_zero_max_len_returns_empty(self):
+        assert truncate_middle("anything", max_len=0) == ""
+
+    def test_negative_max_len_returns_empty(self):
+        assert truncate_middle("anything", max_len=-5) == ""
+
+    def test_no_prev_long_text_uses_head_and_tail_fallback(self):
+        out = truncate_middle("a" * 80, max_len=20)
+        assert len(out) == 20
+        assert "..." in out
+        assert out.startswith("a") and out.endswith("a")
+
+    def test_unicode_length_counted_in_codepoints(self):
+        # Length budget is in chars (Python str codepoints), not bytes.
+        text = "日本語" + "x" * 80
+        out = truncate_middle(text, max_len=12)
+        assert len(out) == 12
+
+    def test_prefix_too_small_to_replace_with_ellipsis(self):
+        # When prefix is only 1-2 chars but full text overflows, we
+        # show "..." + tail rather than wasting room on tiny prefix
+        # content.  This case exists for parity, not common use.
+        prev = "x"
+        curr = "x-here-is-a-very-long-tail-that-fills-most-of-the-budget"
+        out = truncate_middle(curr, max_len=20, prev=prev)
+        # Tail alone is much longer than budget → head-tail fallback.
+        assert len(out) == 20
+
+
+# ── End-to-end against the gateway dedup loop ───────────────────────────
+
+class TestGatewayDedupPipeline:
+    """Simulate the producer side of ``gateway/run.py``: dedup on RAW
+    identity ``(tool_name, raw preview)`` while ``truncate_middle`` runs
+    for display only.  The counts hold regardless of how the previews
+    truncate — that is the whole point of keying on raw identity."""
+
+    @staticmethod
+    def _simulate(previews, max_len=40):
+        """Run the gateway's producer loop.  Return
+        ``(distinct_msgs, repeat_ticks)``."""
+        last_raw_key = None
+        last_display_raw = None
+        distinct = 0
+        repeats = 0
+        for preview in previews:
+            raw_key = ("terminal", preview)
+            # Display only — its output does NOT drive dedup.
+            _ = truncate_middle(preview, max_len, prev=last_display_raw)
+            if raw_key == last_raw_key:
+                repeats += 1
+            else:
+                distinct += 1
+                last_raw_key = raw_key
+                last_display_raw = preview
+        return distinct, repeats
+
+    def test_five_true_repeats_collapse_into_one_message_plus_four_ticks(self):
+        # The model genuinely re-issued the same command five times.
+        previews = ["cd /opt/app && git status"] * 5
+        assert self._simulate(previews) == (1, 4)
+
+    def test_five_prefix_sharing_commands_each_show_separately(self):
+        # All five commands share `cd /opt/app/sub/dir && ` but the
+        # action at the end is different every time.  None should
+        # collapse into (×N).
+        previews = [
+            "cd /opt/app/sub/dir && git status",
+            "cd /opt/app/sub/dir && git log -1",
+            "cd /opt/app/sub/dir && cat README",
+            "cd /opt/app/sub/dir && ls plugins",
+            "cd /opt/app/sub/dir && wc -l Gemfile",
+        ]
+        assert self._simulate(previews) == (5, 0)
+
+    def test_two_repeats_then_change_separates_correctly(self):
+        previews = [
+            "cd /opt/app && git status",
+            "cd /opt/app && git status",  # repeat ← tick
+            "cd /opt/app && git status",  # repeat ← tick
+            "cd /opt/app && cat README",  # different ← new msg
+        ]
+        assert self._simulate(previews) == (2, 2)
+
+    def test_long_shared_path_under_tight_budget_distinguishes(self):
+        # 20-char budget, 39-char commands.  Even if two previews were to
+        # truncate alike, raw-identity keying keeps them distinct.
+        previews = [
+            "cd /opt/myproject/sub/dir && git status",
+            "cd /opt/myproject/sub/dir && cat README",
+            "cd /opt/myproject/sub/dir && ls plugins",
+        ]
+        distinct, repeats = self._simulate(previews, max_len=20)
+        assert (distinct, repeats) == (3, 0)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1479,6 +1479,96 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
     assert 'terminal: "' not in all_content
 
 
+class PrefixSharingTerminalAgent:
+    """Two prefix-sharing but DISTINCT terminal commands, then an adjacent
+    true repeat.  The shared prefix is longer than the preview cap, so a
+    head-cut would render CMD_A and CMD_B identically and wrongly fold them
+    into one ``(×N)`` bubble — the reason dedup must key on raw identity."""
+
+    CMD_A = "cd /srv/really/long/shared/workspace/path && make build TARGET=alpha_service"
+    CMD_B = "cd /srv/really/long/shared/workspace/path && make build TARGET=beta_service"
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        cb("tool.started", "terminal", self.CMD_A, {"command": self.CMD_A})
+        cb("tool.started", "terminal", self.CMD_B, {"command": self.CMD_B})
+        cb("tool.started", "terminal", self.CMD_B, {"command": self.CMD_B})  # true repeat
+        time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+async def _run_prefix_sharing_agent(monkeypatch, tmp_path, adapter):
+    import yaml
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = PrefixSharingTerminalAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    # Cap short enough that CMD_A and CMD_B share a prefix longer than the cap
+    # (a head-cut would make them identical).
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_preview_length": 40}}), encoding="utf-8"
+    )
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=adapter.platform, chat_id="12345", chat_type="dm", thread_id=None
+    )
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-prefix-dedup",
+        session_key="agent:main:telegram:dm:12345",
+    )
+    assert result["final_response"] == "done"
+    content = " ".join(c["content"] for c in adapter.sent)
+    content += " " + " ".join(c["content"] for c in adapter.edits)
+    return content
+
+
+@pytest.mark.asyncio
+async def test_prefix_sharing_terminal_dedup_on_raw_identity_code_block(monkeypatch, tmp_path):
+    """supports_code_blocks path: two prefix-sharing but distinct commands must
+    NOT collapse into one ``(×N)`` (a head-cut of the shared prefix would), while
+    an adjacent true repeat still collapses.  Dedup keys on raw tool identity,
+    truncation is presentation only (PR #24304, teknium1 review)."""
+    adapter = CodeBlockProgressAdapter(platform=Platform.TELEGRAM)
+    content = await _run_prefix_sharing_agent(monkeypatch, tmp_path, adapter)
+    # Distinct commands render distinctly — both differentiators survive.
+    assert "alpha_service" in content
+    assert "beta_service" in content
+    # The adjacent true repeat DID collapse...
+    assert "(×2)" in content
+    # ...but the two distinct commands were NOT folded together.
+    assert "(×3)" not in content
+
+
+@pytest.mark.asyncio
+async def test_prefix_sharing_terminal_dedup_on_raw_identity_plain(monkeypatch, tmp_path):
+    """Same guarantee on the plain-preview path (adapter without code blocks):
+    distinct prefix-sharing commands stay distinct, true repeat collapses."""
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)  # supports_code_blocks False
+    content = await _run_prefix_sharing_agent(monkeypatch, tmp_path, adapter)
+    assert "alpha_service" in content
+    assert "beta_service" in content
+    assert "(×2)" in content
+    assert "(×3)" not in content
+
+
 @pytest.mark.asyncio
 async def test_terminal_progress_verbose_shows_full_command(monkeypatch, tmp_path):
     """Verbose mode on a markdown-capable gateway renders the FULL multi-line


### PR DESCRIPTION
Fixes #24298

Replaces the inline head-cut at gateway/run.py with a diff-aware truncate_middle() that maximizes visible content while keeping the gateway's dedup-by-equality (×N) counter working correctly.

The bug it fixes: when the model issues several `cd <same_path> && X` commands in a row with different X, the head-cut to ~40 chars collapses them all to the same `cd <same_path>...` preview.  The downstream dedup-by-equality then folds them into a single bubble with `(×N)`, making the loop-detection signal misleading -- different commands look like a stall.

## agent/display.py

truncate_middle(text, max_len, prev=None, prev_trunc=None) -> str

Resolution order:
1. text == prev and prev_trunc given -> return prev_trunc verbatim. The (×N) dedup contract is preserved by construction, not by happy accident of the truncation math.
2. text fits in max_len -> return text unchanged.  No reason to hide characters we have room to display.
3. prev provided -> show text from the first differing char through the end (the part the reader needs to see), then prepend as much of the shared prefix as budget allows, with "..." marking the elision.
4. No prev (or diff-aware path doesn't fit) -> stateless head + ellipsis + short tail.

Two private helpers (_truncate_around_diff, _head_tail_truncate) keep the public function's branch logic linear.

## gateway/run.py

Two new state closures alongside last_progress_msg / repeat_count:
- last_progress_preview: the untruncated input from the previous tick
- last_progress_preview_trunc: the truncated output that was emitted

These are passed to truncate_middle on the next tick so an identical re-call returns the exact same string, and a prefix-sharing-but-distinct call gets a tail-revealing truncation instead of a head-cut.

The single call site at the "all"/"new" tool-progress mode now reads:

    truncated = truncate_middle(
        preview, _cap,
        prev=last_progress_preview[0],
        prev_trunc=last_progress_preview_trunc[0],
    )
    last_progress_preview[0] = preview
    last_progress_preview_trunc[0] = truncated
    msg = f"{emoji} {tool_name}: \"{truncated}\""

The dedup block below is unchanged -- still `if msg == last_progress_msg[0]`.

## tests/agent/test_display_truncate_middle.py

18 tests across six scenario classes:
- TestPassThroughWhenItFits: the "use the whole budget" property
- TestDedupContractEnforced: cached-output guarantee for true repeats
- TestRevealsTheDiff: shared prefix collapsed when budget is tight
- TestFallbackWhenDiffTooBig: graceful head+tail when diff overflows
- TestEdgeCases: zero/negative max_len, unicode, prefix-shorter-than-ellipsis
- TestGatewayDedupPipeline: end-to-end simulation of the producer loop against the (×N) dedup check, verifying that true repeats coalesce and that prefix-sharing distincts do not collide

All 57 tests in tests/agent/test_display*.py pass.

## What does this PR do?

Replaces the inline head-cut at `gateway/run.py` with a new `truncate_middle()` helper in `agent/display.py` that maximizes visible preview content while keeping the gateway's dedup-by-equality `(×N)` repeat counter working correctly.

Today the gateway head-truncates each tool preview to ~40 chars then dedupes consecutive identical lines. When the model issues several `cd <same_path> && <different_action>` commands, they all map to the same truncated preview, the dedup collapses them into one bubble with `(×N)`, and the user/orchestrator sees what looks like a stall — even though every command was actually different.

The new function:

1. Returns the cached truncation verbatim when the input equals the previous input (dedup contract preserved by construction).
2. Returns the input unchanged when it fits in the budget (no reason to hide chars we have room to display).
3. When the input overflows and a previous preview is available, shows `text` from the first differing char through the end (the part the reader needs), then prepends as much of the shared prefix as fits, with `"..."` marking the elision.
4. Falls back to a stateless head + ellipsis + tail when no previous preview is available.

## Related Issue

Fixes #24298

## Type of Change

- [x] ✨ Fixes gateway (×N) repeat counter fires for distinct commands that share a long prefix

## Changes Made

### `agent/display.py` (+102 lines)

- New public function `truncate_middle(text, max_len, prev=None, prev_trunc=None) -> str` with full docstring covering the resolution order and the dedup-by-equality contract.
- Two private helpers: `_truncate_around_diff` (the diff-aware path), `_head_tail_truncate` (the stateless fallback).
- Module-level constants `_ELLIPSIS`, `_TAIL_FRACTION_NUM`, `_TAIL_FRACTION_DEN` for the fallback's prefix/tail split.

### `gateway/run.py` (+22 / −4)

- Two new closure state containers next to the existing `last_progress_msg` / `repeat_count`:

  ```python
  last_progress_preview = [None]        # untruncated preview from prev tick
  last_progress_preview_trunc = [None]  # its truncated form (cached)
  ```

- The single call site in `progress_callback` (`"all"`/`"new"` modes) now reads:

  ```python
  truncated = truncate_middle(
      preview, _cap,
      prev=last_progress_preview[0],
      prev_trunc=last_progress_preview_trunc[0],
  )
  last_progress_preview[0] = preview
  last_progress_preview_trunc[0] = truncated
  msg = f'{emoji} {tool_name}: "{truncated}"'
  ```

- The dedup block below is unchanged: `if msg == last_progress_msg[0]` still compares the final-display string, and `truncate_middle` guarantees byte-identical output for byte-identical input.

### `tests/agent/test_display_truncate_middle.py` (new, 18 tests)

Each test is a documented worked example (prev preview / new preview / budget / expected output) — they read top-to-bottom like behaviour documentation. Six scenario classes:

- `TestPassThroughWhenItFits` — full-display behaviour when the budget allows it
- `TestDedupContractEnforced` — cached-output guarantee for true repeats
- `TestRevealsTheDiff` — shared prefix collapsed when the budget is tight
- `TestFallbackWhenDiffTooBig` — graceful head+tail when the diff overflows
- `TestEdgeCases` — zero/negative `max_len`, unicode (chars not bytes), short shared prefix
- `TestGatewayDedupPipeline` — end-to-end simulation of the producer loop against the `(×N)` dedup check, verifying that true repeats coalesce and prefix-sharing distincts do not collide

## How to Test

A real-world reproduction:

```bash
# In a Hermes session attached to a gateway (Telegram / Matrix / Slack / Discord),
# prompt the agent to run several shell commands in the same long path.
# Before this PR: all five collapse into one bubble with (×5).
# After:         each lands as its own bubble, distinguishable by its tail.

agent$ cd /home/agent/Coding/my-project && git rev-parse --abbrev-ref HEAD
agent$ cd /home/agent/Coding/my-project && git log -1 --oneline
agent$ cd /home/agent/Coding/my-project && git status -s | wc -l
agent$ cd /home/agent/Coding/my-project && git branch --show-current
agent$ cd /home/agent/Coding/my-project && cat config/database.yml | head -1
```

Expected tool-progress bubbles after this PR:

```
💻 terminal: "cd /home/agent/Coding/G...bbrev-ref HEAD"
💻 terminal: "cd /home/agent/Coding...log -1 --oneline"
💻 terminal: "cd /home/agent/Codin...status -s | wc -l"
💻 terminal: "cd /home/agent/Codin...nch --show-current"
💻 terminal: "cd /home/age...se.yml | head -1"
```

Tests:

```bash
pytest tests/agent/test_display_truncate_middle.py -v   # 18 passed
pytest tests/agent/test_display.py tests/agent/test_display_emoji.py \
       tests/agent/test_display_truncate_middle.py       # 57 passed (no regression)
```

## Checklist

- [x] Tests added/updated
- [x] No existing tests regressed
- [x] Behaviour matches what's described in the linked issue
- [x] Single, focused change (no incidental refactors)

