### PR TITLE
fix(auth): skip per-source suppression when survivors share the source (#24390)

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -472,7 +472,22 @@ def auth_remove_command(args) -> None:
     for line in result.cleaned:
         print(line)
     if result.suppress:
-        suppress_credential_source(provider, removed.source)
+        # ``removed.source`` (e.g. ``manual:device_code``) can be shared by
+        # multiple pool entries — each `hermes auth add openai-codex --type oauth`
+        # produces another entry with the same source tag. Suppressing the
+        # shared source here would gate the survivors at every seed-time
+        # ``is_source_suppressed()`` check and pollute auth.json's
+        # ``suppressed_sources`` with a marker that contradicts the live
+        # pool. Only suppress when no survivor still carries that source.
+        # The source-specific ``remove_fn`` is still responsible for its
+        # own canonical-source suppression (e.g. codex's ``device_code``
+        # re-seed gate); we only skip the dispatcher's per-source default.
+        # See #24390.
+        shared_with_survivors = any(
+            entry.source == removed.source for entry in pool.entries()
+        )
+        if not shared_with_survivors:
+            suppress_credential_source(provider, removed.source)
     for line in result.hints:
         print(line)
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1376,6 +1376,135 @@ def test_auth_remove_codex_manual_source_suppresses_reseed(tmp_path, monkeypatch
     assert "openai-codex" not in updated.get("providers", {})
 
 
+def test_auth_remove_shared_manual_source_leaves_survivors_unsuppressed(tmp_path, monkeypatch):
+    """Removing one of multiple manual entries that share a source tag must NOT
+    suppress that source — the survivors still carry it and every downstream
+    ``is_source_suppressed()`` gate would silently gag them. See #24390.
+
+    The codex-specific remove_fn still suppresses the canonical ``device_code``
+    re-seed gate, but the dispatcher's per-source default suppression of
+    ``manual:device_code`` must be skipped.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    auth_store = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "acc-shared", "refresh_token": "ref-shared"},
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "cx1",
+                    "label": "account-a",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "acc-a",
+                    "refresh_token": "ref-a",
+                },
+                {
+                    "id": "cx2",
+                    "label": "account-b",
+                    "auth_type": "oauth",
+                    "priority": 1,
+                    "source": "manual:device_code",
+                    "access_token": "acc-b",
+                    "refresh_token": "ref-b",
+                },
+                {
+                    "id": "cx3",
+                    "label": "account-c",
+                    "auth_type": "oauth",
+                    "priority": 2,
+                    "source": "manual:device_code",
+                    "access_token": "acc-c",
+                    "refresh_token": "ref-c",
+                },
+            ]
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_remove_command
+
+    auth_remove_command(SimpleNamespace(provider="openai-codex", target="account-a"))
+
+    updated = json.loads((hermes_home / "auth.json").read_text())
+    suppressed = updated.get("suppressed_sources", {}).get("openai-codex", [])
+    # Survivors (account-b, account-c) still carry manual:device_code — the
+    # dispatcher must NOT suppress that source.
+    assert "manual:device_code" not in suppressed, (
+        "manual:device_code must not be suppressed while survivors share it"
+    )
+    # The codex-specific remove_fn still suppresses canonical device_code so
+    # ~/.codex/auth.json doesn't get re-imported as a fresh seeded entry.
+    assert "device_code" in suppressed
+    # The two survivors remain in the pool.
+    survivors = updated["credential_pool"]["openai-codex"]
+    assert len(survivors) == 2
+    assert {entry["label"] for entry in survivors} == {"account-b", "account-c"}
+    assert all(entry["source"] == "manual:device_code" for entry in survivors)
+
+
+def test_auth_remove_last_manual_source_still_suppresses(tmp_path, monkeypatch):
+    """When removing the LAST entry with a given source (no survivors), the
+    dispatcher's default per-source suppression is preserved — this is the
+    pre-#24390 behaviour and is the right behaviour when nothing remains.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    auth_store = {
+        "version": 1,
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "acc-only", "refresh_token": "ref-only"},
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "cx-only",
+                    "label": "only-account",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:device_code",
+                    "access_token": "acc-only",
+                },
+            ]
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+
+    from types import SimpleNamespace
+    from hermes_cli.auth_commands import auth_remove_command
+
+    auth_remove_command(SimpleNamespace(provider="openai-codex", target="1"))
+
+    updated = json.loads((hermes_home / "auth.json").read_text())
+    suppressed = updated.get("suppressed_sources", {}).get("openai-codex", [])
+    # No survivors: dispatcher suppresses the source as before.
+    assert "manual:device_code" in suppressed
+    # Codex's own remove_fn also suppressed the canonical key.
+    assert "device_code" in suppressed
+    assert updated["credential_pool"]["openai-codex"] == []
+
+
 def test_auth_add_codex_clears_suppression_marker(tmp_path, monkeypatch):
     """Re-linking codex via `hermes auth add openai-codex` must clear any suppression marker."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Summary

`hermes auth remove openai-codex <label>` calls `suppress_credential_source(provider, removed.source)` unconditionally in the central dispatcher (`hermes_cli/auth_commands.py`). When several pool entries share `removed.source` — every `hermes auth add openai-codex --type oauth` produces a new entry with `source=manual:device_code` — the call silently suppresses the source the *survivors* still carry. This PR scopes the dispatcher's per-source suppression to the case where no survivor shares the source.

## The bug

Steps to reproduce (from #24390):

```bash
hermes auth add openai-codex --type oauth --label account-a
hermes auth add openai-codex --type oauth --label account-b
hermes auth add openai-codex --type oauth --label account-c
hermes auth remove openai-codex account-a
```

`~/.hermes/auth.json` then contains:

```json
"suppressed_sources": {"openai-codex": ["device_code", "manual:device_code"]}
```

The first marker (`device_code`) is intentional — `_remove_codex_device_code` suppresses the canonical re-seed key so `~/.codex/auth.json` is not auto-imported as a fresh entry. The second marker (`manual:device_code`) is the bug introduced by the central dispatcher: it gags the live survivors via every `is_source_suppressed()` gate in `agent/credential_pool.py`, even though `account-b` and `account-c` are still healthy pool entries that depend on that source tag.

This is the inverse of #13427 — that PR correctly made removal sticky, but the sticky behaviour is too aggressive when several pool entries share one source.

## The fix

Narrow change in `auth_remove_command`. After the source-specific `remove_fn` returns, the dispatcher now checks the remaining `pool.entries()` for any entry that still carries `removed.source` before calling `suppress_credential_source`. The source-specific remove step is still responsible for its own canonical re-seed gate (e.g. codex's `device_code`), so single-entry removals behave exactly as before.

```python
if result.suppress:
    shared_with_survivors = any(
        entry.source == removed.source for entry in pool.entries()
    )
    if not shared_with_survivors:
        suppress_credential_source(provider, removed.source)
```

## Test plan

- [x] Focused regression test (`test_auth_remove_shared_manual_source_leaves_survivors_unsuppressed`): three `manual:device_code` entries, remove one, assert `manual:device_code` NOT in suppressed_sources, canonical `device_code` IS suppressed, two survivors remain.
- [x] Single-entry preservation test (`test_auth_remove_last_manual_source_still_suppresses`): one entry, remove it, assert dispatcher still suppresses `manual:device_code` (no survivors → pre-existing behaviour).
- [x] Adjacent suite: `tests/hermes_cli/test_auth_commands.py` (48 passed), `tests/hermes_cli/test_auth_nous_provider.py` + `tests/hermes_cli/test_runtime_provider_resolution.py` (155 passed).
- [x] Regression guard: reverted the production fix, re-ran the new test → fails with `assert 'manual:device_code' not in ['device_code', 'manual:device_code']`. Restored the fix → passes.

## Contract preserved

| Scenario | Before | After |
|---|---|---|
| Single `manual:device_code` entry, remove it | both `device_code` and `manual:device_code` suppressed | both `device_code` and `manual:device_code` suppressed |
| Three `manual:device_code` entries, remove one | `device_code` and `manual:device_code` suppressed; survivors gagged | `device_code` suppressed; `manual:device_code` NOT suppressed; survivors keep working |
| Codex canonical re-seed gate from `~/.codex/auth.json` | suppressed by `_remove_codex_device_code` | same |
| `hermes auth add openai-codex` clears suppression | works | works (existing test preserved) |

## Related

- Fixes #24390.
- Inverse follow-up to #13427 (unified credential source removal, the PR that introduced the sticky-suppress behaviour).