### PR TITLE
fix(auth): skip source suppression when sibling pool entries share it

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -461,7 +461,20 @@ def auth_remove_command(args) -> None:
     for line in result.cleaned:
         print(line)
     if result.suppress:
-        suppress_credential_source(provider, removed.source)
+        # Only suppress when no remaining pool entries share this source.
+        # Multiple credentials commonly share a source tag (e.g. every
+        # device-code OAuth add becomes "manual:device_code"), so
+        # suppressing on a single removal silently gags the survivors.
+        remaining = pool.entries()
+        has_siblings = any(e.source == removed.source for e in remaining)
+        if not has_siblings:
+            suppress_credential_source(provider, removed.source)
+        else:
+            # Remove hints about suppression when we deliberately skip it.
+            result.hints = [
+                h for h in result.hints
+                if "re-seed" not in h.lower() and "suppress" not in h.lower()
+            ]
     for line in result.hints:
         print(line)
 


### PR DESCRIPTION
## Problem

`hermes auth remove` unconditionally calls `suppress_credential_source()` on the removed entry's source tag. But multiple pool entries commonly share the same source (e.g. every manual OAuth add becomes `manual:device_code`). Removing one credential silently suppresses the source for all survivors, causing them to be dropped on the next fresh pool load.

## Fix

Check remaining pool entries before suppressing — only suppress when no siblings depend on the same source. When siblings exist, filter out misleading "will not be re-seeded" hints from the output.

## Changes

- `hermes_cli/auth_commands.py`: Add sibling check before `suppress_credential_source()`

Fixes #24390