### PR TITLE
fix(cli): parse positional insights days

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8805,6 +8805,9 @@ class HermesCLI:
             elif parts[i] == "--source" and i + 1 < len(parts):
                 source = parts[i + 1]
                 i += 2
+            elif parts[i].isdigit():
+                days = int(parts[i])
+                i += 1
             else:
                 i += 1
 

--- a/tests/cli/test_cli_insights_command.py
+++ b/tests/cli/test_cli_insights_command.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _InsightsEngineStub:
+    calls = []
+
+    def __init__(self, db):
+        self.db = db
+
+    def generate(self, *, days=30, source=None):
+        self.calls.append({"days": days, "source": source})
+        return {"days": days, "source": source}
+
+    def format_terminal(self, report):
+        return f"days={report['days']} source={report['source']}"
+
+
+def _run_show_insights(command: str):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    db = MagicMock()
+    _InsightsEngineStub.calls = []
+    with patch("hermes_state.SessionDB", return_value=db), \
+         patch("agent.insights.InsightsEngine", _InsightsEngineStub):
+        cli_obj._show_insights(command)
+    return _InsightsEngineStub.calls, db
+
+
+def test_cli_insights_accepts_positional_days(capsys):
+    calls, db = _run_show_insights("/insights 7")
+
+    assert calls == [{"days": 7, "source": None}]
+    db.close.assert_called_once()
+    assert "days=7 source=None" in capsys.readouterr().out
+
+
+def test_cli_insights_keeps_days_flag_and_source(capsys):
+    calls, db = _run_show_insights("/insights --days 14 --source discord")
+
+    assert calls == [{"days": 14, "source": "discord"}]
+    db.close.assert_called_once()
+    assert "days=14 source=discord" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Fixes the classic CLI `/insights` slash command so `/insights 7` uses a 7-day window, matching the gateway behavior.

The gateway already accepted positional day shorthand, but the classic CLI parser only handled `--days`, so `/insights 7` silently fell back to the default 30-day report.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `cli.py` to parse a positional numeric argument in `HermesCLI._show_insights()` as `days`.
- Added `tests/cli/test_cli_insights_command.py` covering `/insights 7` and the existing `--days` / `--source` path.

## How to Test

1. Run `/insights 7` in the classic CLI.
2. Confirm the report says `Last 7 days` instead of `Last 30 days`.
3. Run `/insights --days 14 --source discord` and confirm explicit flags still work.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL development environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, parser-only CLI slash command change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted tests before opening PR:

`scripts/run_tests.sh tests/cli/test_cli_insights_command.py tests/gateway/test_insights_unicode_flags.py -q`

Result: `14 passed in 3.12s`

Full suite after opening draft PR:

`scripts/run_tests.sh`

Result: failed, `64 failed, 22216 passed, 59 skipped, 19 errors in 715.22s (0:11:55)`.

The new CLI insights tests passed in both targeted runs. The full-suite errors/failures are outside this PR's touched files; notable hard errors include `tests/tools/test_browser_supervisor.py` teardown failures where `tests/conftest.py` live-system guard blocked `os.kill(...)` for headless Chrome PIDs outside the test process subtree.