### PR TITLE
fix: stabilize generated systemd gateway units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2800,24 +2800,24 @@ def _read_restart_drain_timeout_from_hermes_home(hermes_home: str | None) -> str
         import yaml
     except ImportError as exc:
         logger.debug(
-            "Unable to read restart drain timeout from %s: %s", config_path, exc
+            "Cannot read target Hermes config %s: PyYAML unavailable: %s",
+            config_path,
+            exc,
         )
         return None
 
     try:
-        with config_path.open(encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
+        config_text = config_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
     except OSError as exc:
-        logger.debug(
-            "Unable to read restart drain timeout from %s: %s", config_path, exc
-        )
+        logger.debug("Cannot read target Hermes config %s: %s", config_path, exc)
         return None
+
+    try:
+        cfg = yaml.safe_load(config_text) or {}
     except yaml.YAMLError as exc:
-        logger.debug(
-            "Unable to parse restart drain timeout from %s: %s", config_path, exc
-        )
+        logger.debug("Cannot parse target Hermes config %s: %s", config_path, exc)
         return None
     agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
     if not isinstance(agent_cfg, dict) or "restart_drain_timeout" not in agent_cfg:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2418,6 +2418,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
+        restart_timeout = _systemd_timeout_stop_sec(hermes_home=hermes_home)
         profile_arg = _profile_arg_for_target_user(hermes_home, home_dir)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
@@ -2466,6 +2467,7 @@ WantedBy=multi-user.target
 """
 
     hermes_home = str(get_hermes_home().resolve())
+    restart_timeout = _systemd_timeout_stop_sec()
     profile_arg = _profile_arg(hermes_home)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
@@ -2499,10 +2501,6 @@ WantedBy=default.target
 """
 
 
-def _normalize_service_definition(text: str) -> str:
-    return "\n".join(line.rstrip() for line in text.strip().splitlines())
-
-
 # Directives that older systemd versions silently ignore/strip.  Normalize
 # them out of stale-check comparisons so a unit that differs only by these
 # directives is not perpetually flagged as outdated.
@@ -2524,6 +2522,32 @@ def _strip_optional_systemd_directives(text: str) -> str:
                 continue
         filtered.append(line)
     return "\n".join(filtered)
+
+
+def _normalize_service_definition(text: str) -> str:
+    return "\n".join(line.rstrip() for line in text.strip().splitlines())
+
+
+def _normalize_systemd_unit_for_comparison(text: str) -> str:
+    """Normalize systemd unit text for staleness checks.
+
+    The generated PATH intentionally captures environment-dependent user-local,
+    Node, and WSL interop directories so background tools keep working under
+    systemd. That payload can differ between the installing shell (often root
+    via sudo) and a later status check by the target user, so ignore only the
+    PATH value while keeping all other unit fields exact.
+    """
+    import re
+
+    normalized = _normalize_service_definition(
+        _strip_optional_systemd_directives(text)
+    )
+    return re.sub(
+        r'^Environment="PATH=.*"$',
+        'Environment="PATH=__HERMES_PATH__"',
+        normalized,
+        flags=re.M,
+    )
 
 
 def _normalize_launchd_plist_for_comparison(text: str) -> str:
@@ -2553,16 +2577,9 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     installed = unit_path.read_text(encoding="utf-8")
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     expected = generate_systemd_unit(system=system, run_as_user=expected_user)
-    # Normalize out directives that older systemd versions silently drop
-    # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
-    # those directives is not perpetually flagged as outdated.
-    norm_installed = _normalize_service_definition(
-        _strip_optional_systemd_directives(installed)
-    )
-    norm_expected = _normalize_service_definition(
-        _strip_optional_systemd_directives(expected)
-    )
-    return norm_installed == norm_expected
+    normalized_installed = _normalize_systemd_unit_for_comparison(installed)
+    normalized_expected = _normalize_systemd_unit_for_comparison(expected)
+    return normalized_installed == normalized_expected
 
 
 def _temp_home_in_service_definition(definition: str) -> str | None:
@@ -2774,9 +2791,52 @@ def _print_system_scope_remediation(action: str) -> None:
     print_info("         hermes gateway start")
 
 
-def _get_restart_drain_timeout() -> float:
+def _read_restart_drain_timeout_from_hermes_home(hermes_home: str | None) -> str | None:
+    """Read agent.restart_drain_timeout from a specific Hermes home, if present."""
+    if not hermes_home:
+        return None
+    config_path = Path(hermes_home).expanduser() / "config.yaml"
+    try:
+        import yaml
+    except ImportError as exc:
+        logger.debug(
+            "Unable to read restart drain timeout from %s: %s", config_path, exc
+        )
+        return None
+
+    try:
+        with config_path.open(encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.debug(
+            "Unable to read restart drain timeout from %s: %s", config_path, exc
+        )
+        return None
+    except yaml.YAMLError as exc:
+        logger.debug(
+            "Unable to parse restart drain timeout from %s: %s", config_path, exc
+        )
+        return None
+    agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(agent_cfg, dict) or "restart_drain_timeout" not in agent_cfg:
+        return None
+    return str(agent_cfg.get("restart_drain_timeout"))
+
+
+def _get_restart_drain_timeout(hermes_home: str | None = None) -> float:
     """Return the configured gateway restart drain timeout in seconds."""
     raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
+    if not raw and hermes_home is not None:
+        # For system services installed via sudo, ``hermes_home`` points at the
+        # target user's config. If that config is missing or unreadable, fall
+        # back to the built-in default rather than accidentally reading the
+        # installer/root user's config via read_raw_config().
+        raw = (
+            _read_restart_drain_timeout_from_hermes_home(hermes_home)
+            or str(DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT)
+        )
     if not raw:
         cfg = read_raw_config()
         agent_cfg = cfg.get("agent", {}) if isinstance(cfg, dict) else {}
@@ -2786,6 +2846,17 @@ def _get_restart_drain_timeout() -> float:
             )
         )
     return parse_restart_drain_timeout(raw)
