### PR TITLE
feat: heuristic tool-name normalizer for hallucinated tool names

### DIFF
--- a/environments/tool_call_parsers/test_tool_name_normalizer.py
+++ b/environments/tool_call_parsers/test_tool_name_normalizer.py
@@ -1,0 +1,127 @@
+"""
+Tests for the heuristic tool-name normalizer.
+
+Run with:
+    ./venv/bin/python -m pytest environments/tool_call_parsers/test_tool_name_normalizer.py -v
+or:
+    ./venv/bin/python -m unittest environments.tool_call_parsers.test_tool_name_normalizer
+"""
+import unittest
+from environments.tool_call_parsers.tool_name_normalizer import normalize_tool_name
+
+
+class TestNormalizeToolName(unittest.TestCase):
+
+    # ------------------------------------------------------------------ #
+    # Werner's three real-world examples                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_google_search_with_web_search_available(self):
+        """'google/search' -> 'web_search' when web_search is available."""
+        result = normalize_tool_name("google/search", ["web_search", "terminal"])
+        self.assertEqual(result, "web_search")
+
+    def test_google_search_with_only_terminal_and_process(self):
+        """'google/search' with only [terminal, process] — no clear match.
+
+        Strategy 2 won't fire (neither 'terminal' nor 'process' is in 'google/search').
+        Strategy 4 fires on token 'search' → candidates ['web_search', 'web', 'search'],
+        none of which are in ['terminal', 'process'] → None.
+        """
+        result = normalize_tool_name("google/search", ["terminal", "process"])
+        self.assertIsNone(result)
+
+    def test_google_tool_shell_index_0_to_terminal(self):
+        """'google:tool:shell:index:0' with [terminal, process] -> 'terminal' via shell alias."""
+        result = normalize_tool_name("google:tool:shell:index:0", ["terminal", "process"])
+        self.assertEqual(result, "terminal")
+
+    def test_tool_execute_terminal_to_terminal(self):
+        """'tool:execute_terminal' with [terminal, process] -> 'terminal' via substring."""
+        result = normalize_tool_name("tool:execute_terminal", ["terminal", "process"])
+        self.assertEqual(result, "terminal")
+
+    # ------------------------------------------------------------------ #
+    # Exact match                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_exact_match(self):
+        """'terminal' with ['terminal'] -> 'terminal' via exact match."""
+        result = normalize_tool_name("terminal", ["terminal"])
+        self.assertEqual(result, "terminal")
+
+    def test_exact_match_case_insensitive(self):
+        """'Terminal' with ['terminal'] -> 'terminal' via case-insensitive exact match."""
+        result = normalize_tool_name("Terminal", ["terminal"])
+        self.assertEqual(result, "terminal")
+
+    # ------------------------------------------------------------------ #
+    # Edge cases                                                           #
+    # ------------------------------------------------------------------ #
+
+    def test_empty_hallucinated_returns_none(self):
+        """Empty hallucinated name -> None."""
+        result = normalize_tool_name("", ["terminal", "process"])
+        self.assertIsNone(result)
+
+    def test_none_hallucinated_returns_none(self):
+        """None hallucinated name -> None."""
+        result = normalize_tool_name(None, ["terminal", "process"])
+        self.assertIsNone(result)
+
+    def test_empty_available_returns_none(self):
+        """Empty available list -> None."""
+        result = normalize_tool_name("terminal", [])
+        self.assertIsNone(result)
+
+    def test_no_match_returns_none(self):
+        """Completely unrelated name -> None."""
+        result = normalize_tool_name("xyz_completely_unknown_xyz", ["terminal", "process"])
+        self.assertIsNone(result)
+
+    # ------------------------------------------------------------------ #
+    # Substring strategies                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_available_name_substring_of_hallucinated(self):
+        """'run_terminal_now' should match 'terminal' via Strategy 2."""
+        result = normalize_tool_name("run_terminal_now", ["terminal", "process"])
+        self.assertEqual(result, "terminal")
+
+    def test_alias_token_bash_maps_to_terminal(self):
+        """Token 'bash' in hallucinated name -> 'terminal'."""
+        result = normalize_tool_name("google:bash:run", ["terminal", "process"])
+        self.assertEqual(result, "terminal")
+
+    def test_alias_token_exec_maps_to_terminal(self):
+        """Token 'exec' in hallucinated name -> 'terminal' when terminal available."""
+        result = normalize_tool_name("google:exec:command", ["terminal", "process"])
+        self.assertEqual(result, "terminal")
+
+    def test_alias_token_search_maps_to_web_search(self):
+        """Token 'search' in hallucinated name -> 'web_search' when available."""
+        result = normalize_tool_name("do_search_now", ["web_search", "terminal"])
+        self.assertEqual(result, "web_search")
+
+    def test_longest_available_matched_first(self):
+        """Longest available name matched first in Strategy 2.
+
+        'execute_terminal' (hypothetical) would beat 'terminal' but since
+        only 'terminal' is available it still maps correctly.
+        """
+        result = normalize_tool_name(
+            "run:execute_terminal:v2",
+            ["terminal", "process"],
+        )
+        self.assertEqual(result, "terminal")
+
+    def test_short_hallucinated_name_skips_strategy3(self):
+        """Names shorter than 4 chars skip Strategy 3 (weak-signal guard)."""
+        # 'run' is only 3 chars; even if it were substring of an available tool,
+        # we skip. Here no match should occur at all.
+        result = normalize_tool_name("run", ["terminal", "process"])
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environments/tool_call_parsers/tool_name_normalizer.py
+++ b/environments/tool_call_parsers/tool_name_normalizer.py
@@ -1,0 +1,86 @@
+"""
+Heuristic Tool-Name Normalizer
+
+When an LLM hallucinates a tool name that doesn't exist in the available tools,
+try to map the hallucinated name to the closest available tool by substring
+matching. Useful for Gemma 4 and similar models trained on different tool
+naming conventions (e.g. Google-AI tool namespace).
+
+Examples:
+    google:tool:shell:index:0  -> terminal  (matches "shell" hint)
+    tool:execute_terminal      -> terminal  (matches "terminal" substring)
+    google/search              -> web_search  (matches "search" substring)
+"""
+from typing import Optional, Iterable
+import logging
+import re
+
+_LOG = logging.getLogger(__name__)
+
+# Tool-name aliases. Maps tokens that appear in hallucinated names to
+# canonical Hermes tool-name patterns. Specific before generic.
+_ALIAS_TOKENS = {
+    "shell": ["terminal", "bash", "execute_command"],
+    "bash": ["terminal"],
+    "exec": ["terminal", "code_execution"],
+    "terminal": ["terminal"],
+    "process": ["process"],
+    "search": ["web_search", "web", "search"],
+    "browser": ["browser_navigate", "browser"],
+    "read": ["read_file", "file_read"],
+    "write": ["write_file", "file_write"],
+    "edit": ["edit_file", "file_edit"],
+    "memory": ["memory_search", "memory"],
+}
+
+
+def _tokenize(name: str) -> list[str]:
+    """Split hallucinated name into lowercase tokens by non-alphanum boundaries."""
+    return [t for t in re.split(r"[^a-zA-Z0-9]+", name.lower()) if t]
+
+
+def normalize_tool_name(
+    hallucinated: str,
+    available: Iterable[str],
+) -> Optional[str]:
+    """
+    Try to map a hallucinated tool name to an available one.
+
+    Returns the matched available tool name, or None if no plausible match.
+    Strategy (in order):
+        1. Exact match (case-insensitive)
+        2. Available name is substring of hallucinated (e.g. "terminal" in "tool:execute_terminal")
+        3. Hallucinated name is substring of available (rare)
+        4. Token-based alias mapping via _ALIAS_TOKENS
+    """
+    if not hallucinated or not available:
+        return None
+    available_list = list(available)
+    avail_lower = {a.lower(): a for a in available_list}
+    h_lower = hallucinated.lower()
+
+    # 1. Exact match (already case-fixed)
+    if h_lower in avail_lower:
+        return avail_lower[h_lower]
+
+    # 2. Available name is substring of hallucinated
+    # Sort longest-first so "execute_terminal" matches "terminal" not "exec"
+    for avail in sorted(available_list, key=len, reverse=True):
+        if avail.lower() in h_lower:
+            return avail
+
+    # 3. Hallucinated name is substring of available (rare, weak signal)
+    if len(h_lower) >= 4:
+        for avail in available_list:
+            if h_lower in avail.lower():
+                return avail
+
+    # 4. Token-based alias mapping
+    tokens = _tokenize(hallucinated)
+    for token in tokens:
+        if token in _ALIAS_TOKENS:
+            for candidate in _ALIAS_TOKENS[token]:
+                if candidate in avail_lower:
+                    return avail_lower[candidate]
+
+    return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -6264,6 +6264,9 @@ class AIAgent:
            TodoTool -> Todo -> todo). Applied twice so double-tacked
            suffixes like ``TodoTool_tool`` reduce all the way.
         5. Fuzzy match (difflib, cutoff=0.7).
