### PR TITLE
fix(kanban): auto-subscribe gateway origin to kanban_create notificat…

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -608,6 +608,96 @@ def test_create_rejects_no_title(worker_env):
     assert json.loads(kt._handle_create({"title": "   ", "assignee": "x"})).get("error")
 
 
+def test_create_auto_subscribes_when_in_gateway_session(worker_env, monkeypatch):
+    """When kanban_create runs inside a gateway-bound session (the LLM was
+    invoked from a chat message on Telegram/Feishu/Discord/...), the new
+    task should automatically register a notify subscription so the user
+    is pinged when it reaches done/blocked. Mirrors the auto-subscribe
+    behavior of the /kanban create slash command."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(
+        kt,
+        "_capture_origin_from_session",
+        lambda: {
+            "platform": "telegram",
+            "chat_id": "-100123",
+            "thread_id": "42",
+            "user_id": "u_abc",
+        },
+    )
+
+    out = kt._handle_create({"title": "ping me when done", "assignee": "peer"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["notify_subscribed"] == "telegram"
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id=d["task_id"])
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    sub = subs[0]
+    assert sub["platform"] == "telegram"
+    assert sub["chat_id"] == "-100123"
+    assert sub["thread_id"] == "42"
+    assert sub["user_id"] == "u_abc"
+
+
+def test_create_skips_subscription_when_no_gateway_session(worker_env, monkeypatch):
+    """When kanban_create runs in CLI / cron / any non-gateway context where
+    HERMES_SESSION_PLATFORM isn't bound, no subscription is created (there
+    is no inbox to notify). Task creation itself still succeeds."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kt, "_capture_origin_from_session", lambda: None)
+
+    out = kt._handle_create({"title": "cli task", "assignee": "peer"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d.get("notify_subscribed") is None
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id=d["task_id"])
+    finally:
+        conn.close()
+    assert subs == []
+
+
+def test_create_subscription_failure_does_not_break_task(worker_env, monkeypatch):
+    """Auto-subscribe is best-effort: if writing the subscription row throws
+    (e.g. schema drift, locked DB), task creation must still succeed and
+    return a usable task_id. The subscription error gets logged."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(
+        kt,
+        "_capture_origin_from_session",
+        lambda: {
+            "platform": "discord",
+            "chat_id": "999",
+            "thread_id": None,
+            "user_id": None,
+        },
+    )
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated subscription failure")
+
+    monkeypatch.setattr(kb, "add_notify_sub", _boom)
+
+    out = kt._handle_create({"title": "resilient", "assignee": "peer"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["task_id"]
+    assert d.get("notify_subscribed") is None
+
+
 def test_create_rejects_no_assignee(worker_env):
     from tools import kanban_tools as kt
     assert json.loads(kt._handle_create({"title": "t"})).get("error")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -698,6 +698,77 @@ def test_create_subscription_failure_does_not_break_task(worker_env, monkeypatch
     assert d.get("notify_subscribed") is None
 
 
+def test_resolve_notifier_profile_prefers_env_var(monkeypatch):
+    """When dispatcher spawns a worker it exports HERMES_PROFILE; that
+    must take precedence so worker-created child tasks are owned by the
+    worker's profile (not the default gateway's profile)."""
+    from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_PROFILE", "writer-cat")
+    assert kt._resolve_notifier_profile() == "writer-cat"
+
+
+def test_resolve_notifier_profile_falls_back_to_active_profile(monkeypatch):
+    """When HERMES_PROFILE isn't set (default profile gateway processes
+    don't export it), the resolver must derive the profile from
+    HERMES_HOME so the subscription is still owned by a real profile —
+    not None, which would let every connected gateway claim the event
+    and deliver duplicate notifications."""
+    from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    # worker_env-style monkeypatching is not needed; we just stub the
+    # imported helper to avoid coupling to HERMES_HOME state.
+    import hermes_cli.profiles as profiles_mod
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "default")
+    assert kt._resolve_notifier_profile() == "default"
+
+
+def test_resolve_notifier_profile_final_fallback(monkeypatch):
+    """If HERMES_PROFILE is unset AND get_active_profile_name raises (e.g.
+    hermes_cli.profiles unimportable in some test contexts), the resolver
+    must still return a non-None string. Returning None would silently
+    duplicate notifications across all connected gateway profiles."""
+    from tools import kanban_tools as kt
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    import hermes_cli.profiles as profiles_mod
+    def _boom():
+        raise RuntimeError("simulated import failure")
+    monkeypatch.setattr(profiles_mod, "get_active_profile_name", _boom)
+    assert kt._resolve_notifier_profile() == "default"
+
+
+def test_create_writes_resolved_notifier_profile_to_subscription(worker_env, monkeypatch):
+    """End-to-end: the subscription row written by kanban_create must
+    carry a non-None notifier_profile so the gateway's profile-ownership
+    filter routes events to exactly one gateway (avoiding duplicate
+    deliveries when multiple profile gateways are running concurrently)."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(
+        kt,
+        "_capture_origin_from_session",
+        lambda: {
+            "platform": "feishu",
+            "chat_id": "oc_xxx",
+            "thread_id": None,
+            "user_id": "ou_xxx",
+        },
+    )
+    monkeypatch.setenv("HERMES_PROFILE", "writer-cat")
+
+    out = kt._handle_create({"title": "owned task", "assignee": "peer"})
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id=d["task_id"])
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["notifier_profile"] == "writer-cat"
+
+
 def test_create_rejects_no_assignee(worker_env):
     from tools import kanban_tools as kt
     assert json.loads(kt._handle_create({"title": "t"})).get("error")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -551,6 +551,35 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _resolve_notifier_profile() -> Optional[str]:
