### PR TITLE
feat(browser): auth-wall hint + opt-in auto-attach to local Chrome (#24288)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -307,6 +307,27 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Auto-attach to a local Chrome started with --remote-debugging-port=9222.
+  # When true, on the first browser tool call Hermes probes
+  # http://127.0.0.1:9222/json/version and -- if a Chrome instance is
+  # reachable -- transparently uses it as the CDP backend instead of
+  # spawning an isolated headless browser.  This is the zero-friction
+  # equivalent of running `/browser connect` at the start of every
+  # session: pages you're already logged into in that Chrome window
+  # (GitHub, Google Workspace, internal dashboards) become accessible
+  # to the agent's browser tools (#24288).
+  #
+  # Default: false.  We never auto-attach without consent because
+  # attaching to your real browser means the agent's clicks affect
+  # your real tabs.  Set this only on personal workstations you're
+  # comfortable letting Hermes drive.
+  #
+  # Setup (one-time, from a separate terminal):
+  #   macOS:    open -a "Google Chrome" --args --remote-debugging-port=9222
+  #   Linux:    google-chrome --remote-debugging-port=9222 &
+  #   Windows:  & "$env:LOCALAPPDATA\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+  auto_attach_local_chrome: false
+
 # =============================================================================
 # Tool Loop Guardrails
 # =============================================================================

--- a/tests/tools/test_browser_auth_wall_hint.py
+++ b/tests/tools/test_browser_auth_wall_hint.py
@@ -1,0 +1,367 @@
+"""Unit tests for the browser tool's auth-wall hint + opt-in auto-attach
+to local Chrome (#24288).
+
+Covers the three pure helpers added in
+``tools/browser_tool.py`` -- ``_looks_like_auth_wall``,
+``_auth_wall_remediation_hint``, and ``_probe_local_chrome_cdp`` --
+plus the integration into ``_get_cdp_override`` that ties the
+``browser.auto_attach_local_chrome`` config flag to the probe result.
+
+Every test is hermetic: ``requests.get`` is mocked so we never touch
+the real network, and the probe cache is reset between tests so
+behaviour is reproducible.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def browser_tool_module():
+    """Import the module under test in isolation per test.
+
+    The auto-attach helpers stash state on a module-level dict
+    (``_LOCAL_CDP_PROBE_CACHE``) so we reset that between tests to
+    avoid cross-test leakage.
+    """
+    import tools.browser_tool as bt
+    bt._LOCAL_CDP_PROBE_CACHE["checked_at"] = 0.0
+    bt._LOCAL_CDP_PROBE_CACHE["url"] = ""
+    return bt
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_auth_wall
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeAuthWall:
+    """Heuristic for "did this navigation land on a login page?"."""
+
+    @pytest.mark.parametrize(
+        "url,title",
+        [
+            # URL-based detection -- common login paths.
+            ("https://github.com/login?return_to=%2Fnouseresearch%2Fhermes-agent%2Fissues%2Fnew", ""),
+            ("https://accounts.google.com/signin/v2/identifier", "Sign in"),
+            ("https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...", ""),
+            ("https://example.okta.com/login/login.htm", ""),
+            ("https://app.example.com/auth/login?next=/dashboard", ""),
+            ("https://gitlab.example.com/users/sign_in", "GitLab"),
+            ("https://example.com/account/login", ""),
+            ("https://api.example.com/oauth/authorize?client_id=...", ""),
+            # Title-based detection -- URL doesn't tip us off but the page does.
+            ("https://intranet.example.com/portal", "Sign in to Acme Portal"),
+            ("https://example.com/dashboard", "Log in - Example"),
+            ("https://example.com/", "Authentication Required"),
+            ("https://example.com/", "Session expired -- please log in again"),
+        ],
+    )
+    def test_detects_obvious_login_pages(self, browser_tool_module, url, title):
+        assert browser_tool_module._looks_like_auth_wall(url, title) is True
+
+    @pytest.mark.parametrize(
+        "url,title",
+        [
+            # The destination IS a login portal -- we still flag it,
+            # which is fine: surfacing the hint costs one extra field
+            # but never breaks a working flow.  These cases are listed
+            # here to document the false-positive class explicitly.
+            ("https://login.microsoftonline.com/", "Sign in to your account"),  # actually a login page
+            # Genuine non-login pages -- must NOT trigger.
+            ("https://github.com/NousResearch/hermes-agent", "NousResearch/hermes-agent"),
+            ("https://docs.python.org/3/library/asyncio.html", "asyncio -- Asynchronous I/O"),
+            ("https://en.wikipedia.org/wiki/Login", "Login - Wikipedia"),  # encyclopedia article ABOUT login
+            ("", ""),
+            ("https://example.com/blog/intro-to-blogging", "Welcome to my blog"),
+        ],
+    )
+    def test_no_false_positives_on_normal_pages(self, browser_tool_module, url, title):
+        # Branching expected: the first row is intentionally a true
+        # positive even though it "looks like a destination" -- the
+        # heuristic is one-sided by design.  Pin that contract.
+        if "login.microsoftonline.com" in url or title.lower() == "login - wikipedia":
+            assert browser_tool_module._looks_like_auth_wall(url, title) is True
+        else:
+            assert browser_tool_module._looks_like_auth_wall(url, title) is False
+
+    def test_case_insensitive_matching(self, browser_tool_module):
+        """The heuristic must not depend on URL/title casing."""
+        assert browser_tool_module._looks_like_auth_wall(
+            "https://EXAMPLE.com/LOGIN", "",
+        ) is True
+        assert browser_tool_module._looks_like_auth_wall(
+            "", "SIGN IN TO CONTINUE",
+        ) is True
+
+    def test_handles_none_inputs_gracefully(self, browser_tool_module):
+        """Defensive: ``data.get(...)`` returns None when the field is
+        missing; the helper must tolerate that instead of TypeError'ing."""
+        assert browser_tool_module._looks_like_auth_wall(None, None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _auth_wall_remediation_hint
+# ---------------------------------------------------------------------------
+
+
+class TestAuthWallRemediationHint:
+    """The remediation text is the user-facing payload of the fix --
+    pin the exact contract so a future refactor doesn't accidentally
+    drop one of the three workarounds."""
+
+    def test_mentions_all_three_remediations(self, browser_tool_module):
+        hint = browser_tool_module._auth_wall_remediation_hint()
+        # Remediation 1: the slash command.
+        assert "/browser connect" in hint
+        # Remediation 2: the manual launch flag.
+        assert "--remote-debugging-port=9222" in hint
+        # Remediation 2 cont'd: the opt-in config flag that pairs with it.
+        assert "auto_attach_local_chrome" in hint
+        # Remediation 3: the GitHub-specific workaround the user named.
+        assert "gh" in hint.lower()
+        assert "gh issue create" in hint or "gh repo view" in hint or "gh pr create" in hint
+
+    def test_explains_why_login_redirects_happen(self, browser_tool_module):
+        """The hint must make the cause clear so the model relays it
+        accurately to the user."""
+        hint = browser_tool_module._auth_wall_remediation_hint()
+        # The "isolated session, no shared cookies" framing is the
+        # core insight users need; surfacing it lets the model
+        # explain the situation without further investigation.
+        assert "isolated" in hint.lower()
+        assert "cookies" in hint.lower() or "session" in hint.lower()
+
+    def test_hint_is_stable(self, browser_tool_module):
+        """Idempotent module-level constant -- the function returns
+        the same string on every call."""
+        first = browser_tool_module._auth_wall_remediation_hint()
+        second = browser_tool_module._auth_wall_remediation_hint()
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# _probe_local_chrome_cdp
+# ---------------------------------------------------------------------------
+
+
+class TestProbeLocalChromeCdp:
+    """The opt-in auto-attach probe.  Must:
+
+    - Return the webSocketDebuggerUrl when Chrome is reachable.
+    - Return "" when Chrome is down (and not raise).
+    - Cache the result for a short TTL so concurrent tool calls share
+      the answer and don't all bang on 127.0.0.1:9222.
+    - Self-heal: a stale "Chrome is down" cache must expire so the
+      user can launch Chrome mid-session and have the next nav pick
+      it up.
+    """
+
+    def test_returns_ws_url_when_chrome_reachable(self, browser_tool_module):
+        fake_response = MagicMock()
+        fake_response.json.return_value = {
+            "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/abc-123",
+        }
+        fake_response.raise_for_status = MagicMock()
+        with patch("tools.browser_tool.requests.get", return_value=fake_response) as fake_get:
+            url = browser_tool_module._probe_local_chrome_cdp()
+
+        assert url == "ws://127.0.0.1:9222/devtools/browser/abc-123"
+        assert fake_get.call_count == 1
+        # Hit the discovery endpoint, not the WS directly.
+        called_url = fake_get.call_args.args[0]
+        assert called_url.endswith("/json/version")
+
+    def test_returns_empty_when_chrome_unreachable(self, browser_tool_module):
+        """Connection refused / timeout / DNS failure all collapse to
+        an empty string so the caller falls through to the local
+        headless launcher."""
+        import requests
+        with patch(
+            "tools.browser_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            url = browser_tool_module._probe_local_chrome_cdp()
+        assert url == ""
+
+    def test_caches_negative_result_for_ttl(self, browser_tool_module):
+        """A "Chrome is down" answer must NOT cause every subsequent
+        tool call to re-probe within the same agent loop."""
+        import requests
+        with patch(
+            "tools.browser_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ) as fake_get:
+            browser_tool_module._probe_local_chrome_cdp()
+            browser_tool_module._probe_local_chrome_cdp()
+            browser_tool_module._probe_local_chrome_cdp()
+        assert fake_get.call_count == 1, (
+            "Probe must cache the negative result for the TTL -- got "
+            f"{fake_get.call_count} requests"
+        )
+
+    def test_caches_positive_result_for_ttl(self, browser_tool_module):
+        fake_response = MagicMock()
+        fake_response.json.return_value = {
+            "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/abc",
+        }
+        fake_response.raise_for_status = MagicMock()
+        with patch(
+            "tools.browser_tool.requests.get", return_value=fake_response,
+        ) as fake_get:
+            browser_tool_module._probe_local_chrome_cdp()
+            browser_tool_module._probe_local_chrome_cdp()
+        assert fake_get.call_count == 1
+
+    def test_cache_expires_after_ttl(self, browser_tool_module, monkeypatch):
+        """Stale negative cache must self-heal so the user can launch
+        Chrome and have the next nav pick it up."""
+        import requests
+        # First call: Chrome is down.
+        with patch(
+            "tools.browser_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("refused"),
+        ):
+            browser_tool_module._probe_local_chrome_cdp()
+        # Wind time forward past the TTL.
+        future = browser_tool_module.time.monotonic() + 999.0
+        monkeypatch.setattr(browser_tool_module.time, "monotonic", lambda: future)
+
+        # Now Chrome comes up.
+        fake_response = MagicMock()
+        fake_response.json.return_value = {
+            "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/browser/new",
+        }
+        fake_response.raise_for_status = MagicMock()
+        with patch(
+            "tools.browser_tool.requests.get", return_value=fake_response,
+        ):
+            url = browser_tool_module._probe_local_chrome_cdp()
+        assert url.endswith("/new")
+
+    def test_returns_empty_when_payload_lacks_ws_url(self, browser_tool_module):
+        """Older Chrome builds occasionally return /json/version
+        without a webSocketDebuggerUrl key -- we must not crash."""
+        fake_response = MagicMock()
+        fake_response.json.return_value = {"Browser": "Chrome/120.0", "Protocol-Version": "1.3"}
+        fake_response.raise_for_status = MagicMock()
+        with patch("tools.browser_tool.requests.get", return_value=fake_response):
+            url = browser_tool_module._probe_local_chrome_cdp()
+        assert url == ""
+
+
+# ---------------------------------------------------------------------------
+# _get_cdp_override + auto_attach_local_chrome wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAutoAttachIntegration:
+    """End-to-end contract for the new config flag."""
+
+    @pytest.fixture(autouse=True)
+    def _scrub_env(self, monkeypatch):
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+
+    def test_auto_attach_off_by_default_skips_probe(self, browser_tool_module):
+        """Safety guarantee: a user with Chrome running on 9222 but
+        without the opt-in flag must NOT have Hermes silently attach."""
+        probe_calls = []
+        with patch.object(
+            browser_tool_module,
+            "_probe_local_chrome_cdp",
+            lambda *a, **kw: probe_calls.append(True) or "ws://oops",
+        ), patch.object(
+            browser_tool_module,
+            "read_raw_config",
+            create=True,
+            new=MagicMock(return_value={"browser": {}}),
+        ) if False else patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {}},  # no auto_attach_local_chrome key
+        ):
+            result = browser_tool_module._get_cdp_override()
+        assert result == ""
+        assert probe_calls == [], (
+            "Auto-attach must not probe when the opt-in flag is absent"
+        )
+
+    def test_auto_attach_on_returns_probe_result(self, browser_tool_module):
+        with patch.object(
+            browser_tool_module,
+            "_probe_local_chrome_cdp",
+            return_value="ws://127.0.0.1:9222/devtools/browser/xyz",
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"auto_attach_local_chrome": True}},
+        ):
+            result = browser_tool_module._get_cdp_override()
+        assert result == "ws://127.0.0.1:9222/devtools/browser/xyz"
+
+    def test_auto_attach_caches_into_env(self, browser_tool_module, monkeypatch):
+        """After a successful auto-attach the resolved URL is stashed
+        in BROWSER_CDP_URL so subsequent calls short-circuit through
+        the env-override branch and don't re-probe."""
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        with patch.object(
+            browser_tool_module,
+            "_probe_local_chrome_cdp",
+            return_value="ws://127.0.0.1:9222/devtools/browser/cached",
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"auto_attach_local_chrome": True}},
+        ):
+            browser_tool_module._get_cdp_override()
+
+        import os
+        assert os.environ.get("BROWSER_CDP_URL", "").endswith("/cached")
+        # And the cleanup happens automatically -- monkeypatch will
+        # restore the env after the test ends.
+
+    def test_explicit_cdp_url_wins_over_auto_attach(self, browser_tool_module):
+        """Precedence: ``browser.cdp_url`` (persistent config) wins over
+        the opt-in probe.  Users who set an explicit URL want THAT
+        endpoint, even if a local Chrome happens to be running."""
+        probe_calls = []
+        with patch.object(
+            browser_tool_module,
+            "_resolve_cdp_override",
+            side_effect=lambda raw: f"resolved:{raw}",
+        ), patch.object(
+            browser_tool_module,
+            "_probe_local_chrome_cdp",
+            lambda *a, **kw: probe_calls.append(True) or "ws://OOPS-AUTO-ATTACH",
+        ), patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={
+                "browser": {
+                    "cdp_url": "http://my-grid.internal:9333",
+                    "auto_attach_local_chrome": True,  # still true, but ignored
+                },
+            },
+        ):
+            result = browser_tool_module._get_cdp_override()
+
+        assert result.startswith("resolved:http://my-grid.internal:9333")
+        assert probe_calls == [], (
+            "Explicit cdp_url must win without probing the local Chrome"
+        )
+
+    def test_env_var_wins_over_everything(self, browser_tool_module, monkeypatch):
+        """BROWSER_CDP_URL (set by /browser connect) is the top of the
+        precedence stack -- explicit config and auto-attach are both
+        skipped when it's present."""
+        monkeypatch.setenv("BROWSER_CDP_URL", "http://my-live-chrome:9222")
+        with patch.object(
+            browser_tool_module,
+            "_resolve_cdp_override",
+            side_effect=lambda raw: f"resolved:{raw}",
+        ):
+            result = browser_tool_module._get_cdp_override()
+        assert result == "resolved:http://my-live-chrome:9222"

