### PR TITLE
fix(honcho): disclose cloud data flow during setup

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -16,6 +16,8 @@ hermes honcho setup    # full interactive wizard (cloud or local)
 hermes memory setup    # generic picker, also works
 ```
 
+When you choose Honcho cloud, Hermes sends conversation messages, peer/session identifiers, memory facts/conclusions, and context requests to `api.honcho.dev`. Honcho cloud may run backend LLM inference for observation, summaries, peer representations, and dialectic reasoning. Choose `local` during setup if you want to use a self-hosted Honcho server instead.
+
 Or manually:
 ```bash
 hermes config set memory.provider honcho

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -354,6 +354,18 @@ def _ensure_sdk_installed() -> bool:
         return False
 
 
+def _confirm_cloud_data_flow() -> bool:
+    """Ask for explicit consent before configuring the hosted Honcho service."""
+    print("\n  Honcho cloud privacy notice:")
+    print("    - Hermes will send conversation messages, peer/session identifiers,")
+    print("      memory facts/conclusions, and context requests to api.honcho.dev.")
+    print("    - Honcho cloud may run backend LLM inference for observation,")
+    print("      summaries, peer representations, and dialectic reasoning.")
+    print("    - Choose 'local' instead if you want to use a self-hosted Honcho server.")
+    answer = _prompt("Continue with Honcho cloud?", default="n")
+    return answer.lower() in ("y", "yes")
+
+
 def cmd_setup(args) -> None:
     """Interactive Honcho setup wizard."""
     cfg = _read_config()
@@ -383,6 +395,9 @@ def cmd_setup(args) -> None:
     ) else "cloud"
     deploy = _prompt("Cloud or local?", default=current_deploy)
     is_local = deploy.lower() in ("local", "l")
+    if not is_local and not _confirm_cloud_data_flow():
+        print("\n  Honcho cloud setup canceled. Re-run setup and choose 'local' for a self-hosted server.\n")
+        return
 
     # Clean up legacy snake_case key
     cfg.pop("base_url", None)

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -100,6 +100,88 @@ class TestResolveApiKey:
                 f"expected local sentinel for legacy schemeless {legacy!r}"
 
 
+class TestCmdSetup:
+    def test_cloud_setup_requires_data_flow_confirmation(self, monkeypatch, capsys, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        writes = []
+        prompts = iter(["cloud", "n"])
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {})
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg: writes.append(cfg))
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr(
+            honcho_cli,
+            "_prompt",
+            lambda label, default=None, secret=False: next(prompts),
+        )
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "Honcho cloud privacy notice" in out
+        assert "conversation messages" in out
+        assert "api.honcho.dev" in out
+        assert "backend LLM inference" in out
+        assert "setup canceled" in out
+        assert writes == []
+
+    def test_local_setup_skips_cloud_data_flow_confirmation(self, monkeypatch, capsys, tmp_path):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        written = {}
+
+        class FakeConfig:
+            workspace_id = "hermes"
+            peer_name = "test-user"
+            ai_peer = "hermes"
+            observation_mode = "directional"
+            write_frequency = "async"
+            recall_mode = "hybrid"
+            session_strategy = "per-session"
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        def prompt(label, default=None, secret=False):
+            if label == "Cloud or local?":
+                return "local"
+            return default or ""
+
+        def fail_cloud_confirmation():
+            raise AssertionError("local setup should not ask for Honcho cloud consent")
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {})
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg: written.setdefault("cfg", cfg))
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr(honcho_cli, "_confirm_cloud_data_flow", fail_cloud_confirmation)
+        monkeypatch.setattr(honcho_cli, "_prompt", prompt)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"memory": {}})
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda config: None)
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: FakeConfig(),
+        )
+        monkeypatch.setattr("plugins.memory.honcho.client.get_honcho_client", lambda cfg: object())
+        monkeypatch.setattr("plugins.memory.honcho.client.reset_honcho_client", lambda: None)
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "Honcho cloud privacy notice" not in out
+        assert "Honcho is ready." in out
+        assert written["cfg"]["baseUrl"] == "http://localhost:8000"
+        assert written["cfg"]["hosts"]["hermes"]["enabled"] is True
+
+
 class TestCmdStatus:
     def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
         import plugins.memory.honcho.cli as honcho_cli

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -68,6 +68,8 @@ hermes memory setup        # select "honcho" — runs the Honcho-specific post-s
 
 The legacy `hermes honcho setup` command still works (it now redirects to `hermes memory setup`), but is only registered after Honcho is selected as the active memory provider.
 
+**Cloud privacy notice:** When configured for Honcho cloud, Hermes sends conversation messages, peer/session identifiers, memory facts/conclusions, and context requests to `api.honcho.dev`. Honcho cloud may run backend LLM inference for observation, summaries, peer representations, and dialectic reasoning. Choose the `local` setup option for a self-hosted Honcho server instead.
+
 **Config:** `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.json` (global). Resolution order: `$HERMES_HOME/honcho.json` > `~/.hermes/honcho.json` > `~/.honcho/config.json`. See the [config reference](https://github.com/hermes-ai/hermes-agent/blob/main/plugins/memory/honcho/README.md) and the [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 
 <details>


### PR DESCRIPTION
## Summary
- add an explicit Honcho cloud privacy notice during setup before collecting the API key
- require confirmation before continuing with api.honcho.dev, canceling without writing config when declined
- document the cloud data flow in the Honcho README and memory provider guide

Closes #4074

## Tests
- python3 -m pytest tests/honcho_plugin/test_cli.py -q -o 'addopts='
- python3 -m pytest tests/honcho_plugin tests/test_honcho_client_config.py -q -o 'addopts='
- python3 -m py_compile plugins/memory/honcho/cli.py
- git diff --check