### PR TITLE
fix(cli): fall back to ASCII display on Windows MSYS terminals

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -13,6 +13,13 @@ from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
 
+from hermes_cli.display_compat import (
+    get_ascii_spinner_frames,
+    get_ascii_thinking_faces,
+    get_ascii_waiting_faces,
+    make_terminal_display_safe,
+    terminal_prefers_ascii,
+)
 from utils import safe_json_loads
 
 # ANSI escape codes for coloring tool failure indicators
@@ -126,6 +133,8 @@ def _get_skin():
 
 def get_skin_tool_prefix() -> str:
     """Get tool output prefix character from active skin."""
+    if terminal_prefers_ascii():
+        return "|"
     skin = _get_skin()
     if skin:
         return skin.tool_prefix
@@ -140,6 +149,8 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
     2. Tool registry's per-tool ``emoji`` field
     3. *default* fallback
     """
+    if terminal_prefers_ascii():
+        return "*"
     # 1. Skin override
     skin = _get_skin()
     if skin and skin.tool_emojis:
@@ -605,6 +616,8 @@ class KawaiiSpinner:
     @classmethod
     def get_waiting_faces(cls) -> list:
         """Return waiting faces from the active skin, falling back to KAWAII_WAITING."""
+        if terminal_prefers_ascii():
+            return get_ascii_waiting_faces()
         try:
             skin = _get_skin()
             if skin:
@@ -618,6 +631,8 @@ class KawaiiSpinner:
     @classmethod
     def get_thinking_faces(cls) -> list:
         """Return thinking faces from the active skin, falling back to KAWAII_THINKING."""
+        if terminal_prefers_ascii():
+            return get_ascii_thinking_faces()
         try:
             skin = _get_skin()
             if skin:
@@ -643,7 +658,10 @@ class KawaiiSpinner:
 
     def __init__(self, message: str = "", spinner_type: str = 'dots', print_fn=None):
         self.message = message
-        self.spinner_frames = self.SPINNERS.get(spinner_type, self.SPINNERS['dots'])
+        if terminal_prefers_ascii():
+            self.spinner_frames = list(get_ascii_spinner_frames())
+        else:
+            self.spinner_frames = self.SPINNERS.get(spinner_type, self.SPINNERS['dots'])
         self.running = False
         self.thread = None
         self.frame_idx = 0
@@ -663,6 +681,7 @@ class KawaiiSpinner:
         If a print_fn was supplied at construction, all output is routed through
         it instead — allowing callers to silence the spinner with a no-op lambda.
         """
+        text = make_terminal_display_safe(text)
         if self._print_fn is not None:
             try:
                 self._print_fn(text)
