### PR TITLE
fix(compressor): reject provider error/refusal strings as fake summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -75,6 +75,45 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
+# When an auxiliary provider can't satisfy the request (unknown model, refused
+# prompt, etc.) it sometimes returns a 200 OK with an error-text body rather
+# than raising an exception. Without this guard, ContextCompressor would accept
+# that text as the conversation summary and drop the real middle turns. The
+# patterns below are conservative — they only match phrases that look like a
+# control plane talking, not a model summarising a conversation about control
+# planes. Match is substring-based, case-insensitive, against the FULL summary.
+_PROVIDER_ERROR_SUMMARY_PATTERNS = (
+    # Generic OpenAI-compatible provider "model not found" responses (e.g. the
+    # claude-bridge / Codex-via-bridge case where literal 'auto' propagated to
+    # the wire and the bridge politely refused).
+    "there's an issue with the selected model",
+    "there is an issue with the selected model",
+    "run --model to pick a different model",
+    "may not exist or you may not have access",
+    # OpenAI / Anthropic / OpenRouter refusal-by-content patterns. Conservative
+    # — these phrases would not occur naturally in a faithful conversation
+    # summary; if they appear in summary output it means the auxiliary LLM
+    # refused the prompt rather than producing one.
+    "i can't help with that",
+    "i cannot help with that",
+    "i'm sorry, but i can't",
+    "i'm sorry, but i cannot",
+    "i am sorry, but i can't",
+    "i am sorry, but i cannot",
+)
+
+
+def _looks_like_provider_error_summary(summary: str) -> bool:
+    """True when the auxiliary LLM returned an error / refusal string instead of a summary.
+
+    Used to reject 200-OK responses whose body is actually the provider's
+    control plane talking. See ``_PROVIDER_ERROR_SUMMARY_PATTERNS``.
+    """
+    if not summary or not isinstance(summary, str):
+        return False
+    needle = summary.lower()
+    return any(p in needle for p in _PROVIDER_ERROR_SUMMARY_PATTERNS)
+
 
 def _content_length_for_budget(raw_content: Any) -> int:
     """Return the effective char-length of a message's content for token budgeting.
@@ -956,6 +995,44 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
+            # Provider-error guard: some OpenAI-compatible providers return a
+            # 200 OK with control-plane error text (e.g. "the model 'auto' does
+            # not exist, run --model to pick a different model") instead of
+            # raising. Without this check, ContextCompressor would store that
+            # text as the conversation summary, drop the real middle turns,
+            # and the user would see a corrupted handoff with no warning.
+            # Treat as a provider failure: short cooldown, no fallback summary,
+            # propagate the same _last_summary_error path the exception branch
+            # uses so downstream consumers can surface a warning.
+            if _looks_like_provider_error_summary(summary):
+                _preview = summary[:200].replace("\n", " ")
+                logger.error(
+                    "Context compression: auxiliary LLM returned a provider "
+                    "error/refusal string instead of a summary (preview: %r). "
+                    "Rejecting to avoid silent context corruption. Check "
+                    "auxiliary.compression.{provider,model} in config.yaml.",
+                    _preview,
+                )
+                self._last_summary_error = "provider returned error string as summary"
+                self._last_aux_model_failure_error = _preview
+                # If a distinct summary model is configured and we haven't
+                # already fallen back, retry once on the main model — losing N
+                # turns of context is almost always worse than one extra
+                # summary attempt. Mirrors the exception path retry logic.
+                if (
+                    self.summary_model
+                    and self.summary_model != self.model
+                    and not getattr(self, "_summary_model_fallen_back", False)
+                ):
+                    _fake_err = RuntimeError(
+                        f"summary returned provider error string: {_preview}"
+                    )
+                    self._fallback_to_main_for_compression(_fake_err, "provider-error-summary")
+                    return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+                # No fallback path available — enter cooldown so we stop
+                # making the same broken call repeatedly.
+                self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
+                return None
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0


### PR DESCRIPTION
## Problem

Some OpenAI-compatible auxiliary providers return a 200 OK with a control-plane error string rather than raising an HTTP error. The two common shapes today:

1. **Model-not-found via the provider's own catalogue** — e.g. when literal `"auto"` propagates to the wire (separate resolver bug in PR #24361), the bridge replies `200 OK` with body `"There's an issue with the selected model (auto). It may not exist or you may not have access to it. Run --model to pick a different model."`
2. **Content-policy refusal worded as a normal response** — e.g. `"I can't help with that"` / `"I'm sorry, but I can't ..."`

Before this fix, `ContextCompressor` accepted those texts as the conversation summary, stored them in `_previous_summary` for iterative updates, and dropped the real middle turns. **Silent context corruption** — the agent saw a "summary" that was actually an error message, no exception was raised, `_last_summary_error` stayed `None`, and the user had no signal that anything had gone wrong until they noticed the agent seemed to have forgotten the conversation.

## Reproduction (pre-fix)

With `auxiliary.compression.model: auto` against any provider that resolves model names against a real catalogue (claude-bridge does this):

```python
import sys
sys.path.insert(0, '~/.hermes/hermes-agent')
from agent.context_compressor import ContextCompressor
cc = ContextCompressor(model='claude-bridge/claude-opus-4-7', provider='claude-bridge', ...)
out = cc.compress(messages_long_enough_to_trigger_compaction)
# Inspect the [CONTEXT COMPACTION] block in out:
#   summary body: "There's an issue with the selected model (auto). ..."
# _last_summary_error: None  <- nothing flagged
```

## Fix

Add a conservative substring match (`_looks_like_provider_error_summary`) against the summary content before storing it. Patterns are intentionally narrow and bridge / aggregator control-plane shaped — they would not match a real conversation summary that happens to discuss "models" or "selection".

When the match fires, treat it the same way the existing exception path does:

- Log clearly with a content preview (capped at 200 chars).
- Set `_last_summary_error` and `_last_aux_model_failure_error` so downstream consumers can surface a warning.
- If a distinct `summary_model_override` is configured and we haven't already fallen back, invoke `_fallback_to_main_for_compression(...)` and recurse — losing N turns of context is almost always worse than one extra summary attempt. Mirrors the retry logic at line ~1115.
- Otherwise enter the standard `_SUMMARY_FAILURE_COOLDOWN_SECONDS` cooldown so we stop making the same broken call repeatedly.

The substring set is the start of a list, not the end of one. New patterns should be added as they're observed in the wild; the comments above the constant document the philosophy ("only match phrases that look like a control plane talking, not a model summarising a conversation about control planes").

## Scope

Single file (`agent/context_compressor.py`), +77 lines:

- One module-level constant `_PROVIDER_ERROR_SUMMARY_PATTERNS`.
- One pure helper `_looks_like_provider_error_summary(summary)`.
- One guard block inserted in `_generate_summary` after `summary = redact_sensitive_text(...)` and before `self._previous_summary = summary`.

No behavior change for users whose auxiliary provider returns either valid summaries or HTTP errors. Only fires on the "200 OK with error string body" failure mode, which was previously silent corruption.

## Verification

Verification scripts at `/tmp/verify-compressor-error-guard.py` and `/tmp/verify-compressor-fallback.py` (not part of the diff):

- **Pure detection:** 5 positive cases (known provider error / refusal phrasings) all match; 5 negative cases (real summary mentioning "model", empty string, arbitrary summary, `None`, `int`) all reject.
- **Integration without fallback:** `compress()` patched `call_llm` to return the bridge's `"...issue with the selected model (auto)..."` text. After fix: `_last_summary_error == 'provider returned error string as summary'`, `_last_aux_model_failure_error` carries the preview, and no message in the output contains `"issue with the selected model"` or `"Run --model to pick"`.
- **Integration with fallback:** `summary_model_override='gpt-broken-5.5'` returns the error string on call 0; main model returns a valid summary on call 1; output contains the real summary, none of the error text.

## Companion PR

[#24361](https://github.com/NousResearch/hermes-agent/pull/24361) — `fix(auxiliary): treat aux <task>.model: auto as sentinel, not a literal model id`. That PR fixes the proximate cause of the `"auto"` flow. This PR is the second-half defense: even if some future config / provider combination produces 200-OK-with-error-text by another path, the compressor will no longer silently corrupt the conversation.

The two are independent and can land in either order.
