### PR TITLE
Add 9Router support - fix 403 error from OpenAI User-Agent blocking

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1327,6 +1327,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
+            # 9Router support - must use non-OpenAI User-Agent to avoid 403
+            elif "9router" in base_url.lower() or "router." in base_url.lower():
+                extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
             else:
                 try:
                     from providers import get_provider_profile as _gpf_aux
@@ -1362,6 +1365,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
+        # 9Router support - must use non-OpenAI User-Agent to avoid 403
+        elif "9router" in base_url.lower() or "router." in base_url.lower():
+            extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
         else:
             try:
                 from providers import get_provider_profile as _gpf_aux2
@@ -2843,6 +2849,9 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
+            # 9Router support - must use non-OpenAI User-Agent to avoid 403
+            elif "9router" in custom_base.lower() or "router." in custom_base.lower():
+                extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
             else:
                 # Fall back to profile.default_headers for providers that
                 # declare client-level attribution headers on their profile.
@@ -3041,6 +3050,10 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
+        # 9Router support - must use non-OpenAI User-Agent to avoid 403
+        # 9Router blocks requests with "OpenAI" in User-Agent header
+        elif "9router" in base_url.lower() or "router." in base_url.lower():
+            headers["User-Agent"] = "HermesAgent/1.0"
         else:
             # Fall back to profile.default_headers for providers that declare
             # client-level attribution headers on their profile (e.g. GMI

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1328,7 +1328,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
                 extra["default_headers"] = copilot_default_headers()
             # 9Router support - must use non-OpenAI User-Agent to avoid 403
-            elif "9router" in base_url.lower() or "router." in base_url.lower():
+            # Detection: URL contains '9router', 'router.', or :20128 (default 9Router port)
+            elif ("9router" in base_url.lower() or "router." in base_url.lower() 
+                  or ":20128" in base_url):
                 extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
             else:
                 try:
@@ -1366,7 +1368,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
             extra["default_headers"] = copilot_default_headers()
         # 9Router support - must use non-OpenAI User-Agent to avoid 403
-        elif "9router" in base_url.lower() or "router." in base_url.lower():
+        # Detection: URL contains '9router', 'router.', or :20128 (default 9Router port)
+        elif ("9router" in base_url.lower() or "router." in base_url.lower() 
+              or ":20128" in base_url):
             extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
         else:
             try:
@@ -2850,7 +2854,9 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             # 9Router support - must use non-OpenAI User-Agent to avoid 403
-            elif "9router" in custom_base.lower() or "router." in custom_base.lower():
+            # Detection: URL contains '9router', 'router.', or :20128 (default 9Router port)
+            elif ("9router" in custom_base.lower() or "router." in custom_base.lower() 
+                  or ":20128" in custom_base):
                 extra["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
             else:
                 # Fall back to profile.default_headers for providers that
@@ -3052,7 +3058,9 @@ def resolve_provider_client(
             ))
         # 9Router support - must use non-OpenAI User-Agent to avoid 403
         # 9Router blocks requests with "OpenAI" in User-Agent header
-        elif "9router" in base_url.lower() or "router." in base_url.lower():
+        # Detection: URL contains '9router', 'router.', or localhost:20128 (default 9Router port)
+        elif ("9router" in base_url.lower() or "router." in base_url.lower() 
+              or ":20128" in base_url):
             headers["User-Agent"] = "HermesAgent/1.0"
         else:
             # Fall back to profile.default_headers for providers that declare

--- a/run_agent.py
+++ b/run_agent.py
@@ -7145,6 +7145,10 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
                 self._client_kwargs.get("api_key", "")
             )
+        # 9Router support - must use non-OpenAI User-Agent to avoid 403
+        # 9Router blocks requests with "OpenAI" in User-Agent header
+        elif "9router" in base_url.lower() or "router." in base_url.lower():
+            self._client_kwargs["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
         else:
             # No URL-specific headers — check profile.default_headers before clearing.
             _ph_headers = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -7147,7 +7147,9 @@ class AIAgent:
             )
         # 9Router support - must use non-OpenAI User-Agent to avoid 403
         # 9Router blocks requests with "OpenAI" in User-Agent header
-        elif "9router" in base_url.lower() or "router." in base_url.lower():
+        # Detection: URL contains '9router', 'router.', or localhost:20128 (default 9Router port)
+        elif ("9router" in base_url.lower() or "router." in base_url.lower() 
+              or ":20128" in base_url):
             self._client_kwargs["default_headers"] = {"User-Agent": "HermesAgent/1.0"}
         else:
             # No URL-specific headers — check profile.default_headers before clearing.


### PR DESCRIPTION
## Summary

Add support for 9Router endpoints by using a non-OpenAI User-Agent header.

## Problem

9Router blocks requests with `User-Agent: OpenAI/Python ...` (the default from OpenAI SDK) with a 403 Forbidden error. This prevents Hermes Agent from working with 9Router endpoints.

## Solution

Override the User-Agent header to `HermesAgent/1.0` when detecting a 9Router endpoint.

### Detection

A URL is detected as 9Router if it:
- Contains `9router` in the URL
- Contains `router.` in the URL
- Uses port `:20128` (the default 9Router port)

This covers:
- Self-hosted instances: `http://localhost:20128/v1`, `http://127.0.0.1:20128/v1`
- Online instances: `https://router.example.com/v1`, `https://my-9router.com/v1`

## Changes

- `agent/auxiliary_client.py`: Add 9Router User-Agent handling in 4 locations
- `run_agent.py`: Add 9Router User-Agent handling in `_apply_client_headers_for_base_url()`

## Testing

Tested with curl and Python urllib:
- `User-Agent: OpenAI/Python ...` ? 403 Forbidden
- `User-Agent: HermesAgent/1.0` ? 200 OK

## Related

- 9Router: https://github.com/decolua/9router