### PR TITLE
fix: migrate Parallel tools to GA API

### DIFF
--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -132,10 +132,20 @@ _get_parallel_client = _get_sync_client
 _get_async_parallel_client = _get_async_client
 
 
+_PARALLEL_LEGACY_TO_GA_MODE = {"fast": "basic", "one-shot": "basic", "agentic": "advanced"}
+_PARALLEL_GA_TO_LEGACY_MODE = {"basic": "fast", "advanced": "agentic"}
+_PARALLEL_ALLOWED_SEARCH_MODES = {"fast", "one-shot", "agentic", "basic", "advanced"}
+
+
 def _resolve_search_mode() -> str:
-    """Return the validated PARALLEL_SEARCH_MODE value (default "agentic")."""
+    """Return the validated PARALLEL_SEARCH_MODE value.
+
+    The legacy beta SDK accepted ``fast`` / ``one-shot`` / ``agentic``;
+    the GA SDK accepts ``basic`` / ``advanced``. Accept both vocabularies so
+    existing env vars keep working while users can opt into GA names too.
+    """
     mode = os.getenv("PARALLEL_SEARCH_MODE", "agentic").lower().strip()
-    if mode not in {"fast", "one-shot", "agentic"}:
+    if mode not in _PARALLEL_ALLOWED_SEARCH_MODES:
         mode = "agentic"
     return mode
 
@@ -174,16 +184,31 @@ class ParallelWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            mode = _resolve_search_mode()
-            logger.info(
-                "Parallel search: '%s' (mode=%s, limit=%d)", query, mode, limit
-            )
-            response = _get_sync_client().beta.search(
-                search_queries=[query],
-                objective=query,
-                mode=mode,
-                max_results=min(limit, 20),
-            )
+            requested_mode = _resolve_search_mode()
+            client = _get_sync_client()
+            max_results = min(limit, 20)
+            if hasattr(client, "search"):
+                mode = _PARALLEL_LEGACY_TO_GA_MODE.get(requested_mode, requested_mode)
+                logger.info(
+                    "Parallel search: '%s' (mode=%s, limit=%d)", query, mode, limit
+                )
+                response = client.search(
+                    search_queries=[query],
+                    objective=query,
+                    mode=mode,
+                    advanced_settings={"max_results": max_results},
+                )
+            else:
+                mode = _PARALLEL_GA_TO_LEGACY_MODE.get(requested_mode, requested_mode)
+                logger.info(
+                    "Parallel beta search: '%s' (mode=%s, limit=%d)", query, mode, limit
+                )
+                response = client.beta.search(
+                    search_queries=[query],
+                    objective=query,
+                    mode=mode,
+                    max_results=max_results,
+                )
 
             web_results = []
             for i, result in enumerate(response.results or []):
@@ -228,10 +253,17 @@ class ParallelWebSearchProvider(WebSearchProvider):
                 ]
 
             logger.info("Parallel extract: %d URL(s)", len(urls))
-            response = await _get_async_client().beta.extract(
-                urls=urls,
-                full_content=True,
-            )
+            client = _get_async_client()
+            if hasattr(client, "extract"):
+                response = await client.extract(
+                    urls=urls,
+                    advanced_settings={"full_content": True},
+                )
+            else:
+                response = await client.beta.extract(
+                    urls=urls,
+                    full_content=True,
+                )
 
             results: List[Dict[str, Any]] = []
             for result in response.results or []:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ anthropic = ["anthropic==0.86.0"]
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]
 firecrawl = ["firecrawl-py==4.17.0"]
