### PR TITLE
fix(agent): strip thinking blocks from content arrays on signature recovery

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -13553,18 +13553,27 @@ class AIAgent:
                     # ── Thinking block signature recovery ─────────────────
                     # Anthropic signs thinking blocks against the full turn
                     # content.  Any upstream mutation (context compression,
-                    # session truncation, message merging) invalidates the
-                    # signature → HTTP 400.  Recovery: strip reasoning_details
-                    # from all messages so the next retry sends no thinking
-                    # blocks at all.  One-shot — don't retry infinitely.
+                    # session truncation, message merging) or cross-provider
+                    # model switch (e.g. MiniMax → Anthropic) invalidates the
+                    # signature → HTTP 400.  Recovery: strip ALL thinking/
+                    # redacted_thinking blocks from assistant message content
+                    # arrays so the next retry sends no thinking blocks at all.
+                    # One-shot — don't retry infinitely.
                     if (
                         classified.reason == FailoverReason.thinking_signature
                         and not thinking_sig_retry_attempted
                     ):
                         thinking_sig_retry_attempted = True
+                        _THINKING_TYPES = ("thinking", "redacted_thinking")
                         for _m in messages:
-                            if isinstance(_m, dict):
-                                _m.pop("reasoning_details", None)
+                            if not isinstance(_m, dict):
+                                continue
+                            _m.pop("reasoning_details", None)
+                            if _m.get("role") == "assistant" and isinstance(_m.get("content"), list):
+                                _m["content"] = [
+                                    _b for _b in _m["content"]
+                                    if not (isinstance(_b, dict) and _b.get("type") in _THINKING_TYPES)
+                                ] or [{"type": "text", "text": "(thinking elided)"}]
                         self._vprint(
                             f"{self.log_prefix}⚠️  Thinking block signature invalid — "
                             f"stripped all thinking blocks, retrying...",
@@ -13572,7 +13581,7 @@ class AIAgent:
                         )
                         logging.warning(
                             "%sThinking block signature recovery: stripped "
-                            "reasoning_details from %d messages",
+                            "thinking blocks from %d messages",
                             self.log_prefix, len(messages),
                         )
                         continue

--- a/tests/agent/test_thinking_signature_recovery.py
+++ b/tests/agent/test_thinking_signature_recovery.py
@@ -1,0 +1,129 @@
+"""Regression tests for thinking block signature recovery (issue #24401).
+
+When switching from a provider that emits thinking blocks (e.g. MiniMax via
+Anthropic transport) to Anthropic proper, the thinking block signatures from
+the previous provider are invalid.  The recovery path must strip thinking
+blocks from assistant message *content* arrays, not just the top-level
+``reasoning_details`` field — otherwise ``convert_messages_to_anthropic`` on
+the retry keeps the signed blocks from the last assistant message and the
+API rejects them again with the same HTTP 400.
+"""
+
+import pytest
+
+
+class TestThinkingSignatureRecovery:
+    """Verify that the thinking-signature recovery strips content blocks."""
+
+    @staticmethod
+    def _simulate_recovery(messages: list) -> None:
+        """Replay the recovery logic from run_agent.py (thinking_signature branch)."""
+        _THINKING_TYPES = ("thinking", "redacted_thinking")
+        for _m in messages:
+            if not isinstance(_m, dict):
+                continue
+            _m.pop("reasoning_details", None)
+            if _m.get("role") == "assistant" and isinstance(_m.get("content"), list):
+                _m["content"] = [
+                    _b for _b in _m["content"]
+                    if not (isinstance(_b, dict) and _b.get("type") in _THINKING_TYPES)
+                ] or [{"type": "text", "text": "(thinking elided)"}]
+
+    def test_strips_thinking_from_content_array(self):
+        """Thinking blocks in assistant content arrays must be removed."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Let me think...", "signature": "miniMaxSig123"},
+                    {"type": "text", "text": "Here is my answer."},
+                ],
+            },
+        ]
+        self._simulate_recovery(messages)
+        assistant = messages[1]
+        assert len(assistant["content"]) == 1
+        assert assistant["content"][0]["type"] == "text"
+        assert assistant["content"][0]["text"] == "Here is my answer."
+
+    def test_strips_redacted_thinking_from_content(self):
+        """Redacted thinking blocks must also be stripped."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": "encrypted_stuff"},
+                    {"type": "text", "text": "Response."},
+                ],
+            },
+        ]
+        self._simulate_recovery(messages)
+        assert len(messages[1]["content"]) == 1
+        assert messages[1]["content"][0]["type"] == "text"
+
+    def test_all_thinking_stripped_leaves_placeholder(self):
+        """When all content was thinking, a placeholder is inserted."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Only thinking, no text.", "signature": "sig"},
+                ],
+            },
+        ]
+        self._simulate_recovery(messages)
+        assert len(messages[1]["content"]) == 1
+        assert messages[1]["content"][0]["type"] == "text"
+        assert "thinking elided" in messages[1]["content"][0]["text"]
+
+    def test_strips_reasoning_details_field(self):
+        """The legacy reasoning_details field is also removed."""
+        messages = [
+            {"role": "assistant", "content": "text", "reasoning_details": [{"type": "reasoning"}]},
+        ]
+        self._simulate_recovery(messages)
+        assert "reasoning_details" not in messages[0]
+
+    def test_does_not_touch_user_messages(self):
+        """User messages are left untouched."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        ]
+        self._simulate_recovery(messages)
+        assert len(messages[0]["content"]) == 1
+
+    def test_multiple_assistant_messages_all_stripped(self):
+        """Thinking blocks in ALL assistant messages are stripped, not just the last."""
+        messages = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "old think", "signature": "old_sig"},
+                    {"type": "text", "text": "old answer"},
+                ],
+            },
+            {"role": "user", "content": "q2"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "new think", "signature": "new_sig"},
+                    {"type": "text", "text": "new answer"},
+                ],
+            },
+        ]
+        self._simulate_recovery(messages)
+        # Both assistant messages should have thinking stripped
+        assert messages[1]["content"] == [{"type": "text", "text": "old answer"}]
+        assert messages[3]["content"] == [{"type": "text", "text": "new answer"}]
+
+    def test_string_content_untouched(self):
+        """Assistant messages with string content (not list) are not modified."""
+        messages = [
+            {"role": "assistant", "content": "plain text"},
+        ]
+        self._simulate_recovery(messages)
+        assert messages[0]["content"] == "plain text"


### PR DESCRIPTION
## What does this PR do?

The thinking-signature recovery path only stripped the top-level `reasoning_details` field from messages, but Anthropic thinking blocks live inside assistant message `content` arrays. After recovery, `convert_messages_to_anthropic()` on the retry kept the signed thinking blocks from the last assistant message, causing the same HTTP 400 "Invalid signature in thinking block" error on every retry attempt.


### Root Cause

When a user switches from a provider that emits thinking blocks with its own signatures (e.g. MiniMax via Anthropic transport) to Anthropic proper, the message history contains thinking blocks with MiniMax-specific signatures. Anthropic rejects these with HTTP 400. The recovery code at `run_agent.py` (thinking_signature branch) only did:

```python
_m.pop("reasoning_details", None)
```

But the thinking blocks are in `_m["content"]` as a list of content blocks, not in `reasoning_details`. After the `continue`, the retry goes through `convert_messages_to_anthropic()` which re-processes messages and keeps signed thinking blocks from the last assistant message — the same invalid signatures that caused the original error.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A