### PR TITLE
feat: add code_index and symbol_search tools

### DIFF
--- a/tests/tools/test_code_index.py
+++ b/tests/tools/test_code_index.py
@@ -1,0 +1,257 @@
+"""Tests for code_index tool."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+
+class TestCodeIndex:
+    @pytest.fixture
+    def temp_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "src")
+            os.makedirs(src)
+            py_file = os.path.join(src, "main.py")
+            with open(py_file, "w") as f:
+                f.write("class User:\n    def __init__(self, name):\n        self.name = name\n")
+                f.write("\ndef hello():\n    return 'world'\n")
+                f.write("\nimport os\nfrom pathlib import Path\n")
+            ts_file = os.path.join(src, "types.ts")
+            with open(ts_file, "w") as f:
+                f.write("export interface User {\n  name: string;\n  age: number;\n}\n")
+                f.write("\nexport function greet(name: string): string {\n  return `Hello ${name}`;\n}\n")
+            yield tmpdir
+
+    def test_check_requirements(self):
+        from tools.code_index import check_code_index_requirements
+        assert check_code_index_requirements() is True
+
+    def test_build_index(self, temp_project):
+        from tools.code_index import code_index
+        output = code_index(temp_project, operation="build")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["operation"] == "build"
+        assert data["stats"]["new_files"] >= 2
+        assert data["stats"]["symbols_found"] >= 4
+
+    def test_clear_index(self, temp_project):
+        from tools.code_index import code_index
+        code_index(temp_project, operation="build")
+        output = code_index(temp_project, operation="clear")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["operation"] == "clear"
+
+    def test_status_after_build(self, temp_project):
+        from tools.code_index import code_index
+        code_index(temp_project, operation="build")
+        output = code_index(temp_project, operation="status")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["indexed"] is True
+        assert data["symbols"] >= 4
+
+    def test_status_no_index(self, temp_project):
+        from tools.code_index import code_index
+        output = code_index(temp_project, operation="status")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["indexed"] is False
+
+    def test_project_root_not_found(self):
+        from tools.code_index import code_index
+        output = code_index("/nonexistent/path", operation="build")
+        data = json.loads(output)
+        assert data["success"] is False
+
+    def test_build_with_file_pattern(self, temp_project):
+        from tools.code_index import code_index
+        output = code_index(temp_project, operation="build", file_pattern="*.ts")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["stats"]["new_files"] >= 1
+
+    def test_build_targeted_path(self, temp_project):
+        from tools.code_index import code_index
+        src = os.path.join(temp_project, "src")
+        output = code_index(temp_project, operation="build", path=src)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["stats"]["new_files"] >= 2
+
+
+class TestCodeIndexSchema:
+    def test_schema_has_required_fields(self):
+        from tools.code_index import CODE_INDEX_SCHEMA
+        assert CODE_INDEX_SCHEMA["name"] == "code_index"
+        props = CODE_INDEX_SCHEMA["parameters"]["properties"]
+        assert "project_root" in props
+        assert "operation" in props
+        assert props["operation"]["enum"] == ["build", "status", "clear"]
+
+
+class TestExtractSymbols:
+    def test_python_symbols(self):
+        from tools.code_index import _extract_symbols
+        content = "class Foo:\n    def bar(self):\n        pass\ndef baz():\n    pass"
+        symbols = _extract_symbols(content, "python")
+        names = [s["name"] for s in symbols if s["type"] in ("class", "function")]
+        assert "Foo" in names
+        assert "baz" in names
+
+    def test_ts_symbols(self):
+        from tools.code_index import _extract_symbols
+        content = "interface User {}\nfunction greet() {}\nconst x = 1"
+        symbols = _extract_symbols(content, "typescript")
+        names = [s["name"] for s in symbols]
+        assert "User" in names
+        assert "greet" in names
+
+    def test_go_symbols(self):
+        from tools.code_index import _extract_symbols
+        content = "func Hello() {}\ntype Config struct {}\nconst MaxValue = 100"
+        symbols = _extract_symbols(content, "go")
+        names = [s["name"] for s in symbols]
+        assert "Hello" in names
+
+    def test_rust_symbols(self):
+        from tools.code_index import _extract_symbols
+        content = "fn hello() {}\nstruct Config {}"
+        symbols = _extract_symbols(content, "rust")
+        names = [s["name"] for s in symbols]
+        assert "hello" in names
+
+    def test_detect_language(self):
+        from tools.code_index import _detect_language
+        assert _detect_language("test.py") == "python"
+        assert _detect_language("test.ts") == "typescript"
+        assert _detect_language("test.js") == "javascript"
+        assert _detect_language("test.go") == "go"
+        assert _detect_language("test.rs") == "rust"
+        assert _detect_language("test.unknown") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Regression: Rust impl capture group
+# ---------------------------------------------------------------------------
+
+
+class TestRustImplCapture:
+    """Rust impl lines must be captured with a valid symbol name, not skipped."""
+
+    def test_impl_named_type(self):
+        from tools.code_index import _extract_symbols
+        content = "impl Foo {\n    fn bar(&self) {}\n}"
+        symbols = _extract_symbols(content, "rust")
+        impl_names = [s["name"] for s in symbols if s["type"] == "impl"]
+        assert "Foo" in impl_names
+
+    def test_impl_for_type(self):
+        from tools.code_index import _extract_symbols
+        content = "impl Display for MyStruct {\n    fn fmt(&self) {}\n}"
+        symbols = _extract_symbols(content, "rust")
+        impl_names = [s["name"] for s in symbols if s["type"] == "impl"]
+        assert "Display for MyStruct" in impl_names
+
+    def test_impl_no_crash_on_bare_impl(self):
+        """Bare 'impl {' without a name must not crash."""
+        from tools.code_index import _extract_symbols
+        content = "impl {\n    fn new() {}\n}"
+        # Should not raise IndexError
+        symbols = _extract_symbols(content, "rust")
+        # No impl symbol should be captured (no name to capture)
+        impl_syms = [s for s in symbols if s["type"] == "impl"]
+        assert len(impl_syms) == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: DB key collision (basename → hash)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexDbCollision:
+    """Two projects with the same basename must get separate indexes."""
+
+    def test_same_basename_different_roots(self):
+        from tools.code_index import code_index, _index_db_path
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root_a = os.path.join(tmpdir, "work", "a", "api")
+            root_b = os.path.join(tmpdir, "work", "b", "api")
+            os.makedirs(root_a)
+            os.makedirs(root_b)
+
+            with open(os.path.join(root_a, "a.py"), "w") as f:
+                f.write("def alpha(): pass\n")
+            with open(os.path.join(root_b, "b.py"), "w") as f:
+                f.write("def beta(): pass\n")
+
+            code_index(root_a, operation="build")
+            code_index(root_b, operation="build")
+
+            db_a = _index_db_path(os.path.abspath(root_a))
+            db_b = _index_db_path(os.path.abspath(root_b))
+            assert db_a != db_b
+
+            # Verify each index only contains its own file
+            import sqlite3
+            conn_a = sqlite3.connect(db_a)
+            rows_a = conn_a.execute("SELECT path FROM files").fetchall()
+            conn_a.close()
+            assert any("a.py" in r[0] for r in rows_a)
+            assert not any("b.py" in r[0] for r in rows_a)
+
+            conn_b = sqlite3.connect(db_b)
+            rows_b = conn_b.execute("SELECT path FROM files").fetchall()
+            conn_b.close()
+            assert any("b.py" in r[0] for r in rows_b)
+            assert not any("a.py" in r[0] for r in rows_b)
+
+
+# ---------------------------------------------------------------------------
+# Regression: stale rows on rebuild (deleted files pruned)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRowPruning:
+    """Rebuild must remove rows for files that no longer exist on disk."""
+
+    def test_deleted_file_removed_after_rebuild(self):
+        from tools.code_index import code_index
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f1 = os.path.join(tmpdir, "keep.py")
+            f2 = os.path.join(tmpdir, "delete_me.py")
+            with open(f1, "w") as f:
+                f.write("def keep(): pass\n")
+            with open(f2, "w") as f:
+                f.write("def doomed(): pass\n")
+
+            code_index(tmpdir, operation="build")
+
+            # Verify both are indexed
+            status1 = json.loads(code_index(tmpdir, operation="status"))
+            assert status1["files"] == 2
+
+            # Delete one file and rebuild
+            os.unlink(f2)
+            code_index(tmpdir, operation="build")
+
+            status2 = json.loads(code_index(tmpdir, operation="status"))
+            assert status2["files"] == 1
+
+            # Verify the deleted file's symbols are also gone
+            import sqlite3, hashlib
+            abs_root = os.path.abspath(tmpdir)
+            root_hash = hashlib.sha256(abs_root.encode()).hexdigest()[:16]
+            db_path = os.path.join(
+                os.path.dirname(os.path.dirname(abs_root)),  # walk up from tmpdir
+            )
+            # Use the helper to find the DB
+            from tools.code_index import _index_db_path
+            db_path = _index_db_path(abs_root)
+            conn = sqlite3.connect(db_path)
+            sym_files = conn.execute("SELECT DISTINCT file_path FROM symbols").fetchall()
+            conn.close()
+            assert not any("delete_me.py" in r[0] for r in sym_files)

--- a/tests/tools/test_symbol_search.py
+++ b/tests/tools/test_symbol_search.py
@@ -1,0 +1,147 @@
+"""Tests for symbol_search tool."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+
+class TestSymbolSearch:
+    @pytest.fixture
+    def indexed_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "src")
+            os.makedirs(src)
+            with open(os.path.join(src, "main.py"), "w") as f:
+                f.write("class User:\n    def __init__(self, name):\n        self.name = name\n")
+                f.write("\ndef hello():\n    return 'world'\n")
+                f.write("\nimport os\nfrom pathlib import Path\n")
+            with open(os.path.join(src, "utils.py"), "w") as f:
+                f.write("def helper():\n    pass\n")
+                f.write("\nclass Config:\n    pass\n")
+            from tools.code_index import code_index
+            code_index(tmpdir, operation="build")
+            yield tmpdir
+
+    def test_check_requirements(self):
+        from tools.symbol_search import check_symbol_search_requirements
+        assert check_symbol_search_requirements() is True
+
+    def test_search_by_name(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("User", indexed_project)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 1
+        assert any(r["name"] == "User" for r in data["results"])
+
+    def test_search_partial(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("help", indexed_project)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 1
+
+    def test_search_exact(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("nonexistent_symbol_xyz", indexed_project, exact=True)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] == 0
+
+    def test_search_by_type(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("", indexed_project, symbol_type="class")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 2
+        types = [r["type"] for r in data["results"]]
+        assert all(t == "class" for t in types)
+
+    def test_search_by_language(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("", indexed_project, language="python")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 4
+
+    def test_search_find_usages(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("User", indexed_project, find_usages=True)
+        data = json.loads(output)
+        assert data["success"] is True
+        if data["total"] > 0:
+            assert "usages" in data["results"][0]
+            assert "usage_count" in data["results"][0]
+
+    def test_project_root_not_found(self):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("test", "/nonexistent/path")
+        data = json.loads(output)
+        assert data["success"] is False
+
+    def test_no_index(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from tools.symbol_search import symbol_search
+            output = symbol_search("test", tmpdir)
+            data = json.loads(output)
+            assert data["success"] is False
+            assert "Run 'code_index'" in data["error"]
+
+    def test_limit(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("", indexed_project, limit=2)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert len(data["results"]) <= 2
+
+    def test_results_have_by_file(self, indexed_project):
+        from tools.symbol_search import symbol_search
+        output = symbol_search("", indexed_project)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert "by_file" in data
+
+
+class TestSymbolSearchSchema:
+    def test_schema_has_required_fields(self):
+        from tools.symbol_search import SYMBOL_SEARCH_SCHEMA
+        assert SYMBOL_SEARCH_SCHEMA["name"] == "symbol_search"
+        props = SYMBOL_SEARCH_SCHEMA["parameters"]["properties"]
+        assert "query" in props
+        assert "project_root" in props
+        assert "symbol_type" in props
+        assert "language" in props
+        assert "find_usages" in props
+
+
+# ---------------------------------------------------------------------------
+# Regression: cross-file find_usages
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFileUsages:
+    """find_usages must search all indexed files, not just the definition's file."""
+
+    def test_usage_in_different_file(self):
+        from tools.symbol_search import symbol_search
+        from tools.code_index import code_index
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # File A defines the symbol
+            with open(os.path.join(tmpdir, "defs.py"), "w") as f:
+                f.write("class Calculator:\n    pass\n")
+            # File B uses the symbol
+            with open(os.path.join(tmpdir, "main.py"), "w") as f:
+                f.write("from defs import Calculator\ncalc = Calculator()\n")
+
+            code_index(tmpdir, operation="build")
+            output = symbol_search("Calculator", tmpdir, find_usages=True)
+            data = json.loads(output)
+            assert data["success"] is True
+            assert data["total"] >= 1
+            result = data["results"][0]
+            assert result["usage_count"] >= 2  # def + import + usage
+            # Usages should span both files
+            usage_files = {u["file"] for u in result["usages"]}
+            assert len(usage_files) >= 2

--- a/tools/code_index.py
+++ b/tools/code_index.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Code Index Tool - Build and maintain a persistent code index.
+
+Provides codebase indexing: symbol extraction, dependency graph,
+and persistent storage for fast code search and navigation.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+INDEX_VERSION = 2
+MAX_FILE_SIZE = 5 * 1024 * 1024
+
+
+def _index_db_path(abs_root: str) -> str:
+    """Stable DB name from a hash of the canonical project root."""
+    root_hash = hashlib.sha256(abs_root.encode()).hexdigest()[:16]
+    index_dir = get_hermes_home() / "code-index"
+    return str(index_dir / f"{root_hash}.db")
+
+
+def _detect_language(file_path: str) -> str:
+    ext = os.path.splitext(file_path)[1].lower()
+    mapping = {
+        ".py": "python", ".pyw": "python", ".pyx": "python",
+        ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript",
+        ".ts": "typescript", ".tsx": "typescript",
+        ".go": "go",
+        ".rs": "rust",
+        ".java": "java", ".kt": "kotlin",
+        ".rb": "ruby",
+        ".c": "c", ".h": "c", ".cpp": "cpp", ".hpp": "cpp",
+        ".cs": "csharp",
+        ".swift": "swift",
+    }
+    return mapping.get(ext, "unknown")
+
+
+def _extract_symbols(content: str, language: str) -> List[Dict[str, Any]]:
+    symbols = []
+
+    if language == "python":
+        patterns = [
+            (r"^class\s+(\w+)", "class"),
+            (r"^def\s+(\w+)", "function"),
+            (r"^async\s+def\s+(\w+)", "function"),
+            (r"^\s+class\s+(\w+)", "class"),
+            (r"^\s+def\s+(\w+)", "method"),
+            (r"^\s+async\s+def\s+(\w+)", "method"),
+        ]
+    elif language in ("javascript", "typescript"):
+        patterns = [
+            (r"(?:export\s+)?(?:class|interface)\s+(\w+)", "class"),
+            (r"(?:export\s+)?function\s+(\w+)", "function"),
+            (r"(?:export\s+)?(?:const|let|var)\s+(\w+)\s*[=:]\s*(?:async\s+)?(?:\(|function)", "function"),
+            (r"(?:export\s+)?(?:const|let|var)\s+(\w+)", "variable"),
+            (r"(?:export\s+)?type\s+(\w+)", "type"),
+        ]
+    elif language == "go":
+        patterns = [
+            (r"^func\s+(\w+)", "function"),
+            (r"^type\s+(\w+)\s+struct", "struct"),
+            (r"^type\s+(\w+)\s+interface", "interface"),
+            (r"^type\s+(\w+)\s*=", "type"),
+            (r"^const\s+(\w+)", "constant"),
+            (r"^var\s+(\w+)", "variable"),
+        ]
+    elif language == "rust":
+        patterns = [
+            (r"^fn\s+(\w+)", "function"),
+            (r"^struct\s+(\w+)", "struct"),
+            (r"^enum\s+(\w+)", "enum"),
+            (r"^trait\s+(\w+)", "trait"),
+            (r"^impl\s+(\w+(?:\s+for\s+\w+)?)", "impl"),
+            (r"^(?:pub\s+)?(?:const|let|static)\s+(?:mut\s+)?(\w+)", "variable"),
+        ]
+    else:
+        patterns = [
+            (r"(?:class|struct|enum|interface)\s+(\w+)", "type"),
+            (r"(?:def|function|fn|func)\s+(\w+)", "function"),
+        ]
+
+    for pattern, sym_type in patterns:
+        for match in re.finditer(pattern, content, re.MULTILINE):
+            if match.lastindex:
+                name = match.group(1)
+            else:
+                continue
+            line_num = content[:match.start()].count("\n") + 1
+            symbols.append({
+                "name": name,
+                "type": sym_type,
+                "line": line_num,
+            })
+
+    return symbols
+
+
+def _extract_dependencies(content: str, language: str) -> List[str]:
+    deps = []
+
+    if language == "python":
+        matches = re.findall(
+            r"^(?:from\s+([^\s]+)\s+import|import\s+([^\s]+))",
+            content, re.MULTILINE,
+        )
+        for m in matches:
+            deps.append(m[0] or m[1])
+    elif language in ("javascript", "typescript"):
+        matches = re.findall(
+            r"(?:import\s+(?:\{[^}]*\}\s+from\s+)?['\"]([^'\"]+)['\"]"
+            r"|require\(['\"]([^'\"]+)['\"]\))",
+            content,
+        )
+        for m in matches:
+            deps.append(m[0] or m[1])
+    elif language == "go":
+        matches = re.findall(r'^\s+"([^"]+)"', content, re.MULTILINE)
+        deps.extend(matches)
+
+    return list(set(deps))
+
+
+def code_index(
+    project_root: str,
+    operation: str = "build",
+    file_pattern: Optional[str] = None,
+    path: Optional[str] = None,
+    include_unsafe: bool = False,
+    task_id: Optional[str] = None,
+) -> str:
+    """Build and maintain a persistent code index."""
+    if not os.path.isdir(project_root):
+        return json.dumps({
+            "success": False,
+            "error": f"Project root not found: {project_root}",
+        })
+
+    abs_root = os.path.abspath(project_root)
+    db_path = _index_db_path(abs_root)
+
+    if operation == "clear":
+        if os.path.exists(db_path):
+            os.unlink(db_path)
+            return json.dumps({"success": True, "operation": "clear", "message": "Index cleared"})
+        return json.dumps({"success": True, "operation": "clear", "message": "No index to clear"})
+
+    if operation == "status":
+        if not os.path.exists(db_path):
+            return json.dumps({"success": True, "operation": "status", "indexed": False, "message": "No index found"})
+        conn = None
+        try:
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
+            cursor.execute("SELECT COUNT(*) FROM files")
+            file_count = cursor.fetchone()[0]
+            cursor.execute("SELECT COUNT(*) FROM symbols")
+            symbol_count = cursor.fetchone()[0]
+            cursor.execute("SELECT COUNT(DISTINCT file_path) FROM symbols")
+            indexed_files = cursor.fetchone()[0]
+            return json.dumps({
+                "success": True,
+                "operation": "status",
+                "indexed": True,
+                "files": file_count,
+                "files_with_symbols": indexed_files,
+                "symbols": symbol_count,
+                "index_path": db_path,
+            })
+        except sqlite3.Error as e:
+            return json.dumps({"success": False, "error": f"Index read error: {e}"})
+        finally:
+            if conn:
+                conn.close()
+
+    if operation == "build":
+        conn = None
+        try:
+            index_dir = os.path.dirname(db_path)
+            os.makedirs(index_dir, exist_ok=True)
+
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
+
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT
+                )
+            """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS files (
+                    path TEXT PRIMARY KEY,
+                    language TEXT,
+                    last_modified REAL,
+                    size INTEGER,
+                    line_count INTEGER
+                )
+            """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS symbols (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT,
+                    name TEXT,
+                    type TEXT,
+                    line INTEGER,
+                    FOREIGN KEY (file_path) REFERENCES files(path)
+                )
+            """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS dependencies (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT,
+                    dependency TEXT,
+                    FOREIGN KEY (file_path) REFERENCES files(path)
+                )
+            """)
+            cursor.execute("PRAGMA synchronous = OFF")
+            cursor.execute("PRAGMA journal_mode = MEMORY")
+
+            cursor.execute(
+                "INSERT OR REPLACE INTO meta VALUES (?, ?)",
+                ("version", str(INDEX_VERSION)),
+            )
+            cursor.execute(
+                "INSERT OR REPLACE INTO meta VALUES (?, ?)",
+                ("project_root", abs_root),
+            )
+
+            exclude_dirs = {
+                ".git", "__pycache__", "node_modules", ".venv", "venv", ".env",
+                ".tox", ".eggs", "build", "dist", ".mypy_cache", ".pytest_cache",
+                ".ruff_cache", ".hermes",
+            }
+
+            stats = {"files_scanned": 0, "new_files": 0, "symbols_found": 0}
+            walk_root = path if path else abs_root
+            seen_files: set = set()
+
+            for root, dirs, files in os.walk(walk_root):
+                if not include_unsafe:
+                    dirs[:] = [d for d in dirs if d not in exclude_dirs and not d.startswith(".")]
+
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    rel_path = os.path.relpath(file_path, abs_root)
+
+                    if file_pattern:
+                        pat = file_pattern.replace("*", ".*").replace("?", ".")
+                        if not re.search(pat, file_path):
+                            continue
+
+                    try:
+                        stat_info = os.stat(file_path)
+                        if stat_info.st_size > MAX_FILE_SIZE:
+                            continue
+                    except OSError:
+                        continue
+
+                    seen_files.add(rel_path)
+
+                    cursor.execute(
+                        "SELECT last_modified FROM files WHERE path = ?",
+                        (rel_path,),
+                    )
+                    existing = cursor.fetchone()
+                    if existing and existing[0] >= stat_info.st_mtime:
+                        continue
+
+                    try:
+                        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                            content = f.read()
+                    except Exception:
+                        continue
+
+                    language = _detect_language(file_path)
+                    line_count = content.count("\n") + 1
+
+                    cursor.execute(
+                        "INSERT OR REPLACE INTO files VALUES (?, ?, ?, ?, ?)",
+                        (rel_path, language, stat_info.st_mtime, stat_info.st_size, line_count),
+                    )
+                    stats["new_files"] += 1
+
+                    cursor.execute("DELETE FROM symbols WHERE file_path = ?", (rel_path,))
+                    symbols = _extract_symbols(content, language)
+                    for sym in symbols:
+                        cursor.execute(
+                            "INSERT INTO symbols (file_path, name, type, line) VALUES (?, ?, ?, ?)",
+                            (rel_path, sym["name"], sym["type"], sym["line"]),
+                        )
+                    stats["symbols_found"] += len(symbols)
+
+                    cursor.execute("DELETE FROM dependencies WHERE file_path = ?", (rel_path,))
+                    deps = _extract_dependencies(content, language)
+                    for dep in deps:
+                        cursor.execute(
+                            "INSERT INTO dependencies (file_path, dependency) VALUES (?, ?)",
+                            (rel_path, dep),
+                        )
+
+                    stats["files_scanned"] += 1
+
+            # Prune stale rows for files that no longer exist on disk.
+            cursor.execute("SELECT path FROM files")
+            for (existing_path,) in cursor.fetchall():
+                if existing_path not in seen_files:
+                    cursor.execute("DELETE FROM symbols WHERE file_path = ?", (existing_path,))
+                    cursor.execute("DELETE FROM dependencies WHERE file_path = ?", (existing_path,))
+                    cursor.execute("DELETE FROM files WHERE path = ?", (existing_path,))
+
+            conn.commit()
+            return json.dumps({
+                "success": True,
+                "operation": "build",
+                "project": abs_root,
+                "stats": stats,
+                "message": (
+                    f"Scanned {stats['files_scanned']} files, "
+                    f"indexed {stats['new_files']} new, "
+                    f"found {stats['symbols_found']} symbols"
+                ),
+            })
+
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "error": f"Index build failed: {e}",
+            })
+        finally:
+            if conn:
+                conn.close()
+
+    return json.dumps({
+        "success": False,
+        "error": f"Unknown operation: {operation}",
+    })
+
+
+def check_code_index_requirements() -> bool:
+    """Code index uses Python standard library."""
+    return True
+
+
+CODE_INDEX_SCHEMA = {
+    "name": "code_index",
+    "description": (
+        "Build and maintain a persistent code index for fast code search and navigation.\n\n"
+        "Operations:\n"
+        "- build: Scan project, extract symbols (classes, functions), track dependencies\n"
+        "- status: Show index statistics (files, symbols, indexed paths)\n"
+        "- clear: Remove the index\n\n"
+        "Extracts: classes, functions, methods, interfaces, structs, enums, traits\n"
+        "Supported: Python, TypeScript, JavaScript, Go, Rust"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_root": {
+                "type": "string",
+                "description": "Root directory of the project to index",
+            },
+            "operation": {
+                "type": "string",
+                "description": "Operation: build, status, clear",
+                "enum": ["build", "status", "clear"],
+                "default": "build",
+            },
+            "file_pattern": {
+                "type": "string",
+                "description": "File pattern to filter (e.g., *.py, src/**/*.ts)",
+            },
+            "path": {
+                "type": "string",
+                "description": "Specific file or directory to index (for targeted updates)",
+            },
+            "include_unsafe": {
+                "type": "boolean",
+                "description": "Include hidden/node_modules directories",
+                "default": False,
+            },
+            "task_id": {
+                "type": "string",
+                "description": "Optional task ID for tracking",
+            },
+        },
+        "required": ["project_root"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="code_index",
+    toolset="code_search",
+    schema=CODE_INDEX_SCHEMA,
+    handler=lambda args, **kw: code_index(
+        project_root=args.get("project_root", ""),
+        operation=args.get("operation", "build"),
+        file_pattern=args.get("file_pattern"),
+        path=args.get("path"),
+        include_unsafe=args.get("include_unsafe", False),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_code_index_requirements,
+    emoji="📑",
+)

--- a/tools/symbol_search.py
+++ b/tools/symbol_search.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Symbol Search Tool - Search code symbols across indexed codebase.
+
+Provides symbol lookup, usage finding, type hierarchy, and cross-referencing
+using the code index built by code_index tool.
+"""
+
+import json
+import os
+import re
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+from tools.code_index import _index_db_path
+
+
+def symbol_search(
+    query: str,
+    project_root: str,
+    symbol_type: Optional[str] = None,
+    language: Optional[str] = None,
+    find_usages: bool = False,
+    exact: bool = False,
+    limit: int = 50,
+    task_id: Optional[str] = None,
+) -> str:
+    """Search for symbols (classes, functions, variables) across the indexed codebase."""
+    if not os.path.isdir(project_root):
+        return json.dumps({
+            "success": False,
+            "error": f"Project root not found: {project_root}",
+        })
+
+    abs_root = os.path.abspath(project_root)
+    db_path = _index_db_path(abs_root)
+
+    if not os.path.isfile(db_path):
+        return json.dumps({
+            "success": False,
+            "error": "No code index found. Run 'code_index' tool with operation='build' first.",
+        })
+
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT value FROM meta WHERE key = 'project_root'")
+        row = cursor.fetchone()
+        indexed_root = row[0] if row else abs_root
+
+        conditions: List[str] = []
+        params: List[Any] = []
+
+        if exact:
+            conditions.append("s.name = ?")
+            params.append(query)
+        else:
+            conditions.append("s.name LIKE ?")
+            params.append(f"%{query}%")
+
+        if symbol_type:
+            types = [t.strip().lower() for t in symbol_type.split(",")]
+            placeholders = ",".join("?" * len(types))
+            conditions.append(f"s.type IN ({placeholders})")
+            params.extend(types)
+
+        if language:
+            conditions.append("f.language = ?")
+            params.append(language)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+
+        cursor.execute(f"""
+            SELECT s.name, s.type, s.file_path, s.line, f.language
+            FROM symbols s
+            JOIN files f ON s.file_path = f.path
+            WHERE {where}
+            ORDER BY s.name
+            LIMIT ?
+        """, params + [limit])
+
+        results = []
+        for name, sym_type, file_path, line, lang in cursor.fetchall():
+            full_path = os.path.join(indexed_root, file_path)
+            results.append({
+                "name": name,
+                "type": sym_type,
+                "file": file_path,
+                "full_path": full_path,
+                "line": line,
+                "language": lang,
+            })
+
+        # Cross-file usage search: search ALL indexed source files, not
+        # just the definition's own file.
+        if find_usages and results:
+            cursor.execute("SELECT path FROM files")
+            all_indexed = [r[0] for r in cursor.fetchall()]
+
+            for r in results:
+                usages = []
+                pattern = re.compile(r"\b" + re.escape(r["name"]) + r"\b", re.MULTILINE)
+                for indexed_path in all_indexed:
+                    full = os.path.join(indexed_root, indexed_path)
+                    try:
+                        with open(full, "r", encoding="utf-8", errors="replace") as f:
+                            content = f.read()
+                    except Exception:
+                        continue
+                    for match in pattern.finditer(content):
+                        line_num = content[:match.start()].count("\n") + 1
+                        line_start = content.rfind("\n", 0, match.start()) + 1
+                        line_end = content.find("\n", match.end())
+                        line_content = content[
+                            line_start : line_end if line_end != -1 else len(content)
+                        ].strip()
+                        usages.append({
+                            "file": indexed_path,
+                            "line": line_num,
+                            "context": line_content[:120],
+                        })
+                r["usages"] = usages[:30]
+                r["usage_count"] = len(usages)
+
+        per_file: Dict[str, List[Dict]] = {}
+        for r in results:
+            key = r["file"]
+            if key not in per_file:
+                per_file[key] = []
+            per_file[key].append(r)
+
+        return json.dumps({
+            "success": True,
+            "query": query,
+            "total": len(results),
+            "results": results[:limit],
+            "by_file": {k: v for k, v in list(per_file.items())[:30]},
+        }, ensure_ascii=False)
+
+    except sqlite3.Error as e:
+        return json.dumps({
+            "success": False,
+            "error": f"Index query failed: {e}",
+        })
+    except Exception as e:
+        return json.dumps({
+            "success": False,
+            "error": str(e),
+        })
+    finally:
+        if conn:
+            conn.close()
+
+
+def check_symbol_search_requirements() -> bool:
+    """Symbol search requires Python standard library."""
+    return True
+
+
+SYMBOL_SEARCH_SCHEMA = {
+    "name": "symbol_search",
+    "description": (
+        "Search for symbols (classes, functions, variables) across the indexed codebase.\n\n"
+        "Requires the code index to be built first using the 'code_index' tool with operation='build'.\n\n"
+        "Parameters:\n"
+        "- query: Symbol name to search for (partial match by default)\n"
+        "- project_root: Root directory of the project\n"
+        "- symbol_type: Filter by type: class, function, method, variable, type, struct, enum, trait, interface\n"
+        "- language: Filter by language: python, typescript, javascript, go, rust\n"
+        "- find_usages: Find all usages of matching symbols across all indexed files\n"
+        "- exact: Exact match instead of partial\n"
+        "- limit: Maximum results to return (default 50)"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Symbol name to search for (partial match by default)",
+            },
+            "project_root": {
+                "type": "string",
+                "description": "Root directory of the project",
+            },
+            "symbol_type": {
+                "type": "string",
+                "description": "Filter by type: class, function, method, variable, type, struct, enum, trait, interface",
+            },
+            "language": {
+                "type": "string",
+                "description": "Filter by language: python, typescript, javascript, go, rust",
+            },
+            "find_usages": {
+                "type": "boolean",
+                "description": "Find all usages of matching symbols across all indexed files",
+                "default": False,
+            },
+            "exact": {
+                "type": "boolean",
+                "description": "Exact match instead of partial",
+                "default": False,
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results to return",
+                "default": 50,
+            },
+            "task_id": {
+                "type": "string",
+                "description": "Optional task ID for tracking",
+            },
+        },
+        "required": ["query", "project_root"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="symbol_search",
+    toolset="code_search",
+    schema=SYMBOL_SEARCH_SCHEMA,
+    handler=lambda args, **kw: symbol_search(
+        query=args.get("query", ""),
+        project_root=args.get("project_root", ""),
+        symbol_type=args.get("symbol_type"),
+        language=args.get("language"),
+        find_usages=args.get("find_usages", False),
+        exact=args.get("exact", False),
+        limit=args.get("limit", 50),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_symbol_search_requirements,
+    emoji="🔍",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -106,6 +106,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "code_search": {
+        "description": "Code search and indexing: build code index, search symbols, find usages across indexed files",
+        "tools": ["code_index", "symbol_search"],
+        "includes": []
+    },
+
     "x_search": {
         "description": (
             "Search X (Twitter) posts and threads via xAI's built-in "


### PR DESCRIPTION
## What does this PR do?
Adds two new code search and indexing tools for navigating codebases efficiently:

- **code_index** — Build and maintain a persistent SQLite-backed code index. Scans projects and extracts symbols (classes, functions, methods, structs, enums, traits) from Python, TypeScript, JavaScript, Go, and Rust files. Tracks file dependencies (imports/requires). Supports build, status, and clear operations with file pattern filtering and targeted reindexing. Index stored at `~/.hermes/code-index/`.

- **symbol_search** — Search the indexed codebase for symbols by name (partial or exact match), filter by symbol type or language, and optionally find all usages with surrounding context. Results grouped by file for easy navigation.

## Changes Made
- `tools/code_index.py` — Indexing engine, per-language symbol extraction, dependency parsing, SQLite persistence with versioned schema
- `tools/symbol_search.py` — Symbol lookup, type/language filtering, usage finding with inline context
- `tests/tools/test_code_index.py` — 14 tests (build/status/clear, symbols for Python/TS/Go/Rust)
- `tests/tools/test_symbol_search.py` — 12 tests (search modes, filtering, usages, error handling)
- `toolsets.py` — Added `code_index`, `symbol_search` to `_HERMES_CORE_TOOLS` + new `code_search` toolset

## How to Test
1. `from tools.code_index import code_index; code_index("/path/to/project", operation="build")`
2. `from tools.symbol_search import symbol_search; symbol_search("class_name", "/path/to/project")`
3. `symbol_search("func", "/path", symbol_type="function", language="python")`
4. `symbol_search("User", "/path", find_usages=True)`

## Checklist
- [x] New feature
- [x] 26 tests passing
- [x] Multi-language support (Python, TS, JS, Go, Rust)
- [x] Persistent SQLite index with versioned schema
- [x] try/finally connection cleanup on all DB operations
- [x] Index stored at `~/.hermes/code-index/` (profile-safe)
- [x] Tested on Windows