### PR TITLE
fix(install): don't clobber venv hermes entry point via symlink

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1226,6 +1226,11 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
+    # Remove any pre-existing file or symlink at the launcher path. A prior
+    # setup-hermes.sh run creates this as `ln -sf … venv/bin/hermes`, and
+    # writing via `cat >` follows symlinks — which would truncate the venv
+    # entry point and turn the shim into a self-exec'ing infinite loop.
+    rm -f "$command_link_dir/hermes"
     cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH

--- a/tests/test_install_sh_launcher_symlink_safe.py
+++ b/tests/test_install_sh_launcher_symlink_safe.py
@@ -1,0 +1,87 @@
+"""Regression tests for install.sh launcher writing over a pre-existing symlink.
+
+setup-hermes.sh creates ``~/.local/bin/hermes`` as a symlink → ``venv/bin/hermes``
+via ``ln -sf``. If install.sh is then run on the same machine, the launcher
+write at ``setup_path`` previously used ``cat > "$command_link_dir/hermes"``
+which follows the symlink and truncates the venv entry point, leaving a shim
+whose ``exec "$HERMES_BIN" "$@"`` calls itself. The ``hermes`` command then
+hangs in an infinite recursion.
+
+These tests guard the fix: ``rm -f`` must precede the ``cat >`` so a
+pre-existing symlink is removed before the shim is written.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_rm_minus_f_precedes_cat_in_setup_path() -> None:
+    text = INSTALL_SH.read_text()
+
+    rm_marker = 'rm -f "$command_link_dir/hermes"'
+    cat_marker = 'cat > "$command_link_dir/hermes" <<EOF'
+
+    assert rm_marker in text, (
+        "setup_path must `rm -f` the launcher path before writing, so a "
+        "pre-existing symlink (from setup-hermes.sh) isn't followed and "
+        "clobbered."
+    )
+    assert cat_marker in text, "launcher write line missing"
+    assert text.index(rm_marker) < text.index(cat_marker), (
+        "`rm -f` must come BEFORE the `cat >` redirect — otherwise the "
+        "redirect follows any pre-existing symlink and overwrites its target."
+    )
+
+
+def test_launcher_write_pattern_does_not_clobber_symlink_target(tmp_path: Path) -> None:
+    """End-to-end: simulate the exact filesystem layout that triggered the bug
+    and verify the patched write pattern leaves the venv entry point intact."""
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_hermes = venv_bin / "hermes"
+    sentinel = "#!/usr/bin/env python3\n# real entry point - must not be truncated\n"
+    venv_hermes.write_text(sentinel)
+    venv_hermes.chmod(0o755)
+
+    link_dir = tmp_path / "local" / "bin"
+    link_dir.mkdir(parents=True)
+    link_path = link_dir / "hermes"
+    link_path.symlink_to(venv_hermes)
+
+    assert link_path.is_symlink()
+    assert link_path.resolve() == venv_hermes.resolve()
+
+    # Mirror the post-fix setup_path snippet from scripts/install.sh.
+    script = f'''
+set -eu
+command_link_dir={link_dir!s}
+HERMES_BIN={venv_hermes!s}
+mkdir -p "$command_link_dir"
+rm -f "$command_link_dir/hermes"
+cat > "$command_link_dir/hermes" <<EOF
+#!/usr/bin/env bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec "$HERMES_BIN" "\\$@"
+EOF
+chmod +x "$command_link_dir/hermes"
+'''
+    subprocess.run(["bash", "-c", script], check=True)
+
+    assert venv_hermes.read_text() == sentinel, (
+        "venv entry point was clobbered — `rm -f` did not protect the symlink "
+        "target from being truncated by the launcher write."
+    )
+
+    assert not link_path.is_symlink(), "shim should be a regular file, not a symlink"
+    shim_text = link_path.read_text()
+    assert "unset PYTHONPATH" in shim_text
+    assert "unset PYTHONHOME" in shim_text
+    assert f'exec "{venv_hermes}" "$@"' in shim_text
+    assert os.stat(link_path).st_mode & stat.S_IXUSR, "shim must be executable"


### PR DESCRIPTION
## What does this PR do?

`scripts/install.sh::setup_path` writes the user-facing launcher via
`cat > "$command_link_dir/hermes" <<EOF`. If a prior `setup-hermes.sh` run
had created that path as `ln -sf … venv/bin/hermes` (which it does on line 335),
the redirect **follows the symlink** and truncates the venv entry point itself.
The shim's `exec "$HERMES_BIN" "$@"` then exec's the file it just rewrote → the
`hermes` command hangs forever in infinite recursion. Users hit this whenever
they run `setup-hermes.sh` and `scripts/install.sh` on the same machine.

Fix: `rm -f "$command_link_dir/hermes"` before the `cat >`, so any pre-existing
symlink is removed before the shim is written.

## Related Issue

<!-- No existing issue — opening this directly. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: add `rm -f "$command_link_dir/hermes"` before the launcher write in `setup_path`, with a comment explaining the symlink-clobber hazard.
- `tests/test_install_sh_launcher_symlink_safe.py` (new): two regression tests — a static check that `rm -f` precedes the `cat >`, plus an end-to-end filesystem simulation that creates the exact symlink layout and verifies the venv entry point is not truncated.

## How to Test

Reproduce the bug on `main`:
```bash
tmp=$(mktemp -d) && mkdir -p "$tmp/venv/bin" "$tmp/link"
printf 'real entry point\n' > "$tmp/venv/bin/hermes"
ln -sf "$tmp/venv/bin/hermes" "$tmp/link/hermes"
HERMES_BIN="$tmp/venv/bin/hermes" command_link_dir="$tmp/link" \
  bash -c 'cat > "$command_link_dir/hermes" <<EOF
exec "\$HERMES_BIN" "\$@"
EOF'
cat "$tmp/venv/bin/hermes"   # sentinel is gone — venv binary was clobbered
```

On this branch, the new test demonstrates the fix:
```bash
pytest tests/test_install_sh_launcher_symlink_safe.py -v
```

Both tests pass; running the snippet above with `rm -f "$command_link_dir/hermes"` inserted leaves the sentinel intact.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/test_install_sh_launcher_symlink_safe.py tests/test_install_sh_pythonpath_sanitization.py -v` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] N/A — no doc surface affected
- [x] N/A — no config keys changed
- [x] N/A — no architecture change
- [x] Cross-platform: fix is a portable `rm -f` and applies on every non-Windows install path
- [x] N/A — no tool schemas changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)