### PR TITLE
feat: add model-callable set_goal tool

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -395,6 +395,7 @@ class GoalState:
     max_turns: int = DEFAULT_MAX_TURNS
     created_at: float = 0.0
     last_turn_at: float = 0.0
+    updated_at: float = 0.0
     last_verdict: Optional[str] = None        # "done" | "continue" | "skipped"
     last_reason: Optional[str] = None
     paused_reason: Optional[str] = None       # why we auto-paused (budget, etc.)
@@ -453,6 +454,7 @@ class GoalState:
             max_turns=int(data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS),
             created_at=float(data.get("created_at", 0.0) or 0.0),
             last_turn_at=float(data.get("last_turn_at", 0.0) or 0.0),
+            updated_at=float(data.get("updated_at", data.get("last_turn_at", data.get("created_at", 0.0))) or 0.0),
             last_verdict=data.get("last_verdict"),
             last_reason=data.get("last_reason"),
             paused_reason=data.get("paused_reason"),
@@ -544,17 +546,25 @@ def load_goal(session_id: str) -> Optional[GoalState]:
         return None
 
 
-def save_goal(session_id: str, state: GoalState) -> None:
-    """Persist a goal to SessionDB. No-op if DB unavailable."""
+def save_goal(session_id: str, state: GoalState) -> bool:
+    """Persist a goal to SessionDB.
+
+    Returns ``True`` when the write reached SessionDB and ``False`` when the
+    DB is unavailable or rejects the write. Callers that keep live in-memory
+    goal state use this to avoid replacing newer local state with stale rows
+    on the next refresh.
+    """
     if not session_id:
-        return
+        return False
     db = _get_session_db()
     if db is None:
-        return
+        return False
     try:
         db.set_meta(_meta_key(session_id), state.to_json())
     except Exception as exc:
         logger.debug("GoalManager: set_meta failed: %s", exc)
+        return False
+    return True
 
 
 def clear_goal(session_id: str) -> None:
@@ -1095,23 +1105,61 @@ class GoalManager:
         self.session_id = session_id
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
         self._state: Optional[GoalState] = load_goal(session_id)
+        self._dirty_since: Optional[float] = None
 
     # --- introspection ------------------------------------------------
 
     @property
     def state(self) -> Optional[GoalState]:
+        return self.refresh()
+
+    def refresh(self) -> Optional[GoalState]:
+        """Reload state from SessionDB and return it.
+
+        Live CLI/gateway sessions may keep a ``GoalManager`` cached while a
+        model-callable tool updates the same session's goal through the DB.
+        Refreshing on public reads/mutations keeps those cached managers in
+        sync with externally-written goal state. Cleared audit rows are exposed
+        as ``None`` here so callers keep the long-standing "no active state"
+        semantics while ``load_goal`` still preserves the row for audit.
+        """
+        state = load_goal(self.session_id)
+        if self._dirty_since is not None:
+            if state is not None and self._state is not None and state.to_json() == self._state.to_json():
+                self._dirty_since = None
+            elif state is not None and max(state.created_at, state.last_turn_at, state.updated_at) > self._dirty_since:
+                self._dirty_since = None
+            else:
+                return None if self._state is None or self._state.status == "cleared" else self._state
+        if state is None:
+            return self._state
+        self._state = None if state.status == "cleared" else state
         return self._state
 
+    def _persist_state(self, state: GoalState) -> bool:
+        saved = save_goal(self.session_id, state)
+        self._dirty_since = None if saved else time.time()
+        return saved
+
+    @staticmethod
+    def _touch_state(state: GoalState) -> GoalState:
+        state.updated_at = time.time()
+        return state
+
     def is_active(self) -> bool:
+        self.refresh()
         return self._state is not None and self._state.status == "active"
 
     def has_goal(self) -> bool:
+        self.refresh()
         return self._state is not None and self._state.status in {"active", "paused"}
 
     def has_contract(self) -> bool:
+        self.refresh()
         return self._state is not None and self._state.has_contract()
 
     def status_line(self) -> str:
+        self.refresh()
         s = self._state
         if s is None or s.status in {"cleared",}:
             return "No active goal. Set one with /goal <text>."
