### PR TITLE
fix(deepseek): update provider picker description

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -852,7 +852,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
+    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V4 Pro, V4 Flash — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),

--- a/tests/hermes_cli/test_deepseek_provider.py
+++ b/tests/hermes_cli/test_deepseek_provider.py
@@ -1,0 +1,16 @@
+from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_MODELS
+
+
+def test_deepseek_models_include_v4_variants():
+    models = _PROVIDER_MODELS["deepseek"]
+
+    assert "deepseek-v4-pro" in models
+    assert "deepseek-v4-flash" in models
+
+
+def test_deepseek_provider_description_mentions_v4_models():
+    entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "deepseek")
+
+    assert "V4 Pro" in entry.tui_desc
+    assert "V4 Flash" in entry.tui_desc
+    assert "V3" not in entry.tui_desc


### PR DESCRIPTION
## Summary
- Update the DeepSeek provider picker description to advertise V4 Pro and V4 Flash instead of stale V3/R1/coder wording.
- Add regression coverage that ensures the provider description stays aligned with the V4 DeepSeek model entries.

Fixes #24471

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_deepseek_provider.py tests/hermes_cli/test_model_normalize.py