### PR TITLE
fix(gateway): delete stale Discord slash commands before creating new ones

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1257,6 +1257,16 @@ class DiscordAdapter(BasePlatformAdapter):
             mutation_count += 1
             return result
 
+        # Delete stale commands FIRST (commands that exist on Discord but are
+        # no longer in our desired set).  Doing this before creating new
+        # commands ensures the total never exceeds Discord's hard limit of
+        # 100 global application commands.
+        stale_keys = [k for k in existing_by_key if k not in desired_by_key]
+        for key in stale_keys:
+            current = existing_by_key.pop(key)
+            await mutate(http.delete_global_command, app_id, current.id)
+            deleted += 1
+
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
@@ -1279,10 +1289,6 @@ class DiscordAdapter(BasePlatformAdapter):
 
             await mutate(http.edit_global_command, app_id, current.id, desired)
             updated += 1
-
-        for current in existing_by_key.values():
-            await mutate(http.delete_global_command, app_id, current.id)
-            deleted += 1
 
         return {
             "total": len(desired_payloads),

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1264,8 +1264,18 @@ class DiscordAdapter(BasePlatformAdapter):
         stale_keys = [k for k in existing_by_key if k not in desired_by_key]
         for key in stale_keys:
             current = existing_by_key.pop(key)
-            await mutate(http.delete_global_command, app_id, current.id)
-            deleted += 1
+            try:
+                await mutate(http.delete_global_command, app_id, current.id)
+                deleted += 1
+            except Exception as e:
+                logger.warning(
+                    "[%s] Failed to delete stale command '%s' (id=%s): %s. "
+                    "Continuing with remaining stale commands.",
+                    self.name, current.name, current.id, e,
+                )
+                # Popped from existing_by_key so the create/update loop
+                # skips it. The stale command remains on Discord but won't
+                # block new commands from being registered.
 
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -724,6 +724,142 @@ async def test_safe_sync_slash_commands_paces_mutation_writes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_safe_sync_slash_commands_deletes_stale_before_creating():
+    """Stale commands must be deleted BEFORE any new commands are created,
+    to avoid exceeding Discord's hard limit of 100 global application
+    commands during the sync window."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+
+        def to_dict(self):
+            return {"id": self.id, "application_id": 999, **self._payload}
+
+    # Two stale commands that should be deleted
+    stale_a = _ExistingCommand(101, {"name": "old-alpha", "description": "gone", "type": 1})
+    stale_b = _ExistingCommand(102, {"name": "old-beta", "description": "gone", "type": 1})
+    # One new command that should be created
+    desired_new = {"name": "fresh", "description": "new command", "type": 1, "options": []}
+    # One existing command that should be updated
+    desired_updated = {"name": "keep", "description": "updated desc", "type": 1, "options": []}
+    existing_keep = _ExistingCommand(
+        200, {"name": "keep", "description": "old desc", "type": 1, "options": []}
+    )
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [
+            _DesiredCommand(desired_new),
+            _DesiredCommand(desired_updated),
+        ],
+        fetch_commands=AsyncMock(return_value=[stale_a, stale_b, existing_keep]),
+    )
+
+    # Track the order in which HTTP methods are called
+    call_order = []
+
+    async def track_upsert(*_args, **_kwargs):
+        call_order.append("upsert")
+
+    async def track_edit(*_args, **_kwargs):
+        call_order.append("edit")
+
+    async def track_delete(*_args, **_kwargs):
+        call_order.append("delete")
+
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(side_effect=track_upsert),
+        edit_global_command=AsyncMock(side_effect=track_edit),
+        delete_global_command=AsyncMock(side_effect=track_delete),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    await adapter._safe_sync_slash_commands()
+
+    # All deletes must occur before any upsert or edit
+    last_delete = max(i for i, c in enumerate(call_order) if c == "delete")
+    first_non_delete = min(i for i, c in enumerate(call_order) if c != "delete")
+    assert last_delete < first_non_delete, (
+        f"Delete must happen before create/update. Call order: {call_order}"
+    )
+    assert call_order.count("delete") == 2
+    assert call_order.count("upsert") == 1
+    assert call_order.count("edit") == 1
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_slash_commands_deletion_error_does_not_block_sync():
+    """If deleting a stale command fails, the sync should continue with
+    the remaining stale commands and still create/update desired ones."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+
+    stale_fail = _ExistingCommand(101, {"name": "broken", "description": "x", "type": 1})
+    stale_ok = _ExistingCommand(102, {"name": "old-two", "description": "x", "type": 1})
+    desired_new = {"name": "fresh", "description": "new", "type": 1, "options": []}
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand(desired_new)],
+        fetch_commands=AsyncMock(return_value=[stale_fail, stale_ok]),
+    )
+
+    delete_calls = []
+
+    async def failing_delete(app_id, cmd_id):
+        delete_calls.append(cmd_id)
+        if cmd_id == 101:
+            raise RuntimeError("discord API error")
+
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(side_effect=failing_delete),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    # Both stale commands were attempted for deletion
+    assert set(delete_calls) == {101, 102}
+    # The new command was still created despite the first deletion failing
+    fake_http.upsert_global_command.assert_awaited_once_with(999, desired_new)
+    assert summary["deleted"] == 1  # only the second one succeeded
+    assert summary["created"] == 1
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_reads_permission_attrs_from_existing_command():
     """Regression: AppCommand.to_dict() in discord.py does NOT include
     nsfw, dm_permission, or default_member_permissions — they live only


### PR DESCRIPTION
## What does this PR do?

    Fixes a synchronization bug in the Discord platform adapter that causes command registration to fail when stale commands from old versions push the total count over Discord's hard limit of 100 global application commands.

    In _safe_sync_slash_commands(), stale (removed) commands were deleted AFTER new commands were created/updated. This means that during the sync, the temporary command count on Discord could exceed 100 (stale + new), causing Discord to reject the entire batch. This fix reverses the order so stale commands are always deleted first, guaranteeing the active command count never exceeds the desired count during sync.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

    - gateway/platforms/discord.py: In _safe_sync_slash_commands(), moved the stale command deletion loop to execute BEFORE the create/update loop. Changed the deletion logic from iterating over remaining entries in existing_by_key (post-update) to computing stale_keys = [k for k in existing_by_key if k not in desired_by_key] upfront and deleting them before any upsert_global_command calls.
    - Removed the redundant post-loop deletion block that was no longer needed after the reordering.
     
 ## How to Test

    1. Set up a Discord bot application with 95+ existing slash commands that are no longer in the current desired set
    2. Configure hermes-agent with 10+ new slash commands not currently registered
    3. Start the gateway and observe the Discord sync log — verify that stale commands are deleted first, then new commands are registered, and the sync completes without exceeding Discord's 100 command limit
    4. Verify pytest tests/gateway/test_discord_connect.py -q passes (specifically test_safe_sync_slash_commands_only_mutates_diffs)
 
## Checklist


### Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [x] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform:Ubuntu 24.04

### Documentation & Housekeeping

    - [N/A] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [N/A] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [N/A] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [N/A] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A