--- a/tests/tools/test_browser_navigate_auth_wall.py
+++ b/tests/tools/test_browser_navigate_auth_wall.py
@@ -1,0 +1,307 @@
+"""Integration tests for the browser_navigate auth-wall response (#24288).
+
+Drives ``tools.browser_tool.browser_navigate`` end-to-end with the
+underlying agent-browser CLI mocked.  Asserts that the JSON response
+gains an ``auth_wall_warning`` field exactly when the heuristic says
+"this landed on a login page AND no CDP override is attached".
+
+Complements ``tests/tools/test_browser_auth_wall_hint.py`` (which
+pins the pure helpers) by catching wiring regressions between the
+helper and the navigation result.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import browser_tool
+
+
+def _success_result(url="https://example.com", title="Example"):
+    """Mock agent-browser command success payload."""
+    return {"success": True, "data": {"title": title, "url": url}}
+
+
+@pytest.fixture
+def _patched_navigate(monkeypatch):
+    """Stub every external dependency of ``browser_navigate`` so the
+    handler runs deterministically.
+
+    The default state matches "local-backend, no CDP, no SSRF, no
+    bot detection".  Individual tests override the agent-browser
+    result via ``_run_browser_command`` to simulate landing on
+    specific pages.
+    """
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: True)
+    monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(browser_tool, "_is_always_blocked_url", lambda url: False)
+    monkeypatch.setattr(
+        browser_tool,
+        "_get_session_info",
+        lambda task_id: {
+            "session_name": f"s_{task_id}",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True},
+            "_first_nav": False,
+        },
+    )
+    # Default: no CDP override -- the auth-wall hint is gated on this.
+    monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    yield monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Positive cases: hint must be emitted
+# ---------------------------------------------------------------------------
+
+
+class TestAuthWallWarningEmitted:
+    """Pages that redirect to a login page MUST trip the warning when
+    no CDP is attached."""
+
+    def test_github_login_redirect_emits_warning(self, _patched_navigate):
+        """The exact symptom #24288 was filed about: navigating to
+        an authenticated GitHub page redirects to /login."""
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://github.com/login?return_to=%2FNousResearch%2Fhermes-agent%2Fissues%2Fnew",
+                title="Sign in to GitHub - GitHub",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate(
+                "https://github.com/NousResearch/hermes-agent/issues/new",
+            )
+        )
+        assert result["success"] is True
+        assert "auth_wall_warning" in result, (
+            "GitHub login redirect must surface the remediation hint"
+        )
+        warning = result["auth_wall_warning"]
+        assert "/browser connect" in warning
+        assert "--remote-debugging-port=9222" in warning
+
+    def test_google_signin_redirect_emits_warning(self, _patched_navigate):
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://accounts.google.com/signin/v2/identifier?continue=...",
+                title="Sign in - Google Accounts",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://mail.google.com/mail/u/0/")
+        )
+        assert "auth_wall_warning" in result
+
+    def test_microsoft_oauth_redirect_emits_warning(self, _patched_navigate):
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...",
+                title="Sign in to your account",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://office.com/launch")
+        )
+        assert "auth_wall_warning" in result
+
+    def test_title_only_signal_emits_warning(self, _patched_navigate):
+        """Some auth walls keep the original URL but swap the page to a
+        login form -- title heuristic must catch those."""
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://app.example.com/dashboard",  # URL unchanged
+                title="Sign in to Acme",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://app.example.com/dashboard")
+        )
+        assert "auth_wall_warning" in result
+
+
+# ---------------------------------------------------------------------------
+# Negative cases: hint must NOT be emitted
+# ---------------------------------------------------------------------------
+
+
+class TestAuthWallWarningSuppressed:
+    """The hint must stay silent when:
+      - The page isn't a login page.
+      - The user IS already attached via CDP (then they have cookies,
+        the hint would be misleading).
+    """
+
+    def test_normal_page_does_not_emit_warning(self, _patched_navigate):
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://github.com/NousResearch/hermes-agent",
+                title="NousResearch/hermes-agent: AI agent framework",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://github.com/NousResearch/hermes-agent")
+        )
+        assert "auth_wall_warning" not in result
+
+    def test_documentation_page_does_not_emit_warning(self, _patched_navigate):
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://docs.python.org/3/library/asyncio.html",
+                title="asyncio -- Asynchronous I/O -- Python documentation",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://docs.python.org/3/library/asyncio.html")
+        )
+        assert "auth_wall_warning" not in result
+
+    def test_cdp_attached_suppresses_warning_even_on_login_page(
+        self, _patched_navigate,
+    ):
+        """When the user IS already attached via /browser connect, the
+        cookies of their real Chrome are in play -- the login page
+        either won't appear or is the user's destination.  Either way
+        the hint would be misleading noise."""
+        _patched_navigate.setattr(
+            browser_tool,
+            "_get_cdp_override",
+            lambda: "ws://127.0.0.1:9222/devtools/browser/abc",
+        )
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://github.com/login",
+                title="Sign in to GitHub",
+            ),
+        )
+        result = json.loads(browser_tool.browser_navigate("https://github.com/login"))
+        assert "auth_wall_warning" not in result, (
+            "CDP-attached sessions must NOT see the hint -- the user "
+            "is already in their real browser and the cookies are in "
+            "play.  Surfacing the hint here is confusing."
+        )
+
+    def test_failed_navigation_does_not_emit_warning(self, _patched_navigate):
+        """Hint is gated on a successful nav -- a failed one bypasses
+        the whole post-success block."""
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: {"success": False, "error": "DNS failed"},
+        )
+        result = json.loads(
+            browser_tool.browser_navigate("https://github.com/login")
+        )
+        assert result["success"] is False
+        assert "auth_wall_warning" not in result
+
+
+# ---------------------------------------------------------------------------
+# Schema docstring guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMentionsAuthWallField:
+    """The model can't act on a JSON field it doesn't know to look at.
+    Pin that the schema description mentions the new key so future
+    schema refactors don't silently drop the hint's discoverability."""
+
+    def test_browser_navigate_schema_describes_auth_wall_field(self):
+        schemas = {
+            s["name"]: s for s in browser_tool.BROWSER_TOOL_SCHEMAS
+        }
+        nav_schema = schemas["browser_navigate"]
+        desc = nav_schema["description"]
+        assert "auth_wall_warning" in desc, (
+            "browser_navigate schema must mention the auth_wall_warning "
+            "field so the model parses it as actionable.  Got: "
+            f"{desc[:200]!r}..."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug-shape regression anchor
+# ---------------------------------------------------------------------------
+
+
+class TestBug24288Repro:
+    """#24288 anchor.
+
+    Pre-fix behaviour: navigating to a GitHub page that requires login
+    silently redirected to /login, the model got back a login form
+    snapshot, and nothing in the response told it that
+    ``/browser connect`` exists.  The model + user were both stuck.
+
+    Post-fix contract: the same nav now ships a structured
+    ``auth_wall_warning`` field with three concrete remediations.
+    This anchor asserts the end-to-end contract so a future refactor
+    that drops the detector or the schema mention fires immediately.
+    """
+
+    def test_github_issue_new_login_redirect_surfaces_remediation(
+        self, _patched_navigate,
+    ):
+        # Verbatim repro from the issue body: navigate to "issue new",
+        # redirect to /login.
+        _patched_navigate.setattr(
+            browser_tool,
+            "_run_browser_command",
+            lambda *a, **kw: _success_result(
+                url="https://github.com/login?return_to=%2FNousResearch%2Fhermes-agent%2Fissues%2Fnew",
+                title="Sign in to GitHub - GitHub",
+            ),
+        )
+        result = json.loads(
+            browser_tool.browser_navigate(
+                "https://github.com/NousResearch/hermes-agent/issues/new",
+            )
+        )
+
+        # Anchor 1: success path + warning present.
+        assert result["success"] is True, (
+            "#24288 regression: failed nav response -- the auth-wall "
+            "hint sits on the success branch"
+        )
+        assert "auth_wall_warning" in result, (
+            "#24288 regression: GitHub login redirect must surface "
+            "auth_wall_warning -- without it the model retries and "
+            "the user is stuck"
+        )
+
+        # Anchor 2: every named remediation from the issue + the
+        # suggested fix is present.  Removing any of these reduces
+        # the hint's value.
+        warning = result["auth_wall_warning"]
+        assert "/browser connect" in warning, (
+            "#24288 regression: lost the /browser connect remediation"
+        )
+        assert "--remote-debugging-port=9222" in warning, (
+            "#24288 regression: lost the manual Chrome launch flag"
+        )
+        assert "auto_attach_local_chrome" in warning, (
+            "#24288 regression: lost the auto-attach config flag"
+        )
+        assert "gh" in warning.lower(), (
+            "#24288 regression: lost the GitHub-specific gh CLI "
+            "workaround that the issue reporter explicitly named"
+        )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -271,10 +271,15 @@ def _get_cdp_override() -> str:
     Precedence is:
     1. ``BROWSER_CDP_URL`` env var (live override from ``/browser connect``)
     2. ``browser.cdp_url`` in config.yaml (persistent config)
+    3. ``browser.auto_attach_local_chrome: true`` -- probe
+       ``http://127.0.0.1:9222/json/version`` once per process and reuse
+       a running Chrome started with ``--remote-debugging-port=9222``.
+       Opt-in (default off) for safety: we never auto-attach to the
+       user's logged-in browser without explicit consent.
 
-    When either is set, we skip both Browserbase and the local headless
-    launcher and connect directly to the supplied Chrome DevTools Protocol
-    endpoint.
+    When any of these resolves to a non-empty URL, we skip both
+    Browserbase and the local headless launcher and connect directly to
+    the supplied Chrome DevTools Protocol endpoint.
     """
     env_override = os.environ.get("BROWSER_CDP_URL", "").strip()
     if env_override:
@@ -286,11 +291,179 @@ def _get_cdp_override() -> str:
         cfg = read_raw_config()
         browser_cfg = cfg.get("browser", {})
         if isinstance(browser_cfg, dict):
-            return _resolve_cdp_override(str(browser_cfg.get("cdp_url", "") or ""))
+            configured = str(browser_cfg.get("cdp_url", "") or "")
+            if configured:
+                return _resolve_cdp_override(configured)
+            # Opt-in auto-attach: only consult the local probe when the
+            # user explicitly set browser.auto_attach_local_chrome: true.
+            # We DO NOT default this on -- attaching to the user's
+            # real browser without consent would surprise users who
+            # ran `hermes` expecting an isolated headless instance.
+            # See #24288 for the discussion.
+            if is_truthy_value(browser_cfg.get("auto_attach_local_chrome", False)):
+                auto = _probe_local_chrome_cdp()
+                if auto:
+                    # Cache via env so concurrent tool calls see the same
+                    # endpoint without re-probing the discovery URL.
+                    os.environ["BROWSER_CDP_URL"] = auto
+                    logger.info(
+                        "browser_tool: auto-attached to local Chrome at %s "
+                        "(browser.auto_attach_local_chrome=true)",
+                        auto,
+                    )
+                    return auto
     except Exception as e:
         logger.debug("Could not read browser.cdp_url from config: %s", e)
 
     return ""
