### PR TITLE
Add model/provider controls for cron jobs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2554,6 +2554,8 @@ class CronJobCreate(BaseModel):
     schedule: str
     name: str = ""
     deliver: str = "local"
+    model: Optional[str] = None
+    provider: Optional[str] = None
 
 
 class CronJobUpdate(BaseModel):
@@ -2580,7 +2582,8 @@ async def create_cron_job(body: CronJobCreate):
     from cron.jobs import create_job
     try:
         job = create_job(prompt=body.prompt, schedule=body.schedule,
-                         name=body.name, deliver=body.deliver)
+                         name=body.name, deliver=body.deliver,
+                         model=body.model, provider=body.provider)
         return job
     except Exception as e:
         _log.exception("POST /api/cron/jobs failed")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -587,6 +587,56 @@ class TestNewEndpoints:
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
 
+    def test_cron_create_accepts_model_provider(self):
+        resp = self.client.post(
+            "/api/cron/jobs",
+            json={
+                "name": "Pinned model job",
+                "prompt": "Say hello",
+                "schedule": "30m",
+                "deliver": "local",
+                "model": "anthropic/claude-sonnet-4",
+                "provider": "openrouter",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "anthropic/claude-sonnet-4"
+        assert data["provider"] == "openrouter"
+
+        listed = self.client.get("/api/cron/jobs").json()
+        assert any(
+            job["id"] == data["id"]
+            and job["model"] == "anthropic/claude-sonnet-4"
+            and job["provider"] == "openrouter"
+            for job in listed
+        )
+
+    def test_cron_update_model_provider(self):
+        created = self.client.post(
+            "/api/cron/jobs",
+            json={
+                "name": "Editable model job",
+                "prompt": "Say hello",
+                "schedule": "30m",
+                "deliver": "local",
+            },
+        ).json()
+
+        resp = self.client.put(
+            f"/api/cron/jobs/{created['id']}",
+            json={
+                "updates": {
+                    "model": "openai/gpt-5.1",
+                    "provider": "openrouter",
+                }
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "openai/gpt-5.1"
+        assert data["provider"] == "openrouter"
+
     def test_cron_job_not_found(self):
         resp = self.client.get("/api/cron/jobs/nonexistent-id")
         assert resp.status_code == 404

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -139,11 +139,27 @@ export const api = {
 
   // Cron jobs
   getCronJobs: () => fetchJSON<CronJob[]>("/api/cron/jobs"),
-  createCronJob: (job: { prompt: string; schedule: string; name?: string; deliver?: string }) =>
+  createCronJob: (job: {
+    prompt: string;
+    schedule: string;
+    name?: string;
+    deliver?: string;
+    model?: string;
+    provider?: string;
+  }) =>
     fetchJSON<CronJob>("/api/cron/jobs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(job),
+    }),
+  updateCronJob: (
+    id: string,
+    updates: Partial<Pick<CronJob, "model" | "provider">>,
+  ) =>
+    fetchJSON<CronJob>(`/api/cron/jobs/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ updates }),
     }),
   pauseCronJob: (id: string) =>
     fetchJSON<{ ok: boolean }>(`/api/cron/jobs/${id}/pause`, { method: "POST" }),
@@ -556,6 +572,9 @@ export interface CronJob {
   name?: string | null;
   prompt?: string | null;
   script?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  base_url?: string | null;
   schedule?: { kind?: string; expr?: string; display?: string };
   schedule_display?: string | null;
   enabled: boolean;

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Clock, Pause, Play, Plus, Trash2, Zap } from "lucide-react";
+import { Clock, Pause, Pencil, Play, Plus, Trash2, Zap } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
@@ -39,6 +39,14 @@ function getJobPrompt(job: CronJob): string {
 
 function getJobName(job: CronJob): string {
   return asText(job.name).trim();
+}
+
+function getJobModel(job: CronJob): string {
+  return asText(job.model).trim();
+}
+
+function getJobProvider(job: CronJob): string {
+  return asText(job.provider).trim();
 }
 
 function getJobTitle(job: CronJob): string {
@@ -86,7 +94,13 @@ export default function CronPage() {
   const [schedule, setSchedule] = useState("");
   const [name, setName] = useState("");
   const [deliver, setDeliver] = useState("local");
+  const [model, setModel] = useState("");
+  const [provider, setProvider] = useState("");
   const [creating, setCreating] = useState(false);
+  const [editingJobId, setEditingJobId] = useState<string | null>(null);
+  const [editModel, setEditModel] = useState("");
+  const [editProvider, setEditProvider] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
 
   const loadJobs = useCallback(() => {
     api
@@ -112,17 +126,44 @@ export default function CronPage() {
         schedule: schedule.trim(),
         name: name.trim() || undefined,
         deliver,
+        model: model.trim() || undefined,
+        provider: provider.trim() || undefined,
       });
       showToast(t.common.create + " ✓", "success");
       setPrompt("");
       setSchedule("");
       setName("");
       setDeliver("local");
+      setModel("");
+      setProvider("");
       loadJobs();
     } catch (e) {
       showToast(`${t.config.failedToSave}: ${e}`, "error");
     } finally {
       setCreating(false);
+    }
+  };
+
+  const openModelEdit = (job: CronJob) => {
+    setEditingJobId(job.id);
+    setEditModel(getJobModel(job));
+    setEditProvider(getJobProvider(job));
+  };
+
+  const handleSaveModelEdit = async (job: CronJob) => {
+    setSavingEdit(true);
+    try {
+      await api.updateCronJob(job.id, {
+        model: editModel.trim() || null,
+        provider: editProvider.trim() || null,
+      });
+      showToast(t.common.save + " ✓", "success");
+      setEditingJobId(null);
+      loadJobs();
+    } catch (e) {
+      showToast(`${t.config.failedToSave}: ${e}`, "error");
+    } finally {
+      setSavingEdit(false);
     }
   };
 
@@ -243,6 +284,28 @@ export default function CronPage() {
               />
             </div>
 
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="cron-model">Model (optional)</Label>
+                <Input
+                  id="cron-model"
+                  placeholder="default from config.yaml"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cron-provider">Provider (optional)</Label>
+                <Input
+                  id="cron-provider"
+                  placeholder="e.g. openrouter, anthropic, custom:name"
+                  value={provider}
+                  onChange={(e) => setProvider(e.target.value)}
+                />
+              </div>
+            </div>
+
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="grid gap-2">
                 <Label htmlFor="cron-schedule">{t.cron.schedule}</Label>
@@ -317,10 +380,13 @@ export default function CronPage() {
           const title = getJobTitle(job);
           const hasName = Boolean(getJobName(job));
           const deliver = asText(job.deliver);
+          const jobModel = getJobModel(job);
+          const jobProvider = getJobProvider(job);
+          const isEditingModel = editingJobId === job.id;
 
           return (
             <Card key={job.id}>
-              <CardContent className="flex items-center gap-4 py-4">
+              <CardContent className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <span className="font-medium text-sm truncate">
@@ -338,8 +404,16 @@ export default function CronPage() {
                       {truncateText(promptText, 100)}
                     </p>
                   )}
-                  <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                    <span className="font-mono">{getJobScheduleDisplay(job)}</span>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <span className="font-mono truncate">
+                      {getJobScheduleDisplay(job)}
+                    </span>
+                    <span className="min-w-0 truncate">
+                      Model: {jobModel || "default"}
+                    </span>
+                    <span className="min-w-0 truncate">
+                      Provider: {jobProvider || "default"}
+                    </span>
                     <span>
                       {t.cron.last}: {formatTime(job.last_run_at)}
                     </span>
@@ -354,7 +428,17 @@ export default function CronPage() {
                   )}
                 </div>
 
-                <div className="flex items-center gap-1 shrink-0">
+                <div className="flex items-center gap-1 shrink-0 self-end sm:self-auto">
+                  <Button
+                    ghost
+                    size="icon"
+                    title="Edit model/provider"
+                    aria-label="Edit model/provider"
+                    onClick={() => openModelEdit(job)}
+                  >
+                    <Pencil />
+                  </Button>
+
                   <Button
                     ghost
                     size="icon"
@@ -392,6 +476,52 @@ export default function CronPage() {
                   </Button>
                 </div>
               </CardContent>
+
+              {isEditingModel && (
+                <div className="border-t border-border px-4 pb-4 pt-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-3 items-end">
+                    <div className="grid gap-2">
+                      <Label htmlFor={`cron-edit-model-${job.id}`}>
+                        Model
+                      </Label>
+                      <Input
+                        id={`cron-edit-model-${job.id}`}
+                        placeholder="default from config.yaml"
+                        value={editModel}
+                        onChange={(e) => setEditModel(e.target.value)}
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label htmlFor={`cron-edit-provider-${job.id}`}>
+                        Provider
+                      </Label>
+                      <Input
+                        id={`cron-edit-provider-${job.id}`}
+                        placeholder="e.g. openrouter, anthropic, custom:name"
+                        value={editProvider}
+                        onChange={(e) => setEditProvider(e.target.value)}
+                      />
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => handleSaveModelEdit(job)}
+                        disabled={savingEdit}
+                      >
+                        {savingEdit ? t.common.saving : t.common.save}
+                      </Button>
+                      <Button
+                        size="sm"
+                        ghost
+                        onClick={() => setEditingJobId(null)}
+                        disabled={savingEdit}
+                      >
+                        {t.common.cancel}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </Card>
           );
         })}


### PR DESCRIPTION
## Summary
- allow dashboard-created cron jobs to persist optional model/provider overrides
- display cron job model/provider values and add inline editing controls
- add web server coverage for cron job model/provider create and update flows

Closes #24258

## Testing
- `.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_web_server.py -q -k 'cron_'`
- `npm run build`
- `git diff --check`