### PR TITLE
fix(model-metadata): add explicit context length for kimi-k2.6 family

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -217,6 +217,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
+    # Bare-model IDs for kimi-k2.6 family — OpenRouter metadata incorrectly
+    # reports 32,768 for these slugs (issue #24268).  The bare "kimi" pattern
+    # above acts as a catch-all via substring match, but explicit entries
+    # guarantee correct resolution regardless of how the model name is prefixed
+    # or normalised by the caller.
+    "kimi-k2.6": 262144,
+    "kimi-k2.6-20260420": 262144,
+    "kimi-latest": 262144,
     # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
     # OpenRouter live metadata reports 262144 (256 × 1024); align the
     # static fallback so cache and offline both agree (issue #22268).


### PR DESCRIPTION
Closes #24268

## Summary

Add explicit `DEFAULT_CONTEXT_LENGTHS` entries for the kimi-k2.6 bare-model IDs:

- `kimi-k2.6` → 262,144
- `kimi-k2.6-20260420` → 262,144
- `kimi-latest` → 262,144

OpenRouter metadata incorrectly reports 32,768 tokens for these slugs, causing `AIAgent.__init__` to raise a `ValueError` ("below the minimum 64,000 required by Hermes Agent") when the model is used with the `kimi-coding` provider.

## Root cause

`get_model_context_length()` falls through several resolution steps. While the bare `"kimi"` catch-all (substring match) should cover `kimi-k2.6`, explicit entries guarantee correct resolution regardless of how the model name is normalised or prefixed by the caller.

## Verification

`python -c "from agent.model_metadata import get_model_context_length; print(get_model_context_length('kimi-k2.6'))"`
→ should print `262144` (not `32768`)