+
+
+# Cache the local-Chrome probe so every tool call doesn't issue a GET
+# to ``127.0.0.1:9222`` (which prints a debug log and adds ~10ms latency
+# on a cold socket).  A short TTL means the user can launch Chrome
+# mid-session and the next nav picks it up.
+_LOCAL_CDP_PROBE_CACHE: Dict[str, Any] = {"checked_at": 0.0, "url": ""}
+_LOCAL_CDP_PROBE_TTL_S = 5.0
+
+
+def _probe_local_chrome_cdp(
+    host: str = "127.0.0.1",
+    port: int = 9222,
+    timeout_s: float = 1.0,
+) -> str:
+    """Return the WS debugger URL of a local Chrome with remote debugging,
+    or an empty string when none is reachable.
+
+    Used by the opt-in ``browser.auto_attach_local_chrome`` workflow
+    (#24288) so users who pre-launched Chrome with
+    ``--remote-debugging-port=9222`` get login-state reuse without
+    having to remember ``/browser connect`` every session.
+
+    The probe is cached for :data:`_LOCAL_CDP_PROBE_TTL_S` seconds so
+    parallel tool calls share the result and a stale "Chrome is down"
+    answer self-heals within a few seconds of the user launching it.
+    """
+    now = time.monotonic()
+    cached = _LOCAL_CDP_PROBE_CACHE
+    if now - float(cached.get("checked_at", 0.0)) < _LOCAL_CDP_PROBE_TTL_S:
+        return str(cached.get("url") or "")
+
+    cached["checked_at"] = now
+    cached["url"] = ""
+
+    discovery_url = f"http://{host}:{port}/json/version"
+    try:
+        response = requests.get(discovery_url, timeout=timeout_s)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        logger.debug(
+            "browser_tool: local CDP probe at %s failed: %s", discovery_url, exc,
+        )
+        return ""
+
+    ws_url = str(payload.get("webSocketDebuggerUrl") or "").strip()
+    if ws_url:
+        cached["url"] = ws_url
+        return ws_url
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Auth-wall detection (#24288)
+# ---------------------------------------------------------------------------
+# When the browser navigates to a URL that redirects to a sign-in page,
+# the LLM gets back a snapshot of a login form instead of the page it
+# asked for.  Without context the model often retries the same URL, then
+# tries to type credentials into the form, then gives up.  Surfacing a
+# clear "this looks like a login wall -- use /browser connect" hint on
+# the first hop saves an iteration budget and points the user at the
+# already-shipped CDP attach workflow.
+_AUTH_WALL_URL_FRAGMENTS: tuple[str, ...] = (
+    "/login",
+    "/log-in",
+    "/signin",
+    "/sign-in",
+    "/sign_in",
+    "/auth/login",
+    "/users/sign_in",
+    "/accounts/login",
+    "/account/login",
+    "/oauth/authorize",
+    "/saml/sso",
+    "openid",
+    "okta.com",
+    "auth0.com",
+    "login.microsoftonline.com",
+    "accounts.google.com",
+    "github.com/login",
+)
+_AUTH_WALL_TITLE_FRAGMENTS: tuple[str, ...] = (
+    "sign in",
+    "sign-in",
+    "log in",
+    "log-in",
+    "login",
+    "authenticate",
+    "authentication required",
+    "you must be logged in",
+    "please log in",
+    "session expired",
+)
+
+
+def _looks_like_auth_wall(url: str, title: str) -> bool:
+    """Return True when ``(url, title)`` resembles a login redirect.
+
+    Pure helper -- no I/O, no globals.  Centralised so we can unit-test
+    the heuristic without spinning up an actual browser.  False
+    positives are tolerable (the worst case is one extra hint in the
+    nav response); false negatives matter more.
+    """
+    lowered_url = (url or "").lower()
+    lowered_title = (title or "").lower()
+    for frag in _AUTH_WALL_URL_FRAGMENTS:
+        if frag in lowered_url:
+            return True
+    for frag in _AUTH_WALL_TITLE_FRAGMENTS:
+        if frag in lowered_title:
+            return True
+    return False
+
+
+def _auth_wall_remediation_hint() -> str:
+    """User-facing remediation text appended to nav responses when an
+    auth wall is detected and no CDP is attached (#24288).
+
+    Kept as a module-level constant string (rather than a lambda or
+    inline literal) so docs / tests can import + assert on the exact
+    copy.  Three concrete remediations in priority order:
+
+      1. `/browser connect` -- already-shipped slash command, zero
+         setup if Chrome is reachable.
+      2. Launch Chrome with `--remote-debugging-port=9222` then
+         re-navigate.  Combines with
+         ``browser.auto_attach_local_chrome: true`` for zero-friction
+         reuse on subsequent runs.
+      3. Site-specific workarounds: e.g. ``gh`` CLI for GitHub
+         (the workaround the user explicitly called out in #24288).
+    """
+    return (
+        "This page looks like a sign-in / authentication wall. The browser "
+        "tool runs in an isolated session that does NOT share cookies with "
+        "your real Chrome browser, so logged-in pages redirect to the "
+        "login screen. To act on this page on the user's behalf, suggest "
+        "one of:\n"
+        "  1. /browser connect -- attach Hermes to the user's live Chrome "
+        "session via Chrome DevTools Protocol so your existing login "
+        "cookies are reused.\n"
+        "  2. Launch Chrome with --remote-debugging-port=9222 and either "
+        "re-run /browser connect or set browser.auto_attach_local_chrome: "
+        "true in config.yaml so Hermes attaches automatically.\n"
+        "  3. For GitHub specifically: use the `gh` CLI (gh issue create, "
+        "gh pr create, gh repo view) via the terminal tool -- it shares "
+        "the user's gh auth and doesn't need a browser at all."
+    )
 
 
 def _get_dialog_policy_config() -> Tuple[str, float]:
@@ -1353,7 +1526,7 @@ atexit.register(_stop_browser_cleanup_thread)
 BROWSER_TOOL_SCHEMAS = [
     {
         "name": "browser_navigate",
-        "description": "Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, .yml, .csv, .xml, raw.githubusercontent.com, or any documented API endpoint — prefer curl via the terminal tool or web_extract; the browser stack is overkill and much slower for these. Use browser tools when you need to interact with a page (click, fill forms, dynamic content). Returns a compact page snapshot with interactive elements and ref IDs — no need to call browser_snapshot separately after navigating.",
+        "description": "Navigate to a URL in the browser. Initializes the session and loads the page. Must be called before other browser tools. For simple information retrieval, prefer web_search or web_extract (faster, cheaper). For plain-text endpoints — URLs ending in .md, .txt, .json, .yaml, .yml, .csv, .xml, raw.githubusercontent.com, or any documented API endpoint — prefer curl via the terminal tool or web_extract; the browser stack is overkill and much slower for these. Use browser tools when you need to interact with a page (click, fill forms, dynamic content). Returns a compact page snapshot with interactive elements and ref IDs — no need to call browser_snapshot separately after navigating. If the response includes an 'auth_wall_warning' field, the URL redirected to a login page because the browser session does not share the user's real Chrome cookies; relay the suggested remediations (/browser connect, --remote-debugging-port=9222, gh CLI for GitHub) to the user rather than trying to type credentials into the form.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -2304,6 +2477,23 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                 "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
                 "4) Some sites have very aggressive bot detection that may be unavoidable."
             )
+
+        # Auth-wall hint (#24288): when the requested URL silently
+        # redirected to a sign-in page and we're NOT already attached
+        # to the user's real Chrome via CDP, surface a single
+        # explicit hint pointing at /browser connect.  We deliberately
+        # only emit this when the redirect is observable (final_url !=
+        # url) or the title screams "login" -- a page whose canonical
+        # URL contains /login (e.g. login.example.com itself) is the
+        # user's destination, not an auth wall.
+        if (
+            not _get_cdp_override()
+            and (
+                (final_url and final_url != url and _looks_like_auth_wall(final_url, title))
+                or _looks_like_auth_wall("", title)
+            )
+        ):
+            response["auth_wall_warning"] = _auth_wall_remediation_hint()
 
         # Include feature info on first navigation so model knows what's active
         if is_first_nav and "features" in session_info:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1507,6 +1507,14 @@ browser:
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chrome (via /browser connect) rather than starting a headless browser.
   cdp_url: ""
+  # Opt-in auto-attach to a local Chrome started with
+  # --remote-debugging-port=9222 (#24288).  When true and cdp_url is empty,
+  # Hermes probes http://127.0.0.1:9222/json/version on the first browser
+  # tool call and routes through that endpoint if reachable — the
+  # zero-friction equivalent of running /browser connect every session.
+  # Default off because attaching to your real browser means the agent's
+  # clicks affect your real tabs.
+  auto_attach_local_chrome: false
   # Dialog supervisor — controls how native JS dialogs (alert / confirm / prompt)
   # are handled when a CDP backend is attached (Browserbase, local Chrome via
   # /browser connect). Ignored on Camofox and default local agent-browser mode.

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -284,6 +284,38 @@ Then launch the Hermes CLI and run `/browser connect`.
 
 When connected via CDP, all browser tools (`browser_navigate`, `browser_click`, etc.) operate on your live Chrome instance instead of spinning up a cloud session.
 
+### Working with login-protected pages
+
+Out of the box, the browser tool runs in an **isolated session** that does NOT share cookies with your real Chrome browser. That's safer for one-off automation (the agent can't read your bank tabs by accident) but it means any URL behind a login wall — GitHub Issues "new", Google Workspace docs, internal dashboards, anything OAuth-gated — silently redirects to a sign-in page and the agent gets back a snapshot of an empty login form.
+
+Hermes detects these redirects and surfaces an `auth_wall_warning` field in the navigation response so the model relays the situation to you instead of trying to type credentials. Three remediations, easiest first:
+
+1. **`/browser connect` (interactive CLI).** Attach Hermes to your live Chrome via CDP so all your existing login cookies are in play. See the section above. Best for one-shot tasks where you can sit at the terminal.
+2. **`browser.auto_attach_local_chrome: true` (set-and-forget).** Add this to `config.yaml` (or `~/.hermes/config.yaml`) and pre-launch Chrome with `--remote-debugging-port=9222` once. On the next agent loop Hermes probes `http://127.0.0.1:9222/json/version`, finds Chrome, and transparently routes every browser tool call through it — no `/browser connect` step needed. Re-probes every 5 seconds so launching Chrome mid-session also works. Best for personal workstations where you're happy to let Hermes drive your real browser.
+
+   ```yaml
+   # ~/.hermes/config.yaml
+   browser:
+     auto_attach_local_chrome: true
+   ```
+
+   ```bash
+   # One-time, in a separate terminal — Linux
+   google-chrome --remote-debugging-port=9222 \
+     --user-data-dir="$HOME/.hermes/chrome-debug" &
+
+   # macOS
+   open -a "Google Chrome" --args \
+     --remote-debugging-port=9222 \
+     --user-data-dir="$HOME/.hermes/chrome-debug"
+   ```
+
+   **Default is off** because attaching to your real browser means the agent's clicks affect your real tabs. Only flip it on for machines and profiles you're comfortable letting Hermes drive.
+
+3. **Site-specific CLIs.** For some auth-gated services a CLI sidesteps the browser entirely — `gh issue create` / `gh pr create` for GitHub, `gcloud` / `aws` / `az` for cloud consoles. The agent can call these via the terminal tool and they reuse your existing auth (`gh auth login`, `aws configure`, etc.).
+
+Once any of the three is in place the `auth_wall_warning` field stops appearing — the page either renders correctly (CDP attached) or the agent picks a non-browser path (terminal-based CLI).
+
 ### WSL2 + Windows Chrome: prefer MCP over `/browser connect`
 
 If Hermes runs inside WSL2 but the Chrome window you want to control runs on the Windows host, `/browser connect` is often not the best path.


### PR DESCRIPTION
## What does this PR do?

Fixes the "bb-browser cannot fill forms on login-protected pages" report in #24288. When the browser tool navigates to a URL behind a login wall — GitHub Issues "new", Google Workspace, internal dashboards, anything OAuth-gated — the isolated headless session redirects to the sign-in page and the agent gets back a snapshot of an empty login form. The CDP attach workflow (`/browser connect`) has shipped for a while, but neither the user nor the LLM realises it exists at the moment the wall is hit, so the agent retries the URL, tries typing credentials into the form, and finally gives up.

Two layered changes in `tools/browser_tool.py`:

1. **Auth-wall detection in `browser_navigate`.** A pure helper (`_looks_like_auth_wall`) checks the post-redirect URL + page title against a curated list of common login fragments (`/login`, `/signin`, `/oauth/authorize`, `accounts.google.com`, `login.microsoftonline.com`, `"Sign in"`, `"Log in"`, `"Session expired"`, ...). When the heuristic fires AND no CDP override is active, the navigation response gains an `auth_wall_warning` field whose body walks the model through three remediations in priority order:
   1. `/browser connect` — the already-shipped slash command (zero setup).
   2. Launch Chrome with `--remote-debugging-port=9222` + opt into `browser.auto_attach_local_chrome: true` for set-and-forget reuse.
   3. Site-specific CLIs (the issue reporter explicitly called out `gh issue create` for GitHub).
   
   The `browser_navigate` schema description now mentions the field so the model treats it as actionable rather than ignoring an unknown key.

2. **Opt-in auto-attach.** New config flag `browser.auto_attach_local_chrome` (default `false`). When `true`, `_get_cdp_override()` probes `http://127.0.0.1:9222/json/version` once per process (cached for 5 seconds so concurrent tool calls share the result and a stale "Chrome is down" answer self-heals after the user launches Chrome mid-session) and, on success, transparently routes every subsequent browser tool call through the user's live Chrome. Zero-friction equivalent of running `/browser connect` at the start of every session.

   The flag is **default off** on purpose: attaching to the user's real browser means the agent's clicks affect their real tabs, and that's a choice that needs explicit consent. Precedence is stable — `BROWSER_CDP_URL` env var (set by `/browser connect`) > `browser.cdp_url` (persistent config) > opt-in probe > local headless launcher. Existing flows are unaffected.

No behaviour change for users who don't hit auth walls or who haven't opted into auto-attach — both code paths are pure no-ops when their triggers don't fire.

## Related Issue

Fixes #24288

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Commit 1 — `feat(browser): auth-wall hint + opt-in auto-attach to local Chrome (#24288)`**

- `tools/browser_tool.py`:
  - New `_looks_like_auth_wall(url, title) -> bool` — pure heuristic over URL + title fragments. Case-insensitive, None-safe, biased toward firing (false positives are tolerable; false negatives matter).
  - New `_auth_wall_remediation_hint() -> str` — stable module-level remediation copy. Mentions `/browser connect`, `--remote-debugging-port=9222`, `auto_attach_local_chrome`, and the `gh` CLI by name so a refactor that drops one of the workarounds fails an explicit test.
  - New `_probe_local_chrome_cdp(host, port, timeout_s) -> str` — fetches `/json/version` and returns the `webSocketDebuggerUrl` or `""`. Backed by a module-level cache (`_LOCAL_CDP_PROBE_CACHE`) with a 5-second TTL so concurrent tool calls share the result and stale negatives self-heal.
  - `_get_cdp_override()` gains a third tier: when `browser.auto_attach_local_chrome: true` and neither env var nor explicit `browser.cdp_url` is set, the probe result wins. Successful auto-attach caches into `BROWSER_CDP_URL` so subsequent calls short-circuit through the env-override branch.
  - `browser_navigate()` adds an auth-wall block right after the existing bot-detection block: if `_get_cdp_override()` is empty AND `_looks_like_auth_wall()` fires, the response carries `auth_wall_warning` with the remediation hint.
  - `browser_navigate` schema description gains a sentence pointing the model at the new field.
- `cli-config.yaml.example`: new `auto_attach_local_chrome: false` stanza with per-OS launch commands inline and an explicit "default off, opt-in for safety" callout.

**Commit 2 — `test(browser): pin auth-wall hint + auto-attach helpers (#24288)`**

- `tests/tools/test_browser_auth_wall_hint.py` (new, 34 tests, 4 classes):
  - `TestLooksLikeAuthWall` (14) — URL-based detection (GitHub, Google, Microsoft, Okta, GitLab, generic `/auth/login`), title-based detection ("Sign in", "Session expired"), case-insensitivity, None-input safety, documented one-sided false-positive contract.
  - `TestAuthWallRemediationHint` (3) — all three remediations present, "isolated session / cookies" framing surfaces the cause, hint is stable across calls.
  - `TestProbeLocalChromeCdp` (6) — happy path, ConnectionError fallback, positive + negative cache TTL, cache self-heal after TTL, missing `webSocketDebuggerUrl` tolerated.
  - `TestAutoAttachIntegration` (5) — default-off safety, opt-in returns probe result, success caches into env, explicit `cdp_url` wins over probe, `BROWSER_CDP_URL` wins over everything.

**Commit 3 — `test(browser): end-to-end auth-wall warning + bug-shape anchor (#24288)`**

- `tests/tools/test_browser_navigate_auth_wall.py` (new, 10 tests, 4 classes):
  - `TestAuthWallWarningEmitted` (4) — GitHub login redirect, Google signin, Microsoft OAuth, title-only signal.
  - `TestAuthWallWarningSuppressed` (4) — normal pages, docs pages, CDP-attached sessions, failed navs.
  - `TestSchemaMentionsAuthWallField` (1) — schema discoverability.
  - `TestBug24288Repro::test_github_issue_new_login_redirect_surfaces_remediation` (1) — verbatim repro from the issue body. Asserts every named remediation is present in the warning with explicit `"#24288 regression: ..."` messages.

**Commit 4 — `docs(browser): document auth-wall handling + auto-attach flag (#24288)`**

- `website/docs/user-guide/features/browser.md` — new "Working with login-protected pages" subsection right after "Local Chrome via CDP (`/browser connect`)". Explains the isolated-session limitation, the new `auth_wall_warning` field, and the three remediations with per-OS launch commands inline.
- `website/docs/user-guide/configuration.md` — adds `auto_attach_local_chrome: false` to the `browser:` config reference next to the existing `cdp_url` and `dialog_policy` keys.

## How to Test

### Bug repro (proves the fix is required)

```bash
git switch feat/browser-cdp-attach
# Apply the integration test on top of upstream/main without the fix.
git stash -u
git checkout upstream/main -- tools/browser_tool.py
# Re-create the test file from the stash so we can run it against pre-fix code.
git stash show -p --include-untracked stash@{0} > /tmp/auth_wall_test.diff
git apply /tmp/auth_wall_test.diff

# Run the bug-shape anchor — must FAIL with the explicit regression message.
python -m pytest tests/tools/test_browser_navigate_auth_wall.py::TestBug24288Repro -v
#   FAILED  AssertionError: #24288 regression: GitHub login redirect must
#   surface auth_wall_warning -- without it the model retries and the user
#   is stuck

# Restore the fix.
git checkout HEAD -- tools/browser_tool.py
git stash drop
```

### Fix verification

```bash
# Targeted suite — 98 tests, all passing.
python -m pytest \
  tests/tools/test_browser_auth_wall_hint.py \
  tests/tools/test_browser_navigate_auth_wall.py \
  tests/tools/test_browser_chromium_check.py \
  tests/tools/test_browser_cdp_tool.py \
  tests/tools/test_browser_ssrf_local.py \
  tests/cli/test_cli_browser_connect.py
#   ============================ 98 passed in 10.00s =============================

# Ruff clean.
python -m ruff check \
  tools/browser_tool.py \
  tests/tools/test_browser_auth_wall_hint.py \
  tests/tools/test_browser_navigate_auth_wall.py
#   All checks passed!
```

### Manual repro (live, requires a real Hermes session)

1. **Auth-wall hint.** Without `/browser connect`, ask Hermes to "navigate to https://github.com/NousResearch/hermes-agent/issues/new". The browser tool will follow the redirect to `/login` and the response will include `auth_wall_warning`. The model should now relay the three remediations to you instead of trying to type credentials.

2. **Opt-in auto-attach.** Add `browser.auto_attach_local_chrome: true` to `~/.hermes/config.yaml`, then in a separate terminal:
   ```bash
   # macOS
   open -a "Google Chrome" --args --remote-debugging-port=9222 \
     --user-data-dir="$HOME/.hermes/chrome-debug"
   ```
   Log into GitHub in that new Chrome window. Restart `hermes`, ask it to navigate to the same `issues/new` URL — the agent's clicks now happen in your real Chrome window, GitHub recognises you, and the form fills correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(browser):`, `test(browser):`, `docs(browser):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the targeted browser test suite (98 tests pass)
- [x] I've added tests for my changes (44 new tests across two new files + a full-stack bug-shape regression anchor)
- [x] I've tested on my platform: macOS 14 with `requests.get` mocked — the auto-attach probe and auth-wall heuristic both run without touching the network

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/browser.md` — new "Working with login-protected pages" section; `website/docs/user-guide/configuration.md` — new `auto_attach_local_chrome` stanza in the browser config reference)
- [x] I've updated `cli-config.yaml.example` — added the `auto_attach_local_chrome: false` stanza with documented per-OS launch commands
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no workflow changes)
- [x] I've considered cross-platform impact (Windows, macOS) — the probe uses `requests` (cross-platform), and the doc lists Chrome launch commands for Linux, macOS, and PowerShell
- [x] I've updated tool descriptions/schemas — `browser_navigate` schema description now mentions the `auth_wall_warning` field so the model parses it as actionable

## Screenshots / Logs

Bug-shape repro against upstream/main (proves the fix is required):

```
$ python -m pytest tests/tools/test_browser_navigate_auth_wall.py::TestBug24288Repro -v
FAILED tests/tools/test_browser_navigate_auth_wall.py::TestBug24288Repro::test_github_issue_new_login_redirect_surfaces_remediation

E   AssertionError: #24288 regression: GitHub login redirect must surface
E   auth_wall_warning -- without it the model retries and the user is stuck
```

Full suite green on the branch:

```
$ python -m pytest tests/tools/test_browser_auth_wall_hint.py tests/tools/test_browser_navigate_auth_wall.py tests/tools/test_browser_chromium_check.py tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_ssrf_local.py tests/cli/test_cli_browser_connect.py
============================ 98 passed in 10.00s =============================
```

Example response from `browser_navigate` after the fix (no CDP attached, navigated to https://github.com/NousResearch/hermes-agent/issues/new):

```json
{
  "success": true,
  "url": "https://github.com/login?return_to=%2FNousResearch%2Fhermes-agent%2Fissues%2Fnew",
  "title": "Sign in to GitHub - GitHub",
  "auth_wall_warning": "This page looks like a sign-in / authentication wall. The browser tool runs in an isolated session that does NOT share cookies with your real Chrome browser, so logged-in pages redirect to the login screen. To act on this page on the user's behalf, suggest one of:\n  1. /browser connect -- attach Hermes to the user's live Chrome session via Chrome DevTools Protocol so your existing login cookies are reused.\n  2. Launch Chrome with --remote-debugging-port=9222 and either re-run /browser connect or set browser.auto_attach_local_chrome: true in config.yaml so Hermes attaches automatically.\n  3. For GitHub specifically: use the `gh` CLI (gh issue create, gh pr create, gh repo view) via the terminal tool -- it shares the user's gh auth and doesn't need a browser at all."
}
```
