### PR TITLE
Fix agent initialization indentation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9914,12 +9914,12 @@ class HermesCLI:
         # Initialize agent if needed
         if self.agent is None:
             _cprint(f"{_DIM}Initializing agent...{_RST}")
-        if not self._init_agent(
-            model_override=turn_route["model"],
-            runtime_override=turn_route["runtime"],
-            request_overrides=turn_route.get("request_overrides"),
-        ):
-            return None
+            if not self._init_agent(
+                model_override=turn_route["model"],
+                runtime_override=turn_route["runtime"],
+                request_overrides=turn_route.get("request_overrides"),
+            ):
+                return None
         
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters


### PR DESCRIPTION
Corrects a logic bug in cli.py where _init_agent was called every turn regardless of whether the agent already existed. This ensures proper agent state persistence across turns.