### PR TITLE
docs(skills): replace what-it-does descriptions with when-to-use triggers

### DIFF
--- a/optional-skills/mlops/whisper/SKILL.md
+++ b/optional-skills/mlops/whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whisper
-description: OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and language identification. Six model sizes from tiny (39M params) to large (1550M params). Use for speech-to-text, podcast transcription, or multilingual audio processing. Best for robust, multilingual ASR.
+description: "Use when transcribing audio (podcasts, meetings, voice memos, lectures, video soundtracks), translating non-English audio to English text, generating subtitles in SRT/VTT, or building a speech-to-text pipeline. Triggers: 'transcribe this audio', 'extract speech from <file>', 'subtitle this video', 'translate this Spanish audio'. OpenAI Whisper: 99 languages, 6 model sizes (tiny→large/turbo), word-level timestamps, `initial_prompt` for domain vocabulary. For real-time/streaming prefer `faster-whisper`."
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/whisper/SKILL.md
+++ b/optional-skills/mlops/whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whisper
-description: "Use when transcribing audio (podcasts, meetings, voice memos, lectures, video soundtracks), translating non-English audio to English text, generating subtitles in SRT/VTT, or building a speech-to-text pipeline. Triggers: 'transcribe this audio', 'extract speech from <file>', 'subtitle this video', 'translate this Spanish audio'. OpenAI Whisper: 99 languages, 6 model sizes (tiny→large/turbo), word-level timestamps, `initial_prompt` for domain vocabulary. For real-time/streaming prefer `faster-whisper`."
+description: "Use when transcribing audio (podcasts, meetings, voice memos, lectures, video soundtracks), translating non-English audio to English text, generating subtitles in SRT/VTT, or building a speech-to-text pipeline. Triggers: 'transcribe this audio', 'extract speech from <file>', 'subtitle this video', 'translate this Spanish audio to English', 'word-level timestamps'. For real-time/streaming prefer `faster-whisper`."
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/skills/github/codebase-inspection/SKILL.md
+++ b/skills/github/codebase-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-inspection
-description: "Inspect codebases w/ pygount: LOC, languages, ratios."
+description: "Use when the user asks for LOC counts, a language breakdown of a repo, code-vs-comment ratios, 'how big is this repo', codebase size/composition, or wants to compare languages in a repository. Uses pygount."
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ocr-and-documents
-description: "Use when extracting text from a local PDF, scanned document, or image-based PDF; when `web_extract` failed for a remote PDF and a local fallback is needed; or for batch PDF processing. Chooses `pymupdf` (lightweight, text-based PDFs) vs `marker-pdf` (OCR, equations, complex layouts) based on document characteristics. For arXiv papers prefer the `alphaxiv` skill first; for DOCX use python-docx; for PPTX use the `powerpoint` skill."
+description: "Use when extracting text from a local PDF, scanned document, or image-based PDF; when `web_extract` failed for a remote PDF and a local fallback is needed; or for batch PDF processing. Triggers: 'OCR this scan', 'extract text from this PDF', 'parse equations from <paper>', 'read this PDF'. Chooses `pymupdf` (lightweight, text-based PDFs) vs `marker-pdf` (OCR, equations, complex layouts) based on document characteristics. For arXiv papers prefer the `alphaxiv` skill first; for DOCX use python-docx; for PPTX use the `powerpoint` skill."
 version: 2.3.0
 author: Hermes Agent
 license: MIT

--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ocr-and-documents
-description: "Extract text from PDFs/scans (pymupdf, marker-pdf)."
+description: "Use when extracting text from a local PDF, scanned document, or image-based PDF; when `web_extract` failed for a remote PDF and a local fallback is needed; or for batch PDF processing. Chooses `pymupdf` (lightweight, text-based PDFs) vs `marker-pdf` (OCR, equations, complex layouts) based on document characteristics. For arXiv papers prefer the `alphaxiv` skill first; for DOCX use python-docx; for PPTX use the `powerpoint` skill."
 version: 2.3.0
 author: Hermes Agent
 license: MIT

