### PR TITLE
docs(skills): document Claude Code goal command

### DIFF
--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -365,6 +365,7 @@ Use the `#` prefix in interactive mode to quickly add to memory: `# Always use 2
 | Command | Purpose |
 |---------|---------|
 | `/help` | Show all commands (including custom and MCP commands) |
+| `/goal [objective]` | Set the session goal for longer interactive work |
 | `/compact [focus]` | Compress context to save tokens; CLAUDE.md survives compaction. E.g., `/compact focus on auth logic` |
 | `/clear` | Wipe conversation history for a fresh start |
 | `/context` | Visualize context usage as a colored grid with optimization tips |

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
@@ -383,6 +383,7 @@ Use the `#` prefix in interactive mode to quickly add to memory: `# Always use 2
 | Command | Purpose |
 |---------|---------|
 | `/help` | Show all commands (including custom and MCP commands) |
+| `/goal [objective]` | Set the session goal for longer interactive work |
 | `/compact [focus]` | Compress context to save tokens; CLAUDE.md survives compaction. E.g., `/compact focus on auth logic` |
 | `/clear` | Wipe conversation history for a fresh start |
 | `/context` | Visualize context usage as a colored grid with optimization tips |


### PR DESCRIPTION
## What does this PR do?

Documents Claude Code's `/goal [objective]` interactive slash command in the bundled `claude-code` skill's Session & Context table. The Purpose text is intentionally short so it matches the length/style of neighboring rows.

## Related Issue

Fixes #24349

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/autonomous-ai-agents/claude-code/SKILL.md` with a concise `/goal [objective]` row.
- Regenerated `website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md` from the skill source.

## How to Test

1. Run `python website/scripts/generate-skill-docs.py`.
2. Run `python -m pytest tests/website/test_generate_skill_docs.py -q -o 'addopts='`.
3. Confirm the generated Claude Code skill docs include `/goal [objective]` with concise Purpose text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux local checkout

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — updates an existing bundled skill.

## Screenshots / Logs

```text
$ python -m pytest tests/website/test_generate_skill_docs.py -q -o 'addopts='
.......                                                                  [100%]
7 passed in 0.87s
```
