### PR TITLE
fix(dashboard): replay chat events after sidebar reconnect

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from collections import deque
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -3186,12 +3187,34 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
         return True
     return client_host in _LOOPBACK_HOSTS
 
-# Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
+# Per-channel event state used by /api/pub (PTY-side gateway → dashboard)
 # and /api/events (dashboard → browser sidebar).  Keyed by an opaque channel id
-# the chat tab generates on mount; entries auto-evict when the last subscriber
-# drops AND the publisher has disconnected.
+# the chat tab generates on mount.  While the PTY-side publisher is alive, keep
+# a small replay buffer so a transient browser-side /api/events disconnect does
+# not permanently lose the final tool/status frames that arrive during the gap.
+# State auto-evicts when the last subscriber drops AND the publisher has
+# disconnected.
+_EVENT_REPLAY_LIMIT = 128
 _event_channels: dict[str, set] = {}
+_event_replay_buffers: dict[str, deque[tuple[int, str]]] = {}
+_event_sequences: dict[str, int] = {}
+_event_replay_after: dict[str, int] = {}
+_event_publishers: dict[str, int] = {}
 _event_lock = asyncio.Lock()
+
+
+def _evict_event_channel_if_idle_locked(channel: str) -> None:
+    """Drop replay state once no publisher or subscriber can use it."""
+    if _event_channels.get(channel):
+        return
+    if _event_publishers.get(channel, 0) > 0:
+        return
+
+    _event_channels.pop(channel, None)
+    _event_replay_buffers.pop(channel, None)
+    _event_sequences.pop(channel, None)
+    _event_replay_after.pop(channel, None)
+    _event_publishers.pop(channel, None)
 
 
 def _resolve_chat_argv(
@@ -3253,17 +3276,40 @@ def _build_sidecar_url(channel: str) -> Optional[str]:
 
 
 async def _broadcast_event(channel: str, payload: str) -> None:
-    """Fan out one publisher frame to every subscriber on `channel`."""
+    """Record and fan out one publisher frame to every subscriber."""
     async with _event_lock:
+        seq = _event_sequences.get(channel, 0) + 1
+        _event_sequences[channel] = seq
+        _event_replay_buffers.setdefault(
+            channel,
+            deque(maxlen=_EVENT_REPLAY_LIMIT),
+        ).append((seq, payload))
         subs = list(_event_channels.get(channel, ()))
 
+    failed_subs = []
     for sub in subs:
         try:
             await sub.send_text(payload)
         except Exception:
-            # Subscriber went away mid-send; the /api/events finally clause
-            # will remove it from the registry on its next iteration.
-            pass
+            failed_subs.append(sub)
+
+    if not failed_subs:
+        return
+
+    async with _event_lock:
+        current_subs = _event_channels.get(channel)
+        if current_subs is None:
+            return
+
+        for sub in failed_subs:
+            current_subs.discard(sub)
+
+        if not current_subs:
+            _event_channels.pop(channel, None)
+            # send_text raised before this frame could be considered
+            # delivered, so replay should resume from the previous sequence.
+            _event_replay_after[channel] = seq - 1
+            _evict_event_channel_if_idle_locked(channel)
 
 
 def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
@@ -3448,11 +3494,22 @@ async def pub_ws(ws: WebSocket) -> None:
 
     await ws.accept()
 
+    async with _event_lock:
+        _event_publishers[channel] = _event_publishers.get(channel, 0) + 1
+
     try:
         while True:
             await _broadcast_event(channel, await ws.receive_text())
     except WebSocketDisconnect:
         pass
+    finally:
+        async with _event_lock:
+            publishers = _event_publishers.get(channel, 0) - 1
+            if publishers > 0:
+                _event_publishers[channel] = publishers
+            else:
+                _event_publishers.pop(channel, None)
+            _evict_event_channel_if_idle_locked(channel)
 
 
 @app.websocket("/api/events")
@@ -3477,7 +3534,23 @@ async def events_ws(ws: WebSocket) -> None:
 
     await ws.accept()
 
+    # Replay is sent while holding the event lock so any concurrent publisher
+    # frame waits until this subscriber has received the backlog and joined the
+    # live fan-out set.  The backlog is deliberately tiny and in-memory only,
+    # scoped to a live PTY-side publisher, so this preserves ordering without
+    # turning the channel into durable session storage.
     async with _event_lock:
+        replay_after = _event_replay_after.get(channel, 0)
+        replay = [
+            payload
+            for seq, payload in _event_replay_buffers.get(channel, ())
+            if seq > replay_after
+        ]
+        for payload in replay:
+            try:
+                await ws.send_text(payload)
+            except Exception:
+                return
         _event_channels.setdefault(channel, set()).add(ws)
 
     try:
@@ -3497,6 +3570,12 @@ async def events_ws(ws: WebSocket) -> None:
 
                 if not subs:
                     _event_channels.pop(channel, None)
+                    _event_replay_after[channel] = _event_sequences.get(
+                        channel,
+                        _event_replay_after.get(channel, 0),
+                    )
+
+            _evict_event_channel_if_idle_locked(channel)
 
 
 def _normalise_prefix(raw: Optional[str]) -> str:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2315,6 +2315,55 @@ class TestPtyWebSocket:
         assert "tool.start" in received
         assert '"tool_id":"t1"' in received
 
+    def test_events_replays_missed_frames_after_subscriber_reconnect(self, monkeypatch):
+        """A transient /api/events subscriber drop should not lose PTY-side
+        events published while the PTY-side /api/pub connection is still alive.
+
+        Dashboard users otherwise see "events feed disconnected" and reconnect
+        to a session whose final tool/status events have already disappeared.
+        """
+        import time
+        from urllib.parse import urlencode
+        from hermes_cli import web_server as ws_mod
+
+        channel = "replay-test"
+        qs = urlencode({"token": self.token, "channel": channel})
+        pub_path = f"/api/pub?{qs}"
+        sub_path = f"/api/events?{qs}"
+
+        def wait_for_subscriber(expected: bool) -> None:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                present = bool(ws_mod._event_channels.get(channel))
+                if present is expected:
+                    return
+                time.sleep(0.01)
+            raise AssertionError(f"subscriber present did not become {expected}")
+
+        with self.client.websocket_connect(pub_path) as pub:
+            with self.client.websocket_connect(sub_path) as sub:
+                wait_for_subscriber(True)
+                pub.send_text(
+                    '{"type":"tool.start","payload":{"tool_id":"before-drop"}}'
+                )
+                assert "before-drop" in sub.receive_text()
+
+            wait_for_subscriber(False)
+            pub.send_text(
+                '{"type":"tool.complete","payload":{"tool_id":"missed-final"}}'
+            )
+            time.sleep(0.05)
+
+            with self.client.websocket_connect(sub_path) as sub:
+                wait_for_subscriber(True)
+                pub.send_text(
+                    '{"type":"tool.start","payload":{"tool_id":"after-reconnect"}}'
+                )
+                received = sub.receive_text()
+
+        assert "missed-final" in received
+        assert "after-reconnect" not in received
+
     def test_events_rejects_missing_channel(self):
         from starlette.websockets import WebSocketDisconnect
 

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -159,28 +159,25 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     const qs = new URLSearchParams({ token, channel });
-    const ws = new WebSocket(
-      `${proto}//${window.location.host}/api/events?${qs.toString()}`,
-    );
+    const url = `${proto}//${window.location.host}/api/events?${qs.toString()}`;
 
-    // `unmounting` suppresses the banner during cleanup — `ws.close()`
+    // `stopped` suppresses the banner/reconnect during cleanup — `ws.close()`
     // from the effect's return fires a close event with code 1005 that
     // would otherwise look like an unexpected drop.
     const DISCONNECTED = "events feed disconnected — tool calls may not appear";
-    let unmounting = false;
-    const surface = (msg: string) => !unmounting && setError(msg);
+    const RECONNECT_DELAY_MS = 1000;
+    let stopped = false;
+    let eventWs: WebSocket | null = null;
+    let retryTimer: number | undefined;
 
-    ws.addEventListener("error", () => surface(DISCONNECTED));
+    const surface = (msg: string) => !stopped && setError(msg);
+    const clearEventsError = () => {
+      setError((current) => (current === DISCONNECTED ? null : current));
+    };
 
-    ws.addEventListener("close", (ev) => {
-      if (ev.code === 4401 || ev.code === 4403) {
-        surface(`events feed rejected (${ev.code}) — reload the page`);
-      } else if (ev.code !== 1000) {
-        surface(DISCONNECTED);
-      }
-    });
+    const handleMessage = (ev: MessageEvent) => {
+      clearEventsError();
 
-    ws.addEventListener("message", (ev) => {
       let frame: RpcEnvelope;
 
       try {
@@ -264,11 +261,62 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
           ),
         );
       }
-    });
+    };
+
+    const scheduleReconnect = () => {
+      if (stopped || retryTimer !== undefined) {
+        return;
+      }
+
+      retryTimer = window.setTimeout(() => {
+        retryTimer = undefined;
+        connect();
+      }, RECONNECT_DELAY_MS);
+    };
+
+    function connect() {
+      if (stopped) {
+        return;
+      }
+
+      const ws = new WebSocket(url);
+      eventWs = ws;
+
+      ws.addEventListener("open", clearEventsError);
+      ws.addEventListener("error", () => surface(DISCONNECTED));
+
+      ws.addEventListener("close", (ev) => {
+        if (eventWs === ws) {
+          eventWs = null;
+        }
+
+        if (stopped) {
+          return;
+        }
+
+        if (ev.code === 4401 || ev.code === 4403) {
+          surface(`events feed rejected (${ev.code}) — reload the page`);
+          return;
+        }
+
+        if (ev.code !== 1000) {
+          surface(DISCONNECTED);
+        }
+
+        scheduleReconnect();
+      });
+
+      ws.addEventListener("message", handleMessage);
+    }
+
+    connect();
 
     return () => {
-      unmounting = true;
-      ws.close();
+      stopped = true;
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer);
+      }
+      eventWs?.close();
     };
   }, [channel, version]);
 


### PR DESCRIPTION
## Summary
- keep a small in-memory replay buffer for Dashboard Chat `/api/pub` → `/api/events` channels while the PTY-side publisher is alive
- replay missed event frames before reconnecting subscribers rejoin live fan-out
- reconnect the ChatSidebar events websocket automatically and clear stale disconnected banners on recovery

## Scope
This is intentionally limited to Dashboard Chat sidebar/tool-status event delivery after a transient `/api/events` subscriber disconnect. It does not change PTY output reconnect, durable session storage, or final assistant text hydration.

## Test Plan
- `git diff --check`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pub_broadcasts_to_events_subscribers tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_events_replays_missed_frames_after_subscriber_reconnect -q`
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestPtyWebSocket -q`
- `npm run build` in `ui-tui/`
- `npm run build` in `web/`
