### PR TITLE
fix(gateway): MEDIA: extraction regex — prefix-glue, space-truncation, narrow allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2061,10 +2061,23 @@ class BasePlatformAdapter(ABC):
         # keep it out of the user-visible cleaned text.
         cleaned = cleaned.replace("[[as_document]]", "")
         
-        # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
+        # Extract MEDIA:<path> tags, allowing optional HORIZONTAL whitespace after
+        # the colon and quoted/backticked paths for LLM-formatted outputs.
+        #
+        # Fixes (2026-05-12):
+        #   1. Use ``[^\S\n]*`` instead of ``\s*`` so the regex cannot bridge
+        #      across newlines from a prose ``MEDIA:`` mention to a later real
+        #      ``MEDIA:/path.ext`` tag (which used to fall through to the
+        #      ``\S+`` fallback and capture the literal ``MEDIA:`` prefix as
+        #      part of the path).
+        #   2. Drop the trailing ``|\S+`` fallback. ``\S+`` truncated paths
+        #      containing spaces (e.g. ``/Users/.../Ace Place/foo.html`` →
+        #      ``/Users/.../Ace``) and re-captured the ``MEDIA:`` prefix in
+        #      pathological cases. Unrecognized extensions now require quoting.
+        #   3. Expand the allowlist to common developer text formats (html,
+        #      svg, md, json, yaml, xml, log, source code, shell, config).
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:[^\S\n]*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|svg|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|html?|md|markdown|json|ya?ml|xml|log|py|jsx?|tsx?|sh|bash|zsh|toml|ini|conf|cfg|env)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10012,9 +10012,16 @@ class GatewayRunner:
             # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
             force_document_attachments = "[[as_document]]" in response
 
