### PR TITLE
fix: self-heal missing session rows after startup DB lock

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4597,6 +4597,22 @@ class AIAgent:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
                 self._ensure_db_session()
+            if not self._session_db_created and self.session_id:
+                # Final persistence is our last chance to heal a session row
+                # that transiently failed to insert at startup. Without this,
+                # the JSON transcript can exist while state.db lacks the
+                # corresponding session row, breaking /resume and analytics.
+                self._session_db.ensure_session(
+                    session_id=self.session_id,
+                    source=self.platform
+                    or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model=self.model,
+                    model_config=self._session_init_model_config,
+                    system_prompt=self._cached_system_prompt,
+                    user_id=None,
+                    parent_session_id=self._parent_session_id,
+                )
+                self._session_db_created = True
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
             for msg in messages[flush_from:]:

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -24,7 +24,7 @@ import pytest
 class TestFlushDeduplication:
     """Verify _flush_messages_to_session_db tracks what it already wrote."""
 
-    def _make_agent(self, session_db):
+    def _make_agent(self, session_db, *, ensure_row=True):
         """Create a minimal AIAgent with a real session DB."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             from run_agent import AIAgent
@@ -38,8 +38,9 @@ class TestFlushDeduplication:
                 skip_context_files=True,
                 skip_memory=True,
             )
-        # Simulate lazy session creation (normally done by run_conversation)
-        agent._ensure_db_session()
+        # Simulate lazy session creation (normally done by run_conversation).
+        if ensure_row:
+            agent._ensure_db_session()
         return agent
 
     def test_flush_writes_only_new_messages(self):
@@ -165,6 +166,58 @@ class TestFlushDeduplication:
             # Old session should still have its 2 messages
             old_rows = db.get_messages(old_session)
             assert len(old_rows) == 2
+
+    def test_flush_self_heals_missing_session_row_before_appending(self):
+        """Flush should backfill a missing session row before appending messages."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db, ensure_row=False)
+            agent._ensure_db_session = MagicMock()
+
+            messages = [
+                {"role": "user", "content": "hello after missed create"},
+            ]
+
+            agent._flush_messages_to_session_db(messages, [])
+
+            row = db.get_session(agent.session_id)
+            assert row is not None
+            assert row["source"] == "cli"
+            assert row["model"] == "test/model"
+            assert agent._session_db_created is True
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 1
+            assert rows[0]["content"] == "hello after missed create"
+
+    def test_flush_self_heals_missing_row_even_when_no_new_messages(self):
+        """A fully-flushed session must still recreate its missing DB row."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db, ensure_row=False)
+            agent._ensure_db_session = MagicMock()
+
+            conversation_history = [
+                {"role": "user", "content": "already persisted elsewhere"},
+            ]
+            agent._last_flushed_db_idx = len(conversation_history)
+
+            agent._flush_messages_to_session_db(conversation_history, conversation_history)
+
+            row = db.get_session(agent.session_id)
+            assert row is not None
+            assert row["source"] == "cli"
+            assert row["model"] == "test/model"
+            assert agent._session_db_created is True
+            assert db.get_messages(agent.session_id) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backfill the SQLite session row during final flush when startup session creation silently missed
- preserve the original session metadata when healing the row so `/resume` and analytics can find JSON-backed sessions again
- add regression coverage for both append and fully-flushed/no-new-message cases

## Testing
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- `uv run --frozen pytest -q -o addopts='' tests/test_hermes_state.py -k ensure_session`
- `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_860_dedup.py`
- `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_compression_persistence.py`
- `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_413_compression.py`
- `env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" SHELL="${SHELL:-/bin/zsh}" TERM="${TERM:-xterm-256color}" bash scripts/run_tests.sh tests/ -q --tb=short`  
  local full-mainline attribution: red in untouched shared baseline areas only; representative failures reproduce on latest `origin/main`
- `uv run --frozen python scripts/check-windows-footguns.py --all`  
  preexisting unrelated blocker on latest `origin/main` (`tools/process_registry.py:588`)

Closes #2914.
