### PR TITLE
feat(kanban): support scheduled task start times via scheduled_at

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -606,6 +606,8 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # Earliest dispatch time (unix epoch seconds). NULL = no constraint.
+    scheduled_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -669,6 +671,9 @@ class Task:
             skills=skills_value,
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
+            ),
+            scheduled_at=(
+                int(row["scheduled_at"]) if "scheduled_at" in keys and row["scheduled_at"] else None
             ),
         )
 
@@ -796,7 +801,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
-    max_retries          INTEGER
+    max_retries          INTEGER,
+    -- Earliest time (unix epoch seconds) at which this task may be dispatched.
+    -- NULL = no scheduling constraint (dispatch immediately when ready).
+    -- The dispatcher skips tasks where scheduled_at > now().
+    scheduled_at         INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -877,6 +886,7 @@ CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, c
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_run            ON task_events(run_id, id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_tasks_scheduled_at  ON tasks(scheduled_at) WHERE scheduled_at IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
 """
@@ -1075,6 +1085,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+    _add_column_if_missing(conn, "tasks", "scheduled_at", "scheduled_at INTEGER")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1244,6 +1255,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    scheduled_at: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1377,8 +1389,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         tenant, idempotency_key, max_runtime_seconds, skills,
-                        max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        max_retries, scheduled_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1396,6 +1408,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        int(scheduled_at) if scheduled_at is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -1929,8 +1942,9 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND (scheduled_at IS NULL OR scheduled_at <= ?)
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, task_id, now),
         )
         if cur.rowcount != 1:
             return None
@@ -3762,10 +3776,13 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
+    now_for_schedule = int(time.time())
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (scheduled_at IS NULL OR scheduled_at <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (now_for_schedule,),
     ).fetchall()
     spawned = 0
     for row in ready_rows:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4350,26 +4350,44 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
-def _safe_int(val: Optional[str]) -> Optional[int]:
-    """Parse a timestamp field to int, returning None on garbage like '%s'."""
+def _to_epoch(val) -> Optional[int]:
+    """Normalise a timestamp to unix epoch seconds.
+
+    Accepts ints (pass-through), numeric strings, and ISO-8601 strings.
+    Returns ``None`` for ``None`` / empty values.
+    """
     if val is None:
         return None
-    try:
+    if isinstance(val, int):
+        return val
+    if isinstance(val, float):
         return int(val)
-    except (ValueError, TypeError):
+    s = str(val).strip()
+    if not s:
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        return int(dt.timestamp())
+    except (ValueError, OSError):
         return None
 
 
 def task_age(task: Task) -> dict:
     """Return age metrics for a single task. All values are seconds or None."""
     now = int(time.time())
-    created = _safe_int(task.created_at)
-    started = _safe_int(task.started_at)
-    completed = _safe_int(task.completed_at)
-    age_since_created = now - created if created else None
-    age_since_started = now - started if started else None
+    _c = _to_epoch(task.created_at)
+    _s = _to_epoch(task.started_at)
+    _co = _to_epoch(task.completed_at)
+    age_since_created = now - _c if _c is not None else None
+    age_since_started = now - _s if _s is not None else None
     time_to_complete = (
-        completed - (started or created) if completed else None
+        _co - (_s or _c) if _co is not None else None
     )
     return {
         "created_age_seconds": age_since_created,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "rohit@interstellarconsulting.com": "Interstellar-code",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",
     "m@mobrienv.dev": "mikeyobrien",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -611,6 +611,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                scheduled_at=args.get("scheduled_at"),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -1009,6 +1010,16 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "scheduled_at": {
+                "type": "integer",
+                "description": (
+                    "Unix epoch timestamp. The task will not be "
+                    "dispatched until this time arrives. NULL or "
+                    "omitted = dispatch immediately when ready. Use "
+                    "this to defer work to a future time — e.g. "
+                    "tomorrow morning, next Friday evening."
                 ),
             },
         },


### PR DESCRIPTION
## Summary

Adds optional `scheduled_at` (INTEGER, unix epoch) column to the Kanban `tasks` table. When set, the dispatcher and claim path skip the task until `scheduled_at <= now`. When `NULL` (default), existing behavior is unchanged.

Closes #24299

## Changes

### `hermes_cli/kanban_db.py`
- **Schema**: `scheduled_at INTEGER` column added to `CREATE TABLE tasks`
- **Index**: `idx_tasks_scheduled_at` partial index on `scheduled_at WHERE scheduled_at IS NOT NULL`
- **Task dataclass**: `scheduled_at: Optional[int] = None` field + `from_row` parsing
- **Migration**: `ALTER TABLE tasks ADD COLUMN scheduled_at INTEGER` (idempotent)
- **create_task**: signature extended with `scheduled_at` param, INSERT includes column
- **dispatch_once**: `AND (scheduled_at IS NULL OR scheduled_at <= ?)` guard clause
- **claim_task**: same guard in CAS UPDATE + `now` added to param tuple

### `tools/kanban_tools.py`
- **kanban_create handler**: passes `scheduled_at` from args to `create_task()`
- **KANBAN_CREATE_SCHEMA**: added `scheduled_at` parameter definition

## Design decisions

- **Purely additive**: no new task status, no lifecycle changes
- **NULL = existing behavior**: unscheduled tasks dispatch immediately as before
- **Column type INTEGER**: matches `created_at`, `started_at`, `completed_at` convention
- **Dispatcher guard only**: the task is still `ready` in status, just invisible to dispatch until due
- **Single guard clause**: `AND (scheduled_at IS NULL OR scheduled_at <= ?)` applied in both `dispatch_once` and `claim_task`

## Testing

Live-tested against a running Hermes Agent gateway (v2.3.0-based):

1. **Syntax verification**: both patched files compile cleanly (`python3 -m py_compile`)
2. **Migration**: `ALTER TABLE` applied successfully, column appears in `PRAGMA table_info`
3. **Future-scheduled tasks**: planted two tasks with `scheduled_at` set 2min and 3min in the future
   - Both stayed at `status=ready` with `started_at=NULL` while `now < scheduled_at`
   - Dispatcher ticked every 60s and correctly skipped both
4. **Due tasks dispatched**: after `scheduled_at` elapsed, both tasks were picked up by the dispatcher and completed normally (`status=done`)
5. **No regression**: existing unscheduled tasks continued to dispatch immediately
6. **Cleanup**: all test tasks removed after verification