### PR TITLE
fix(agent): adjacency-aware tool-message orphan detection

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1129,23 +1129,33 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         This method removes orphaned results and inserts stub results for
         orphaned calls so the message list is always well-formed.
         """
-        surviving_call_ids: set = set()
+        # --- Adjacency-aware orphan detection ---
+        # A tool result is only valid when it immediately follows (possibly
+        # after other tool results) the assistant message that owns its
+        # tool_call_id.  A non-assistant, non-tool message breaks the chain.
+        active_call_ids: set = set()
+        orphaned_results: set = set()
+        all_result_call_ids: set = set()
         for msg in messages:
-            if msg.get("role") == "assistant":
+            role = msg.get("role")
+            if role == "assistant":
+                call_ids = set()
                 for tc in msg.get("tool_calls") or []:
                     cid = self._get_tool_call_id(tc)
                     if cid:
-                        surviving_call_ids.add(cid)
-
-        result_call_ids: set = set()
-        for msg in messages:
-            if msg.get("role") == "tool":
+                        call_ids.add(cid)
+                if call_ids:
+                    active_call_ids = call_ids
+            elif role == "tool":
                 cid = msg.get("tool_call_id")
                 if cid:
-                    result_call_ids.add(cid)
+                    all_result_call_ids.add(cid)
+                    if cid not in active_call_ids:
+                        orphaned_results.add(cid)
+            else:
+                active_call_ids = set()
 
-        # 1. Remove tool results whose call_id has no matching assistant tool_call
-        orphaned_results = result_call_ids - surviving_call_ids
+        # 1. Remove orphaned tool results
         if orphaned_results:
             messages = [
                 m for m in messages
@@ -1154,8 +1164,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if not self.quiet_mode:
                 logger.info("Compression sanitizer: removed %d orphaned tool result(s)", len(orphaned_results))
 
+        # Rebuild surviving_call_ids from the filtered message list
+        surviving_call_ids: set = set()
+        for msg in messages:
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    cid = self._get_tool_call_id(tc)
+                    if cid:
+                        surviving_call_ids.add(cid)
+
         # 2. Add stub results for assistant tool_calls whose results were dropped
-        missing_results = surviving_call_ids - result_call_ids
+        missing_results = surviving_call_ids - all_result_call_ids
         if missing_results:
             patched: List[Dict[str, Any]] = []
             for msg in messages:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6011,23 +6011,44 @@ class AIAgent:
             filtered.append(msg)
         messages = filtered
 
-        surviving_call_ids: set = set()
+        # --- Adjacency-aware orphan detection ---
+        # A tool result is only valid when it immediately follows (possibly
+        # after other tool results) the assistant message that owns its
+        # tool_call_id.  A non-assistant, non-tool message (user, system,
+        # etc.) breaks the chain, so we track the *active* set of call_ids
+        # from the most recent assistant and reset it on any gap.  This
+        # catches the Moonshot/Kimi strict-adjacency requirement and
+        # prevents tool results from dangling after thinking-only drops.
+        active_call_ids: set = set()
+        orphaned_results: set = set()
+        all_result_call_ids: set = set()
         for msg in messages:
-            if msg.get("role") == "assistant":
+            role = msg.get("role")
+            if role == "assistant":
+                # Build active set from this assistant's tool_calls
+                call_ids = set()
                 for tc in msg.get("tool_calls") or []:
                     cid = AIAgent._get_tool_call_id_static(tc)
                     if cid:
-                        surviving_call_ids.add(cid)
-
-        result_call_ids: set = set()
-        for msg in messages:
-            if msg.get("role") == "tool":
+                        call_ids.add(cid)
+                if call_ids:
+                    # New assistant with tool_calls — this becomes the
+                    # active set (replaces any previous one).
+                    active_call_ids = call_ids
+                # If no tool_calls, don't reset active_call_ids — the
+                # assistant might be a thinking-only turn that will be
+                # dropped later; its predecessor's calls are still valid
+                # if the turn is dropped.
+            elif role == "tool":
                 cid = msg.get("tool_call_id")
                 if cid:
-                    result_call_ids.add(cid)
+                    all_result_call_ids.add(cid)
+                    if cid not in active_call_ids:
+                        orphaned_results.add(cid)
+            else:
+                # user, system, function, developer — breaks adjacency
+                active_call_ids = set()
 
-        # 1. Drop tool results with no matching assistant call
-        orphaned_results = result_call_ids - surviving_call_ids
         if orphaned_results:
             messages = [
                 m for m in messages
@@ -6038,8 +6059,17 @@ class AIAgent:
                 len(orphaned_results),
             )
 
+        # Rebuild surviving_call_ids from the filtered message list
+        surviving_call_ids: set = set()
+        for msg in messages:
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    cid = AIAgent._get_tool_call_id_static(tc)
+                    if cid:
+                        surviving_call_ids.add(cid)
+
         # 2. Inject stub results for calls whose result was dropped
-        missing_results = surviving_call_ids - result_call_ids
+        missing_results = surviving_call_ids - all_result_call_ids
         if missing_results:
             patched: List[Dict[str, Any]] = []
             for msg in messages:


### PR DESCRIPTION
## Problem

The previous sanitizer used a global set check: collect all `tool_call_id`s from ALL assistant messages, then drop tool messages not in that set. This is insufficient for strict providers (Moonshot/Kimi) that require tool results to immediately follow their owning assistant message.

When a thinking-only assistant turn is dropped, or a compressor boundary shift leaves a tool result after a non-assistant message, the tool result was kept but the provider rejected it.

## Fix

Replace the global set check with a forward-pass that tracks the active set of `tool_call_id`s from the most recent assistant. Any non-assistant, non-tool message resets the active set.

## Changes

- `run_agent.py`: `_sanitize_api_messages()`
- `agent/context_compressor.py`: `_sanitize_tool_pairs()`

Fixes #24328