+
+
+def _systemd_timeout_stop_sec(hermes_home: str | None = None) -> int:
+    # systemd's TimeoutStopSec must exceed the gateway's drain_timeout so
+    # there's budget left for post-interrupt cleanup (tool subprocess kill,
+    # adapter disconnect, session DB close) before systemd escalates to
+    # SIGKILL on the cgroup — otherwise bash/sleep tool-call children left
+    # by a force-interrupted agent get reaped by systemd instead of us
+    # (#8202). 30s of headroom covers the worst case we've observed.
+    drain_timeout = int(_get_restart_drain_timeout(hermes_home=hermes_home) or 0)
+    return max(60, drain_timeout) + 30
 
 
 def systemd_install(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -419,7 +419,7 @@ class TestGeneratedSystemdUnits:
         monkeypatch.setattr(
             gateway_cli,
             "_get_restart_drain_timeout",
-            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+            lambda hermes_home=None: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
         )
         unit = gateway_cli.generate_systemd_unit(system=False)
 
@@ -480,7 +480,7 @@ class TestGeneratedSystemdUnits:
         monkeypatch.setattr(
             gateway_cli,
             "_get_restart_drain_timeout",
-            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+            lambda hermes_home=None: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
         )
         unit = gateway_cli.generate_systemd_unit(system=True)
 
@@ -493,6 +493,74 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
         assert "WantedBy=multi-user.target" in unit
+
+    def test_system_unit_timeout_uses_target_users_config_when_installed_via_sudo(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "alice"
+        hermes_home = home / ".hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  restart_drain_timeout: 60\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", str(home)),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda home_dir: str(hermes_home),
+        )
+        monkeypatch.setattr(gateway_cli, "_build_wsl_interop_paths", lambda path_entries: [])
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert "Environment=\"HERMES_HOME=" + str(hermes_home) + "\"" in unit
+        assert "TimeoutStopSec=90" in unit
+
+    def test_systemd_current_comparison_ignores_environment_path_drift(self):
+        installed = '[Service]\nEnvironment="PATH=/old/bin:/usr/bin"\nTimeoutStopSec=90\n'
+        expected = '[Service]\nEnvironment="PATH=/new/bin:/usr/bin"\nTimeoutStopSec=90\n'
+
+        assert (
+            gateway_cli._normalize_systemd_unit_for_comparison(installed)
+            == gateway_cli._normalize_systemd_unit_for_comparison(expected)
+        )
+
+    def test_system_unit_timeout_uses_default_when_target_config_missing(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "alice"
+        hermes_home = home / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", str(home)),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda home_dir: str(hermes_home),
+        )
+        monkeypatch.setattr(gateway_cli, "_build_wsl_interop_paths", lambda path_entries: [])
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"restart_drain_timeout": 999}},
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert self._expected_timeout_stop_sec() in unit
+        assert "TimeoutStopSec=1029" not in unit
 
 
 class TestGatewayStopCleanup:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -523,6 +523,27 @@ class TestGeneratedSystemdUnits:
         assert "Environment=\"HERMES_HOME=" + str(hermes_home) + "\"" in unit
         assert "TimeoutStopSec=90" in unit
 
+    def test_user_unit_timeout_uses_read_raw_config_when_hermes_home_config_missing(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "hermes-home-without-config"
+        hermes_home.mkdir()
+        monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"agent": {"restart_drain_timeout": 120}},
+        )
+        monkeypatch.setattr(gateway_cli, "_build_wsl_interop_paths", lambda path_entries: [])
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "Environment=\"HERMES_HOME=" + str(hermes_home) + "\"" in unit
+        assert "TimeoutStopSec=150" in unit
+        assert self._expected_timeout_stop_sec() not in unit
+
     def test_systemd_current_comparison_ignores_environment_path_drift(self):
         installed = '[Service]\nEnvironment="PATH=/old/bin:/usr/bin"\nTimeoutStopSec=90\n'
         expected = '[Service]\nEnvironment="PATH=/new/bin:/usr/bin"\nTimeoutStopSec=90\n'


### PR DESCRIPTION
## Summary
- Use the target user's Hermes config when generating a system-level gateway unit via sudo
- Avoid false outdated warnings from environment-dependent systemd PATH drift
- Fall back to the built-in restart drain timeout when the target config is missing instead of reading the installer/root config

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestGeneratedSystemdUnits -q`
