### PR TITLE
fix: include arg-taking commands in Telegram menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -468,20 +468,23 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
 
     Telegram command names cannot contain hyphens, so they are replaced with
     underscores.  Aliases are skipped -- Telegram shows one menu entry per
-    canonical command. Commands that require arguments are skipped because
-    selecting a Telegram BotCommand sends only ``/command`` and would execute
-    an incomplete command.
+    canonical command.
 
-    Plugin-registered slash commands are included so plugins get native
-    autocomplete in Telegram without touching core code.
+    Built-in commands that require arguments (e.g. /queue, /steer, /background)
+    are **included** because their handlers return usage text when selected
+    without a payload, making them discoverable via autocomplete.
+
+    Plugin-registered slash commands that require arguments are **excluded**
+    because plugins may not provide a no-arg usage fallback.
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        if _requires_argument(cmd.args_hint):
-            continue
+        # Built-in arg-taking commands are included — their handlers show
+        # usage text when invoked without arguments, and hiding them from
+        # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
             result.append((tg_name, cmd.description))

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -242,12 +242,14 @@ class TestTelegramBotCommands:
                 tg_name = cmd.name.replace("-", "_")
                 assert tg_name not in names
 
-    def test_excludes_commands_with_required_args(self):
+    def test_includes_builtin_commands_with_required_args(self):
+        """Built-in arg-taking commands (e.g. /queue, /steer, /background)
+        are now included because their handlers return usage text when
+        invoked without arguments — issue #24312."""
         names = {name for name, _ in telegram_bot_commands()}
-        assert "background" not in names
-        assert "queue" not in names
-        assert "steer" not in names
-        assert "background" in GATEWAY_KNOWN_COMMANDS
+        assert "background" in names
+        assert "queue" in names
+        assert "steer" in names
 
 
 class TestSlackSubcommandMap:


### PR DESCRIPTION
## Summary

Fixes #24312

Built-in commands with required args (e.g. `/queue`, `/steer`, `/background`) were excluded from Telegram `setMyCommands` output, making them invisible in the autocomplete menu. However, their handlers already return usage text when invoked without arguments, so hiding them hurts discoverability.

## Changes

- **Removed** the `_requires_argument(cmd.args_hint)` filter for built-in commands (`COMMAND_REGISTRY`) in `telegram_bot_commands()`
- **Kept** the filter for plugin-registered slash commands, which may not provide a no-arg usage fallback
- **Updated test** `test_excludes_commands_with_required_args` → `test_includes_builtin_commands_with_required_args` — now asserts that `background`, `queue`, `steer` ARE in the Telegram menu

## Test Plan

```
python -m pytest tests/hermes_cli/test_commands.py -v   # 142 passed
```

All existing Telegram menu tests pass, including:
- `test_plugin_command_with_required_args_excluded_from_telegram_menu` — plugin commands with required args still excluded ✅
- `test_includes_builtin_commands_with_required_args` — built-in arg commands now included ✅
