### PR TITLE
[codex] Preserve Feishu markdown rendering in replies

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -174,6 +174,14 @@ _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
+_MARKDOWN_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_MARKDOWN_BOLD_RE = re.compile(r"\*\*([^*\n](?:.*?[^*\n])?)\*\*")
+_MARKDOWN_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*|\s)([^*\n]+?)(?<!\s)\*(?!\*)")
+_MARKDOWN_STRIKE_RE = re.compile(r"~~([^~\n]+)~~")
+_MARKDOWN_UNDERLINE_RE = re.compile(r"<u>(.*?)</u>")
+_MARKDOWN_HEADING_RE = re.compile(r"^\s*#{1,6}\s+(.*)$")
+_MARKDOWN_HR_RE = re.compile(r"^\s*---+\s*$")
+_MARKDOWN_UNORDERED_LIST_RE = re.compile(r"^(\s*)[-*]\s+(.*)$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
@@ -488,8 +496,15 @@ def _to_boolean(value: Any) -> bool:
     return value is True or value == 1 or value == "true"
 
 
-def _is_style_enabled(style: Dict[str, Any] | None, key: str) -> bool:
+def _is_style_enabled(style: Any, key: str) -> bool:
     if not style:
+        return False
+    aliases = {
+        "strikethrough": {"strikethrough", "lineThrough", "line_through"},
+    }.get(key, {key})
+    if isinstance(style, (list, tuple, set)):
+        return any(str(item) in aliases for item in style)
+    if not isinstance(style, dict):
         return False
     return _to_boolean(style.get(key))
 
@@ -508,21 +523,20 @@ def _sanitize_fence_language(language: str) -> str:
 def _render_text_element(element: Dict[str, Any]) -> str:
     text = str(element.get("text", "") or "")
     style = element.get("style")
-    style_dict = style if isinstance(style, dict) else None
 
-    if _is_style_enabled(style_dict, "code"):
+    if _is_style_enabled(style, "code"):
         return _wrap_inline_code(text)
 
     rendered = _escape_markdown_text(text)
     if not rendered:
         return ""
-    if _is_style_enabled(style_dict, "bold"):
+    if _is_style_enabled(style, "bold"):
         rendered = f"**{rendered}**"
-    if _is_style_enabled(style_dict, "italic"):
+    if _is_style_enabled(style, "italic"):
         rendered = f"*{rendered}*"
-    if _is_style_enabled(style_dict, "underline"):
+    if _is_style_enabled(style, "underline"):
         rendered = f"<u>{rendered}</u>"
-    if _is_style_enabled(style_dict, "strikethrough"):
+    if _is_style_enabled(style, "strikethrough"):
         rendered = f"~~{rendered}~~"
     return rendered
 
@@ -634,6 +648,169 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 
     _flush_current()
     return rows or [[{"tag": "md", "text": content}]]
+
+
+def _build_native_markdown_post_payload(content: str) -> str:
+    rows = _build_native_markdown_post_rows(content)
+    return json.dumps(
+        {
+            "zh_cn": {
+                "content": rows,
+            }
+        },
+        ensure_ascii=False,
+    )
+
+
+def _build_text_post_element(text: str, *styles: str) -> Dict[str, Any]:
+    element: Dict[str, Any] = {"tag": "text", "text": text}
+    if styles:
+        element["style"] = list(dict.fromkeys(styles))
+    return element
+
+
+def _build_link_post_element(label: str, href: str) -> Dict[str, str]:
+    return {"tag": "a", "text": label, "href": href}
+
+
+def _sanitize_feishu_post_href(url: str) -> str:
+    stripped = url.strip()
+    scheme = stripped.split(":", 1)[0].lower().strip() if ":" in stripped else ""
+    return stripped if scheme in {"http", "https"} else ""
+
+
+def _merge_post_styles(element: Dict[str, Any], styles: Sequence[str]) -> Dict[str, Any]:
+    if not styles or element.get("tag") != "text":
+        return element
+    merged = list(dict.fromkeys([*element.get("style", []), *styles]))
+    styled = dict(element)
+    styled["style"] = merged
+    return styled
+
+
+def _find_next_inline_markdown(text: str) -> Optional[tuple[int, int, str, re.Match[str]]]:
+    patterns: Sequence[tuple[str, re.Pattern[str]]] = (
+        ("link", _MARKDOWN_LINK_RE),
+        ("code", _MARKDOWN_INLINE_CODE_RE),
+        ("bold", _MARKDOWN_BOLD_RE),
+        ("strike", _MARKDOWN_STRIKE_RE),
+        ("underline", _MARKDOWN_UNDERLINE_RE),
+        ("italic", _MARKDOWN_ITALIC_RE),
+    )
+    best: Optional[tuple[int, int, str, re.Match[str]]] = None
+    for kind, pattern in patterns:
+        match = pattern.search(text)
+        if not match:
+            continue
+        candidate = (match.start(), match.end(), kind, match)
+        if best is None or candidate[:2] < best[:2]:
+            best = candidate
+    return best
+
+
+def _parse_inline_markdown_to_post_elements(text: str, styles: Sequence[str] = ()) -> List[Dict[str, Any]]:
+    elements: List[Dict[str, Any]] = []
+    remaining = text
+    while remaining:
+        match_info = _find_next_inline_markdown(remaining)
+        if not match_info:
+            if remaining:
+                elements.append(_build_text_post_element(remaining, *styles))
+            break
+
+        start, end, kind, match = match_info
+        if start > 0:
+            elements.append(_build_text_post_element(remaining[:start], *styles))
+
+        if kind == "link":
+            label = _strip_markdown_to_plain_text(match.group(1)).strip()
+            href = _sanitize_feishu_post_href(match.group(2))
+            if href and label:
+                elements.append(_merge_post_styles(_build_link_post_element(label, href), styles))
+            else:
+                elements.append(_build_text_post_element(match.group(0), *styles))
+        elif kind == "code":
+            elements.append(_build_text_post_element(match.group(1), *styles, "code"))
+        elif kind == "bold":
+            elements.extend(_parse_inline_markdown_to_post_elements(match.group(1), (*styles, "bold")))
+        elif kind == "strike":
+            elements.extend(_parse_inline_markdown_to_post_elements(match.group(1), (*styles, "lineThrough")))
+        elif kind == "underline":
+            elements.extend(_parse_inline_markdown_to_post_elements(match.group(1), (*styles, "underline")))
+        elif kind == "italic":
+            elements.extend(_parse_inline_markdown_to_post_elements(match.group(1), (*styles, "italic")))
+
+        remaining = remaining[end:]
+
+    return elements or [_build_text_post_element("", *styles)]
+
+
+def _build_native_markdown_line_row(line: str) -> List[Dict[str, Any]]:
+    heading = _MARKDOWN_HEADING_RE.match(line)
+    if heading:
+        return _parse_inline_markdown_to_post_elements(heading.group(1), ("bold",))
+
+    unordered = _MARKDOWN_UNORDERED_LIST_RE.match(line)
+    if unordered:
+        return [
+            _build_text_post_element(f"{unordered.group(1)}• "),
+            *_parse_inline_markdown_to_post_elements(unordered.group(2)),
+        ]
+
+    return _parse_inline_markdown_to_post_elements(line)
+
+
+def _build_native_markdown_post_rows(content: str) -> List[List[Dict[str, Any]]]:
+    if not content:
+        return [[_build_text_post_element("")]]
+
+    rows: List[List[Dict[str, Any]]] = []
+    in_code_block = False
+    code_language = ""
+    code_lines: List[str] = []
+
+    for raw_line in content.replace("\r\n", "\n").split("\n"):
+        stripped_line = raw_line.strip()
+        if in_code_block:
+            if _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line):
+                rows.append([
+                    {
+                        "tag": "code_block",
+                        "language": _sanitize_fence_language(code_language),
+                        "text": "\n".join(code_lines),
+                    }
+                ])
+                code_language = ""
+                code_lines = []
+                in_code_block = False
+            else:
+                code_lines.append(raw_line)
+            continue
+
+        fence_open = _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
+        if fence_open:
+            in_code_block = True
+            code_language = fence_open.group(1)
+            code_lines = []
+            continue
+
+        if _MARKDOWN_HR_RE.match(stripped_line):
+            rows.append([{"tag": "hr"}])
+        elif not stripped_line:
+            rows.append([_build_text_post_element("")])
+        else:
+            rows.append(_build_native_markdown_line_row(raw_line))
+
+    if in_code_block:
+        rows.append([
+            {
+                "tag": "code_block",
+                "language": _sanitize_fence_language(code_language),
+                "text": "\n".join(code_lines),
+            }
+        ])
+
+    return rows or [[_build_text_post_element(content)]]
 
 
 def parse_feishu_post_payload(
@@ -1918,12 +2095,21 @@ class FeishuAdapter(BasePlatformAdapter):
         # decision at the whole-message level so every chunk consistently
         # uses ``post``. See #26841.
         prefer_post = bool(_MARKDOWN_HINT_RE.search(formatted))
+        # Feishu's ``md``-tag post element renders raw markdown source when the
+        # message is a direct or thread/topic reply, even though the same
+        # element renders correctly for non-reply sends. Build native
+        # ``text``/``a``/``code_block`` post elements for replies instead; the
+        # reply-target resolution here mirrors ``_send_raw_message``'s
+        # ``effective_reply_to`` so both paths agree on what counts as a reply.
+        is_reply = bool(reply_to) or bool(
+            (metadata or {}).get("thread_id") and (metadata or {}).get("reply_to_message_id")
+        )
         last_response = None
 
         try:
             for chunk in chunks:
                 msg_type, payload = self._build_outbound_payload(
-                    chunk, prefer_post=prefer_post,
+                    chunk, prefer_post=prefer_post, native_post=is_reply,
                 )
                 try:
                     response = await self._feishu_send_with_retry(
@@ -4577,7 +4763,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(
-        self, content: str, *, prefer_post: bool = False,
+        self, content: str, *, prefer_post: bool = False, native_post: bool = False,
     ) -> tuple[str, str]:
         # Empirically (issue #52786), current Feishu clients render markdown
         # tables inside ``post``-type ``md`` elements natively. The previous
@@ -4591,6 +4777,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # MAX_MESSAGE_LENGTH, the per-chunk regex would otherwise
         # mis-classify a plain-prose chunk as ``text``. See #26841.
         if prefer_post or _MARKDOWN_HINT_RE.search(content):
+            if native_post:
+                return "post", _build_native_markdown_post_payload(content)
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1304,6 +1304,31 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(media_types, [])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_extract_post_message_understands_style_lists(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            message_type="post",
+            content=(
+                '{"zh_cn":{"content":[['
+                '{"tag":"text","text":"bold","style":["bold"]},'
+                '{"tag":"text","text":" and "},'
+                '{"tag":"text","text":"gone","style":["lineThrough"]}'
+                ']]}}'
+            ),
+            message_id="om_post_styles",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(text, "**bold** and ~~gone~~")
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_post_message_with_rich_elements_does_not_drop_content(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -2911,6 +2936,109 @@ class TestAdapterBehavior(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         elements = payload["zh_cn"]["content"][0]
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_reply_uses_native_post_elements_for_markdown(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_markdown_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = (
+            "## 双语摘要\n"
+            "✅ **已入库 Shared Intel**\n"
+            "🔗 [查看 Base 记录](https://example.com/base/rec)\n"
+            "Use `code`."
+        )
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                    reply_to="om_parent",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        rows = payload["zh_cn"]["content"]
+        self.assertEqual(
+            rows[0],
+            [{"tag": "text", "text": "双语摘要", "style": ["bold"]}],
+        )
+        self.assertEqual(
+            rows[1][1],
+            {"tag": "text", "text": "已入库 Shared Intel", "style": ["bold"]},
+        )
+        self.assertEqual(
+            rows[2][1],
+            {"tag": "a", "text": "查看 Base 记录", "href": "https://example.com/base/rec"},
+        )
+        self.assertEqual(rows[3][1], {"tag": "text", "text": "code", "style": ["code"]})
+        self.assertNotIn('"tag": "md"', captured["request"].request_body.content)
+        self.assertNotIn("**已入库", captured["request"].request_body.content)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_thread_metadata_reply_uses_native_post_elements_for_markdown(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_markdown_thread_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="**状态**：完成",
+                    metadata={
+                        "thread_id": "omt-thread",
+                        "reply_to_message_id": "om_trigger",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].message_id, "om_trigger")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(
+            payload["zh_cn"]["content"][0][0],
+            {"tag": "text", "text": "状态", "style": ["bold"]},
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):


### PR DESCRIPTION
## Summary

Fixes Feishu/Lark reply rendering for Markdown responses by keeping normal sends on the existing `post` + `md` path while converting reply and topic-reply payloads into native Feishu rich-text `post` elements.

## Root cause

Hermes already selected `msg_type=post` for Markdown, but the reply path still relied on a single `tag: md` element. In Feishu replies this can render as raw Markdown text, even though non-reply messages render correctly.

## Changes

- Add a reply-safe Markdown-to-native-Feishu-post converter for headings, bold, italic, strike, underline, inline code, fenced code blocks, links, dividers, and bullet lines.
- Use native post payloads only when sending a reply or a thread/topic reply.
- Preserve the existing non-reply Markdown payload behavior.
- Parse Feishu post style arrays such as `["bold"]` and `["lineThrough"]` when fetching/referencing rich text messages.
- Add regression tests for reply and thread reply payloads.

## Validation

- `python -m pytest tests/gateway/test_feishu.py tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer.py -q`
- `python -m ruff check gateway/platforms/feishu.py tests/gateway/test_feishu.py`
- `python -m py_compile gateway/platforms/feishu.py`

## Notes

I did not send a live Feishu message from CI/local tests; validation covers the SDK request body and gateway routing paths.