-parallel-web = ["parallel-web==0.4.2"]
+parallel-web = ["parallel-web==0.6.0"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -448,6 +448,109 @@ class TestParallelClientConfig:
             assert client1 is client2
 
 
+class TestParallelSearchAndExtractCompatibility:
+    """Parallel SDK compatibility across beta and GA clients."""
+
+    def test_parallel_search_uses_ga_client_and_maps_agentic_to_advanced(self):
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        calls = {}
+
+        class FakeClient:
+            def search(self, **kwargs):
+                calls.update(kwargs)
+                return types.SimpleNamespace(
+                    results=[
+                        types.SimpleNamespace(
+                            title="Parallel docs",
+                            url="https://docs.parallel.ai",
+                            excerpts=["Excerpt"],
+                        )
+                    ]
+                )
+
+        with patch("plugins.web.parallel.provider._get_sync_client", return_value=FakeClient()), \
+             patch.dict(os.environ, {"PARALLEL_SEARCH_MODE": "agentic"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = ParallelWebSearchProvider().search("Parallel SDK", limit=3)
+
+        assert calls["mode"] == "advanced"
+        assert calls["advanced_settings"] == {"max_results": 3}
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Parallel docs"
+
+    def test_parallel_search_falls_back_to_beta_client_and_maps_advanced_to_agentic(self):
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        calls = {}
+
+        class FakeClient:
+            class beta:
+                @staticmethod
+                def search(**kwargs):
+                    calls.update(kwargs)
+                    return types.SimpleNamespace(results=[])
+
+        with patch("plugins.web.parallel.provider._get_sync_client", return_value=FakeClient()), \
+             patch.dict(os.environ, {"PARALLEL_SEARCH_MODE": "advanced"}), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = ParallelWebSearchProvider().search("Parallel SDK", limit=3)
+
+        assert calls["mode"] == "agentic"
+        assert calls["max_results"] == 3
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_parallel_extract_uses_ga_client_with_advanced_settings(self):
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        calls = {}
+
+        class FakeAsyncClient:
+            async def extract(self, **kwargs):
+                calls.update(kwargs)
+                return types.SimpleNamespace(
+                    results=[
+                        types.SimpleNamespace(
+                            title="Parallel docs",
+                            url="https://docs.parallel.ai",
+                            full_content="Full content",
+                            excerpts=["Excerpt"],
+                        )
+                    ],
+                    errors=[],
+                )
+
+        with patch("plugins.web.parallel.provider._get_async_client", return_value=FakeAsyncClient()), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = await ParallelWebSearchProvider().extract(["https://docs.parallel.ai"])
+
+        assert calls["advanced_settings"] == {"full_content": True}
+        assert result[0]["content"] == "Full content"
+
+    @pytest.mark.asyncio
+    async def test_parallel_extract_falls_back_to_beta_client(self):
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+        calls = {}
+
+        class Beta:
+            @staticmethod
+            async def extract(**kwargs):
+                calls.update(kwargs)
+                return types.SimpleNamespace(results=[], errors=[])
+
+        class FakeAsyncClient:
+            beta = Beta()
+
+        with patch("plugins.web.parallel.provider._get_async_client", return_value=FakeAsyncClient()), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = await ParallelWebSearchProvider().extract(["https://docs.parallel.ai"])
+
+        assert calls == {"urls": ["https://docs.parallel.ai"], "full_content": True}
+        assert result == []
+
+
 class TestWebSearchSchema:
     """Test suite for web_search tool schema and handler wiring."""
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -90,7 +90,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Web search backends ───────────────────────────────────────────────
     "search.exa": ("exa-py==2.10.2",),
     "search.firecrawl": ("firecrawl-py==4.17.0",),
-    "search.parallel": ("parallel-web==0.4.2",),
+    "search.parallel": ("parallel-web==0.6.0",),
 
     # ─── TTS providers ─────────────────────────────────────────────────────
     # Pinned to exact versions to match pyproject.toml's no-ranges policy

--- a/uv.lock
+++ b/uv.lock
@@ -1650,7 +1650,7 @@ requires-dist = [
     { name = "nemo-relay", marker = "extra == 'nemo-relay'", specifier = "==0.3" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },
-    { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
+    { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.6.0" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
@@ -2686,7 +2686,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "0.4.2"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2696,9 +2696,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/50/fb9b28a679e01682006b5259abff96de3d16e114e9447a7793fec31715de/parallel_web-0.4.2.tar.gz", hash = "sha256:599b5a8f387dc35c7dc8c81e372eadf6958a40acacea58bf170dfc663c003da7", size = 140026, upload-time = "2026-03-09T22:24:35.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/81/101c961fe6665212df01fb39a70ebb379dc33529c7bc9210675c0f525139/parallel_web-0.6.0.tar.gz", hash = "sha256:f8aecd3f1958090090c4516881cefea4f55c40948ba3bb99217ca9a6d4263225", size = 173149, upload-time = "2026-05-06T19:13:09.782Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/3e/2218fa29637781b8e7ac35a928108ff2614ddd40879389d3af2caa725af5/parallel_web-0.4.2-py3-none-any.whl", hash = "sha256:aa3a4a9aecc08972c5ce9303271d4917903373dff4dd277d9a3e30f9cff53346", size = 144012, upload-time = "2026-03-09T22:24:33.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7c/7e8b63a0e90efaf567a818fca86c6ad3a85711f8995d2657b51b0cae2351/parallel_web-0.6.0-py3-none-any.whl", hash = "sha256:dc5342ef7262bd2e9f85eb7eace32833bd3d7e3af0bf5fbd780d1ea8c8d9ceb0", size = 199217, upload-time = "2026-05-06T19:13:08.316Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- migrate Parallel search/extract calls to GA SDK 0.6.0 APIs in the current plugin-based web provider
- keep beta fallback compatibility for older SDK clients
- update lazy dependency pin and regression tests

## Test Plan
- `scripts/run_tests.sh tests/tools/test_web_tools_config.py` → 54 passed
- `ruff check plugins/web/parallel/provider.py tests/tools/test_web_tools_config.py` → passed

## Notes
- Rebased onto current `origin/main` and adapted the original fix after Parallel moved from `tools/web_tools.py` into `plugins/web/parallel/provider.py`.
- Previous approval was dismissed by GitHub after the branch update; needs maintainer review again.
