### PR TITLE
[security] fix(mcp): cap image content cache payloads

### DIFF
--- a/tests/tools/test_mcp_image_content.py
+++ b/tests/tools/test_mcp_image_content.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
+from unittest.mock import patch
 
 
 
@@ -37,6 +38,7 @@ def _png_bytes():
 class TestMimeExtension:
     def test_maps_jpeg_variants_to_jpg(self):
         from tools.mcp_tool import _mcp_image_extension_for_mime_type
+
         assert _mcp_image_extension_for_mime_type("image/jpeg") == ".jpg"
         assert _mcp_image_extension_for_mime_type("image/jpg") == ".jpg"
         assert _mcp_image_extension_for_mime_type("IMAGE/JPEG") == ".jpg"
@@ -44,10 +46,12 @@ class TestMimeExtension:
 
     def test_png_falls_through_to_mimetypes(self):
         from tools.mcp_tool import _mcp_image_extension_for_mime_type
+
         assert _mcp_image_extension_for_mime_type("image/png") == ".png"
 
     def test_unknown_defaults_to_png(self):
         from tools.mcp_tool import _mcp_image_extension_for_mime_type
+
         assert _mcp_image_extension_for_mime_type("") == ".png"
         assert _mcp_image_extension_for_mime_type("image/unheard-of-format") == ".png"
 
@@ -67,13 +71,14 @@ class TestCacheMcpImageBlock:
         assert tag.startswith("MEDIA:"), f"expected MEDIA: tag, got {tag!r}"
         # The cached file should be in Hermes' image cache dir
         from gateway.platforms.base import get_image_cache_dir
+
         cache_dir = str(get_image_cache_dir().resolve())
         assert tag.startswith(f"MEDIA:{cache_dir}"), (
             f"cached file not under HERMES_HOME image cache dir. "
             f"tag={tag!r}, cache_dir={cache_dir!r}"
         )
         # And it should exist + have the PNG bytes
-        path = tag[len("MEDIA:"):]
+        path = tag[len("MEDIA:") :]
         with open(path, "rb") as fh:
             assert fh.read() == _png_bytes()
 
@@ -107,7 +112,9 @@ class TestCacheMcpImageBlock:
         )
         assert _cache_mcp_image_block(block) == ""
 
-    def test_returns_empty_when_bytes_dont_look_like_an_image(self, tmp_path, monkeypatch):
+    def test_returns_empty_when_bytes_dont_look_like_an_image(
+        self, tmp_path, monkeypatch
+    ):
         """``cache_image_from_bytes`` has a format sniff; if the claimed
         ``image/png`` is actually an HTML error page, the cache raises and
         we log + drop rather than propagate."""
@@ -134,3 +141,43 @@ class TestCacheMcpImageBlock:
         tag = _cache_mcp_image_block(block)
         assert tag.startswith("MEDIA:")
         assert tag.endswith(".jpg"), f"expected .jpg extension, got {tag!r}"
