### PR TITLE
fix(whatsapp): move bridge default port off 3000

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -231,7 +231,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     
     Configuration:
     - bridge_script: Path to the Node.js bridge script
-    - bridge_port: Port for HTTP communication (default: 3000)
+    - bridge_port: Port for HTTP communication (default: 3099)
     - session_path: Path to store WhatsApp session data
     - dm_policy: "open" | "allowlist" | "disabled" — how DMs are handled (default: "open")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
@@ -242,6 +242,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     # WhatsApp message limits — practical UX limit, not protocol max.
     # WhatsApp allows ~65K but long messages are unreadable on mobile.
     MAX_MESSAGE_LENGTH = 4096
+    DEFAULT_BRIDGE_PORT = 3099
     DEFAULT_REPLY_PREFIX = "⚕ *Hermes Agent*\n────────────\n"
     
     # Default bridge location relative to the hermes-agent install
@@ -250,7 +251,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
         self._bridge_process: Optional[subprocess.Popen] = None
-        self._bridge_port: int = config.extra.get("bridge_port", 3000)
+        self._bridge_port: int = config.extra.get("bridge_port", self.DEFAULT_BRIDGE_PORT)
         self._bridge_script: Optional[str] = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -15,7 +15,7 @@
  *   GET  /health         - Health check
  *
  * Usage:
- *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session
+ *   node bridge.js --port 3099 --session ~/.hermes/whatsapp/session
  */
 
 import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage } from '@whiskeysockets/baileys';
@@ -43,7 +43,7 @@ const WHATSAPP_DEBUG =
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
 
-const PORT = parseInt(getArg('port', '3000'), 10);
+const PORT = parseInt(getArg('port', '3099'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 const IMAGE_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'image_cache');
 const DOCUMENT_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'document_cache');

--- a/tests/gateway/test_whatsapp_reply_prefix.py
+++ b/tests/gateway/test_whatsapp_reply_prefix.py
@@ -88,6 +88,18 @@ class TestConfigYamlBridging:
 class TestAdapterInit:
     """Test that WhatsAppAdapter reads reply_prefix from config.extra."""
 
+    def test_bridge_port_default_avoids_common_dev_server_port(self):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+        config = PlatformConfig(enabled=True)
+        adapter = WhatsAppAdapter(config)
+        assert adapter._bridge_port == WhatsAppAdapter.DEFAULT_BRIDGE_PORT == 3099
+
+    def test_bridge_port_override_is_preserved(self):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+        config = PlatformConfig(enabled=True, extra={"bridge_port": 3000})
+        adapter = WhatsAppAdapter(config)
+        assert adapter._bridge_port == 3000
+
     def test_reply_prefix_from_extra(self):
         from gateway.platforms.whatsapp import WhatsAppAdapter
         config = PlatformConfig(enabled=True, extra={"reply_prefix": "Bot\\n"})


### PR DESCRIPTION
## Summary
- change the WhatsApp bridge default port from `3000` to `3099`
- keep explicit `bridge_port` overrides unchanged
- add regression coverage for the new default and override preservation

## Testing
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_formatting.py`
- `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k TestSendToPlatformWhatsapp`
- `env -i HOME="$HOME" PATH="$PATH" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 ./.venv/bin/python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short --collect-only`

## Notes
- This stays intentionally narrow and only changes the default port; callers that explicitly set `bridge_port` are unaffected.
- Local lint-diff attribution against `origin/main` showed no new ruff or ty diagnostics; remaining ty warnings on touched files are pre-existing and unchanged.

Closes #24122
