### PR TITLE
[codex] stabilize Hermes Feishu gateway lifecycle

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2699,6 +2699,7 @@ class APIServerAdapter(BasePlatformAdapter):
         loop = asyncio.get_running_loop()
 
         def _run():
+            agent = None
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -2708,26 +2709,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
             )
-            if agent_ref is not None:
-                agent_ref[0] = agent
-            effective_task_id = session_id or str(uuid.uuid4())
-            result = agent.run_conversation(
-                user_message=user_message,
-                conversation_history=conversation_history,
-                task_id=effective_task_id,
-            )
-            usage = {
-                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
-                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
-            }
-            # Include the effective session ID in the result so callers
-            # (e.g. X-Hermes-Session-Id header) can track compression-
-            # triggered session rotations. (#16938)
-            _eff_sid = getattr(agent, "session_id", session_id)
-            if isinstance(_eff_sid, str) and _eff_sid:
-                result["session_id"] = _eff_sid
-            return result, usage
+            try:
+                if agent_ref is not None:
+                    agent_ref[0] = agent
+                effective_task_id = session_id or str(uuid.uuid4())
+                result = agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=conversation_history,
+                    task_id=effective_task_id,
+                )
+                usage = {
+                    "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                    "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                    "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                }
+                # Include the effective session ID in the result so callers
+                # (e.g. X-Hermes-Session-Id header) can track compression-
+                # triggered session rotations. (#16938)
+                _eff_sid = getattr(agent, "session_id", session_id)
+                if isinstance(_eff_sid, str) and _eff_sid:
+                    result["session_id"] = _eff_sid
+                return result, usage
+            finally:
+                if agent is not None:
+                    try:
+                        agent.shutdown_memory_provider()
+                    except Exception:
+                        logger.debug("[api_server] memory shutdown failed", exc_info=True)
 
         return await loop.run_in_executor(None, _run)
 
@@ -2914,6 +2922,7 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
         async def _run_and_close():
+            agent = None
             try:
                 self._set_run_status(run_id, "running")
                 agent = self._create_agent(
@@ -3074,6 +3083,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     q.put_nowait(None)
                 except Exception:
                     pass
+                if agent is not None:
+                    try:
+                        agent.shutdown_memory_provider()
+                    except Exception:
+                        logger.debug("[api_server] run %s memory shutdown failed", run_id, exc_info=True)
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -190,6 +190,7 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
+_FEISHU_WS_READY_TIMEOUT_SECONDS = float(os.getenv("FEISHU_WS_READY_TIMEOUT", "25"))
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
@@ -1290,6 +1291,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
+    original_ws_connect = getattr(ws_client, "_connect", None)
 
     def _apply_runtime_ws_overrides() -> None:
         try:
@@ -1300,12 +1302,13 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    async def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+        """Preserve websockets.connect's context-manager return type."""
         if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
+        return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
@@ -1314,9 +1317,21 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
+    async def _connect_with_ready_signal(*args: Any, **kwargs: Any) -> Any:
+        if original_ws_connect is None:
+            raise RuntimeError("Feishu websocket client has no _connect coroutine")
+        result = await original_ws_connect(*args, **kwargs)
+        try:
+            adapter._mark_websocket_ready()
+        except Exception:
+            logger.debug("[Feishu] Failed to mark websocket ready", exc_info=True)
+        return result
+
     ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
+    if original_ws_connect is not None:
+        setattr(ws_client, "_connect", _connect_with_ready_signal)
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
@@ -1326,6 +1341,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
+        if original_ws_connect is not None:
+            setattr(ws_client, "_connect", original_ws_connect)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
         for task in pending:
             task.cancel()
@@ -1393,6 +1410,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._connect_time: Optional[float] = None  # set in connect(); used to skip stale restart replays
+        self._ws_ready_event = threading.Event()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -1606,6 +1625,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            self._connect_time = time.time()
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             return True
@@ -1622,10 +1642,40 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
+        self._ws_ready_event.clear()
+
+        # Send a WebSocket CLOSE frame before tearing down the SDK loop. Without
+        # this, Feishu may keep routing messages to the stale connection until
+        # its server-side timeout expires. See upstream issue #10202.
+        ws_client = self._ws_client
+        ws_thread_loop = self._ws_thread_loop
         self._disable_websocket_auto_reconnect()
         await self._stop_webhook_server()
 
-        ws_thread_loop = self._ws_thread_loop
+        if (
+            ws_client is not None
+            and ws_thread_loop is not None
+            and not ws_thread_loop.is_closed()
+            and hasattr(ws_client, "_disconnect")
+        ):
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    ws_client._disconnect(), ws_thread_loop
+                )
+                await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
+                logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Feishu] CLOSE frame not acknowledged within 5s; Feishu "
+                    "may briefly route messages to the stale connection"
+                )
+            except Exception as exc:
+                logger.debug(
+                    "[Feishu] Could not send WebSocket CLOSE frame: %s",
+                    exc,
+                    exc_info=True,
+                )
+
         if ws_thread_loop is not None and not ws_thread_loop.is_closed():
             logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
 
