### PR TITLE
fix(discord): honor bot handoff config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -853,6 +853,10 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "ignore_no_mention" in discord_cfg and not os.getenv("DISCORD_IGNORE_NO_MENTION"):
+                    os.environ["DISCORD_IGNORE_NO_MENTION"] = str(discord_cfg["ignore_no_mention"]).lower()
+                if "allow_bots" in discord_cfg and not os.getenv("DISCORD_ALLOW_BOTS"):
+                    os.environ["DISCORD_ALLOW_BOTS"] = str(discord_cfg["allow_bots"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -444,6 +444,52 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("FEISHU_ALLOW_BOTS") == "none"
 
+    def test_bridges_discord_bot_handoff_settings_from_config_yaml_to_env(self, tmp_path, monkeypatch):
+        """discord.allow_bots must work from config.yaml, not only .env.
+
+        Regression guard for Discord mention handoff: two Hermes agents using
+        Discord-mediated A2A routing need bot-authored messages to be admitted
+        when the sender explicitly @mentions this bot.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_bots: mentions\n"
+            "  ignore_no_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+        monkeypatch.delenv("DISCORD_IGNORE_NO_MENTION", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == "mentions"
+        assert os.environ.get("DISCORD_IGNORE_NO_MENTION") == "true"
+
+    def test_discord_bot_handoff_env_takes_precedence_over_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  allow_bots: all\n"
+            "  ignore_no_mention: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+        monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+
+        load_gateway_config()
+
+        assert os.environ.get("DISCORD_ALLOW_BOTS") == "none"
+        assert os.environ.get("DISCORD_IGNORE_NO_MENTION") == "true"
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -100,7 +100,8 @@ class TestDiscordBotFilter(unittest.TestCase):
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
-        default = os.getenv("DISCORD_ALLOW_BOTS", "none")
+        with patch.dict(os.environ, {}, clear=True):
+            default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
     def test_case_insensitive(self):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -252,6 +252,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_HOME_CHANNEL_NAME` | Display name for the Discord home channel |
 | `DISCORD_COMMAND_SYNC_POLICY` | Discord slash-command startup sync policy: `safe` (diff and reconcile), `bulk` (legacy `tree.sync()`), or `off` |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
+| `DISCORD_IGNORE_NO_MENTION` | Stay silent when another user/bot is mentioned but this bot is not (default: `true`) |
+| `DISCORD_ALLOW_BOTS` | Accept inbound messages from other bots: `none` (default), `mentions`, or `all`. Use `mentions` for targeted Discord-mediated A2A handoff. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -302,6 +302,8 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 # Discord-specific settings
 discord:
   require_mention: true           # Require @mention in server channels
+  ignore_no_mention: true         # Stay silent when another bot/user is mentioned but Hermes is not
+  allow_bots: none                # none | mentions | all; use mentions for Discord-mediated A2A handoff
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -323,6 +325,30 @@ group_sessions_per_user: true     # Isolate sessions per user in shared channels
 **Type:** boolean — **Default:** `true`
 
 When enabled, the bot only responds in server channels when directly `@mentioned`. DMs always get a response regardless of this setting.
+
+#### `discord.ignore_no_mention`
+
+**Type:** boolean — **Default:** `true`
+
+When enabled, Hermes stays silent if a server message mentions other users or bots but does **not** mention this bot. This prevents one Hermes instance from jumping into a message intended for another agent in a shared Discord channel.
+
+#### `discord.allow_bots`
+
+**Type:** string — **Default:** `"none"` — valid values: `"none"`, `"mentions"`, `"all"`
+
+By default, Hermes ignores messages authored by other Discord bots to prevent bot loops. For Discord-mediated agent-to-agent handoff, set this to `mentions` on the receiving Hermes instance:
+
+```yaml
+discord:
+  allow_bots: mentions
+  ignore_no_mention: true
+```
+
+With `mentions`, a bot-authored message is admitted only when it explicitly `@mentions` this bot. This is the recommended setting for multi-agent handoff because it allows targeted goal-contract messages while still rejecting unrelated bot chatter. `all` should only be used in tightly controlled channels.
+
+:::warning
+Agent-to-agent Discord handoff requires **separate Discord bot identities/tokens** for each Hermes instance. A Hermes gateway always ignores messages from its own bot user, so two agents sharing the same Discord bot token cannot use mentions to talk to each other.
+:::
 
 #### `discord.free_response_channels`
 


### PR DESCRIPTION
## Summary
- Bridge `discord.allow_bots` and `discord.ignore_no_mention` from `config.yaml` into the env-backed Discord adapter settings
- Add regression coverage for Discord-mediated agent-to-agent mention handoff config
- Document the recommended `allow_bots: mentions` setup and separate-bot-token requirement for A2A Discord handoff

## Validation
- `python -m pytest tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_discord_bot_handoff_settings_from_config_yaml_to_env tests/gateway/test_config.py::TestLoadGatewayConfig::test_discord_bot_handoff_env_takes_precedence_over_config_yaml tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_bot_auth_bypass.py -q -o 'addopts='` → 19 passed

## Notes
- Full `tests/gateway/test_config.py -q -o 'addopts='` currently has an unrelated existing expectation mismatch: `StreamingConfig.edit_interval` fallback expects 1.0 but code returns 0.8.
