### PR TITLE
fix(gateway): preserve full Matrix IDs in DeliveryTarget.parse

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -71,16 +71,33 @@ class DeliveryTarget:
         if target_lower == "local":
             return cls(platform=Platform.LOCAL)
         
-        # Check for platform:chat_id or platform:chat_id:thread_id format
-        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs
+        # Check for platform:chat_id or platform:chat_id:thread_id format.
+        # Use the original case for chat_id/thread_id to preserve case-sensitive IDs.
+        # Matrix room/user IDs themselves contain ":" (for example
+        # ``matrix:!roomid:server.org``), so keep the full remainder as chat_id
+        # to stay compatible with send_message target syntax.
         if ":" in target_stripped:
-            parts = target_stripped.split(":", 2)
-            platform_str = parts[0].lower()  # Platform names are case-insensitive
-            chat_id = parts[1] if len(parts) > 1 else None
-            thread_id = parts[2] if len(parts) > 2 else None
+            platform_part, remainder = target_stripped.split(":", 1)
+            platform_str = platform_part.lower()  # Platform names are case-insensitive
             try:
                 platform = Platform(platform_str)
-                return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
+                if platform == Platform.MATRIX and remainder.startswith(("!", "@")):
+                    return cls(
+                        platform=platform,
+                        chat_id=remainder,
+                        thread_id=None,
+                        is_explicit=True,
+                    )
+
+                parts = target_stripped.split(":", 2)
+                chat_id = parts[1] if len(parts) > 1 else None
+                thread_id = parts[2] if len(parts) > 2 else None
+                return cls(
+                    platform=platform,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    is_explicit=True,
+                )
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -83,20 +83,18 @@ class TestCaseSensitiveChatIdParsing:
         assert target.thread_id == "thread123"
     
     def test_matrix_room_id_preserved(self):
-        """Matrix room IDs like !RoomABC:example.org should preserve case.
-        
-        Note: Matrix room IDs contain colons (e.g., !RoomABC:example.org).
-        Due to the platform:chat_id:thread_id format, these are parsed as
-        chat_id=!RoomABC and thread_id=example.org. This is a known limitation
-        of the current format. The fix preserves case but doesn't change the
-        parsing structure.
-        """
+        """Matrix room IDs should stay intact even though they contain ':'."""
         target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
         assert target.platform == Platform.MATRIX
-        # The room ID is split at the first colon after the platform prefix
-        # This is a format limitation - the case is preserved but the structure is split
-        assert target.chat_id == "!RoomABC"
-        assert target.thread_id == "example.org"
+        assert target.chat_id == "!RoomABC:example.org"
+        assert target.thread_id is None
+
+    def test_matrix_user_id_preserved(self):
+        """Matrix user IDs should also stay intact."""
+        target = DeliveryTarget.parse("matrix:@HermesBot:example.org")
+        assert target.platform == Platform.MATRIX
+        assert target.chat_id == "@HermesBot:example.org"
+        assert target.thread_id is None
     
     def test_mixed_case_chat_id_roundtrip(self):
         """Mixed-case chat IDs should survive parse-to_string roundtrip."""


### PR DESCRIPTION
## What does this PR do?

Fixes a delivery parser drift on the gateway path so explicit Matrix targets are handled consistently with the existing `send_message` target syntax.

Before this change, `DeliveryTarget.parse()` treated every explicit target as `platform:chat_id[:thread_id]`. That breaks Matrix room and user IDs because Matrix identifiers themselves contain `:` characters, so inputs like `matrix:!roomid:server.org` were incorrectly split into `chat_id="!roomid"` and `thread_id="server.org"`.

This patch keeps explicit Matrix room IDs and Matrix user IDs intact as full `chat_id` values, with no `thread_id`, while preserving existing parsing behavior for Telegram, Discord, Slack, and other target formats.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/delivery.py`: preserve full Matrix room/user IDs when parsing explicit delivery targets
- `tests/gateway/test_delivery.py`: replace the old Matrix "known limitation" expectation with regression coverage for full Matrix room/user ID parsing

## How to Test

1. Run `uv run pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/gateway/test_delivery.py`
2. Confirm all tests pass
3. Run `uv run --extra dev ruff check gateway/delivery.py tests/gateway/test_delivery.py`
4. Run `PYTHONIOENCODING=utf-8 uv run python scripts/check-windows-footguns.py gateway/delivery.py tests/gateway/test_delivery.py`

## Checklist Notes

- Contributing guide considered: yes
- Conventional commit title: `fix(gateway): preserve full Matrix IDs in DeliveryTarget.parse`
- Duplicate PR search: not performed locally
- Scope: single-purpose
- Tests added/updated: yes, focused regression coverage in `tests/gateway/test_delivery.py`
- Platform tested: Windows
- Docs updated or N/A: N/A
- `cli-config.yaml.example` updated or N/A: N/A
- `AGENTS.md`/`CONTRIBUTING.md` updated or N/A: N/A
- Cross-platform impact considered: yes
- Tool schema/description updated or N/A: N/A

## Verification

- `uv run pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/gateway/test_delivery.py` -> `17 passed`
- `uv run --extra dev ruff check gateway/delivery.py tests/gateway/test_delivery.py` -> `All checks passed!`
- `PYTHONIOENCODING=utf-8 uv run python scripts/check-windows-footguns.py gateway/delivery.py tests/gateway/test_delivery.py` -> `No Windows footguns found`