@@ -1660,6 +1710,9 @@ class FeishuAdapter(BasePlatformAdapter):
 
         self._mark_disconnected()
         logger.info("[Feishu] Disconnected")
+
+    def _mark_websocket_ready(self) -> None:
+        self._ws_ready_event.set()
 
     async def _cancel_pending_tasks(self, tasks: Dict[str, asyncio.Task]) -> None:
         pending = [task for task in tasks.values() if task and not task.done()]
@@ -2348,6 +2401,20 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message or not sender or not getattr(sender, "sender_id", None):
             logger.debug("[Feishu] Dropping malformed inbound event: missing message/sender")
             return
+
+        create_time_raw = getattr(message, "create_time", None)
+        if create_time_raw is not None and self._connect_time is not None:
+            try:
+                create_ts = int(str(create_time_raw)) / 1000.0
+                if create_ts < self._connect_time:
+                    logger.info(
+                        "[Feishu] Dropping stale pre-connect message %s (created %.1fs before connect)",
+                        getattr(message, "message_id", "?"),
+                        self._connect_time - create_ts,
+                    )
+                    return
+            except (TypeError, ValueError):
+                pass
 
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):
@@ -4377,16 +4444,39 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_client = FeishuWSClient(
             app_id=self._app_id,
             app_secret=self._app_secret,
-            log_level=lark.LogLevel.INFO,
+            log_level=lark.LogLevel.WARNING,
             event_handler=self._event_handler,
             domain=domain,
         )
+        self._ws_ready_event.clear()
         self._ws_future = loop.run_in_executor(
             None,
             _run_official_feishu_ws_client,
             self._ws_client,
             self,
         )
+        await self._wait_for_websocket_ready()
+
+    async def _wait_for_websocket_ready(self, timeout: float = _FEISHU_WS_READY_TIMEOUT_SECONDS) -> None:
+        if self._ws_ready_event.is_set():
+            return
+        deadline = time.monotonic() + timeout
+        while not self._ws_ready_event.is_set():
+            ws_future = self._ws_future
+            if ws_future is not None and ws_future.done():
+                try:
+                    exc = ws_future.exception()
+                except Exception as err:
+                    exc = err
+                if exc is not None:
+                    raise RuntimeError("Feishu websocket client exited before connecting") from exc
+                raise RuntimeError("Feishu websocket client exited before connecting")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Feishu websocket did not establish within {timeout:.1f}s"
+                )
+            await asyncio.sleep(min(0.1, remaining))
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3580,26 +3580,27 @@ class GatewayRunner:
                 return True
             if enabled_platform_count > 0:
                 if startup_retryable_errors:
-                    # At least one platform attempted a connection and failed —
-                    # this is a real startup error that should block the gateway.
+                    # At least one platform attempted a connection and failed,
+                    # but all observed failures are retryable. Keep the gateway
+                    # alive so cron and the reconnect watcher can recover,
+                    # rather than letting service managers spin in restart loops.
                     reason = "; ".join(startup_retryable_errors)
