### PR TITLE
[codex] make Feishu websocket readiness explicit

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -190,6 +190,7 @@ _FEISHU_DOC_UPLOAD_TYPES = {
 _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
+_FEISHU_WS_READY_TIMEOUT_SECONDS = float(os.getenv("FEISHU_WS_READY_TIMEOUT", "25"))
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
@@ -1290,6 +1291,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
+    original_ws_connect = getattr(ws_client, "_connect", None)
 
     def _apply_runtime_ws_overrides() -> None:
         try:
@@ -1314,9 +1316,21 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         _apply_runtime_ws_overrides()
         return result
 
+    async def _connect_with_ready_signal(*args: Any, **kwargs: Any) -> Any:
+        if original_ws_connect is None:
+            raise RuntimeError("Feishu websocket client has no _connect coroutine")
+        result = await original_ws_connect(*args, **kwargs)
+        try:
+            adapter._mark_websocket_ready()
+        except Exception:
+            logger.debug("[Feishu] Failed to mark websocket ready", exc_info=True)
+        return result
+
     ws_client_module.websockets.connect = _connect_with_overrides
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
+    if original_ws_connect is not None:
+        setattr(ws_client, "_connect", _connect_with_ready_signal)
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
@@ -1326,6 +1340,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
+        if original_ws_connect is not None:
+            setattr(ws_client, "_connect", original_ws_connect)
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
         for task in pending:
             task.cancel()
@@ -1393,6 +1409,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._connect_time: Optional[float] = None
+        self._ws_ready_event = threading.Event()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -1606,6 +1624,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            self._connect_time = time.time()
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             return True
@@ -1622,6 +1641,7 @@ class FeishuAdapter(BasePlatformAdapter):
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
+        self._ws_ready_event.clear()
         self._disable_websocket_auto_reconnect()
         await self._stop_webhook_server()
 
@@ -1660,6 +1680,9 @@ class FeishuAdapter(BasePlatformAdapter):
 
         self._mark_disconnected()
         logger.info("[Feishu] Disconnected")
+
+    def _mark_websocket_ready(self) -> None:
+        self._ws_ready_event.set()
 
     async def _cancel_pending_tasks(self, tasks: Dict[str, asyncio.Task]) -> None:
         pending = [task for task in tasks.values() if task and not task.done()]
@@ -2348,6 +2371,20 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message or not sender or not getattr(sender, "sender_id", None):
             logger.debug("[Feishu] Dropping malformed inbound event: missing message/sender")
             return
+
+        create_time_raw = getattr(message, "create_time", None)
+        if create_time_raw is not None and self._connect_time is not None:
+            try:
+                create_ts = int(str(create_time_raw)) / 1000.0
+                if create_ts < self._connect_time:
+                    logger.info(
+                        "[Feishu] Dropping stale pre-connect message %s (created %.1fs before connect)",
+                        getattr(message, "message_id", "?"),
+                        self._connect_time - create_ts,
+                    )
+                    return
+            except (TypeError, ValueError):
+                pass
 
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):
@@ -4387,6 +4424,26 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        await self._wait_for_websocket_ready()
+
+    async def _wait_for_websocket_ready(self, timeout: float = _FEISHU_WS_READY_TIMEOUT_SECONDS) -> None:
+        if self._ws_ready_event.is_set():
+            return
+        deadline = time.monotonic() + timeout
+        while not self._ws_ready_event.is_set():
+            ws_future = self._ws_future
+            if ws_future is not None and ws_future.done():
+                try:
+                    exc = ws_future.exception()
+                except Exception as err:
+                    exc = err
+                if exc is not None:
+                    raise RuntimeError("Feishu websocket client exited before connecting") from exc
+                raise RuntimeError("Feishu websocket client exited before connecting")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Feishu websocket did not establish within {timeout:.1f}s")
+            await asyncio.sleep(min(0.1, remaining))
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -8,7 +8,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict
+from typing import Any, Dict
 from unittest.mock import AsyncMock, Mock, patch
 
 from gateway.platforms.base import ProcessingOutcome
@@ -229,6 +229,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
 
             class _Loop:
                 def run_in_executor(self, *_args, **_kwargs):
+                    adapter._mark_websocket_ready()
                     return future
 
                 def is_closed(self):
@@ -313,6 +314,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
                     self.calls += 1
                     if self.calls == 1:
                         raise OSError("temporary websocket failure")
+                    adapter._mark_websocket_ready()
                     return future
 
                 def is_closed(self):