+    """Resolve the profile name that should own this notify subscription,
+    matching the resolution order used by the gateway's ``/kanban create``
+    auto-subscribe path (``gateway/run.py``: ``self._active_profile_name()``).
+
+    Order:
+    1. ``HERMES_PROFILE`` env var (set by the dispatcher when spawning a
+       worker, so worker-created tasks are owned by the worker's profile).
+    2. ``hermes_cli.profiles.get_active_profile_name()`` (derives from
+       ``HERMES_HOME`` — handles the gateway-bound default profile, which
+       does not export ``HERMES_PROFILE``).
+    3. ``"default"`` as a final fallback.
+
+    Without this, default-profile gateways would write ``None`` as the
+    subscription owner, and the gateway notifier's profile-ownership
+    filter (``if owner_profile and owner_profile != notifier_profile``)
+    would let *every* connected gateway profile claim and deliver the
+    same event — duplicating notifications across N profiles.
+    """
+    env_profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if env_profile:
+        return env_profile
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
 def _capture_origin_from_session() -> Optional[Dict[str, Any]]:
     """Capture the gateway source (platform/chat/thread/user) of the current
     LLM call, mirroring the pattern used by cronjob_tools._origin_from_env.
@@ -657,7 +686,7 @@ def _handle_create(args: dict, **kw) -> str:
                         chat_id=origin["chat_id"],
                         thread_id=origin["thread_id"],
                         user_id=origin["user_id"],
-                        notifier_profile=os.environ.get("HERMES_PROFILE") or None,
+                        notifier_profile=_resolve_notifier_profile(),
                     )
                     subscribed_to = origin["platform"]
                 except Exception as _sub_exc:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from tools.registry import registry, tool_error
 
@@ -551,6 +551,32 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _capture_origin_from_session() -> Optional[Dict[str, Any]]:
+    """Capture the gateway source (platform/chat/thread/user) of the current
+    LLM call, mirroring the pattern used by cronjob_tools._origin_from_env.
+
+    Returns None when running outside a gateway context (e.g. CLI chat or
+    cron-spawned worker without bound session env), in which case there is
+    no inbox to notify and the caller should skip auto-subscription.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+    platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip()
+    chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+    if not platform or not chat_id:
+        return None
+    thread_id = (get_session_env("HERMES_SESSION_THREAD_ID", "") or "").strip() or None
+    user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip() or None
+    return {
+        "platform": platform.lower(),
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+        "user_id": user_id,
+    }
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -614,9 +640,35 @@ def _handle_create(args: dict, **kw) -> str:
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
+            # Auto-subscribe the originating gateway session to terminal-state
+            # notifications for this task, so the user (in their original
+            # chat/thread) receives a ping when the task reaches done/blocked.
+            # Mirrors the auto-subscribe behavior the gateway already applies
+            # to /kanban create slash commands. Best-effort: any failure is
+            # logged and swallowed — task creation has already succeeded.
+            origin = _capture_origin_from_session()
+            subscribed_to: Optional[str] = None
+            if origin:
+                try:
+                    kb.add_notify_sub(
+                        conn,
+                        task_id=new_tid,
+                        platform=origin["platform"],
+                        chat_id=origin["chat_id"],
+                        thread_id=origin["thread_id"],
+                        user_id=origin["user_id"],
+                        notifier_profile=os.environ.get("HERMES_PROFILE") or None,
+                    )
+                    subscribed_to = origin["platform"]
+                except Exception as _sub_exc:
+                    logger.warning(
+                        "kanban_create: auto-subscribe failed for task %s: %s",
+                        new_tid, _sub_exc,
+                    )
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                notify_subscribed=subscribed_to,
             )
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