@@ -1144,17 +1192,19 @@ class GoalManager:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        now = time.time()
         state = GoalState(
             goal=goal,
             status="active",
             turns_used=0,
             max_turns=int(max_turns) if max_turns else self.default_max_turns,
-            created_at=time.time(),
+            created_at=now,
             last_turn_at=0.0,
+            updated_at=now,
             contract=contract if contract is not None else GoalContract(),
         )
         self._state = state
-        save_goal(self.session_id, state)
+        self._persist_state(state)
         return state
 
     def set_contract(self, contract: GoalContract) -> Optional[GoalState]:
@@ -1162,13 +1212,16 @@ class GoalManager:
 
         Returns the updated state, or None when there is no goal to attach to.
         """
+        self.refresh()
         if self._state is None:
             return None
         self._state.contract = contract or GoalContract()
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
+        self.refresh()
         if not self._state:
             return None
         self._state.status = "paused"
@@ -1179,10 +1232,12 @@ class GoalManager:
         self._state.waiting_until = 0.0
         self._state.waiting_reason = None
         self._state.waiting_since = 0.0
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
+        self.refresh()
         if not self._state:
             return None
         self._state.status = "active"
@@ -1195,23 +1250,28 @@ class GoalManager:
         self._state.waiting_since = 0.0
         if reset_budget:
             self._state.turns_used = 0
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def clear(self) -> None:
+        self.refresh()
         if self._state is None:
             return
         self._state.status = "cleared"
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         self._state = None
 
     def mark_done(self, reason: str) -> None:
+        self.refresh()
         if not self._state:
             return
         self._state.status = "done"
         self._state.last_verdict = "done"
         self._state.last_reason = reason
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
 
     # --- /subgoal user controls ---------------------------------------
 
@@ -1227,7 +1287,8 @@ class GoalManager:
         if not text:
             raise ValueError("subgoal text is empty")
         self._state.subgoals.append(text)
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return text
 
     def remove_subgoal(self, index_1based: int) -> str:
@@ -1240,7 +1301,8 @@ class GoalManager:
                 f"index out of range (1..{len(self._state.subgoals)})"
             )
         removed = self._state.subgoals.pop(idx)
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return removed
 
     def clear_subgoals(self) -> int:
@@ -1249,11 +1311,13 @@ class GoalManager:
             raise RuntimeError("no active goal")
         prev = len(self._state.subgoals)
         self._state.subgoals = []
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return prev
 
     def render_subgoals(self) -> str:
         """Public helper for the /subgoal slash command."""
+        self.refresh()
         if self._state is None:
             return "(no active goal)"
         if not self._state.subgoals:
@@ -1272,6 +1336,9 @@ class GoalManager:
         active goal. For a process with a watch_patterns/notify_on_complete
         trigger, prefer ``wait_on_session`` so a mid-run trigger (not just
         exit) releases the barrier.
+
+        Does not refresh first: ``evaluate_after_turn`` may call this while
+        holding unpersisted turn/verdict mutations on ``self._state``.
         """
         if self._state is None or self._state.status != "active":
             raise RuntimeError("no active goal to park")
@@ -1283,7 +1350,8 @@ class GoalManager:
         self._state.waiting_until = 0.0
         self._state.waiting_reason = (reason or "").strip() or None
         self._state.waiting_since = time.time()
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def wait_on_session(self, session_id: str, reason: str = "") -> GoalState:
@@ -1294,6 +1362,9 @@ class GoalManager:
         with ``watch_patterns`` — its pattern matches. This is the right
         barrier for a long-lived watcher/server/poller that signals mid-run
         and may never exit. Requires an active goal.
+
+        Does not refresh first — may be called mid-evaluate with unpersisted
+        local mutations that must not be clobbered by a DB reload.
         """
         if self._state is None or self._state.status != "active":
             raise RuntimeError("no active goal to park")
@@ -1305,7 +1376,8 @@ class GoalManager:
         self._state.waiting_until = 0.0
         self._state.waiting_reason = (reason or "").strip() or None
         self._state.waiting_since = time.time()
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def wait_for_seconds(self, seconds: int, reason: str = "") -> GoalState:
@@ -1315,6 +1387,9 @@ class GoalManager:
         where there's no process to track (e.g. the agent is rate-limited).
         The barrier auto-clears once the deadline passes. Requires an active
         goal.
+
+        Does not refresh first — may be called mid-evaluate with unpersisted
+        local mutations that must not be clobbered by a DB reload.
         """
         if self._state is None or self._state.status != "active":
             raise RuntimeError("no active goal to park")