+
+    def test_skips_oversized_image_before_decoding(self, tmp_path, monkeypatch):
+        """MCP servers should not be able to force huge image decodes/writes."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_tool import _cache_mcp_image_block
+
+        # Starts with a valid PNG signature so this would pass the later
+        # magic-byte sniff if the size guard did not stop it first.
+        payload = b"\x89PNG\r\n\x1a\n" + b"A" * 32
+        block = SimpleNamespace(
+            data=base64.b64encode(payload).decode("ascii"),
+            mimeType="image/png",
+        )
+
+        with (
+            patch("gateway.platforms.base.get_inbound_media_max_bytes", return_value=16),
+            patch("base64.b64decode") as decode_mock,
+            patch("gateway.platforms.base.cache_image_from_bytes") as cache_mock,
+        ):
+            assert _cache_mcp_image_block(block) == ""
+
+        decode_mock.assert_not_called()
+        cache_mock.assert_not_called()
+
+    def test_accepts_image_at_configured_size_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        payload = _png_bytes()
+        from tools.mcp_tool import _cache_mcp_image_block
+
+        block = SimpleNamespace(
+            data=base64.b64encode(payload).decode("ascii"),
+            mimeType="image/png",
+        )
+
+        with patch(
+            "gateway.platforms.base.get_inbound_media_max_bytes",
+            return_value=len(payload),
+        ):
+            tag = _cache_mcp_image_block(block)
+        assert tag.startswith("MEDIA:")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -661,6 +661,49 @@ def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
 # ---------------------------------------------------------------------------
 
 
+class _McpImagePayloadTooLarge(ValueError):
+    """Raised when an MCP ImageContent payload exceeds the media cap."""
+
+    def __init__(self, decoded_upper_bound: int, max_bytes: int):
+        super().__init__(
+            f"decoded payload exceeds limit ({decoded_upper_bound} > {max_bytes} bytes)"
+        )
+        self.decoded_upper_bound = decoded_upper_bound
+        self.max_bytes = max_bytes
+
+
+def _compact_base64_with_decoded_limit(data, max_bytes: int) -> tuple[str, int]:
+    """Normalize base64 whitespace once while bounding decoded size.
+
+    MCP ImageContent carries base64 text.  Do not build a full compact copy of
+    an obviously oversized block before rejecting it: count significant base64
+    characters as we normalize, stop once even the shortest possible decoded
+    payload would exceed the configured inbound-media cap, then perform the
+    precise padding-aware bound on the one compact string we kept.
+    """
+    max_encoded_chars = None
+    if max_bytes > 0:
+        max_encoded_chars = ((max_bytes + 2) // 3) * 4
+
+    compact_chars: list[str] = []
+    significant_chars = 0
+    for char in str(data):
+        if char.isspace():
+            continue
+        significant_chars += 1
+        if max_encoded_chars is not None and significant_chars > max_encoded_chars:
+            decoded_lower_bound = ((significant_chars - 1) // 4) * 3 + 1
+            raise _McpImagePayloadTooLarge(decoded_lower_bound, max_bytes)
+        compact_chars.append(char)
+
+    compact = "".join(compact_chars)
+    padding = len(compact) - len(compact.rstrip("="))
+    decoded_upper_bound = max(0, (len(compact) * 3) // 4 - padding)
+    if max_bytes > 0 and decoded_upper_bound > max_bytes:
+        raise _McpImagePayloadTooLarge(decoded_upper_bound, max_bytes)
+    return compact, decoded_upper_bound
+
+
 def _mcp_image_extension_for_mime_type(mime_type: str) -> str:
     """Return a reasonable file extension for an MCP image MIME type."""
     import mimetypes
@@ -689,14 +732,50 @@ def _cache_mcp_image_block(block) -> str:
         return ""
 
     try:
-        raw_bytes = base64.b64decode(data)
+        from gateway.platforms.base import (
+            cache_image_from_bytes,
+            get_inbound_media_max_bytes,
+        )
+    except ImportError:
+        # gateway.platforms.base not importable in this process (e.g. cron
+        # without gateway deps). Fall back to silently dropping — callers
+        # get any text blocks that did parse.
+        logger.debug("MCP image caching skipped — gateway.platforms.base unavailable")
+        return ""
+
+    max_bytes = get_inbound_media_max_bytes()
+    try:
+        encoded_data, _decoded_upper_bound = _compact_base64_with_decoded_limit(
+            data,
+            max_bytes,
+        )
+    except _McpImagePayloadTooLarge as exc:
+        logger.warning(
+            "MCP image block skipped (%s): decoded payload exceeds limit "
+            "(%d > %d bytes)",
+            normalized_mime,
+            exc.decoded_upper_bound,
+            exc.max_bytes,
+        )
+        return ""
+
+    try:
+        raw_bytes = base64.b64decode(encoded_data, validate=True)
     except (TypeError, ValueError) as exc:
         logger.warning("MCP image block decode failed (%s): %s", normalized_mime, exc)
         return ""
 
-    try:
-        from gateway.platforms.base import cache_image_from_bytes
+    if max_bytes > 0 and len(raw_bytes) > max_bytes:
+        logger.warning(
+            "MCP image block skipped (%s): decoded payload exceeds limit "
+            "(%d > %d bytes)",
+            normalized_mime,
+            len(raw_bytes),
+            max_bytes,
+        )
+        return ""
 
+    try:
         image_path = cache_image_from_bytes(
             raw_bytes,
             ext=_mcp_image_extension_for_mime_type(normalized_mime),


### PR DESCRIPTION
## Summary

This PR adds a decoded-size guard for MCP `ImageContent` blocks before Hermes decodes and caches them as gateway `MEDIA:` files.

MCP image-result support currently accepts any `image/*` block, base64-decodes the full payload, and forwards the bytes to `cache_image_from_bytes()`. A malicious or compromised MCP server can therefore return a very large base64 image block during a tool call and force the Hermes process to allocate and write that payload under the image cache.

The patch keeps normal MCP screenshot/image results working, but drops oversized image blocks before decoding them.

## Security issues covered

| Issue | Impact | Fix |
| --- | --- | --- |
| Unbounded MCP `ImageContent` decode/cache | Malicious MCP server can force large memory allocation and image-cache disk writes during tool-result handling | Add a configurable per-block decoded-byte cap and reject oversized blocks before decode/cache |

## Before this PR

- `_cache_mcp_image_block()` accepted any `image/*` MCP content block with `data`.
- The helper base64-decoded the full payload before any size check.
- The decoded bytes were passed to `cache_image_from_bytes()`, which writes the entire blob to the Hermes image cache after only a magic-byte sniff.
- There was no MCP-specific limit for image-result payload size.

## After this PR

- MCP image blocks are checked against a decoded-size upper bound before decoding.
- Oversized blocks are logged and skipped without calling `cache_image_from_bytes()`.
- A second length check after decode preserves the invariant even if encoding edge cases appear.
- The default cap is 10 MiB per MCP image block.
- Operators can tune the cap with `HERMES_MCP_IMAGE_MAX_BYTES`.

## Why this matters

MCP servers are external programs or remote services that Hermes invokes as tools. A server that is malicious, compromised, or unexpectedly returns huge image data should not be able to consume unbounded Hermes memory or fill the profile image cache merely by returning an `ImageContent` result.

The issue is especially relevant because image-capable MCP servers commonly expose screenshots or rendered artifacts, and those results flow through this helper automatically once the agent calls the MCP tool.

## How this differs from related issue/PR

This is related to the MCP image-result support work, but it fixes a different boundary:

- #21328 added support for surfacing MCP image blocks as `MEDIA:` tags instead of dropping them.
- #10759 / #21559 discuss image blocks being silently discarded or surfaced incorrectly.
- #21607 documents image content results.

Those items are about preserving or documenting image results. This PR addresses the resource-boundary introduced by accepting image blocks: before decoding and caching MCP-supplied image bytes, Hermes now enforces a size cap.

Duplicate searches were run for:

- `"MCP" "ImageContent" "size"`
- `"cache_image_from_bytes" "MCP"`
- `"MCP image" "resource"`
- `"ImageContent" "cache" "mcp_tool"`
- `"mcp_tool" "image" "limit"`
- `"MCP ImageContent" "DoS"`

No existing PR or issue was found that adds a size/resource cap to `_cache_mcp_image_block()`.

## Attack flow

1. Operator configures or uses an MCP server that can return image content.
2. The server returns an `ImageContent` block with MIME type `image/png` or another `image/*` type.
3. The block contains a very large base64 payload beginning with valid image magic bytes.
4. Hermes decodes the full payload and passes it to the image cache helper.
5. The Hermes process consumes memory and writes the large blob under the image cache.

## Affected code

- `tools/mcp_tool.py`
  - `_cache_mcp_image_block()` decoded and cached MCP-supplied image data without a size cap.
- `gateway/platforms/base.py`
  - `cache_image_from_bytes()` writes all supplied bytes after a magic-byte check, so callers must enforce resource limits before passing untrusted payloads in.

## Root cause

- Image format validation checked whether bytes looked like an image, but not whether the image payload was reasonably sized.
- MCP tool results are server-controlled, and the image-result bridge treated `ImageContent.data` as bounded trusted input.
- The only guard was after decoding, and it was content-type/magic-byte oriented rather than resource-oriented.

## CVSS assessment

- Issue: MCP ImageContent unbounded decode/cache resource exhaustion
- CVSS v3.1: 5.5 Medium
- Vector: `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H`
- Rationale: exploitation requires a configured/used MCP server or a compromised MCP server in the operator's environment, but once reached it can impact local Hermes availability by forcing large memory and disk use. Confidentiality and integrity are not directly impacted by this patch.

## Safe reproduction steps

On the vulnerable code path, a narrow harness can show that a large MCP image block reaches the cache helper:

```bash
python3.11 - <<'PY'
from types import SimpleNamespace
from unittest.mock import patch
import base64, sys
sys.path.insert(0, '.')
from tools.mcp_tool import _cache_mcp_image_block

payload = b'\x89PNG\r\n\x1a\n' + b'A' * (2 * 1024 * 1024)
block = SimpleNamespace(
    data=base64.b64encode(payload).decode('ascii'),
    mimeType='image/png',
)
with patch('gateway.platforms.base.cache_image_from_bytes', return_value='/tmp/fake.png') as cache_mock:
    tag = _cache_mcp_image_block(block)
print({'tag': tag, 'cache_called': cache_mock.called, 'bytes_forwarded': len(cache_mock.call_args.args[0]) if cache_mock.called else 0})
PY
```

## Expected vulnerable behavior

On `origin/main` at `dd0923bb89ed2dd56f82cb63656a1323f6f42e6f`, the harness prints:

```text
{'tag': 'MEDIA:/tmp/fake.png', 'cache_called': True, 'bytes_forwarded': 2097160}
```

That shows the MCP-supplied image payload is fully decoded and forwarded into the cache path.

With this PR and a small test cap, the same shape is skipped before cache:

```text
{'tag': '', 'cache_called': False}
```

## Changes in this PR

- Add `_DEFAULT_MAX_MCP_IMAGE_BYTES` with a 10 MiB default cap.
- Add `HERMES_MCP_IMAGE_MAX_BYTES` override support for operators who need a different cap.
- Estimate decoded base64 size before allocating decoded bytes.
- Skip oversized MCP image blocks before `base64.b64decode()` and before `cache_image_from_bytes()`.
- Keep a post-decode length check as a defense-in-depth invariant.
- Add regression tests for oversized rejection and at-limit acceptance.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| MCP image handling | `tools/mcp_tool.py` | Adds decoded-size limit helpers and enforces them in `_cache_mcp_image_block()` |
| Regression tests | `tests/tools/test_mcp_image_content.py` | Covers oversized pre-decode rejection and valid image acceptance at the configured cap |

## Maintainer impact

- Normal small MCP image results continue to work.
- Oversized image results are dropped with a warning instead of being cached.
- Operators with legitimate larger images can raise `HERMES_MCP_IMAGE_MAX_BYTES`.
- The patch is limited to MCP image-result handling and does not change general gateway image caching semantics.

## Fix rationale

The resource boundary belongs at the MCP image-result admission point because that is where server-controlled base64 crosses into Hermes-managed memory and disk. Checking the estimated decoded size before allocating the decoded bytes prevents the most expensive step from happening for oversized blocks.

The existing `cache_image_from_bytes()` magic-byte check remains useful for rejecting non-images, but it is not a size-control mechanism.

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Regression tests
- [ ] Documentation-only change
- [ ] Refactor only

## Test plan

Validated locally:

```bash
python3.11 -m pytest tests/tools/test_mcp_image_content.py -q
python3.11 -m ruff check tools/mcp_tool.py tests/tools/test_mcp_image_content.py
python3.11 -m py_compile tools/mcp_tool.py tests/tools/test_mcp_image_content.py
python3.11 -m pytest tests/tools/test_mcp_image_content.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_structured_content.py -q
git diff --check
python3 scripts/check-windows-footguns.py --diff origin/main
```

Results:

- `tests/tools/test_mcp_image_content.py`: `11 passed`
- Broader touched MCP tests: `199 passed`
- Ruff check: passed
- py_compile: passed
- whitespace diff check: passed
- Windows footgun diff check: passed

Formatting note: `python3.11 -m ruff format --check tools/mcp_tool.py` still reports broad pre-existing formatting changes for the legacy file. I avoided committing whole-file formatting churn so the security diff stays reviewable. `python3.11 -m ruff format --check tests/tools/test_mcp_image_content.py` passes.

## Disclosure notes

This PR is intentionally bounded to MCP `ImageContent` resource handling. It does not claim that MCP servers are untrusted in every deployment, and it does not change MCP server configuration, transport authentication, or tool approval semantics. It only ensures that image-result handling has a local resource cap before decoding and caching server-controlled image bytes.