-            media_files, _ = adapter.extract_media(response)
-            _, cleaned = adapter.extract_images(response)
-            local_files, _ = adapter.extract_local_files(cleaned)
+            # Chain cleaned text through each extractor so MEDIA: tags and image
+            # URLs are stripped before extract_local_files runs its bare-path
+            # auto-detect. Previously this dropped the cleaned text on the floor
+            # (used ``_``), causing extract_local_files to scan raw ``MEDIA:``
+            # text and produce false-positive bare-path matches with the
+            # ``MEDIA:`` prefix glued on. Matches the chain order used by the
+            # non-streaming path in gateway/platforms/base.py.
+            media_files, response_cleaned = adapter.extract_media(response)
+            _, response_cleaned = adapter.extract_images(response_cleaned)
+            local_files, _ = adapter.extract_local_files(response_cleaned)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -360,6 +360,82 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    # -----------------------------------------------------------------
+    # Regression tests for the 2026-05-12 extract_media regex fixes.
+    # See gateway/platforms/base.py for the corresponding inline comment.
+    # -----------------------------------------------------------------
+
+    def test_prose_media_word_does_not_bridge_to_later_tag(self):
+        """Regression: when the response contains ``MEDIA:`` as conversational
+        text on one line and a real ``MEDIA:/path.ext`` tag on a later line,
+        the regex must NOT bridge across the newlines and capture the
+        literal ``MEDIA:`` prefix as part of the path.
+
+        Previously the ``\\s*`` after ``MEDIA:`` consumed the newlines and
+        the path slot fell through to the ``|\\S+`` fallback, producing
+        ``('MEDIA:/Users/.../foo.png', False)``.
+        """
+        content = (
+            "Test 3 — the PNG via MEDIA:\n"
+            "\n"
+            "MEDIA:/tmp/output/foo.png\n"
+        )
+        media, _ = BasePlatformAdapter.extract_media(content)
+        # The real ``MEDIA:/tmp/output/foo.png`` tag should extract cleanly
+        # — no ``MEDIA:`` prefix glued onto the path.
+        assert media == [("/tmp/output/foo.png", False)]
+
+    def test_html_extension_is_allowlisted(self):
+        """Regression: ``.html`` and other common developer text formats
+        (svg, md, json, yaml, xml, log, py, jsx, tsx, sh, toml, ini, conf,
+        env) are now allowlisted so MEDIA: can attach them."""
+        for ext in (
+            "html", "htm", "svg", "md", "markdown", "json", "yaml", "yml",
+            "xml", "log", "py", "js", "jsx", "ts", "tsx", "sh", "bash",
+            "zsh", "toml", "ini", "conf", "cfg", "env",
+        ):
+            content = f"MEDIA:/tmp/foo.{ext}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert media == [(f"/tmp/foo.{ext}", False)], (
+                f"extension {ext!r} should be allowlisted by extract_media"
+            )
+
+    def test_unquoted_path_with_unrecognized_extension_is_left_alone(self):
+        """Regression: the ``|\\S+`` fallback at the end of the path
+        alternatives was removed because it (a) truncated paths with
+        spaces at the first whitespace and (b) re-captured the ``MEDIA:``
+        prefix in pathological cases. Unrecognized extensions are now
+        left as plain text (user can quote the path to opt in)."""
+        content = "MEDIA:/tmp/foo.unknownext"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        # The original MEDIA: tag remains in the cleaned text since it
+        # didn't match — agent + user can see the unsupported-extension
+        # state instead of silently dropping it.
+        assert "MEDIA:/tmp/foo.unknownext" in cleaned
+
+    def test_quoted_path_with_unrecognized_extension_still_works(self):
+        """Quoted (single, double, or backtick) paths bypass the extension
+        allowlist — the quotes act as the explicit opt-in. This preserves
+        the ``MEDIA:\"/path/anything\"`` escape hatch for unusual files."""
+        for quote in ('"', "'", "`"):
+            content = f"MEDIA:{quote}/tmp/foo.unknownext{quote}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert media == [("/tmp/foo.unknownext", False)], (
+                f"quoted path with {quote!r} should bypass extension allowlist"
+            )
+
+    def test_path_with_spaces_in_allowlisted_extension_still_works(self):
+        """Verify the existing unquoted-spaces support didn't regress.
+        Internal spaces within an unquoted path are still allowed as long
+        as the final extension is allowlisted (since allowlisted extensions
+        give the regex an unambiguous anchor)."""
+        content = "MEDIA:/tmp/Ace Place/Engineering/Subagent Router.html"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/tmp/Ace Place/Engineering/Subagent Router.html", False)
+        ]
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio


### PR DESCRIPTION
## Summary

Three compounding bugs in `extract_media` (`gateway/platforms/base.py`) caused `MEDIA:/path` tags to silently fail on Discord and likely other platforms. Discovered while trying to attach an HTML file from chat.

## Bugs Fixed

### 1. `\s*` after `MEDIA:` consumes newlines, bridges to later `MEDIA:` tag

When the agent's response contains `MEDIA:` as conversational text on one line AND a real `MEDIA:/path` tag on a later line, the old regex bridges across the gap and the path slot falls through to the `|\S+` fallback — capturing the literal `MEDIA:` prefix as part of the path.

**Repro:**
```python
response = "Test 3 PNG via MEDIA:\n\nMEDIA:/tmp/foo.png"
BasePlatformAdapter.extract_media(response)
# Old: [('MEDIA:/tmp/foo.png', False)]   ← prefix glued on
# New: [('/tmp/foo.png', False)]
```

Downstream `send_multiple_images` then checks `os.path.exists("MEDIA:/tmp/foo.png")` → False → logs `Skipping missing image`.

**Fix:** change `\s*` to `[^\S\n]*` (horizontal whitespace only).

### 2. `|\S+` final fallback truncates paths with spaces

The `|\S+` catch-all in the path alternatives truncated paths containing spaces at the first whitespace character. For example, an Obsidian vault path:

