### PR TITLE
fix(windows): enable VT processing + ASCII fallback for setup wizard (#24345)

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -9,6 +9,14 @@ def should_use_color() -> bool:
 
     Respects the NO_COLOR environment variable (https://no-color.org/)
     and TERM=dumb, in addition to the existing TTY check.
+
+    On Windows we additionally consult the VT-processing detector from
+    :mod:`hermes_cli.stdio`.  If ``configure_windows_stdio`` was unable
+    to enable ``ENABLE_VIRTUAL_TERMINAL_PROCESSING`` for the attached
+    console (legacy Windows Console Host, very old cmd.exe, etc.) we
+    suppress colors entirely — otherwise the setup wizard's banner
+    prints as literal ``←[35m┌────...`` garbage which is exactly the
+    issue users hit on Windows native (#24345).
     """
     if os.environ.get("NO_COLOR") is not None:
         return False
@@ -16,6 +24,16 @@ def should_use_color() -> bool:
         return False
     if not sys.stdout.isatty():
         return False
+    # Defensive import: colors.py is loaded very early during CLI
+    # startup, sometimes before configure_windows_stdio() has run.  We
+    # tolerate a missing detector rather than break colour output on
+    # POSIX in that window.
+    try:
+        from hermes_cli.stdio import is_legacy_windows_console
+        if is_legacy_windows_console():
+            return False
+    except Exception:
+        pass
     return True
 
 

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -4,10 +4,100 @@ Used by `hermes tools` and `hermes skills` for interactive checklists.
 Provides a curses multi-select with keyboard navigation, plus a
 text-based numbered fallback for terminals without curses support.
 """
+import os
 import sys
 from typing import Callable, List, Optional, Set
 
 from hermes_cli.colors import Colors, color
+
+
+# Tracks whether we've already nudged the user about installing
+# ``windows-curses`` so we only mention it once per process — the
+# nudge is helpful the first time a Windows user hits a wizard that
+# would have used arrow-key navigation, noise otherwise (#24345).
+_WINDOWS_CURSES_HINT_SHOWN = False
+
+
+def _is_windows() -> bool:
+    """Local platform check.  Mirrors :func:`hermes_cli.stdio.is_windows`.
+
+    Kept private and dependency-free so this module stays importable
+    even when ``hermes_cli.stdio`` hasn't been initialised yet (e.g.
+    during early test bootstrapping).
+    """
+    return sys.platform == "win32"
+
+
+def _use_ascii_safe_glyphs() -> bool:
+    """Return True when the wizard UI should avoid exotic Unicode.
+
+    The numbered-fallback path uses ``✓``, ``→``, ``●``, ``○``, ``↑↓``
+    glyphs by default.  Those render fine on Linux/macOS terminals and
+    on modern Windows Terminal with a Unicode-capable font (Cascadia
+    Code, Consolas under MS Sans Serif, etc.).  They mojibake under
+    cmd.exe / PowerShell 5 with the default raster font, which is the
+    exact "looks not like Linux" failure mode reported in #24345.
+
+    The detection is conservative: ASCII-only kicks in when **both**
+
+      * the platform is native Windows, and
+      * ``hermes_cli.stdio.is_legacy_windows_console()`` reports the
+        console couldn't get VT processing enabled.
+
+    Modern Windows Terminal users see no change.  Power users can also
+    force the ASCII path by setting ``HERMES_ASCII_GLYPHS=1`` (handy
+    for screen readers and the rare terminal font without box-drawing).
+    """
+    if os.environ.get("HERMES_ASCII_GLYPHS") in {"1", "true", "True", "yes"}:
+        return True
+    if not _is_windows():
+        return False
+    try:
+        from hermes_cli.stdio import is_legacy_windows_console
+        return is_legacy_windows_console()
+    except Exception:
+        return False
+
+
+def _glyph(unicode_glyph: str, ascii_fallback: str) -> str:
+    """Pick the Unicode or ASCII variant depending on the console.
+
+    Centralised so the dozen-or-so call sites below don't each
+    re-implement the platform check.  Returns ``ascii_fallback`` only
+    when :func:`_use_ascii_safe_glyphs` says we must — everywhere else
+    the user keeps the prettier Unicode rendering.
+    """
+    return ascii_fallback if _use_ascii_safe_glyphs() else unicode_glyph
+
+
+def _maybe_show_windows_curses_hint() -> None:
+    """Print a one-time hint when curses can't load on Windows (#24345).
+
+    On native Windows the ``curses`` stdlib module isn't shipped — it
+    requires the ``windows-curses`` PyPI package.  Without it every
+    ``curses_*`` selector silently downgrades to the numbered-fallback
+    path, which works but loses arrow-key navigation.  Users who hit
+    the issue tracker describe this as "can't use the keys to
+    change/toggle" because the fallback expects them to type a digit.
+
+    This helper prints a single, gentle suggestion on the first
+    fallback we trigger per process.  Subsequent fallbacks are silent
+    so we don't carpet-bomb the wizard output.
+    """
+    global _WINDOWS_CURSES_HINT_SHOWN
+    if _WINDOWS_CURSES_HINT_SHOWN or not _is_windows():
+        return
+    _WINDOWS_CURSES_HINT_SHOWN = True
+    try:
+        print(
+            color(
+                "  Tip: install 'windows-curses' for arrow-key navigation in setup wizards:",
+                Colors.DIM,
+            )
+        )
+        print(color("        pip install windows-curses", Colors.DIM))
+    except Exception:
+        pass
 
 
 def flush_stdin() -> None:
@@ -293,11 +383,18 @@ def _radio_numbered_fallback(
     cancel_returns: int,
 ) -> int:
     """Text-based numbered fallback for radio selection."""
+    _maybe_show_windows_curses_hint()
     print(color(f"\n  {title}", Colors.YELLOW))
-    print(color("  Select by number, Enter to confirm.\n", Colors.DIM))
+    print(color("  Select by number, then press Enter to confirm.\n", Colors.DIM))
 
+    selected_glyph = _glyph("\u25cf", "*")  # ● vs *
+    empty_glyph = _glyph("\u25cb", " ")      # ○ vs (space)
     for i, label in enumerate(items):
-        marker = color("(\u25cf)", Colors.GREEN) if i == selected else "(\u25cb)"
+        marker = (
+            color(f"({selected_glyph})", Colors.GREEN)
+            if i == selected
+            else f"({empty_glyph})"
+        )
         print(f"  {marker} {i + 1:>2}. {label}")
     print()
     try:
@@ -419,6 +516,7 @@ def _numbered_single_fallback(
     cancel_idx: int,
 ) -> int | None:
     """Text-based numbered fallback for single-select."""
+    _maybe_show_windows_curses_hint()
     print(f"\n  {title}\n")
     for i, label in enumerate(items, 1):
         print(f"  {i}. {label}")
@@ -445,13 +543,22 @@ def _numbered_fallback(
     status_fn: Optional[Callable[[Set[int]], str]] = None,
 ) -> Set[int]:
     """Text-based toggle fallback for terminals without curses."""
+    _maybe_show_windows_curses_hint()
     chosen = set(selected)
     print(color(f"\n  {title}", Colors.YELLOW))
-    print(color("  Toggle by number, Enter to confirm.\n", Colors.DIM))
+    print(color(
+        "  Type the item number to toggle it, then press Enter to confirm.\n",
+        Colors.DIM,
+    ))
 
+    checked_glyph = _glyph("\u2713", "x")  # ✓ vs x
     while True:
         for i, label in enumerate(items):
-            marker = color("[✓]", Colors.GREEN) if i in chosen else "[ ]"
+            marker = (
+                color(f"[{checked_glyph}]", Colors.GREEN)
+                if i in chosen
+                else "[ ]"
+            )
             print(f"  {marker} {i + 1:>2}. {label}")
         if status_fn:
             status_text = status_fn(chosen)

--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -32,10 +32,26 @@ from __future__ import annotations
 import os
 import sys
 
-__all__ = ["configure_windows_stdio", "is_windows"]
+__all__ = [
+    "configure_windows_stdio",
+    "is_windows",
+    "is_legacy_windows_console",
+]
 
 
 _CONFIGURED = False
+# Tracks the outcome of the VT processing enable attempt during the most
+# recent configure_windows_stdio() call.  Other modules (colors.py,
+# curses_ui.py) consult this through :func:`is_legacy_windows_console`
+# to decide whether to emit ANSI escape sequences or fall back to
+# plain-text UI.  Tri-state on purpose:
+#   None  — not yet configured / non-Windows (no opinion).
+#   False — VT processing is on (the modern path, ANSI is safe).
+#   True  — VT processing could not be enabled (legacy console host:
+#           cmd.exe on Windows < 10 1809, Windows Console Host without
+#           VT, a pre-Win10 terminal, etc.).  ANSI escapes would print
+#           as literal ←[33m... garbage so callers should degrade.
+_VT_PROCESSING_ENABLED: "bool | None" = None
 
 
 def is_windows() -> bool:
@@ -64,6 +80,101 @@ def _flip_console_code_page_to_utf8() -> None:
         # ctypes import, missing kernel32, or non-Windows — any failure here
         # is non-fatal.  We've still reconfigured Python's own streams below.
         pass
+
+
+# Win32 constants for the SetConsoleMode VT flag.  Kept local to avoid
+# importing pywin32 (which is heavy and not in the dep tree).
+_STD_OUTPUT_HANDLE = -11
+_STD_ERROR_HANDLE = -12
+_ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+
+def _enable_virtual_terminal_processing() -> bool:
+    """Turn on ANSI/VT processing for the attached console (#24345).
+
+    The setup wizard prints its banner with raw ANSI escape sequences
+    (``\\x1b[35m┌────...``).  On a fresh Windows 10 / 11 Windows Console
+    Host (the one ``cmd.exe`` and PowerShell 5.1 attach to by default)
+    ``ENABLE_VIRTUAL_TERMINAL_PROCESSING`` is **off**, so those escapes
+    print as literal text — the user sees ``←[35m`` glyphs in front of
+    every banner line and every menu item, which is exactly what the
+    issue's screenshots show.
+
+    Windows Terminal sets the flag automatically, but the legacy console
+    host does not — and `irm install.ps1 | iex` lands new users in the
+    legacy host more often than not (PowerShell 5.1 is still the
+    default ``powershell.exe``).  We fix it ourselves with one call to
+    ``SetConsoleMode``, matching what Node, Rust, Go, and Cargo do at
+    process startup.
+
+    Returns ``True`` when at least one of stdout / stderr now has VT
+    processing on (success).  Returns ``False`` only when *both*
+    handles failed — that's the "legacy console" signal callers use to
+    suppress ANSI emission entirely.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32.GetStdHandle.restype = wintypes.HANDLE
+        kernel32.GetStdHandle.argtypes = [wintypes.DWORD]
+        kernel32.GetConsoleMode.restype = wintypes.BOOL
+        kernel32.GetConsoleMode.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        kernel32.SetConsoleMode.restype = wintypes.BOOL
+        kernel32.SetConsoleMode.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+
+        # INVALID_HANDLE_VALUE is -1 on Win32.  ctypes returns it as a
+        # Python int that compares equal to ``-1 & 0xFFFFFFFFFFFFFFFF``
+        # in HANDLE space (it's an opaque pointer), so we compare against
+        # the ``0`` returned for "no console" and the explicit invalid
+        # sentinel below.
+        INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+        any_success = False
+        for std_id in (_STD_OUTPUT_HANDLE, _STD_ERROR_HANDLE):
+            handle = kernel32.GetStdHandle(std_id)
+            if not handle or handle == INVALID_HANDLE_VALUE:
+                continue
+            mode = wintypes.DWORD()
+            if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                # Not a console (redirected to a pipe/file).  ANSI passes
+                # through redirected streams just fine without VT flag,
+                # so a "no console" handle doesn't taint the result.
+                any_success = True
+                continue
+            new_mode = mode.value | _ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            if kernel32.SetConsoleMode(handle, new_mode):
+                any_success = True
+        return any_success
+    except Exception:
+        # ctypes failure, missing kernel32, weird CI runner — bail out
+        # and let callers assume a legacy console.  Better to drop colors
+        # than to spam ``←[33m...`` at the user.
+        return False
+
+
+def is_legacy_windows_console() -> bool:
+    """Return True when we're on Windows and VT processing is off.
+
+    Modules that produce ANSI-colored output (``hermes_cli.colors``,
+    ``hermes_cli.curses_ui``) consult this **after**
+    :func:`configure_windows_stdio` has run to decide whether to emit
+    ANSI escapes at all.  See :func:`_enable_virtual_terminal_processing`
+    for the underlying detection.
+
+    Returns ``False`` on non-Windows (POSIX terminals universally
+    process ANSI; the question doesn't apply).  Returns ``False`` on
+    Windows when VT processing was successfully enabled or when the
+    streams are redirected (pipes don't need the flag).  Returns
+    ``True`` only when we KNOW the console host won't render escapes.
+    """
+    if not is_windows():
+        return False
+    return _VT_PROCESSING_ENABLED is False
 
 
 def _reconfigure_stream(stream, *, encoding: str = "utf-8", errors: str = "replace") -> None:
@@ -141,6 +252,14 @@ def configure_windows_stdio() -> bool:
     # Flip the console code page first so that any subprocess that
     # inherits the console (e.g. a launched shell) also sees CP_UTF8.
     _flip_console_code_page_to_utf8()
+
+    # Enable ANSI/VT processing for stdout+stderr.  Without this, the
+    # setup wizard's banner and every coloured prompt prints as literal
+    # ``←[35m`` garbage on legacy Windows Console Host (cmd.exe,
+    # PowerShell 5.1 default).  See _enable_virtual_terminal_processing
+    # for the full story.  #24345.
+    global _VT_PROCESSING_ENABLED
+    _VT_PROCESSING_ENABLED = _enable_virtual_terminal_processing()
 
     # Reconfigure Python's own stdio wrappers so ``print()`` calls from
     # this process round-trip emoji / box-drawing / non-Latin text.

--- a/tests/hermes_cli/test_setup_wizard_windows_ui.py
+++ b/tests/hermes_cli/test_setup_wizard_windows_ui.py
@@ -1,0 +1,318 @@
+"""End-to-end tests for the Windows setup-wizard UI fix (#24345).
+
+Drives the setup wizard's banner and the ``curses_ui`` numbered
+fallbacks under a simulated legacy Windows Console Host (no VT
+processing, no ``curses`` stdlib module) and asserts the user-visible
+output is clean -- no literal ``\\x1b[`` escape codes, no mojibake-prone
+exotic Unicode, and a single ``pip install windows-curses`` hint when
+the curses fallback fires.
+
+Complements ``tests/tools/test_windows_setup_wizard_ui.py`` (which
+pins the individual helpers in isolation) with full-stack behaviour
+tests that catch wiring regressions between modules.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simulate_legacy_windows_console(monkeypatch):
+    """Make ``hermes_cli.stdio.is_legacy_windows_console()`` return True
+    and ``hermes_cli.curses_ui._is_windows()`` return True, mirroring a
+    fresh `irm install.ps1 | iex` install into the default PowerShell
+    5.1 console host."""
+    sys.modules.pop("hermes_cli.stdio", None)
+    sys.modules.pop("hermes_cli.colors", None)
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+    import hermes_cli.stdio as stdio
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: True)
+
+    import hermes_cli.curses_ui as cu
+    monkeypatch.setattr(cu, "_is_windows", lambda: True)
+    cu._WINDOWS_CURSES_HINT_SHOWN = False
+
+    # The colours helper recomputes on each call; nothing else to do.
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.delenv("HERMES_ASCII_GLYPHS", raising=False)
+
+    yield stdio, cu
+
+    sys.modules.pop("hermes_cli.stdio", None)
+    sys.modules.pop("hermes_cli.colors", None)
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+
+@pytest.fixture
+def simulate_modern_console(monkeypatch):
+    """Modern host: VT processing on, curses available.  Used as the
+    baseline so we can prove the fix is a no-op for users who weren't
+    affected by the bug."""
+    sys.modules.pop("hermes_cli.stdio", None)
+    sys.modules.pop("hermes_cli.colors", None)
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+    import hermes_cli.stdio as stdio
+    monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+
+    import hermes_cli.curses_ui as cu
+    monkeypatch.setattr(cu, "_is_windows", lambda: False)
+    cu._WINDOWS_CURSES_HINT_SHOWN = False
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.delenv("HERMES_ASCII_GLYPHS", raising=False)
+
+    yield stdio, cu
+
+    sys.modules.pop("hermes_cli.stdio", None)
+    sys.modules.pop("hermes_cli.colors", None)
+    sys.modules.pop("hermes_cli.curses_ui", None)
+
+
+# ---------------------------------------------------------------------------
+# colours helper
+# ---------------------------------------------------------------------------
+
+
+# Regex matching any ANSI CSI sequence ("\x1b[" + parameters + final byte).
+# We assert it's NOT present in legacy-host output -- that's exactly the
+# garbage the user reported in #24345.
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+class TestColorOutputOnLegacyConsole:
+    """``hermes_cli.colors.color()`` must strip ANSI on a legacy host."""
+
+    def test_color_strips_ansi_on_legacy_windows(
+        self, simulate_legacy_windows_console, monkeypatch,
+    ):
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+
+        result = colors.color(
+            "Hermes Setup Wizard", colors.Colors.MAGENTA, colors.Colors.BOLD,
+        )
+
+        assert _ANSI_CSI_RE.search(result) is None, (
+            "color() must not emit ANSI on a legacy Windows console -- "
+            f"got {result!r}"
+        )
+        assert "Hermes Setup Wizard" in result
+
+    def test_color_preserves_ansi_on_modern_console(
+        self, simulate_modern_console, monkeypatch,
+    ):
+        """Baseline: the bug fix must not regress users who weren't
+        affected."""
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+
+        result = colors.color("Hermes Setup Wizard", colors.Colors.MAGENTA)
+        assert _ANSI_CSI_RE.search(result) is not None
+        assert "Hermes Setup Wizard" in result
+
+
+# ---------------------------------------------------------------------------
+# Numbered fallback rendering
+# ---------------------------------------------------------------------------
+
+
+class TestNumberedFallbackOnLegacyConsole:
+    """The ``curses_ui`` fallback paths must output:
+
+      * clear "type a number" instructions (#24345's third complaint
+        was 'I can't use the keys to change/toggle' -- users didn't
+        realise they were supposed to type a digit);
+      * ASCII-safe glyphs (``x``, ``*``, ``( )`` instead of ``✓``,
+        ``●``, ``○``) so they don't mojibake under the default raster
+        font;
+      * a single ``pip install windows-curses`` tip so users know how
+        to get the arrow-key UX back.
+    """
+
+    def test_radio_fallback_uses_ascii_glyphs(
+        self, simulate_legacy_windows_console, monkeypatch, capsys,
+    ):
+        import hermes_cli.curses_ui as cu
+        # Auto-confirm the default to keep the test deterministic.
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+        result = cu._radio_numbered_fallback(
+            "Pick your provider",
+            ["openrouter", "anthropic", "openai"],
+            selected=1,
+            cancel_returns=1,
+        )
+
+        assert result == 1
+        out = capsys.readouterr().out
+        # Unicode markers stripped.
+        assert "\u25cf" not in out and "\u25cb" not in out
+        # ASCII markers used instead.
+        assert "(*)" in out  # the selected one
+        # User-friendly instruction copy.
+        assert "Select by number" in out
+        assert "Enter to confirm" in out
+
+    def test_toggle_fallback_uses_ascii_check_mark(
+        self, simulate_legacy_windows_console, monkeypatch, capsys,
+    ):
+        import hermes_cli.curses_ui as cu
+        # Confirm on first prompt.
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+        result = cu._numbered_fallback(
+            "Pick tools",
+            ["search", "edit", "browse"],
+            selected={0, 2},
+            cancel_returns=set(),
+        )
+
+        assert result == {0, 2}
+        out = capsys.readouterr().out
+        # ✓ (U+2713) downgraded to x.
+        assert "\u2713" not in out
+        assert "[x]" in out
+        # User instruction is clearer than the pre-fix
+        # "Toggle by number, Enter to confirm" one-liner.
+        assert "type the item number" in out.lower()
+
+    def test_radio_fallback_keeps_unicode_on_modern_host(
+        self, simulate_modern_console, monkeypatch, capsys,
+    ):
+        """Baseline: modern hosts keep the prettier rendering."""
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+        cu._radio_numbered_fallback(
+            "Pick your provider",
+            ["openrouter", "anthropic"],
+            selected=0,
+            cancel_returns=0,
+        )
+        out = capsys.readouterr().out
+        assert "\u25cf" in out  # ● selected
+        assert "\u25cb" in out  # ○ empty
+
+
+# ---------------------------------------------------------------------------
+# windows-curses install hint
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsCursesHintWiring:
+    """The hint must appear exactly once per process when the fallback
+    fires on Windows, regardless of which selector hit the fallback."""
+
+    def test_hint_appears_on_first_fallback_only(
+        self, simulate_legacy_windows_console, monkeypatch, capsys,
+    ):
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+        # Trip three different fallback paths in a row.
+        cu._radio_numbered_fallback(
+            "First", ["a", "b"], selected=0, cancel_returns=0,
+        )
+        cu._numbered_fallback(
+            "Second", ["x", "y"], selected=set(), cancel_returns=set(),
+        )
+        cu._numbered_single_fallback("Third", ["m", "n"], cancel_idx=1)
+
+        out = capsys.readouterr().out
+        # Exactly one nudge across the three fallbacks.
+        assert out.count("pip install windows-curses") == 1
+
+    def test_no_hint_on_modern_host(
+        self, simulate_modern_console, monkeypatch, capsys,
+    ):
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+
+        cu._radio_numbered_fallback(
+            "Linux user", ["a", "b"], selected=0, cancel_returns=0,
+        )
+        out = capsys.readouterr().out
+        assert "windows-curses" not in out
+
+
+# ---------------------------------------------------------------------------
+# Regression anchor — full stack
+# ---------------------------------------------------------------------------
+
+
+class TestBug24345EndToEnd:
+    """Full-stack anchor for #24345.
+
+    Pre-fix Windows behaviour reproduced verbatim from the issue's
+    screenshots:
+
+      1. The wizard banner contains literal ``\\x1b[35m`` sequences
+         (the user sees ``←[35m┌───...``).
+      2. The numbered fallback prints ``●``/``○``/``✓`` glyphs that
+         mojibake under the default raster font.
+      3. No nudge anywhere tells users how to get arrow-key
+         navigation back.
+
+    This anchor asserts the post-fix invariants in a single test so
+    the bug shape is pinned end-to-end.  Reverting any of the three
+    changes (VT processing, ASCII glyph fallback, install hint)
+    causes one of the assertions to fail with an explicit
+    "#24345 regression" message.
+    """
+
+    def test_legacy_console_setup_wizard_renders_cleanly(
+        self, simulate_legacy_windows_console, monkeypatch, capsys,
+    ):
+        import hermes_cli.colors as colors
+        import hermes_cli.curses_ui as cu
+
+        # Simulate the wizard's first banner line + a checklist prompt.
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        banner = colors.color(
+            "┌───────────────────────────────────────┐", colors.Colors.MAGENTA,
+        )
+        # Drive a checklist that downgrades to the fallback (no curses
+        # on a legacy host).  Confirm immediately.
+        monkeypatch.setattr("builtins.input", lambda *a, **kw: "")
+        cu._numbered_fallback(
+            "Pick your tools",
+            ["search", "edit"],
+            selected={0},
+            cancel_returns=set(),
+        )
+        out = capsys.readouterr().out
+        full_output = banner + "\n" + out
+
+        # 1. No literal ANSI escapes leaked through.
+        assert _ANSI_CSI_RE.search(full_output) is None, (
+            "#24345 regression: ANSI escape leaked into wizard output on "
+            f"legacy console host. Output snippet: {full_output!r}"
+        )
+
+        # 2. Exotic Unicode glyphs replaced with ASCII.
+        for bad in ("\u2713", "\u25cf", "\u25cb", "\u2192"):
+            assert bad not in full_output, (
+                f"#24345 regression: legacy console got Unicode glyph "
+                f"{bad!r} that mojibakes under the default Windows font."
+            )
+
+        # 3. windows-curses hint was emitted exactly once.
+        assert full_output.count("pip install windows-curses") == 1, (
+            "#24345 regression: the one-time windows-curses install hint "
+            "did not fire -- users won't know how to get arrow-key "
+            "navigation back."
+        )

--- a/tests/tools/test_windows_setup_wizard_ui.py
+++ b/tests/tools/test_windows_setup_wizard_ui.py
@@ -1,0 +1,513 @@
+"""Unit tests for the Windows setup-wizard UI fixes (#24345).
+
+Pins three behaviours that together resolve the "Setup wizard looks
+broken on Windows" symptoms users reported in the issue:
+
+  1. ``hermes_cli.stdio._enable_virtual_terminal_processing`` actually
+     issues the SetConsoleMode call (and never blows up if ctypes /
+     kernel32 are unhappy).
+  2. ``hermes_cli.stdio.is_legacy_windows_console`` is the gate the
+     rest of the CLI uses to decide "render ANSI or not", so its
+     tri-state contract (None / True / False) must hold across the
+     happy path, the legacy-console path, and POSIX.
+  3. ``hermes_cli.colors.should_use_color`` and the ``curses_ui``
+     fallback helpers honour that gate -- otherwise the fix would be
+     a no-op for the exact users who reported the bug.
+
+Every test mocks ``sys.platform`` and the ctypes layer so the suite
+runs identically on Linux CI and a real Windows host.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_stdio_module(monkeypatch) -> Iterator[object]:
+    """Reload ``hermes_cli.stdio`` so the per-process configured flag resets.
+
+    Same pattern as the existing ``test_windows_native_support`` fixture --
+    each test starts with a clean slate so the idempotency latch doesn't
+    swallow follow-up ``configure_windows_stdio()`` calls.
+    """
+    sys.modules.pop("hermes_cli.stdio", None)
+    import hermes_cli.stdio as _s
+    _s._CONFIGURED = False
+    _s._VT_PROCESSING_ENABLED = None
+    yield _s
+    sys.modules.pop("hermes_cli.stdio", None)
+
+
+# ---------------------------------------------------------------------------
+# _enable_virtual_terminal_processing
+# ---------------------------------------------------------------------------
+
+
+class TestEnableVirtualTerminalProcessing:
+    """The SetConsoleMode wrapper that fixes the literal-escape bug."""
+
+    def test_success_path_calls_setconsolemode_on_both_handles(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        """Happy path: kernel32 returns success, both stdout+stderr get the flag."""
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+        # Stub the entire ctypes.windll.kernel32 surface.
+        fake_kernel32 = MagicMock()
+        fake_kernel32.GetStdHandle.side_effect = lambda _id: 100 + _id  # nonzero handle
+        fake_kernel32.GetConsoleMode.return_value = 1  # success → fills mode
+        fake_kernel32.SetConsoleMode.return_value = 1
+        fake_ctypes = MagicMock()
+        fake_ctypes.windll.kernel32 = fake_kernel32
+        # byref / POINTER / c_void_p need to exist with sane defaults.
+        fake_ctypes.byref.side_effect = lambda x: x
+        fake_ctypes.c_void_p.side_effect = lambda v: MagicMock(value=v)
+        monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+        # ctypes.wintypes is consulted for DWORD / HANDLE / BOOL.
+        fake_wintypes = MagicMock()
+        fake_wintypes.DWORD.side_effect = lambda *a: MagicMock(value=0)
+        monkeypatch.setitem(sys.modules, "ctypes.wintypes", fake_wintypes)
+
+        result = stdio._enable_virtual_terminal_processing()
+
+        assert result is True
+        # GetStdHandle hit for both stdout (-11) and stderr (-12).
+        called_ids = [c.args[0] for c in fake_kernel32.GetStdHandle.call_args_list]
+        assert -11 in called_ids and -12 in called_ids
+        # SetConsoleMode called twice (stdout + stderr).
+        assert fake_kernel32.SetConsoleMode.call_count == 2
+
+    def test_legacy_host_returns_false_when_setconsolemode_fails(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        """Legacy Console Host: GetConsoleMode succeeds but SetConsoleMode rejects
+        the VT flag (e.g. pre-Win10 1809).  We must report False so callers
+        suppress ANSI emission."""
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+        fake_kernel32 = MagicMock()
+        fake_kernel32.GetStdHandle.return_value = 42
+        fake_kernel32.GetConsoleMode.return_value = 1
+        fake_kernel32.SetConsoleMode.return_value = 0  # rejected on both handles
+        fake_ctypes = MagicMock()
+        fake_ctypes.windll.kernel32 = fake_kernel32
+        fake_ctypes.byref.side_effect = lambda x: x
+        fake_ctypes.c_void_p.side_effect = lambda v: MagicMock(value=v)
+        monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+        fake_wintypes = MagicMock()
+        fake_wintypes.DWORD.side_effect = lambda *a: MagicMock(value=0)
+        monkeypatch.setitem(sys.modules, "ctypes.wintypes", fake_wintypes)
+
+        result = stdio._enable_virtual_terminal_processing()
+        assert result is False
+
+    def test_returns_false_when_ctypes_blows_up(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        """ctypes import fails (e.g. weirdly stripped CI runner).  Must not
+        propagate -- the rest of stdio configuration still needs to run."""
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+        # Make ctypes.windll.kernel32 access blow up.
+        fake_ctypes = MagicMock()
+        fake_ctypes.windll.kernel32 = property(
+            lambda self: (_ for _ in ()).throw(OSError("boom"))
+        )
+        monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+
+        # No raise; just False.
+        assert stdio._enable_virtual_terminal_processing() is False
+
+    def test_treats_redirected_handle_as_neutral(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        """When stdout/stderr is redirected to a pipe/file, GetConsoleMode
+        returns 0 (no console).  ANSI escapes pass through pipes fine, so
+        a redirected handle must NOT poison the legacy-console verdict."""
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+
+        fake_kernel32 = MagicMock()
+        fake_kernel32.GetStdHandle.return_value = 42
+        fake_kernel32.GetConsoleMode.return_value = 0  # not a console
+        fake_kernel32.SetConsoleMode.return_value = 1
+        fake_ctypes = MagicMock()
+        fake_ctypes.windll.kernel32 = fake_kernel32
+        fake_ctypes.byref.side_effect = lambda x: x
+        fake_ctypes.c_void_p.side_effect = lambda v: MagicMock(value=v)
+        monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+        fake_wintypes = MagicMock()
+        fake_wintypes.DWORD.side_effect = lambda *a: MagicMock(value=0)
+        monkeypatch.setitem(sys.modules, "ctypes.wintypes", fake_wintypes)
+
+        # Both handles "no console" → any_success path treats this as fine,
+        # returning True (== "ANSI is safe, no need to suppress").
+        assert stdio._enable_virtual_terminal_processing() is True
+
+
+# ---------------------------------------------------------------------------
+# is_legacy_windows_console
+# ---------------------------------------------------------------------------
+
+
+class TestIsLegacyWindowsConsole:
+    """Tri-state gate used by colors.py and curses_ui.py."""
+
+    def test_false_on_posix_regardless_of_state(self, fresh_stdio_module, monkeypatch):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: False)
+        stdio._VT_PROCESSING_ENABLED = False  # would say "legacy" on Windows
+        assert stdio.is_legacy_windows_console() is False
+
+    def test_false_when_vt_enabled_on_windows(self, fresh_stdio_module, monkeypatch):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        stdio._VT_PROCESSING_ENABLED = True
+        assert stdio.is_legacy_windows_console() is False
+
+    def test_true_only_when_vt_explicitly_failed_on_windows(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        stdio._VT_PROCESSING_ENABLED = False
+        assert stdio.is_legacy_windows_console() is True
+
+    def test_false_when_unconfigured_on_windows(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        """Pre-configure state must not poison the gate -- assume modern
+        until proven otherwise so we don't disable colours on POSIX-style
+        early imports."""
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        stdio._VT_PROCESSING_ENABLED = None
+        assert stdio.is_legacy_windows_console() is False
+
+
+# ---------------------------------------------------------------------------
+# configure_windows_stdio wiring
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureWindowsStdioVtIntegration:
+    """``configure_windows_stdio`` must invoke the VT enable hook and
+    publish the result via ``_VT_PROCESSING_ENABLED`` so callers can
+    read it through :func:`is_legacy_windows_console`."""
+
+    def test_vt_enable_called_after_code_page_flip(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        monkeypatch.delenv("HERMES_DISABLE_WINDOWS_UTF8", raising=False)
+        # Stub the inner calls so we can assert ordering.
+        order: list[str] = []
+        monkeypatch.setattr(
+            stdio,
+            "_flip_console_code_page_to_utf8",
+            lambda: order.append("flip"),
+        )
+        monkeypatch.setattr(
+            stdio,
+            "_enable_virtual_terminal_processing",
+            lambda: (order.append("vt"), True)[1],
+        )
+        monkeypatch.setattr(stdio, "_reconfigure_stream", lambda *a, **kw: order.append("reconfigure"))
+        monkeypatch.setattr(stdio, "_default_windows_editor", lambda: "notepad")
+
+        stdio.configure_windows_stdio()
+
+        # Code-page flip must precede VT enable (matches the docstring
+        # contract -- VT processing needs a sane code page to make
+        # sense to the user).
+        assert order.index("flip") < order.index("vt")
+        # VT enable must precede stream reconfiguration so the new mode
+        # is in effect by the time we re-wrap stdout/stderr.
+        assert order.index("vt") < order.index("reconfigure")
+
+    def test_vt_failure_marks_legacy_console(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        monkeypatch.delenv("HERMES_DISABLE_WINDOWS_UTF8", raising=False)
+        monkeypatch.setattr(stdio, "_flip_console_code_page_to_utf8", lambda: None)
+        monkeypatch.setattr(
+            stdio, "_enable_virtual_terminal_processing", lambda: False
+        )
+        monkeypatch.setattr(stdio, "_reconfigure_stream", lambda *a, **kw: None)
+        monkeypatch.setattr(stdio, "_default_windows_editor", lambda: "notepad")
+
+        stdio.configure_windows_stdio()
+        assert stdio.is_legacy_windows_console() is True
+
+    def test_vt_success_does_not_mark_legacy_console(
+        self, fresh_stdio_module, monkeypatch,
+    ):
+        stdio = fresh_stdio_module
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        monkeypatch.delenv("HERMES_DISABLE_WINDOWS_UTF8", raising=False)
+        monkeypatch.setattr(stdio, "_flip_console_code_page_to_utf8", lambda: None)
+        monkeypatch.setattr(
+            stdio, "_enable_virtual_terminal_processing", lambda: True
+        )
+        monkeypatch.setattr(stdio, "_reconfigure_stream", lambda *a, **kw: None)
+        monkeypatch.setattr(stdio, "_default_windows_editor", lambda: "notepad")
+
+        stdio.configure_windows_stdio()
+        assert stdio.is_legacy_windows_console() is False
+
+
+# ---------------------------------------------------------------------------
+# colors.should_use_color gating
+# ---------------------------------------------------------------------------
+
+
+class TestShouldUseColorGating:
+    """``should_use_color`` must return False on a legacy Windows console
+    EVEN when stdout.isatty() is True -- otherwise the wizard banner
+    keeps printing literal ←[35m escapes (#24345)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_color_module(self, monkeypatch):
+        # Force a fresh import so the inline ``from hermes_cli.stdio
+        # import is_legacy_windows_console`` inside should_use_color
+        # picks up the module under test.
+        sys.modules.pop("hermes_cli.colors", None)
+        sys.modules.pop("hermes_cli.stdio", None)
+        yield
+        sys.modules.pop("hermes_cli.colors", None)
+        sys.modules.pop("hermes_cli.stdio", None)
+
+    def test_color_disabled_on_legacy_windows_console(self, monkeypatch):
+        # Reload stdio with the legacy flag tripped.
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: True)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+
+        assert colors.should_use_color() is False
+
+    def test_color_enabled_on_modern_windows_console(self, monkeypatch):
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+
+        assert colors.should_use_color() is True
+
+    def test_color_disabled_when_no_color_set(self, monkeypatch):
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.delenv("TERM", raising=False)
+
+        assert colors.should_use_color() is False
+
+    def test_color_disabled_when_term_dumb(self, monkeypatch):
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("TERM", "dumb")
+
+        assert colors.should_use_color() is False
+
+    def test_color_disabled_when_stdout_redirected(self, monkeypatch):
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+
+        assert colors.should_use_color() is False
+
+    def test_color_unaffected_when_legacy_detector_blows_up(self, monkeypatch):
+        """A broken detector must NOT disable colours on POSIX -- we'd
+        regress every Linux/macOS user with one stack trace."""
+        # Simulate hermes_cli.stdio failing to import / not exposing the symbol.
+        sys.modules.pop("hermes_cli.stdio", None)
+
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+
+        # Use monkeypatch.setattr on sys.modules to inject a broken stdio.
+        broken = MagicMock()
+        broken.is_legacy_windows_console.side_effect = RuntimeError("nope")
+        monkeypatch.setitem(sys.modules, "hermes_cli.stdio", broken)
+
+        assert colors.should_use_color() is True
+
+
+# ---------------------------------------------------------------------------
+# curses_ui ASCII glyph + windows-curses hint
+# ---------------------------------------------------------------------------
+
+
+class TestCursesUiAsciiFallback:
+    """``_use_ascii_safe_glyphs`` must mirror the legacy-console gate,
+    and ``_glyph`` must pick the right variant per platform."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_modules(self):
+        sys.modules.pop("hermes_cli.stdio", None)
+        sys.modules.pop("hermes_cli.curses_ui", None)
+        yield
+        sys.modules.pop("hermes_cli.stdio", None)
+        sys.modules.pop("hermes_cli.curses_ui", None)
+
+    def test_ascii_glyphs_on_legacy_windows_console(self, monkeypatch):
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: True)
+        # Force the stdio gate to report legacy.
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: True)
+        monkeypatch.delenv("HERMES_ASCII_GLYPHS", raising=False)
+
+        assert cu._use_ascii_safe_glyphs() is True
+        assert cu._glyph("\u2713", "x") == "x"
+        assert cu._glyph("\u2192", ">") == ">"
+
+    def test_unicode_glyphs_on_modern_windows_console(self, monkeypatch):
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: True)
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: False)
+        monkeypatch.delenv("HERMES_ASCII_GLYPHS", raising=False)
+
+        assert cu._use_ascii_safe_glyphs() is False
+        assert cu._glyph("\u2713", "x") == "\u2713"
+
+    def test_unicode_glyphs_on_posix(self, monkeypatch):
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: False)
+        monkeypatch.delenv("HERMES_ASCII_GLYPHS", raising=False)
+
+        assert cu._use_ascii_safe_glyphs() is False
+        assert cu._glyph("\u2713", "x") == "\u2713"
+
+    @pytest.mark.parametrize("val", ["1", "true", "True", "yes"])
+    def test_env_override_forces_ascii_glyphs(self, monkeypatch, val):
+        """HERMES_ASCII_GLYPHS=1 must work on any platform -- screen
+        readers, OCR pipelines, and exotic Linux fonts all benefit."""
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: False)
+        monkeypatch.setenv("HERMES_ASCII_GLYPHS", val)
+
+        assert cu._use_ascii_safe_glyphs() is True
+        assert cu._glyph("\u2713", "x") == "x"
+
+    def test_windows_curses_hint_appears_once(self, monkeypatch, capsys):
+        """The 'install windows-curses' tip is a one-time nudge so it
+        doesn't carpet-bomb a wizard that hits the fallback for every
+        section."""
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: True)
+        cu._WINDOWS_CURSES_HINT_SHOWN = False
+
+        cu._maybe_show_windows_curses_hint()
+        cu._maybe_show_windows_curses_hint()
+        cu._maybe_show_windows_curses_hint()
+        out = capsys.readouterr().out
+        # Exactly one occurrence of the install command.
+        assert out.count("pip install windows-curses") == 1
+
+    def test_windows_curses_hint_noop_on_posix(self, monkeypatch, capsys):
+        """Linux/macOS users don't need (and don't want) the hint."""
+        import hermes_cli.curses_ui as cu
+        monkeypatch.setattr(cu, "_is_windows", lambda: False)
+        cu._WINDOWS_CURSES_HINT_SHOWN = False
+
+        cu._maybe_show_windows_curses_hint()
+        out = capsys.readouterr().out
+        assert "windows-curses" not in out
+
+
+# ---------------------------------------------------------------------------
+# Regression anchor — fails if the VT enable wiring is removed.
+# ---------------------------------------------------------------------------
+
+
+class TestBug24345Repro:
+    """Bug-shape anchor for #24345.
+
+    Pre-fix behaviour: ``configure_windows_stdio`` never called
+    ``SetConsoleMode``, so VT processing stayed off on the legacy
+    Windows Console Host and every ANSI escape printed as literal
+    text.  ``is_legacy_windows_console`` didn't even exist.
+
+    This anchor pins the post-fix contract: on a Windows host where
+    ``_enable_virtual_terminal_processing`` reports failure,
+    ``is_legacy_windows_console`` MUST return True and
+    ``should_use_color`` MUST suppress ANSI emission.  If a future
+    refactor decouples the gate from the enable hook, this anchor
+    fires immediately.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        sys.modules.pop("hermes_cli.stdio", None)
+        sys.modules.pop("hermes_cli.colors", None)
+        yield
+        sys.modules.pop("hermes_cli.stdio", None)
+        sys.modules.pop("hermes_cli.colors", None)
+
+    def test_legacy_console_kills_color_emission_end_to_end(self, monkeypatch):
+        import hermes_cli.stdio as stdio
+        monkeypatch.setattr(stdio, "is_windows", lambda: True)
+        monkeypatch.delenv("HERMES_DISABLE_WINDOWS_UTF8", raising=False)
+        monkeypatch.setattr(stdio, "_flip_console_code_page_to_utf8", lambda: None)
+        # Force VT processing to fail (legacy host).
+        monkeypatch.setattr(
+            stdio, "_enable_virtual_terminal_processing", lambda: False
+        )
+        monkeypatch.setattr(stdio, "_reconfigure_stream", lambda *a, **kw: None)
+        monkeypatch.setattr(stdio, "_default_windows_editor", lambda: "notepad")
+
+        stdio.configure_windows_stdio()
+
+        # Contract 1: the gate flips.
+        assert stdio.is_legacy_windows_console() is True, (
+            "#24345 regression: VT-enable failed but legacy-console gate "
+            "did NOT report True -- callers won't know to suppress ANSI."
+        )
+
+        # Contract 2: colors stop being emitted.
+        import hermes_cli.colors as colors
+        monkeypatch.setattr(colors.sys.stdout, "isatty", lambda: True)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.delenv("TERM", raising=False)
+        coloured = colors.color("hello", colors.Colors.MAGENTA)
+        assert coloured == "hello", (
+            "#24345 regression: should_use_color() returned True on a "
+            "legacy Windows console -- the setup wizard banner will "
+            f"print literal ANSI escapes again.  Got: {coloured!r}"
+        )

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -100,13 +100,35 @@ Python's default stdio on Windows uses the console's active code page (usually c
 The fix is in `hermes_cli/stdio.py::configure_windows_stdio()`, called early in every entry point (`cli.py::main`, `hermes_cli/main.py::main`, `gateway/run.py::main`). It:
 
 1. Flips the console code page to CP_UTF8 (65001) via `kernel32.SetConsoleCP` / `SetConsoleOutputCP`.
-2. Reconfigures `sys.stdout` / `sys.stderr` / `sys.stdin` to UTF-8 with `errors='replace'`.
-3. Sets `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` (via `setdefault`, so explicit user values win) so child Python subprocesses inherit UTF-8.
-4. Sets `EDITOR=notepad` if neither `EDITOR` nor `VISUAL` is set (see the Editor section below).
+2. Calls `SetConsoleMode` with `ENABLE_VIRTUAL_TERMINAL_PROCESSING` so ANSI escapes render as colors instead of literal `←[33m` garbage (see [Setup wizard UI](#setup-wizard-ui) below).
+3. Reconfigures `sys.stdout` / `sys.stderr` / `sys.stdin` to UTF-8 with `errors='replace'`.
+4. Sets `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` (via `setdefault`, so explicit user values win) so child Python subprocesses inherit UTF-8.
+5. Sets `EDITOR=notepad` if neither `EDITOR` nor `VISUAL` is set (see the Editor section below).
 
 Idempotent. No-op on non-Windows.
 
 **Opt out:** `HERMES_DISABLE_WINDOWS_UTF8=1` in the environment falls back to the legacy cp1252 stdio path. Useful for bisecting an encoding bug; unlikely to be the right setting in normal operation.
+
+## Setup wizard UI
+
+`hermes setup` renders its banner with raw ANSI escape sequences (`\x1b[35m┌────...`). On a fresh Windows 10 / 11 **Windows Console Host** — the one `cmd.exe` and PowerShell 5.1 attach to by default — `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is **off**, so those escapes print as literal `←[35m` text and the wizard banner shows up as a wall of garbage glyphs. Windows Terminal sets the flag automatically; the legacy console does not. `irm install.ps1 | iex` lands new users in the legacy host more often than not (it's still the default for `powershell.exe`).
+
+Hermes's `configure_windows_stdio()` now turns the flag on at startup via `SetConsoleMode`, matching what Node, Rust, Go, and Cargo do. After that one call the same banner that looked broken before renders with proper colors in every supported host.
+
+On the rare pre-Win10-1809 console where `SetConsoleMode` rejects the flag, Hermes detects the failure (`hermes_cli.stdio.is_legacy_windows_console()`) and:
+
+- `hermes_cli.colors.should_use_color()` returns `False`, so the wizard prints uncoloured text instead of literal escape codes.
+- The `curses_ui` numbered fallbacks substitute ASCII glyphs (`[x]`, `(*)`, `( )`, `>`) for the Unicode versions (`[✓]`, `(●)`, `(○)`, `→`) so the menu still renders with the default raster font.
+
+**Arrow-key navigation.** The setup wizard prefers `curses` for arrow-key checklists. The `curses` module isn't bundled with Windows Python — install the `windows-curses` shim to get arrow keys:
+
+```powershell
+pip install windows-curses
+```
+
+Without `windows-curses`, the wizard transparently falls back to a numbered prompt ("Select by number, then press Enter to confirm") and prints a one-time hint pointing at this fix. Both paths complete the same configuration; the arrow-key path is just prettier.
+
+**Force ASCII glyphs anywhere:** set `HERMES_ASCII_GLYPHS=1` to force the ASCII fallback on any platform (handy for screen readers, exotic terminal fonts, or CI snapshot tests that dislike Unicode).
 
 ## The editor (`Ctrl-X Ctrl-E`, `/edit`)
 
@@ -285,6 +307,12 @@ The installer provisions Node 22 at `%LOCALAPPDATA%\hermes\node` but your PATH m
 
 **Chinese / Japanese / Arabic characters show as `?` in the CLI.**
 The UTF-8 stdio shim didn't activate. Check that `HERMES_DISABLE_WINDOWS_UTF8` is NOT set (`Get-ChildItem env:HERMES_DISABLE_WINDOWS_UTF8`). If it's empty and you still see `?`, the console host (very old `cmd.exe`) may not support UTF-8 at all — switch to Windows Terminal.
+
+**Setup wizard banner shows literal `←[35m` glyphs.**
+Your console host doesn't have VT processing enabled and the auto-fix in `configure_windows_stdio()` couldn't turn it on. Easiest fix: upgrade to **Windows Terminal** (it's free and bundled on Windows 11) or use PowerShell 7+, both of which honor ANSI escapes natively. If you must stay on PowerShell 5.1 / `cmd.exe`, Hermes will detect the legacy host and suppress colours so the wizard at least reads cleanly. See [Setup wizard UI](#setup-wizard-ui) for the full story.
+
+**Setup wizard menus don't respond to arrow keys.**
+The wizard uses `curses` for arrow-key navigation and `curses` isn't bundled with Windows Python. Run `pip install windows-curses` once and arrow keys come back. Without it, the wizard falls back to a numbered prompt — type the option number then press Enter. Both paths complete the same configuration.
 
 **Gateway can't send Telegram photos — "`BadRequest: payload contains invalid characters`".**
 This is unrelated to Windows but sometimes surfaces first there. Usually it means your file path contains unescaped backslashes in a JSON body. Telegram should be receiving paths Hermes normalizes, not raw Windows paths — if you're seeing this inside a custom plugin, make sure you're passing the Hermes-provided path, not `str(Path(...))` from user input.


### PR DESCRIPTION
## What does this PR do?

Fixes the "Hermes Setup in Native Windows UI Issue" reported in #24345. The setup wizard's banner and menus were unreadable on a fresh Windows 10 / 11 install — literal `←[35m┌────...` escape codes in front of every banner line, mojibake glyphs in numbered prompts, and no arrow-key navigation. All three symptoms had the same root cause: native Windows attaches new processes to the **legacy Windows Console Host** by default, which (a) has `ENABLE_VIRTUAL_TERMINAL_PROCESSING` off, (b) renders the default raster font that mojibakes `✓` `●` `○` `→`, and (c) doesn't ship the `curses` stdlib module that the arrow-key UI relies on. Windows Terminal users were fine; everyone landing in PowerShell 5.1 / cmd.exe via `irm install.ps1 | iex` saw the broken wizard.

The fix has three layers, all in `hermes_cli/`:

1. **VT processing.** `configure_windows_stdio()` now calls `SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)` for stdout and stderr right after the existing code-page flip. That alone fixes 95% of the reports — modern Windows 10/11 hosts support VT, they just don't have it on by default. (Node, Rust, Go, Cargo all do this at startup; Python doesn't.)
2. **Defense in depth for the rare host where VT really can't be enabled** (pre-Win10-1809 cmd.exe, super-locked-down enterprise images). `is_legacy_windows_console()` exposes the failure to callers. `should_use_color()` returns False on a legacy host (so the wizard prints clean uncoloured text instead of literal escape codes), and `curses_ui.py`'s numbered fallbacks swap exotic Unicode glyphs (`✓`, `●`, `○`, `→`) for ASCII (`x`, `*`, `(space)`, `>`).
3. **Arrow-key navigation discoverability.** When `curses` is unavailable (no `windows-curses` shim installed), the numbered fallback now prints a single, gentle one-time hint pointing users at `pip install windows-curses`. The numbered prompt itself reads "Select by number, then press Enter to confirm" instead of the pre-fix terse "Toggle by number, Enter to confirm" — the user complaint in the issue ("I can't use the keys to change/toggle") was that they didn't realise the wizard expected them to type a digit.

No behaviour change on Linux, macOS, WSL2, Windows Terminal, or any other host where VT is already on — the `is_legacy_windows_console()` gate keeps returning False on those, so colour and Unicode work exactly as before.

## Related Issue

Fixes #24345

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Commit 1 — `fix(windows): enable VT processing + ASCII glyph fallback for setup (#24345)`**

- `hermes_cli/stdio.py`:
  - New `_enable_virtual_terminal_processing()` — `GetStdHandle` + `GetConsoleMode` + `SetConsoleMode` for stdout & stderr, returns True/False (legacy host signal).
  - `configure_windows_stdio()` invokes it after the code-page flip, stores the result in `_VT_PROCESSING_ENABLED`.
  - New public `is_legacy_windows_console()` returns True only when we KNOW the host won't process ANSI.
- `hermes_cli/colors.py`:
  - `should_use_color()` now defers to `is_legacy_windows_console()` and returns False on legacy hosts. Defensive import so a broken detector can't regress POSIX users.
- `hermes_cli/curses_ui.py`:
  - `_use_ascii_safe_glyphs()` + `_glyph()` swap exotic Unicode for ASCII on legacy Windows; `HERMES_ASCII_GLYPHS=1` forces ASCII anywhere (screen readers, OCR, exotic fonts).
  - `_maybe_show_windows_curses_hint()` prints a one-time `pip install windows-curses` nudge from the numbered fallbacks. No-op on POSIX.
  - All three fallback functions (`_radio_numbered_fallback`, `_numbered_single_fallback`, `_numbered_fallback`) now call the hint helper and use `_glyph()` for the bullet/check characters.

**Commit 2 — `test(windows): pin VT processing + legacy-console gate (#24345)`**

- `tests/tools/test_windows_setup_wizard_ui.py` (new, 27 tests, 5 test classes):
  - `TestEnableVirtualTerminalProcessing` (4): success path, legacy host returns False, ctypes failure is non-fatal, redirected pipes don't taint the verdict.
  - `TestIsLegacyWindowsConsole` (4): POSIX/modern/legacy/unconfigured tri-state.
  - `TestConfigureWindowsStdioVtIntegration` (3): VT enable runs between code-page flip and stream reconfiguration; outcome reaches `_VT_PROCESSING_ENABLED`.
  - `TestShouldUseColorGating` (6): NO_COLOR, TERM=dumb, redirected stdout, defensive path when detector blows up.
  - `TestCursesUiAsciiFallback` (8): glyph selection, env-var override, single-fire hint, POSIX no-op.
  - Bug-shape regression anchor `TestBug24345Repro::test_legacy_console_kills_color_emission_end_to_end` — end-to-end contract pin with explicit "#24345 regression" failure message.

**Commit 3 — `test(windows): end-to-end legacy-console wizard rendering (#24345)`**

- `tests/hermes_cli/test_setup_wizard_windows_ui.py` (new, 8 tests, 4 test classes):
  - `TestColorOutputOnLegacyConsole` (2): `color()` strips ANSI on legacy hosts but preserves it on modern hosts.
  - `TestNumberedFallbackOnLegacyConsole` (3): ASCII glyphs render in radio and toggle fallbacks; modern hosts keep Unicode.
  - `TestWindowsCursesHintWiring` (2): the install hint fires exactly once across multiple fallback calls; silent on POSIX.
  - `TestBug24345EndToEnd::test_legacy_console_setup_wizard_renders_cleanly` — full-stack anchor: no ANSI, no exotic Unicode, exactly one install hint, with explicit "#24345 regression" messages so a future refactor that breaks the chain surfaces the cause immediately.

**Commit 4 — `docs(windows-native): document setup wizard UI fix (#24345)`**

- `website/docs/user-guide/windows-native.md`:
  - New "Setup wizard UI" section explaining the VT processing flip, the fallback path on pre-Win10-1809 hosts, the `pip install windows-curses` arrow-key workflow, and the `HERMES_ASCII_GLYPHS=1` escape hatch.
  - "UTF-8 console" section's enumerated steps now include the VT enable step so the docs match `configure_windows_stdio()`.
  - Two new "Common pitfalls" entries: literal `←[35m` glyphs (point at Windows Terminal / PS7 + link to new section) and arrow-key non-responsiveness (`pip install windows-curses`).

## How to Test

### Bug repro (proves the fix is required)

```bash
git switch fix/windows-setup-wizard-ui
# Roll the three patched files back to upstream/main.
git stash -u
git checkout upstream/main -- hermes_cli/stdio.py hermes_cli/colors.py hermes_cli/curses_ui.py

# Run the anchor — must error at fixture setup because the new
# is_legacy_windows_console() symbol doesn't exist on upstream/main.
python -m pytest tests/hermes_cli/test_setup_wizard_windows_ui.py::TestBug24345EndToEnd -v
#   AttributeError: module 'hermes_cli.stdio' has no attribute
#   'is_legacy_windows_console'  ← exactly the "fix wasn't applied" signal

# Restore the fix.
git checkout HEAD -- hermes_cli/stdio.py hermes_cli/colors.py hermes_cli/curses_ui.py
git stash pop
```

### Fix verification

```bash
# Targeted suite — 93 tests, all passing.
python -m pytest \
  tests/tools/test_windows_native_support.py \
  tests/tools/test_windows_setup_wizard_ui.py \
  tests/hermes_cli/test_setup_wizard_windows_ui.py -v
#   ============================== 93 passed in 1.25s ==============================

# Ruff clean on every touched file.
python -m ruff check \
  hermes_cli/stdio.py hermes_cli/colors.py hermes_cli/curses_ui.py \
  tests/tools/test_windows_setup_wizard_ui.py \
  tests/hermes_cli/test_setup_wizard_windows_ui.py
#   All checks passed!
```

### Manual repro on Windows (#24345's environment)

1. On Windows 10 / 11 with stock PowerShell 5.1 (NOT Windows Terminal), install `pip install windows-curses` and run `hermes setup`.
2. Pre-fix: banner shows literal `←[35m┌────...` escape codes; toggle/radio prompts show `●` / `○` / `✓` mojibake squares; no hint about arrow keys.
3. Post-fix: banner renders with proper magenta colours; arrow keys work in checklists; if `windows-curses` isn't installed, a one-time `pip install windows-curses` hint appears at the first numbered fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(windows):`, `test(windows):`, `docs(windows-native):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the targeted Windows test suite (`pytest tests/tools/test_windows_*.py tests/hermes_cli/test_setup_wizard_windows_ui.py`) and all 93 tests pass
- [x] I've added tests for my changes (35 new tests across two new files + a full-stack bug-shape regression anchor)
- [x] I've tested on my platform: macOS 14 with `sys.platform` / `ctypes.windll.kernel32` mocked — every Windows-specific code path runs under simulated Windows on Linux CI by design (matches the existing `tests/tools/test_windows_native_support.py` pattern)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/windows-native.md` — new "Setup wizard UI" section + 2 "Common pitfalls" entries; the enumerated steps in the UTF-8 section now match `configure_windows_stdio()`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; opt-in env vars `HERMES_ASCII_GLYPHS` and the pre-existing `HERMES_DISABLE_WINDOWS_UTF8` are documented inline)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is Windows-specific by design; `is_legacy_windows_console()` returns False on POSIX so `should_use_color()` and `_use_ascii_safe_glyphs()` stay no-ops there
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Bug-shape repro on upstream/main (proves the fix is required):

```
$ python -m pytest tests/hermes_cli/test_setup_wizard_windows_ui.py::TestBug24345EndToEnd -v
ERROR tests/hermes_cli/test_setup_wizard_windows_ui.py::TestBug24345EndToEnd::test_legacy_console_setup_wizard_renders_cleanly

monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x104a75b20>
    def simulate_legacy_windows_console(monkeypatch):
        monkeypatch.setattr(stdio, "is_windows", lambda: True)
>       monkeypatch.setattr(stdio, "is_legacy_windows_console", lambda: True)
E       AttributeError: <module 'hermes_cli.stdio' ...> has no attribute 'is_legacy_windows_console'
```

Full suite green on the branch:

```
$ python -m pytest tests/tools/test_windows_native_support.py tests/tools/test_windows_setup_wizard_ui.py tests/hermes_cli/test_setup_wizard_windows_ui.py
============================== 93 passed in 1.25s ==============================
```