+        6. Gemma-normalize: heuristic substring + alias-token matching for
+           namespace-prefixed hallucinations like "google:tool:shell:index:0"
+           or "tool:execute_terminal" (Gemma 4 via Ollama, see PR #7449).
 
         See #14784 for the original reports (TodoTool_tool, Patch_tool,
         BrowserClick_tool were all returning "Unknown tool" before).
@@ -6318,6 +6321,18 @@ class AIAgent:
         matches = get_close_matches(lowered, self.valid_tool_names, n=1, cutoff=0.7)
         if matches:
             return matches[0]
+
+        # 6. Gemma-normalize: heuristic substring + alias-token matching.
+        # Handles namespace-prefixed hallucinations emitted by Gemma 4 via Ollama,
+        # e.g. "google:tool:shell:index:0" -> "terminal", "tool:execute_terminal" -> "terminal".
+        try:
+            from environments.tool_call_parsers.tool_name_normalizer import normalize_tool_name
+            normalized_guess = normalize_tool_name(tool_name, self.valid_tool_names)
+            if normalized_guess:
+                logging.warning(f"[gemma-normalize] {tool_name} -> {normalized_guess}")
+                return normalized_guess
+        except ImportError:
+            pass
 
         return None
 


### PR DESCRIPTION
## Summary

