### PR TITLE
fix(tui): repair mouse-tracked link interactions

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -11,14 +11,20 @@ const makeApp = () => {
     lastHoverCol: -1,
     lastHoverRow: -1,
     mouseCaptureTarget: undefined,
+    pendingHyperlinkTimer: null,
     props: {
+      getHyperlinkAt: vi.fn(),
       getSelectedText: vi.fn(() => 'selected text'),
+      onClickAt: vi.fn(),
       onCopySelectionNoClear: vi.fn(async () => 'selected text'),
       onHoverAt: vi.fn(),
       onMouseDownAt: vi.fn(),
       onMouseDragAt: vi.fn(),
       onMouseUpAt: vi.fn(),
+      onMultiClick: vi.fn(),
+      onOpenHyperlink: vi.fn(),
       onSelectionChange: vi.fn(),
+      onSelectionDrag: vi.fn(),
       selection
     }
   } as any
@@ -112,6 +118,17 @@ describe('handleMouseEvent right-click selection behavior', () => {
     expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
   })
 
+  it('does not dispatch right-button motion as paste when no text is selected', () => {
+    const app = makeApp()
+
+    handleMouseEvent(app, { action: 'press', button: 34, col: 3, kind: 'mouse', row: 1 })
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+    expect(app.props.onMouseDragAt).not.toHaveBeenCalled()
+    expect(app.props.onSelectionDrag).not.toHaveBeenCalled()
+  })
+
   it('still dispatches right-click handlers when no text is selected', () => {
     const app = makeApp()
 
@@ -119,5 +136,29 @@ describe('handleMouseEvent right-click selection behavior', () => {
 
     expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
     expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
+  })
+})
+
+describe('handleMouseEvent modified left-button releases', () => {
+  it('opens links after a button-8 press and button-11 release', () => {
+    vi.useFakeTimers()
+    vi.stubEnv('TERM_PROGRAM', '')
+
+    try {
+      const app = makeApp()
+
+      app.props.getHyperlinkAt.mockReturnValue('https://example.com')
+
+      handleMouseEvent(app, { action: 'press', button: 8, col: 10, kind: 'mouse', row: 5 })
+      handleMouseEvent(app, { action: 'release', button: 11, col: 10, kind: 'mouse', row: 5 })
+
+      expect(app.props.getHyperlinkAt).toHaveBeenCalledWith(9, 4)
+      vi.runOnlyPendingTimers()
+      expect(app.props.onOpenHyperlink).toHaveBeenCalledWith('https://example.com')
+    } finally {
+      vi.clearAllTimers()
+      vi.unstubAllEnvs()
+      vi.useRealTimers()
+    }
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -781,15 +781,29 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       return
     }
 
+    if ((m.button & 0x20) !== 0) {
+      if (app.mouseCaptureTarget) {
+        app.props.onMouseDragAt(app.mouseCaptureTarget, col, row, baseButton)
+
+        return
+      }
+
+      if (baseButton !== 0) {
+        return
+      }
+
+      // Drag motion: mode-aware extension (char/word/line). onSelectionDrag
+      // calls notifySelectionChange internally — no extra onSelectionChange.
+      app.props.onSelectionDrag(col, row)
+
+      return
+    }
+
     if (baseButton !== 0) {
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
 
       if (baseButton === 2 && hasSelection(sel)) {
-        if ((m.button & 0x20) !== 0) {
-          return
-        }
-
         if (!app.props.getSelectedText()) {
           return
         }
@@ -815,20 +829,6 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       }
 
       app.props.onMouseDownAt(col, row, baseButton)
-
-      return
-    }
-
-    if ((m.button & 0x20) !== 0) {
-      if (app.mouseCaptureTarget) {
-        app.props.onMouseDragAt(app.mouseCaptureTarget, col, row, baseButton)
-
-        return
-      }
-
-      // Drag motion: mode-aware extension (char/word/line). onSelectionDrag
-      // calls notifySelectionChange internally — no extra onSelectionChange.
-      app.props.onSelectionDrag(col, row)
 
       return
     }

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -895,20 +895,23 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     return
   }
 
-  // Release: end the drag even for non-zero button codes. Some terminals
-  // encode release with the motion bit or button=3 "no button" (carried
-  // over from pre-SGR X10 encoding) — filtering those would orphan
-  // isDragging=true and leave drag-to-scroll's timer running until the
-  // scroll boundary. Only act on non-left releases when we ARE dragging
-  // (so an unrelated middle/right click-release doesn't touch selection).
+  // Release: SGR commonly encodes button release as low bits 3 ("no
+  // button"), with modifier bits preserved (e.g. meta-left press 8 →
+  // release 11). If a left press started a selection, treat that release as
+  // the matching left release so modified link clicks still activate.
+  // Non-left releases only end an active drag; unrelated middle/right
+  // click-release should not touch selection.
+  const isLeftRelease = baseButton === 0 || (baseButton === 3 && sel.isDragging)
+  const releaseButton = isLeftRelease ? 0 : baseButton
+
   if (app.mouseCaptureTarget) {
-    app.props.onMouseUpAt(app.mouseCaptureTarget, col, row, baseButton)
+    app.props.onMouseUpAt(app.mouseCaptureTarget, col, row, releaseButton)
     app.mouseCaptureTarget = undefined
 
     return
   }
 
-  if (baseButton !== 0) {
+  if (!isLeftRelease) {
     if (!sel.isDragging) {
       return
     }
@@ -918,6 +921,8 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
 
     return
   }
+
+  const hadSelection = hasSelection(sel)
 
   finishSelection(sel)
 
@@ -933,7 +938,7 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
   // set anchor+focus (hasSelection true), so release just keeps the
   // highlight. The anchor check guards against an orphaned release (no
   // prior press — e.g. button was held when mouse tracking was enabled).
-  if (!hasSelection(sel) && sel.anchor) {
+  if (!hadSelection && sel.anchor) {
     // Single click: dispatch DOM click immediately (cursor repositioning
     // etc. are latency-sensitive). If no DOM handler consumed it, defer
     // the hyperlink check so a second click can cancel it.


### PR DESCRIPTION
## Rationale

Mouse tracking in the fullscreen TUI currently breaks several expected terminal/link behaviors: right-button motion can be misread as a paste-triggering right click, modifier-assisted link clicks can be missed, and link hover feedback is hard to discover when the app intercepts terminal-native mouse handling. These fixes make mouse-tracked links behave closer to browser/terminal expectations while preserving visible link affordance.

## Summary

- Ignore right-button mouse motion unless a component has explicit mouse capture, while preserving real right-click handling.
- Treat modified mouse releases as link-click releases so Cmd/modified clicks can open hyperlinks.
- Open fullscreen hyperlinks through Hermes mouse handling by default.
- Add OSC 22 pointer-shape feedback over tracked links and reset it on exit.
- Keep Markdown links visibly underlined, including through the `ink-link` boundary.

## Test Plan

- [x] `pnpm exec vitest run src/__tests__/markdown.test.ts --testNamePattern "keeps static underline"`
- [x] `FORCE_COLOR=1 pnpm exec vitest run src/__tests__/markdown.test.ts --testNamePattern "keeps static underline"`
- [x] `pnpm exec vitest run packages/hermes-ink/src/ink/components/AppMouse.test.ts`
- [x] `pnpm --filter @hermes/ink build`
- [x] `git diff --check -- ui-tui/packages/hermes-ink/src/ink/components/Link.tsx ui-tui/src/components/markdown.tsx ui-tui/src/__tests__/markdown.test.ts ui-tui/packages/hermes-ink/dist/entry-exports.js`
