### PR TITLE
fix(api-server): wake SSE writer immediately on agent_task completion (#24451)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1168,6 +1168,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
             ))
+            # _on_delta filters out None (used as a CLI box-close signal),
+            # so the agent never emits an EOS sentinel itself.  Without this
+            # callback, the SSE writer can only learn the agent finished by
+            # observing agent_task.done() after a queue-timeout — which adds
+            # up to one full poll-interval of latency to every response and
+            # is brittle if the writer is parked in run_in_executor while
+            # the task completes.  Pushing None on done is a reliable EOS.
+            agent_task.add_done_callback(lambda _t: _stream_q.put_nowait(None))
 
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
@@ -2197,6 +2205,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
             ))
+            # See chat-completions branch above: _on_delta filters None, so
+            # the agent never feeds an EOS sentinel itself.  Wake the SSE
+            # writer immediately on task completion instead of waiting for
+            # the next queue-timeout iteration to spot agent_task.done().
+            agent_task.add_done_callback(lambda _t: _stream_q.put_nowait(None))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1182,6 +1182,156 @@ class TestChatCompletionsEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Streaming completion / response promptness — regression for #24451
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingCompletionPromptness:
+    """The agent never emits a None EOS sentinel itself: ``_on_delta``
+    filters None as a CLI box-close signal so it stays off the SSE wire.
+    That left ``_write_sse_chat_completion`` / ``_write_sse_responses``
+    polling ``agent_task.done()`` on every queue-timeout — up to a full
+    0.5s poll interval after the agent actually finished, and (per the
+    upstream report on #24451) sometimes parking the writer in
+    ``run_in_executor`` long enough to send keepalives indefinitely.
+
+    Both streaming entry points now register an
+    ``agent_task.add_done_callback`` that pushes ``None`` onto the stream
+    queue, waking ``stream_q.get(timeout=0.5)`` immediately so the writer
+    exits via its EOS-sentinel branch instead of the polling fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stream_terminates_promptly_with_no_deltas(self, adapter):
+        """Streaming chat-completions must terminate near-instantly when
+        the agent finishes without emitting any deltas.
+
+        Pre-fix the writer needed a full ``stream_q.get(timeout=0.5)``
+        cycle to spot ``agent_task.done()``; the 0.4s assertion would
+        fail without the EOS-pushing done callback and passes with
+        headroom when it is wired correctly.
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _silent_agent(**kwargs):
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_silent_agent):
+                start = time.monotonic()
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent",
+                          "messages": [{"role": "user", "content": "hi"}],
+                          "stream": True},
+                )
+                body = await resp.text()
+                elapsed = time.monotonic() - start
+
+            assert resp.status == 200
+            assert "data: [DONE]" in body
+            assert elapsed < 0.4, (
+                f"chat-completions SSE took {elapsed:.3f}s with no deltas; "
+                "should be near-instant via agent_task.add_done_callback."
+            )
+
+    @pytest.mark.asyncio
+    async def test_responses_stream_terminates_promptly_with_no_deltas(self, adapter):
+        """Same guarantee on the /v1/responses path: when the agent
+        finishes without ever invoking ``stream_delta_callback`` (e.g.
+        a no-op turn, or one whose tool-only output is dropped by the
+        handler), ``response.completed`` must still be emitted without
+        a 0.5s poll round-trip.
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _silent_agent(**kwargs):
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_silent_agent):
+                start = time.monotonic()
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                body = await resp.text()
+                elapsed = time.monotonic() - start
+
+            assert resp.status == 200
+            assert "event: response.completed" in body
+            assert elapsed < 0.4, (
+                f"responses SSE took {elapsed:.3f}s with no deltas; "
+                "should be near-instant via agent_task.add_done_callback."
+            )
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_eos_sentinel_path_exits_when_done_never_reports(self, adapter):
+        """White-box guard that the EOS sentinel actually escapes the
+        writer when ``agent_task.done()`` keeps returning False — the
+        worst-case race the upstream report describes.
+
+        The fix's add_done_callback is what would push the sentinel in
+        production; we replay that contract here against the writer
+        directly so a future refactor of either side fails loudly.
+        """
+        fake_request = MagicMock()
+        fake_request.headers = {}
+
+        written: list[bytes] = []
+
+        class _FakeStreamResponse:
+            async def prepare(self, req):
+                pass
+
+            async def write(self, payload):
+                written.append(payload)
+
+        import gateway.platforms.api_server as api_mod
+        import queue as _q
+
+        stream_q: _q.Queue = _q.Queue()
+
+        async def _silent_agent():
+            await asyncio.sleep(0.01)
+            return (
+                {"final_response": "ok", "messages": [], "api_calls": 0},
+                {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            )
+
+        agent_task = asyncio.ensure_future(_silent_agent())
+        agent_task.add_done_callback(lambda _t: stream_q.put_nowait(None))
+
+        # Pin done() to False so the polling-fallback exit cannot fire;
+        # only the add_done_callback EOS path can rescue the writer.
+        # ``patch.object`` is used instead of direct attribute assignment
+        # so behavior is consistent across CPython 3.11/3.12 + xdist.
+        with patch.object(agent_task, "done", return_value=False), \
+             patch.object(api_mod.web, "StreamResponse", return_value=_FakeStreamResponse()):
+            await asyncio.wait_for(
+                adapter._write_sse_chat_completion(
+                    fake_request,
+                    "chatcmpl-xyz",
+                    "hermes-agent",
+                    int(time.time()),
+                    stream_q,
+                    agent_task,
+                    [None],
+                    session_id="s1",
+                    gateway_session_key=None,
+                ),
+                timeout=3.0,
+            )
+
+        body = b"".join(written).decode()
+        assert "[DONE]" in body
+
+
+# ---------------------------------------------------------------------------
 # _derive_chat_session_id unit tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Both streaming entry points (`/v1/chat/completions` and `/v1/responses`) register an `agent_task.add_done_callback` that pushes a `None` EOS sentinel onto the per-request stream queue, so the SSE writer wakes immediately when the agent finishes instead of waiting for the next `agent_task.done()` poll.
- Two end-to-end timing regressions (chat-completions + responses) plus one white-box guard prove the callback is wired up and the writer escapes even when `done()` never reports True.

## The bug

In `gateway/platforms/api_server.py` both streaming paths wrap `_run_agent` in a fresh task and hand the queue + task to `_write_sse_chat_completion` / `_write_sse_responses`. The writers consume the queue with:

```python
delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
```

— and only check `agent_task.done()` on the `_q.Empty` branch.

The agent itself never feeds a `None` EOS sentinel: `_on_delta` filters `None` because the agent uses it as a CLI box-close signal mid-run, and forwarding it would close the SSE stream before tool calls land. That leaves `agent_task.done()` polling as the only exit path. The upstream report on #24451 describes this leaking out as `response.completed` never sent / clients seeing `: keepalive` indefinitely; even on the happy path the writer pays up to a full 0.5s poll interval of post-run latency before terminating.

## The fix

```python
agent_task = asyncio.ensure_future(self._run_agent(...))
agent_task.add_done_callback(lambda _t: _stream_q.put_nowait(None))
```

at both call sites ([`api_server.py:1170`](https://github.com/NousResearch/hermes-agent/blob/main/gateway/platforms/api_server.py#L1170) for chat-completions, [`api_server.py:2199`](https://github.com/NousResearch/hermes-agent/blob/main/gateway/platforms/api_server.py#L2199) for responses).

The callback runs in the asyncio loop the instant the task transitions to done — success, exception, or cancel — and `queue.Queue.put_nowait` is thread-safe on the unbounded stdlib queue used here. The SSE writers already have an `if item is None: break` EOS branch, so the new sentinel exits the loop through code that has been on the happy path forever; the polling fallback stays in place as a belt-and-suspenders backstop.

## Test plan

- [x] Focused regression tests in `tests/gateway/test_api_server.py::TestStreamingCompletionPromptness`:
  - `test_chat_completions_stream_terminates_promptly_with_no_deltas` — POSTs to `/v1/chat/completions` with `stream=true`, mocks `_run_agent` to return immediately without calling any callbacks, asserts the `data: [DONE]` chunk arrives in `< 0.4s` (would be `≥ 0.5s` pre-fix via the polling fallback).
  - `test_responses_stream_terminates_promptly_with_no_deltas` — same shape against `/v1/responses`, asserts `event: response.completed`.
  - `test_chat_completions_eos_sentinel_path_exits_when_done_never_reports` — white-box: drives `_write_sse_chat_completion` directly with a task whose `done()` is patched to return False, proving the EOS-sentinel branch is the only exit and is reachable via `add_done_callback`.
- [x] Regression guard verified: with the production change stashed, the two timing tests fail with `elapsed ≈ 0.51s`; restoring the change brings them under 0.05s.
- [x] Adjacent suite: `tests/gateway/test_api_server.py` + `tests/gateway/test_sse_agent_cancel.py` — 150 passed locally with the `.[messaging]` extras pulled in to match CI's install.

## Related

- Fixes #24451