@@ -1326,12 +1401,17 @@ class GoalManager:
         self._state.waiting_until = time.time() + seconds
         self._state.waiting_reason = (reason or "").strip() or None
         self._state.waiting_since = time.time()
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return self._state
 
     def stop_waiting(self) -> bool:
         """Clear any active wait barrier (pid / session / time). Returns True
-        if one was cleared."""
+        if one was cleared.
+
+        Operates on the in-memory state without refreshing first so lazy
+        auto-clear and mid-evaluate paths keep unpersisted local mutations.
+        """
         if self._state is None:
             return False
         if (
@@ -1345,7 +1425,8 @@ class GoalManager:
         self._state.waiting_until = 0.0
         self._state.waiting_reason = None
         self._state.waiting_since = 0.0
-        save_goal(self.session_id, self._state)
+        self._touch_state(self._state)
+        self._persist_state(self._state)
         return True
 
     def is_waiting(self) -> bool:
@@ -1356,6 +1437,10 @@ class GoalManager:
         barrier: active until the deadline passes. Side effect: a satisfied
         barrier is cleared here (lazy auto-clear) so the next evaluation
         resumes normal judging.
+
+        Uses the in-memory state without refreshing first so tests and
+        evaluate paths can mutate barrier fields and observe auto-clear
+        without a DB reload clobbering the mutation.
         """
         s = self._state
         if s is None:
@@ -1405,7 +1490,7 @@ class GoalManager:
           - ``reason``: str
           - ``message``: user-visible one-liner to print/send
         """
-        state = self._state
+        state = self.refresh()
         if state is None or state.status != "active":
             return {
                 "status": state.status if state else None,
@@ -1486,7 +1571,8 @@ class GoalManager:
 
         if verdict == "done":
             state.status = "done"
-            save_goal(self.session_id, state)
+            self._touch_state(state)
+            self._persist_state(state)
             return {
                 "status": "done",
                 "should_continue": False,
@@ -1507,7 +1593,8 @@ class GoalManager:
             state.paused_reason = (
                 f"judge model returned unparseable output {state.consecutive_parse_failures} turns in a row"
             )
-            save_goal(self.session_id, state)
+            self._touch_state(state)
+            self._persist_state(state)
             return {
                 "status": "paused",
                 "should_continue": False,
@@ -1529,7 +1616,8 @@ class GoalManager:
         if state.turns_used >= state.max_turns:
             state.status = "paused"
             state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
-            save_goal(self.session_id, state)
+            self._touch_state(state)
+            self._persist_state(state)
             return {
                 "status": "paused",
                 "should_continue": False,
@@ -1542,7 +1630,8 @@ class GoalManager:
                 ),
             }
 
-        save_goal(self.session_id, state)
+        self._touch_state(state)
+        self._persist_state(state)
         return {
             "status": "active",
             "should_continue": True,
@@ -1555,6 +1644,7 @@ class GoalManager:
         }
 
     def next_continuation_prompt(self) -> Optional[str]:
+        self.refresh()
         if not self._state or self._state.status != "active":
             return None
         # Contract takes priority: it carries the verification surface and
@@ -1581,6 +1671,7 @@ class GoalManager:
 
     def render_contract(self) -> str:
         """Public helper for the /goal show + /goal draft slash commands."""
+        self.refresh()
         if self._state is None:
             return "(no active goal)"
         if not self._state.has_contract():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1766,7 +1766,11 @@ AUTHOR_MAP = {
     "ambuj@dodopayments.com": "that-ambuj",  # PR #26582 (preserve underscores)
     "zccyman@163.com": "zccyman",  # PR #25294 (custom provider api_key_env alias)
     # xAI cluster batch salvage (May 2026)
-    "lgndscntn@gmail.com": "Fewmanism",  # PR #27420 (threaded xAI OAuth callback)
+    # Fewmanism: canonical author email is lgndscntn@googlemail.com.
+    # lgndscntn@gmail.com appears only on older commits as a mis-set author email;
+    # keep the map entry for release attribution of that history, not as a preferred identity.
+    "lgndscntn@googlemail.com": "Fewmanism",  # canonical; PR #24477 and later
+    "lgndscntn@gmail.com": "Fewmanism",  # historical mis-set author email (pre-googlemail); PR #27420 era
     "slimydog@Faisals-Mac-mini.local": "Slimydog21",  # PR #28021 (strip slash enums xAI Responses)
     "194121339+Slimydog21@users.noreply.github.com": "Slimydog21",  # PR #28021 salvage (noreply form)
     "bitkyc08@gmail.com": "lidge-jun",  # PR #26814 (api server browser security headers)

--- a/tests/tools/test_goal_tool.py
+++ b/tests/tools/test_goal_tool.py
@@ -1,0 +1,301 @@
+"""Tests for the model-callable set_goal tool."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so goal state never touches the real session DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+class TestSetGoalTool:
+    def test_sets_goal_for_current_session(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(
+            set_goal_tool(
+                goal="finish the pull request",
+                session_id="tool-session",
+                max_turns=7,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "set"
+        assert result["goal"] == "finish the pull request"
+        assert result["status"] == "active"
+        assert result["max_turns"] == 7
+        assert "standing goal" in result["message"].lower()
+
+        mgr = GoalManager(session_id="tool-session")
+        assert mgr.is_active()
+        assert mgr.state.goal == "finish the pull request"
+        assert mgr.state.max_turns == 7
+
+    def test_omitted_max_turns_uses_supplied_default(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(
+            set_goal_tool(
+                goal="use the configured budget",
+                session_id="default-budget-session",
+                default_max_turns=4,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["max_turns"] == 4
+        assert GoalManager(session_id="default-budget-session").state.max_turns == 4
+
+    def test_rejects_max_turns_above_configured_budget(self, hermes_home):
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(
+            set_goal_tool(
+                goal="do not overrun",
+                session_id="budget-cap-session",
+                max_turns=99,
+                default_max_turns=5,
+            )
+        )
+
+        assert result["success"] is False
+        assert "exceeds" in result["error"].lower()
+
+    def test_rejects_non_integral_float_max_turns(self, hermes_home):
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(
+            set_goal_tool(
+                goal="do not truncate floats",
+                session_id="float-budget-session",
+                max_turns=3.7,
+                default_max_turns=5,
+            )
+        )
+
+        assert result["success"] is False
+        assert "positive integer" in result["error"].lower()
+
+    def test_reports_error_when_goal_state_does_not_persist(self, hermes_home, monkeypatch):
+        from hermes_cli import goals
+        from tools.goal_tool import set_goal_tool
+
+        monkeypatch.setattr(goals, "save_goal", lambda session_id, state: False)
+
+        result = json.loads(
+            set_goal_tool(
+                goal="must persist to be useful",
+                session_id="missing-persist-session",
+                default_max_turns=5,
+            )
+        )
+
+        assert result["success"] is False
+        assert "persist" in result["error"].lower()
+
+    def test_reports_error_when_stale_same_goal_row_remains_after_save_failure(
+        self, hermes_home, monkeypatch
+    ):
+        from hermes_cli import goals
+        from tools.goal_tool import set_goal_tool
+
+        old = goals.GoalState(
+            goal="same visible goal",
+            status="active",
+            turns_used=0,
+            max_turns=5,
+            created_at=1.0,
+            updated_at=1.0,
+        )
+        goals.save_goal("stale-same-goal-session", old)
+        monkeypatch.setattr(goals, "save_goal", lambda session_id, state: False)
+
+        result = json.loads(
+            set_goal_tool(
+                goal="same visible goal",
+                session_id="stale-same-goal-session",
+                default_max_turns=5,
+            )
+        )
+
+        assert result["success"] is False
+        assert "persist" in result["error"].lower()
+
+    def test_rejects_non_string_goal(self, hermes_home):
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(set_goal_tool(goal=["bad"], session_id="tool-session"))
+
+        assert result["success"] is False
+        assert "string" in result["error"].lower()
+
+    def test_existing_goal_manager_observes_tool_set_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+        from tools.goal_tool import set_goal_tool
+
+        mgr = GoalManager(session_id="cached-session", default_max_turns=6)
+        assert not mgr.is_active()
+
+        result = json.loads(
+            set_goal_tool(
+                goal="wake cached manager",
+                session_id="cached-session",
+                default_max_turns=6,
+            )
+        )
+
+        assert result["success"] is True
+        assert mgr.state.goal == "wake cached manager"
+        assert mgr.state.max_turns == 6
+
+    def test_refresh_preserves_in_memory_goal_when_db_load_fails(self, hermes_home, monkeypatch):
+        from hermes_cli import goals
+
+        mgr = goals.GoalManager(session_id="transient-db-failure", default_max_turns=6)
+        mgr.set("survive transient db failure")
+        monkeypatch.setattr(goals, "load_goal", lambda session_id: None)
+
+        assert mgr.is_active()
+        assert mgr.state.goal == "survive transient db failure"
+
+    def test_refresh_preserves_newer_in_memory_goal_after_save_failure(self, hermes_home, monkeypatch):
+        from hermes_cli import goals
+
+        mgr = goals.GoalManager(session_id="stale-row-after-save-failure", default_max_turns=6)
+        mgr.set("old persisted goal")
+        monkeypatch.setattr(goals, "save_goal", lambda session_id, state: False)
+
+        mgr.set("new in-memory goal")
+
+        assert mgr.state.goal == "new in-memory goal"
+        assert mgr.is_active()
+
+    def test_dirty_manager_observes_later_external_clear(self, hermes_home, monkeypatch):
+        from hermes_cli import goals
+
+        original_save_goal = goals.save_goal
+        mgr = goals.GoalManager(session_id="dirty-manager-external-clear", default_max_turns=6)
+        mgr.set("shared goal")
+        monkeypatch.setattr(goals, "save_goal", lambda session_id, state: False)
+        mgr.pause("local save failed")
+        assert mgr.state.status == "paused"
+        mgr._dirty_since = 1.0
+
+        monkeypatch.setattr(goals, "save_goal", original_save_goal)
+        goals.GoalManager(session_id="dirty-manager-external-clear", default_max_turns=6).clear()
+
+        assert mgr.state is None
+        assert not mgr.has_goal()
+
+    def test_requires_active_session(self, hermes_home):
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(set_goal_tool(goal="do the thing", session_id=""))
+
+        assert result["success"] is False
+        assert "active session" in result["error"].lower()
+
+    def test_rejects_empty_goal(self, hermes_home):
+        from tools.goal_tool import set_goal_tool
+
+        result = json.loads(set_goal_tool(goal="   ", session_id="tool-session"))
+
+        assert result["success"] is False
+        assert "empty" in result["error"].lower()
+
+
+class TestSetGoalToolSchema:
+    def test_registered_in_goal_toolset_not_core_default(self):
+        from model_tools import get_tool_definitions
+        from toolsets import _HERMES_CORE_TOOLS
+
+        assert "set_goal" not in _HERMES_CORE_TOOLS
+
+        goal_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["goal"], quiet_mode=True)
+        }
+        assert "set_goal" in goal_names
+
+        cli_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["hermes-cli"], quiet_mode=True)
+        }
+        assert "set_goal" not in cli_names
+
+    def test_registry_dispatch_accepts_session_id(self):
+        """set_goal is registry-backed; generic fallback forwards session_id."""
+        from model_tools import _AGENT_LOOP_TOOLS, handle_function_call
+        from hermes_cli.goals import GoalManager
+
+        assert "set_goal" not in _AGENT_LOOP_TOOLS
+
+        # Without session_id the tool itself fails closed.
+        bare = json.loads(handle_function_call("set_goal", {"goal": "x"}))
+        assert bare.get("success") is False
+        assert "session" in bare.get("error", "").lower()
+
+
+class TestSetGoalLiveAIAgentPath:
+    def test_invoke_tool_sets_goal_via_registry_fallback(self, hermes_home, monkeypatch):
+        """End-to-end: AIAgent._invoke_tool -> runtime helpers -> handle_function_call."""
+        from hermes_cli.goals import GoalManager, load_goal
+        from run_agent import AIAgent
+
+        # Ensure discovery has registered set_goal.
+        import tools.goal_tool  # noqa: F401
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "live-aiagent-set-goal"
+        agent.valid_tool_names = {"set_goal"}
+        agent.enabled_toolsets = ["goal"]
+        agent.disabled_toolsets = None
+        agent._current_turn_id = "turn-1"
+        agent._current_api_request_id = "req-1"
+        agent._todo_store = None
+        agent._memory_store = None
+        agent._memory_manager = None
+        agent.clarify_callback = None
+        agent.read_terminal_callback = None
+
+        # Avoid plugin/middleware side effects that require a fully-built agent.
+        monkeypatch.setattr(
+            "hermes_cli.plugins.resolve_pre_tool_block",
+            lambda *a, **k: None,
+        )
+
+        result = json.loads(
+            agent._invoke_tool(
+                "set_goal",
+                {"goal": "live path works", "max_turns": 3},
+                "task-live",
+                tool_call_id="tc-set-goal",
+            )
+        )
+
+        assert result["success"] is True
+        assert result["goal"] == "live path works"
+        assert result["max_turns"] == 3
+
+        persisted = load_goal("live-aiagent-set-goal")
+        assert persisted is not None
+        assert persisted.goal == "live path works"
+        assert GoalManager(session_id="live-aiagent-set-goal").is_active()

--- a/tools/goal_tool.py
+++ b/tools/goal_tool.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Goal Tool Module - model-callable standing goals.
+
+This tool lets the model set a persistent per-session goal without asking the
+user to type the /goal slash command. The continuation loop itself remains
+owned by the CLI/gateway goal hooks: after the current turn ends, those hooks
+judge the active goal and enqueue continuation prompts as needed.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+
+def _normalize_max_turns(max_turns: Optional[int]) -> Optional[int]:
+    """Return a positive integer max_turns value, or None for the default."""
+    if max_turns is None:
+        return None
+    if isinstance(max_turns, bool):
+        raise ValueError("max_turns must be a positive integer")
+    if isinstance(max_turns, float) and not max_turns.is_integer():
+        raise ValueError("max_turns must be a positive integer")
+    try:
+        value = int(max_turns)
+    except (TypeError, ValueError):
+        raise ValueError("max_turns must be a positive integer")
+    if value <= 0:
+        raise ValueError("max_turns must be a positive integer")
+    return value
+
+
+def _resolve_default_max_turns(default_max_turns: Optional[int] = None) -> int:
+    """Resolve the configured goal turn budget, falling back to DEFAULT_MAX_TURNS."""
+    from hermes_cli.goals import DEFAULT_MAX_TURNS
+
+    if default_max_turns is not None:
+        value = _normalize_max_turns(default_max_turns)
+        return int(value or DEFAULT_MAX_TURNS)
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        goals_cfg = cfg.get("goals") or {}
+        return int(goals_cfg.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS)
+    except Exception:
+        return DEFAULT_MAX_TURNS
+
+
+def set_goal_tool(
+    goal: str,
+    *,
+    session_id: str,
+    max_turns: Optional[int] = None,
+    default_max_turns: Optional[int] = None,
+) -> str:
+    """Set or replace the standing goal for the current Hermes session."""
+    sid = (session_id or "").strip()
+    if not sid:
+        return tool_error(
+            "set_goal requires an active session_id; this tool must be handled by the agent loop",
+            success=False,
+        )
+
+    if not isinstance(goal, str):
+        return tool_error("goal must be a string", success=False)
+    goal_text = goal.strip()
+    if not goal_text:
+        return tool_error("goal text is empty", success=False)
+
+    try:
+        default_turns = _resolve_default_max_turns(default_max_turns)
+        turns = _normalize_max_turns(max_turns)
+    except ValueError as exc:
+        return tool_error(str(exc), success=False)
+
+    if turns is not None and turns > default_turns:
+        return tool_error(
+            f"max_turns ({turns}) exceeds configured goal budget ({default_turns})",
+            success=False,
+        )
+
+    try:
+        from hermes_cli.goals import GoalManager, load_goal
+
+        manager = GoalManager(session_id=sid, default_max_turns=default_turns)
+        state = manager.set(goal_text, max_turns=turns)
+        persisted = load_goal(sid)
+        if persisted is None or persisted.to_json() != state.to_json():
+            return tool_error("failed to persist goal state", success=False)
+    except Exception as exc:
+        return tool_error(f"failed to set goal: {type(exc).__name__}: {exc}", success=False)
+
+    return tool_result(
+        success=True,
+        action="set",
+        goal=state.goal,
+        status=state.status,
+        turns_used=state.turns_used,
+        max_turns=state.max_turns,
+        message=(
+            "Standing goal set. Hermes will keep working toward it after this "
+            "turn until the goal is judged complete, paused, cleared, or the "
+            "turn budget is exhausted."
+        ),
+    )
+
+
+def check_goal_requirements() -> bool:
+    """Goal tool has no external requirements -- always available."""
+    return True
+
+
+SET_GOAL_SCHEMA = {
+    "name": "set_goal",
+    "description": (
+        "Set or replace the standing goal for the current Hermes session. "
+        "Use this when the user gives an objective that should persist across "
+        "turns and Hermes should keep taking concrete steps until it is done. "
+        "Do not use this for ordinary short task planning; use todo for that. "
+        "After this tool succeeds, the CLI/gateway /goal loop will judge the "
+        "goal after each turn and continue automatically when appropriate."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {
+                "type": "string",
+                "description": "The persistent objective Hermes should work toward.",
+            },
+            "max_turns": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "Optional turn budget before the goal auto-pauses. Omit to "
+                    "use the configured default."
+                ),
+            },
+        },
+        "required": ["goal"],
+    },
+}
+
+
+registry.register(
+    name="set_goal",
+    toolset="goal",
+    schema=SET_GOAL_SCHEMA,
+    handler=lambda args, **kw: set_goal_tool(
+        goal=args.get("goal", ""),
+        max_turns=args.get("max_turns"),
+        session_id=kw.get("session_id", ""),
+        default_max_turns=kw.get("default_max_turns"),
+    ),
+    check_fn=check_goal_requirements,
+    emoji="⊙",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -205,6 +205,12 @@ TOOLSETS = {
         "tools": ["todo"],
         "includes": []
     },
+
+    "goal": {
+        "description": "Set a persistent per-session goal for autonomous continuation",
+        "tools": ["set_goal"],
+        "includes": []
+    },
     
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",


### PR DESCRIPTION
## Summary
- add a model-callable `set_goal` tool registered under the `goal` toolset
- dispatch through the current runtime path: `AIAgent._invoke_tool` → `agent/agent_runtime_helpers.invoke_tool` generic fallback → registry handler with live `session_id`
- keep `set_goal` out of `_HERMES_CORE_TOOLS` and `_AGENT_LOOP_TOOLS` so hermes-* bundles do not get the schema by default (maintainer decision still needed if core exposure is desired)
- make `GoalManager` refresh cached state safely, preserve dirty in-memory fallback on DB write/read failures, and verify persistence for tool success
- cover malformed args, budget caps, persistence failures, stale rows, cached-manager refresh, registry session_id handling, and live AIAgent invoke path

## Review response
Addresses https://github.com/NousResearch/hermes-agent/pull/24477#issuecomment-4954271462:
1. Ported off pre-refactor `run_agent.py` special dispatch onto current registry fallback (session_id already forwarded at `agent/agent_runtime_helpers.py`).
2. Removed core-schema exposure via `_HERMES_CORE_TOOLS`; tool is opt-in through the `goal` toolset only until a maintainer decides otherwise.

## Test Plan
- `/Users/tet/.hermes/hermes-agent/.venv/bin/python -m pytest tests/tools/test_goal_tool.py tests/hermes_cli/test_goals.py -q` (117 passed)
- `python -m compileall -q tools/goal_tool.py hermes_cli/goals.py toolsets.py tests/tools/test_goal_tool.py`
- `git diff --check`