@@ -870,6 +889,7 @@ def get_cute_tool_message(
         """Apply skin tool prefix and failure suffix."""
         if skin_prefix != "┊":
             line = line.replace("┊", skin_prefix, 1)
+        line = make_terminal_display_safe(line)
         if not is_failure:
             return line
         return f"{line}{failure_suffix}"
@@ -1004,5 +1024,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/cli.py
+++ b/cli.py
@@ -108,6 +108,11 @@ from hermes_cli.browser_connect import (
     manual_chrome_debug_command,
     try_launch_chrome_debug,
 )
+from hermes_cli.display_compat import (
+    get_ascii_spinner_frames,
+    make_terminal_display_safe,
+    terminal_prefers_ascii,
+)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import base_url_host_matches, is_truthy_value
 
@@ -1507,6 +1512,7 @@ def _cprint(text: str):
     ``loop.call_soon_threadsafe``, which pauses the input area, prints
     the line above it, and redraws the prompt cleanly.
     """
+    text = make_terminal_display_safe(text)
     _record_output_history(text)
 
     try:
@@ -3811,8 +3817,9 @@ class HermesCLI:
 
     def _command_spinner_frame(self) -> str:
         """Return the current spinner frame for slow slash commands."""
-        frame_idx = int(time.monotonic() * 10) % len(_COMMAND_SPINNER_FRAMES)
-        return _COMMAND_SPINNER_FRAMES[frame_idx]
+        frames = get_ascii_spinner_frames() if terminal_prefers_ascii() else _COMMAND_SPINNER_FRAMES
+        frame_idx = int(time.monotonic() * 10) % len(frames)
+        return frames[frame_idx]
 
     @contextmanager
     def _busy_command(self, status: str):
@@ -10854,6 +10861,7 @@ class HermesCLI:
         except Exception:
             symbol = "❯ "
 
+        symbol = make_terminal_display_safe(symbol)
         symbol = (symbol or "❯ ").rstrip() + " "
 
         # Prepend profile name when not default
@@ -10866,6 +10874,8 @@ class HermesCLI:
             pass
         stripped = symbol.rstrip()
         if not stripped:
+            if terminal_prefers_ascii():
+                return "> ", "> "
             return "❯ ", "❯ "
 
         parts = stripped.split()

--- a/hermes_cli/display_compat.py
+++ b/hermes_cli/display_compat.py
@@ -1,0 +1,115 @@
+"""ASCII fallbacks for terminals with weak Unicode rendering.
+
+Git Bash / MSYS2 on Windows can accept UTF-8 bytes while still rendering some
+decorative CLI glyphs as ``?``.  Keep the normal rich glyphs everywhere else,
+but downgrade display-only adornments to ASCII in those terminals.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_ASCII_SPINNER_FRAMES = ("-", "\\", "|", "/")
+_ASCII_WAITING_FACES = ["(...)", "(wait)", "(idle)"]
+_ASCII_THINKING_FACES = ["(...)", "(think)", "(work)"]
+
+_ASCII_REPLACEMENTS = (
+    ("◆ Hermes:", "* Hermes:"),
+    ("● You:", "* You:"),
+    ("⚕ Hermes Agent", "Hermes Agent"),
+    ("⚕ Hermes", "Hermes"),
+    ("⚠️", "!"),
+    ("⚠", "!"),
+    ("💾", "[save]"),
+    ("📎", "[img]"),
+    ("👁️", "view"),
+    ("👁", "view"),
+    ("🖼️", "img"),
+    ("🖼", "img"),
+    ("⌨️", "key"),
+    ("⌨", "key"),
+    ("✍️", "write"),
+    ("✍", "write"),
+    ("🕸️", "web"),
+    ("🕸", "web"),
+    ("🔍", "search"),
+    ("📄", "file"),
+    ("💻", "$"),
+    ("⚙️", "proc"),
+    ("⚙", "proc"),
+    ("📖", "read"),
+    ("🔧", "patch"),
+    ("🔎", "grep"),
+    ("🌐", "web"),
+    ("📸", "snap"),
+    ("👆", "click"),
+    ("📋", "plan"),
+    ("🧠", "mem"),
+    ("📚", "skills"),
+    ("🎨", "art"),
+    ("🔊", "speak"),
+    ("📨", "send"),
+    ("⏰", "cron"),
+    ("🧪", "rl"),
+    ("🐍", "py"),
+    ("🔀", "->"),
+    ("◀️", "back"),
+    ("◀", "back"),
+    ("✨", "*"),
+    ("✦", "*"),
+    ("⚡", "*"),
+    ("⏳", "*"),
+    ("✓", "OK"),
+    ("✔", "OK"),
+    ("✗", "x"),
+    ("✘", "x"),
+    ("❯", ">"),
+    ("›", ">"),
+    ("»", ">>"),
+    ("→", "->"),
+    ("←", "<-"),
+    ("↑", "^"),
+    ("↓", "v"),
+    ("┊", "|"),
+)
+
+
+def terminal_prefers_ascii() -> bool:
+    """Return True when the current terminal should avoid decorative Unicode."""
+    forced = os.getenv("HERMES_FORCE_ASCII_DISPLAY")
+    if forced is not None:
+        return forced.strip().lower() not in {"", "0", "false", "no", "off"}
+
+    if sys.platform != "win32":
+        return False
+
+    if os.getenv("MSYSTEM"):
+        return True
+
+    ostype = (os.getenv("OSTYPE") or "").lower()
+    term = (os.getenv("TERM") or "").lower()
+    return any(token in ostype or token in term for token in ("msys", "mingw"))
+
+
+def make_terminal_display_safe(text: str) -> str:
+    """Downgrade display-only glyphs to ASCII when the terminal needs it."""
+    rendered = str(text)
+    if not rendered or not terminal_prefers_ascii():
+        return rendered
+
+    for source, replacement in _ASCII_REPLACEMENTS:
+        rendered = rendered.replace(source, replacement)
+    return rendered
+
+
+def get_ascii_spinner_frames() -> tuple[str, ...]:
+    return _ASCII_SPINNER_FRAMES
+
+
+def get_ascii_waiting_faces() -> list[str]:
+    return list(_ASCII_WAITING_FACES)
+
+
+def get_ascii_thinking_faces() -> list[str]:
+    return list(_ASCII_THINKING_FACES)

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -118,6 +118,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
+from hermes_cli.display_compat import make_terminal_display_safe, terminal_prefers_ascii
 
 logger = logging.getLogger(__name__)
 
@@ -793,7 +794,9 @@ def get_active_prompt_symbol(fallback: str = "❯") -> str:
     except Exception:
         raw = fallback
 
-    cleaned = (raw or fallback).strip()
+    cleaned = make_terminal_display_safe((raw or fallback).strip())
+    if not cleaned and terminal_prefers_ascii():
+        cleaned = ">"
 
     return f"{cleaned or fallback.strip()} "
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -149,6 +149,27 @@ class TestCuteToolMessagePreviewLength:
         assert path in line
         assert "..." not in line
 
+    def test_tool_message_uses_ascii_fallback_when_terminal_prefers_it(self, monkeypatch):
+        monkeypatch.setenv("HERMES_FORCE_ASCII_DISPLAY", "1")
+
+        line = get_cute_tool_message("browser_scroll", {"direction": "right"}, 0.1)
+
+        assert line.startswith("|")
+        assert "->" in line
+        assert "┊" not in line
+        assert "→" not in line
+
+
+class TestSpinnerAsciiFallback:
+    def test_spinner_uses_ascii_frames_in_msys_terminals(self, monkeypatch):
+        from agent.display import KawaiiSpinner
+
+        monkeypatch.setenv("HERMES_FORCE_ASCII_DISPLAY", "1")
+
+        spinner = KawaiiSpinner("⚡ working")
+
+        assert spinner.spinner_frames == ["-", "\\", "|", "/"]
+
 
 class TestEditDiffPreview:
     def test_extract_edit_diff_for_patch(self):

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -33,6 +33,7 @@ def test_cprint_no_app_direct_print(monkeypatch):
     calls = []
     monkeypatch.setattr(cli, "_pt_print", lambda x: calls.append(("pt_print", x)))
     monkeypatch.setattr(cli, "_PT_ANSI", lambda t: ("ANSI", t))
+    monkeypatch.setattr(cli, "make_terminal_display_safe", lambda text: text.replace("◆", "*"))
 
     # Patch the prompt_toolkit import the function performs internally.
     fake_pt_app = types.ModuleType("prompt_toolkit.application")
@@ -43,6 +44,22 @@ def test_cprint_no_app_direct_print(monkeypatch):
     cli._cprint("hello")
 
     assert calls == [("pt_print", ("ANSI", "hello"))]
+
+
+def test_cprint_applies_ascii_display_fallback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli, "_pt_print", lambda x: calls.append(x))
+    monkeypatch.setattr(cli, "_PT_ANSI", lambda t: t)
+    monkeypatch.setattr(cli, "make_terminal_display_safe", lambda text: text.replace("◆", "*").replace("❯", ">"))
+
+    fake_pt_app = types.ModuleType("prompt_toolkit.application")
+    fake_pt_app.get_app_or_none = lambda: None
+    fake_pt_app.run_in_terminal = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "prompt_toolkit.application", fake_pt_app)
+
+    cli._cprint("◆ Hermes: ready ❯")
+
+    assert calls == ["* Hermes: ready >"]
 
 
 def test_cprint_app_not_running_direct_print(monkeypatch):

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -254,6 +254,14 @@ class TestCliBrandingHelpers:
         set_active_skin("ares")
         assert get_active_prompt_symbol() == "⚔ "
 