@@ -328,6 +330,41 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(connected)
         self.assertEqual(sleeps, [1])
         self.assertEqual(fake_loop.calls, 2)
+
+    def test_wait_for_websocket_ready_times_out(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        with self.assertRaises(TimeoutError):
+            asyncio.run(adapter._wait_for_websocket_ready(timeout=0.01))
+
+    def test_connect_websocket_waits_for_sdk_ready_signal(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        async def _run() -> tuple[AsyncMock, Any]:
+            adapter._loop = asyncio.get_running_loop()
+            with (
+                patch("gateway.platforms.feishu.FEISHU_WEBSOCKET_AVAILABLE", True),
+                patch("gateway.platforms.feishu.lark", SimpleNamespace(LogLevel=SimpleNamespace(INFO="INFO"))),
+                patch("gateway.platforms.feishu.FeishuWSClient", return_value=SimpleNamespace()) as ws_client_cls,
+                patch("gateway.platforms.feishu._run_official_feishu_ws_client", lambda *_args: None),
+                patch.object(adapter, "_hydrate_bot_identity", new=AsyncMock()),
+                patch.object(adapter, "_build_lark_client", return_value=SimpleNamespace()),
+                patch.object(adapter, "_build_event_handler", return_value=object()),
+                patch.object(adapter, "_wait_for_websocket_ready", new=AsyncMock()) as wait_ready,
+            ):
+                await adapter._connect_websocket()
+                return wait_ready, ws_client_cls
+
+        wait_ready, ws_client_cls = asyncio.run(_run())
+
+        wait_ready.assert_awaited_once()
+        ws_client_cls.assert_called_once()
 
     @patch.dict(os.environ, {}, clear=True)
     def test_edit_message_updates_existing_feishu_message(self):
@@ -1513,6 +1550,30 @@ class TestAdapterBehavior(unittest.TestCase):
             adapter._on_message_event(data)
 
         self.assertTrue(submit.called)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_stale_pre_connect_message_is_dropped(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = time.time()
+        adapter._admit = Mock(return_value=None)
+        adapter._process_inbound_message = AsyncMock()
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        message = SimpleNamespace(
+            message_id="om_stale",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            create_time=str(int((adapter._connect_time - 5) * 1000)),
+        )
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        asyncio.run(adapter._handle_message_event_data(data))
+
+        adapter._process_inbound_message.assert_not_awaited()
 
     @patch.dict(os.environ, {}, clear=True)
     def test_webhook_request_uses_same_message_dispatch_path(self):


### PR DESCRIPTION
## What does this PR do?

Splits the Feishu websocket readiness portion out of #24337 into a smaller draft PR.

The adapter now waits until the official Feishu/Lark SDK has actually completed websocket `_connect()` before Hermes marks the platform connected. It also records the connect time and drops stale pre-connect message replays.

## Why

Before this, Hermes could mark Feishu connected immediately after scheduling the SDK websocket client in an executor thread, even if the SDK was still connecting or retrying internally. During unstable startup/reconnect windows, that made gateway state look healthier than the actual Feishu websocket.

## Changes made

- Add a websocket ready event that is set from the SDK thread after the SDK `_connect()` coroutine succeeds.
- Wait for that ready signal before `_connect_websocket()` returns.
- Surface timeout/early-exit failures instead of marking Feishu connected too early.
- Record adapter connect time and drop stale message replays created before the current connection.
- Add focused Feishu tests for readiness waiting, timeout behavior, and stale pre-connect event drops.

## Important scope note

This intentionally does not include the broader #24337 shutdown experiment that proactively called the SDK internal `_disconnect()` from Hermes shutdown. Local re-diagnosis showed event-loop lifecycle risk there (`Future attached to a different loop`), so this PR avoids cross-loop SDK internal disconnect calls and leaves shutdown cleanup on the existing thread-loop cancel/stop path.

This PR also does not change launchd, gateway runner startup semantics, Hindsight/API server lifecycle, Wi-Fi, DNS, system proxy settings, or any third-party proxy app configuration.

## Related upstream work

- Related to closed #21712 for stale pre-connect message handling.
- Related to closed #5500 for Feishu websocket lifecycle diagnosis, but intentionally narrower.
- Related to open #4789 only in the broad Feishu reliability area; this PR does not implement event queueing or multi-process changes.

## Validation

- `venv/bin/python -m ruff check .`
- `scripts/run_tests.sh tests/gateway/test_feishu.py`

Result: `201 passed`.