### PR TITLE
feat(api_server): honour per-request reasoning_effort and fast_mode

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -804,6 +804,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        reasoning_effort_override: Optional[str] = None,
+        fast_mode_override: Optional[bool] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -819,6 +821,18 @@ class APIServerAdapter(BasePlatformAdapter):
         key is meant to persist across transcripts so long-term memory
         providers (e.g. Honcho) can scope their per-chat state correctly
         — matching the semantics of the native gateway's ``session_key``.
+
+        ``reasoning_effort_override`` accepts an OpenAI-style effort value
+        (``"none"``, ``"minimal"``, ``"low"``, ``"medium"``, ``"high"``,
+        ``"xhigh"``) from the request body and supersedes the gateway
+        ``agent.reasoning_effort`` config for this call only.  Empty,
+        ``None``, or unrecognised values fall back to the gateway default.
+
+        ``fast_mode_override`` is a Hermes-specific boolean: when ``True``
+        and the resolved model supports Priority Processing / Anthropic
+        Fast Mode, the matching provider-specific ``request_overrides`` are
+        injected so external API consumers can opt into fast mode per
+        request without persisting it to ``config.yaml``.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
@@ -837,6 +851,34 @@ class APIServerAdapter(BasePlatformAdapter):
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         fallback_model = GatewayRunner._load_fallback_model()
 
+        # Apply reasoning effort override from the request body.  External
+        # UIs (e.g. Mission Control, CCC) send per-request effort hints so
+        # users can dial thinking depth on the fly without touching
+        # config.yaml; an unrecognised value is logged and ignored so a
+        # malformed client cannot silently force the gateway default away.
+        if reasoning_effort_override is not None:
+            from hermes_constants import parse_reasoning_effort
+
+            parsed_effort = parse_reasoning_effort(reasoning_effort_override)
+            if parsed_effort is not None:
+                reasoning_config = parsed_effort
+            elif str(reasoning_effort_override).strip():
+                logger.warning(
+                    "Ignoring unknown reasoning_effort '%s' from request body",
+                    reasoning_effort_override,
+                )
+
+        # Apply fast mode override from the request body.  Mirrors the
+        # gateway's ``/fast`` slash command: we only set request_overrides
+        # when the resolved model actually supports Priority Processing
+        # (OpenAI) or Anthropic Fast Mode, so toggling fast_mode against an
+        # unsupported model is a silent no-op rather than a hard error.
+        request_overrides = None
+        if fast_mode_override:
+            from hermes_cli.models import resolve_fast_mode_overrides
+
+            request_overrides = resolve_fast_mode_overrides(model) or None
+
         agent = AIAgent(
             model=model,
             **runtime_kwargs,
@@ -854,6 +896,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
+            request_overrides=request_overrides,
             gateway_session_key=gateway_session_key,
         )
         return agent
@@ -1085,6 +1128,14 @@ class APIServerAdapter(BasePlatformAdapter):
         model_name = body.get("model", self._model_name)
         created = int(time.time())
 
+        # Per-request thinking depth / fast-mode hints.  Extracted here so
+        # both the streaming and idempotent paths feed the same values into
+        # _run_agent without re-reading body further down.
+        _chat_reasoning_effort = body.get("reasoning_effort")
+        if _chat_reasoning_effort is not None and not isinstance(_chat_reasoning_effort, str):
+            _chat_reasoning_effort = None
+        _chat_fast_mode = bool(body.get("fast_mode")) if body.get("fast_mode") is not None else None
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -1167,6 +1218,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                reasoning_effort_override=_chat_reasoning_effort,
+                fast_mode_override=_chat_fast_mode,
             ))
 
             return await self._write_sse_chat_completion(
@@ -1183,6 +1236,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                reasoning_effort_override=_chat_reasoning_effort,
+                fast_mode_override=_chat_fast_mode,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2143,6 +2198,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # groups the entire conversation under one session entry.
         session_id = stored_session_id or str(uuid.uuid4())
 
+        # Per-request thinking depth / fast-mode hints for /v1/responses.
+        # Extracted up here so both streaming and idempotent paths share
+        # the same body lookup without re-reading it later.
+        _resp_reasoning_effort = body.get("reasoning_effort")
+        if _resp_reasoning_effort is not None and not isinstance(_resp_reasoning_effort, str):
+            _resp_reasoning_effort = None
+        _resp_fast_mode = bool(body.get("fast_mode")) if body.get("fast_mode") is not None else None
+
         stream = bool(body.get("stream", False))
         if stream:
             # Streaming branch — emit OpenAI Responses SSE events as the
@@ -2196,6 +2259,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                reasoning_effort_override=_resp_reasoning_effort,
+                fast_mode_override=_resp_fast_mode,
             ))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
