### PR TITLE
[security] fix(qqbot): bind approval buttons to initiating user

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -253,6 +253,11 @@ class QQAdapter(BasePlatformAdapter):
         self._interaction_callback: Optional[
             Callable[[InteractionEvent], Awaitable[None]]
         ] = None
+        # Pending approval buttons are visible inside the chat. Keep the
+        # intended approver and chat bound to each approval session so a
+        # different group member cannot resolve another user's dangerous
+        # command prompt by clicking the inline keyboard.
+        self._approval_context: Dict[str, Dict[str, str]] = {}
 
         # Default interaction dispatcher: routes approval-button clicks to
         # tools.approval.resolve_gateway_approval() and update-prompt clicks
@@ -1040,6 +1045,8 @@ class QQAdapter(BasePlatformAdapter):
                     self._log_tag, decision, session_key,
                 )
                 return
+            if not self._is_approval_click_authorized(session_key, event):
+                return
             try:
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
@@ -1051,6 +1058,7 @@ class QQAdapter(BasePlatformAdapter):
                     self._log_tag, count, session_key, choice,
                     event.operator_openid,
                 )
+                self._approval_context.pop(session_key, None)
             except Exception as exc:
                 logger.error(
                     "[%s] resolve_gateway_approval failed for session %s: %s",
@@ -1067,6 +1075,74 @@ class QQAdapter(BasePlatformAdapter):
             "[%s] Unrecognised button_data %r from interaction %s",
             self._log_tag, button_data, event.id,
         )
+
+    def _is_approval_click_authorized(
+            self,
+            session_key: str,
+            event: InteractionEvent,
+    ) -> bool:
+        """Return whether a QQ approval-button click may resolve a session.
+
+        QQ group keyboards can be rendered to everyone in the group. The
+        button payload routes to a pending approval session, but the clicker is
+        separately reported as ``operator_openid`` on the interaction event.
+        Dangerous-command approvals must therefore verify the clicker and chat
+        context before resolving the approval.
+        """
+        operator = str(event.operator_openid or "").strip()
+        ctx = self._approval_context.get(session_key)
+        if not ctx:
+            # In a C2C chat the interaction is delivered from the same user
+            # who can see the private approval prompt. Group chats need an
+            # explicit bound operator because every member can see/click the
+            # same keyboard.
+            if event.scene == "c2c":
+                return True
+            logger.warning(
+                "[%s] Rejecting approval button without bound context "
+                "(session=%s, operator=%s, scene=%s)",
+                self._log_tag, session_key, operator, event.scene,
+            )
+            return False
+
+        expected_operator = ctx.get("operator", "")
+        expected_chat_id = ctx.get("chat_id", "")
+        expected_chat_type = ctx.get("chat_type", "")
+        event_chat_id = event.group_openid if event.scene == "group" else event.user_openid
+
+        created_at = float(ctx.get("created_at") or 0.0)
+        if created_at and time.time() - created_at > self._APPROVAL_TIMEOUT_SECONDS:
+            logger.warning(
+                "[%s] Rejecting expired approval button (session=%s, operator=%s)",
+                self._log_tag, session_key, operator,
+            )
+            self._approval_context.pop(session_key, None)
+            return False
+
+        if expected_chat_type and event.scene != expected_chat_type:
+            logger.warning(
+                "[%s] Rejecting approval button from wrong QQ scene "
+                "(session=%s, expected=%s, got=%s, operator=%s)",
+                self._log_tag, session_key, expected_chat_type, event.scene, operator,
+            )
+            return False
+        if expected_chat_id and event_chat_id != expected_chat_id:
+            logger.warning(
+                "[%s] Rejecting approval button from wrong QQ chat "
+                "(session=%s, expected=%s, got=%s, operator=%s)",
+                self._log_tag, session_key, expected_chat_id,
+                event_chat_id or "<missing>", operator,
+            )
+            return False
+        if not expected_operator or operator != expected_operator:
+            logger.warning(
+                "[%s] Rejecting approval button from unauthorized QQ operator "
+                "(session=%s, expected=%s, got=%s)",
+                self._log_tag, session_key, expected_operator or "<missing>",
+                operator or "<missing>",
+            )
+            return False
+        return True
 
     @staticmethod
     def _write_update_response(answer: str, operator: str = "") -> None:
@@ -2543,12 +2619,28 @@ class QQAdapter(BasePlatformAdapter):
         :func:`tools.approval.resolve_gateway_approval` — dispatched by the
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
-        del metadata  # QQ doesn't have thread_id / DM targeting overrides.
+        metadata = metadata or {}
 
         # Use the reply-to message for passive-message context when we have one.
         # QQ requires a msg_id on outbound messages to a user we've never
         # seen; the last inbound msg_id is the natural choice.
         msg_id = self._last_msg_id.get(chat_id)
