### PR TITLE
Fix background review profile home isolation

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,10 +5,23 @@ without risk of circular imports.
 """
 
 import os
+import threading
 from pathlib import Path
 
 
 _profile_fallback_warned: bool = False
+_thread_local = threading.local()
+
+
+def set_thread_hermes_home(path: os.PathLike[str] | str) -> None:
+    """Set a thread-local Hermes home override for background workers."""
+    _thread_local.hermes_home = str(path)
+
+
+def clear_thread_hermes_home() -> None:
+    """Clear this thread's Hermes home override, if one is set."""
+    if hasattr(_thread_local, "hermes_home"):
+        delattr(_thread_local, "hermes_home")
 
 
 def get_hermes_home() -> Path:
@@ -27,6 +40,10 @@ def get_hermes_home() -> Path:
     template in ``hermes_cli/gateway.py`` and the kanban dispatcher in
     ``hermes_cli/kanban_db.py``).  See https://github.com/NousResearch/hermes-agent/issues/18594.
     """
+    override = getattr(_thread_local, "hermes_home", "")
+    if override:
+        return Path(override)
+
     val = os.environ.get("HERMES_HOME", "").strip()
     if val:
         return Path(val)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4254,8 +4254,13 @@ class AIAgent:
         else:
             prompt = self._SKILL_REVIEW_PROMPT
 
+        _background_hermes_home = get_hermes_home()
+
         def _run_review():
             import contextlib
+            from hermes_constants import clear_thread_hermes_home, set_thread_hermes_home
+
+            set_thread_hermes_home(_background_hermes_home)
             # Install a non-interactive approval callback on this worker
             # thread so any dangerous-command guard the review agent trips
             # resolves to "deny" instead of falling back to input() -- which
@@ -4371,6 +4376,7 @@ class AIAgent:
                     _set_approval_callback(None)
                 except Exception:
                     pass
+                clear_thread_hermes_home()
 
         t = threading.Thread(target=_run_review, daemon=True, name="bg-review")
         t.start()

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -37,6 +37,18 @@ class ImmediateThread:
         self._target()
 
 
+class DeferredThread:
+    pending = []
+
+    def __init__(self, *, target, daemon=None, name=None):
+        self._target = target
+        self.daemon = daemon
+        self.name = name
+
+    def start(self):
+        self.pending.append(self._target)
+
+
 def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
     events = []
 
@@ -71,6 +83,63 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         "shutdown_memory_provider",
         "close",
     ]
+
+
+def test_background_review_preserves_parent_hermes_home_after_env_restore(monkeypatch, tmp_path):
+    """Background review must keep the parent profile home after env restore.
+
+    WebUI sets process-level HERMES_HOME while the parent turn runs, then
+    restores it after run_conversation returns. The background review thread is
+    started before the restore but may not construct its AIAgent until after it.
+    """
+    import hermes_constants
+    from tools import memory_tool
+
+    profile_home = tmp_path / "profiles" / "work"
+    default_home = tmp_path / "default"
+    profile_home.mkdir(parents=True)
+    default_home.mkdir()
+
+    observed = {}
+    DeferredThread.pending = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            observed["hermes_home"] = hermes_constants.get_hermes_home()
+            observed["memory_dir"] = memory_tool.get_memory_dir()
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", DeferredThread)
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert len(DeferredThread.pending) == 1
+
+    # Simulate the parent streaming request restoring process env before the
+    # daemon thread reaches AIAgent.__init__.
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    DeferredThread.pending[0]()
+
+    assert observed["hermes_home"] == profile_home
+    assert observed["memory_dir"] == profile_home / "memories"
+    assert hermes_constants.get_hermes_home() == default_home
 
 
 def test_background_review_installs_auto_deny_approval_callback(monkeypatch):


### PR DESCRIPTION
## Summary

- add a thread-local Hermes home override used by `get_hermes_home()`
- set that override for post-turn background memory/skill review threads before constructing the review `AIAgent`
- add regression coverage for the WebUI-triggered race where process-level `HERMES_HOME` is restored before the background review thread initializes

## Root Cause

WebUI can run an agent turn under a non-default profile by temporarily setting process-level `HERMES_HOME`. After the user-visible turn finishes, WebUI restores the process env. The Agent post-turn background review is started before that restore, but the daemon thread may not construct its own `AIAgent` until after the restore.

`AIAgent.__init__`, memory provider setup, and built-in memory writes all resolve their home through `get_hermes_home()`. Without an inherited thread-local home, the background review can load config and write memory under the default profile instead of the parent run's profile.

## What Changed

This keeps the background review scoped to the parent run's Hermes home without mutating process-wide environment from the background thread. The override is cleared in the background thread's existing cleanup path.

## Verification

- `.venv/bin/python -m pytest -q tests/run_agent/test_background_review.py::test_background_review_preserves_parent_hermes_home_after_env_restore`
- `.venv/bin/python -m pytest -q tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py tests/test_hermes_home_profile_warning.py tests/tools/test_memory_tool.py`
- `python3 -m py_compile hermes_constants.py run_agent.py`
- `git diff --check`

## Related

Refs nesquena/hermes-webui#2134.
