### PR TITLE
fix(cli): /model picker for Copilot ignored live catalog when models.dev knew github-copilot

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1200,12 +1200,27 @@ def list_authenticated_providers(
             live = [current_model]
         curated["lmstudio"] = live
 
+    # Providers whose authoritative model catalog comes from a live
+    # endpoint owned by Hermes (handled in Section 2 via
+    # ``provider_model_ids``), NOT from the static curated list. These
+    # MUST be skipped in Section 1 even when they are advertised by
+    # models.dev (e.g. ``github-copilot``), otherwise the curated list
+    # short-circuits the live fetch and the picker silently lags behind
+    # the account's real catalog.
+    _LIVE_CATALOG_PROVIDERS = frozenset({"copilot", "copilot-acp"})
+
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
         # Skip aliases that map to the same models.dev provider (e.g.
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
         if mdev_id in seen_mdev_ids:
+            continue
+        # Hand off to Section 2 for providers whose catalog comes from a
+        # live Hermes-owned endpoint (e.g. Copilot's /v1/models). The
+        # curated list under Section 1 is months behind the live catalog
+        # and lacks subscription-dependent models like ``claude-opus-4.7``.
+        if hermes_id in _LIVE_CATALOG_PROVIDERS:
             continue
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -39,3 +39,48 @@ def test_copilot_picker_uses_live_catalog_when_available():
     assert copilot is not None
     assert copilot["models"] == live_models
     assert copilot["total_models"] == len(live_models)
+
+
+@patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)
+def test_copilot_picker_uses_live_catalog_even_when_models_dev_has_github_copilot():
+    """Regression: when models.dev exposes ``github-copilot``, the picker
+    used to short-circuit in Section 1 and emit the curated list before
+    Section 2's live ``provider_model_ids`` dispatch had a chance to run.
+
+    The live catalog must win because (a) GitHub adds models faster than
+    Hermes releases (e.g. ``claude-opus-4.7``, ``gpt-5.5``), and (b) the
+    available models depend on the account's subscription tier.
+    """
+    # models.dev DOES include github-copilot in production. Mock its return
+    # so credential detection in Section 1 still succeeds (would short-circuit
+    # to the curated list under the bug).
+    fake_models_dev = {
+        "github-copilot": {
+            "id": "github-copilot",
+            "name": "GitHub Copilot",
+            "env": ["GITHUB_TOKEN"],
+        },
+    }
+    live_models = [
+        "gpt-5.4",
+        "gpt-5.5",
+        "claude-opus-4.6",
+        "claude-opus-4.7",
+        "claude-sonnet-4.6",
+    ]
+
+    with patch("agent.models_dev.fetch_models_dev", return_value=fake_models_dev), \
+         patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
+         patch("hermes_cli.models._fetch_github_models", return_value=live_models):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    copilot = next((p for p in providers if p["slug"] == "copilot"), None)
+
+    assert copilot is not None, "copilot must be in the picker when credentials are present"
+    assert copilot["models"] == live_models, (
+        f"expected live catalog, got curated/static list: {copilot['models']!r}"
+    )
+    assert copilot["total_models"] == len(live_models)
+    # And no duplicate copilot entry should slip in from a later section.
+    copilot_entries = [p for p in providers if p["slug"] == "copilot"]
+    assert len(copilot_entries) == 1, f"got {len(copilot_entries)} copilot entries"


### PR DESCRIPTION
## What

The `/model` picker in the TUI (and any consumer of `list_authenticated_providers()`) was showing a stale curated list for **GitHub Copilot** when the user had any of `GITHUB_TOKEN` / `GH_TOKEN` / `COPILOT_GITHUB_TOKEN` exported. Models that the account is authorised to use — `claude-opus-4.6`, `claude-opus-4.7`, `gpt-5.5`, etc. — silently disappeared. The classic `hermes model` flow was unaffected, so the two pickers disagreed.

## Why

`list_authenticated_providers` processes providers in two sections:

1. **Section 1** — iterates `PROVIDER_TO_MODELS_DEV` and emits an entry with the curated list from `_PROVIDER_MODELS`.
2. **Section 2** — iterates `HERMES_OVERLAYS` and, for Hermes-only providers like `copilot`, calls `provider_model_ids("copilot")`, which fetches the live GitHub Copilot `/v1/models` catalog.

`copilot` is mapped to `github-copilot` in `PROVIDER_TO_MODELS_DEV`. As soon as one of the Copilot env vars is set, Section 1 wins: it emits the curated list, registers `copilot` in `seen_slugs`, and Section 2 then skips it via `if hermes_slug.lower() in seen_slugs: continue`. The live fetch never runs.

The bug was masked in tests because `tests/hermes_cli/test_copilot_in_model_list.py` mocks `fetch_models_dev` to `{}` — without `github-copilot` in models.dev, Section 1 has no idea Copilot exists, so Section 2 happily runs. In production, `fetch_models_dev` does return `github-copilot`.

## How

Skip Copilot in Section 1 and let Section 2 own its catalog. The dispatch in Section 2 already does the right thing — the bug was that Section 1 happened to run first.

A new regression test (`test_copilot_picker_uses_live_catalog_even_when_models_dev_has_github_copilot`) verifies the fix without mocking `fetch_models_dev` to empty, so this can't silently regress again.

## Reproduction

Before the fix, on a host with `GH_TOKEN` (or `GITHUB_TOKEN`, or `COPILOT_GITHUB_TOKEN`) set:

```bash
hermes        # enter TUI
/model        # pick "GitHub Copilot"
# → 17 hardcoded models, NO claude-opus-4.6/4.7, NO gpt-5.5
```

Then in a separate shell with no TUI:

```bash
hermes model  # pick "GitHub Copilot"
# → 16 live models including claude-opus-4.6, claude-opus-4.7, gpt-5.5
```

Two pickers, two different lists, same account.

After the fix, both pickers show the same 16 live models.

## Tests

- Adds `test_copilot_picker_uses_live_catalog_even_when_models_dev_has_github_copilot` — regression test that fails without the fix and passes with it.
- Existing tests still pass:
  - `tests/hermes_cli/test_copilot_in_model_list.py` (3/3)
  - 177 tests across the model/picker/copilot/bedrock/ollama area (no regressions)
- `ruff check` clean.

## Manual verification

- Linux, `~/.hermes/hermes-agent` install
- TUI `/model` → "GitHub Copilot" now lists 16 live models including `claude-opus-4.6`, `claude-opus-4.6-1m`, `claude-opus-4.7`, `claude-opus-4.5`, `gpt-5.5`, `claude-haiku-4.5`, etc.
- `hermes model` shows the same 16 (unchanged — this flow was already correct).

## Scope

- Single function change in `hermes_cli/model_switch.py` (+15 lines).
- One new regression test (+45 lines).
- No behavior change for any non-Copilot provider — the new `_LIVE_CATALOG_PROVIDERS` set is `{"copilot", "copilot-acp"}` only.
- Future Hermes-only providers with live `/v1/models` endpoints can opt in by adding their slug to that set.