+        chat_type = str(metadata.get("chat_type") or self._guess_chat_type(chat_id))
+        expected_operator = str(metadata.get("user_id") or "").strip()
+        if not expected_operator and chat_type == "c2c":
+            expected_operator = chat_id
+        if chat_type == "group" and not expected_operator:
+            return SendResult(
+                success=False,
+                error="QQ group approval requires an expected operator",
+                retryable=False,
+            )
+        self._approval_context[session_key] = {
+            "operator": expected_operator,
+            "chat_id": chat_id,
+            "chat_type": chat_type,
+            "created_at": str(time.time()),
+        }
 
         req = ApprovalRequest(
             session_key=session_key,
@@ -2557,9 +2649,12 @@ class QQAdapter(BasePlatformAdapter):
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )
-        return await self.send_approval_request(
+        result = await self.send_approval_request(
             chat_id, req, reply_to=msg_id,
         )
+        if not result.success:
+            self._approval_context.pop(session_key, None)
+        return result
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16652,7 +16652,11 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata={
+                                    **(_status_thread_metadata or {}),
+                                    "user_id": source.user_id,
+                                    "chat_type": source.chat_type,
+                                },
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/tests/gateway/test_qqbot_approval_auth.py
+++ b/tests/gateway/test_qqbot_approval_auth.py
@@ -1,0 +1,126 @@
+"""Regression tests for QQBot inline approval authorization."""
+
+import asyncio
+import sys
+import types
+from unittest import mock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.qqbot.adapter import QQAdapter
+from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
+
+def _make_adapter(**extra):
+    return QQAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _approval_event(*, session_key: str, operator: str, group_openid: str = "group-1"):
+    return parse_interaction_event({
+        "id": "interaction-1",
+        "chat_type": 1,
+        "group_openid": group_openid,
+        "group_member_openid": operator,
+        "data": {
+            "type": 11,
+            "resolved": {
+                "button_data": f"approve:{session_key}:allow-always",
+                "button_id": "always",
+            },
+        },
+    })
+
+
+def _install_fake_approval(monkeypatch):
+    calls = []
+    fake = types.ModuleType("tools.approval")
+
+    def resolve_gateway_approval(session_key, choice):
+        calls.append((session_key, choice))
+        return 1
+
+    fake.resolve_gateway_approval = resolve_gateway_approval
+    monkeypatch.setitem(sys.modules, "tools.approval", fake)
+    return calls
+
+
+def test_qqbot_group_approval_button_rejects_other_group_member(monkeypatch):
+    calls = _install_fake_approval(monkeypatch)
+    adapter = _make_adapter(app_id="a", client_secret="b")
+    session_key = "agent:main:qqbot:group:group-1"
+    adapter._approval_context[session_key] = {
+        "operator": "victim-openid",
+        "chat_id": "group-1",
+        "chat_type": "group",
+    }
+
+    event = _approval_event(session_key=session_key, operator="attacker-openid")
+    asyncio.run(adapter._default_interaction_dispatch(event))
+
+    assert calls == []
+    assert session_key in adapter._approval_context
+
+
+def test_qqbot_group_approval_button_allows_bound_operator(monkeypatch):
+    calls = _install_fake_approval(monkeypatch)
+    adapter = _make_adapter(app_id="a", client_secret="b")
+    session_key = "agent:main:qqbot:group:group-1"
+    adapter._approval_context[session_key] = {
+        "operator": "victim-openid",
+        "chat_id": "group-1",
+        "chat_type": "group",
+    }
+
+    event = _approval_event(session_key=session_key, operator="victim-openid")
+    asyncio.run(adapter._default_interaction_dispatch(event))
+
+    assert calls == [(session_key, "always")]
+    assert session_key not in adapter._approval_context
+
+
+def test_qqbot_send_exec_approval_binds_expected_operator_from_metadata():
+    adapter = _make_adapter(app_id="a", client_secret="b")
+    adapter._chat_type_map["group-1"] = "group"
+    adapter.send_approval_request = mock.AsyncMock(
+        return_value=SendResult(success=True, message_id="approval-msg")
+    )
+
+    result = asyncio.run(
+        adapter.send_exec_approval(
+            chat_id="group-1",
+            command="rm -rf /tmp/example",
+            session_key="agent:main:qqbot:group:group-1",
+            metadata={"user_id": "victim-openid", "chat_type": "group"},
+        )
+    )
+
+    assert result.success is True
+    context = adapter._approval_context["agent:main:qqbot:group:group-1"]
+    assert context["operator"] == "victim-openid"
+    assert context["chat_id"] == "group-1"
+    assert context["chat_type"] == "group"
+    assert float(context["created_at"]) > 0
+    adapter.send_approval_request.assert_awaited_once()
+
+
+def test_qqbot_group_exec_approval_without_operator_falls_back_to_text():
+    adapter = _make_adapter(app_id="a", client_secret="b")
+    adapter._chat_type_map["group-1"] = "group"
+    adapter.send_approval_request = mock.AsyncMock(
+        return_value=SendResult(success=True, message_id="approval-msg")
+    )
+
+    result = asyncio.run(
+        adapter.send_exec_approval(
+            chat_id="group-1",
+            command="rm -rf /tmp/example",
+            session_key="agent:main:qqbot:group:group-1",
+            metadata={},
+        )
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert "requires an expected operator" in (result.error or "")
+    assert adapter._approval_context == {}
+    adapter.send_approval_request.assert_not_awaited()


### PR DESCRIPTION
## Summary

This PR hardens QQBot dangerous-command approval buttons so a group-visible inline keyboard cannot be used by a different group member to approve another user's pending command.

- Binds each QQBot button-based exec approval to the initiating operator and chat context.
- Rejects group button clicks from the wrong operator, chat, scene, expired approval context, or unbound group approvals.
- Passes the initiating `source.user_id` from the gateway runner into the adapter's approval metadata.
- Adds focused regression tests for unauthorized group-member rejection, authorized operator approval, metadata binding, and safe fallback when no group operator is known.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| QQBot group approval buttons were resolved from button payload alone | Any group member who could see the dangerous-command approval keyboard could click `allow-once`, `allow-always`, or `deny` for another user's pending command | High in mixed-trust QQ group deployments |

## Before this PR

- QQBot approval buttons embedded only `approve:<session_key>:<decision>` in the button payload.
- QQ group keyboards are visible/clickable by group members, but `_default_interaction_dispatch()` did not verify the clicker's `operator_openid` before resolving the approval.
- The dispatcher logged the operator identity but still called `resolve_gateway_approval(session_key, choice)` solely from button data.
- There were no QQBot regression tests proving that a different group member cannot approve another user's dangerous command.

## After this PR

- `send_exec_approval()` records an in-memory approval context containing:
  - expected operator openid
  - expected chat id
  - expected chat type
  - creation time
- The default QQBot interaction dispatcher checks that context before resolving dangerous-command approvals.
- Group approval buttons without an expected operator fail safely so the gateway can fall back to the text approval flow.
- Approval context is removed after successful resolution, failed inline send, or expired click rejection.
- Tests lock in both the reject and allow paths.

## Why this matters

Dangerous-command approval is a human-in-the-loop security boundary. In QQ group chats, the approval prompt may be visible to multiple people, but the pending command belongs to the user/session that triggered it.

Without checking the clicker identity, the boundary becomes "anyone who sees the group button can approve." The highest-impact case is a bystander clicking `allow-always`, which maps to the approval subsystem's persistent `always` decision.

## How this differs from #18180

[#18180](https://github.com/NousResearch/hermes-agent/pull/18180) hardened Telegram inline approval callbacks by enforcing Telegram callback authorization through gateway user policy.

This PR fixes the same trust-boundary class for a different platform and code path:

- different adapter: `gateway/platforms/qqbot/adapter.py`
- different event type: QQ `INTERACTION_CREATE`
- different identity field: QQ `group_member_openid` / `operator_openid`
- different UI behavior: QQ group inline keyboards can be visible/clickable by group members
- different tests: focused QQBot interaction-dispatch regression tests

The Telegram fix does not cover QQBot's inline keyboard dispatcher.

## Attack flow

```text
QQ group member sees another user's dangerous-command approval prompt
    -> clicks the inline "allow always" button
        -> QQBot adapter parses approve:<session_key>:allow-always
            -> pre-patch dispatcher resolves the approval without checking operator_openid
                -> dangerous command proceeds without approval from the initiating user
```

## Affected code

| Issue | Files |
|-------|-------|
| QQBot group approval click authorization | `gateway/platforms/qqbot/adapter.py`, `gateway/run.py` |
| Regression coverage | `tests/gateway/test_qqbot_approval_auth.py` |

## Root cause

QQBot group approval button authorization gap:

- The approval session key and decision were trusted from button data alone.
- `InteractionEvent.operator_openid` was parsed but not enforced before calling `resolve_gateway_approval()`.
- The gateway did not pass the initiating platform user id into `send_exec_approval()` metadata, so the QQ adapter had no durable expected-operator binding for group prompts.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| QQBot group approval button authorization gap | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale:

- Attackers need access to the QQ group where the bot posts approval prompts.
- No additional user interaction from the intended approver is required once the prompt is visible.
- Impact depends on enabled tools and the pending command, but dangerous-command approval can guard host file, credential, or destructive terminal operations.
- Availability impact is not the primary claim for this PR.

## Safe reproduction steps

1. Create a QQBot adapter instance and bind a pending approval context for `session_key = agent:main:qqbot:group:group-1` to `victim-openid`.
2. Feed `_default_interaction_dispatch()` a QQ group `INTERACTION_CREATE` event with:
   - `group_openid = group-1`
   - `group_member_openid = attacker-openid`
   - `button_data = approve:agent:main:qqbot:group:group-1:allow-always`
3. Observe that the patched dispatcher rejects the click and does not call `resolve_gateway_approval()`.
4. Repeat with `group_member_openid = victim-openid` and observe that the dispatcher resolves the approval as `always`.

The new regression tests implement this flow without sending live QQ traffic.

## Expected vulnerable behavior

On vulnerable code, the attacker event resolves the approval:

```json
{
  "parsed_operator_openid": "attacker-openid",
  "approval_calls": [
    ["agent:main:qqbot:group:group-1", "always"]
  ]
}
```

That should not be allowed for a group-visible dangerous-command approval prompt.

## Changes in this PR

- Adds `_approval_context` to QQBot adapter instances for pending button-based dangerous-command approvals.
- Adds `_is_approval_click_authorized()` to enforce expected operator, scene, chat id, and timeout before resolving approval button clicks.
- Makes group `send_exec_approval()` fail safely when no expected operator is available, allowing the gateway fallback text approval flow instead of sending an unbound group keyboard.
- Removes approval context after successful resolution, failed inline send, or expired click rejection.
- Passes `source.user_id` and `source.chat_type` from `gateway/run.py` into adapter `send_exec_approval()` metadata.
- Adds QQBot approval authorization regression tests.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| QQBot adapter hardening | `gateway/platforms/qqbot/adapter.py` | Binds approval prompts to expected operator/chat and rejects unauthorized clicks before resolving approvals |
| Gateway metadata | `gateway/run.py` | Passes initiating user/chat metadata to adapter button approval hooks |
| Tests | `tests/gateway/test_qqbot_approval_auth.py` | Adds focused regression tests for group approval authorization |

## Maintainer impact

- Scope is limited to button-based QQBot dangerous-command approval UX and gateway approval metadata.
- C2C/private QQ approval behavior remains supported.
- Group approvals now require an initiating operator binding; if that binding is not available, QQBot returns a non-retryable send failure so the existing text `/approve` fallback remains available.
- No keyboard payload format migration is required.

## Fix rationale

The authorization check belongs at the adapter dispatch boundary because QQ reports the clicker identity on each `INTERACTION_CREATE` event. The button payload identifies which approval to resolve, but it should not by itself authorize the clicker to resolve that approval.

Passing the initiating user id from the gateway runner keeps the fix narrow and avoids changing the shared approval subsystem or adding platform-specific data to the approval session key.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3.11 -m pytest tests/gateway/test_qqbot.py tests/gateway/test_qqbot_approval_auth.py -q`
  - Result: `148 passed, 1 warning`
  - Warning is from an existing QQBot dispatch test: `RuntimeWarning: coroutine 'QQAdapter._send_identify' was never awaited`.
- [x] `python3.11 -m ruff check gateway/platforms/qqbot/adapter.py gateway/run.py tests/gateway/test_qqbot_approval_auth.py`
  - Result: `All checks passed!`
- [x] `git diff --check --cached`
  - Result: passed.
- [x] `python3.11 -m py_compile gateway/platforms/qqbot/adapter.py gateway/run.py tests/gateway/test_qqbot_approval_auth.py`
  - Result: passed.
- [x] `python3.11 -m ruff format --check tests/gateway/test_qqbot_approval_auth.py`
  - Result: `1 file already formatted`.
- [ ] `python3.11 -m ruff format --check gateway/platforms/qqbot/adapter.py gateway/run.py`
  - Not applied because these large legacy files already require broad unrelated formatting changes; this PR keeps the diff surgical.


## Disclosure notes

- This PR is intentionally bounded to QQBot inline dangerous-command approval buttons.
- It does not claim that all QQ group members are untrusted in every deployment; if a group is intentionally a shared operator set, the operational impact is lower.
- The security boundary fixed here is that a group-visible button should not let a different group member resolve another user's pending dangerous-command approval by default.
- No unrelated files are changed.