+    def test_active_prompt_symbol_uses_ascii_fallback_when_needed(self, monkeypatch):
+        from hermes_cli.skin_engine import get_active_prompt_symbol, set_active_skin
+
+        set_active_skin("default")
+        monkeypatch.setenv("HERMES_FORCE_ASCII_DISPLAY", "1")
+
+        assert get_active_prompt_symbol() == "> "
+
     def test_active_help_header_ares(self):
         from hermes_cli.skin_engine import set_active_skin, get_active_help_header
 


### PR DESCRIPTION
## Summary
- add a small display-compat layer that detects Windows MSYS-style terminals and swaps decorative glyphs for ASCII-safe equivalents
- apply the fallback to CLI prefixes, prompt symbols, tool-progress output, and spinner faces/frames so the UI stops rendering `?` in these terminals
- cover the regression with targeted CLI, display, and skin-engine tests

Closes #24277.

## Verification
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- `uv run --frozen python scripts/lint_diff.py --base-ruff .paperclip_artifacts/quality-gate/lint-diff/touched-base-ruff.json --head-ruff .paperclip_artifacts/quality-gate/lint-diff/touched-head-ruff.json --base-ty .paperclip_artifacts/quality-gate/lint-diff/touched-base-ty.json --head-ty .paperclip_artifacts/quality-gate/lint-diff/touched-head-ty.json --base-ref dd0923bb89ed2dd56f82cb63656a1323f6f42e6f --head-ref 1d6911258-touched --output .paperclip_artifacts/quality-gate/lint-diff/touched-summary-1d6911258.json`
- `scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/agent/test_display.py tests/hermes_cli/test_skin_engine.py`
- `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /bin/bash -lc 'cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-24277-20260512-180720 && scripts/run_tests.sh --collect-only tests/cli/test_cprint_bg_thread.py tests/agent/test_display.py tests/hermes_cli/test_skin_engine.py'`

## Attribution
- touched-surface lint diff is `preexisting_unrelated` for existing `ty` noise and shows no new ruff findings on the changed surface