--- a/skills/research/arxiv/SKILL.md
+++ b/skills/research/arxiv/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arxiv
-description: "Search arXiv papers by keyword, author, category, or ID."
+description: "Use when searching arXiv for papers by topic/author/category, fetching paper metadata or BibTeX, looking up a specific arXiv ID, or finding citation/reference graphs via Semantic Scholar. Triggers: 'find papers on X', 'who cited Y', 'arxiv search', 'bibtex for arxiv:1706.03762'. Returns Atom XML; helper script `scripts/search_arxiv.py` parses to readable output. For per-paper structured overviews use the `alphaxiv` skill; for full-body acknowledgments use `arxiv-body-search`; for local PDFs use `ocr-and-documents`."
 version: 1.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/research/arxiv/SKILL.md
+++ b/skills/research/arxiv/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arxiv
-description: "Use when searching arXiv for papers by topic/author/category, fetching paper metadata or BibTeX, looking up a specific arXiv ID, or finding citation/reference graphs via Semantic Scholar. Triggers: 'find papers on X', 'who cited Y', 'arxiv search', 'bibtex for arxiv:1706.03762'. Returns Atom XML; helper script `scripts/search_arxiv.py` parses to readable output. For per-paper structured overviews use the `alphaxiv` skill; for full-body acknowledgments use `arxiv-body-search`; for local PDFs use `ocr-and-documents`."
+description: "Use when searching arXiv for papers by topic/author/category, fetching paper metadata or BibTeX, looking up a specific arXiv ID, or finding citation/reference graphs via Semantic Scholar. Triggers: 'find papers on X', 'who cited Y', 'arxiv search', 'bibtex for arxiv:1706.03762'. For per-paper structured overviews use the `alphaxiv` skill; for full-body acknowledgments use `arxiv-body-search`; for local PDFs use `ocr-and-documents`."
 version: 1.0.0
 author: Hermes Agent
 license: MIT


### PR DESCRIPTION
## What does this PR do?

Replaces the `description:` frontmatter on four bundled skills (`arxiv`, `ocr-and-documents`, `codebase-inspection`, `whisper`) with "Use when..." triggering conditions instead of one-line summaries of what the skill does.

**Why**: Anthropic's Agent Skills authoring best-practices recommend that the `description` field answer "when should I load this skill" rather than "what does this skill do." Workflow-summary descriptions cause models to short-circuit on the description and skip the skill body content. The current terse forms also make discovery ambiguous when several related skills could match — `arxiv` vs `alphaxiv` vs `arxiv-body-search`, and `ocr-and-documents` vs `alphaxiv` for arXiv-paper PDFs.

Body content for all four files is unchanged.

(Supersedes #24473 — same content under the correct branch prefix `docs/` per CONTRIBUTING.md.)

## Related Issue

No related issue — small documentation improvement. Happy to file one retroactively if maintainers prefer.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

Four frontmatter `description:` fields updated; SKILL.md body content unchanged.

- `skills/research/arxiv/SKILL.md` — add triggers + cross-references to `alphaxiv`, `arxiv-body-search`, `ocr-and-documents`
- `skills/productivity/ocr-and-documents/SKILL.md` — add triggers + the pymupdf-vs-marker-pdf decision pointer
- `skills/github/codebase-inspection/SKILL.md` — add user-phrase triggers (LOC counts, "how big is this repo", code-vs-comment ratios)
- `optional-skills/mlops/whisper/SKILL.md` — lead with triggers; compress the 99-languages / 6-model-sizes feature listing to one line so the load-decision triggers come first

## How to Test

1. `git diff --stat upstream/main..HEAD` should show exactly 4 files, 4 insertions, 4 deletions.
2. Verify the YAML frontmatter still parses for each file:
   ```bash
   for f in \
     skills/research/arxiv/SKILL.md \
     skills/productivity/ocr-and-documents/SKILL.md \
     skills/github/codebase-inspection/SKILL.md \
     optional-skills/mlops/whisper/SKILL.md; do
     python -c "import yaml; yaml.safe_load(open('$f').read().split('---')[1])" && echo "  ok: $f"
   done
   ```
3. Optional smoke: `hermes skills inspect arxiv` (and the other three) should show the new descriptions in the metadata block without error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `docs(skills): ...`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — none touching these descriptions
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] N/A — frontmatter-only doc change; no Python tests to add/run
- [ ] N/A — doc-only change, no behavior to test
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] N/A — only `SKILL.md` `description:` frontmatter changed
- [x] N/A — no config keys touched
- [x] N/A — no architecture or workflow changes
- [x] N/A — frontmatter text only; no platform-specific code paths
- [x] N/A — no tool behavior changed