### PR TITLE
fix(prompt): gate skill_view help guidance on tool + honor documented env var (#24438)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,6 +24,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -99,7 +100,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    # Only inject when skill_view is loaded; otherwise the directive tells the agent
+    # to call a tool that doesn't exist. The HERMES_AGENT_HELP_GUIDANCE env var
+    # appends additional guidance text for custom deployments (documented in
+    # website/docs/reference/environment-variables.md).
+    if "skill_view" in agent.valid_tool_names:
+        stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    _help_guidance_extra = os.environ.get("HERMES_AGENT_HELP_GUIDANCE", "").strip()
+    if _help_guidance_extra:
+        stable_parts.append(_help_guidance_extra)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1146,6 +1146,52 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_tools"] == set(toolset_map)
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
+    def test_help_guidance_skipped_when_skill_view_not_loaded(self, agent, monkeypatch):
+        """Default agent has no skill_view tool; the skill-call directive must not be injected."""
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+        monkeypatch.delenv("HERMES_AGENT_HELP_GUIDANCE", raising=False)
+        assert "skill_view" not in agent.valid_tool_names
+        prompt = agent._build_system_prompt()
+        assert HERMES_AGENT_HELP_GUIDANCE not in prompt
+
+    def test_help_guidance_included_when_skill_view_loaded(self, monkeypatch):
+        """When skill_view is in the toolset, the directive is injected."""
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+        monkeypatch.delenv("HERMES_AGENT_HELP_GUIDANCE", raising=False)
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "skill_view"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            prompt = a._build_system_prompt()
+        assert HERMES_AGENT_HELP_GUIDANCE in prompt
+
+    def test_help_guidance_env_var_appended(self, agent, monkeypatch):
+        """The documented HERMES_AGENT_HELP_GUIDANCE env var appends custom guidance."""
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "Custom deployment guidance line.")
+        prompt = agent._build_system_prompt()
+        assert "Custom deployment guidance line." in prompt
+
+    def test_help_guidance_env_var_blank_ignored(self, agent, monkeypatch):
+        """Blank/whitespace env var must not append an empty section to the prompt."""
+        from agent.prompt_builder import HERMES_AGENT_HELP_GUIDANCE
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "   \n  ")
+        prompt = agent._build_system_prompt()
+        # Default agent has no skill_view, so neither the default nor the (blank) override should appear.
+        assert HERMES_AGENT_HELP_GUIDANCE not in prompt
+        # And the prompt must not contain a stray blank "  \n  " section.
+        assert "   \n  " not in prompt
+
 
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""


### PR DESCRIPTION
## Summary

- Gate `HERMES_AGENT_HELP_GUIDANCE` injection on `skill_view` being in `valid_tool_names`. The guidance instructs the agent to call `skill_view(name='hermes-agent')`; unconditionally injecting it when the tool is not loaded sends the agent on a guaranteed-to-fail tool call.
- Honor the documented `HERMES_AGENT_HELP_GUIDANCE` env var. Docs (`website/docs/reference/environment-variables.md:541`) promise that setting this env var "appends additional guidance text to the system prompt for custom deployments" — but the code never read `os.environ["HERMES_AGENT_HELP_GUIDANCE"]`, leaving the contract unimplemented.

Single injection site changed; no behavior change for the default case where `skill_view` is loaded and no env var is set.

## The bug

[`run_agent.py:5773`](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L5773):

```python
# Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
```

`HERMES_AGENT_HELP_GUIDANCE` (defined at [`agent/prompt_builder.py:144`](https://github.com/NousResearch/hermes-agent/blob/main/agent/prompt_builder.py#L144)) tells the agent:

> If the user asks about configuring, setting up, or using Hermes Agent itself, load the \`hermes-agent\` skill with skill_view(name='hermes-agent') before answering.

Two problems:

1. **Always injected, even when `skill_view` isn't loaded.** The very next block at [`run_agent.py:5834`](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L5834) demonstrates the canonical pattern — gate skill-related guidance on skill tools being present:
   ```python
   has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
   if has_skills_tools:
       ...
   ```
   The `HERMES_AGENT_HELP_GUIDANCE` block was the lone unconditional exception.

2. **Documented env var override never read.** [`website/docs/reference/environment-variables.md:541`](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/environment-variables.md#L541) advertises:

   > \`HERMES_AGENT_HELP_GUIDANCE\` — Append additional guidance text to the system prompt for custom deployments.

   But there is no `os.environ.get(\"HERMES_AGENT_HELP_GUIDANCE\")` anywhere in the prompt-assembly path. The documented behavior simply wasn't wired up.

Reported in #24438 with file:line references and a clear minimum-bar list.

## The fix

```python
# Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
# Only inject when skill_view is loaded; otherwise the directive tells the agent
# to call a tool that doesn't exist. The HERMES_AGENT_HELP_GUIDANCE env var
# appends additional guidance text for custom deployments (documented in
# website/docs/reference/environment-variables.md).
if \"skill_view\" in self.valid_tool_names:
    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
_help_guidance_extra = os.environ.get(\"HERMES_AGENT_HELP_GUIDANCE\", \"\").strip()
if _help_guidance_extra:
    stable_parts.append(_help_guidance_extra)
```

- The skill_view check mirrors the existing pattern at line 5834.
- The env var is appended (matches the doc verb \"Append\"), not used as a replacement, so docs and code now agree.
- `.strip()` ensures a whitespace-only env var doesn't append an empty section to the prompt.

## Test plan

- [x] **Focused regression tests** (`tests/run_agent/test_run_agent.py::TestBuildSystemPrompt`):
  - `test_help_guidance_skipped_when_skill_view_not_loaded` — default agent (web_search only) does not get the directive
  - `test_help_guidance_included_when_skill_view_loaded` — agent with `skill_view` in the toolset still gets the directive
  - `test_help_guidance_env_var_appended` — the documented env var appends custom text
  - `test_help_guidance_env_var_blank_ignored` — whitespace-only env var doesn't append a blank section
- [x] **Adjacent suite** — full `tests/run_agent/test_run_agent.py` passes (329 tests, 40.9s).
- [x] **Regression guard** — removed the production change and reran the focused tests: 3 of the 4 new tests fail (confirming they cover the new behavior); the 4th was a forward-compatibility check that still passes against the old always-append code path. Production change restored before commit.

## Related / Positioning

- #24163 (GregTheMiz) also touches `agent/prompt_builder.py` to **prepend a Runtime block** to the `HERMES_AGENT_HELP_GUIDANCE` constant. That PR changes the constant's textual content; this PR changes the constant's injection logic in `run_agent.py`. The two are complementary and conflict-free at the file level.

> Sibling code paths that may need the same treatment: none. The adjacent guidance blocks (`MEMORY_GUIDANCE`, `SESSION_SEARCH_GUIDANCE`, `SKILLS_GUIDANCE`, `KANBAN_GUIDANCE`) are already gated on their respective tools/conditions at [run_agent.py:5777-5782](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L5777-L5782) and beyond. This was the lone unconditional skill-call directive.

## Related

- Fixes #24438