### PR TITLE
fix(kimi): normalize Anthropic SDK base URL

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -81,9 +81,29 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"
-    if hostname == "api.kimi.com" and "/coding" in normalized:
+    if hostname == "api.kimi.com" and re.search(r"/coding(?:/|$)", normalized):
         return "anthropic_messages"
     return None
+
+
+def _normalize_anthropic_sdk_base_url(provider: Optional[str], base_url: str, api_mode: str) -> str:
+    """Normalize base URLs for Anthropic SDK transports.
+
+    The Anthropic SDK prepends its own /v1/messages path. Providers that expose
+    OpenAI-compatible health/model URLs under a trailing /v1 must be stripped
+    when the resolved runtime uses anthropic_messages, otherwise requests hit a
+    double-/v1 path such as /coding/v1/v1/messages.
+    """
+    normalized = (base_url or "").strip().rstrip("/")
+    if api_mode != "anthropic_messages":
+        return normalized
+    pathish = normalized.lower()
+    if (
+        (provider or "") in {"opencode-zen", "opencode-go"}
+        or (base_url_host_matches(normalized, "api.kimi.com") and re.search(r"/coding(?:/|$)", pathish))
+    ):
+        return re.sub(r"/v1/?$", "", normalized)
+    return normalized
 
 
 def _auto_detect_local_model(base_url: str) -> str:
@@ -286,12 +306,8 @@ def _resolve_runtime_from_pool_entry(
             if detected:
                 api_mode = detected
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
-        base_url = re.sub(r"/v1/?$", "", base_url)
+    # Normalize Anthropic SDK base URLs after provider-specific api_mode detection.
+    base_url = _normalize_anthropic_sdk_base_url(provider, base_url, api_mode)
 
     return {
         "provider": provider,
@@ -343,9 +359,11 @@ def _try_resolve_from_custom_pool(
         pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         if not pool_api_key:
             return None
+        api_mode = api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions"
+        base_url = _normalize_anthropic_sdk_base_url(provider_label, base_url, api_mode)
         return {
             "provider": provider_label,
-            "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": api_mode,
             "base_url": base_url,
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
@@ -516,9 +534,11 @@ def _resolve_named_custom_runtime(
             (c for c in api_key_candidates if has_usable_secret(c)),
             "",
         ) or "no-key-required"
+        api_mode = _detect_api_mode_for_url(base_url) or "chat_completions"
+        base_url = _normalize_anthropic_sdk_base_url("custom", base_url, api_mode)
         return {
             "provider": "custom",
-            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": api_mode,
             "base_url": base_url,
             "api_key": api_key,
             "source": "direct-alias",
@@ -555,11 +575,11 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = custom_provider.get("api_mode") or _detect_api_mode_for_url(base_url) or "chat_completions"
+    base_url = _normalize_anthropic_sdk_base_url("custom", base_url, api_mode)
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -668,11 +688,11 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    api_mode = _parse_api_mode(model_cfg.get("api_mode")) or _detect_api_mode_for_url(base_url) or "chat_completions"
+    base_url = _normalize_anthropic_sdk_base_url(effective_provider, base_url, api_mode)
     return {
         "provider": effective_provider,
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -896,10 +916,11 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
+        base_url = _normalize_anthropic_sdk_base_url(provider, base_url, api_mode)
         return {
             "provider": provider,
             "api_mode": api_mode,
-            "base_url": base_url.rstrip("/"),
+            "base_url": base_url,
             "api_key": api_key,
             "source": "explicit",
             "requested_provider": requested_provider,
@@ -1332,9 +1353,7 @@ def resolve_runtime_provider(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
-        # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
-        if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
-            base_url = re.sub(r"/v1/?$", "", base_url)
+        base_url = _normalize_anthropic_sdk_base_url(provider, base_url, api_mode)
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2321,3 +2321,91 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
     assert resolved["provider"] == "minimax-oauth"
     assert resolved["api_mode"] == "anthropic_messages"
     assert resolved["base_url"] == "https://api.minimax.io/anthropic"
+
+
+def test_resolve_runtime_provider_kimi_anthropic_strips_v1(monkeypatch):
+    class _Entry:
+        access_token = "sk-kimi-test"
+        source = "env:KIMI_API_KEY"
+        base_url = "https://api.kimi.com/coding/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "kimi-coding", "default": "kimi-for-coding"})
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding", target_model="kimi-for-coding")
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+    assert resolved["api_key"] == "sk-kimi-test"
+
+
+def test_resolve_runtime_provider_kimi_explicit_strips_v1(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "kimi-coding", "default": "kimi-for-coding"})
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="kimi-coding",
+        explicit_api_key="sk-kimi-test",
+        explicit_base_url="https://api.kimi.com/coding/v1",
+        target_model="kimi-for-coding",
+    )
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+    assert resolved["api_key"] == "sk-kimi-test"
+
+
+def test_resolve_runtime_provider_kimi_api_key_fallback_strips_v1(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "kimi-coding", "default": "kimi-for-coding"})
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {"base_url": "https://api.kimi.com/coding/v1", "api_key": "sk-kimi-test", "source": "env:KIMI_API_KEY"},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding", target_model="kimi-for-coding")
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+    assert resolved["api_key"] == "sk-kimi-test"
+
+
+def test_kimi_anthropic_base_url_normalizer_preserves_non_coding_and_chat_modes():
+    assert (
+        rp._normalize_anthropic_sdk_base_url("kimi-coding", "https://api.kimi.com/coding/v1", "anthropic_messages")
+        == "https://api.kimi.com/coding"
+    )
+    assert (
+        rp._normalize_anthropic_sdk_base_url("kimi-coding", "https://api.kimi.com/v1", "chat_completions")
+        == "https://api.kimi.com/v1"
+    )
+    assert (
+        rp._normalize_anthropic_sdk_base_url("kimi-coding", "https://api.kimi.com/coder/v1", "anthropic_messages")
+        == "https://api.kimi.com/coder/v1"
+    )
+    assert (
+        rp._normalize_anthropic_sdk_base_url("kimi-coding", "https://api.moonshot.ai/v1", "anthropic_messages")
+        == "https://api.moonshot.ai/v1"
+    )


### PR DESCRIPTION
## Summary
- normalize Kimi Coding Anthropic Messages base URLs by stripping trailing `/v1` from `https://api.kimi.com/coding/v1`
- centralize Anthropic SDK base-url normalization across pool, explicit API-key, no-pool API-key fallback, and custom endpoint resolution paths
- keep `/coding/v1` usable for OpenAI-compatible model/health calls while preventing Anthropic SDK from producing `/coding/v1/v1/messages`
- add regression coverage for pool, explicit, API-key fallback, and negative non-coding/chat-mode cases

## Root cause
Kimi Coding exposes `/coding/v1` for OpenAI-compatible calls, but the Anthropic SDK appends its own `/v1/messages` path. When Hermes resolves Kimi to `anthropic_messages` with base URL `/coding/v1`, requests are sent to `/coding/v1/v1/messages` and return HTTP 404 before fallback/Kanban workers can respond.

## Test plan
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_kimi_anthropic_strips_v1 tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_kimi_explicit_strips_v1 tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_kimi_api_key_fallback_strips_v1 tests/hermes_cli/test_runtime_provider_resolution.py::test_kimi_anthropic_base_url_normalizer_preserves_non_coding_and_chat_modes tests/hermes_cli/test_kanban_core_functionality.py::test_detect_crashed_workers_protocol_violation_auto_blocks -q`
- `python -m py_compile hermes_cli/runtime_provider.py`
