### PR TITLE
fix(agent): skip dead /v1/models probes when LM Studio slug isn't loaded

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -19,7 +19,7 @@ import yaml
 
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname
 
-from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_constants import OPENROUTER_MODELS_URL, display_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -1653,6 +1653,33 @@ def _model_name_suggests_grok_4_3(model: str) -> bool:
     return "grok-4.3" in model.lower()
 
 
+# One-shot deduplication for the LM Studio "model not loaded" warning so a
+# stale config slug logs once per (model, server) pair instead of every time
+# an aux client probes context length.
+_LMSTUDIO_MISSING_MODEL_WARNED: set[tuple[str, str]] = set()
+
+
+def _warn_lmstudio_model_not_loaded(model: str, server_url: str, models_in_list: list) -> None:
+    """Log a one-time warning when the requested model isn't loaded in LM Studio."""
+    key = (model, server_url)
+    if key in _LMSTUDIO_MISSING_MODEL_WARNED:
+        return
+    _LMSTUDIO_MISSING_MODEL_WARNED.add(key)
+    loaded_ids = sorted({
+        str(m.get("id") or m.get("key") or "").strip()
+        for m in models_in_list
+        if (m.get("id") or m.get("key"))
+    })
+    loaded_summary = ", ".join(loaded_ids) if loaded_ids else "(none loaded)"
+    logger.warning(
+        "Model %r is not loaded in LM Studio at %s. Loaded models: %s. "
+        "Skipping /v1/models/{model} and /v1/models probes (they would 404). "
+        "Either load %r in LM Studio, edit %s/config.yaml model.default, "
+        "or run `hermes model` to pick from the loaded list.",
+        model, server_url, loaded_summary, model, display_hermes_home(),
+    )
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length (short-TTL cached).
 
@@ -1746,8 +1773,11 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 resp = client.get(f"{lmstudio_url}/api/v1/models")
                 if resp.status_code == 200:
                     data = resp.json()
-                    for m in data.get("models", []):
+                    models_in_list = data.get("models", []) or []
+                    matched = False
+                    for m in models_in_list:
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
+                            matched = True
                             # Prefer loaded instance context (actual runtime value)
                             for inst in m.get("loaded_instances", []):
                                 cfg = inst.get("config", {})
@@ -1755,6 +1785,17 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                                 if ctx and isinstance(ctx, (int, float)):
                                     return int(ctx)
                             break
+                    # LM Studio confirmed reachable. If the requested model
+                    # isn't in its model list, the OpenAI-compat probes below
+                    # (GET /v1/models/{model} and GET /v1/models) will both
+                    # 404 in a loop and spam LM Studio's log. See #24102 —
+                    # most often the user's config.yaml has a stale
+                    # aggregator slug (e.g. google/gemini-3-flash-preview)
+                    # left over from an earlier OpenRouter/Nous setup. Bail
+                    # out with a one-shot, actionable warning instead.
+                    if not matched:
+                        _warn_lmstudio_model_not_loaded(model, server_url, models_in_list)
+                        return None
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}
             resp = client.get(f"{server_url}/v1/models/{model}")

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -468,6 +468,66 @@ class TestQueryLocalContextLengthLmStudio:
         assert client_mock.get.call_args_list[0].args[0] == "http://127.0.0.1:1234/api/v1/models"
 
 
