### PR TITLE
feat(webhook): accept Linear-Signature header for HMAC validation

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -581,6 +581,14 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return hmac.compare_digest(generic_sig, expected)
 
+        # Linear: Linear-Signature = <hex HMAC-SHA256>
+        linear_sig = request.headers.get("Linear-Signature", "")
+        if linear_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_sig, expected)
+
         # No recognised signature header but secret is configured → reject
         logger.debug(
             "[webhook] Secret configured but no signature header found"


### PR DESCRIPTION
## Summary

The webhook adapter currently recognizes GitHub (`X-Hub-Signature-256`), GitLab (`X-Gitlab-Token`), and generic (`X-Webhook-Signature`) signature headers, but not Linear's. Legitimate Linear webhook deliveries are therefore rejected with `401 Invalid signature` even when the route's secret matches Linear's signing secret.

Linear signs each webhook with HMAC-SHA256 of the raw body using the configured secret and sends the hex-encoded result in the `Linear-Signature` header (per [Linear's webhook docs](https://linear.app/developers/webhooks)).

This adds a fourth recognizer for that header. Same algorithm as the generic case, just a different header name.

## Diff

8 lines added in `gateway/platforms/webhook.py`, no other files touched.

## Test plan

- [x] Verified locally: POST with a correct `Linear-Signature` → 202
- [x] Verified locally: POST with a wrong `Linear-Signature` → 401
- [x] Verified locally: POST with no signature header → 401 (unchanged behavior)
- [x] Existing recognizers (GitHub / GitLab / generic) still work — code path is additive
- [x] Real Linear → Cloudflare tunnel → Hermes end-to-end delivery succeeds