@@ -2226,6 +2291,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                reasoning_effort_override=_resp_reasoning_effort,
+                fast_mode_override=_resp_fast_mode,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2684,6 +2751,8 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        reasoning_effort_override: Optional[str] = None,
+        fast_mode_override: Optional[bool] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2695,6 +2764,11 @@ class APIServerAdapter(BasePlatformAdapter):
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
+
+        ``reasoning_effort_override`` and ``fast_mode_override`` are
+        forwarded to :meth:`_create_agent` so per-request body hints can
+        adjust thinking depth and Priority Processing for a single call
+        without mutating ``config.yaml``.
         """
         loop = asyncio.get_running_loop()
 
@@ -2707,6 +2781,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
+                reasoning_effort_override=reasoning_effort_override,
+                fast_mode_override=fast_mode_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -2881,6 +2957,15 @@ class APIServerAdapter(BasePlatformAdapter):
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
+
+        # Per-request thinking depth / fast-mode hints — same shape as
+        # /v1/chat/completions and /v1/responses so external schedulers
+        # (e.g. Mission Control, CCC) can issue a one-off "/v1/runs +
+        # high effort" without persisting to config.yaml.
+        _run_reasoning_effort = body.get("reasoning_effort")
+        if _run_reasoning_effort is not None and not isinstance(_run_reasoning_effort, str):
+            _run_reasoning_effort = None
+        _run_fast_mode = bool(body.get("fast_mode")) if body.get("fast_mode") is not None else None
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
@@ -2922,6 +3007,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                     gateway_session_key=gateway_session_key,
+                    reasoning_effort_override=_run_reasoning_effort,
+                    fast_mode_override=_run_fast_mode,
                 )
                 self._active_run_agents[run_id] = agent
 

--- a/tests/gateway/test_api_server_reasoning_fast_mode.py
+++ b/tests/gateway/test_api_server_reasoning_fast_mode.py
@@ -1,0 +1,219 @@
+"""Tests for per-request reasoning_effort and fast_mode honour in the API server.
+
+When API consumers (e.g. Mission Control, CCC task dispatcher, external
+UIs) include ``reasoning_effort`` or ``fast_mode`` fields in their
+request body, the API server must apply them for that call only, without
+mutating ``config.yaml``.
+
+Mirrors the layered pattern of ``test_api_server_model_override.py``:
+exercise ``_create_agent`` directly so the override plumbing is covered
+without spinning up an aiohttp test client (which the rest of the
+gateway test suite avoids for the same reasons).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Build a minimal APIServerAdapter with stubbed internals."""
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._model_name = "claude-opus-4-6"
+    adapter._session_db = None
+    return adapter
+
+
+def _stub_runtime(monkeypatch, *, model="claude-opus-4-6", gateway_reasoning=None):
+    """Patch the heavy imports that _create_agent() pulls in.
+
+    *model* lets a test pin the resolved runtime model (e.g. an OpenAI
+    name vs. an Anthropic name) so ``resolve_fast_mode_overrides`` picks
+    the right provider-specific override shape.
+    """
+    monkeypatch.setattr(
+        "gateway.platforms.api_server.APIServerAdapter._ensure_session_db",
+        lambda self: None,
+    )
+
+    mock_agent_cls = MagicMock()
+    mock_agent_cls.return_value = MagicMock()
+
+    def _fake_resolve_runtime():
+        return {
+            "api_key": "sk-test",
+            "base_url": "https://api.example.com",
+            "provider": "anthropic",
+            "api_mode": None,
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    def _fake_resolve_model():
+        return model
+
+    def _fake_load_config():
+        return {"providers": {}}
+
+    monkeypatch.setattr("gateway.run._resolve_runtime_agent_kwargs", _fake_resolve_runtime)
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", _fake_resolve_model)
+    monkeypatch.setattr("gateway.run._load_gateway_config", _fake_load_config)
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda: gateway_reasoning),
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model",
+        staticmethod(lambda: None),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda cfg, platform: ["terminal"],
+    )
+    monkeypatch.setattr("run_agent.AIAgent", mock_agent_cls)
+
+    return mock_agent_cls
+
+
+def _kwargs(mock_cls):
+    """Return the kwargs of the last AIAgent(...) call."""
+    return mock_cls.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort
+# ---------------------------------------------------------------------------
+
+class TestCreateAgentReasoningEffortOverride:
+    """_create_agent honours reasoning_effort_override for this call only."""
+
+    def test_no_override_uses_gateway_default(self, monkeypatch):
+        mock_cls = _stub_runtime(
+            monkeypatch, gateway_reasoning={"enabled": True, "effort": "medium"}
+        )
+        adapter = _make_adapter()
+
+        adapter._create_agent()
+
+        assert _kwargs(mock_cls)["reasoning_config"] == {"enabled": True, "effort": "medium"}
+
+    def test_valid_override_replaces_gateway_default(self, monkeypatch):
+        mock_cls = _stub_runtime(
+            monkeypatch, gateway_reasoning={"enabled": True, "effort": "medium"}
+        )
+        adapter = _make_adapter()
+
+        adapter._create_agent(reasoning_effort_override="high")
+
+        assert _kwargs(mock_cls)["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+    def test_none_disables_thinking(self, monkeypatch):
+        mock_cls = _stub_runtime(
+            monkeypatch, gateway_reasoning={"enabled": True, "effort": "medium"}
+        )
+        adapter = _make_adapter()
+
+        adapter._create_agent(reasoning_effort_override="none")
+
+        assert _kwargs(mock_cls)["reasoning_config"] == {"enabled": False}
+
+    def test_unknown_effort_falls_back_to_gateway_default(self, monkeypatch):
+        mock_cls = _stub_runtime(
+            monkeypatch, gateway_reasoning={"enabled": True, "effort": "medium"}
+        )
+        adapter = _make_adapter()
+
+        adapter._create_agent(reasoning_effort_override="ludicrous")
+
+        assert _kwargs(mock_cls)["reasoning_config"] == {"enabled": True, "effort": "medium"}
+
+    def test_empty_string_does_not_override(self, monkeypatch):
+        mock_cls = _stub_runtime(
+            monkeypatch, gateway_reasoning={"enabled": True, "effort": "low"}
+        )
+        adapter = _make_adapter()
+
+        adapter._create_agent(reasoning_effort_override="")
+
+        assert _kwargs(mock_cls)["reasoning_config"] == {"enabled": True, "effort": "low"}
+
+
+# ---------------------------------------------------------------------------
+# fast_mode
+# ---------------------------------------------------------------------------
+
+class TestCreateAgentFastModeOverride:
+    """_create_agent honours fast_mode_override based on model support."""
+
+    def test_no_override_leaves_request_overrides_none(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent()
+
+        assert _kwargs(mock_cls)["request_overrides"] is None
+
+    def test_false_leaves_request_overrides_none(self, monkeypatch):
+        mock_cls = _stub_runtime(monkeypatch)
+        adapter = _make_adapter()
+
+        adapter._create_agent(fast_mode_override=False)
+
+        assert _kwargs(mock_cls)["request_overrides"] is None
+
+    def test_anthropic_model_injects_speed_fast(self, monkeypatch):
+        from hermes_cli.models import resolve_fast_mode_overrides, _is_anthropic_fast_model
+
+        # Pick a known Anthropic fast-mode-capable model.  We probe
+        # resolve_fast_mode_overrides directly so the test is decoupled
+        # from the catalog as it evolves.
+        anthropic_model = "claude-opus-4-6"
+        if not _is_anthropic_fast_model(anthropic_model):
+            anthropic_model = "claude-sonnet-4-5"
+        expected = resolve_fast_mode_overrides(anthropic_model)
+        assert expected is not None, "Anthropic fast-mode model picker is stale"
+
+        mock_cls = _stub_runtime(monkeypatch, model=anthropic_model)
+        adapter = _make_adapter()
+
+        adapter._create_agent(fast_mode_override=True)
+
+        assert _kwargs(mock_cls)["request_overrides"] == expected
+
+    def test_openai_model_injects_service_tier_priority(self, monkeypatch):
+        from hermes_cli.models import resolve_fast_mode_overrides, _is_openai_fast_model
+
+        openai_model = "gpt-5"
+        if not _is_openai_fast_model(openai_model):
+            openai_model = "gpt-5.5"
+        expected = resolve_fast_mode_overrides(openai_model)
+        if expected is None:
+            # The fast-mode catalog may not include every gpt-5* alias in
+            # all forks — skip rather than hard-fail to keep this test
+            # forward-compatible with upstream catalog updates.
+            import pytest
+            pytest.skip("No OpenAI fast-mode model available in this catalog")
+
+        mock_cls = _stub_runtime(monkeypatch, model=openai_model)
+        adapter = _make_adapter()
+
+        adapter._create_agent(fast_mode_override=True)
+
+        assert _kwargs(mock_cls)["request_overrides"] == expected
+
+    def test_unsupported_model_silently_skips_fast_mode(self, monkeypatch):
+        """Toggling fast_mode against a model without fast-mode support
+        must not crash — it should just leave request_overrides empty."""
+        mock_cls = _stub_runtime(monkeypatch, model="some-obscure-model-name")
+        adapter = _make_adapter()
+
+        adapter._create_agent(fast_mode_override=True)
+
+        assert _kwargs(mock_cls)["request_overrides"] is None


### PR DESCRIPTION
## Summary

External UIs (Mission Control, CCC task dispatcher, etc.) already pass `reasoning_effort` and `fast_mode` on every request to `/v1/chat/completions`, `/v1/responses` and `/v1/runs`, but the API server adapter silently dropped them — the only way to dial thinking depth or opt into Priority Processing / Anthropic Fast Mode was to edit `~/.hermes/config.yaml` and restart, so the in-UI toggles were no-ops and per-call effort could not be chosen at all.

This PR threads those two body fields through `_create_agent` / `_run_agent` for one call only, mirroring the same vocabulary and helpers the in-process `/reasoning` and `/fast` slash commands already use, without persisting anything to `config.yaml`.

## Changes

`gateway/platforms/api_server.py`

- `_create_agent(...)` accepts `reasoning_effort_override: Optional[str]` and `fast_mode_override: Optional[bool]`.
  - Effort goes through `parse_reasoning_effort` so the same vocabulary as `/reasoning` (`"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`) is honoured. Unknown values are logged and ignored, so a malformed client cannot silently force the gateway default away.
  - Fast mode goes through `resolve_fast_mode_overrides(model)`, the same helper `/fast` and `_resolve_turn_agent_config` use. Unsupported models stay a silent no-op (no `request_overrides` set), matching the `/fast` behaviour.
- `_run_agent` forwards both overrides to `_create_agent`.
- `_handle_chat_completions`, `_handle_responses` and `_handle_runs` extract `body.reasoning_effort` and `body.fast_mode` once at the top of the handler, then thread them through the streaming, idempotent and non-streaming branches uniformly.

`tests/gateway/test_api_server_reasoning_fast_mode.py` (new)

10 regression cases covering:

- gateway-default fallback when no override is passed,
- valid effort override replaces gateway default,
- `"none"` disables thinking,
- unknown effort falls back to gateway default,
- empty-string does not override,
- no `fast_mode` field leaves `request_overrides` `None`,
- explicit `false` leaves `request_overrides` `None`,
- Anthropic fast-mode-capable model gets `{"speed": "fast"}`,
- OpenAI fast-mode-capable model gets `{"service_tier": "priority"}`,
- unsupported model silently skips fast mode.

## Why this shape

`reasoning_effort` matches the OpenAI-compatible field name and string vocabulary `parse_reasoning_effort` already understands, so OpenAI-compatible clients (Open WebUI, Mission Control, CCC) work without protocol changes.

`fast_mode` is the same boolean the in-CLI `/fast` already toggles — using the existing `resolve_fast_mode_overrides` keeps Priority Processing / Anthropic Fast Mode behaviour identical to the slash-command path, including the silent no-op for unsupported models.

Neither override mutates `config.yaml`, so per-request hints from one client cannot leak into other channels or persist past process restart.

## Test Plan

- [x] `pytest tests/gateway/test_api_server_reasoning_fast_mode.py` — 10 new tests pass.
- [x] `pytest tests/gateway/test_api_server*.py` — all 266 existing API server tests continue to pass.
- [ ] Manual: `curl -X POST .../v1/chat/completions` with `reasoning_effort: "high"` and verify upstream provider sees the higher effort.
- [ ] Manual: `curl` with `fast_mode: true` against an Anthropic / OpenAI fast-mode-capable model and confirm provider-side fast-mode behaviour.
