### PR TITLE
fix(agent): use container-aware hint when running on WSL host

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -12,7 +12,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_hermes_home, get_skills_dir, is_container, is_wsl
 from typing import Optional
 
 from agent.skill_utils import (
@@ -606,6 +606,14 @@ WSL_ENVIRONMENT_HINT = (
     "the Windows username if needed."
 )
 
+CONTAINER_ON_WSL_HINT = (
+    "You are running inside a container on a WSL (Windows Subsystem for "
+    "Linux) host. The /mnt/c/ Windows filesystem is NOT available inside "
+    "this container unless explicitly bind-mounted. Do NOT suggest "
+    "WSL-specific tools like wslpath or assume /mnt/c/ paths exist. "
+    "Treat this as a standard Linux container environment."
+)
+
 
 # Non-local terminal backends that run commands (and therefore every file
 # tool: read_file, write_file, patch, search_files) inside a separate
@@ -816,7 +824,9 @@ def build_environment_hints() -> str:
                 f"`uname -a && whoami && pwd`."
             )
 
-    if is_wsl():
+    if is_container() and is_wsl():
+        hints.append(CONTAINER_ON_WSL_HINT)
+    elif is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
     return "\n\n".join(hints)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -847,6 +847,7 @@ class TestEnvironmentHints:
     def test_build_environment_hints_on_wsl(self, monkeypatch):
         import agent.prompt_builder as _pb
         monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: False)
         monkeypatch.delenv("TERMINAL_ENV", raising=False)
         _pb._clear_backend_probe_cache()
         result = _pb.build_environment_hints()
@@ -854,6 +855,22 @@ class TestEnvironmentHints:
         assert "WSL" in result
         # WSL block still carries the always-on host info ahead of it.
         assert "User home directory:" in result
+
+    def test_build_environment_hints_container_on_wsl(self, monkeypatch):
+        """Container on WSL host should NOT get /mnt/c/ path hints."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: True)
+        monkeypatch.setattr(_pb, "is_container", lambda: True)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        # Should get the container-specific hint, not the full WSL one
+        assert "container" in result.lower()
+        # The container hint explicitly warns against /mnt/c/ assumptions
+        assert "NOT available" in result
+        # The full WSL_ENVIRONMENT_HINT (which tells the agent /mnt/c/ IS
+        # available and to translate Windows paths) must NOT appear.
+        assert WSL_ENVIRONMENT_HINT not in result
 
     def test_build_environment_hints_on_linux_local(self, monkeypatch):
         import agent.prompt_builder as _pb


### PR DESCRIPTION
## Issue Summary

When hermes-agent runs inside a Docker/Podman container on a WSL2 host, `is_wsl()` returns True because `/proc/version` still contains `microsoft`. `build_environment_hints()` only checks `is_wsl()` and injects the full `WSL_ENVIRONMENT_HINT`, which tells the agent:

- `/mnt/c/` paths are available (they are NOT unless bind-mounted)
- `wslpath` can be used (it cannot inside the container)
- The user's Windows files are at `/mnt/c/Users/...` (not accessible)

This causes the agent to attempt file operations at `/mnt/c/Users/...` which silently fail, or to recommend WSL-specific workarounds that don't work.

## Reproduction Steps

1. Run hermes-agent inside a Docker container on WSL2:
   ```bash
   docker run -it --rm hermes-agent
   ```
2. Ask the agent to list `/mnt/c/Users/`
3. Observe: operation fails because `/mnt/c/` doesn't exist inside the container

## Root Cause

In `agent/prompt_builder.py`, `build_environment_hints()` at the end of the function:

```python
if is_wsl():
    hints.append(WSL_ENVIRONMENT_HINT)  # fires inside containers on WSL
```

The existing `is_container()` function in `hermes_constants.py` correctly detects container environments, but `build_environment_hints()` never checks it.

## Fix

Add a `CONTAINER_ON_WSL_HINT` constant that explicitly warns the agent that `/mnt/c/` is NOT available and WSL-specific tools don't work. Check `is_container()` before `is_wsl()`:

```python
if is_container() and is_wsl():
    hints.append(CONTAINER_ON_WSL_HINT)
elif is_wsl():
    hints.append(WSL_ENVIRONMENT_HINT)
```

## Changes

- `agent/prompt_builder.py`: Add `CONTAINER_ON_WSL_HINT`, import `is_container`, update hint selection logic
- `tests/agent/test_prompt_builder.py`: Add test for container-on-WSL case, update existing WSL test to explicitly mock `is_container=False`

## Before vs After

| Scenario | Before | After |
|---|---|---|
| WSL (no container) | WSL hint with /mnt/c/ guidance | Same (unchanged) |
| Container on WSL | WSL hint with /mnt/c/ guidance (WRONG) | Container-aware hint warning /mnt/c/ NOT available |
| Container (no WSL) | No hint | No hint (unchanged) |
| Linux (no WSL, no container) | No hint | No hint (unchanged) |

Fixes #24370