### PR TITLE
fix(auxiliary): treat aux <task>.model: auto as sentinel, not a literal model id

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3809,6 +3809,16 @@ def _resolve_task_provider_model(
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
+    # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not
+    # a literal model id. Without this, a config of `auxiliary.<task>.model: auto`
+    # propagates the literal string "auto" to the wire, where the provider returns
+    # a 200 OK with an error-text body (e.g. "the model 'auto' does not exist"),
+    # which downstream consumers like ContextCompressor accept as the task output.
+    # The provider-side 'auto' is handled in _resolve_auto() via main_runtime
+    # fallback, so dropping cfg_model to None here lets that path do its job.
+    if cfg_model and cfg_model.lower() == "auto":
+        cfg_model = None
+
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 


### PR DESCRIPTION
## Problem

When `auxiliary.<task>.model` is set to `auto` in `config.yaml`, `_resolve_task_provider_model()` was treating it as a truthy model id and propagating the literal string `"auto"` to the wire.

The provider then returned a 200 OK with an error-text body (e.g. `"There's an issue with the selected model (auto). It may not exist or you may not have access to it. Run --model to pick a different model."`), which downstream consumers such as `ContextCompressor` accept as the compressed summary content. The result: **silent corruption with no exception raised**. `compressor._last_summary_error` stays `None` because nothing technically failed — the response was a 200 OK with text in the expected shape.

This is particularly bad for context compaction: the user gets a "summary" that is actually a model-selection error message, and earlier turns are dropped based on that fake summary.

## Reproduction (pre-fix)

```yaml
# ~/.hermes/config.yaml
auxiliary:
  compression:
    provider: auto
    model: auto
```

```python
from agent.auxiliary_client import _resolve_task_provider_model
>>> _resolve_task_provider_model("compression")
("auto", "auto", None, None, None)   # literal "auto" as model id
```

When this hits an OpenAI-compatible bridge that resolves models against a real catalogue, the bridge correctly refuses (`"model auto does not exist"`) and returns that text in a `chat.completion` response. `ContextCompressor` accepts the text as the summary.

## Fix

Normalize the `auto` sentinel at the resolver layer. When `cfg_model.lower() == "auto"`, drop it to `None` so the existing `_resolve_auto()` → `main_runtime` fallback path can substitute the user's main model.

```diff
     if task:
         task_config = _get_auxiliary_task_config(task)
         cfg_model = str(task_config.get("model", "")).strip() or None
         ...
+    if cfg_model and cfg_model.lower() == "auto":
+        cfg_model = None
+
     resolved_model = model or cfg_model
```

## Post-fix

```python
>>> _resolve_task_provider_model("compression")
("auto", None, None, None, None)
```

Verified end-to-end on a fresh Python process: `ContextCompressor.compress()` against a 64-message synthetic conversation produces a real 4174-char compaction summary in ~20s, with `_last_summary_error` and `_last_aux_model_failure_error` both `None`, and no "issue with the selected model" / "Run --model to pick" strings appearing in the summary body.

## Scope

10-line change, single file (`agent/auxiliary_client.py`). No behavior change for users who set `provider` and `model` explicitly. Only fires when `cfg_model.lower() == "auto"`, which was silently broken before.

## Companion PR

[#24369](https://github.com/NousResearch/hermes-agent/pull/24369) — `fix(compressor): reject provider error/refusal strings as fake summaries`. The structural defense for the failure mode this PR's symptom exposed: `ContextCompressor` now rejects any auxiliary response that matches known provider-error / refusal patterns, so even if some future config / provider combination produces a 200 OK with control-plane text, the compressor will no longer silently corrupt the conversation summary.

The two PRs are independent and can land in either order — this one fixes the proximate cause of the `auto` propagation; #24369 makes the failure class impossible regardless of what reaches the wire.
