### PR TITLE
Feat/new all bulk topic reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6343,14 +6343,37 @@ class GatewayRunner:
                 return self._telegram_topic_root_new_message()
             async def _do_reset():
                 return await self._handle_reset_command(event)
+            # #24362 — ``/new all`` resets every topic session in the
+            # current group chat.  Without a tailored confirmation message
+            # the user sees the single-session prompt ("discards the
+            # current conversation history") and would have no way to
+            # tell apart the bulk wipe from a normal /new.  We detect the
+            # bulk token here (same matcher as the handler, see
+            # _is_bulk_reset_token) and surface a distinct detail string
+            # so the confirm dialog accurately describes the scope.
+            _raw_args = event.get_command_args() if event else ""
+            if (
+                self._is_bulk_reset_token(_raw_args)
+                and self._chat_type_is_group_like(source.chat_type)
+            ):
+                _confirm_title = "/new all"
+                _confirm_detail = (
+                    "This resets EVERY topic/thread session in the current "
+                    "group chat that you can reset, not just this one. Use "
+                    "this after a model/provider switch to keep all topics "
+                    "consistent."
+                )
+            else:
+                _confirm_title = "/new"
+                _confirm_detail = (
+                    "This starts a fresh session and discards the current "
+                    "conversation history."
+                )
             return await self._maybe_confirm_destructive_slash(
                 event=event,
                 command="new",
-                title="/new",
-                detail=(
-                    "This starts a fresh session and discards the current "
-                    "conversation history."
-                ),
+                title=_confirm_title,
+                detail=_confirm_detail,
                 execute=_do_reset,
             )
 
@@ -8058,10 +8081,133 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    # Reserved tokens that, when passed as the ``/new`` / ``/reset`` argument,
+    # switch the handler from "reset this session" to "reset every topic
+    # session in this group chat" (#24362).  Kept case-insensitive so users
+    # don't have to remember the exact spelling.  ``*`` is included as a
+    # power-user alias mirroring the shell glob.  Anyone who legitimately
+    # wants a session *titled* "all" can pick a different one-word title
+    # (e.g. ``/new all-hands``) — the bulk-reset semantics deliberately win
+    # over title-setting because the feature request explicitly asked for
+    # ``/new all`` as the slash spelling.
+    _BULK_RESET_ARG_TOKENS = frozenset({"all", "*"})
+
+    @staticmethod
+    def _is_bulk_reset_token(raw_arg: str) -> bool:
+        """Return True iff ``raw_arg`` requests a bulk topic reset.
+
+        Centralised so the dispatch confirmation site and the actual
+        handler use the same matcher (otherwise ``/new ALL`` would confirm
+        as a per-session reset and then surprise the user with a bulk
+        wipe).
+        """
+        return raw_arg.strip().lower() in GatewayRunner._BULK_RESET_ARG_TOKENS
+
+    @staticmethod
+    def _chat_type_is_group_like(chat_type: Optional[str]) -> bool:
+        """Return True for chat types where ``/new all`` is meaningful.
+
+        DMs only ever have one ``(chat_id, thread_id)`` session per user;
+        bulk reset is a no-op there and worse — if we let it run, a stray
+        ``/new all`` could quietly reset a user's private session because
+        they typed it in the wrong place.  We restrict bulk reset to
+        anything that is NOT a DM/private chat: groups, supergroups,
+        Telegram forum topics, Discord/Slack threads, channels.
+        """
+        normalized = (chat_type or "").strip().lower()
+        return normalized not in {"", "dm", "private"}
+
+    def _collect_topic_session_keys_for_bulk_reset(
+        self, source: SessionSource
+    ) -> List[str]:
+        """Return all session keys eligible for ``/new all`` from ``source``.
+
+        Used by the bulk-reset path of ``_handle_reset_command`` (#24362).
+
+        Filter rules (every entry must satisfy ALL of these):
+
+          1. ``entry.platform == source.platform`` — never cross platforms
+             (a stray Slack session with the same chat_id must not be
+             touched by a Telegram ``/new all``).
+          2. ``entry.chat_type`` is group-like (see
+             :meth:`_chat_type_is_group_like`).  We deliberately skip DMs
+             even if their chat_id collides — the feature is about
+             Telegram forum topics / group threads, not private chats.
+          3. ``entry.origin and entry.origin.chat_id == source.chat_id`` —
+             same parent group/channel.
+          4. Per-user scoping safety net: when the entry was created with
+             a ``user_id`` AND that ``user_id`` differs from
+             ``source.user_id``, skip it.  This protects per-user-thread
+             mode (``thread_sessions_per_user: true``) — user A typing
+             ``/new all`` must never wipe user B's threads.  Shared-thread
+             entries (no per-user isolation) are reset normally because
+             that's the entire point of the feature request.
+
+        DM-issued bulk reset returns an empty list — the caller handles
+        the user-facing "not in a group" message.
+        """
+        if not self._chat_type_is_group_like(source.chat_type):
+            return []
+
+        store = getattr(self, "session_store", None)
+        if store is None:
+            return []
+        entries = getattr(store, "_entries", None)
+        if not isinstance(entries, dict):
+            return []
+
+        source_chat_id = source.chat_id
+        if not source_chat_id:
+            # No chat_id → we cannot identify siblings.  Bail out instead
+            # of accidentally matching every group entry on this platform.
+            return []
+        source_user_id = source.user_id
+
+        keys: List[str] = []
+        for key, entry in entries.items():
+            entry_platform = getattr(entry, "platform", None)
+            if entry_platform != source.platform:
+                continue
+            if not self._chat_type_is_group_like(getattr(entry, "chat_type", None)):
+                continue
+            origin = getattr(entry, "origin", None)
+            if origin is None or getattr(origin, "chat_id", None) != source_chat_id:
+                continue
+            entry_user_id = getattr(origin, "user_id", None)
+            if (
+                entry_user_id
+                and source_user_id
+                and entry_user_id != source_user_id
+            ):
+                # Per-user scoped entry belonging to someone else: skip.
+                continue
+            keys.append(key)
+        return keys
+
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
-        """Handle /new or /reset command."""
+        """Handle /new or /reset command.
+
+        Two modes:
+          * Default — reset the single session that issued the command
+            (historical behaviour, used by every prior caller).
+          * Bulk (``/new all`` or ``/reset all``) — reset every topic
+            session in the same group chat that the caller is entitled
+            to reset.  See :meth:`_collect_topic_session_keys_for_bulk_reset`
+            for the eligibility rules.  Feature #24362.
+        """
         source = event.source
-        
+
+        # Bulk path: detect ``/new all`` BEFORE the title-setting logic
+        # below consumes the raw argument.  Restricted to group-like chats
+        # so a DM ``/new all`` falls through to "fresh session titled all"
+        # (which is the only sensible interpretation in a DM — there are
+        # no sibling topic sessions to reset there).
+        _raw_args = event.get_command_args().strip()
+        if self._is_bulk_reset_token(_raw_args) and self._chat_type_is_group_like(
+            source.chat_type
+        ):
+            return await self._handle_reset_command_bulk(event)
+
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
@@ -8205,6 +8351,271 @@ class GatewayRunner:
         if session_info:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