When the LLM calls the `kanban_create` tool inside a gateway-bound session (a chat message from Telegram / Feishu / Discord / Slack / etc.), the new task is now auto-subscribed to terminal-state notifications, so the originating user receives a ping in their original chat/thread when the task reaches `done` or `blocked`.

## Why

The gateway already auto-subscribes when the user types `/kanban create ...` as a slash command (see [`gateway/run.py` ~L8510](https://github.com/NousResearch/hermes-agent/blob/main/gateway/run.py#L8510) — it parses the CLI's success line and calls `add_notify_sub`).

But when the user **talks to the LLM in natural language** — the most common multi-agent UX, e.g. *"PM, please dispatch this to the writer"* — the LLM goes through the `kanban_create` tool. That tool path bypasses the auto-subscribe entirely, so:

1. The task is created.
2. The dispatcher spawns a worker.
3. The worker completes / blocks → emits a `task_events` row.
4. The gateway's `_kanban_notifier_watcher` polls `kanban_notify_subs` every 5s — and finds nothing for this task.
5. **The user is never notified.** They have to poll `kanban_list` themselves or pester the PM agent ("how's it going?").

This makes orchestrator-style workflows feel broken — the user dispatches work, the PM cheerfully says "I'll watch the board", but neither the PM (which has no way to wake up later) nor the gateway has any idea where to deliver the result.

## Implementation

Mirrors the pattern used by `cronjob_tools._origin_from_env`:

- New helper `_capture_origin_from_session()` reads `HERMES_SESSION_PLATFORM` / `CHAT_ID` / `THREAD_ID` / `USER_ID` from the per-call gateway session env (already wired up via `gateway.session_context` for cronjob / yuanbao / approval / terminal / skills tools).
- `_handle_create()` calls `kanban_db.add_notify_sub()` after a successful task creation, on the same DB connection.
- The subscription is **best-effort**: if `add_notify_sub` raises, the error is logged and the task creation result is still returned (the user has a usable `task_id`, just no auto-ping).
- When not running under a gateway session (CLI chat, cron-spawned worker without bound source), no subscription is created. The result field `notify_subscribed` is `null`, and the existing watcher correctly does nothing for that task.

The result envelope gains one optional field — `notify_subscribed: <platform> | null` — so callers can confirm whether a ping is wired up.

## Tests

Three new tests in `tests/tools/test_kanban_tools.py`:

- `test_create_auto_subscribes_when_in_gateway_session` — happy path; verifies a row appears in `kanban_notify_subs` with the right platform / chat / thread / user.
- `test_create_skips_subscription_when_no_gateway_session` — CLI/cron path; verifies no subscription is created and the field is `null`.
- `test_create_subscription_failure_does_not_break_task` — resilience; task creation still succeeds when `add_notify_sub` throws.

All 77 tests in the kanban_tools / kanban_notifier / kanban_notify suites pass:

```
$ pytest tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py
77 passed in 5.39s
```

## Backward compatibility

- Existing `/kanban create` slash-command flow: unchanged (still auto-subscribes via `gateway/run.py`).
- Existing `kanban_create` tool calls from CLI / cron contexts: behavior unchanged (no subscription, since no platform is bound).
- New optional response field `notify_subscribed`: clients that ignore unknown fields are unaffected.

## Out of scope

- Subscribing to a *different* destination than the origin chat (e.g. broadcasting to all connected channels). The gateway notifier already supports multiple subscriptions per task; that can be exposed via a follow-up `kanban_notify_subscribe` tool if there's demand.
- Re-subscribing existing tasks created before this fix.
