### PR TITLE
feat(api-server): X-Hermes-User-* / Chat-* headers for multi-user identity

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1261,6 +1261,30 @@ def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
+def _identity_scoped_idempotency_key(
+    idempotency_key: str,
+    user_identity: Optional[Dict[str, str]] = None,
+) -> str:
+    """Scope an Idempotency-Key by the request's resolved identity.
+
+    Identity (X-Hermes-User-*/Chat-*/Thread-Id headers, or the OpenAI
+    ``user`` body fallback — both already folded into *user_identity* by
+    ``_parse_user_identity_headers``) changes the agent/memory result for
+    an otherwise identical body, so cached responses must never be shared
+    across identities: without scoping, two callers reusing one key with
+    the same body would read each other's cached result.  Scoping the key
+    (rather than the fingerprint) keeps each identity in its own cache
+    slot, so one identity's retries still hit while another identity can
+    neither read nor evict them.  Identity-less requests keep the raw key
+    unchanged.
+    """
+    if not user_identity:
+        return idempotency_key
+    from hashlib import sha256
+    ident = repr(sorted(user_identity.items()))
+    return f"{idempotency_key}:{sha256(ident.encode('utf-8')).hexdigest()[:16]}"
+
+
 def _derive_chat_session_id(
     system_prompt: Optional[str],
     first_user_message: str,
@@ -4342,6 +4366,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            idempotency_key = _identity_scoped_idempotency_key(idempotency_key, user_identity)
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
@@ -5491,6 +5516,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            idempotency_key = _identity_scoped_idempotency_key(idempotency_key, user_identity)
             fp = _make_request_fingerprint(
                 body,
                 keys=[

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2,8 +2,8 @@
 OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
-- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
-- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
+- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id; opt-in long-term memory scoping via X-Hermes-Session-Key; opt-in multi-user identity via X-Hermes-User-*/Chat-*/Thread-Id headers + OpenAI `user` body field fallback)
+- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key + X-Hermes-User-*/Chat-* supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
@@ -2157,6 +2157,88 @@ class APIServerAdapter(BasePlatformAdapter):
         return raw, None
 
     # ------------------------------------------------------------------
+    # User identity headers — subset of SessionSource fields used by
+    # native adapters to scope per-user memory and chat context.
+    # ------------------------------------------------------------------
+
+    # Each pair: (HTTP header name, AIAgent.__init__ kwarg name).  The
+    # kwargs already exist on AIAgent (run_agent.py:1098-1103) and are
+    # threaded by native adapters via GatewayRunner._run_agent_task
+    # (gateway/run.py:14881-14888).  This makes the api_server symmetrical
+    # with native adapters for multi-user / multi-chat scenarios.
+    _USER_IDENTITY_HEADERS: tuple[tuple[str, str], ...] = (
+        ("X-Hermes-User-Id",   "user_id"),
+        ("X-Hermes-User-Name", "user_name"),
+        ("X-Hermes-Chat-Id",   "chat_id"),
+        ("X-Hermes-Chat-Name", "chat_name"),
+        ("X-Hermes-Chat-Type", "chat_type"),
+        ("X-Hermes-Thread-Id", "thread_id"),
+    )
+
+    def _parse_user_identity_headers(
+        self,
+        request: "web.Request",
+        body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, str]:
+        """Extract optional X-Hermes-User-* / Chat-* / Thread-Id headers.
+
+        Returns a dict of AIAgent kwargs (subset of: user_id, user_name,
+        chat_id, chat_name, chat_type, thread_id) for present, validated
+        headers.  Absent → key omitted.
+
+        Same auth gate as X-Hermes-Session-Key: without ``API_SERVER_KEY``
+        configured, identity headers are silently ignored (rather than
+        rejected with 403) so local-only dev without a key stays
+        frictionless.  Once a key is configured, headers from authenticated
+        callers are accepted.
+
+        Header values are best-effort: control chars (header-injection)
+        and oversized values are silently dropped with a WARN log, not
+        rejected with 4xx — partial identity is better than failing the
+        whole request.
+
+        When ``body`` is provided and contains an OpenAI-style top-level
+        ``"user"`` string, it is used as fallback for ``user_id`` when the
+        ``X-Hermes-User-Id`` header is absent.  This makes vanilla OpenAI
+        SDK clients (which already populate ``user`` for abuse monitoring)
+        work without custom header configuration.  Header always wins.
+        """
+        if not self._api_key:
+            return {}
+
+        out: Dict[str, str] = {}
+        for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+            raw = request.headers.get(header_name, "").strip()
+            if not raw:
+                continue
+            if re.search(r"[\r\n\x00]", raw):
+                logger.warning(
+                    "%s rejected: control characters in value", header_name,
+                )
+                continue
+            if len(raw) > self._MAX_SESSION_HEADER_LEN:
+                logger.warning(
+                    "%s rejected: value exceeds %d chars",
+                    header_name, self._MAX_SESSION_HEADER_LEN,
+                )
+                continue
+            out[kwarg_name] = raw
+
+        # OpenAI `user` body field fallback when X-Hermes-User-Id absent
+        if "user_id" not in out and body is not None:
+            body_user = body.get("user")
+            if isinstance(body_user, str):
+                stripped = body_user.strip()
+                if (
+                    stripped
+                    and not re.search(r"[\r\n\x00]", stripped)
+                    and len(stripped) <= self._MAX_SESSION_HEADER_LEN
+                ):
+                    out["user_id"] = stripped
+
+        return out
+
+    # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
 
@@ -2598,6 +2680,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
+        user_identity: Optional[Dict[str, str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -2631,6 +2714,17 @@ class APIServerAdapter(BasePlatformAdapter):
         session ``/model`` override, disables the global fallback model
         chain, and fails closed if the locked provider's credentials cannot
         be resolved.
+
+        ``user_identity`` is an optional dict subset of the keys
+        ``{user_id, user_name, chat_id, chat_name, chat_type, thread_id}``
+        extracted from the corresponding ``X-Hermes-User-*`` /
+        ``X-Hermes-Chat-*`` / ``X-Hermes-Thread-Id`` headers.  Each key
+        maps directly to an existing ``AIAgent.__init__`` kwarg
+        (run_agent.py:1097-1102), so values flow through to the same
+        downstream consumers (Honcho ``runtime_user_peer_name``, per-user
+        memory directories, session DB).  Mirrors the SessionSource subset
+        that native adapters pass via GatewayRunner._run_agent_task
+        (gateway/run.py:14881-14888).
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -2899,6 +2993,12 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if request_service_tier is not _REQUEST_OPTION_MISSING:
             agent_kwargs["service_tier"] = request_service_tier
+        # Per-request caller identity (X-Hermes-User-*/Chat-*/Thread-Id).  Each
+        # key is an existing AIAgent.__init__ kwarg, so it flows to the same
+        # downstream consumers (Honcho runtime_user_peer_name, per-user memory,
+        # session DB) as the SessionSource subset native adapters pass.
+        if user_identity:
+            agent_kwargs.update(user_identity)
 
         agent = AIAgent(**agent_kwargs)
         agent._hermes_api_runtime = {
@@ -3125,6 +3225,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "user_id_header": "X-Hermes-User-Id",
+                "user_name_header": "X-Hermes-User-Name",
+                "chat_id_header": "X-Hermes-Chat-Id",
+                "chat_name_header": "X-Hermes-Chat-Name",
+                "chat_type_header": "X-Hermes-Chat-Type",
+                "thread_id_header": "X-Hermes-Thread-Id",
+                "user_body_fallback": "user",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -4032,6 +4139,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
+        # Optional multi-user identity headers (subset of SessionSource).
+        # When set on an authenticated request, threads through to AIAgent
+        # the same way native adapters do — drives Honcho per-user peer,
+        # per-user memory tooling, session DB attribution, etc.  Falls back
+        # to OpenAI's ``user`` body field for user_id.  See
+        # _parse_user_identity_headers.
+        user_identity = self._parse_user_identity_headers(request, body=body)
+
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
         #
@@ -4199,6 +4314,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                user_identity=user_identity,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -4208,6 +4324,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_identity=user_identity,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -4220,6 +4337,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                user_identity=user_identity,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -4268,6 +4386,12 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        # Echo identity headers so clients can confirm what the server saw
+        # (parity with X-Hermes-Session-Key echo above).
+        for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+            value = user_identity.get(kwarg_name)
+            if value:
+                response_headers[header_name] = value
 
         # Hard-fail path: no usable assistant text AND a real failure → 5xx
         # with OpenAI-style error envelope so SDK clients raise instead of
@@ -4330,6 +4454,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
         gateway_session_key: str = None,
+        user_identity: Optional[Dict[str, str]] = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -4352,6 +4477,11 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_identity:
+            for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+                value = user_identity.get(kwarg_name)
+                if value:
+                    sse_headers[header_name] = value
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -4536,6 +4666,7 @@ class APIServerAdapter(BasePlatformAdapter):
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        user_identity: Optional[Dict[str, str]] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -4578,6 +4709,11 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_identity:
+            for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+                value = user_identity.get(kwarg_name)
+                if value:
+                    sse_headers[header_name] = value
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -5149,6 +5285,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        # Multi-user identity headers (see chat_completions for details).
+        user_identity = self._parse_user_identity_headers(request, body=body)
+
         raw_input = body.get("input")
         if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -5310,6 +5449,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                user_identity=user_identity,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -5334,6 +5474,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_identity=user_identity,
             )
 
         async def _compute_response():
@@ -5345,6 +5486,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                user_identity=user_identity,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -5446,6 +5588,10 @@ class APIServerAdapter(BasePlatformAdapter):
         response_headers = {"X-Hermes-Session-Id": _effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+            value = user_identity.get(kwarg_name)
+            if value:
+                response_headers[header_name] = value
         return web.json_response(response_data, headers=response_headers)
 
     # ------------------------------------------------------------------
@@ -6058,6 +6204,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        user_identity: Optional[Dict[str, str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -6115,6 +6262,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
+                        user_identity=user_identity,
                     )
                     if agent_ref is not None:
                         agent_ref[0] = agent
@@ -6409,6 +6557,9 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
+        # Multi-user identity headers (see chat_completions for details).
+        user_identity = self._parse_user_identity_headers(request, body=body)
+
         raw_input = body.get("input")
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
@@ -6554,6 +6705,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
                         route=route,
+                        user_identity=user_identity,
                     )
                 self._active_run_agents[run_id] = agent
 
@@ -6789,9 +6941,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = (
-            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
-        )
+        response_headers: Dict[str, str] = {}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+            value = user_identity.get(kwarg_name)
+            if value:
+                response_headers[header_name] = value
         return web.json_response(
             {"run_id": run_id, "status": "started"},
             status=202,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -72,7 +72,11 @@ _STATIC_FEATURE_FLAGS = {
     "admin_config_rw": False, "jobs_admin": False, "memory_write_api": False,
     "skills_api": True, "audio_api": False, "realtime_voice": False,
     "session_continuity_header": "X-Hermes-Session-Id",
-    "session_key_header": "X-Hermes-Session-Key"}
+    "session_key_header": "X-Hermes-Session-Key",
+    "user_id_header": "X-Hermes-User-Id", "user_name_header": "X-Hermes-User-Name",
+    "chat_id_header": "X-Hermes-Chat-Id", "chat_name_header": "X-Hermes-Chat-Name",
+    "chat_type_header": "X-Hermes-Chat-Type", "thread_id_header": "X-Hermes-Thread-Id",
+    "user_body_fallback": "user"}
 # /v1/capabilities "endpoints" table: name -> (method, path).
 _CAPABILITY_ENDPOINTS = (
     ("health", ("GET", "/health")), ("health_detailed", ("GET", "/health/detailed")),
@@ -1648,6 +1652,58 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             return None, _invalid_request("Session key too long")
         return raw, None
 
+    # ``X-Hermes-*`` header -> ``AIAgent.__init__`` kwarg. Each kwarg already exists on
+    # AIAgent and is threaded by native adapters from their SessionSource, so values reach
+    # the same consumers (Honcho ``runtime_user_peer_name``, per-user memory, session DB).
+    _USER_IDENTITY_HEADERS = (
+        ("X-Hermes-User-Id", "user_id"), ("X-Hermes-User-Name", "user_name"),
+        ("X-Hermes-Chat-Id", "chat_id"), ("X-Hermes-Chat-Name", "chat_name"),
+        ("X-Hermes-Chat-Type", "chat_type"), ("X-Hermes-Thread-Id", "thread_id"))
+
+    def _parse_user_identity_headers(
+        self, request: "web.Request", body: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        """Extract the optional identity headers -> dict of AIAgent kwargs (absent key omitted).
+
+        Same auth gate as ``X-Hermes-Session-Key``: without ``API_SERVER_KEY`` the headers are
+        silently ignored rather than 403'd, so local-only dev stays frictionless. Malformed
+        values (control chars, oversized) are dropped per-header with a warning instead of
+        failing the request — a partial identity beats rejecting the turn.
+
+        ``body``'s OpenAI-standard top-level ``user`` field is a fallback for ``user_id`` so
+        vanilla OpenAI SDK clients work without custom headers; the header wins when both exist.
+        """
+        if not self._api_key:
+            return {}
+        out: Dict[str, str] = {}
+        for header_name, kwarg_name in self._USER_IDENTITY_HEADERS:
+            raw = request.headers.get(header_name, "").strip()
+            if not raw:
+                continue
+            if re.search(r"[\r\n\x00]", raw):
+                logger.warning("%s rejected: control characters in value", header_name)
+                continue
+            if len(raw) > self._MAX_SESSION_HEADER_LEN:
+                logger.warning(
+                    "%s rejected: value exceeds %d chars", header_name, self._MAX_SESSION_HEADER_LEN)
+                continue
+            out[kwarg_name] = raw
+        if "user_id" not in out and body is not None:
+            body_user = body.get("user")
+            if isinstance(body_user, str):
+                stripped = body_user.strip()
+                if (stripped and not re.search(r"[\r\n\x00]", stripped)
+                        and len(stripped) <= self._MAX_SESSION_HEADER_LEN):
+                    out["user_id"] = stripped
+        return out
+
+    @staticmethod
+    def _identity_response_headers(user_identity: Optional[Dict[str, str]]) -> Dict[str, str]:
+        """Echo the accepted identity back so clients can confirm what the server saw."""
+        if not user_identity:
+            return {}
+        by_kwarg = {kwarg: header for header, kwarg in APIServerAdapter._USER_IDENTITY_HEADERS}
+        return {by_kwarg[k]: v for k, v in user_identity.items() if k in by_kwarg}
+
     # -- Session DB -------------------------------------------------------------------
 
     def _open_and_cache_session_db(self, home) -> Optional[Any]:
@@ -2121,11 +2177,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         model_options: Optional[Dict[str, Any]] = None, route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None, confirmed_runtime_lock: bool = False,
         room_dispatch: Optional[Dict[str, Any]] = None,
-        room_execution_policy: Optional[Dict[str, Any]] = None) -> Any:
+        room_execution_policy: Optional[Dict[str, Any]] = None,
+        user_identity: Optional[Dict[str, str]] = None) -> Any:
         """Create an AIAgent from the gateway runtime config + platform toolsets.
         ``gateway_session_key`` persists across transcripts (memory scope), unlike ``session_id``;
         ``route`` / ``session_model`` are mutually exclusive; ``confirmed_runtime_lock`` beats the
-        session ``/model`` override, disables the fallback chain and fails closed."""
+        session ``/model`` override, disables the fallback chain and fails closed.
+        ``user_identity`` is the parsed identity-header subset (see
+        ``_parse_user_identity_headers``); each key is an existing AIAgent kwarg."""
         from run_agent import AIAgent
         from gateway.run import (
             _checkpoint_agent_kwargs, _current_max_iterations, _resolve_runtime_agent_kwargs,
@@ -2176,6 +2235,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             "gateway_session_key": gateway_session_key}
         if request_service_tier is not _REQUEST_OPTION_MISSING:
             agent_kwargs["service_tier"] = request_service_tier
+        # Per-request caller identity; each key is an existing AIAgent kwarg, so it reaches the
+        # same consumers as the SessionSource subset native adapters thread.
+        if user_identity:
+            agent_kwargs.update(user_identity)
         agent = AIAgent(**agent_kwargs)
         route_source = (
             "session_model_lock" if confirmed_runtime_lock
@@ -3668,7 +3731,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None, route_source: str = "global",
         confirmed_runtime_lock: bool = False, bind_declared_conversation: bool = False,
         session_history_delivery: str = "", turn_author: Optional[Dict[str, Any]] = None,
-        relay_metadata: Optional[Dict[str, Any]] = None) -> tuple:
+        relay_metadata: Optional[Dict[str, Any]] = None,
+        user_identity: Optional[Dict[str, str]] = None) -> tuple:
         """Create an agent and run one turn in a thread executor -> ``(result, usage)``.
         ``agent_ref[0]`` receives the agent so SSE writers can interrupt it; ``active_run_id``
         registers it in ``_active_run_agents``. Under a confirmed model lock the actual
@@ -3700,7 +3764,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                         tool_start_callback=tool_start_callback, tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key, requested_model=requested_model,
                         requested_provider=requested_provider, model_options=model_options, route=route,
-                        session_model=session_model, confirmed_runtime_lock=confirmed_runtime_lock)
+                        session_model=session_model, confirmed_runtime_lock=confirmed_runtime_lock,
+                        user_identity=user_identity)
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     if active_run_id:

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -7,6 +7,7 @@ module (top-level import = cycle), and lazy lookup keeps ``patch("...api_server.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import re
@@ -500,11 +501,14 @@ class OpenAICompatRoutesMixin:
             model_alias=model_name)
         if selection_error is not None:
             return selection_error
+        # Optional per-request caller identity (X-Hermes-User-*/Chat-*/Thread-Id, or the
+        # OpenAI `user` body field) for multi-user deployments behind one API key.
+        user_identity = self._parse_user_identity_headers(request, body=body)
         run_kwargs = dict(
             user_message=user_message, conversation_history=history,
             ephemeral_system_prompt=system_prompt, session_id=session_id,
             gateway_session_key=gateway_session_key, **agent_overrides, route=route,
-            relay_metadata=relay_metadata,
+            relay_metadata=relay_metadata, user_identity=user_identity,
             # #98619: only an explicitly provided X-Hermes-Session-Id is wake-capable (the
             # header is 403-gated on API_SERVER_KEY, so the wake self-post can authenticate
             # and the client can resume the session by sending it again). A fingerprint-derived
@@ -555,7 +559,7 @@ class OpenAICompatRoutesMixin:
         outcome, err = await self._run_idempotent(
             request, body, _compute_completion, log_label="chat completions",
             fingerprint_keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
-            route="chat_completions",
+            route="chat_completions", user_identity=user_identity,
         )
         if err is not None:
             return err
@@ -571,6 +575,7 @@ class OpenAICompatRoutesMixin:
         response_headers = {"X-Hermes-Session-Id": (provided_session_id or result.get("session_id", session_id))}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        response_headers.update(self._identity_response_headers(user_identity))
         # Hard fail (no usable text AND a real failure) -> 502 OpenAI error envelope so SDK
         # clients raise instead of rendering the failure string as message.content.
         if not final_response and (is_failed or is_partial):
@@ -600,7 +605,8 @@ class OpenAICompatRoutesMixin:
 
     async def _run_idempotent(
         self, request: "web.Request", body: Dict[str, Any], compute, *,
-        log_label: str, fingerprint_keys: List[str], route: str) -> tuple:
+        log_label: str, fingerprint_keys: List[str], route: str,
+        user_identity: Optional[Dict[str, str]] = None) -> tuple:
         """Run ``compute()`` once per (principal scope, logical route, Idempotency-Key) + body fingerprint
         -> ``((result, usage), None)`` or ``(None, 500 response)``.
 
@@ -610,6 +616,13 @@ class OpenAICompatRoutesMixin:
         colliding across profiles, or a rotated API_SERVER_KEY, never replays another principal's response.
         ``route`` is the logical endpoint (``/v1/...`` and its ``/p/<profile>/v1/...`` alias are the same
         route), folded into the key because the store keeps the fingerprint only as the slot's value.
+
+        ``user_identity`` extends that namespace below the principal: callers sharing one
+        ``API_SERVER_KEY`` land in the same principal scope, yet identity changes the agent/memory
+        result, so an identical body under two identities must not replay one another's response.
+        Folding it into the key (not the fingerprint) keeps each identity in its own slot, so
+        retries still hit within an identity and neither can evict the other. Identity-less
+        requests keep the unextended key.
         """
         from gateway.platforms.api_server import _error_response, _idem_cache, _make_request_fingerprint
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -617,6 +630,10 @@ class OpenAICompatRoutesMixin:
             if idempotency_key:
                 principal_scope = self._run_idempotency_scope(request)
                 scoped_key = f"{principal_scope}\0{route}\0{idempotency_key}"
+                if user_identity:
+                    identity_scope = hashlib.sha256(
+                        repr(sorted(user_identity.items())).encode("utf-8")).hexdigest()[:16]
+                    scoped_key = f"{scoped_key}\0{identity_scope}"
                 fp = _make_request_fingerprint(body, keys=fingerprint_keys)
                 result, usage = await _idem_cache.get_or_set(scoped_key, fp, compute)
             else:
@@ -857,11 +874,14 @@ class OpenAICompatRoutesMixin:
             model_alias=body.get("model"))
         if selection_error is not None:
             return selection_error
+        # Same optional per-request identity contract as /v1/chat/completions.
+        user_identity = self._parse_user_identity_headers(request, body=body)
         run_kwargs = dict(
             user_message=user_message, conversation_history=conversation_history,
             ephemeral_system_prompt=instructions, session_id=session_id,
             gateway_session_key=gateway_session_key, bind_declared_conversation=_declared_selected,
-            **agent_overrides, route=route, relay_metadata=relay_metadata)
+            **agent_overrides, route=route, relay_metadata=relay_metadata,
+            user_identity=user_identity)
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
 
@@ -894,7 +914,7 @@ class OpenAICompatRoutesMixin:
         outcome, err = await self._run_idempotent(
             request, body, _compute_response, log_label="responses",
             fingerprint_keys=["input", "instructions", "previous_response_id", "conversation", "model", "provider", "model_options", "tools"],
-            route="responses",
+            route="responses", user_identity=user_identity,
         )
         if err is not None:
             return err
@@ -929,6 +949,7 @@ class OpenAICompatRoutesMixin:
         response_headers = {"X-Hermes-Session-Id": _effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        response_headers.update(self._identity_response_headers(user_identity))
         return web.json_response(response_data, headers=response_headers)
 
     async def _handle_get_response(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -388,6 +388,8 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     body, room_error = await self._normalize_room_dispatch(request, body)
     if room_error is not None:
         return room_error
+    # Optional per-request caller identity (see chat_completions for details).
+    user_identity = self._parse_user_identity_headers(request, body=body)
     room_dispatch, room_execution_policy = (
         v if isinstance(v, dict) else None for v in (
             (body.get("hosted_room_dispatch"), body.get("_room_execution_policy"))
@@ -490,6 +492,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         agent_kwargs=dict(
             ephemeral_system_prompt=instructions, session_id=session_id, gateway_session_key=gateway_session_key,
             route=route, room_dispatch=room_dispatch, room_execution_policy=room_execution_policy,
+            user_identity=user_identity,
             **{k: agent_overrides.get(k) for k in ("requested_model", "requested_provider", "model_options")}),
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24427,6 +24427,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             headers["Authorization"] = f"Bearer {proxy_key}"
         if session_id:
             headers["X-Hermes-Session-Id"] = session_id
+        # Forward SessionSource identity so the remote api_server can
+        # reconstruct per-user peer scoping (matches the headers added to
+        # api_server in the same PR).  Each forwarded only when set on
+        # the source — partial SessionSource is better than no identity.
+        if getattr(source, "user_id", None):
+            headers["X-Hermes-User-Id"] = str(source.user_id)
+        if getattr(source, "user_name", None):
+            headers["X-Hermes-User-Name"] = str(source.user_name)
+        if getattr(source, "chat_id", None):
+            headers["X-Hermes-Chat-Id"] = str(source.chat_id)
+        if getattr(source, "chat_name", None):
+            headers["X-Hermes-Chat-Name"] = str(source.chat_name)
+        if getattr(source, "chat_type", None):
+            headers["X-Hermes-Chat-Type"] = str(source.chat_type)
+        if getattr(source, "thread_id", None):
+            headers["X-Hermes-Thread-Id"] = str(source.thread_id)
 
         body = {
             "model": "hermes-agent",

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2555,6 +2555,21 @@ class GatewayTurnMixin:
             headers["Authorization"] = f"Bearer {proxy_key}"
         if session_id:
             headers["X-Hermes-Session-Id"] = session_id
+        # Forward SessionSource identity so the remote api_server can reconstruct
+        # per-user peer scoping (same subset the api_server identity headers accept).
+        # Each is sent only when set on the source — a partial identity is more
+        # useful downstream than none.
+        for _header, _attr in (
+            ("X-Hermes-User-Id", "user_id"),
+            ("X-Hermes-User-Name", "user_name"),
+            ("X-Hermes-Chat-Id", "chat_id"),
+            ("X-Hermes-Chat-Name", "chat_name"),
+            ("X-Hermes-Chat-Type", "chat_type"),
+            ("X-Hermes-Thread-Id", "thread_id"),
+        ):
+            _value = getattr(source, _attr, None)
+            if _value:
+                headers[_header] = str(_value)
         body = {"model": "hermes-agent", "messages": api_messages, "stream": True}
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -33,6 +33,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
+    _identity_scoped_idempotency_key,
     _redact_api_error_text,
     _request_agent_overrides,
     check_api_server_requirements,
@@ -3082,3 +3083,145 @@ class TestUserIdentityHeaders:
             assert features["thread_id_header"] == "X-Hermes-Thread-Id"
             assert features["user_body_fallback"] == "user"
 
+
+
+# ---------------------------------------------------------------------------
+# Identity-scoped idempotency (cross-identity cache isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityScopedIdempotencyKey:
+    """Unit tests for _identity_scoped_idempotency_key.
+
+    Identity changes the agent/memory result, so the idempotency cache must
+    be partitioned by resolved identity: same key + same body under two
+    identities must never share a cached response.
+    """
+
+    def test_no_identity_keeps_raw_key(self):
+        assert _identity_scoped_idempotency_key("idem-1", {}) == "idem-1"
+        assert _identity_scoped_idempotency_key("idem-1", None) == "idem-1"
+
+    def test_identity_appends_stable_suffix(self):
+        k1 = _identity_scoped_idempotency_key("idem-1", {"user_id": "alice"})
+        k2 = _identity_scoped_idempotency_key("idem-1", {"user_id": "alice"})
+        assert k1 == k2
+        assert k1 != "idem-1"
+        assert k1.startswith("idem-1:")
+
+    def test_different_identities_get_different_keys(self):
+        ka = _identity_scoped_idempotency_key("idem-1", {"user_id": "alice"})
+        kb = _identity_scoped_idempotency_key("idem-1", {"user_id": "bob"})
+        assert ka != kb
+
+    def test_dict_insertion_order_does_not_matter(self):
+        k1 = _identity_scoped_idempotency_key("idem-1", {"user_id": "u", "chat_id": "c"})
+        k2 = _identity_scoped_idempotency_key("idem-1", {"chat_id": "c", "user_id": "u"})
+        assert k1 == k2
+
+
+class TestIdentityScopedIdempotencyEndpoints:
+    """Same Idempotency-Key + identical body across two identities must not
+    share a cached response (chat + Responses); same identity retries and
+    identity-less requests keep normal idempotency semantics."""
+
+    @staticmethod
+    def _mock_run(payloads):
+        """AsyncMock for _run_agent returning successive payloads."""
+        results = [
+            ({"final_response": p, "messages": [], "api_calls": 1},
+             {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            for p in payloads
+        ]
+        return AsyncMock(side_effect=results)
+
+    @pytest.mark.asyncio
+    async def test_chat_cross_identity_does_not_share_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-hdr",
+                             "X-Hermes-User-Id": "alice"},
+                    json=body,
+                )
+                r2 = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-hdr",
+                             "X-Hermes-User-Id": "bob"},
+                    json=body,
+                )
+            assert r1.status == 200 and r2.status == 200
+            d1, d2 = await r1.json(), await r2.json()
+            assert d1["choices"][0]["message"]["content"] == "for-alice"
+            assert d2["choices"][0]["message"]["content"] == "for-bob"
+            assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_chat_same_identity_retry_hits_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-retry",
+                   "X-Hermes-User-Id": "alice"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["first", "second"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+                r2 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+            assert r1.status == 200 and r2.status == 200
+            d1, d2 = await r1.json(), await r2.json()
+            assert d1["choices"][0]["message"]["content"] == "first"
+            assert d2["choices"][0]["message"]["content"] == "first"
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_identity_less_requests_keep_old_semantics(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-plain"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["first", "second"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+                r2 = await cli.post("/v1/chat/completions", headers=headers, json=body)
+            assert r1.status == 200 and r2.status == 200
+            d2 = await r2.json()
+            assert d2["choices"][0]["message"]["content"] == "first"
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_body_user_fallback_also_scopes_cache(self, auth_adapter):
+        """OpenAI body `user` fallback partitions the cache like the header does."""
+        app = _create_app(auth_adapter)
+        base = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-body"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", headers=headers, json={**base, "user": "alice"})
+                r2 = await cli.post("/v1/chat/completions", headers=headers, json={**base, "user": "bob"})
+            assert r1.status == 200 and r2.status == 200
+            d1, d2 = await r1.json(), await r2.json()
+            assert d1["choices"][0]["message"]["content"] == "for-alice"
+            assert d2["choices"][0]["message"]["content"] == "for-bob"
+            assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_responses_cross_identity_does_not_share_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "input": "hi", "store": False}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-resp-hdr",
+                             "X-Hermes-User-Id": "alice"},
+                    json=body,
+                )
+                r2 = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-resp-hdr",
+                             "X-Hermes-User-Id": "bob"},
+                    json=body,
+                )
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 2

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2860,3 +2860,225 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
+
+
+# X-Hermes-User-* / Chat-* / Thread-Id headers (multi-user identity)
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdentityHeaders:
+    """The 6 identity headers thread through to AIAgent kwargs, mirroring the
+    SessionSource subset that native gateway adapters pass via
+    GatewayRunner._run_agent_task (gateway/run.py:14881-14888).
+
+    Drives Honcho's ``runtime_user_peer_name`` resolution, per-user memory
+    tooling, session DB attribution, etc. — same downstream consumers as
+    the native adapters, just reached through ``api_server``.
+
+    Mirrors the X-Hermes-Session-Key test template above.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_six_headers_threaded_to_agent(self, auth_adapter):
+        """All 6 identity headers reach _run_agent as a single user_identity dict."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "user-42",
+                        "X-Hermes-User-Name": "Alice",
+                        "X-Hermes-Chat-Id": "group-abc",
+                        "X-Hermes-Chat-Name": "PM Discussion",
+                        "X-Hermes-Chat-Type": "group",
+                        "X-Hermes-Thread-Id": "thread-99",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {
+                "user_id": "user-42",
+                "user_name": "Alice",
+                "chat_id": "group-abc",
+                "chat_name": "PM Discussion",
+                "chat_type": "group",
+                "thread_id": "thread-99",
+            }
+
+    @pytest.mark.asyncio
+    async def test_headers_echoed_back_in_response(self, auth_adapter):
+        """Identity headers are echoed back so clients can confirm what the server saw."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "user-42",
+                        "X-Hermes-Chat-Type": "group",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User-Id") == "user-42"
+            assert resp.headers.get("X-Hermes-Chat-Type") == "group"
+
+    @pytest.mark.asyncio
+    async def test_absent_headers_yield_empty_identity(self, auth_adapter):
+        """No identity headers → user_identity={} → no kwargs forwarded to AIAgent."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {}
+
+    @pytest.mark.asyncio
+    async def test_headers_silently_ignored_without_auth(self, adapter):
+        """Without API_SERVER_KEY configured, identity headers are silently dropped.
+
+        Same posture as X-Hermes-Session-Key's auth gate but without the 403
+        — identity headers carry less risk than memory-scope, so partial
+        functionality (no identity) is preferred over a hard reject that
+        would break local-only dev.
+        """
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-User-Id": "user-42"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {}
+
+    @pytest.mark.asyncio
+    async def test_control_chars_silently_dropped(self, auth_adapter):
+        """Header-injection attempts in identity headers are silently dropped via the helper.
+
+        Note: aiohttp client refuses to SEND a header containing CR/LF
+        (client-side check), so test the helper directly instead.
+        """
+        mock_request = MagicMock()
+        mock_request.headers = {
+            "X-Hermes-User-Id": "user-42\r\nX-Injected: evil",
+            "X-Hermes-Chat-Id": "ok",
+        }
+        out = auth_adapter._parse_user_identity_headers(mock_request, body=None)
+        assert out == {"chat_id": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_oversized_values_silently_dropped(self, auth_adapter):
+        """Values exceeding the soft length cap (256 chars) are silently dropped per-header."""
+        mock_request = MagicMock()
+        long_value = "x" * 257
+        mock_request.headers = {
+            "X-Hermes-User-Id": long_value,
+            "X-Hermes-Chat-Id": "valid",
+        }
+        out = auth_adapter._parse_user_identity_headers(mock_request, body=None)
+        assert out == {"chat_id": "valid"}
+
+    @pytest.mark.asyncio
+    async def test_openai_user_body_field_fallback(self, auth_adapter):
+        """OpenAI's standard top-level ``user`` body field used as fallback for X-Hermes-User-Id.
+
+        Lets vanilla OpenAI SDK clients (which already populate ``user`` for
+        abuse monitoring) work without configuring custom headers.
+        """
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "user": "openai-style-user-id",
+                    },
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"]["user_id"] == "openai-style-user-id"
+
+    @pytest.mark.asyncio
+    async def test_header_wins_over_openai_body_field(self, auth_adapter):
+        """When both X-Hermes-User-Id and OpenAI ``user`` field present, header wins."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "from-header",
+                    },
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "user": "from-body",
+                    },
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"]["user_id"] == "from-header"
+
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_accepts_identity_headers(self, auth_adapter):
+        """/v1/responses honors the same identity-header contract."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "user-7",
+                        "X-Hermes-Chat-Id": "channel-1",
+                    },
+                    json={"model": "hermes-agent", "input": "hello", "store": False},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User-Id") == "user-7"
+            assert resp.headers.get("X-Hermes-Chat-Id") == "channel-1"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_identity"]["user_id"] == "user-7"
+            assert call_kwargs["user_identity"]["chat_id"] == "channel-1"
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertises_identity_headers(self, adapter):
+        """GET /v1/capabilities advertises all 6 new headers + body fallback for feature detection."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            features = (await resp.json())["features"]
+            assert features["user_id_header"] == "X-Hermes-User-Id"
+            assert features["user_name_header"] == "X-Hermes-User-Name"
+            assert features["chat_id_header"] == "X-Hermes-Chat-Id"
+            assert features["chat_name_header"] == "X-Hermes-Chat-Name"
+            assert features["chat_type_header"] == "X-Hermes-Chat-Type"
+            assert features["thread_id_header"] == "X-Hermes-Thread-Id"
+            assert features["user_body_fallback"] == "user"
+

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3205,3 +3205,254 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="s2", gateway_session_key="ch")
         assert captured[1]["model"] == "anthropic/claude-opus-4.6"
+
+
+# ---------------------------------------------------------------------------
+# X-Hermes-User-* / Chat-* / Thread-Id headers (multi-user identity)
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdentityHeaders:
+    """The identity headers thread through to AIAgent kwargs, mirroring the
+    SessionSource subset native gateway adapters pass — same downstream
+    consumers (Honcho ``runtime_user_peer_name``, per-user memory, session DB),
+    reached through api_server instead."""
+
+    @pytest.mark.asyncio
+    async def test_all_six_headers_threaded_to_agent(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "user-42",
+                        "X-Hermes-User-Name": "Alice",
+                        "X-Hermes-Chat-Id": "group-abc",
+                        "X-Hermes-Chat-Name": "PM Discussion",
+                        "X-Hermes-Chat-Type": "group",
+                        "X-Hermes-Thread-Id": "thread-99",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {
+                "user_id": "user-42", "user_name": "Alice", "chat_id": "group-abc",
+                "chat_name": "PM Discussion", "chat_type": "group", "thread_id": "thread-99",
+            }
+
+    @pytest.mark.asyncio
+    async def test_headers_echoed_back_in_response(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret",
+                             "X-Hermes-User-Id": "user-42", "X-Hermes-Chat-Type": "group"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User-Id") == "user-42"
+            assert resp.headers.get("X-Hermes-Chat-Type") == "group"
+
+    @pytest.mark.asyncio
+    async def test_absent_headers_yield_empty_identity(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {}
+
+    @pytest.mark.asyncio
+    async def test_headers_silently_ignored_without_auth(self, adapter):
+        """Without API_SERVER_KEY the headers are dropped, not 403'd: identity carries
+        less risk than memory scope, so local-only dev stays frictionless."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-User-Id": "user-42"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"] == {}
+
+    def test_control_chars_silently_dropped(self, auth_adapter):
+        """aiohttp's client refuses to send CR/LF headers, so exercise the helper directly."""
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-User-Id": "user-42\r\nX-Injected: evil",
+                                "X-Hermes-Chat-Id": "ok"}
+        assert auth_adapter._parse_user_identity_headers(mock_request, body=None) == {"chat_id": "ok"}
+
+    def test_oversized_values_silently_dropped(self, auth_adapter):
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-User-Id": "x" * 257, "X-Hermes-Chat-Id": "valid"}
+        assert auth_adapter._parse_user_identity_headers(mock_request, body=None) == {"chat_id": "valid"}
+
+    @pytest.mark.asyncio
+    async def test_openai_user_body_field_fallback(self, auth_adapter):
+        """Vanilla OpenAI SDK clients already populate top-level ``user``; accept it."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}],
+                          "user": "openai-style-user-id"},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"]["user_id"] == "openai-style-user-id"
+
+    @pytest.mark.asyncio
+    async def test_header_wins_over_openai_body_field(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret", "X-Hermes-User-Id": "from-header"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}],
+                          "user": "from-body"},
+                )
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["user_identity"]["user_id"] == "from-header"
+
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_accepts_identity_headers(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={"Authorization": "Bearer sk-secret",
+                             "X-Hermes-User-Id": "user-7", "X-Hermes-Chat-Id": "channel-1"},
+                    json={"model": "hermes-agent", "input": "hello", "store": False},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User-Id") == "user-7"
+            assert resp.headers.get("X-Hermes-Chat-Id") == "channel-1"
+            identity = mock_run.call_args.kwargs["user_identity"]
+            assert identity["user_id"] == "user-7" and identity["chat_id"] == "channel-1"
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertises_identity_headers(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            features = (await resp.json())["features"]
+            assert features["user_id_header"] == "X-Hermes-User-Id"
+            assert features["user_name_header"] == "X-Hermes-User-Name"
+            assert features["chat_id_header"] == "X-Hermes-Chat-Id"
+            assert features["chat_name_header"] == "X-Hermes-Chat-Name"
+            assert features["chat_type_header"] == "X-Hermes-Chat-Type"
+            assert features["thread_id_header"] == "X-Hermes-Thread-Id"
+            assert features["user_body_fallback"] == "user"
+
+
+class TestIdentityScopedIdempotency:
+    """Identity extends the principal scope of the Idempotency-Key cache: callers sharing
+    one API_SERVER_KEY have the same principal scope, but identity changes the agent
+    result, so an identical body under two identities must not replay each other."""
+
+    @staticmethod
+    def _mock_run(payloads):
+        return AsyncMock(side_effect=[
+            ({"final_response": p, "messages": [], "api_calls": 1},
+             {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}) for p in payloads])
+
+    @pytest.mark.asyncio
+    async def test_chat_cross_identity_does_not_share_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", json=body, headers={
+                    "Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-hdr",
+                    "X-Hermes-User-Id": "alice"})
+                r2 = await cli.post("/v1/chat/completions", json=body, headers={
+                    "Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-hdr",
+                    "X-Hermes-User-Id": "bob"})
+            assert r1.status == 200 and r2.status == 200
+            assert (await r1.json())["choices"][0]["message"]["content"] == "for-alice"
+            assert (await r2.json())["choices"][0]["message"]["content"] == "for-bob"
+            assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_chat_same_identity_retry_hits_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-retry",
+                   "X-Hermes-User-Id": "alice"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["first", "second"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", json=body, headers=headers)
+                r2 = await cli.post("/v1/chat/completions", json=body, headers=headers)
+            assert r1.status == 200 and r2.status == 200
+            assert (await r2.json())["choices"][0]["message"]["content"] == "first"
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_identity_less_requests_keep_plain_key(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-plain"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["first", "second"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", json=body, headers=headers)
+                r2 = await cli.post("/v1/chat/completions", json=body, headers=headers)
+            assert r1.status == 200 and r2.status == 200
+            assert (await r2.json())["choices"][0]["message"]["content"] == "first"
+            assert mock_run.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_body_user_fallback_also_scopes_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        base = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        headers = {"Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-chat-body"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post("/v1/chat/completions", headers=headers, json={**base, "user": "alice"})
+                r2 = await cli.post("/v1/chat/completions", headers=headers, json={**base, "user": "bob"})
+            assert r1.status == 200 and r2.status == 200
+            assert (await r1.json())["choices"][0]["message"]["content"] == "for-alice"
+            assert (await r2.json())["choices"][0]["message"]["content"] == "for-bob"
+            assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_responses_cross_identity_does_not_share_cache(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        body = {"model": "hermes-agent", "input": "hi", "store": False}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new=self._mock_run(["for-alice", "for-bob"])) as mock_run:
+                r1 = await cli.post("/v1/responses", json=body, headers={
+                    "Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-resp-hdr",
+                    "X-Hermes-User-Id": "alice"})
+                r2 = await cli.post("/v1/responses", json=body, headers={
+                    "Authorization": "Bearer sk-secret", "Idempotency-Key": "xid-resp-hdr",
+                    "X-Hermes-User-Id": "bob"})
+            assert r1.status == 200 and r2.status == 200
+            assert mock_run.call_count == 2

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -637,3 +637,69 @@ class TestRunsProviderAuthFailure:
                 assert status["status"] == "failed"
                 assert status["error"] == "⚠️ Provider authentication failed: No credentials found for provider 'nous'"
                 assert status["last_event"] == "run.failed"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs — multi-user identity headers
+# ---------------------------------------------------------------------------
+
+
+class TestRunsUserIdentity:
+    """X-Hermes-User-*/Chat-* headers on /v1/runs thread through to the agent,
+    same as on /v1/chat/completions and /v1/responses."""
+
+    @staticmethod
+    def _fast_agent():
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        return mock_agent
+
+    @staticmethod
+    async def _wait_for_call(mock_create, timeout: float = 5.0):
+        deadline = time.monotonic() + timeout
+        while mock_create.call_args is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+        assert mock_create.call_args is not None, "agent was never created"
+
+    @pytest.mark.asyncio
+    async def test_identity_headers_threaded_to_agent(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_create.return_value = self._fast_agent()
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-User-Id": "user-42",
+                        "X-Hermes-Chat-Id": "group-abc",
+                        "X-Hermes-Chat-Type": "group",
+                    },
+                    json={"input": "hello"},
+                )
+                assert resp.status == 202
+                await self._wait_for_call(mock_create)
+                identity = mock_create.call_args.kwargs["user_identity"]
+                assert identity == {
+                    "user_id": "user-42",
+                    "chat_id": "group-abc",
+                    "chat_type": "group",
+                }
+
+    @pytest.mark.asyncio
+    async def test_no_identity_headers_yield_empty_identity(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_create.return_value = self._fast_agent()
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"input": "hello"},
+                )
+                assert resp.status == 202
+                await self._wait_for_call(mock_create)
+                assert mock_create.call_args.kwargs["user_identity"] == {}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -2194,3 +2194,57 @@ class TestHostedRoomRuns:
                 )
             assert rejected.status == 403
             create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs — multi-user identity headers
+# ---------------------------------------------------------------------------
+
+
+class TestRunsUserIdentity:
+    """Identity headers on /v1/runs reach the agent, same contract as
+    /v1/chat/completions and /v1/responses."""
+
+    @staticmethod
+    def _fast_agent():
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        return mock_agent
+
+    @staticmethod
+    async def _wait_for_call(mock_create, timeout: float = 5.0):
+        deadline = time.monotonic() + timeout
+        while mock_create.call_args is None and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+        assert mock_create.call_args is not None, "agent was never created"
+
+    @pytest.mark.asyncio
+    async def test_identity_headers_threaded_to_agent(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_create.return_value = self._fast_agent()
+                resp = await cli.post("/v1/runs", json={"input": "hello"}, headers={
+                    "Authorization": "Bearer sk-secret",
+                    "X-Hermes-User-Id": "user-42",
+                    "X-Hermes-Chat-Id": "group-abc",
+                    "X-Hermes-Chat-Type": "group"})
+                assert resp.status == 202
+                await self._wait_for_call(mock_create)
+                assert mock_create.call_args.kwargs["user_identity"] == {
+                    "user_id": "user-42", "chat_id": "group-abc", "chat_type": "group"}
+
+    @pytest.mark.asyncio
+    async def test_no_identity_headers_yield_empty_identity(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent") as mock_create:
+                mock_create.return_value = self._fast_agent()
+                resp = await cli.post("/v1/runs", json={"input": "hello"},
+                                      headers={"Authorization": "Bearer sk-secret"})
+                assert resp.status == 202
+                await self._wait_for_call(mock_create)
+                assert mock_create.call_args.kwargs["user_identity"] == {}

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -209,6 +209,16 @@ class TestRunAgentViaProxy:
         # Verify session ID header
         assert session.captured_headers["X-Hermes-Session-Id"] == "session-abc"
 
+        # Verify SessionSource identity headers forwarded so remote
+        # api_server can reconstruct per-user peer scoping
+        assert session.captured_headers["X-Hermes-User-Id"] == "@user:server.org"
+        assert session.captured_headers["X-Hermes-User-Name"] == "testuser"
+        assert session.captured_headers["X-Hermes-Chat-Id"] == "!room:server.org"
+        assert session.captured_headers["X-Hermes-Chat-Name"] == "Test Room"
+        assert session.captured_headers["X-Hermes-Chat-Type"] == "group"
+        # thread_id is None in the fixture source, must NOT be in headers
+        assert "X-Hermes-Thread-Id" not in session.captured_headers
+
         # Verify messages include system, history, and current message
         messages = session.captured_json["messages"]
         assert messages[0] == {"role": "system", "content": "You are helpful."}

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -209,6 +209,16 @@ class TestRunAgentViaProxy:
         # Verify session ID header
         assert session.captured_headers["X-Hermes-Session-Id"] == "session-abc"
 
+        # SessionSource identity is forwarded so the remote api_server can
+        # reconstruct per-user peer scoping across the proxy boundary.
+        assert session.captured_headers["X-Hermes-User-Id"] == "@user:server.org"
+        assert session.captured_headers["X-Hermes-User-Name"] == "testuser"
+        assert session.captured_headers["X-Hermes-Chat-Id"] == "!room:server.org"
+        assert session.captured_headers["X-Hermes-Chat-Name"] == "Test Room"
+        assert session.captured_headers["X-Hermes-Chat-Type"] == "group"
+        # thread_id is unset on this source, so the header must be omitted entirely
+        assert "X-Hermes-Thread-Id" not in session.captured_headers
+
         # Verify messages include system, history, and current message
         messages = session.captured_json["messages"]
         assert messages[0] == {"role": "system", "content": "You are helpful."}

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -131,6 +131,10 @@ OpenAI clients that already populate the standard top-level `user` body field fo
 
 Headers require an authenticated request (i.e. `API_SERVER_KEY` configured and `Authorization: Bearer …` sent); on an unauthenticated local-only server they are silently ignored, matching the posture of `X-Hermes-Session-Key`.
 
+Identity also partitions the `Idempotency-Key` cache: the same key with the same body under two different identities is treated as two distinct requests, so one caller can never read (or evict) another identity's cached response. Identity-less requests keep plain key semantics.
+
+**Scope — stateless endpoints only.** Identity headers apply to `/v1/chat/completions`, `/v1/responses`, and `/v1/runs` — the stateless surface where each request carries its own full context and may legitimately come from a different end-user. The persisted-session routes (`POST /api/sessions/{id}/chat` and `/chat/stream`) are deliberately excluded: a persisted session's identity is fixed when the session is created and addressed via `X-Hermes-Session-Key`, so accepting a different per-request identity mid-session would fragment the session's memory attribution. If you need per-user identity, use the stateless endpoints; if you need a long-lived named session, its identity belongs to the session, not the request.
+
 Example: a chat-bot bridge proxying many users in a group:
 
 ```bash

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,6 +112,41 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
+#### Multi-user identity headers
+
+When one Hermes process serves multiple end-users (Open WebUI multi-user, chat-bot bridges, multi-tenant deployments), clients can pass per-request identity via the following optional headers.  They mirror the `SessionSource` fields that native gateway adapters (Telegram, Discord, Slack, …) thread to `AIAgent` for the same purpose — driving Honcho's per-user peer cards, per-user memory directories, session attribution, etc.
+
+| Header | Purpose |
+|---|---|
+| `X-Hermes-User-Id` | Stable per-user identifier (the speaker) |
+| `X-Hermes-User-Name` | Human-readable display name |
+| `X-Hermes-Chat-Id` | Chat / room / group identifier |
+| `X-Hermes-Chat-Name` | Chat / room display name |
+| `X-Hermes-Chat-Type` | `"dm"`, `"group"`, `"channel"`, or `"thread"` |
+| `X-Hermes-Thread-Id` | Sub-thread within a chat (e.g. Telegram forum topic, Discord thread) |
+
+All six are optional and independent — send only the ones your client has. Values are bounded at 256 characters; control-character values are silently dropped. Headers are echoed back on the response so clients can confirm what the server saw.
+
+OpenAI clients that already populate the standard top-level `user` body field for abuse-monitoring get the same effect for free: `user` is used as a fallback for `X-Hermes-User-Id` when the header is absent (header wins when both are set).
+
+Headers require an authenticated request (i.e. `API_SERVER_KEY` configured and `Authorization: Bearer …` sent); on an unauthenticated local-only server they are silently ignored, matching the posture of `X-Hermes-Session-Key`.
+
+Example: a chat-bot bridge proxying many users in a group:
+
+```bash
+curl http://localhost:8642/v1/chat/completions \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -H "X-Hermes-Session-Key: agent:main:nonebot-onebot11:group:12345" \
+  -H "X-Hermes-User-Id: user-42" \
+  -H "X-Hermes-User-Name: Alice" \
+  -H "X-Hermes-Chat-Id: 12345" \
+  -H "X-Hermes-Chat-Name: Product Discussion" \
+  -H "X-Hermes-Chat-Type: group" \
+  -d '{"model": "hermes-agent", "messages": [{"role": "user", "content": "..."}]}'
+```
+
+Subsequent requests from the same `user-42` in the same group land on the same per-user peer in Honcho; requests from `user-43` in the same group share the group-scoped `Session-Key` but accumulate their own peer card. See [Multi-User Setup](#multi-user-setup) below for the full picture.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.
@@ -250,10 +285,21 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "session_continuity_header": "X-Hermes-Session-Id",
+    "session_key_header": "X-Hermes-Session-Key",
+    "user_id_header": "X-Hermes-User-Id",
+    "user_name_header": "X-Hermes-User-Name",
+    "chat_id_header": "X-Hermes-Chat-Id",
+    "chat_name_header": "X-Hermes-Chat-Name",
+    "chat_type_header": "X-Hermes-Chat-Type",
+    "thread_id_header": "X-Hermes-Thread-Id",
+    "user_body_fallback": "user"
   }
 }
 ```
+
+The `*_header` fields advertise the multi-user identity header set so clients can feature-detect support without parsing version strings. `user_body_fallback: "user"` indicates the server accepts OpenAI's standard top-level `user` body field as a fallback for `X-Hermes-User-Id`.
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
@@ -618,9 +664,50 @@ Any frontend that supports the OpenAI API format works. Tested/documented integr
 | OpenAI Python SDK | — | `OpenAI(base_url="http://localhost:8642/v1")` |
 | curl | — | Direct HTTP requests |
 
-## Multi-User Setup with Profiles
+## Multi-User Setup
 
-To give multiple users their own isolated Hermes instance (separate config, memory, skills), use [profiles](/user-guide/profiles):
+The API server supports two complementary multi-user strategies. Pick the one that matches your isolation requirements and operational cost tolerance.
+
+### Strategy A — Per-request identity headers (shared process)
+
+One Hermes process serves many users distinguished per-request via the [identity headers](#multi-user-identity-headers) (`X-Hermes-User-Id`, `X-Hermes-Chat-Id`, …) on `/v1/chat/completions`, `/v1/responses`, and `/v1/runs`.
+
+**Best for**:
+- chat-bot bridges (multiple end-users sharing one bot infrastructure)
+- multi-tenant SaaS deployments
+- gateway proxy mode (a native adapter on one host forwarding to a shared remote api_server — identity is preserved across the proxy boundary)
+- Open WebUI / LobeChat / LibreChat shared-instance deployments
+
+**Trade-offs**:
+- One LLM context budget shared across all users (no per-user `~/.hermes` separation)
+- All users share the same memory provider workspace — per-user scoping happens *inside* the provider (e.g. Honcho `peer` cards) rather than via process isolation
+- Lower operational cost than per-user processes
+
+Configure once, then pass identity headers per request:
+
+```bash
+hermes profile create main
+cat >> ~/.hermes/profiles/main/.env <<EOF
+API_SERVER_ENABLED=true
+API_SERVER_PORT=8642
+API_SERVER_KEY=shared-secret
+EOF
+hermes -p main gateway &
+
+# Each request carries the per-user identity in headers:
+curl http://localhost:8642/v1/chat/completions \
+  -H "Authorization: Bearer shared-secret" \
+  -H "X-Hermes-User-Id: alice" \
+  -H "X-Hermes-Chat-Id: dm-alice" \
+  -H "X-Hermes-Chat-Type: dm" \
+  -d '{"model": "hermes-agent", "messages": [{"role": "user", "content": "..."}]}'
+```
+
+Memory providers that honor `runtime_user_peer_name` (Honcho is the reference implementation) build separate peer representations per `X-Hermes-User-Id` value, so each user gets a distinct picture across shared sessions. Native gateway adapters (Telegram, Discord, …) drive the same provider-side scoping; this is what makes a single Hermes process work as a multi-user chat bot today.
+
+### Strategy B — Profile-per-user (full process isolation)
+
+Each user gets a separate Hermes process — separate config, separate memory directory, separate skills — distinguished by port and API key:
 
 ```bash
 # Create a profile per user
@@ -651,7 +738,16 @@ Each profile's API server automatically advertises the profile name as the model
 - `http://localhost:8643/v1/models` → model `alice`
 - `http://localhost:8644/v1/models` → model `bob`
 
-In Open WebUI, add each as a separate connection. The model dropdown shows `alice` and `bob` as distinct models, each backed by a fully isolated Hermes instance. See the [Open WebUI guide](/user-guide/messaging/open-webui#multi-user-setup-with-profiles) for details.
+**Best for**:
+- strong isolation requirements (e.g. each user runs different skills / config)
+- few users at large scale per user (each gets full single-user resources)
+- legacy frontends that can't send custom headers
+
+In Open WebUI, add each as a separate connection. The model dropdown shows `alice` and `bob` as distinct models, each backed by a fully isolated Hermes instance. See the [Open WebUI multi-user guide](/user-guide/messaging/open-webui#strategy-b--profile-per-user-full-process-isolation) for details.
+
+### Mixing strategies
+
+Strategy A (per-request) and Strategy B (per-process) compose: a tenant boundary can be a profile while users within the tenant are distinguished by header. Useful for multi-tenant SaaS where each tenant gets a sandboxed `~/.hermes` but the tenant's own users share the in-tenant process.
 
 ## Limitations
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -112,6 +112,45 @@ Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs re
 - **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
+#### Multi-user identity headers
+
+When one Hermes process serves multiple end-users (Open WebUI multi-user, chat-bot bridges, multi-tenant deployments), clients can pass per-request identity via the following optional headers.  They mirror the `SessionSource` fields that native gateway adapters (Telegram, Discord, Slack, …) thread to `AIAgent` for the same purpose — driving Honcho's per-user peer cards, per-user memory directories, session attribution, etc.
+
+| Header | Purpose |
+|---|---|
+| `X-Hermes-User-Id` | Stable per-user identifier (the speaker) |
+| `X-Hermes-User-Name` | Human-readable display name |
+| `X-Hermes-Chat-Id` | Chat / room / group identifier |
+| `X-Hermes-Chat-Name` | Chat / room display name |
+| `X-Hermes-Chat-Type` | `"dm"`, `"group"`, `"channel"`, or `"thread"` |
+| `X-Hermes-Thread-Id` | Sub-thread within a chat (e.g. Telegram forum topic, Discord thread) |
+
+All six are optional and independent — send only the ones your client has. Values are bounded at 256 characters; control-character values are silently dropped. Headers are echoed back on the response so clients can confirm what the server saw.
+
+OpenAI clients that already populate the standard top-level `user` body field for abuse-monitoring get the same effect for free: `user` is used as a fallback for `X-Hermes-User-Id` when the header is absent (header wins when both are set).
+
+Headers require an authenticated request (i.e. `API_SERVER_KEY` configured and `Authorization: Bearer …` sent); on an unauthenticated local-only server they are silently ignored, matching the posture of `X-Hermes-Session-Key`.
+
+Identity also extends the `Idempotency-Key` namespace below the principal scope. Callers sharing one `API_SERVER_KEY` are the same principal, so without this the same key and body under two identities would replay one another's response; with it, each identity gets its own cache slot — retries still hit within an identity, and neither can read or evict the other's. Identity-less requests keep the plain principal-scoped key.
+
+**Scope — stateless endpoints only.** Identity headers apply to `/v1/chat/completions`, `/v1/responses`, and `/v1/runs` — the stateless surface where each request carries its own full context and may legitimately come from a different end-user. The persisted-session routes (`POST /api/sessions/{id}/chat` and `/chat/stream`) are deliberately excluded: a persisted session's identity is fixed when the session is created and addressed via `X-Hermes-Session-Key`, so accepting a different per-request identity mid-session would fragment the session's memory attribution. If you need per-user identity, use the stateless endpoints; if you need a long-lived named session, its identity belongs to the session, not the request.
+
+Example: a chat-bot bridge proxying many users in a group:
+
+```bash
+curl http://localhost:8642/v1/chat/completions \
+  -H "Authorization: Bearer $API_SERVER_KEY" \
+  -H "X-Hermes-Session-Key: agent:main:nonebot-onebot11:group:12345" \
+  -H "X-Hermes-User-Id: user-42" \
+  -H "X-Hermes-User-Name: Alice" \
+  -H "X-Hermes-Chat-Id: 12345" \
+  -H "X-Hermes-Chat-Name: Product Discussion" \
+  -H "X-Hermes-Chat-Type: group" \
+  -d '{"model": "hermes-agent", "messages": [{"role": "user", "content": "..."}]}'
+```
+
+Subsequent requests from the same `user-42` in the same group land on the same per-user peer in Honcho; requests from `user-43` in the same group share the group-scoped `Session-Key` but accumulate their own peer card. See [Multi-User Setup](#multi-user-setup) below for the full picture.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.
@@ -252,10 +291,21 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "session_continuity_header": "X-Hermes-Session-Id",
+    "session_key_header": "X-Hermes-Session-Key",
+    "user_id_header": "X-Hermes-User-Id",
+    "user_name_header": "X-Hermes-User-Name",
+    "chat_id_header": "X-Hermes-Chat-Id",
+    "chat_name_header": "X-Hermes-Chat-Name",
+    "chat_type_header": "X-Hermes-Chat-Type",
+    "thread_id_header": "X-Hermes-Thread-Id",
+    "user_body_fallback": "user"
   }
 }
 ```
+
+The `*_header` fields advertise the multi-user identity header set so clients can feature-detect support without parsing version strings. `user_body_fallback: "user"` indicates the server accepts OpenAI's standard top-level `user` body field as a fallback for `X-Hermes-User-Id`.
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
 
@@ -747,9 +797,50 @@ Any frontend that supports the OpenAI API format works. Tested/documented integr
 | OpenAI Python SDK | — | `OpenAI(base_url="http://localhost:8642/v1")` |
 | curl | — | Direct HTTP requests |
 
-## Multi-User Setup with Profiles
+## Multi-User Setup
 
-To give multiple users their own isolated Hermes instance (separate config, memory, skills), use [profiles](/user-guide/profiles):
+The API server supports two complementary multi-user strategies. Pick the one that matches your isolation requirements and operational cost tolerance.
+
+### Strategy A — Per-request identity headers (shared process)
+
+One Hermes process serves many users distinguished per-request via the [identity headers](#multi-user-identity-headers) (`X-Hermes-User-Id`, `X-Hermes-Chat-Id`, …) on `/v1/chat/completions`, `/v1/responses`, and `/v1/runs`.
+
+**Best for**:
+- chat-bot bridges (multiple end-users sharing one bot infrastructure)
+- multi-tenant SaaS deployments
+- gateway proxy mode (a native adapter on one host forwarding to a shared remote api_server — identity is preserved across the proxy boundary)
+- Open WebUI / LobeChat / LibreChat shared-instance deployments
+
+**Trade-offs**:
+- One LLM context budget shared across all users (no per-user `~/.hermes` separation)
+- All users share the same memory provider workspace — per-user scoping happens *inside* the provider (e.g. Honcho `peer` cards) rather than via process isolation
+- Lower operational cost than per-user processes
+
+Configure once, then pass identity headers per request:
+
+```bash
+hermes profile create main
+cat >> ~/.hermes/profiles/main/.env <<EOF
+API_SERVER_ENABLED=true
+API_SERVER_PORT=8642
+API_SERVER_KEY=shared-secret
+EOF
+hermes -p main gateway &
+
+# Each request carries the per-user identity in headers:
+curl http://localhost:8642/v1/chat/completions \
+  -H "Authorization: Bearer shared-secret" \
+  -H "X-Hermes-User-Id: alice" \
+  -H "X-Hermes-Chat-Id: dm-alice" \
+  -H "X-Hermes-Chat-Type: dm" \
+  -d '{"model": "hermes-agent", "messages": [{"role": "user", "content": "..."}]}'
+```
+
+Memory providers that honor `runtime_user_peer_name` (Honcho is the reference implementation) build separate peer representations per `X-Hermes-User-Id` value, so each user gets a distinct picture across shared sessions. Native gateway adapters (Telegram, Discord, …) drive the same provider-side scoping; this is what makes a single Hermes process work as a multi-user chat bot today.
+
+### Strategy B — Profile-per-user (full process isolation)
+
+Each user gets a separate Hermes process — separate config, separate memory directory, separate skills — distinguished by port and API key:
 
 ```bash
 # Create a profile per user
@@ -780,7 +871,16 @@ Each profile's API server automatically advertises the profile name as the model
 - `http://localhost:8643/v1/models` → model `alice`
 - `http://localhost:8644/v1/models` → model `bob`
 
-In Open WebUI, add each as a separate connection. The model dropdown shows `alice` and `bob` as distinct models, each backed by a fully isolated Hermes instance. See the [Open WebUI guide](/user-guide/messaging/open-webui#multi-user-setup-with-profiles) for details.
+**Best for**:
+- strong isolation requirements (e.g. each user runs different skills / config)
+- few users at large scale per user (each gets full single-user resources)
+- legacy frontends that can't send custom headers
+
+In Open WebUI, add each as a separate connection. The model dropdown shows `alice` and `bob` as distinct models, each backed by a fully isolated Hermes instance. See the [Open WebUI multi-user guide](/user-guide/messaging/open-webui#strategy-b--profile-per-user-full-process-isolation) for details.
+
+### Mixing strategies
+
+Strategy A (per-request) and Strategy B (per-process) compose: a tenant boundary can be a profile while users within the tenant are distinguished by header. Useful for multi-tenant SaaS where each tenant gets a sandboxed `~/.hermes` but the tenant's own users share the in-tenant process.
 
 ## Limitations
 

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -231,7 +231,23 @@ Make sure your `OPENAI_API_KEY` in Open WebUI matches the `API_SERVER_KEY` in He
 Open WebUI persists OpenAI-compatible connection settings in its own database after first launch. If you accidentally saved a wrong key in the Admin UI, fixing the environment variables alone is not enough — update or delete the saved connection in **Admin Settings → Connections**, or reset the Open WebUI data directory / database.
 :::
 
-## Multi-User Setup with Profiles
+## Multi-User Setup
+
+The API server now supports two complementary multi-user strategies — pick one (or combine them) based on whether you want process-level isolation or a single shared instance.
+
+### Strategy A — Single shared instance, per-request identity headers
+
+If you don't need per-user process isolation (separate skills, separate `~/.hermes`), a single Hermes process can serve all Open WebUI users when each request carries `X-Hermes-User-Id` (and friends). This is **simpler to operate** — one port, one process, one config — and lets memory providers like Honcho build per-user peer cards inside the shared instance.
+
+**Catch**: Open WebUI's stock OpenAI connection sends only the model + messages — there's no built-in way to inject `X-Hermes-User-Id` from the logged-in Open WebUI user. Use one of:
+
+- **A reverse proxy / pipeline in front of Hermes** — Open WebUI talks to your proxy; the proxy reads the OpenAI `user` body field (Open WebUI sends this when configured to forward user info) or its own auth layer, then adds the `X-Hermes-*` headers before forwarding to Hermes.
+- **An [Open WebUI Pipeline](https://github.com/open-webui/pipelines)** — a Python plugin that intercepts requests and adds the headers.
+- **The OpenAI `user` body field as fallback** — Hermes accepts the standard top-level `user` field as a fallback for `X-Hermes-User-Id` (header wins when both set). If your Open WebUI deployment is configured to populate `user` automatically (search the Open WebUI codebase for the `user` field setting), no proxy is needed for at least the user-identifier hop.
+
+Strategy A is the right pick for chat-bot bridges, multi-tenant SaaS, or any deployment where shared infrastructure cost matters. See [api_server multi-user identity headers](/docs/user-guide/features/api-server#multi-user-identity-headers) for the full header reference.
+
+### Strategy B — Profile per user (full process isolation)
 
 To run separate Hermes instances per user — each with their own config, memory, and skills — use [profiles](/user-guide/profiles). Each profile runs its own API server on a different port and automatically advertises the profile name as the model in Open WebUI.
 


### PR DESCRIPTION
## Summary

Adds 6 optional headers to `api_server` mirroring `AIAgent.__init__`'s existing identity kwargs, so a single Hermes process can serve multiple end-users distinguished per-request:

| Header | AIAgent kwarg |
|---|---|
| `X-Hermes-User-Id` | `user_id` |
| `X-Hermes-User-Name` | `user_name` |
| `X-Hermes-Chat-Id` | `chat_id` |
| `X-Hermes-Chat-Name` | `chat_name` |
| `X-Hermes-Chat-Type` | `chat_type` |
| `X-Hermes-Thread-Id` | `thread_id` |

Also supports OpenAI's standard top-level `user` body field as a fallback for `X-Hermes-User-Id` (header wins if both present), so vanilla OpenAI SDK clients work without custom header config.

Headers apply to all three agent endpoints: `/v1/chat/completions`, `/v1/responses`, `/v1/runs`. Headers are echoed back on the response just like `X-Hermes-Session-Key` already is. Capabilities are advertised at `/v1/capabilities` so clients can feature-detect.

100% backward-compatible: requests without the new headers behave identically (same fallthrough to single-peer-per-session that native adapters bypass via the same kwargs).

## Why

`AIAgent` already accepts `user_id` / `user_name` / `chat_id` / `chat_name` / `chat_type` / `thread_id` (`run_agent.py:1097-1102`). All native gateway adapters (Telegram, Discord, Slack, Matrix, …) thread these via `GatewayRunner._run_agent_task` (`gateway/run.py:14881-14888`). They drive:
- Honcho's `runtime_user_peer_name` resolution (`run_agent.py:1967-1978` → `plugins/memory/honcho/session.py:304-305`), enabling per-user peer cards in multi-peer-shared-session deployments
- The session-search `user_id` filter (#17989 in flight)
- Memory tool's per-user `~/.hermes/memories/{chat_id}/` directory layout (also #17989)
- Per-platform peer identity routing (#15598 in flight)

`api_server` is the only adapter not threading these. After #20199 added `X-Hermes-Session-Key`, this is the next natural addition.

### The impact today

The current api_server docs (`website/docs/user-guide/features/api-server.md` § *Multi-User Setup with Profiles*) recommend **one Hermes process per user** for multi-user deployments. That works but doesn't scale and blocks shared-session-multi-peer scenarios. With these headers, a single process can serve Open WebUI multi-user, LibreChat multi-tenant, chat-bot bridges (nonebot, custom Discord/Slack bridges via api_server), proxy-mode delegations, etc.

### Hermes-internal beneficiary: proxy mode

`gateway/run.py:_run_agent_via_proxy` currently forwards only `X-Hermes-Session-Id` (lines 13899-13903) — user identity is dropped at the proxy boundary. This PR also patches proxy mode to forward the 6 new headers when present in the source, fixing a latent gap in Hermes's own dogfood.

## Scope

| Change | LOC |
|---|---|
| `gateway/platforms/api_server.py` — `_parse_user_headers()` + thread kwargs through `_create_agent`/`_run_agent` for chat_completions/responses/runs + capabilities advertise + echo on response | ~80 |
| `gateway/run.py` — proxy mode header forwarding | ~25 |
| `tests/gateway/test_api_server.py` — mirror existing `test_session_key_*` template | ~120 |
| `website/docs/user-guide/features/api-server.md` — document new headers + update Multi-User Setup section | ~30 |

**Total ~255 LOC**, no new dependencies, no breaking changes, no migrations.

## Prior art / related work

- **#20199** (merged): `X-Hermes-Session-Key` header for memory scoping — direct precedent, same shape, same `_parse_*_header` style
- **#22708 / #22809** (merged): `session_id` plumbed through `build_api_kwargs_extras` for Grok cache affinity — established the "identity flows through agent transport" pattern on the outgoing side
- **#22714** (open, active): proposes complementary outgoing-side `extra_body.hermes` for downstream dispatcher orchestration — this PR is the **incoming** complement to that
- **#12054** (open): proposes `X-Hermes-Merchant-Id` for tenant isolation — adjacent and compatible (tenant boundary + per-user identity within tenant)
- **#17989** (open): per-user memory/session isolation in tooling — depends on this PR's user_id being passed through
- **#15598** (open): Honcho per-platform peer identity routing — also depends on user_id being available

## Field-naming alignment

`chat_id` (not `room_id`) matches Hermes's `SessionSource.chat_id` (`gateway/session.py:84`) and `build_session_key` output (`agent:main:{platform}:group:{chat_id}:...`). #22714 also moves to this naming for consistency.

## What this PR does NOT include

- ❌ `command_origin` field from #22714's proposal — that's outgoing-side, doesn't belong here
- ❌ `X-Hermes-Merchant-Id` from #12054 — different concern (tenant), separate PR
- ❌ Per-user memory directory creation — that's #17989's scope
- ❌ Authentication / authorization changes — reuses existing `API_SERVER_KEY` gate, same as `X-Hermes-Session-Key`

## Test plan

- [x] Unit: 6 new headers parsed, validated (control chars rejected, length capped at 256, auth required), threaded to AIAgent kwargs
- [x] Unit: OpenAI `user` body field used as `X-Hermes-User-Id` fallback; header wins when both present
- [x] Unit: absent headers → kwargs unset → existing single-peer fallthrough preserved
- [x] Unit: echo-back in response headers
- [x] Unit: `/v1/capabilities` advertises all 6 new `*_header` capabilities
- [x] Unit: proxy mode forwards headers when source has them
- [ ] Integration: existing Honcho integration test confirmed per-user peer card formation (manual, needs Honcho instance)

## Compatibility

- All existing tests pass
- No API surface changes for unmodified callers
- New headers are opt-in
- Unknown header values are silently ignored (validation only rejects control-char injection and oversized values)
- Old api_server clients sending no new headers → unchanged behavior
- New clients targeting old api_server → headers ignored gracefully

## Use cases this unlocks

1. **Open WebUI / LobeChat / LibreChat multi-user**: one Hermes serves many web-UI users with per-user Honcho peer cards (currently requires one Hermes process per user)
2. **Chat-bot bridges via api_server** (nonebot, custom Discord/Slack/Telegram non-native bridges, WhatsApp via Twilio): single Hermes serves many users in many groups with proper memory scoping
3. **Proxy mode** (`#90c98345c`): forwarded calls no longer lose user identity at the api_server boundary
4. **Multi-tenant SaaS Hermes deployments**: one process scales to many end-users, identity-aware per request

---

Refs: #20199 (direct precedent), #22714 (outgoing-side counterpart), #12054, #17989, #15598, #14984
