### PR TITLE
fix: avoid CLI resize redraw artifacts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2607,6 +2607,7 @@ class HermesCLI:
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        self._status_bar_suppressed_after_resize = False
         self._resize_recovery_lock = threading.Lock()
         self._resize_recovery_timer = None
         self._resize_recovery_pending = False
@@ -2671,9 +2672,21 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state."""
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
-        _replay_output_history()
+        """Recover a resized classic CLI without replaying output.
+
+        prompt_toolkit's native resize handler erases the active prompt layout,
+        requests the cursor position again, and redraws.  On column shrink, rows
+        that were already on screen can reflow into scrollback before they can be
+        erased.  Drawing a fresh dynamic status bar immediately after that makes
+        the old and new bars appear duplicated.
+
+        Keep this resize path deliberately narrow: suppress only the idle status
+        bar until the next submitted input, then delegate to prompt_toolkit.  Do
+        not clear viewport/scrollback, reset the renderer, or replay output
+        history here; those heavier recovery attempts caused apparent
+        regeneration, missing reply lines, or a missing prompt in smoke tests.
+        """
+        self._status_bar_suppressed_after_resize = True
         original_on_resize()
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:
@@ -2908,10 +2921,29 @@ class HermesCLI:
             width = self._get_tui_terminal_width()
         return width < 64
 
+    @staticmethod
+    def _scrollback_box_width(width: Optional[int] = None) -> int:
+        """Return a resize-safe width for printed scrollback box rules.
+
+        Lines already printed to terminal scrollback are reflowed by the terminal
+        emulator when columns shrink. Full-width response borders printed at a
+        wide size then wrap into repeated-looking horizontal separators after a
+        resize. Keep decorative scrollback boxes intentionally narrower than the
+        viewport; the live TUI footer can still use the full width.
+        """
+        if width is None:
+            try:
+                width = shutil.get_terminal_size((80, 24)).columns
+            except Exception:
+                width = 80
+        return max(32, min(int(width or 80), 56))
+
     def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
         """Return the visible height for the top/bottom input separator rules."""
         if position not in {"top", "bottom"}:
             raise ValueError(f"Unknown input rule position: {position}")
+        if getattr(self, "_status_bar_suppressed_after_resize", False):
+            return 0
         if position == "top":
             return 1
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
@@ -3421,7 +3453,7 @@ class HermesCLI:
         # Open reasoning box on first reasoning token
         if not getattr(self, "_reasoning_box_opened", False):
             self._reasoning_box_opened = True
-            w = shutil.get_terminal_size().columns
+            w = self._scrollback_box_width()
             r_label = " Reasoning "
             r_fill = w - 2 - len(r_label)
             _cprint(f"\n{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}")
@@ -3445,7 +3477,7 @@ class HermesCLI:
             if buf:
                 _cprint(f"{_DIM}{buf}{_RST}")
                 self._reasoning_buf = ""
-            w = shutil.get_terminal_size().columns
+            w = self._scrollback_box_width()
             _cprint(f"{_DIM}└{'─' * (w - 2)}┘{_RST}")
             self._reasoning_box_opened = False
 
@@ -3636,7 +3668,7 @@ class HermesCLI:
                 self._stream_text_ansi = ""
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime('%H:%M')}"
-            w = shutil.get_terminal_size().columns
+            w = self._scrollback_box_width()
             fill = w - 2 - len(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
@@ -3737,7 +3769,7 @@ class HermesCLI:
 
         # Close the response box
         if self._stream_box_opened:
-            w = shutil.get_terminal_size().columns
+            w = self._scrollback_box_width()
             _cprint(f"{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
 
     def _reset_stream_state(self) -> None:
@@ -10332,7 +10364,7 @@ class HermesCLI:
                     nonlocal _streaming_box_opened
                     if not _streaming_box_opened:
                         _streaming_box_opened = True
-                        w = self.console.width
+                        w = self._scrollback_box_width(getattr(self.console, "width", 80))
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
                             label = f"{label}{datetime.now().strftime('%H:%M')} "
@@ -10617,7 +10649,7 @@ class HermesCLI:
             if self.show_reasoning and result and not _reasoning_already_shown:
                 reasoning = result.get("last_reasoning")
                 if reasoning:
-                    w = shutil.get_terminal_size().columns
+                    w = self._scrollback_box_width()
                     r_label = " Reasoning "
                     r_fill = w - 2 - len(r_label)
                     r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
@@ -10648,7 +10680,7 @@ class HermesCLI:
                 already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
                 if use_streaming_tts and _streaming_box_opened and not is_error_response:
                     # Text was already printed sentence-by-sentence; just close the box
-                    w = shutil.get_terminal_size().columns
+                    w = self._scrollback_box_width()
                     _cprint(f"\n{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
                 elif already_streamed:
                     # Response was already streamed token-by-token with box framing;
@@ -10664,8 +10696,8 @@ class HermesCLI:
                         style=_resp_text,
                         box=rich_box.HORIZONTALS,
                         padding=(1, 4),
+                        width=self._scrollback_box_width(),
                     ))
-
 
             # Play terminal bell when agent finishes (if enabled).
             # Works over SSH — the bell propagates to the user's terminal.
@@ -12698,7 +12730,10 @@ class HermesCLI:
                 # guard against any future width mismatch.
                 wrap_lines=False,
             ),
-            filter=Condition(lambda: cli_ref._status_bar_visible),
+            filter=Condition(
+                lambda: cli_ref._status_bar_visible
+                and not getattr(cli_ref, "_status_bar_suppressed_after_resize", False)
+            ),
         )
 
         # Allow wrapper CLIs to register extra keybindings.
@@ -12795,26 +12830,20 @@ class HermesCLI:
         _disable_prompt_toolkit_cpr_warning(app)
         self._app = app  # Store reference for clarify_callback
 
-        # ── Fix ghost status-bar lines on terminal resize ──────────────
-        # When the terminal shrinks (e.g. un-maximize), the emulator reflows
-        # the previously-rendered full-width rows (status bar, input rules)
-        # into multiple narrower rows.  prompt_toolkit's _on_resize handler
-        # only cursor_up()s by the stored layout height, missing the extra
-        # rows created by reflow — leaving ghost duplicates visible.
-        #
-        # It's not just column-shrink: widening, row-shrinking, and
-        # multiplexer-driven SIGWINCH-less redraws (cmux / tmux tab switch)
-        # all produce the same class of drift, where the renderer's tracked
-        # _cursor_pos.y no longer matches terminal reality. The only reliable
-        # recovery is a full screen-clear (\x1b[2J\x1b[H) before the next
-        # redraw, so we force one on every resize rather than trying to
-        # compute the exact drift.
+        # ── Keep prompt_toolkit sane on terminal resize ───────────────
+        # Resize storms can leave prompt_toolkit's cached screen/cursor state
+        # out of sync with the terminal.  Do not clear the viewport/scrollback,
+        # reset before erase, or replay output history here: native
+        # prompt_toolkit resize erases the active prompt layout and redraws it.
+        # Do not add custom clears/replays here; real resize smoke tests showed
+        # they cause apparent regeneration, duplicated bars, missing reply
+        # lines, or a missing prompt. Full replay remains explicit Ctrl+L / /redraw.
         _original_on_resize = app._on_resize
 
-        def _resize_clear_ghosts():
-            self._schedule_resize_recovery(app, _original_on_resize)
+        def _resize_recover_prompt():
+            self._recover_after_resize(app, _original_on_resize)
 
-        app._on_resize = _resize_clear_ghosts
+        app._on_resize = _resize_recover_prompt
 
         def spinner_loop():
             while not self._should_exit:
@@ -12866,6 +12895,8 @@ class HermesCLI:
                     
                     if not user_input:
                         continue
+
+                    self._status_bar_suppressed_after_resize = False
 
                     # Unpack image payload: (text, [Path, ...]) or plain str
                     submit_images = []

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,31 +71,19 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
-        app = MagicMock()
-        out = app.renderer.output
+    def test_resize_uses_native_prompt_toolkit_handler_without_replay(self, bare_cli, monkeypatch):
         events = []
-        out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
-        out.erase_screen.side_effect = lambda: events.append("erase")
-        out.write_raw.side_effect = lambda text: events.append(("raw", text))
-        out.cursor_goto.side_effect = lambda *_: events.append("home")
-        out.flush.side_effect = lambda: events.append("flush")
-        app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
         monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        app = MagicMock()
         original_on_resize = lambda: events.append("original_resize")
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
-        assert events == [
-            "reset_attrs",
-            "erase",
-            ("raw", "\x1b[3J"),
-            "home",
-            "flush",
-            "renderer_reset",
-            "replay",
-            "original_resize",
-        ]
+        assert events == ["original_resize"]
+        assert bare_cli._status_bar_suppressed_after_resize is True
+        app.renderer.output.erase_screen.assert_not_called()
+        app.renderer.output.write_raw.assert_not_called()
+        app.renderer.reset.assert_not_called()
         app.invalidate.assert_not_called()
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -222,6 +222,27 @@ class TestPromptToolkitTerminalCompatibility:
 
         assert renderer.cpr_not_supported_callback is None
 
+    def test_resize_recovery_delegates_to_native_handler_only(self, monkeypatch):
+        """Ordinary terminal resize must not clear/replay/reset outside prompt_toolkit."""
+        cli_obj = _make_cli()
+        import cli as cli_mod
+
+        events = []
+        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        app = MagicMock()
+
+        def original_on_resize():
+            events.append("original_on_resize")
+
+        cli_obj._recover_after_resize(app, original_on_resize)
+
+        assert events == ["original_on_resize"]
+        assert cli_obj._status_bar_suppressed_after_resize is True
+        app.renderer.output.erase_screen.assert_not_called()
+        app.renderer.output.write_raw.assert_not_called()
+        app.renderer.reset.assert_not_called()
+        app.invalidate.assert_not_called()
+
 
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -53,6 +53,12 @@ def _attach_agent(
 
 
 class TestCLIStatusBar:
+    def test_scrollback_box_width_is_resize_safe(self):
+        assert HermesCLI._scrollback_box_width(120) == 56
+        assert HermesCLI._scrollback_box_width(80) == 56
+        assert HermesCLI._scrollback_box_width(60) == 56
+        assert HermesCLI._scrollback_box_width(20) == 32
+
     def test_context_style_thresholds(self):
         cli_obj = _make_cli()
 
@@ -331,6 +337,13 @@ class TestCLIStatusBar:
         assert cli_obj._tui_input_rule_height("top", width=50) == 1
         assert cli_obj._tui_input_rule_height("bottom", width=50) == 0
         assert cli_obj._tui_input_rule_height("bottom", width=90) == 1
+
+    def test_input_rules_hide_after_resize_until_next_input(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_suppressed_after_resize = True
+
+        assert cli_obj._tui_input_rule_height("top", width=90) == 0
+        assert cli_obj._tui_input_rule_height("bottom", width=90) == 0
 
     def test_agent_spacer_reclaimed_on_narrow_terminals(self):
         cli_obj = _make_cli()


### PR DESCRIPTION
## Summary

This fixes a classic CLI resize regression where resizing the terminal could make Hermes appear to regenerate or append old output.

There were two related visual issues:

1. The resize handler was clearing/rebuilding scrollback and replaying output history. On long replies, that looked like the assistant response was being regenerated.
2. After removing replay, terminal resize could still leave stale footer/status/input-rule rows behind. On vertical resize especially, full-width horizontal rules were redrawn into scrollback and appeared to append repeatedly.

## What changed

- Stop replaying output history on normal terminal resize.
- Delegate resize recovery to prompt_toolkit's native resize handler instead of custom full-screen clears.
- Suppress idle status bar and input separator rules after resize; restore them on the next submitted input.
- Cap printed scrollback response/reasoning box separators to a conservative width so already-printed decorative rules do not wrap badly when a wide terminal is later narrowed.
- Keep full replay/clear behavior reserved for explicit recovery paths like `/redraw` / Ctrl+L.

## Why this approach

The key distinction is between live TUI chrome and already-printed scrollback:

- Normal resize should only repaint the live prompt area.
- It should not replay the conversation transcript.
- It should not clear the user's scrollback.
- Decorative full-width lines printed into scrollback should avoid depending on the current terminal width, because terminals reflow those lines when resized.

This trades a tiny bit of post-resize chrome polish for correctness: immediately after resizing, the idle prompt is plainer until the next input, but it no longer stamps duplicate horizontal lines.

## Test plan

- `git diff --check`
- `python -m pytest tests/cli/test_cli_status_bar.py tests/cli/test_cli_force_redraw.py tests/cli/test_cli_init.py -q -o 'addopts='`
- `python -m pytest tests/cli -q -o 'addopts='`
- Manual tmux smoke tests:
  - start a fresh Hermes session
  - ask for multi-line output
  - resize horizontally and vertically
  - verify output is not replayed/regenerated
  - verify stale status/rule rows are not appended repeatedly
  - verify prompt remains usable after resize

Result: full CLI suite passed locally: 670 passed, 1 pre-existing warning.