Heuristic tool-name normalizer for hallucinated tool names. Addresses the
class of failures where a local LLM sends a structurally-valid OpenAI
tool call but uses a hallucinated name like `tool:execute_terminal` or
`google:tool:shell:index:0` instead of the registered tool name
`terminal`. Before the existing "Tool does not exist" error is raised,
the normalizer attempts to map the hallucinated name to the closest
available tool via a 4-strategy pipeline:

1. Exact match (case-insensitive)
2. Available name as substring of hallucinated (e.g. `execute_terminal` → `terminal`)
3. Hallucinated as substring of available
4. Token-based alias mapping (`shell` → `[terminal, bash]`, `search` → `[web_search]`, etc.)

If no plausible match is found, returns `None` and the original error
path is preserved unchanged — heuristic never replaces a working call
with a wrong one.

## Relation to other work

Complementary to #7449 (Gemma 4 parser, which addresses the format-mismatch
case where Gemma 4 emits raw-text tool calls). This PR addresses a different
failure class observed with local LLMs via Ollama where the structured
OpenAI tool-call format is correct but the function name is hallucinated.

Empirically observed hallucination patterns from Gemma 4 e2b/e4b sessions:
- `tool:execute_terminal` (substring match → `terminal`)
- `google:tool:shell:index:0` (token alias "shell" → `terminal`)
- `google/search` (token alias "search" → `web_search`)

Partially addresses #8993 (tool-calling instability with local LLMs) and
#15985 (Hermes + Gemma 4 forgets skills — pattern where Gemma 4 cannot
find registered `terminal` tool by name).

## Testing

Unit tests included (`environments/tool_call_parsers/test_tool_name_normalizer.py`):
16 cases covering all 4 strategies, edge cases (empty inputs, no match,
exact match, etc.). All passing.

Run via:
```
./venv/bin/python -m pytest environments/tool_call_parsers/test_tool_name_normalizer.py -v
```

## Safety

The normalizer is defensive: when no plausible match exists, it returns
`None` and the original "Tool does not exist" error is raised exactly as
before. The heuristic cannot trigger arbitrary tool execution from
hallucinated names — only maps to tools that are already in the agent's
registered available-tools set.

Logged as `WARNING` level so repeated normalizations are visible in
agent.log for monitoring and tuning.

## Credit

Builds on the `tool_call_parsers/` directory introduced by @0xarkstar in
#7449. The normalizer fits the same modular pattern.