-                    logger.error("Gateway failed to connect any configured messaging platform: %s", reason)
-                    try:
-                        from gateway.status import write_runtime_status
-                        write_runtime_status(gateway_state="startup_failed", exit_reason=reason)
-                    except Exception:
-                        pass
-                    return False
-                # All enabled platforms had no adapter (missing library or credentials).
-                # In fleet deployments the same config.yaml is shared across nodes that
-                # may only have credentials for a subset of platforms.  Rather than
-                # failing hard, degrade gracefully and allow cron jobs to run (#5196).
-                logger.warning(
-                    "No adapter could be created for any of the %d configured platform(s). "
-                    "Check that required dependencies are installed and credentials are set. "
-                    "Gateway will continue for cron job execution.",
-                    enabled_platform_count,
-                )
+                    logger.warning(
+                        "Gateway has no connected messaging platforms yet; "
+                        "retrying transient startup failures in background: %s",
+                        reason,
+                    )
+                else:
+                    # All enabled platforms had no adapter (missing library or credentials).
+                    # In fleet deployments the same config.yaml is shared across nodes that
+                    # may only have credentials for a subset of platforms.  Rather than
+                    # failing hard, degrade gracefully and allow cron jobs to run (#5196).
+                    logger.warning(
+                        "No adapter could be created for any of the %d configured platform(s). "
+                        "Check that required dependencies are installed and credentials are set. "
+                        "Gateway will continue for cron job execution.",
+                        enabled_platform_count,
+                    )
             else:
                 logger.warning("No messaging platforms enabled.")
                 logger.info("Gateway will continue running for cron job execution.")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2781,7 +2781,6 @@ def generate_launchd_plist() -> str:
     prog_args.extend([
         "<string>gateway</string>",
         "<string>run</string>",
-        "<string>--replace</string>",
     ])
     prog_args_xml = "\n        ".join(prog_args)
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -150,6 +150,33 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     return str(version) if version else None
 
 
+def _check_hindsight_api_reachable(api_url: str, api_key: str | None = None,
+                                   timeout: float = 2.0) -> bool:
+    """Return True when a configured Hindsight HTTP API responds successfully."""
+    import urllib.error
+    import urllib.request
+
+    if not api_url:
+        return False
+    base = api_url.rstrip("/")
+    for path in ("/health", "/version"):
+        req = urllib.request.Request(base + path)
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+                status = getattr(resp, "status", 200)
+            if 200 <= int(status) < 300:
+                return True
+        except urllib.error.HTTPError:
+            continue
+        except Exception as exc:
+            logger.debug("Hindsight API reachability probe failed for %s%s: %s",
+                         base, path, exc)
+            continue
+    return False
+
+
 def _check_api_supports_update_mode_append(api_url: str,
                                            api_key: str | None = None) -> bool:
     """Cached capability check for ``update_mode='append'`` on *api_url*.
@@ -597,7 +624,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 available, _ = _check_local_runtime()
                 return available
             if mode == "local_external":
-                return True
+                api_url = cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", "")
+                api_key = (
+                    cfg.get("apiKey")
+                    or cfg.get("api_key")
+                    or os.environ.get("HINDSIGHT_API_KEY", "")
+                    or None
+                )
+                return _check_hindsight_api_reachable(str(api_url), api_key)
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -407,6 +407,22 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+        mock_agent.shutdown_memory_provider.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_agent_shuts_down_memory_provider_on_failure(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.side_effect = RuntimeError("boom")
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            with pytest.raises(RuntimeError, match="boom"):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    session_id="session-123",
+                )
+
+        mock_agent.shutdown_memory_provider.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -3061,4 +3077,3 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
-

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -226,6 +226,11 @@ class TestRunStatus:
                 assert status["output"] == "done"
                 assert status["usage"]["total_tokens"] == 6
                 assert status["last_event"] == "run.completed"
+                for _ in range(20):
+                    if mock_agent.shutdown_memory_provider.called:
+                        break
+                    await asyncio.sleep(0.05)
+                mock_agent.shutdown_memory_provider.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_status_reflects_explicit_session_id(self, adapter):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -8,7 +8,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict
+from typing import Any, Dict
 from unittest.mock import AsyncMock, Mock, patch
 
 from gateway.platforms.base import ProcessingOutcome
@@ -229,6 +229,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
 
             class _Loop:
                 def run_in_executor(self, *_args, **_kwargs):
+                    adapter._mark_websocket_ready()
                     return future
 
                 def is_closed(self):
@@ -249,6 +250,95 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             metadata={"platform": "feishu"},
         )
         release_lock.assert_called_once_with("feishu-app-id", "cli_app")
+
+    def test_disconnect_sends_websocket_close_frame(self):
+        """disconnect() must call the WSS client's _disconnect coroutine."""
+        import threading
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        ws_thread_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run_loop() -> None:
+            asyncio.set_event_loop(ws_thread_loop)
+            ready.set()
+            ws_thread_loop.run_forever()
+
+        thread = threading.Thread(target=_run_loop, daemon=True)
+        thread.start()
+        ready.wait()
+
+        close_called = threading.Event()
+
+        async def _fake_disconnect() -> None:
+            close_called.set()
+
+        adapter._ws_client = SimpleNamespace(_disconnect=_fake_disconnect, _auto_reconnect=True)
+        adapter._ws_thread_loop = ws_thread_loop
+        adapter._ws_future = None
+
+        try:
+            asyncio.run(adapter.disconnect())
+        finally:
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.call_soon_threadsafe(ws_thread_loop.stop)
+            thread.join(timeout=2.0)
+            if not ws_thread_loop.is_closed():
+                ws_thread_loop.close()
+
+        self.assertTrue(close_called.is_set())
+        self.assertIsNone(adapter._ws_client)
+
+    def test_disconnect_tolerates_missing_internal_disconnect(self):
+        """Future lark_oapi clients without _disconnect should still shut down."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._ws_client = SimpleNamespace(_auto_reconnect=True)
+        adapter._ws_thread_loop = None
+        adapter._ws_future = None
+
+        asyncio.run(adapter.disconnect())
+
+        self.assertIsNone(adapter._ws_client)
+
+    def test_wait_for_websocket_ready_times_out(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        with self.assertRaises(TimeoutError):
+            asyncio.run(adapter._wait_for_websocket_ready(timeout=0.01))
+
+    def test_connect_websocket_waits_for_sdk_ready_signal(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        async def _run() -> tuple[AsyncMock, Any]:
+            adapter._loop = asyncio.get_running_loop()
+            with (
+                patch("gateway.platforms.feishu.FEISHU_WEBSOCKET_AVAILABLE", True),
+                patch("gateway.platforms.feishu.lark", SimpleNamespace(LogLevel=SimpleNamespace(WARNING="WARNING"))),
+                patch("gateway.platforms.feishu.FeishuWSClient", return_value=SimpleNamespace()) as ws_client_cls,
+                patch("gateway.platforms.feishu._run_official_feishu_ws_client", lambda *_args: None),
+                patch.object(adapter, "_hydrate_bot_identity", new=AsyncMock()),
+                patch.object(adapter, "_build_lark_client", return_value=SimpleNamespace()),
+                patch.object(adapter, "_build_event_handler", return_value=object()),
+                patch.object(adapter, "_wait_for_websocket_ready", new=AsyncMock()) as wait_ready,
+            ):
+                await adapter._connect_websocket()
+                return wait_ready, ws_client_cls
+
+        wait_ready, ws_client_cls = asyncio.run(_run())
+
+        wait_ready.assert_awaited_once()
+        self.assertEqual(ws_client_cls.call_args.kwargs["log_level"], "WARNING")
 
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",
@@ -313,6 +403,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
                     self.calls += 1
                     if self.calls == 1:
                         raise OSError("temporary websocket failure")
+                    adapter._mark_websocket_ready()
                     return future
 
                 def is_closed(self):
@@ -4823,3 +4914,78 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+    def test_stale_pre_connect_message_is_dropped(self):
+        """Messages created before adapter connect() are skipped on restart."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000010.0
+
+        message = SimpleNamespace(
+            message_id="om_stale",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"old message"}',
+            create_time="1700000000000",
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(adapter._handle_message_event_data(data))
+
+        proc.assert_not_called()
+
+    def test_fresh_post_connect_message_is_accepted(self):
+        """Messages created after adapter connect() are processed normally."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000000.0
+
+        message = SimpleNamespace(
+            message_id="om_fresh",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"new message"}',
+            create_time="1700000060000",
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(adapter._handle_message_event_data(data))
+
+        proc.assert_called_once()
+        self.assertEqual(proc.call_args.kwargs["message_id"], "om_fresh")
+
+    def test_message_without_create_time_is_accepted(self):
+        """Events without create_time remain compatible with older SDKs."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000000.0
+
+        message = SimpleNamespace(
+            message_id="om_no_ts",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"no timestamp"}',
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(adapter._handle_message_event_data(data))
+
+        proc.assert_called_once()

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -64,7 +64,7 @@ class _SuccessfulAdapter(BasePlatformAdapter):
 
 
 @pytest.mark.asyncio
