### PR TITLE
fix: unify venv directory name to .venv across setup scripts and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Quick start for contributors — clone and go with `setup-hermes.sh`:
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
+./setup-hermes.sh     # installs uv, creates .venv, installs .[all], symlinks ~/.local/bin/hermes
+./hermes              # auto-detects the .venv, no need to `source` first
 ```
 
 Manual path (equivalent to the above):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6012,7 +6012,8 @@ def _update_via_zip(args):
     pip_cmd = [sys.executable, "-m", "pip"]
     uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        _venv = _find_venv_dir()
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_venv) if _venv else str(PROJECT_ROOT / ".venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6599,10 +6600,19 @@ def _is_windows() -> bool:
     return sys.platform == "win32"
 
 
+def _find_venv_dir() -> Path | None:
+    """Find the project venv directory (.venv preferred, venv as fallback)."""
+    for name in (".venv", "venv"):
+        candidate = PROJECT_ROOT / name
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
 def _venv_scripts_dir() -> Path | None:
     """Return the venv Scripts directory if we're running inside the project venv."""
-    venv_dir = PROJECT_ROOT / "venv"
-    if not venv_dir.is_dir():
+    venv_dir = _find_venv_dir()
+    if venv_dir is None:
         return None
     scripts = venv_dir / ("Scripts" if _is_windows() else "bin")
     return scripts if scripts.is_dir() else None
@@ -7575,7 +7585,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            _venv = _find_venv_dir()
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_venv) if _venv else str(PROJECT_ROOT / ".venv")}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -58,10 +58,11 @@ def get_launchd_plist_path() -> Path:
 
 def get_python_path() -> str:
     """Get the path to the Python interpreter."""
-    # Prefer the venv if it exists
-    venv_python = PROJECT_DIR / "venv" / "bin" / "python"
-    if venv_python.exists():
-        return str(venv_python)
+    # Prefer .venv (convention), fall back to venv (legacy).
+    for candidate in (".venv", "venv"):
+        venv_python = PROJECT_DIR / candidate / "bin" / "python"
+        if venv_python.exists():
+            return str(venv_python)
     return sys.executable
 
 def get_gateway_script_path() -> str:

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -145,21 +145,27 @@ fi
 
 echo -e "${CYAN}→${NC} Setting up virtual environment..."
 
+# Clean up both old and current venv directories for a fresh install.
+# "venv" is the legacy name; ".venv" is the current convention.
+if [ -d ".venv" ]; then
+    echo -e "${CYAN}→${NC} Removing existing .venv..."
+    rm -rf .venv
+fi
 if [ -d "venv" ]; then
-    echo -e "${CYAN}→${NC} Removing old venv..."
+    echo -e "${CYAN}→${NC} Removing legacy venv/ (project now uses .venv)..."
     rm -rf venv
 fi
 
 if is_termux; then
-    "$PYTHON_PATH" -m venv venv
-    echo -e "${GREEN}✓${NC} venv created with stdlib venv"
+    "$PYTHON_PATH" -m venv .venv
+    echo -e "${GREEN}✓${NC} .venv created with stdlib venv"
 else
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
-    echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"
+    $UV_CMD venv .venv --python "$PYTHON_VERSION"
+    echo -e "${GREEN}✓${NC} .venv created (Python $PYTHON_VERSION)"
 fi
 
-export VIRTUAL_ENV="$SCRIPT_DIR/venv"
-SETUP_PYTHON="$SCRIPT_DIR/venv/bin/python"
+export VIRTUAL_ENV="$SCRIPT_DIR/.venv"
+SETUP_PYTHON="$SCRIPT_DIR/.venv/bin/python"
 
 # ============================================================================
 # Dependencies
@@ -219,7 +225,7 @@ else
         # `uv pip install` re-resolves transitives fresh from PyPI).
         echo -e "${CYAN}→${NC} Using uv.lock for hash-verified installation..."
         _UV_SYNC_LOG=$(mktemp)
-        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --all-extras --locked 2>"$_UV_SYNC_LOG"; then
+        if UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/.venv" $UV_CMD sync --all-extras --locked 2>"$_UV_SYNC_LOG"; then
             echo -e "${GREEN}✓${NC} Dependencies installed (hash-verified via uv.lock)"
             rm -f "$_UV_SYNC_LOG"
         else
@@ -328,7 +334,7 @@ fi
 
 echo -e "${CYAN}→${NC} Setting up hermes command..."
 
-HERMES_BIN="$SCRIPT_DIR/venv/bin/hermes"
+HERMES_BIN="$SCRIPT_DIR/.venv/bin/hermes"
 COMMAND_LINK_DIR="$(get_command_link_dir)"
 COMMAND_LINK_DISPLAY_DIR="$(get_command_link_display_dir)"
 mkdir -p "$COMMAND_LINK_DIR"
@@ -385,7 +391,7 @@ mkdir -p "$HERMES_SKILLS_DIR"
 
 echo ""
 echo "Syncing bundled skills to ~/.hermes/skills/ ..."
-if "$SCRIPT_DIR/venv/bin/python" "$SCRIPT_DIR/tools/skills_sync.py" 2>/dev/null; then
+if "$SCRIPT_DIR/.venv/bin/python" "$SCRIPT_DIR/tools/skills_sync.py" 2>/dev/null; then
     echo -e "${GREEN}✓${NC} Skills synced"
 else
     # Fallback: copy if sync script fails (missing deps, etc.)
@@ -439,5 +445,5 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
     echo ""
     # Run directly with venv Python (no activation needed)
-    "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main setup
+    "$SCRIPT_DIR/.venv/bin/python" -m hermes_cli.main setup
 fi


### PR DESCRIPTION
## Summary

The project inconsistently uses both `venv` and `.venv` for the virtual environment directory. `AGENTS.md` already states "Prefer .venv", `uv` defaults to `.venv`, and runtime code in `gateway.py`/`doctor.py` already checks `.venv` first — but `setup-hermes.sh` and several `main.py` call sites still hardcoded `venv`.

This PR brings all creation and lookup paths in line with the `.venv` convention, while keeping `venv` as a backwards-compatible fallback in runtime code.

## What changed

| File | Change |
|------|--------|
| `setup-hermes.sh` | Create `.venv` instead of `venv`; clean up legacy `venv/` if present |
| `hermes_cli/main.py` | Add `_find_venv_dir()` helper (`.venv` preferred, `venv` fallback); update 3 hardcoded `PROJECT_ROOT / "venv"` references |
| `scripts/hermes-gateway` | Prefer `.venv` with `venv` fallback in `get_python_path()` |
| `README.md` | Update quickstart comment to reference `.venv` |

## What was already correct (no changes needed)

- `hermes_cli/gateway.py:1979` — already checks `.venv` first
- `hermes_cli/doctor.py:851` — already checks `.venv` first
- `scripts/run_tests.sh` — already probes `.venv` first
- `.gitignore` — already excludes both `/venv/` and `.venv/`
- Tests — validate fallback behavior for both names

## Migration path for existing users

Existing `venv/` directories continue to work — all runtime code falls back to `venv` when `.venv` doesn't exist. Users who re-run `setup-hermes.sh` will get a clean `.venv` (the script removes both old directories before creating a fresh one).

🤖 Generated with [Claude Code](https://claude.ai/code)