### PR TITLE
Fix auto voice replies dropped on long-running turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9932,6 +9932,18 @@ class GatewayRunner:
 
     async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
         """Generate TTS audio and send as a voice message before the text reply."""
+        voice_task = asyncio.create_task(self._send_voice_reply_inner(event, text))
+        try:
+            await asyncio.shield(voice_task)
+        except asyncio.CancelledError:
+            logger.info(
+                "Auto voice reply cancelled by caller; detached delivery will continue for %s/%s",
+                event.source.platform,
+                event.source.chat_id,
+            )
+
+    async def _send_voice_reply_inner(self, event: MessageEvent, text: str) -> None:
+        """Best-effort TTS/send path for auto voice replies."""
         import uuid as _uuid
         audio_path = None
         actual_path = None
@@ -9940,6 +9952,11 @@ class GatewayRunner:
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
+                logger.info(
+                    "Auto voice reply skipped: stripped text empty for %s/%s",
+                    event.source.platform,
+                    event.source.chat_id,
+                )
                 return
 
             # Use .mp3 extension so edge-tts conversion to opus works correctly.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -120,10 +120,19 @@ echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
+if ((${#ARGS[@]})); then
+  exec "$PYTHON" -m pytest \
+    -o "addopts=" \
+    -n "$WORKERS" \
+    --ignore=tests/integration \
+    --ignore=tests/e2e \
+    -m "not integration" \
+    "${ARGS[@]}"
+fi
+
 exec "$PYTHON" -m pytest \
   -o "addopts=" \
   -n "$WORKERS" \
   --ignore=tests/integration \
   --ignore=tests/e2e \
-  -m "not integration" \
-  "${ARGS[@]}"
+  -m "not integration"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -473,6 +474,34 @@ class TestSendVoiceReply:
             await runner._send_voice_reply(event, "```code only```")
 
         mock_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_outer_wait_detaches_voice_delivery(self, runner):
+        event = _make_event()
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+        release_tts = asyncio.Event()
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            await release_tts.wait()
+            return tts_result
+
+        with patch("gateway.run.asyncio.to_thread", side_effect=fake_to_thread), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            send_task = asyncio.create_task(runner._send_voice_reply(event, "Hello world"))
+            await asyncio.sleep(0)
+            send_task.cancel()
+            release_tts.set()
+            await send_task
+            await asyncio.sleep(0)
+
+        mock_adapter.send_voice.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_tts_failure_no_crash(self, runner):
@@ -1814,13 +1843,13 @@ class TestPlayInVoiceChannelUsesRunningLoop:
 # =====================================================================
 
 class TestSendVoiceReplyFilename:
-    """_send_voice_reply uses uuid for unique filenames."""
+    """_send_voice_reply inner worker uses uuid for unique filenames."""
 
     def test_filename_uses_uuid(self):
         """The method uses uuid in the filename, not time-based."""
         import inspect
         from gateway.run import GatewayRunner
-        source = inspect.getsource(GatewayRunner._send_voice_reply)
+        source = inspect.getsource(GatewayRunner._send_voice_reply_inner)
         assert "uuid" in source, \
             "_send_voice_reply should use uuid for unique filenames"
         assert "int(time.time())" not in source, \
@@ -2040,7 +2069,7 @@ class TestSendVoiceReplyCleanup:
         """The method has cleanup in a finally block, not inside try."""
         import inspect, textwrap, ast
         from gateway.run import GatewayRunner
-        source = textwrap.dedent(inspect.getsource(GatewayRunner._send_voice_reply))
+        source = textwrap.dedent(inspect.getsource(GatewayRunner._send_voice_reply_inner))
         tree = ast.parse(source)
         func = tree.body[0]
 


### PR DESCRIPTION
## Summary
- keep auto voice replies alive even if the outer caller is cancelled while TTS is still generating
- log the empty-text skip path instead of silently dropping delivery
- make `scripts/run_tests.sh` safe for clean-env full-suite runs with no positional args

## Root cause
`GatewayRunner._send_voice_reply()` awaited the full TTS/send path inline, so a caller-side `CancelledError` could cancel the in-flight auto voice delivery before media send completed. The canonical test runner also had an empty-args expansion bug under `set -u`, which blocked truthful `full_mainline` proof in clean environments.

## Impact
Long-running voice-in turns no longer silently lose their automatic voice reply when the outer wait is cancelled, and the repo's canonical test runner now executes the no-args full suite path correctly.

## Validation
- `cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 && /Library/Frameworks/Python.framework/Versions/3.10/bin/uv sync --frozen --extra all`
- `git -C /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 diff --check`
- `cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 && /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check .`
- `cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 && source /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-main-baseline-20260510-173514/.venv/bin/activate && pytest tests/gateway/test_voice_command.py -q`
- `cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 && bash -n scripts/run_tests.sh`
- `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" TMPDIR="${TMPDIR:-/tmp}" bash -lc 'cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/her-95-23983-20260512-204731 && ./scripts/run_tests.sh'`

## Baseline note
The clean-env `full_mainline` suite completed on this branch with `63 failed, 22185 passed, 84 skipped`; representative untouched failures were reproduced on latest `origin/main`, and `lint_diff.py` reported zero new diagnostics in `gateway/run.py`, `tests/gateway/test_voice_command.py`, and `scripts/run_tests.sh`. Residual red is attributed as `preexisting_unrelated`.
