### PR TITLE
fix(gateway_windows): handle non-UTF-8 schtasks output on localized Windows

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -110,6 +110,8 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             [schtasks, *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the


### PR DESCRIPTION
## Problem

On Chinese Windows (and other non-English locales), `schtasks.exe` outputs status/error messages in the system code page (e.g. GBK). `subprocess.run()` with `text=True` defaults to UTF-8 decoding, causing `UnicodeDecodeError` when the CLI tries to parse schtasks output.

This breaks all `hermes gateway` commands on localized Windows systems:
- `hermes gateway status`
- `hermes gateway start`
- `hermes gateway stop`
- `hermes gateway install`
- `hermes gateway uninstall`

## Error

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xce in position 2: invalid continuation byte
```

## Fix

Add `encoding="utf-8"` with `errors="replace"` to `_exec_schtasks()` in `gateway_windows.py`. This gracefully handles mixed-encoding output from schtasks by replacing undecodable bytes with replacement characters instead of crashing.

## Testing

- [x] Verified on Windows 11 Pro (Chinese locale) — `hermes gateway status` now works without UnicodeDecodeError
- [x] `hermes gateway start/stop` commands functional after fix
- [x] Gateway service installs and runs correctly

## Related

Fixes encoding issue affecting all Windows users with non-English system locales.