+    def test_lmstudio_model_not_loaded_skips_probes_and_returns_none(self):
+        """Bug #24102: when the requested model isn't in LM Studio's loaded list,
+        skip the OpenAI-compat /v1/models/{model} and /v1/models probes — they
+        would 404 in a loop. Return None and let the caller fall back to the
+        default context length."""
+        from agent import model_metadata
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {"key": "google/gemma-4-26b-a4b",
+                 "id": "google/gemma-4-26b-a4b",
+                 "loaded_instances": [{"config": {"context_length": 8192}}]},
+            ]
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = native_resp
+
+        model_metadata._LMSTUDIO_MISSING_MODEL_WARNED.clear()
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "google/gemini-3-flash-preview", "http://127.0.0.1:1234/v1"
+            )
+
+        assert result is None
+        # Exactly one GET — the LM Studio native /api/v1/models. The two
+        # follow-up probes that produced the 404 spam must NOT fire.
+        get_paths = [c.args[0] for c in client_mock.get.call_args_list]
+        assert get_paths == ["http://127.0.0.1:1234/api/v1/models"], get_paths
+
+    def test_lmstudio_missing_model_warning_dedup(self):
+        """The 'not loaded' warning fires once per (model, server) pair."""
+        from agent import model_metadata
+
+        models_in_list = [
+            {"id": "google/gemma-4-26b-a4b", "key": "google/gemma-4-26b-a4b"},
+        ]
+        model_metadata._LMSTUDIO_MISSING_MODEL_WARNED.clear()
+
+        with patch.object(model_metadata.logger, "warning") as warn:
+            model_metadata._warn_lmstudio_model_not_loaded(
+                "google/gemini-3-flash-preview", "http://127.0.0.1:1234", models_in_list
+            )
+            model_metadata._warn_lmstudio_model_not_loaded(
+                "google/gemini-3-flash-preview", "http://127.0.0.1:1234", models_in_list
+            )
+            # Different model → fires again
+            model_metadata._warn_lmstudio_model_not_loaded(
+                "openai/gpt-5", "http://127.0.0.1:1234", models_in_list
+            )
+
+        assert warn.call_count == 2
+
+
 class TestDetectLocalServerTypeAuth:
     def test_passes_bearer_token_to_probe_requests(self):
         from agent.model_metadata import detect_local_server_type


### PR DESCRIPTION
## Summary

When `model.default` in `config.yaml` carries an aggregator-style slug left over from an earlier OpenRouter / Nous / Kilocode setup (e.g. `google/gemini-3-flash-preview`) and the user later points the endpoint at LM Studio, every startup fires two doomed probes against LM Studio:

```
GET /v1/models/google/gemini-3-flash-preview   → 400 "Model with identifier '…' not found"
GET /v1/models                                  → no match
```

The first one surfaces in LM Studio's log as the loud `Error: Model with identifier 'google/gemini-3-flash-preview' not found` reported in #24102.

`_query_local_context_length` (`agent/model_metadata.py`) already queries LM Studio's native `/api/v1/models` first and has the authoritative loaded-model list. This PR uses that list as a gate: when the requested slug isn't loaded, **skip** the two follow-up probes and emit one deduplicated warning telling the user how to fix it (load the model, edit `model.default`, or run `hermes model`). Caller falls back to `DEFAULT_FALLBACK_CONTEXT` as before, so behavior on the read path is unchanged — only the wire chatter and LM Studio's error log are quieted.

Closes #24102.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_model_metadata_local_ctx.py` — 24 passed, including 2 new tests:
  - `test_lmstudio_model_not_loaded_skips_probes_and_returns_none` — asserts the only outbound GET is `/api/v1/models`; the bug-causing `/v1/models/{slug}` and the `/v1/models` fallback are NOT sent.
  - `test_lmstudio_missing_model_warning_dedup` — asserts the warning fires once per (model, server) pair.
- [x] `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/agent/test_model_metadata_local_ctx.py` — 118 passed, no regressions.
- [x] `scripts/check-windows-footguns.py agent/model_metadata.py tests/agent/test_model_metadata_local_ctx.py` — clean.
- [x] `ruff check` on both touched files — clean.
- [x] **End-to-end against a real LM Studio instance** (`qwen/qwen3-1.7b` loaded, no `google/gemini-3-flash-preview` available):
  - bug-trigger scenario → 0 `/v1/models/{bad-slug}` requests fired (down from 1 per call); single warning logged with LM Studio's actual loaded list; ctx falls back to default.
  - happy path with `qwen/qwen3-1.7b` → returns 40960 (the live `context_length` from LM Studio's `/api/v1/models` `loaded_instances[0].config`).
  - direct `curl http://127.0.0.1:1234/v1/models/google/gemini-3-flash-preview` confirmed LM Studio returns `400 {"error":"Model with identifier 'google/gemini-3-flash-preview' not found"}` — verbatim the message in the bug report.

## What this is NOT

While auditing, a few unrelated gaps in the auxiliary-client fallback chain came up — LM Studio has no `plugins/model-providers/lmstudio/` `ProviderProfile`, so `_get_aux_model_for_provider("lmstudio")` returns `""` and the api-key fallback chain in `_resolve_api_key_provider` silently skips it; and `_resolve_auto` Step 1 only propagates `explicit_base_url` for `provider == "custom"`, not for `lmstudio`. Reproduction confirmed these are real but **not** what's producing the 404 spam in #24102. They're out of scope here; happy to file a separate issue if useful.
