### PR TITLE
fix(agent): rewrite SessionDB transcript after message-sequence repair

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1878,6 +1878,7 @@ class AIAgent:
         self._session_db = session_db
         self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+        self._session_db_needs_rewrite = False  # full transcript rewrite after in-place repair
         self._session_db_created = False  # DB row deferred to run_conversation()
         self._session_init_model_config = {
             "max_iterations": self.max_iterations,
@@ -4580,8 +4581,51 @@ class AIAgent:
             # Rewrite in place so downstream paths (persistence, return
             # value, session DB flush) see the repaired sequence.
             messages[:] = merged
+            self._session_db_needs_rewrite = True
 
         return repairs
+
+    def _normalize_message_for_session_db(self, msg: Dict) -> Dict[str, Any]:
+        """Return a SessionDB-safe copy of a transcript message."""
+        role = msg.get("role", "unknown")
+        content = msg.get("content")
+        # Persist multimodal tool results as their text summary only —
+        # base64 images would bloat the session DB and aren't useful
+        # for cross-session replay.
+        if _is_multimodal_tool_result(content):
+            content = _multimodal_text_summary(content)
+        elif isinstance(content, list):
+            # List of OpenAI-style content parts: strip images, keep text.
+            _txt = []
+            for p in content:
+                if isinstance(p, dict) and p.get("type") == "text":
+                    _txt.append(str(p.get("text", "")))
+                elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
+                    _txt.append("[screenshot]")
+            content = "\n".join(_txt) if _txt else None
+
+        tool_calls_data = None
+        if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
+            tool_calls_data = [
+                {"name": tc.function.name, "arguments": tc.function.arguments}
+                for tc in msg.tool_calls
+            ]
+        elif isinstance(msg.get("tool_calls"), list):
+            tool_calls_data = msg["tool_calls"]
+
+        return {
+            "role": role,
+            "content": content,
+            "tool_name": msg.get("tool_name"),
+            "tool_calls": tool_calls_data,
+            "tool_call_id": msg.get("tool_call_id"),
+            "finish_reason": msg.get("finish_reason"),
+            "reasoning": msg.get("reasoning") if role == "assistant" else None,
+            "reasoning_content": msg.get("reasoning_content") if role == "assistant" else None,
+            "reasoning_details": msg.get("reasoning_details") if role == "assistant" else None,
+            "codex_reasoning_items": msg.get("codex_reasoning_items") if role == "assistant" else None,
+            "codex_message_items": msg.get("codex_message_items") if role == "assistant" else None,
+        }
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
@@ -4597,46 +4641,32 @@ class AIAgent:
             # Retry row creation if the earlier attempt failed transiently.
             if not self._session_db_created:
                 self._ensure_db_session()
+            if self._session_db_needs_rewrite:
+                normalized_messages = [
+                    self._normalize_message_for_session_db(msg)
+                    for msg in messages
+                ]
+                self._session_db.replace_messages(self.session_id, normalized_messages)
+                self._last_flushed_db_idx = len(messages)
+                self._session_db_needs_rewrite = False
+                return
             start_idx = len(conversation_history) if conversation_history else 0
-            flush_from = max(start_idx, self._last_flushed_db_idx)
+            flush_from = min(max(start_idx, self._last_flushed_db_idx), len(messages))
             for msg in messages[flush_from:]:
-                role = msg.get("role", "unknown")
-                content = msg.get("content")
-                # Persist multimodal tool results as their text summary only —
-                # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
-                if _is_multimodal_tool_result(content):
-                    content = _multimodal_text_summary(content)
-                elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
-                    _txt = []
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
-                tool_calls_data = None
-                if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
-                    tool_calls_data = [
-                        {"name": tc.function.name, "arguments": tc.function.arguments}
-                        for tc in msg.tool_calls
-                    ]
-                elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
+                normalized = self._normalize_message_for_session_db(msg)
                 self._session_db.append_message(
                     session_id=self.session_id,
-                    role=role,
-                    content=content,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    role=normalized["role"],
+                    content=normalized["content"],
+                    tool_name=normalized["tool_name"],
+                    tool_calls=normalized["tool_calls"],
+                    tool_call_id=normalized["tool_call_id"],
+                    finish_reason=normalized["finish_reason"],
+                    reasoning=normalized["reasoning"],
+                    reasoning_content=normalized["reasoning_content"],
+                    reasoning_details=normalized["reasoning_details"],
+                    codex_reasoning_items=normalized["codex_reasoning_items"],
+                    codex_message_items=normalized["codex_message_items"],
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -9,6 +9,13 @@ providers (violating role alternation), which retriggered the empty-retry
 recovery every turn.
 """
 
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_state import SessionDB
 from run_agent import AIAgent
 
 
@@ -199,3 +206,61 @@ def test_repair_preserves_system_messages():
     AIAgent._repair_message_sequence(agent, messages)
 
     assert messages == original
+
+
+def test_flush_rewrites_session_db_when_repair_merges_current_turn():
+    """If repair merges the current turn into an existing user row, DB must rewrite."""
+    db = None
+    tmpdir = tempfile.mkdtemp()
+    try:
+        db_path = Path(tmpdir) / "repair.db"
+        db = SessionDB(db_path=db_path)
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=db,
+                session_id="repair-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._ensure_db_session()
+
+        db.append_message("repair-session", role="assistant", content="prior answer")
+        db.append_message("repair-session", role="user", content="stale user tail")
+        agent._last_flushed_db_idx = 2
+
+        conversation_history = [
+            {"role": "assistant", "content": "prior answer"},
+            {"role": "user", "content": "stale user tail"},
+        ]
+        messages = list(conversation_history) + [
+            {"role": "user", "content": "CURRENT TURN SHOULD PERSIST"},
+        ]
+
+        repairs = agent._repair_message_sequence(messages)
+
+        assert repairs == 1
+        assert agent._session_db_needs_rewrite is True
+        assert messages == [
+            {"role": "assistant", "content": "prior answer"},
+            {"role": "user", "content": "stale user tail\n\nCURRENT TURN SHOULD PERSIST"},
+        ]
+
+        agent._flush_messages_to_session_db(messages, conversation_history)
+
+        rows = db.get_messages("repair-session")
+        assert [(row["role"], row["content"]) for row in rows] == [
+            ("assistant", "prior answer"),
+            ("user", "stale user tail\n\nCURRENT TURN SHOULD PERSIST"),
+        ]
+        assert agent._last_flushed_db_idx == 2
+        assert agent._session_db_needs_rewrite is False
+    finally:
+        if db is not None:
+            db.close()
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

  Fixes a SessionDB persistence bug where the current turn can be silently skipped after `_repair_message_sequence()` mutates the in-memory transcript before persistence.

  The previous append-only flush logic used `len(conversation_history)` and `_last_flushed_db_idx` as boundaries. That breaks when repair shortens or rewrites the live
  `messages` list:

  - stray/orphan `tool` messages may be dropped
  - consecutive `user` messages may be merged
  - the current turn can be merged into an already-persisted historical row

  In those cases, append-only persistence is not sufficient. The SQLite transcript may need to be rewritten, not just appended.

  Fixes #24187.

  ## What changed

  - added `self._session_db_needs_rewrite` to `AIAgent`
  - when `_repair_message_sequence()` actually mutates `messages`, mark the SessionDB transcript dirty
  - in `_flush_messages_to_session_db()`:
    - if rewrite is needed, call `SessionDB.replace_messages(...)`
    - update `_last_flushed_db_idx`
    - clear the rewrite flag
  - kept the normal append-only path for non-repair cases
  - added a defensive clamp on `flush_from` so stale offsets cannot overflow the slice
  - factored SessionDB message normalization into a helper so rewrite and append paths persist the same normalized shape

  ## Why this approach

  A simple clamp like:

  python
  flush_from = min(max(start_idx, self._last_flushed_db_idx), len(messages))

  prevents the empty-slice failure, but it does not fix the more important case where repair merges the current turn into an already-persisted historical user row. That
  case requires rewriting the stored transcript, not appending.

  This patch uses the existing SessionDB.replace_messages() path, which already matches transcript-rewrite flows like /retry, /undo, and /compress.

  ## Tests

  Added regression coverage for the key failure shape:

  - historical transcript already persisted in SessionDB
  - current turn gets merged into a prior user message by _repair_message_sequence()
  - _flush_messages_to_session_db() must rewrite SQLite so the merged current turn is preserved