### PR TITLE
feat: make context file char limits configurable via config

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -826,6 +826,19 @@ CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 
 
+def _get_context_char_limit(key: str, fallback: int) -> int:
+    """Read a per-file char limit from config, falling back to the module constant."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        val = cfg.get("context", {}).get(key)
+        if val is not None:
+            return int(val)
+    except Exception:
+        pass
+    return fallback
+
+
 # =========================================================================
 # Skills prompt cache
 # =========================================================================
@@ -1322,7 +1335,7 @@ def load_soul_md() -> Optional[str]:
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
+        content = _truncate_content(content, "SOUL.md", max_chars=_get_context_char_limit("soul_char_limit", CONTEXT_FILE_MAX_CHARS))
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
@@ -1362,7 +1375,7 @@ def _load_agents_md(cwd_path: Path) -> str:
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
+                    return _truncate_content(result, "AGENTS.md", max_chars=_get_context_char_limit("agents_char_limit", CONTEXT_FILE_MAX_CHARS))
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
@@ -1424,7 +1437,8 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 
     SOUL.md from HERMES_HOME is independent and always included when present.
-    Each context source is capped at 20,000 chars.
+    Each context source is capped at a configurable number of chars (see
+    ``context.soul_char_limit`` and ``context.agents_char_limit`` in config).
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -468,6 +468,17 @@ memory:
   flush_min_turns: 6        # Min user turns to trigger flush on exit/reset (0 = disabled)
 
 # =============================================================================
+# Context Files
+# =============================================================================
+# Maximum character limits for context files before truncation.
+# When a file exceeds its limit, the head and tail are kept with a truncation
+# marker in the middle.
+#
+# context:
+#   soul_char_limit: 20000       # SOUL.md max chars (default: 20000)
+#   agents_char_limit: 20000    # AGENTS.md max chars (default: 20000)
+
+# =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================
 # Controls when messaging sessions (Telegram, Discord, WhatsApp, Slack) are

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1054,6 +1054,8 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        "soul_char_limit": 20000,      # max chars for SOUL.md before truncation
+        "agents_char_limit": 20000,    # max chars for AGENTS.md before truncation
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -139,6 +139,62 @@ class TestTruncateContent:
         result = _truncate_content(content, "exact.md")
         assert result == content
 
+    def test_custom_max_chars(self):
+        """Custom max_chars overrides the default CONTEXT_FILE_MAX_CHARS."""
+        content = "x" * 500
+        # With default limit, this should pass through
+        result_default = _truncate_content(content, "test.md")
+        assert result_default == content
+
+        # With a custom limit smaller than content, it should truncate
+        result_small = _truncate_content(content, "test.md", max_chars=100)
+        assert len(result_small) < len(content)
+        assert "truncated" in result_small.lower()
+
+
+class TestGetContextCharLimit:
+    """Tests for _get_context_char_limit reading from config."""
+
+    def test_returns_fallback_when_no_config(self, monkeypatch):
+        from agent.prompt_builder import _get_context_char_limit, CONTEXT_FILE_MAX_CHARS
+
+        # If load_config raises, fallback is used
+        monkeypatch.setattr(
+            "agent.prompt_builder._get_context_char_limit.__wrapped__",
+            None,
+            raising=False,
+        )
+        result = _get_context_char_limit("soul_char_limit", CONTEXT_FILE_MAX_CHARS)
+        assert result == CONTEXT_FILE_MAX_CHARS
+
+    def test_returns_config_value_when_set(self, monkeypatch):
+        from agent.prompt_builder import _get_context_char_limit
+
+        fake_config = {"context": {"soul_char_limit": 10000, "agents_char_limit": 15000}}
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: fake_config
+        )
+        assert _get_context_char_limit("soul_char_limit", 20000) == 10000
+        assert _get_context_char_limit("agents_char_limit", 20000) == 15000
+
+    def test_returns_fallback_when_key_missing(self, monkeypatch):
+        from agent.prompt_builder import _get_context_char_limit
+
+        fake_config = {"context": {"engine": "compressor"}}
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: fake_config
+        )
+        assert _get_context_char_limit("soul_char_limit", 20000) == 20000
+
+    def test_returns_fallback_when_context_missing(self, monkeypatch):
+        from agent.prompt_builder import _get_context_char_limit
+
+        fake_config = {}
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: fake_config
+        )
+        assert _get_context_char_limit("soul_char_limit", 20000) == 20000
+
 
 # =========================================================================
 # _parse_skill_file — single-pass skill file reading

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -672,6 +672,8 @@ The context engine controls how conversations are managed when approaching the m
 ```yaml
 context:
   engine: "compressor"    # default — built-in lossy summarization
+  soul_char_limit: 20000  # max chars for SOUL.md before truncation (default: 20000)
+  agents_char_limit: 20000  # max chars for AGENTS.md before truncation (default: 20000)
 ```
 
 To use a plugin engine (e.g., LCM for lossless context management):


### PR DESCRIPTION
Add `context.soul_char_limit` and `context.agents_char_limit` config options to control SOUL.md and AGENTS.md truncation thresholds.

Previously these were hardcoded at 20,000 chars with no way to override. Users can now set custom limits:

```yaml
context:
  soul_char_limit: 10000
  agents_char_limit: 20000
```

The `_get_context_char_limit()` helper reads from config with the module constant as fallback, so existing configs work unchanged.

**Changes:**
- `agent/prompt_builder.py`: new `_get_context_char_limit()` helper, wired into `load_soul_md()` and `_load_agents_md()`
- `hermes_cli/config.py`: add defaults to `DEFAULT_CONFIG`
- `cli-config.yaml.example`: document new options
- `website/docs`: update configuration reference
- `tests`: add `test_custom_max_chars` + `TestGetContextCharLimit` (4 tests)

**Testing:** All 9 new + existing tests pass.