### PR TITLE
fix(tui): Ctrl+D exit on all platforms + EOF detection

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-stdin-eof.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-stdin-eof.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import App from './components/App.js'
+
+// Regression for #24377: when stdin ends (terminal-driver Ctrl+D outside raw
+// mode, parent process closing the pipe), Node fires 'readable' one final
+// time with nothing to read. handleReadable must notice `readableEnded` and
+// exit — otherwise the TUI keeps rendering against a dead input stream.
+
+const makeFakeStdin = (initialChunks: Array<string | null>, opts: { ended: boolean }) => {
+  const queue: Array<string | null> = [...initialChunks]
+  const readableListeners: Array<() => void> = []
+
+  return {
+    addListener: vi.fn((event: string, fn: () => void) => {
+      if (event === 'readable') {
+        readableListeners.push(fn)
+      }
+    }),
+    listeners: vi.fn((event: string) => (event === 'readable' ? [...readableListeners] : [])),
+    read: vi.fn(() => (queue.length > 0 ? queue.shift()! : null)),
+    get readableEnded() {
+      // Real streams flip readableEnded only after the buffer drains.
+      return opts.ended && queue.every(c => c === null)
+    },
+    get readableLength() {
+      return queue.filter(c => c !== null).reduce((n, c) => n + (c as string).length, 0)
+    }
+  }
+}
+
+const noopStream = { isTTY: false, write: () => true } as unknown as NodeJS.WriteStream
+
+const makeApp = (stdin: ReturnType<typeof makeFakeStdin>) => {
+  // Construct a real App instance with minimal props. PureComponent only
+  // stores `props`; class-field arrows (including handleReadable) bind to
+  // the instance during construction.
+  const app = new App({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: noopStream,
+    stderr: noopStream,
+    exitOnCtrlC: false,
+    onExit: vi.fn(),
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: undefined as any,
+    onSelectionChange: vi.fn(),
+    onClickAt: vi.fn(() => false),
+    onMouseDownAt: vi.fn(() => undefined),
+    onMouseUpAt: vi.fn(),
+    onMouseDragAt: vi.fn(),
+    onHoverAt: vi.fn(),
+    onCopySelectionNoClear: vi.fn(async () => ''),
+    getSelectedText: vi.fn(() => ''),
+    getHyperlinkAt: vi.fn(() => undefined),
+    onOpenHyperlink: vi.fn(),
+    onMultiClick: vi.fn(),
+    onSelectionDrag: vi.fn(),
+    onStdinResume: vi.fn(),
+    dispatchKeyboardEvent: vi.fn(),
+    children: null as any
+  } as any)
+
+  ;(app as any).rawModeEnabledCount = 1
+  ;(app as any).handleExit = vi.fn()
+  ;(app as any).processInput = vi.fn()
+
+  return app
+}
+
+describe('App.handleReadable stdin EOF (#24377)', () => {
+  it('drains buffered input, then exits once the stream has ended', () => {
+    const stdin = makeFakeStdin(['final-keystrokes', null], { ended: true })
+
+    const app = makeApp(stdin)
+
+    ;(app as any).handleReadable()
+
+    // Buffered bytes must reach the key parser before teardown — a user's
+    // last keystrokes can arrive in the same readable event as EOF.
+    expect((app as any).processInput).toHaveBeenCalledWith('final-keystrokes')
+    expect((app as any).handleExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('exits on a bare end-of-stream readable event with no data', () => {
+    const stdin = makeFakeStdin([null], { ended: true })
+
+    const app = makeApp(stdin)
+
+    ;(app as any).handleReadable()
+
+    expect((app as any).processInput).not.toHaveBeenCalled()
+    expect((app as any).handleExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not exit while the stream is still open', () => {
+    const stdin = makeFakeStdin(['keystroke', null], { ended: false })
+
+    const app = makeApp(stdin)
+
+    ;(app as any).handleReadable()
+
+    expect((app as any).processInput).toHaveBeenCalledWith('keystroke')
+    expect((app as any).handleExit).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -540,6 +540,16 @@ export default class App extends PureComponent<Props, State> {
         // Process the input chunk
         this.processInput(chunk)
       }
+
+      // stdin can end underneath us (terminal-driver Ctrl+D outside raw
+      // mode, parent closing the pipe). 'readable' fires one final time
+      // with nothing to read; without this check the TUI keeps rendering
+      // against a dead input stream instead of exiting (#24377).
+      if (this.props.stdin.readableEnded) {
+        this.handleExit()
+
+        return
+      }
     } catch (error) {
       // In Bun, an uncaught throw inside a stream 'readable' handler can
       // permanently wedge the stream: data stays buffered and 'readable'

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -558,3 +558,33 @@ describe('isMacActionFallback', () => {
     expect(isMacActionFallback({ ctrl: true, meta: false, super: false }, 'w', 'w')).toBe(false)
   })
 })
+
+describe('isExitShortcut — documented Ctrl+D exit (#24377)', () => {
+  it('accepts raw Ctrl+D on macOS, where the action modifier is Cmd', async () => {
+    const { isExitShortcut } = await importPlatform('darwin')
+
+    expect(isExitShortcut({ ctrl: true, meta: false, super: false }, 'd')).toBe(true)
+    expect(isExitShortcut({ ctrl: true, meta: false, super: false }, 'D')).toBe(true)
+  })
+
+  it('preserves Cmd+D on macOS via both legacy meta and kitty-style super', async () => {
+    const { isExitShortcut } = await importPlatform('darwin')
+
+    expect(isExitShortcut({ ctrl: false, meta: true, super: false }, 'd')).toBe(true)
+    expect(isExitShortcut({ ctrl: false, meta: false, super: true }, 'd')).toBe(true)
+  })
+
+  it('accepts Ctrl+D and rejects Meta+D on Linux', async () => {
+    const { isExitShortcut } = await importPlatform('linux')
+
+    expect(isExitShortcut({ ctrl: true, meta: false, super: false }, 'd')).toBe(true)
+    expect(isExitShortcut({ ctrl: false, meta: true, super: false }, 'd')).toBe(false)
+  })
+
+  it('never fires for other keys or bare d', async () => {
+    const { isExitShortcut } = await importPlatform('darwin')
+
+    expect(isExitShortcut({ ctrl: true, meta: false, super: false }, 'x')).toBe(false)
+    expect(isExitShortcut({ ctrl: false, meta: false, super: false }, 'd')).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/stdinEofExit.test.ts
+++ b/ui-tui/src/__tests__/stdinEofExit.test.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it } from 'vitest'
+
+import { installStdinEofExit } from '../lib/stdinEofExit.js'
+
+// Regression for #24377: `hermes --tui` kept running after stdin EOF. The
+// entry-level fallback must run the full cleanup chain — breadcrumb, memory
+// monitor, terminal modes, gateway — before exiting 0, in that order, so a
+// crash log can attribute the death and the parent shell gets a sane terminal.
+
+const install = (stdin: EventEmitter) => {
+  const calls: string[] = []
+
+  installStdinEofExit(stdin as unknown as NodeJS.ReadStream, {
+    exit: code => calls.push(`exit:${code}`),
+    killGateway: () => calls.push('killGateway'),
+    recordLifecycle: () => calls.push('recordLifecycle'),
+    resetModes: () => calls.push('resetModes'),
+    stopMonitor: () => calls.push('stopMonitor')
+  })
+
+  return calls
+}
+
+describe('installStdinEofExit', () => {
+  it('runs the cleanup chain in order and exits 0 when stdin ends', () => {
+    const stdin = new EventEmitter()
+    const calls = install(stdin)
+
+    stdin.emit('end')
+
+    expect(calls).toEqual(['recordLifecycle', 'stopMonitor', 'resetModes', 'killGateway', 'exit:0'])
+  })
+
+  it('does nothing while stdin stays open', () => {
+    const stdin = new EventEmitter()
+    const calls = install(stdin)
+
+    stdin.emit('data', 'keystroke')
+
+    expect(calls).toEqual([])
+  })
+})

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -11,7 +11,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
+import { isAction, isCopyShortcut, isExitShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 
@@ -568,7 +568,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    if (isAction(key, ch, 'd')) {
+    if (isExitShortcut(key, ch)) {
       return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
         gateway.gw.publishLocalEvent({
           payload: { reason: 'idle_exit_hotkey' },

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -12,6 +12,7 @@ import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.
 import { type MemorySnapshot, startMemoryMonitor } from './lib/memoryMonitor.js'
 import { openExternalUrl } from './lib/openExternalUrl.js'
 import { recordParentLifecycle } from './lib/parentLog.js'
+import { installStdinEofExit } from './lib/stdinEofExit.js'
 import { resetTerminalModes } from './lib/terminalModes.js'
 
 if (!process.stdin.isTTY) {
@@ -120,6 +121,18 @@ if (process.env.HERMES_HEAPDUMP_ON_START === '1') {
 }
 
 process.on('beforeExit', () => stopMemoryMonitor())
+
+// Ctrl+D at the terminal-driver level (or the parent closing our pipe) ends
+// stdin. Ink's readable handler catches most of these via `readableEnded`,
+// but if that handler is detached mid-teardown the 'end' event is the last
+// signal left — exit cleanly instead of idling with dead input (#24377).
+installStdinEofExit(process.stdin, {
+  exit: code => process.exit(code),
+  killGateway: () => void gw.kill('stdin-eof'),
+  recordLifecycle: recordParentLifecycle,
+  resetModes: resetTerminalModes,
+  stopMonitor: stopMemoryMonitor
+})
 
 const [ink, { App }, { logFrameEvent }, { trackFrame }] = await Promise.all([
   import('@hermes/ink'),

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -34,6 +34,14 @@ export const isMacActionFallback = (
 export const isAction = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string, target: string): boolean =>
   isActionMod(key) && ch.toLowerCase() === target
 
+/** Exit chord. The key table documents `Ctrl+D` = Exit, but on macOS the
+ * action modifier is Cmd, so a binding gated on `isAction` alone never fired
+ * for the documented keystroke there (#24377). Accept the raw Ctrl bit on
+ * every platform — Ctrl+D is EOF muscle memory — while `isAction` keeps
+ * Cmd+D working on macOS. */
+export const isExitShortcut = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string): boolean =>
+  (key.ctrl && ch.toLowerCase() === 'd') || isAction(key, ch, 'd')
+
 export const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
   Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
 

--- a/ui-tui/src/lib/stdinEofExit.ts
+++ b/ui-tui/src/lib/stdinEofExit.ts
@@ -1,0 +1,28 @@
+/** Process-level fallback for stdin EOF (terminal-driver Ctrl+D outside raw
+ * mode, parent process closing the pipe). The Ink layer detects
+ * `readableEnded` inside its own 'readable' handler, but that handler can be
+ * detached mid-teardown or wedged after a raw-mode drop; the stream's 'end'
+ * event still fires exactly once after the last byte is consumed, so it is
+ * the reliable backstop (#24377). */
+
+export interface StdinEofExitHooks {
+  exit: (code: number) => void
+  killGateway: () => void
+  recordLifecycle: (line: string) => void
+  resetModes: () => void
+  stopMonitor: () => void
+}
+
+export function installStdinEofExit(stdin: NodeJS.ReadStream, hooks: StdinEofExitHooks): void {
+  stdin.on('end', () => {
+    // Same ordering as the memory-critical exit path in entry.tsx: leave a
+    // breadcrumb first so a post-mortem can tell EOF apart from a signal
+    // kill, restore the terminal before the gateway teardown can block, and
+    // only then exit.
+    hooks.recordLifecycle('stdin EOF → clean exit')
+    hooks.stopMonitor()
+    hooks.resetModes()
+    hooks.killGateway()
+    hooks.exit(0)
+  })
+}


### PR DESCRIPTION
## Problem

`hermes --tui` does not exit on Ctrl+D (EOF) on macOS, and may not exit reliably on other platforms either. This is a documented feature (README.md says `Ctrl+D` = Exit) but the implementation was broken.

## Root Cause

1. **macOS**: the exit binding was gated on `isAction()`, which requires Cmd on macOS — bare Ctrl+D never matched.
2. **Missing EOF detection**: hermes-ink's `handleReadable()` did not check `stdin.readableEnded` after the read loop drained.
3. **Missing fallback**: `entry.tsx` had no `stdin.on('end')` handler.

## Changes

Reworked onto current main per the hermes-sweeper review (production-facing tests, dashboard-aware exit path preserved):

| File | Change |
|------|--------|
| `ui-tui/src/lib/platform.ts` | New `isExitShortcut()` — raw Ctrl+D on every platform, `isAction` keeps Cmd+D on macOS |
| `ui-tui/src/app/useInputHandlers.ts` | Exit binding uses `isExitShortcut()`; the dashboard-aware `handleIdleHotkeyExit` path is untouched |
| `ui-tui/packages/hermes-ink/src/ink/components/App.tsx` | `readableEnded` check in `handleReadable()` after the drain loop |
| `ui-tui/src/lib/stdinEofExit.ts` + `ui-tui/src/entry.tsx` | Entry-level `stdin.on('end')` fallback, extracted for testability (breadcrumb → stop memory monitor → reset terminal modes → kill gateway → exit 0) |

## Tests

All new tests exercise the production exports rather than recreating the predicates:

- `platform.test.ts` — `isExitShortcut` under both darwin and linux via the existing `importPlatform()` module-swap pattern: raw Ctrl+D fires on macOS, Cmd+D (meta and kitty-style super) preserved, Meta+D rejected on Linux
- `packages/hermes-ink/src/ink/app-stdin-eof.test.ts` — drives the real `App.handleReadable`: drains buffered input then calls `handleExit` once the stream has ended; no exit while the stream is open
- `stdinEofExit.test.ts` — cleanup chain ordering and exit code 0

`npm run --prefix ui-tui check` (build + typecheck + vitest): 113 files, 1196 tests passed.

- [x] iTerm2 — Ctrl+D exits
- [x] Terminal.app — Ctrl+D exits
- [x] VSCode integrated terminal — Ctrl+D exits