### PR TITLE
fix(provider): strip reasoning_content alongside reasoning_details on cross-provider switch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2739,6 +2739,29 @@ class AIAgent:
         self._fallback_chain = fallback_chain
         self._fallback_model = fallback_chain[0] if fallback_chain else None
 
+        # ── Strip incompatible thinking blocks on cross-provider switch ──
+        # reasoning_details / reasoning_content from the old provider are
+        # invalid for the new one.
+        # Strip both from in-memory history to avoid a round-trip 400.
+        if old_norm and new_norm and old_norm != new_norm:
+            _session_msgs = getattr(self, "_session_messages", None)
+            if isinstance(_session_msgs, list):
+                _stripped = 0
+                for _sm in _session_msgs:
+                    if isinstance(_sm, dict) and _sm.get("role") == "assistant":
+                        _had_rd = _sm.pop("reasoning_details", None) is not None
+                        _had_rc = _sm.pop("reasoning_content", None) is not None
+                        if _had_rd or _had_rc:
+                            _stripped += 1
+                if _stripped:
+                    logging.info(
+                        "%sCross-provider switch (%s → %s): stripped "
+                        "reasoning_details/reasoning_content from %d "
+                        "assistant messages to prevent thinking-signature "
+                        "errors",
+                        self.log_prefix, old_provider, new_provider, _stripped,
+                    )
+
         logging.info(
             "Model switched in-place: %s (%s) -> %s (%s)",
             old_model, old_provider, new_model, new_provider,
@@ -13555,7 +13578,7 @@ class AIAgent:
                     # content.  Any upstream mutation (context compression,
                     # session truncation, message merging) invalidates the
                     # signature → HTTP 400.  Recovery: strip reasoning_details
-                    # from all messages so the next retry sends no thinking
+                    # and reasoning_content from all messages so the next retry sends no thinking
                     # blocks at all.  One-shot — don't retry infinitely.
                     if (
                         classified.reason == FailoverReason.thinking_signature
@@ -13565,6 +13588,7 @@ class AIAgent:
                         for _m in messages:
                             if isinstance(_m, dict):
                                 _m.pop("reasoning_details", None)
+                                _m.pop("reasoning_content", None)
                         self._vprint(
                             f"{self.log_prefix}⚠️  Thinking block signature invalid — "
                             f"stripped all thinking blocks, retrying...",
@@ -13572,7 +13596,8 @@ class AIAgent:
                         )
                         logging.warning(
                             "%sThinking block signature recovery: stripped "
-                            "reasoning_details from %d messages",
+                            "reasoning_details and reasoning_content from "
+                            "%d messages",
                             self.log_prefix, len(messages),
                         )
                         continue


### PR DESCRIPTION
## What does this PR do?

Closes #24401

fix(provider): strip reasoning_content alongside reasoning_details on cross-provider switch
   1. Recovery path: on thinking_signature 400s, also pop reasoning_content from messages. Previously only reasoning_details was stripped, so the reconverted the leftover reasoning_content into unsigned thinking blocks, re-triggering the same 400 on every retry.
   2. switch_model: when old_provider != new_provider, proactively strip reasoning_details and reasoning_content from _session_messages so the first request on the new provider succeeds without a round-trip 400 + retry.


## Problem

Switching from a MiniMax model to `claude-opus-4-7` mid-conversation causes every subsequent turn to fail with `Invalid signature in thinking block`. The strip-and-retry fallback logs success but the retry hits the identical error at the same content index.

**Root cause:** The recovery logic at `run_agent.py:13298` only strips `reasoning_details` from messages, but leaves `reasoning_content` intact. On retry, the Anthropic adapter (`anthropic_adapter.py:1538`) converts the leftover `reasoning_content` back into an unsigned thinking block, which triggers the same 400 again.

## Fix

Two changes in `run_agent.py`:

### 1. Recovery path: also strip `reasoning_content`

Before retry, pop both `reasoning_details` **and** `reasoning_content` from all messages so the Anthropic adapter has nothing to reconvert.

### 2. `switch_model`: proactive cleanup on cross-provider switch

When `old_provider != new_provider`, strip `reasoning_details` and `reasoning_content` from `self._session_messages` immediately. This prevents the first request on the new provider from hitting a 400 at all, rather than relying on the retry path.