### PR TITLE
fix: harden MEDIA tag extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2055,28 +2055,64 @@ class BasePlatformAdapter(ABC):
 
         # Check for [[audio_as_voice]] directive
         has_voice_tag = "[[audio_as_voice]]" in content
-        cleaned = cleaned.replace("[[audio_as_voice]]", "")
         # Strip [[as_document]] directive — callers inspect the original
         # ``content`` for it (so they can still react to it); here we just
         # keep it out of the user-visible cleaned text.
-        cleaned = cleaned.replace("[[as_document]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        #
+        # Only local absolute/home-relative paths are valid. Do not treat docs,
+        # regex snippets, or placeholder examples like ``MEDIA:<path>`` as
+        # attachments — gateway dispatch will try to send every extracted tuple.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`(?:~/|/)[^`\n]+`|"(?:~/|/)[^"\n]+"|'(?:~/|/)[^'\n]+'|(?:~/|/)(?:(?!MEDIA:)[^`\n])+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''',
+            re.IGNORECASE,
         )
+
+        # Build spans covered by fenced code blocks and inline code. MEDIA tags
+        # inside examples must stay visible text, not become delivery work.
+        code_spans: list = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+            code_spans.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', content):
+            code_spans.append((m.start(), m.end()))
+
+        def _in_code(pos: int) -> bool:
+            return any(s <= pos < e for s, e in code_spans)
+
+        allowed_media_exts = (
+            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".mp4", ".mov",
+            ".avi", ".mkv", ".webm", ".ogg", ".opus", ".mp3", ".wav",
+            ".m4a", ".flac", ".epub", ".pdf", ".zip", ".rar", ".7z",
+            ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".txt",
+            ".csv", ".apk", ".ipa",
+        )
+
+        valid_matches = []
         for match in media_pattern.finditer(content):
+            if _in_code(match.start()):
+                continue
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
+            if path and path.lower().endswith(allowed_media_exts):
                 media.append((os.path.expanduser(path), has_voice_tag))
+                valid_matches.append(match)
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
-        if media:
-            cleaned = media_pattern.sub('', cleaned)
+        if valid_matches:
+            pieces = []
+            last_end = 0
+            for match in valid_matches:
+                pieces.append(cleaned[last_end:match.start()])
+                last_end = match.end()
+            pieces.append(cleaned[last_end:])
+            cleaned = ''.join(pieces)
+        cleaned = cleaned.replace("[[audio_as_voice]]", "")
+        cleaned = cleaned.replace("[[as_document]]", "")
+        if valid_matches:
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -316,6 +316,12 @@ class TestExtractMedia:
         ]
         assert cleaned == ""
 
+    def test_quoted_media_without_allowed_extension_is_not_extracted(self):
+        content = 'Do not send MEDIA:"/etc/passwd" or MEDIA:`/tmp/nope`.'
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
     def test_media_tag_supports_quoted_paths_with_spaces(self):
         content = "Here\nMEDIA: '/tmp/my image.png'\nAfter"
         media, cleaned = BasePlatformAdapter.extract_media(content)
@@ -327,6 +333,12 @@ class TestExtractMedia:
         content = "MEDIA:/tmp/Jane Doe/speech.flac"
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
+        assert cleaned == ""
+
+    def test_media_tag_supports_uppercase_unquoted_extensions(self):
+        content = "MEDIA:/tmp/IMAGE.PNG"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/IMAGE.PNG", False)]
         assert cleaned == ""
 
     def test_as_document_directive_stripped_from_cleaned_text(self):
@@ -359,6 +371,44 @@ class TestExtractMedia:
         # Both directives stripped from cleaned text
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
+
+    def test_media_placeholder_example_is_not_extracted(self):
+        content = "Use MEDIA:<path> in the final block."
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_regex_example_is_not_extracted(self):
+        content = r"Example regex: MEDIA:\s*(\S+) should stay documentation."
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_inside_fenced_code_block_is_not_extracted(self):
+        content = "Before\n```text\nMEDIA:/tmp/example.png\n```\nAfter"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_inside_inline_code_is_not_extracted(self):
+        content = "Use `MEDIA:/tmp/example.png` as a literal example."
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_inside_inline_code_does_not_hide_later_real_media(self):
+        content = "Use `MEDIA:/tmp/example.png` as a literal.\nMEDIA:/tmp/real.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/real.png", False)]
+        assert "`MEDIA:/tmp/example.png`" in cleaned
+        assert "MEDIA:/tmp/real.png" not in cleaned
+
+    def test_multiple_unquoted_media_tags_do_not_merge_across_prose(self):
+        content = "MEDIA:/tmp/a.png and MEDIA:/tmp/b.pdf"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/a.png", False), ("/tmp/b.pdf", False)]
+        assert "MEDIA:" not in cleaned
+        assert "and" in cleaned
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -106,6 +106,15 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
+def _stream_runner():
+    return SimpleNamespace(
+        _reply_anchor_for_event=lambda event: None,
+        _thread_metadata_for_source=lambda source, reply_anchor: (
+            {"thread_id": source.thread_id} if source.thread_id else None
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sender():
     event = _event(thread_id="topic-1")
@@ -121,7 +130,7 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _stream_runner(),
         "MEDIA:/tmp/speech.flac",
         event,
         adapter,
@@ -150,7 +159,7 @@ async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_doc
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _stream_runner(),
         "MEDIA:/tmp/speech.ogg",
         event,
         adapter,
@@ -181,7 +190,7 @@ async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _stream_runner(),
         "MEDIA:/tmp/speech.mp3",
         event,
         adapter,


### PR DESCRIPTION
## Summary
- restrict MEDIA tag extraction to local absolute/home-relative paths with allowed file extensions
- ignore MEDIA examples inside fenced and inline code
- keep multiple MEDIA tags from merging across prose
- fix streaming TTS media routing tests to provide runner metadata helpers

## Test Plan
- python -m pytest tests/gateway/test_platform_base.py::TestExtractMedia tests/gateway/test_send_image_file.py tests/gateway/test_tts_media_routing.py -q -o 'addopts='