-async def test_runner_returns_failure_for_retryable_startup_errors(monkeypatch, tmp_path):
+async def test_runner_keeps_running_for_retryable_startup_errors(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     config = GatewayConfig(
         platforms={
@@ -75,16 +75,20 @@ async def test_runner_returns_failure_for_retryable_startup_errors(monkeypatch, 
     runner = GatewayRunner(config)
 
     monkeypatch.setattr(runner, "_create_adapter", lambda platform, platform_config: _RetryableFailureAdapter())
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
 
     ok = await runner.start()
 
-    assert ok is False
+    assert ok is True
     assert runner.should_exit_cleanly is False
     state = read_runtime_status()
-    assert state["gateway_state"] == "startup_failed"
-    assert "temporary DNS resolution failure" in state["exit_reason"]
+    assert state["gateway_state"] == "running"
     assert state["platforms"]["telegram"]["state"] == "retrying"
     assert state["platforms"]["telegram"]["error_code"] == "telegram_connect_error"
+    assert Platform.TELEGRAM in runner._failed_platforms
+
+    await runner.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -493,7 +493,7 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
-        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        assert "--replace" not in plist_path.read_text(encoding="utf-8")
         assert calls[:2] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -737,6 +741,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -119,33 +119,29 @@ def mock_args():
 
 
 # ---------------------------------------------------------------------------
-# Launchd plist includes --replace
+# Launchd plist avoids --replace
 # ---------------------------------------------------------------------------
 
 
 class TestLaunchdPlistReplace:
-    """The generated launchd plist must include --replace so respawned
-    gateways kill stale instances."""
+    """The generated launchd plist lets launchd own process replacement."""
 
-    def test_plist_contains_replace_flag(self):
+    def test_plist_omits_replace_flag(self):
         plist = gateway_cli.generate_launchd_plist()
-        assert "--replace" in plist
+        assert "--replace" not in plist
 
-    def test_plist_program_arguments_order(self):
-        """--replace comes after 'run' in the ProgramArguments."""
+    def test_plist_program_arguments_end_at_run(self):
         plist = gateway_cli.generate_launchd_plist()
         lines = [line.strip() for line in plist.splitlines()]
-        # Find 'run' and '--replace' in the string entries
         string_values = [
             line.replace("<string>", "").replace("</string>", "")
             for line in lines
             if "<string>" in line and "</string>" in line
         ]
         assert "run" in string_values
-        assert "--replace" in string_values
+        assert "--replace" not in string_values
         run_idx = string_values.index("run")
-        replace_idx = string_values.index("--replace")
-        assert replace_idx == run_idx + 1
+        assert string_values[run_idx - 1:run_idx + 1] == ["gateway", "run"]
 
 
 class TestLaunchdPlistPath:
@@ -249,8 +245,9 @@ class TestLaunchdPlistRefresh:
         result = gateway_cli.refresh_launchd_plist_if_needed()
 
         assert result is True
-        # Plist should now contain the generated content (which includes --replace)
-        assert "--replace" in plist_path.read_text()
+        # Plist should now contain the generated launchd content without an
+        # internal gateway --replace handoff.
+        assert "--replace" not in plist_path.read_text()
         # Should have booted out then bootstrapped
         assert any("bootout" in str(c) for c in calls)
         assert any("bootstrap" in str(c) for c in calls)
@@ -318,7 +315,7 @@ class TestLaunchdPlistRefresh:
 
         # Should have created the plist
         assert plist_path.exists()
-        assert "--replace" in plist_path.read_text()
+        assert "--replace" not in plist_path.read_text()
 
         cmd_strs = [" ".join(c) for c in calls]
         # Should bootstrap the new plist, then kickstart

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1421,6 +1421,46 @@ class TestAvailability:
 
         assert p.is_available()
 
+    def test_local_external_available_when_api_reachable(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_external",
+            "api_url": "http://127.0.0.1:9177",
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_hindsight_api_reachable",
+            lambda api_url, api_key=None: api_url == "http://127.0.0.1:9177",
+        )
+
+        p = HindsightMemoryProvider()
+
+        assert p.is_available()
+
+    def test_local_external_unavailable_when_api_unreachable(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_external",
+            "api_url": "http://127.0.0.1:9177",
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_hindsight_api_reachable",
+            lambda api_url, api_key=None: False,
+        )
+
+        p = HindsightMemoryProvider()
+
+        assert not p.is_available()
+
     def test_local_mode_unavailable_when_runtime_import_fails(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
@@ -1548,4 +1588,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-


### PR DESCRIPTION
## What does this PR do?

Stabilizes Hermes gateway behavior around Feishu websocket startup/reconnect, Hindsight local_external health checks, API server memory-provider cleanup, and macOS launchd restart handoff.

The fixes keep retryable Feishu startup failures inside the gateway lifecycle instead of letting service managers spin in restart loops. They also make Hindsight local_external availability reflect the actual local HTTP endpoint, and close memory providers after API server runs.

## Root Cause

- Feishu websocket startup could be marked connected too early or fail during transient OpenAPI/WSS timeouts.
- When Feishu was the only configured messaging platform, retryable startup failures could make the gateway exit, causing launchd/service-manager churn instead of background reconnect.
- macOS launchd generated `gateway run --replace`, mixing service-manager restart semantics with Hermes replace handoff.
- Hindsight `local_external` availability was config-only and could report healthy while `127.0.0.1:9177` was unreachable.
- API server run paths did not consistently close the agent memory provider after completion.

## Changes Made

- `gateway/platforms/feishu.py`: wait for websocket readiness, improve disconnect/CLOSE handling, reduce sensitive SDK URL logging, and drop stale replayed messages after reconnect.
- `gateway/run.py`: keep the gateway alive for retryable startup platform failures and let the reconnect watcher recover.
- `plugins/memory/hindsight/__init__.py`: require reachable `/health` or `/version` for `local_external` availability.
- `gateway/platforms/api_server.py`: shut down memory provider in `finally` after run handling.
- `hermes_cli/gateway.py`: stop adding `--replace` to macOS launchd plist generation.
- Tests updated/added for the changed gateway, Feishu, Hindsight, API server, and service behavior.

## How to Test

1. `venv/bin/python -m ruff check .`
2. `scripts/run_tests.sh tests/gateway/test_runner_startup_failures.py tests/gateway/test_platform_reconnect.py tests/gateway/test_feishu.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_gateway_restart.py tests/plugins/memory/test_hindsight_provider.py tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py`
3. On macOS launchd, restart `ai.hermes.gateway` and confirm ProgramArguments are `python -m hermes_cli.main gateway run` without `--replace`.
4. With transient Feishu OpenAPI/WSS timeouts, confirm gateway remains `running`, starts the reconnect watcher, and Feishu later returns to `connected`.
5. Confirm Hindsight local API health returns `{"status":"healthy","database":"connected"}`.

## Validation Performed

- Ruff passed.
- Targeted official wrapper tests passed: `670 passed`.
- Rebased cleanly on `origin/main` at `dd0923bb8`.
- macOS runtime check: gateway PID refreshed, launchd has no `--replace`, Hindsight healthy, Feishu connected.

## Platform Tested

- macOS launchd on local Hermes gateway.

## Notes

This PR intentionally does not modify system networking, Wi-Fi, DNS, proxy services, or third-party proxy app configuration. The stability work stays inside Hermes gateway and provider lifecycle boundaries.