```python
response = 'MEDIA:/Users/alex/Obsidian/Ace Place/Engineering/foo.html'
# Old: matched '/Users/alex/Obsidian/Ace'  ← truncated, then File not found
# Old gateway log: '[Discord] Failed to send media (): File not found: /Users/alex/Obsidian/Ace'
```

It also enabled bug #1 by allowing pathological captures of `MEDIA:/...` text.

**Fix:** drop `|\S+` entirely. Unrecognized extensions now require quoting (`MEDIA:"/path/anything"`). Recognized extensions still support unquoted paths with internal spaces via the existing `(?:[^\S\n]+\S+)*?` continuation.

### 3. Extension allowlist excluded common developer text formats

`.html`, `.svg`, `.md`, `.json`, `.yaml`, `.xml`, `.log`, source code (`.py`/`.js`/`.ts`/`.jsx`/`.tsx`), shell (`.sh`/`.bash`/`.zsh`), and config (`.toml`/`.ini`/`.conf`/`.cfg`/`.env`) were all rejected — `MEDIA:` tags for these file types appeared as plain text in chat instead of being uploaded as attachments.

**Fix:** expand the allowlist to cover these formats.

### Bonus fix: streaming dispatch path discards cleaned text

`gateway/run.py:~10015` was dropping the cleaned-text return value from `extract_media`/`extract_images` on the floor:

```python
# BEFORE
media_files, _ = adapter.extract_media(response)        # discards cleaned
_, cleaned = adapter.extract_images(response)            # uses RAW response
local_files, _ = adapter.extract_local_files(cleaned)   # MEDIA: never stripped
```

This caused `extract_local_files` to scan raw `MEDIA:` text in the streaming dispatch path, producing false-positive bare-path matches.

**Fix:** chain cleaned text through the extractors in order, matching the non-streaming path in `base.py:~2983`.

## Testing

Added regression tests in `tests/gateway/test_platform_base.py`:

- `test_prose_media_word_does_not_bridge_to_later_tag` — bug #1
- `test_html_extension_is_allowlisted` — bug #3 (parameterized over 23 extensions)
- `test_unquoted_path_with_unrecognized_extension_is_left_alone` — bug #2 + new behavior
- `test_quoted_path_with_unrecognized_extension_still_works` — verifies the quoted-path escape hatch still works for unusual extensions
- `test_path_with_spaces_in_allowlisted_extension_still_works` — confirms existing unquoted-spaces support didn't regress

All 95 tests in `test_platform_base.py` pass. Three pre-existing failures in `test_tts_media_routing.py` are unrelated (`_thread_metadata_for_source` attribute missing on a mock) — they fail identically on clean `origin/main`.

## Backwards compatibility

- All existing tests pass unchanged.
- The one behavior change for callers: unquoted `MEDIA:/path.unknownext` (unrecognized extension) now leaves the tag in user-visible text instead of silently extracting a truncated/corrupted path. Quoted paths (`MEDIA:"/path.unknownext"`) continue to work for the escape-hatch case. Net result: a clearer failure mode for unsupported extensions.

## Discovery

This was found while trying to attach an HTML spec file to a Discord chat. The agent emitted `MEDIA:/path/spec.html` and the gateway:

1. Failed silently (`.html` not in allowlist → bug #3)
2. When the workaround used an obsidian path with spaces, truncated it (bug #2)
3. When the agent had said `MEDIA:` in prose earlier in the response, the second `MEDIA:/path.png` got the prefix glued on (bug #1)

Log evidence (from `~/.hermes/logs/gateway.log`):
```
[Discord] Failed to send media (.html): File not found: /path/to/foo.html
[Discord] Failed to send media (): File not found: /Users/alexgierczyk/Obsidian/Ace
[Discord] Skipping missing image: MEDIA:/Users/alexgierczyk/.hermes/cache/images/openai_gpt-image-2-medium_20260512_063250_f4610f91.png
```
