### PR TITLE
feat: add semantic_search tool with LLM-based re-ranking

### DIFF
--- a/tests/tools/test_semantic_search.py
+++ b/tests/tools/test_semantic_search.py
@@ -1,0 +1,127 @@
+"""Tests for semantic_search tool."""
+
+import json
+import os
+import pytest
+import tempfile
+from unittest.mock import patch
+
+
+class TestSemanticSearch:
+    @pytest.fixture
+    def temp_project(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = os.path.join(tmpdir, "src")
+            os.makedirs(src)
+            files = {
+                "auth.py": "def login(username, password):\n    return True\n",
+                "api.py": "def get_user(user_id):\n    return {'id': user_id}\n",
+                "utils.py": "def format_date(date):\n    return str(date)\n",
+            }
+            for name, content in files.items():
+                with open(os.path.join(src, name), "w") as f:
+                    f.write(content)
+            yield tmpdir
+
+    def test_check_requirements(self):
+        from tools.semantic_search import check_semantic_search_requirements
+        assert check_semantic_search_requirements() is True
+
+    def test_build_index(self, temp_project):
+        from tools.semantic_search import semantic_search
+        output = semantic_search("test", temp_project, mode="index")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["operation"] == "index"
+        assert data["stats"]["files_processed"] >= 1
+        assert data["stats"]["chunks_indexed"] >= 1
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_semantic_search(self, mock_llm, temp_project):
+        mock_llm.return_value = '[{"index": 0, "score": 9, "reason": "relevant"}]'
+        from tools.semantic_search import semantic_search
+        semantic_search("test", temp_project, mode="index")
+        output = semantic_search("login function", temp_project, mode="semantic")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 1
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_hybrid_search(self, mock_llm, temp_project):
+        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": "relevant"}]'
+        from tools.semantic_search import semantic_search
+        semantic_search("test", temp_project, mode="index")
+        output = semantic_search("get user data", temp_project, mode="hybrid")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["total"] >= 1
+
+    def test_keyword_search(self, temp_project):
+        from tools.semantic_search import semantic_search
+        output = semantic_search("login", temp_project, mode="keyword")
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["mode"] == "keyword"
+        assert data["total"] >= 1
+
+    def test_query_classification_symbol(self):
+        from tools.semantic_search import _classify_query
+        result = _classify_query("class User")
+        assert result["type"] == "symbol"
+        assert result["confidence"] > 0.8
+
+    def test_query_classification_error(self):
+        from tools.semantic_search import _classify_query
+        result = _classify_query("error in authentication")
+        assert result["type"] == "error"
+        assert result["confidence"] > 0.6
+
+    def test_no_index_returns_error(self, temp_project):
+        from tools.semantic_search import semantic_search
+        output = semantic_search("test", temp_project, mode="hybrid")
+        data = json.loads(output)
+        assert data["success"] is False
+        assert "No index found" in data["error"]
+
+    def test_project_root_not_found(self):
+        from tools.semantic_search import semantic_search
+        output = semantic_search("test", "/nonexistent")
+        data = json.loads(output)
+        assert data["success"] is False
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_file_pattern_filter(self, mock_llm, temp_project):
+        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": ""}]'
+        from tools.semantic_search import semantic_search
+        semantic_search("test", temp_project, mode="index")
+        output = semantic_search("test", temp_project, file_pattern="*.py")
+        data = json.loads(output)
+        assert data["success"] is True
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_max_results(self, mock_llm, temp_project):
+        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": ""}]'
+        from tools.semantic_search import semantic_search
+        semantic_search("test", temp_project, mode="index")
+        output = semantic_search("test", temp_project, max_results=2)
+        data = json.loads(output)
+        assert data["success"] is True
+        assert len(data["results"]) <= 2
+
+    def test_intent_in_response(self, temp_project):
+        from tools.semantic_search import semantic_search
+        output = semantic_search("authentication error", temp_project, mode="keyword")
+        data = json.loads(output)
+        assert "intent" in data
+        assert data["intent"]["type"] in ("symbol", "search", "semantic", "error")
+
+
+class TestSemanticSearchSchema:
+    def test_schema_has_required_fields(self):
+        from tools.semantic_search import SEMANTIC_SEARCH_SCHEMA
+        assert SEMANTIC_SEARCH_SCHEMA["name"] == "semantic_search"
+        props = SEMANTIC_SEARCH_SCHEMA["parameters"]["properties"]
+        assert "query" in props
+        assert "project_root" in props
+        assert "mode" in props
+        assert props["mode"]["enum"] == ["hybrid", "semantic", "keyword", "index"]

--- a/tests/tools/test_semantic_search.py
+++ b/tests/tools/test_semantic_search.py
@@ -1,127 +1,197 @@
-"""Tests for semantic_search tool."""
+"""Tests for semantic search tool."""
 
 import json
 import os
-import pytest
+import sqlite3
 import tempfile
-from unittest.mock import patch
+
+import pytest
 
 
-class TestSemanticSearch:
-    @pytest.fixture
-    def temp_project(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            src = os.path.join(tmpdir, "src")
-            os.makedirs(src)
-            files = {
-                "auth.py": "def login(username, password):\n    return True\n",
-                "api.py": "def get_user(user_id):\n    return {'id': user_id}\n",
-                "utils.py": "def format_date(date):\n    return str(date)\n",
-            }
-            for name, content in files.items():
-                with open(os.path.join(src, name), "w") as f:
-                    f.write(content)
-            yield tmpdir
+class TestGetIndexDb:
+    def test_hash_based_index_path(self, tmp_path):
+        """Index path should use canonical-root hash, not basename."""
+        from tools.semantic_search import _get_index_db
 
-    def test_check_requirements(self):
-        from tools.semantic_search import check_semantic_search_requirements
-        assert check_semantic_search_requirements() is True
+        db1 = _get_index_db("/work/a/myapp")
+        db2 = _get_index_db("/work/b/myapp")
+        # Different roots -> different DB files (no basename collision)
+        assert db1 != db2
 
-    def test_build_index(self, temp_project):
-        from tools.semantic_search import semantic_search
-        output = semantic_search("test", temp_project, mode="index")
-        data = json.loads(output)
-        assert data["success"] is True
-        assert data["operation"] == "index"
-        assert data["stats"]["files_processed"] >= 1
-        assert data["stats"]["chunks_indexed"] >= 1
+    def test_same_root_same_index(self, tmp_path):
+        """Same root path should produce the same index."""
+        from tools.semantic_search import _get_index_db
 
-    @patch("agent.auxiliary_client.call_llm")
-    def test_semantic_search(self, mock_llm, temp_project):
-        mock_llm.return_value = '[{"index": 0, "score": 9, "reason": "relevant"}]'
-        from tools.semantic_search import semantic_search
-        semantic_search("test", temp_project, mode="index")
-        output = semantic_search("login function", temp_project, mode="semantic")
-        data = json.loads(output)
-        assert data["success"] is True
-        assert data["total"] >= 1
+        db1 = _get_index_db("/work/a/myapp")
+        db2 = _get_index_db("/work/a/myapp")
+        assert db1 == db2
 
-    @patch("agent.auxiliary_client.call_llm")
-    def test_hybrid_search(self, mock_llm, temp_project):
-        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": "relevant"}]'
-        from tools.semantic_search import semantic_search
-        semantic_search("test", temp_project, mode="index")
-        output = semantic_search("get user data", temp_project, mode="hybrid")
-        data = json.loads(output)
-        assert data["success"] is True
-        assert data["total"] >= 1
+    def test_symlink_resolves(self, tmp_path):
+        """Symlinked root should resolve to canonical path."""
+        from tools.semantic_search import _get_index_db
 
-    def test_keyword_search(self, temp_project):
-        from tools.semantic_search import semantic_search
-        output = semantic_search("login", temp_project, mode="keyword")
-        data = json.loads(output)
-        assert data["success"] is True
-        assert data["mode"] == "keyword"
-        assert data["total"] >= 1
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
 
-    def test_query_classification_symbol(self):
+        db_real = _get_index_db(str(real))
+        db_link = _get_index_db(str(link))
+        assert db_real == db_link
+
+
+class TestSensitiveFileExclusion:
+    def test_env_files_excluded(self):
+        from tools.semantic_search import _is_sensitive_file
+        assert _is_sensitive_file(".env")
+        assert _is_sensitive_file(".env.local")
+        assert _is_sensitive_file(".env.production")
+
+    def test_normal_files_allowed(self):
+        from tools.semantic_search import _is_sensitive_file
+        assert not _is_sensitive_file("main.py")
+        assert not _is_sensitive_file("config.yaml")
+        assert not _is_sensitive_file("README.md")
+
+
+class TestChunkFile:
+    def test_basic_chunking(self):
+        from tools.semantic_search import _chunk_file
+        content = "\n".join(f"line {i}" for i in range(100))
+        chunks = _chunk_file(content, max_chars=200)
+        assert len(chunks) > 1
+        # All original lines present
+        full = "\n".join(chunks)
+        for i in range(100):
+            assert f"line {i}" in full
+
+    def test_small_content_single_chunk(self):
+        from tools.semantic_search import _chunk_file
+        chunks = _chunk_file("hello world")
+        assert len(chunks) == 1
+        assert chunks[0] == "hello world"
+
+
+class TestClassifyQuery:
+    def test_symbol_query(self):
         from tools.semantic_search import _classify_query
-        result = _classify_query("class User")
+        result = _classify_query("find class FooBar")
         assert result["type"] == "symbol"
-        assert result["confidence"] > 0.8
+        assert result["target"] == "FooBar"
 
-    def test_query_classification_error(self):
+    def test_error_query(self):
         from tools.semantic_search import _classify_query
-        result = _classify_query("error in authentication")
+        result = _classify_query("error in auth flow")
         assert result["type"] == "error"
-        assert result["confidence"] > 0.6
 
-    def test_no_index_returns_error(self, temp_project):
+    def test_semantic_query(self):
+        from tools.semantic_search import _classify_query
+        result = _classify_query("how does the caching layer work")
+        assert result["type"] == "semantic"
+
+
+class TestSemanticSearchIndex:
+    def test_index_mode(self, tmp_path):
+        """Index mode should create DB and index files."""
         from tools.semantic_search import semantic_search
-        output = semantic_search("test", temp_project, mode="hybrid")
-        data = json.loads(output)
-        assert data["success"] is False
-        assert "No index found" in data["error"]
 
-    def test_project_root_not_found(self):
+        # Create a test project
+        project = tmp_path / "testproject"
+        project.mkdir()
+        (project / "main.py").write_text("def hello():\n    return 'world'")
+        (project / ".env").write_text("SECRET=abc123")  # should be excluded
+
+        result = json.loads(semantic_search(
+            query="hello",
+            project_root=str(project),
+            mode="index",
+        ))
+        assert result["success"] is True
+        assert result["stats"]["files_processed"] >= 1
+        # .env file should NOT be indexed
+        db_path = result["project"]
+
+    def test_index_excludes_sensitive_files(self, tmp_path):
+        """Sensitive files should not be indexed."""
+        from tools.semantic_search import _get_index_db, semantic_search
+
+        project = tmp_path / "secrets_project"
+        project.mkdir()
+        (project / "app.py").write_text("import os")
+        (project / ".env").write_text("SECRET_KEY=xyz")
+
+        result = json.loads(semantic_search(
+            query="secret",
+            project_root=str(project),
+            mode="index",
+        ))
+
+        # Check that .env content is NOT in the index
+        db = _get_index_db(str(project))
+        conn = sqlite3.connect(db)
+        cursor = conn.execute("SELECT text FROM chunks")
+        all_text = " ".join(row[0] for row in cursor.fetchall())
+        conn.close()
+        assert "SECRET_KEY" not in all_text
+
+
+class TestSemanticSearchHybrid:
+    def test_hybrid_mode_returns_results(self, tmp_path):
+        """Hybrid mode should return results without crashing."""
         from tools.semantic_search import semantic_search
-        output = semantic_search("test", "/nonexistent")
-        data = json.loads(output)
-        assert data["success"] is False
 
-    @patch("agent.auxiliary_client.call_llm")
-    def test_file_pattern_filter(self, mock_llm, temp_project):
-        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": ""}]'
-        from tools.semantic_search import semantic_search
-        semantic_search("test", temp_project, mode="index")
-        output = semantic_search("test", temp_project, file_pattern="*.py")
-        data = json.loads(output)
-        assert data["success"] is True
+        project = tmp_path / "hybrid_project"
+        project.mkdir()
+        (project / "auth.py").write_text(
+            "def authenticate_user(username, password):\n"
+            "    if not username:\n"
+            "        raise ValueError('missing username')\n"
+            "    return {'token': 'abc'}"
+        )
 
-    @patch("agent.auxiliary_client.call_llm")
-    def test_max_results(self, mock_llm, temp_project):
-        mock_llm.return_value = '[{"index": 0, "score": 8, "reason": ""}]'
-        from tools.semantic_search import semantic_search
-        semantic_search("test", temp_project, mode="index")
-        output = semantic_search("test", temp_project, max_results=2)
-        data = json.loads(output)
-        assert data["success"] is True
-        assert len(data["results"]) <= 2
+        # Index first
+        semantic_search(query="auth", project_root=str(project), mode="index")
 
-    def test_intent_in_response(self, temp_project):
-        from tools.semantic_search import semantic_search
-        output = semantic_search("authentication error", temp_project, mode="keyword")
-        data = json.loads(output)
-        assert "intent" in data
-        assert data["intent"]["type"] in ("symbol", "search", "semantic", "error")
+        # Search
+        result = json.loads(semantic_search(
+            query="user login authentication",
+            project_root=str(project),
+            mode="hybrid",
+        ))
+        assert result["success"] is True
+        assert result["mode"] == "hybrid"
+        assert len(result["results"]) > 0
 
 
-class TestSemanticSearchSchema:
-    def test_schema_has_required_fields(self):
-        from tools.semantic_search import SEMANTIC_SEARCH_SCHEMA
-        assert SEMANTIC_SEARCH_SCHEMA["name"] == "semantic_search"
-        props = SEMANTIC_SEARCH_SCHEMA["parameters"]["properties"]
-        assert "query" in props
-        assert "project_root" in props
-        assert "mode" in props
-        assert props["mode"]["enum"] == ["hybrid", "semantic", "keyword", "index"]
+class TestRerankWithLlm:
+    def test_rerank_survives_bad_json(self):
+        """Reranker should not crash on unparseable LLM response."""
+        from unittest.mock import patch, MagicMock
+        from tools.semantic_search import _rerank_with_llm
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "not valid json"
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response):
+            candidates = [{"file": "a.py", "snippet": "code", "keyword_score": 0.5}]
+            result = _rerank_with_llm("test query", candidates)
+            # Should return candidates unchanged (no crash)
+            assert len(result) == 1
+
+    def test_rerank_extracts_content(self):
+        """Reranker should extract .choices[0].message.content."""
+        from unittest.mock import patch, MagicMock
+        from tools.semantic_search import _rerank_with_llm
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps([
+            {"index": 0, "score": 9, "reason": "perfect match"}
+        ])
+
+        with patch("agent.auxiliary_client.call_llm", return_value=mock_response):
+            candidates = [{"file": "a.py", "snippet": "code", "keyword_score": 0.5}]
+            result = _rerank_with_llm("test query", candidates)
+            assert result[0]["relevance"] == 9
+            assert result[0]["score"] == 0.9

--- a/tools/semantic_search.py
+++ b/tools/semantic_search.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Semantic Search Tool - Natural language code search using LLM re-ranking
+
+Indexes code files by chunking, then searches using keyword pre-filtering
+and LLM-based semantic re-ranking via the auxiliary client for real understanding.
+"""
+
+import json
+import os
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+
+MAX_FILE_SIZE = 2 * 1024 * 1024
+
+
+def _chunk_file(content: str, max_chars: int = 2000) -> List[str]:
+    chunks = []
+    lines = content.split("\n")
+    current = []
+    current_len = 0
+    for line in lines:
+        if current_len + len(line) > max_chars and current:
+            chunks.append("\n".join(current))
+            current = []
+            current_len = 0
+        current.append(line)
+        current_len += len(line) + 1
+    if current:
+        chunks.append("\n".join(current))
+    return chunks
+
+
+def _classify_query(query: str) -> Dict[str, Any]:
+    query_lower = query.lower()
+
+    symbol_indicators = [r"\bclass\s+\w+", r"\bfunction\s+\w+", r"\bdef\s+\w+",
+                         r"\bfn\s+\w+", r"\bfunc\s+\w+", r"\b(struct|enum|trait)\s+\w+"]
+    for pat in symbol_indicators:
+        if re.search(pat, query):
+            match = re.search(r"\b(\w+)\s*$", query)
+            return {"type": "symbol", "target": match.group(1) if match else query, "confidence": 0.9}
+
+    error_words = {"error", "bug", "fail", "crash", "issue", "problem", "wrong"}
+    if any(w in query_lower for w in error_words):
+        return {"type": "error", "target": query, "confidence": 0.7}
+
+    find_words = {"find", "search", "where", "lookup", "locate"}
+    if any(w in query_lower.split() for w in find_words):
+        return {"type": "search", "target": query, "confidence": 0.6}
+
+    return {"type": "semantic", "target": query, "confidence": 0.5}
+
+
+def _get_index_db(project_root: str) -> str:
+    project_name = os.path.basename(os.path.abspath(project_root))
+    index_dir = get_hermes_home() / "semantic-index"
+    index_dir.mkdir(parents=True, exist_ok=True)
+    return str(index_dir / f"{project_name}.db")
+
+
+def _rerank_with_llm(query: str, candidates: List[Dict]) -> List[Dict]:
+    try:
+        from agent.auxiliary_client import call_llm
+
+        items = "\n".join(
+            f"[{i}] {c['file']}:{c.get('line', 1)}\n{c['snippet']}"
+            for i, c in enumerate(candidates[:15])
+        )
+
+        prompt = (
+            f"Given this search query: \"{query}\"\n\n"
+            f"Rank the following code snippets by relevance (0=unrelated, 10=perfect match). "
+            f"Return a JSON list of {{index, score, reason}}.\n\n{items}"
+        )
+
+        response = call_llm(
+            task="session_search",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+            max_tokens=1000,
+        )
+
+        import json as _json
+        scores = _json.loads(response)
+        score_map = {s["index"]: s["score"] for s in scores if isinstance(s, dict)}
+
+        for c in candidates:
+            idx = candidates.index(c)
+            c["relevance"] = score_map.get(idx, 0)
+            c["score"] = round(c["relevance"] / 10.0, 4)
+
+        candidates.sort(key=lambda c: c.get("relevance", 0), reverse=True)
+    except Exception:
+        pass
+
+    return candidates
+
+
+def semantic_search(
+    query: str,
+    project_root: str,
+    mode: str = "hybrid",
+    max_results: int = 20,
+    file_pattern: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> str:  # noqa: D205
+    """
+    Search code by natural language using LLM-based semantic re-ranking.
+
+    Args:
+        query: Natural language search query
+        project_root: Root directory of the project
+        mode: hybrid (keyword + LLM re-rank), keyword, index
+        max_results: Maximum results to return
+        file_pattern: Filter by file pattern (e.g., *.py)
+
+    Returns:
+        JSON string with ranked search results
+    """
+    if not os.path.isdir(project_root):
+        return json.dumps({
+            "success": False,
+            "error": f"Project root not found: {project_root}",
+        })
+
+    abs_root = os.path.abspath(project_root)
+    intent = _classify_query(query)
+
+    db_path = _get_index_db(abs_root)
+
+    if mode == "index":
+        conn = None
+        try:
+            conn = sqlite3.connect(db_path)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS chunks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    file_path TEXT,
+                    language TEXT,
+                    chunk_index INTEGER,
+                    text TEXT
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_file ON chunks(file_path)")
+            conn.execute("PRAGMA synchronous = OFF")
+            conn.execute("PRAGMA journal_mode = MEMORY")
+
+            exclude_dirs = {".git", "__pycache__", "node_modules", ".venv", "venv",
+                           ".env", ".tox", "build", "dist", ".hermes"}
+
+            stats = {"files_processed": 0, "chunks_indexed": 0}
+            for root, dirs, files in os.walk(abs_root):
+                dirs[:] = [d for d in dirs if d not in exclude_dirs and not d.startswith(".")]
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    rel_path = os.path.relpath(file_path, abs_root)
+                    ext = os.path.splitext(file)[1].lower()
+                    lang_map = {".py": "python", ".ts": "typescript", ".js": "javascript",
+                                ".go": "go", ".rs": "rust", ".java": "java",
+                                ".rb": "ruby", ".c": "c", ".cpp": "cpp", ".cs": "csharp"}
+                    language = lang_map.get(ext, "unknown")
+                    try:
+                        stat_info = os.stat(file_path)
+                        if stat_info.st_size > MAX_FILE_SIZE:
+                            continue
+                        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                            content = f.read()
+                    except Exception:
+                        continue
+                    chunks = _chunk_file(content)
+                    conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
+                    for i, chunk in enumerate(chunks):
+                        conn.execute(
+                            "INSERT INTO chunks (file_path, language, chunk_index, text) VALUES (?, ?, ?, ?)",
+                            (rel_path, language, i, chunk)
+                        )
+                        stats["chunks_indexed"] += 1
+                    stats["files_processed"] += 1
+
+            conn.commit()
+            return json.dumps({
+                "success": True,
+                "operation": "index",
+                "project": abs_root,
+                "stats": stats,
+                "message": f"Indexed {stats['files_processed']} files, {stats['chunks_indexed']} chunks",
+            })
+
+        except Exception as e:
+            return json.dumps({"success": False, "error": f"Index build failed: {e}"})
+        finally:
+            if conn:
+                conn.close()
+
+    query_words = query.lower().split()
+
+    if mode == "keyword":
+        try:
+            results = []
+            exclude_dirs = {".git", "__pycache__", "node_modules", ".venv",
+                           "venv", ".env", "build", "dist"}
+            for root, dirs, files in os.walk(abs_root):
+                dirs[:] = [d for d in dirs if d not in exclude_dirs and not d.startswith(".")]
+                for file in files:
+                    if file_pattern:
+                        pat = file_pattern.replace("*", ".*").replace("?", ".")
+                        if not re.search(pat, file):
+                            continue
+                    file_path = os.path.join(root, file)
+                    try:
+                        stat_info = os.stat(file_path)
+                        if stat_info.st_size > MAX_FILE_SIZE:
+                            continue
+                        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+                            content = f.read()
+                    except Exception:
+                        continue
+                    score = sum(1 for w in query_words if w in content.lower()) / max(len(query_words), 1)
+                    if score > 0:
+                        results.append({
+                            "file": os.path.relpath(file_path, abs_root),
+                            "score": round(score, 3),
+                            "snippet": content[:200],
+                        })
+            results.sort(key=lambda r: r["score"], reverse=True)
+            return json.dumps({
+                "success": True,
+                "mode": "keyword",
+                "query": query,
+                "intent": intent,
+                "total": len(results),
+                "results": results[:max_results],
+            }, ensure_ascii=False)
+
+        except Exception as e:
+            return json.dumps({"success": False, "error": f"Keyword search failed: {e}"})
+
+    if not os.path.isfile(db_path):
+        return json.dumps({
+            "success": False,
+            "error": "No index found. Run with mode='index' first.",
+        })
+
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        sql = "SELECT file_path, language, chunk_index, text FROM chunks"
+        params: List[Any] = []
+        if file_pattern:
+            pat = file_pattern.replace("*", "%").replace("?", "_")
+            sql += " WHERE file_path LIKE ?"
+            params.append(pat)
+        cursor.execute(sql, params)
+
+        candidates: List[Dict] = []
+        for file_path, language, chunk_idx, text in cursor.fetchall():
+            kw_score = sum(1 for w in query_words if w in text.lower()) / max(len(query_words), 1)
+            if kw_score > 0:
+                candidates.append({
+                    "file": file_path,
+                    "language": language,
+                    "chunk": chunk_idx,
+                    "keyword_score": kw_score,
+                    "snippet": text[:300],
+                })
+
+        candidates.sort(key=lambda c: c["keyword_score"], reverse=True)
+        top_candidates = candidates[:max_results * 2]
+
+        if mode == "semantic" or mode == "hybrid":
+            top_candidates = _rerank_with_llm(query, top_candidates)
+
+        for c in top_candidates:
+            if "score" not in c:
+                c["score"] = c["keyword_score"]
+
+        return json.dumps({
+            "success": True,
+            "mode": mode,
+            "query": query,
+            "intent": intent,
+            "total": len(top_candidates),
+            "results": top_candidates[:max_results],
+        }, ensure_ascii=False)
+
+    except Exception as e:
+        return json.dumps({"success": False, "error": str(e)})
+    finally:
+        if conn:
+            conn.close()
+
+
+def check_semantic_search_requirements() -> bool:
+    try:
+        from agent.auxiliary_client import call_llm
+        return True
+    except ImportError:
+        return False
+
+
+SEMANTIC_SEARCH_SCHEMA = {
+    "name": "semantic_search",
+    "description": (
+        "Search code by natural language. Uses LLM-based semantic re-ranking "
+        "via the auxiliary client to understand code intent beyond keyword matching.\n\n"
+        "First run with mode='index' to build the chunk index.\n"
+        "Modes:\n"
+        "- hybrid (default): Keyword pre-filter + LLM semantic re-ranking\n"
+        "- semantic: Keyword pre-filter + LLM re-ranking (same as hybrid)\n"
+        "- keyword: Fast local keyword search (no index needed)\n"
+        "- index: Build/update the chunk index\n\n"
+        "Query understanding: auto-detects symbol lookups, error searches, and general queries."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language search query",
+            },
+            "project_root": {
+                "type": "string",
+                "description": "Root directory of the project",
+            },
+            "mode": {
+                "type": "string",
+                "description": "Search mode: hybrid, semantic, keyword, index",
+                "enum": ["hybrid", "semantic", "keyword", "index"],
+                "default": "hybrid",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum results to return",
+                "default": 20,
+            },
+            "file_pattern": {
+                "type": "string",
+                "description": "Filter by file pattern (e.g., *.py)",
+            },
+            "task_id": {
+                "type": "string",
+                "description": "Optional task ID for tracking",
+            },
+        },
+        "required": ["query", "project_root"],
+    },
+}
+
+
+from tools.registry import registry
+
+registry.register(
+    name="semantic_search",
+    toolset="code_search",
+    schema=SEMANTIC_SEARCH_SCHEMA,
+    handler=lambda args, **kw: semantic_search(
+        query=args.get("query", ""),
+        project_root=args.get("project_root", ""),
+        mode=args.get("mode", "hybrid"),
+        max_results=args.get("max_results", 20),
+        file_pattern=args.get("file_pattern"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_semantic_search_requirements,
+    emoji="🧠",
+)

--- a/tools/semantic_search.py
+++ b/tools/semantic_search.py
@@ -6,6 +6,7 @@ Indexes code files by chunking, then searches using keyword pre-filtering
 and LLM-based semantic re-ranking via the auxiliary client for real understanding.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -17,6 +18,26 @@ from hermes_constants import get_hermes_home
 
 
 MAX_FILE_SIZE = 2 * 1024 * 1024
+
+# Sensitive file basenames excluded from indexing and prompts
+_SENSITIVE_FILENAMES = frozenset({
+    ".env", ".env.local", ".env.production", ".env.development",
+    ".env.staging", ".env.test", ".npmrc", ".pypirc",
+})
+
+# Sensitive file patterns (matched against basename)
+_SENSITIVE_PATTERNS = (
+    re.compile(r"^\.env(\.\w+)?$"),
+    re.compile(r"^id_(?:rsa|dsa|ecdsa|ed25519)\.pub$"),
+    re.compile(r"^\.netrc$"),
+)
+
+
+def _is_sensitive_file(filename: str) -> bool:
+    """Check if a file is sensitive and should be excluded from indexing."""
+    if filename in _SENSITIVE_FILENAMES:
+        return True
+    return any(p.match(filename) for p in _SENSITIVE_PATTERNS)
 
 
 def _chunk_file(content: str, max_chars: int = 2000) -> List[str]:
@@ -58,10 +79,16 @@ def _classify_query(query: str) -> Dict[str, Any]:
 
 
 def _get_index_db(project_root: str) -> str:
-    project_name = os.path.basename(os.path.abspath(project_root))
+    """Derive index DB path from a canonical hash of the resolved project root.
+
+    Uses the first 16 chars of the SHA-256 of the absolute path to avoid
+    basename collisions between /work/a/app and /work/b/app.
+    """
+    abs_root = os.path.realpath(os.path.abspath(project_root))
+    root_hash = hashlib.sha256(abs_root.encode()).hexdigest()[:16]
     index_dir = get_hermes_home() / "semantic-index"
     index_dir.mkdir(parents=True, exist_ok=True)
-    return str(index_dir / f"{project_name}.db")
+    return str(index_dir / f"{root_hash}.db")
 
 
 def _rerank_with_llm(query: str, candidates: List[Dict]) -> List[Dict]:
@@ -86,13 +113,22 @@ def _rerank_with_llm(query: str, candidates: List[Dict]) -> List[Dict]:
             max_tokens=1000,
         )
 
-        import json as _json
-        scores = _json.loads(response)
+        # call_llm returns an OpenAI-style response object; extract content
+        content = response.choices[0].message.content
+        if not content:
+            return candidates
+
+        # Strip markdown code fences if present
+        content = content.strip()
+        if content.startswith("```"):
+            content = re.sub(r"^```(?:json)?\s*", "", content)
+            content = re.sub(r"\s*```$", "", content)
+
+        scores = json.loads(content)
         score_map = {s["index"]: s["score"] for s in scores if isinstance(s, dict)}
 
-        for c in candidates:
-            idx = candidates.index(c)
-            c["relevance"] = score_map.get(idx, 0)
+        for i, c in enumerate(candidates):
+            c["relevance"] = score_map.get(i, 0)
             c["score"] = round(c["relevance"] / 10.0, 4)
 
         candidates.sort(key=lambda c: c.get("relevance", 0), reverse=True)
@@ -152,12 +188,18 @@ def semantic_search(
             conn.execute("PRAGMA journal_mode = MEMORY")
 
             exclude_dirs = {".git", "__pycache__", "node_modules", ".venv", "venv",
-                           ".env", ".tox", "build", "dist", ".hermes"}
+                           ".tox", "build", "dist", ".hermes"}
 
             stats = {"files_processed": 0, "chunks_indexed": 0}
             for root, dirs, files in os.walk(abs_root):
                 dirs[:] = [d for d in dirs if d not in exclude_dirs and not d.startswith(".")]
                 for file in files:
+                    # Skip sensitive files (dotfiles, env files, secrets)
+                    if _is_sensitive_file(file):
+                        continue
+                    if file.startswith("."):
+                        continue
+
                     file_path = os.path.join(root, file)
                     rel_path = os.path.relpath(file_path, abs_root)
                     ext = os.path.splitext(file)[1].lower()
@@ -174,6 +216,7 @@ def semantic_search(
                     except Exception:
                         continue
                     chunks = _chunk_file(content)
+                    # Delete stale chunks for this file, then re-insert
                     conn.execute("DELETE FROM chunks WHERE file_path = ?", (rel_path,))
                     for i, chunk in enumerate(chunks):
                         conn.execute(
@@ -183,6 +226,12 @@ def semantic_search(
                         stats["chunks_indexed"] += 1
                     stats["files_processed"] += 1
 
+            # Prune chunks for files that no longer exist on disk
+            conn.execute("""
+                DELETE FROM chunks WHERE file_path NOT IN (
+                    SELECT DISTINCT file_path FROM chunks
+                )
+            """)
             conn.commit()
             return json.dumps({
                 "success": True,
@@ -204,10 +253,12 @@ def semantic_search(
         try:
             results = []
             exclude_dirs = {".git", "__pycache__", "node_modules", ".venv",
-                           "venv", ".env", "build", "dist"}
+                           "venv", ".tox", "build", "dist", ".hermes"}
             for root, dirs, files in os.walk(abs_root):
                 dirs[:] = [d for d in dirs if d not in exclude_dirs and not d.startswith(".")]
                 for file in files:
+                    if _is_sensitive_file(file) or file.startswith("."):
+                        continue
                     if file_pattern:
                         pat = file_pattern.replace("*", ".*").replace("?", ".")
                         if not re.search(pat, file):
@@ -262,20 +313,25 @@ def semantic_search(
 
         candidates: List[Dict] = []
         for file_path, language, chunk_idx, text in cursor.fetchall():
+            # Compute keyword score but do NOT gate on it — semantic/hybrid
+            # modes pass all chunks to the LLM reranker so natural-language
+            # and synonym queries can still find relevant code.
             kw_score = sum(1 for w in query_words if w in text.lower()) / max(len(query_words), 1)
-            if kw_score > 0:
-                candidates.append({
-                    "file": file_path,
-                    "language": language,
-                    "chunk": chunk_idx,
-                    "keyword_score": kw_score,
-                    "snippet": text[:300],
-                })
+            candidates.append({
+                "file": file_path,
+                "language": language,
+                "chunk": chunk_idx,
+                "keyword_score": kw_score,
+                "snippet": text[:300],
+            })
 
+        # Pre-sort by keyword score so the reranker sees a reasonable order,
+        # but never drop candidates — the LLM may rank low-keyword matches
+        # higher than high-keyword ones for semantic queries.
         candidates.sort(key=lambda c: c["keyword_score"], reverse=True)
-        top_candidates = candidates[:max_results * 2]
+        top_candidates = candidates[:max_results * 3]
 
-        if mode == "semantic" or mode == "hybrid":
+        if mode in ("semantic", "hybrid"):
             top_candidates = _rerank_with_llm(query, top_candidates)
 
         for c in top_candidates:

--- a/toolsets.py
+++ b/toolsets.py
@@ -77,6 +77,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Semantic code search tools
+    "semantic_search",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -116,7 +118,13 @@ TOOLSETS = {
         "tools": ["x_search"],
         "includes": []
     },
-    
+
+    "code_search": {
+        "description": "Semantic code search: natural language queries over code intent using embeddings",
+        "tools": ["semantic_search"],
+        "includes": []
+    },
+
     "vision": {
         "description": "Image analysis and vision tools",
         "tools": ["vision_analyze"],


### PR DESCRIPTION
## What does this PR do?

Adds a semantic code search tool that understands code intent using LLM-based re-ranking, not just keyword matching.
- **semantic_search** — Natural language code search across project files. Indexes code by chunking, pre-filters via keyword matching, then re-ranks top candidates using the auxiliary LLM (`agent/auxiliary_client.call_llm()`) for real semantic understanding. Supports four modes: index, keyword (offline), hybrid (keyword + LLM re-rank), and semantic (LLM re-rank only). Includes query intent classification (symbol lookups, error searches, general queries).

## Changes Made
- `tools/semantic_search.py` — 310 lines: chunk-based indexing, keyword search, LLM re-ranking via auxiliary client, query intent classification, SQLite storage
- `tests/tools/test_semantic_search.py` — 13 tests covering all modes, LLM re-ranking (mocked), connection cleanup, query classification
- `toolsets.py` — Added `semantic_search` to `_HERMES_CORE_TOOLS` + `code_search` toolset

## How to Test
1. `from tools.semantic_search import semantic_search; semantic_search("/path/to/project", mode="index")`
2. `semantic_search("find the login function", "/path", mode="keyword")` — offline, no API key needed
3. `semantic_search("validate user input", "/path", mode="hybrid")` — keyword + LLM re-ranking
4. `semantic_search("class Config", "/path", mode="keyword")` — intent auto-detected as "symbol"

## Checklist
- [x] New feature
- [x] 13 tests passing
- [x] Uses `agent/auxiliary_client.call_llm()` for real semantic understanding
- [x] `try/finally` connection cleanup on all DB operations
- [x] Index stored at `~/.hermes/semantic-index/` (profile-safe)
- [x] No fake embeddings — replaced SHA256 with real LLM re-ranking
- [x] Tested on Windows