+
+    def _reset_single_topic_session_for_bulk(
+        self, session_key: str
+    ) -> Optional["SessionEntry"]:
+        """Reset one sibling topic session in-place during ``/new all``.
+
+        Performs the same conversation-boundary teardown that the
+        single-session path does (cache eviction, queued-event drop,
+        env passthrough / credential clearing, session_id rotation,
+        per-session override and security-state cleanup, Telegram topic
+        rebinding) but without the user-facing reply, slash confirmation,
+        or run-generation invalidation messages — those belong to the
+        caller (#24362).
+
+        Returns the freshly-created :class:`SessionEntry`, or ``None`` if
+        the key no longer exists in the store (e.g. it was pruned in the
+        microseconds since we collected sibling keys).
+        """
+        # Invalidate any in-flight run generation token so a racing
+        # response never lands in the freshly-rotated session.
+        try:
+            self._invalidate_session_run_generation(
+                session_key, reason="session_reset_bulk"
+            )
+        except Exception:
+            logger.debug(
+                "bulk-reset: invalidate_run_generation failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+        # Close tool resources on the cached agent (terminals, browser
+        # daemons, background processes) BEFORE evicting from cache.
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            try:
+                with _cache_lock:
+                    _cached = self._agent_cache.get(session_key)
+                    _old_agent = (
+                        _cached[0]
+                        if isinstance(_cached, tuple)
+                        else _cached
+                        if _cached
+                        else None
+                    )
+                if _old_agent is not None:
+                    self._cleanup_agent_resources(_old_agent)
+            except Exception:
+                logger.debug(
+                    "bulk-reset: agent-cache cleanup failed for %s",
+                    session_key,
+                    exc_info=True,
+                )
+        try:
+            self._evict_cached_agent(session_key)
+        except Exception:
+            logger.debug(
+                "bulk-reset: evict_cached_agent failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+        # Drop any /queue overflow attached to this sibling — it's stale
+        # by definition once we rotate the session_id.
+        _qe = getattr(self, "_queued_events", None)
+        if _qe is not None:
+            _qe.pop(session_key, None)
+
+        # NOTE: env_passthrough / credential_files are process-global, so
+        # we clear them once in the caller (not per-sibling).
+
+        try:
+            new_entry = self.session_store.reset_session(session_key)
+        except Exception:
+            logger.exception(
+                "bulk-reset: session_store.reset_session failed for %s",
+                session_key,
+            )
+            return None
+
+        # Per-session overrides and approval state — must follow each
+        # sibling's session_id rotation, not just the caller's session.
+        try:
+            self._session_model_overrides.pop(session_key, None)
+        except Exception:
+            pass
+        try:
+            self._set_session_reasoning_override(session_key, None)
+        except Exception:
+            pass
+        if hasattr(self, "_pending_model_notes"):
+            try:
+                self._pending_model_notes.pop(session_key, None)
+            except Exception:
+                pass
+        try:
+            self._clear_session_boundary_security_state(session_key)
+        except Exception:
+            logger.debug(
+                "bulk-reset: clear_session_boundary_security_state failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+        # Telegram topic-lane rebinding: each sibling has its own
+        # (chat_id, thread_id) tuple stored on entry.origin, so we
+        # rebind per sibling.  Without this the binding still points at
+        # the old session and the next message in that topic would
+        # silently switch back.
+        if new_entry is not None and getattr(new_entry, "origin", None) is not None:
+            try:
+                if self._is_telegram_topic_lane(new_entry.origin):
+                    self._record_telegram_topic_binding(new_entry.origin, new_entry)
+            except Exception:
+                logger.debug(
+                    "bulk-reset: telegram topic rebind failed for %s",
+                    session_key,
+                    exc_info=True,
+                )
+        return new_entry
+
+    async def _handle_reset_command_bulk(
+        self, event: MessageEvent
+    ) -> Union[str, EphemeralReply]:
+        """Handle ``/new all`` / ``/reset all`` — bulk reset every sibling
+        topic session in the current group chat (#24362).
+
+        Reply policy: a single acknowledgement is sent back to the topic
+        that issued the command, summarising how many sibling sessions
+        were reset.  Per-topic acks are intentionally NOT emitted — they
+        would race the user's next message in each topic and create
+        notification spam in groups with many threads.
+
+        Caller-side teardown order matches the single-session reset:
+          1. Collect eligible sibling keys.
+          2. Clear process-global state (env passthrough, credential
+             files) ONCE — it's not per-session.
+          3. Reset each sibling via :meth:`_reset_single_topic_session_for_bulk`.
+          4. Fire session-end / session-reset hooks per sibling.
+          5. Send a single summary acknowledgement.
+        """
+        source = event.source
+
+        sibling_keys = self._collect_topic_session_keys_for_bulk_reset(source)
+        if not sibling_keys:
+            # No sessions to reset (e.g. user issued ``/new all`` in a
+            # freshly-joined group with no recorded topic sessions yet).
+            # Fall back to a friendly notice — DON'T silently no-op.
+            return EphemeralReply(t("gateway.reset.bulk_empty"))
+
+        # Process-global resources only need to be cleared once.
+        try:
+            from tools.env_passthrough import clear_env_passthrough
+            clear_env_passthrough()
+        except Exception:
+            pass
+        try:
+            from tools.credential_files import clear_credential_files
+            clear_credential_files()
+        except Exception:
+            pass
+
+        # Snapshot the pre-reset entries so we can fire session:end with
+        # accurate session_ids AFTER reset_session() has rotated them.
+        store = self.session_store
+        old_session_ids: Dict[str, Optional[str]] = {}
+        old_origins: Dict[str, Optional[SessionSource]] = {}
+        for key in sibling_keys:
+            existing = store._entries.get(key) if hasattr(store, "_entries") else None
+            old_session_ids[key] = (
+                getattr(existing, "session_id", None) if existing else None
+            )
+            old_origins[key] = (
+                getattr(existing, "origin", None) if existing else None
+            )
+
+        reset_count = 0
+        failed_keys: List[str] = []
+        for key in sibling_keys:
+            new_entry = self._reset_single_topic_session_for_bulk(key)
+            if new_entry is None:
+                failed_keys.append(key)
+                continue
+            reset_count += 1
+
+            # Fire plugin + hook events per sibling so plugins (e.g.
+            # compress, transcript exporters) see a clean session
+            # boundary for each topic — matching the single-session path.
+            _src_for_hook = old_origins.get(key) or source
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_session_finalize",
+                    session_id=old_session_ids.get(key),
+                    platform=(
+                        _src_for_hook.platform.value
+                        if _src_for_hook.platform
+                        else ""
+                    ),
+                )
+            except Exception:
+                pass
+
+            try:
+                await self.hooks.emit("session:end", {
+                    "platform": (
+                        _src_for_hook.platform.value
+                        if _src_for_hook.platform
+                        else ""
+                    ),
+                    "user_id": _src_for_hook.user_id,
+                    "session_key": key,
+                })
+                await self.hooks.emit("session:reset", {
+                    "platform": (
+                        _src_for_hook.platform.value
+                        if _src_for_hook.platform
+                        else ""
+                    ),
+                    "user_id": _src_for_hook.user_id,
+                    "session_key": key,
+                })
+            except Exception:
+                logger.debug(
+                    "bulk-reset: hook emit failed for %s",
+                    key,
+                    exc_info=True,
+                )
+
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_session_reset",
+                    session_id=new_entry.session_id,
+                    platform=(
+                        _src_for_hook.platform.value
+                        if _src_for_hook.platform
+                        else ""
+                    ),
+                )
+            except Exception:
+                pass
+
+        # User-facing summary.  Plural / singular split keeps the
+        # message grammatical without an explicit pluralisation library.
+        if reset_count == 0:
+            return EphemeralReply(t("gateway.reset.bulk_all_failed"))
+        if reset_count == 1:
+            header = t("gateway.reset.bulk_header_one")
+        else:
+            header = t("gateway.reset.bulk_header_many", count=reset_count)
+
+        try:
+            from hermes_cli.tips import get_random_tip
+            tip_line = t("gateway.reset.tip", tip=get_random_tip())
+        except Exception:
+            tip_line = ""
+
+        if failed_keys:
+            warn_line = t(
+                "gateway.reset.bulk_partial_failure",
+                failed=len(failed_keys),
+            )
+            return EphemeralReply(f"{header}\n{warn_line}{tip_line}")
+        return EphemeralReply(f"{header}{tip_line}")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -226,6 +226,15 @@ gateway:
     title_error_untitled:  "\n⚠️ {error} — session started untitled."
     title_empty_untitled:  "\n⚠️ Title is empty after cleanup — session started untitled."
     tip:                   "\n✦ Tip: {tip}"
+    # /new all — bulk topic reset (#24362). Used only when the slash arg
+    # is `all` (or `*`) in a group/forum chat. Singular vs plural split
+    # keeps the message grammatical without dragging in a real
+    # pluralisation lib.
+    bulk_header_one:       "✨ Reset 1 topic session in this group."
+    bulk_header_many:      "✨ Reset {count} topic sessions in this group."
+    bulk_empty:            "ℹ️ No topic sessions to reset in this group yet."
+    bulk_all_failed:       "⚠️ /new all matched topic sessions but none could be reset — see logs."
+    bulk_partial_failure:  "⚠️ {failed} topic(s) could not be reset; check gateway logs.\n"
 
   restart:
     in_progress:           "⏳ Gateway restart already in progress..."

--- a/tests/gateway/test_new_all_bulk_reset.py
+++ b/tests/gateway/test_new_all_bulk_reset.py
@@ -1,0 +1,577 @@
+"""End-to-end tests for the ``/new all`` bulk-reset flow (#24362).
+
+These tests drive :meth:`gateway.run.GatewayRunner._handle_reset_command`
+directly with bulk-reset arguments and assert on the observable side
+effects across every sibling topic session: session_id rotation, cached
+agent eviction, per-session override cleanup, hook emission counts,
+and the user-facing summary copy.
+
+A regression anchor (``test_bug_24362_repro_*``) intentionally fails if
+someone later removes the bulk-token detection from
+:meth:`_handle_reset_command` — that detection is the heart of the
+feature, and the title-setting code path right below it would silently
+swallow ``/new all`` as "create new session titled 'all'" otherwise.
+"""
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import EphemeralReply, MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _make_source(
+    *,
+    chat_type: str = "supergroup",
+    chat_id: str = "group-1",
+    user_id: str = "user-A",
+    thread_id: str | None = "topic-A",
+    platform: Platform = Platform.TELEGRAM,
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+    )
+
+
+def _make_event(text: str, source: SessionSource | None = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=source if source is not None else _make_source(),
+        message_id="m1",
+    )
+
+
+def _make_entry(
+    *,
+    key: str,
+    chat_id: str = "group-1",
+    chat_type: str = "supergroup",
+    user_id: str | None = None,
+    thread_id: str | None = None,
+    platform: Platform = Platform.TELEGRAM,
+) -> SessionEntry:
+    return SessionEntry(
+        session_key=key,
+        session_id=f"sid-{key}",
+        created_at=datetime(2026, 5, 12),
+        updated_at=datetime(2026, 5, 12),
+        origin=SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            user_id=user_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+        ),
+        platform=platform,
+        chat_type=chat_type,
+    )
+
+
+def _make_runner_with_topic_sessions(
+    entries: Dict[str, SessionEntry],
+) -> GatewayRunner:
+    """Build a minimally-stubbed GatewayRunner ready to drive
+    :meth:`_handle_reset_command` end-to-end.
+
+    The mock ``session_store.reset_session`` rotates the entry in place
+    and returns the new SessionEntry — mirroring the real
+    :class:`SessionStore.reset_session` contract just enough to satisfy
+    the bulk-reset loop.  Anything that touches SQLite, files, or the
+    network is stubbed out.
+    """
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._queued_events = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._format_session_info = lambda: ""
+
+    store = MagicMock()
+    store._entries = dict(entries)
+
+    def _reset_session(key: str) -> SessionEntry | None:
+        existing = store._entries.get(key)
+        if existing is None:
+            return None
+        new = SessionEntry(
+            session_key=existing.session_key,
+            session_id=f"{existing.session_id}-reset",
+            created_at=existing.created_at,
+            updated_at=datetime(2026, 5, 13),
+            origin=existing.origin,
+            platform=existing.platform,
+            chat_type=existing.chat_type,
+            is_fresh_reset=True,
+        )
+        store._entries[key] = new
+        return new
+
+    store.reset_session.side_effect = _reset_session
+    store.get_or_create_session.return_value = next(iter(entries.values()))
+    store._generate_session_key.return_value = next(iter(entries.keys()))
+    runner.session_store = store
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# End-to-end happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_all_resets_every_sibling_topic_session() -> None:
+    """``/new all`` rotates session_id for every sibling topic in the
+    same group chat and emits hooks per session."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B",
+            thread_id="topic-B",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-C": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-C",
+            thread_id="topic-C",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    pre_ids = {k: e.session_id for k, e in entries.items()}
+
+    reply = await runner._handle_reset_command(_make_event("/new all"))
+
+    # User-facing summary mentions the count (singular vs plural is in
+    # locales/en.yaml; "Reset 3 topic sessions" is the rendered plural).
+    assert isinstance(reply, EphemeralReply)
+    assert "3 topic sessions" in reply.text
+
+    # session_id rotated for every sibling.
+    for key, pre_sid in pre_ids.items():
+        post = runner.session_store._entries[key]
+        assert post.session_id != pre_sid, f"sibling {key} kept its old session_id"
+        assert post.session_id.endswith("-reset")
+        assert post.is_fresh_reset is True
+
+    # session:end + session:reset hooks emitted per sibling (3 + 3).
+    emit_calls = runner.hooks.emit.call_args_list
+    hook_names = [c.args[0] for c in emit_calls]
+    assert hook_names.count("session:end") == 3
+    assert hook_names.count("session:reset") == 3
+
+
+@pytest.mark.asyncio
+async def test_new_all_reset_alias_works_the_same() -> None:
+    """The feature request mentioned ``/reset all`` as an alias; this is
+    handled by the same shared bypass that maps ``/reset`` to ``/new``.
+
+    The test exercises the handler directly with the canonical command
+    name and verifies the bulk-token detection doesn't depend on which
+    spelling routed to it (single matcher, two slash spellings)."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B",
+            thread_id="topic-B",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+
+    reply = await runner._handle_reset_command(_make_event("/reset all"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "2 topic sessions" in reply.text
+
+
+@pytest.mark.asyncio
+async def test_new_all_supports_star_alias() -> None:
+    """``/new *`` is documented as a power-user alias."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+
+    reply = await runner._handle_reset_command(_make_event("/new *"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "1 topic session" in reply.text  # singular phrasing
+
+
+@pytest.mark.asyncio
+async def test_new_all_case_insensitive() -> None:
+    """``/new ALL`` and ``/new All`` must both trigger bulk mode."""
+    for variant in ("/new ALL", "/new All", "/new aLL"):
+        entries = {
+            "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+                key="agent:main:telegram:supergroup:group-1:topic-A",
+                thread_id="topic-A",
+            ),
+        }
+        runner = _make_runner_with_topic_sessions(entries)
+        reply = await runner._handle_reset_command(_make_event(variant))
+        assert isinstance(reply, EphemeralReply)
+        assert "topic session" in reply.text, f"variant {variant!r} did not bulk-reset"
+
+
+# ---------------------------------------------------------------------------
+# Scoping rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_all_in_dm_falls_through_to_single_reset() -> None:
+    """``/new all`` in a DM must NOT iterate siblings — it falls
+    through to the existing per-session reset so the literal title
+    'all' lands on the user's solo session, exactly like ``/new foo``
+    today.  This protects users who type ``/new all`` in a DM by
+    accident from accidentally wiping nothing (no siblings exist) or
+    everything (cross-DM blast)."""
+    dm_source = _make_source(chat_type="dm", thread_id=None)
+    dm_key = "agent:main:telegram:dm:group-1"
+    entries = {
+        dm_key: _make_entry(
+            key=dm_key,
+            chat_type="dm",
+            thread_id=None,
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    # The single-session path needs session_store.get_or_create_session
+    # and _session_key_for_source to line up.
+    runner.session_store._generate_session_key.return_value = dm_key
+    runner.session_store.get_or_create_session.return_value = entries[dm_key]
+
+    # /new all in a DM should NOT take the bulk path.  The single-
+    # session path sets a session title ("all"), so we assert that the
+    # reply is NOT the bulk summary copy.
+    reply = await runner._handle_reset_command(_make_event("/new all", dm_source))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "topic sessions in this group" not in reply.text
+    assert "topic session in this group" not in reply.text
+
+
+@pytest.mark.asyncio
+async def test_new_all_does_not_touch_other_groups() -> None:
+    """Sibling sessions in a *different* group must stay intact."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            chat_id="group-1",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-2:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-2:topic-A",
+            chat_id="group-2",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    other_pre = entries["agent:main:telegram:supergroup:group-2:topic-A"].session_id
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    other_post = runner.session_store._entries[
+        "agent:main:telegram:supergroup:group-2:topic-A"
+    ]
+    assert other_post.session_id == other_pre, "other group's session was wiped"
+
+
+@pytest.mark.asyncio
+async def test_new_all_does_not_cross_platforms() -> None:
+    """A Slack channel sharing the same chat_id must NOT be touched
+    by a Telegram ``/new all`` — different platform, different scope."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:slack:channel:group-1:thread-A": _make_entry(
+            key="agent:main:slack:channel:group-1:thread-A",
+            chat_type="channel",
+            thread_id="thread-A",
+            platform=Platform.SLACK,
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    slack_pre = entries["agent:main:slack:channel:group-1:thread-A"].session_id
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    slack_post = runner.session_store._entries[
+        "agent:main:slack:channel:group-1:thread-A"
+    ]
+    assert slack_post.session_id == slack_pre
+
+
+@pytest.mark.asyncio
+async def test_new_all_per_user_thread_mode_respects_caller_user() -> None:
+    """In per-user-thread mode (thread_sessions_per_user=true) the
+    caller's ``/new all`` must reset only their own per-user sessions
+    — never another user's.  This is the cross-user blast guard."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A:user-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A:user-A",
+            user_id="user-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-A:user-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A:user-B",
+            user_id="user-B",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    user_b_pre = entries[
+        "agent:main:telegram:supergroup:group-1:topic-A:user-B"
+    ].session_id
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    user_b_post = runner.session_store._entries[
+        "agent:main:telegram:supergroup:group-1:topic-A:user-B"
+    ]
+    assert user_b_post.session_id == user_b_pre, "cross-user blast happened"
+
+    user_a_post = runner.session_store._entries[
+        "agent:main:telegram:supergroup:group-1:topic-A:user-A"
+    ]
+    assert user_a_post.session_id.endswith("-reset"), "caller's own thread not reset"
+
+
+# ---------------------------------------------------------------------------
+# Side-effect cleanup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_all_clears_per_session_overrides() -> None:
+    """Each sibling's model/reasoning override and pending-model note
+    must be cleared — otherwise the new agent on each topic would
+    silently inherit the previous conversation's overrides."""
+    keys = [
+        "agent:main:telegram:supergroup:group-1:topic-A",
+        "agent:main:telegram:supergroup:group-1:topic-B",
+    ]
+    entries = {
+        k: _make_entry(key=k, thread_id=k.split(":")[-1]) for k in keys
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    for k in keys:
+        runner._session_model_overrides[k] = {
+            "model": "x", "provider": "y", "api_key": "z", "base_url": "", "api_mode": "openai",
+        }
+        runner._session_reasoning_overrides[k] = {"enabled": True, "effort": "high"}
+        runner._pending_model_notes[k] = "[switched]"
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    for k in keys:
+        assert k not in runner._session_model_overrides
+        assert k not in runner._session_reasoning_overrides
+        assert k not in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_new_all_evicts_cached_agents_for_every_sibling() -> None:
+    """The cached agent for each sibling must be evicted so the next
+    message in that topic spawns a fresh agent with the rotated
+    session_id.
+
+    Note: ``_evict_cached_agent`` short-circuits when
+    ``_agent_cache_lock`` is None (a defensive guard for test fixtures
+    that skip __init__), so this test installs a real lock to exercise
+    the actual eviction path that production code follows.
+    """
+    keys = [
+        "agent:main:telegram:supergroup:group-1:topic-A",
+        "agent:main:telegram:supergroup:group-1:topic-B",
+    ]
+    entries = {k: _make_entry(key=k, thread_id=k.split(":")[-1]) for k in keys}
+    runner = _make_runner_with_topic_sessions(entries)
+    runner._agent_cache = {k: ("cached-agent", "cfg") for k in keys}
+    runner._agent_cache_lock = threading.RLock()
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    for k in keys:
+        assert k not in runner._agent_cache
+
+
+@pytest.mark.asyncio
+async def test_new_all_drops_queued_events_for_every_sibling() -> None:
+    """/queue overflow from the prior conversation must not leak into
+    the freshly-rotated sibling sessions."""
+    keys = [
+        "agent:main:telegram:supergroup:group-1:topic-A",
+        "agent:main:telegram:supergroup:group-1:topic-B",
+    ]
+    entries = {k: _make_entry(key=k, thread_id=k.split(":")[-1]) for k in keys}
+    runner = _make_runner_with_topic_sessions(entries)
+    runner._queued_events = {k: [SimpleNamespace(text="queued")] for k in keys}
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    for k in keys:
+        assert k not in runner._queued_events
+
+
+# ---------------------------------------------------------------------------
+# Empty / error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_all_with_no_sibling_sessions_returns_friendly_notice() -> None:
+    """If no eligible siblings exist (fresh group, no recorded
+    sessions yet), the user gets a notice -- never a silent no-op."""
+    entries: Dict[str, SessionEntry] = {}
+    runner = _make_runner_with_topic_sessions({
+        # Dummy entry just so the runner has a session_store layout;
+        # we then strip it before invoking the handler.
+        "placeholder": _make_entry(
+            key="placeholder",
+            chat_type="dm",
+            chat_id="other-group",
+        ),
+    })
+    runner.session_store._entries.clear()
+
+    reply = await runner._handle_reset_command(_make_event("/new all"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "No topic sessions to reset" in reply.text
+
+
+@pytest.mark.asyncio
+async def test_new_all_summary_singular_for_one_session() -> None:
+    """Singular phrasing kicks in when exactly one sibling resets."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+
+    reply = await runner._handle_reset_command(_make_event("/new all"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "Reset 1 topic session" in reply.text
+    assert "topic sessions" not in reply.text  # plural phrasing must NOT fire
+
+
+@pytest.mark.asyncio
+async def test_new_all_records_partial_failure_in_summary() -> None:
+    """If some siblings fail to reset (reset_session returns None) the
+    summary surfaces the failure count -- never silently swallowed."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B",
+            thread_id="topic-B",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+
+    # Force topic-B to fail.
+    original = runner.session_store.reset_session.side_effect
+    def _flaky_reset(key: str):
+        if key.endswith("topic-B"):
+            return None
+        return original(key)
+    runner.session_store.reset_session.side_effect = _flaky_reset
+
+    reply = await runner._handle_reset_command(_make_event("/new all"))
+
+    assert isinstance(reply, EphemeralReply)
+    assert "Reset 1 topic session" in reply.text
+    assert "1 topic(s) could not be reset" in reply.text
+
+
+# ---------------------------------------------------------------------------
+# Regression anchor — fails if the bulk-token dispatch is removed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bug_24362_repro_new_all_must_reset_more_than_one_session() -> None:
+    """Anchor for #24362.
+
+    Pre-fix behaviour: ``/new all`` was treated as ``/new <title='all'>``,
+    so only the current session got reset and the user had to manually
+    visit every topic.
+
+    This test asserts the post-fix invariant: when the same caller types
+    ``/new all`` once, AT LEAST two sibling topic sessions get their
+    session_id rotated.  If a future refactor removes the bulk-token
+    detection from :meth:`_handle_reset_command`, this test fails
+    because at most one session would be reset (the caller's own).
+    """
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B",
+            thread_id="topic-B",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-C": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-C",
+            thread_id="topic-C",
+        ),
+    }
+    runner = _make_runner_with_topic_sessions(entries)
+    pre = {k: e.session_id for k, e in entries.items()}
+
+    await runner._handle_reset_command(_make_event("/new all"))
+
+    rotated: List[str] = [
+        k for k, pre_sid in pre.items()
+        if runner.session_store._entries[k].session_id != pre_sid
+    ]
+    assert len(rotated) >= 2, (
+        f"#24362 regression: /new all only rotated {len(rotated)} session(s) "
+        f"({rotated}); the feature requires every sibling topic to be reset."
+    )

--- a/tests/gateway/test_new_all_bulk_reset_helper.py
+++ b/tests/gateway/test_new_all_bulk_reset_helper.py
@@ -1,0 +1,385 @@
+"""Unit tests for the ``/new all`` bulk-reset helpers on
+:class:`gateway.run.GatewayRunner` (#24362).
+
+The bulk path has three small but security-relevant pure helpers:
+
+  * :meth:`GatewayRunner._is_bulk_reset_token` — same matcher used by
+    the dispatch site (for confirmation copy) and the handler.  A drift
+    here is the worst possible bug — users get the "single session"
+    confirm dialog and then a bulk wipe.
+  * :meth:`GatewayRunner._chat_type_is_group_like` — the DM/private
+    short-circuit that prevents ``/new all`` from ever wiping siblings
+    in a private chat.
+  * :meth:`GatewayRunner._collect_topic_session_keys_for_bulk_reset` —
+    the eligibility filter.  Everything else hangs off this list.
+
+These tests pin the helpers in isolation; the end-to-end test module
+(``test_new_all_bulk_reset.py``) drives the full handler.
+"""
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_source(
+    *,
+    chat_type: str = "supergroup",
+    chat_id: str = "group-1",
+    user_id: str = "user-A",
+    thread_id: str | None = None,
+    platform: Platform = Platform.TELEGRAM,
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+    )
+
+
+def _make_entry(
+    *,
+    key: str,
+    chat_id: str = "group-1",
+    chat_type: str = "supergroup",
+    user_id: str | None = None,
+    platform: Platform = Platform.TELEGRAM,
+    thread_id: str | None = None,
+) -> SessionEntry:
+    return SessionEntry(
+        session_key=key,
+        session_id=f"sid-{key}",
+        created_at=datetime(2026, 5, 12),
+        updated_at=datetime(2026, 5, 12),
+        origin=SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            user_id=user_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+        ),
+        platform=platform,
+        chat_type=chat_type,
+    )
+
+
+def _make_runner_with_entries(entries: dict[str, SessionEntry]) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    runner.session_store._entries = entries
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# _is_bulk_reset_token  (12 cases — covers casing, whitespace, aliases,
+# adjacent-but-not-equal tokens, and explicitly-non-token strings)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("all", True),
+        ("ALL", True),
+        ("All", True),
+        ("aLL", True),
+        ("  all  ", True),
+        ("\tall\n", True),
+        ("*", True),
+        (" * ", True),
+        ("", False),
+        ("   ", False),
+        ("all-hands", False),
+        ("allnighter", False),
+        ("everything", False),
+        ("/all", False),
+        ("**", False),
+        ("a", False),
+        ("ALL TOPICS", False),
+        ("'all'", False),
+        ("all all", False),
+    ],
+)
+def test_is_bulk_reset_token(raw: str, expected: bool) -> None:
+    assert GatewayRunner._is_bulk_reset_token(raw) is expected
+
+
+# ---------------------------------------------------------------------------
+# _chat_type_is_group_like
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "chat_type, expected",
+    [
+        ("dm", False),
+        ("DM", False),
+        ("Dm", False),
+        ("private", False),
+        ("PRIVATE", False),
+        ("", False),
+        (None, False),
+        ("group", True),
+        ("GROUP", True),
+        ("supergroup", True),
+        ("channel", True),
+        ("forum", True),
+        ("thread", True),
+        # Unknown chat types default to group-like (safer for new
+        # platforms — DMs are the only thing we MUST exclude to protect
+        # private conversations).
+        ("mystery", True),
+    ],
+)
+def test_chat_type_is_group_like(chat_type, expected: bool) -> None:
+    assert GatewayRunner._chat_type_is_group_like(chat_type) is expected
+
+
+# ---------------------------------------------------------------------------
+# _collect_topic_session_keys_for_bulk_reset
+# ---------------------------------------------------------------------------
+
+
+def test_collect_returns_all_topic_siblings_in_same_group() -> None:
+    """Three topics in the same group → all three are eligible."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B",
+            thread_id="topic-B",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-C": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-C",
+            thread_id="topic-C",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source()
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert set(got) == set(entries.keys())
+
+
+def test_collect_skips_dm_sessions_even_with_same_chat_id() -> None:
+    """A DM session that happens to share a chat_id (very rare but possible
+    when a user DMs from inside a group manager bot) must NOT be touched."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            chat_type="supergroup",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:dm:group-1": _make_entry(
+            key="agent:main:telegram:dm:group-1",
+            chat_type="dm",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source()
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert got == ["agent:main:telegram:supergroup:group-1:topic-A"]
+
+
+def test_collect_returns_empty_when_source_is_dm() -> None:
+    """DM-issued ``/new all`` collects nothing — the caller turns this
+    into a friendly notice instead of bulk-resetting the user's DMs."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(chat_type="dm")
+
+    assert runner._collect_topic_session_keys_for_bulk_reset(source) == []
+
+
+def test_collect_returns_empty_when_source_has_no_chat_id() -> None:
+    """Source without chat_id → can't identify siblings, so return
+    nothing rather than over-matching on platform alone."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(chat_id="")
+
+    assert runner._collect_topic_session_keys_for_bulk_reset(source) == []
+
+
+def test_collect_filters_by_platform() -> None:
+    """A Slack session with the same chat_id must not be touched by a
+    Telegram ``/new all`` (cross-platform reset is a security bug)."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+        ),
+        "agent:main:slack:channel:group-1:topic-A": _make_entry(
+            key="agent:main:slack:channel:group-1:topic-A",
+            chat_type="channel",
+            thread_id="topic-A",
+            platform=Platform.SLACK,
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(platform=Platform.TELEGRAM)
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert got == ["agent:main:telegram:supergroup:group-1:topic-A"]
+
+
+def test_collect_filters_by_chat_id() -> None:
+    """Different group → no overlap."""
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            chat_id="group-1",
+            thread_id="topic-A",
+        ),
+        "agent:main:telegram:supergroup:group-2:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-2:topic-A",
+            chat_id="group-2",
+            thread_id="topic-A",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(chat_id="group-1")
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert got == ["agent:main:telegram:supergroup:group-1:topic-A"]
+
+
+def test_collect_per_user_thread_mode_only_resets_callers_own_threads() -> None:
+    """When thread_sessions_per_user=true, each (chat, thread, user)
+    has its own session.  /new all from user A must NEVER reset user
+    B's per-user threads -- otherwise a Telegram admin could wipe the
+    whole group's conversations with one command (cross-user blast)."""
+    entries = {
+        # User A's threads (eligible)
+        "agent:main:telegram:supergroup:group-1:topic-A:user-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A:user-A",
+            thread_id="topic-A",
+            user_id="user-A",
+        ),
+        "agent:main:telegram:supergroup:group-1:topic-B:user-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-B:user-A",
+            thread_id="topic-B",
+            user_id="user-A",
+        ),
+        # User B's thread (must skip)
+        "agent:main:telegram:supergroup:group-1:topic-A:user-B": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A:user-B",
+            thread_id="topic-A",
+            user_id="user-B",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(user_id="user-A")
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert set(got) == {
+        "agent:main:telegram:supergroup:group-1:topic-A:user-A",
+        "agent:main:telegram:supergroup:group-1:topic-B:user-A",
+    }
+
+
+def test_collect_shared_thread_entries_have_no_user_filter() -> None:
+    """In shared-thread mode (default) the session_key has no user_id
+    and entry.origin.user_id is whatever user happened to create the
+    session.  We MUST still include those entries -- a thread is
+    shared by definition, so any participant's /new all touches it."""
+    # Shared thread: origin.user_id is set (creator) but the session is
+    # not per-user (no user suffix on the key).  Caller is a *different*
+    # user; we still expect to reset it because the thread is shared.
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-A": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-A",
+            thread_id="topic-A",
+            user_id=None,  # shared
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source(user_id="user-B")
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert got == ["agent:main:telegram:supergroup:group-1:topic-A"]
+
+
+def test_collect_handles_entry_without_origin() -> None:
+    """Legacy entries loaded from sessions.json before origin tracking
+    landed have ``origin=None``.  They must be silently skipped --
+    never error out -- so a single legacy row can't break bulk reset
+    for the whole group."""
+    legacy_entry = _make_entry(
+        key="agent:main:telegram:supergroup:group-1:topic-X",
+        thread_id="topic-X",
+    )
+    legacy_entry.origin = None  # simulate legacy row
+    entries = {
+        "agent:main:telegram:supergroup:group-1:topic-X": legacy_entry,
+        "agent:main:telegram:supergroup:group-1:topic-Y": _make_entry(
+            key="agent:main:telegram:supergroup:group-1:topic-Y",
+            thread_id="topic-Y",
+        ),
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source()
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert got == ["agent:main:telegram:supergroup:group-1:topic-Y"]
+
+
+def test_collect_handles_missing_session_store_gracefully() -> None:
+    """If session_store is None (a runner being torn down) we must
+    return [] rather than crashing -- bulk reset is convenience, not
+    critical path."""
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = None
+    source = _make_source()
+    assert runner._collect_topic_session_keys_for_bulk_reset(source) == []
+
+
+def test_collect_handles_session_store_without_entries() -> None:
+    """Same guarantee when the store has no ``_entries`` attribute
+    (e.g. a test double that only stubs the public surface)."""
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock(spec=[])  # no _entries attr
+    source = _make_source()
+    assert runner._collect_topic_session_keys_for_bulk_reset(source) == []
+
+
+def test_collect_returns_unique_keys() -> None:
+    """Sanity: keys are unique (the underlying dict already enforces
+    this, but anchor the contract so a future refactor that switches
+    to a list of (key, entry) tuples can't accidentally duplicate)."""
+    entries = {
+        f"agent:main:telegram:supergroup:group-1:topic-{i}": _make_entry(
+            key=f"agent:main:telegram:supergroup:group-1:topic-{i}",
+            thread_id=f"topic-{i}",
+        )
+        for i in range(5)
+    }
+    runner = _make_runner_with_entries(entries)
+    source = _make_source()
+
+    got = runner._collect_topic_session_keys_for_bulk_reset(source)
+    assert len(got) == len(set(got)) == 5

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -175,8 +175,8 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 | Command | Description |
 |---------|-------------|
-| `/new` | Start a new conversation. |
-| `/reset` | Reset conversation history. |
+| `/new [title]` | Start a new conversation. With a one-word title (e.g. `/new website-redesign`) the fresh session is created with that title set. In a group/forum chat, `/new all` (or `/reset all`, `/new *`) bulk-resets **every topic session** the caller can reset — handy after a model or provider switch so all threads start from the same baseline. See [Bulk topic reset (`/new all`)](#bulk-topic-reset-new-all). |
+| `/reset [title \| all]` | Alias of `/new` — same single-session and `/reset all` bulk semantics. |
 | `/status` | Show session info. |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
 | `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), auto-detect (`/model custom`), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |
@@ -219,3 +219,30 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, and `/commands` are **messaging-only** commands.
 - `/status`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
+
+## Bulk topic reset (`/new all`)
+
+In a Telegram group with [forum topics](/docs/user-guide/messaging/telegram#private-chat-topics-bot-api-94) (or a Discord/Slack channel with threads) each topic has its own independent Hermes session. After switching models or providers — e.g. `/model anthropic:claude-sonnet-5` — only the **current** topic's session sees the new defaults; the rest still hold whichever model was active when they were last touched.
+
+`/new all` resets every topic session in the current group at once, so all threads start from the same baseline.
+
+```text
+You (in topic "Website"):  /new all
+Hermes:                     ✨ Reset 5 topic sessions in this group.
+```
+
+**Aliases:** `/reset all`, `/new *`. Token matching is case-insensitive (`/new ALL`, `/new All`, etc.).
+
+**Scope rules:**
+
+- **Same group only.** Only sessions in the current group/channel (`chat_id`) are touched. Other groups, DMs, and other platforms are untouched.
+- **Cross-user safety.** When `thread_sessions_per_user: true` is set, your `/new all` only resets _your own_ per-user threads — it cannot wipe another user's threads.
+- **Shared threads** (the default `thread_sessions_per_user: false`) are reset for everyone — that's the point of the feature.
+- **DMs** fall through to the normal `/new <title>` behaviour. `/new all` in a DM creates a fresh session titled `"all"`, which is the only sensible interpretation there.
+
+**Confirmation.** When `approvals.destructive_slash_confirm` is enabled (the default), the gateway prompts you to confirm before running the reset. The prompt for `/new all` uses a tailored detail string so you aren't blindsided by the wider blast radius:
+
+> This resets EVERY topic/thread session in the current group chat that you can reset, not just this one. Use this after a model/provider switch to keep all topics consistent.
+
+This addresses feature request [#24362](https://github.com/NousResearch/hermes-agent/issues/24362).
+

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -414,6 +414,17 @@ Topics with a `skill` field automatically load that skill when a new session sta
 
 For example, a topic with `skill: arxiv` will have the arxiv skill pre-loaded whenever its session resets (due to idle timeout, daily reset, or manual `/reset`).
 
+### Bulk reset across topics (`/new all`)
+
+Switching models or providers from one topic (`/model …`) only affects that topic's session — other topics keep whatever model was active when they were last touched. Use `/new all` (or `/reset all`, `/new *`) to reset **every** topic session in the current group/forum in one command, so all threads start from the same baseline.
+
+```text
+You (in topic "Website"):  /new all
+Hermes:                     ✨ Reset 5 topic sessions in this group.
+```
+
+Cross-user safety: under `thread_sessions_per_user: true` your `/new all` only resets _your own_ per-user threads — it never wipes another user's threads. Under the default shared-thread mode, threads are reset for everyone (that's the point). See the [Bulk topic reset](/docs/reference/slash-commands#bulk-topic-reset-new-all) reference for the full scope rules. This addresses feature request [#24362](https://github.com/NousResearch/hermes-agent/issues/24362).
+
 :::tip
 Topics created outside of the config (e.g., by manually calling the Telegram API) are discovered automatically when a `forum_topic_created` service message arrives. You can also add topics to the config while the gateway is running — they'll be picked up on the next cache miss.
 :::


### PR DESCRIPTION
## What does this PR do?

Adds `/new all` (and the aliases `/reset all`, `/new *`) — a bulk-reset slash command that resets **every topic session in the current group chat** in one go.

In Telegram groups and Discord/Slack channels with topic threads, each topic gets its own independent Hermes session. Today `/new` resets only the current topic, so after switching models or providers users have to walk every thread and type `/new` again. This PR closes that gap:

- Detects the `all` / `*` slash argument in `_handle_reset_command` **before** the title-setting code path consumes it, and only takes the bulk branch in group-like chat types (DMs fall through to the existing per-session reset).
- Collects sibling session keys under the same `(platform, chat_id)` via `_collect_topic_session_keys_for_bulk_reset(source)` with explicit cross-platform / cross-user / DM guards.
- For each sibling, rotates `session_id` via `session_store.reset_session(key)`, evicts the cached agent, drops `/queue` overflow, clears per-session model + reasoning overrides + pending model notes + dangerous-command approval state, rebinds Telegram topic lanes, and emits `session:end` + `session:reset` (plus the plugin `on_session_finalize` / `on_session_reset`) hooks **per topic** so plugins see a clean conversation boundary for each one.
- Tailored destructive-slash confirm dialog warns about the wider blast radius before running.
- Single user-facing acknowledgement back to the topic that issued the command (`✨ Reset 5 topic sessions in this group.`); per-topic acks are intentionally suppressed to avoid notification spam.

## Related Issue

Closes [#24362](https://github.com/NousResearch/hermes-agent/issues/24362) — *Feature Request: `/new all` — reset all group topic sessions in one command*.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Four commits, scoped strictly to the feature:

- `feat(gateway): /new all bulk-resets every topic session (#24362)` — `gateway/run.py` (+418 / -7) + `locales/en.yaml` (+9):
  - New constant `_BULK_RESET_ARG_TOKENS = {"all", "*"}` plus static helpers `_is_bulk_reset_token` and `_chat_type_is_group_like` (shared between the dispatch site and the handler so the confirm copy can't drift from the actual matcher).
  - New helper `_collect_topic_session_keys_for_bulk_reset(source)` — eligibility filter with explicit safety guards (cross-platform, cross-group, cross-user, DM, missing `origin`, missing `session_store`, missing `_entries`, empty `chat_id`).
  - New primitive `_reset_single_topic_session_for_bulk(session_key)` — per-sibling reset that mirrors the single-session teardown but without the user-facing reply / slash confirmation (those belong to the caller).
  - New driver `_handle_reset_command_bulk(event)` — clears process-global state once, snapshots pre-reset session_ids for accurate hook emission, loops over siblings, fires hooks per topic, returns a singular/plural summary `EphemeralReply`.
  - Slash-arg dispatch: `_handle_reset_command` now checks `_is_bulk_reset_token(args)` **before** consuming the argument as a session title, and only takes the bulk path in group-like chat types.
  - Confirm dialog: the `/new` dispatch site builds a tailored detail string for the bulk path so users aren't blindsided.
  - i18n: `gateway.reset.bulk_header_one`, `bulk_header_many`, `bulk_empty`, `bulk_all_failed`, `bulk_partial_failure` in `locales/en.yaml`. Non-EN catalogs fall back through `agent.i18n.t` to English.

- `test(gateway): pin /new all helpers in isolation (#24362)` — `tests/gateway/test_new_all_bulk_reset_helper.py` (+385, 45 cases):
  - `_is_bulk_reset_token` — 19 cases for casing, whitespace, the `*` alias, and near-misses (`all-hands`, `allnighter`, `/all`, `**`, multi-token strings) that must **not** trigger bulk mode.
  - `_chat_type_is_group_like` — 14 cases pinning every observed `chat_type` across telegram/discord/slack/matrix, including the explicit DM-vs-not boundary.
  - `_collect_topic_session_keys_for_bulk_reset` — 12 cases covering cross-platform isolation, per-user-thread blast prevention, shared-thread inclusion, legacy `origin=None` rows, missing `session_store`, missing `_entries` attr, and the `chat_id==""` / source-is-DM short-circuits.

- `test(gateway): end-to-end + regression anchor for /new all (#24362)` — `tests/gateway/test_new_all_bulk_reset.py` (+577, 15 cases):
  - Happy path: 3-topic group → all 3 rotated + 3 × `session:end` + 3 × `session:reset` hooks emitted.
  - Alias surface: `/reset all`, `/new *`, `/new ALL` all hit the same path.
  - Scoping safety: DM falls through to single-session, other groups untouched, other platforms untouched, per-user-thread mode refuses to wipe another user's threads.
  - Side effects: per-session model + reasoning overrides, pending model notes, agent cache entries, `/queue` overflow — all cleared per sibling.
  - Error & empty paths: no eligible siblings returns a friendly notice (never a silent no-op); partial `reset_session` failures are surfaced in the summary with the failure count.
  - **Bug-shape regression anchor** `test_bug_24362_repro_new_all_must_reset_more_than_one_session` — fails the moment the bulk-token dispatch is removed (pre-fix code rotates exactly one session because `"all"` is consumed as a session title).

- `docs(slash-commands): document /new all + cross-link from telegram (#24362)` — `website/docs/reference/slash-commands.md` (+25 / -2) + `website/docs/user-guide/messaging/telegram.md` (+13):
  - Extended the `/new` and `/reset` rows in the messaging slash-commands table to mention the bulk-token argument.
  - Added a dedicated "Bulk topic reset (`/new all`)" section covering aliases, scope rules (same group only, cross-user safety, shared vs per-user threads, DM fallthrough), and the verbatim confirm-dialog copy so users know exactly what they're agreeing to.
  - Cross-linked from the Telegram Private Chat Topics section — the doc page users land on when researching topic-mode UX.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py tests/gateway/test_new_all_bulk_reset_helper.py -v
   ```
   Expected: 60 passed (45 helper + 15 end-to-end).
3. Run the related gateway suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py \
                       tests/gateway/test_new_all_bulk_reset_helper.py \
                       tests/gateway/test_session_model_reset.py \
                       tests/gateway/test_destructive_slash_confirm.py \
                       tests/gateway/test_session_split_brain_11016.py \
                       tests/gateway/test_title_command.py \
                       tests/gateway/test_session_boundary_security_state.py \
                       tests/gateway/test_telegram_topic_mode.py \
                       tests/gateway/test_session_boundary_hooks.py
   ```
   Expected: 133 passed.
4. Verify the bug reproduction — revert `gateway/run.py` to `upstream/main` and re-run the regression anchor; it must fail with `#24362 regression: /new all only rotated 1 session(s); the feature requires every sibling topic to be reset.`:
   ```
   git stash
   git checkout upstream/main -- gateway/run.py
   scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py::test_bug_24362_repro_new_all_must_reset_more_than_one_session
   # → 1 failed (this is the bug repro)
   git checkout HEAD -- gateway/run.py
   git stash pop
   ```
5. Manual smoke test on a real Telegram supergroup with topics:
   1. Bring up a gateway connected to a Telegram supergroup with at least three topics (e.g. *Website*, *Backend*, *Docs*).
   2. In each topic send one message so the session is registered in `session_store._entries`.
   3. From any topic send `/new all`.
   4. Confirm the destructive-slash dialog → *"This resets EVERY topic/thread session in the current group chat that you can reset, not just this one. Use this after a model/provider switch to keep all topics consistent."*
   5. Tap **once**.
   6. Expect a single ack in the topic that issued the command — `✨ Reset 3 topic sessions in this group.`
   7. Send a new message in each topic; each one must respond from a fresh session (no carry-over of prior conversation, model overrides, or `/queue` overflow).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): …`, `test(gateway): …`, `docs(slash-commands): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py tests/gateway/test_new_all_bulk_reset_helper.py` and all tests pass
- [x] I've added tests for my changes (45 unit + 15 end-to-end + 1 bug-shape regression anchor)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/slash-commands.md`, `website/docs/user-guide/messaging/telegram.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tests are hermetic (`MagicMock` + in-memory `_entries`), no real filesystem or platform-specific calls; production code uses only stdlib + existing `gateway` / `hermes_cli` modules
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py tests/gateway/test_new_all_bulk_reset_helper.py -v
4 workers [60 items]
============================== 60 passed in 0.59s ==============================

$ scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py \
                     tests/gateway/test_new_all_bulk_reset_helper.py \
                     tests/gateway/test_session_model_reset.py \
                     tests/gateway/test_destructive_slash_confirm.py \
                     tests/gateway/test_session_split_brain_11016.py \
                     tests/gateway/test_title_command.py \
                     tests/gateway/test_session_boundary_security_state.py \
                     tests/gateway/test_telegram_topic_mode.py \
                     tests/gateway/test_session_boundary_hooks.py
4 workers [133 items]
============================= 133 passed in 7.10s ==============================

$ ruff check gateway/run.py tests/gateway/test_new_all_bulk_reset.py tests/gateway/test_new_all_bulk_reset_helper.py
All checks passed!

# Bug reproduction — anchor fails on upstream/main
$ git checkout upstream/main -- gateway/run.py
$ scripts/run_tests.sh tests/gateway/test_new_all_bulk_reset.py::test_bug_24362_repro_new_all_must_reset_more_than_one_session
…
E   AssertionError: #24362 regression: /new all only rotated 1 session(s)
    (['agent:main:telegram:supergroup:group-1:topic-A']); the feature
    requires every sibling topic to be reset.
FAILED tests/gateway/test_new_all_bulk_reset.py::test_bug_24362_repro_new_all_must_reset_more_than_one_session
============================== 1 failed in 0.57s ===============================
```

---

**Branch:** `feat/new-all-bulk-topic-reset`
