### PR TITLE
fix(agent): dispatch external memory sync to daemon thread

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5561,6 +5561,9 @@ class AIAgent:
         wrapped in ``try/except Exception`` because external memory
         providers are strictly best-effort — a misconfigured or offline
         backend must not block the user from seeing their response.
+
+        Called from a background daemon thread by ``run_conversation`` so
+        slow providers do not delay ``response.completed`` in SSE clients.
         """
         if interrupted:
             return
@@ -15422,12 +15425,22 @@ class AIAgent:
             _should_review_skills = True
             self._iters_since_skill = 0
 
-        # External memory provider: sync the completed turn + queue next prefetch.
-        self._sync_external_memory_for_turn(
-            original_user_message=original_user_message,
-            final_response=final_response,
-            interrupted=interrupted,
-        )
+        # External memory provider: sync the completed turn + queue next
+        # prefetch.  Dispatched to a daemon thread so slow providers (e.g.
+        # Hindsight, which runs LLM-based entity resolution) do not block
+        # run_conversation from returning and delay response.completed in
+        # the SSE client (#24453).  The method is already best-effort
+        # (try/except) so a background failure is safe to ignore.
+        threading.Thread(
+            target=self._sync_external_memory_for_turn,
+            kwargs={
+                "original_user_message": original_user_message,
+                "final_response": final_response,
+                "interrupted": interrupted,
+            },
+            daemon=True,
+            name="hermes-memory-sync",
+        ).start()
 
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -193,3 +193,92 @@ class TestSyncExternalMemoryForTurn:
         else:
             agent._memory_manager.sync_all.assert_not_called()
             agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+
+class TestMemorySyncNonblocking:
+    """Regression guard for #24453 — _sync_external_memory_for_turn must
+    work correctly when called from a background daemon thread.
+
+    run_conversation dispatches the call to a daemon thread so slow providers
+    (e.g. Hindsight, which runs LLM-based entity resolution taking 30-50s)
+    do not block run_conversation from returning and delay response.completed
+    in SSE clients.
+    """
+
+    def test_sync_completes_when_called_from_background_thread(self):
+        """sync_all and queue_prefetch_all are called correctly when
+        _sync_external_memory_for_turn is invoked from a daemon thread,
+        matching how run_conversation dispatches it after the fix."""
+        import threading
+
+        agent = _bare_agent()
+        done = threading.Event()
+
+        def _run():
+            agent._sync_external_memory_for_turn(
+                original_user_message="What is the capital of France?",
+                final_response="Paris.",
+                interrupted=False,
+            )
+            done.set()
+
+        t = threading.Thread(target=_run, daemon=True, name="hermes-memory-sync")
+        t.start()
+        done.wait(timeout=2.0)
+
+        assert done.is_set(), "memory-sync thread did not complete in time"
+        agent._memory_manager.sync_all.assert_called_once_with(
+            "What is the capital of France?", "Paris.",
+            session_id="test_session_001",
+        )
+        agent._memory_manager.queue_prefetch_all.assert_called_once_with(
+            "What is the capital of France?",
+            session_id="test_session_001",
+        )
+
+    def test_interrupted_still_skipped_from_background_thread(self):
+        """The interrupted-turn guard in _sync_external_memory_for_turn
+        works identically whether the method is called on the main thread
+        (old behaviour) or from the daemon thread (new call site)."""
+        import threading
+
+        agent = _bare_agent()
+        done = threading.Event()
+
+        def _run():
+            agent._sync_external_memory_for_turn(
+                original_user_message="hello",
+                final_response="partial...",
+                interrupted=True,
+            )
+            done.set()
+
+        threading.Thread(target=_run, daemon=True, name="hermes-memory-sync").start()
+        done.wait(timeout=2.0)
+
+        assert done.is_set()
+        agent._memory_manager.sync_all.assert_not_called()
+
+    def test_exception_in_thread_does_not_propagate(self):
+        """A crash inside sync_all must stay contained within the daemon
+        thread and must not surface to the caller (run_conversation)."""
+        import threading
+
+        agent = _bare_agent()
+        agent._memory_manager.sync_all.side_effect = RuntimeError("provider down")
+        done = threading.Event()
+
+        def _run():
+            agent._sync_external_memory_for_turn(
+                original_user_message="hi",
+                final_response="hey",
+                interrupted=False,
+            )
+            done.set()
+
+        t = threading.Thread(target=_run, daemon=True, name="hermes-memory-sync")
+        t.start()
+        done.wait(timeout=2.0)
+
+        assert done.is_set(), "thread raised and was not caught"
+        agent._memory_manager.sync_all.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

**Root cause:** `_sync_external_memory_for_turn()` calls `memory_manager.sync_all()` and `queue_prefetch_all()` synchronously at the end of `run_conversation()`. Providers that perform LLM-based entity resolution (e.g. Hindsight) block for 30-50s, holding the `run_in_executor` thread. The API server only sends `response.completed` after `run_conversation()` returns, so SSE clients see a 30-50s spinner after the last response token even though all content was already streamed.

**Fix:** Wrap the call site in a `threading.Thread(daemon=True)` so the sync runs concurrently instead of blocking. `_sync_external_memory_for_turn()` itself is unchanged — it remains the direct unit-test target. The existing `try/except Exception: pass` contains any provider failure so a background exception cannot surface to `run_conversation()`. Arguments are captured at call time so there is no risk of the next turn overwriting them.

## Related Issue

Fixes #24453

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `run_agent.py`: replace inline `_sync_external_memory_for_turn()` call with `threading.Thread(daemon=True, name="hermes-memory-sync").start()` (+10 lines)
- `tests/run_agent/test_memory_sync_interrupted.py`: add `TestMemorySyncNonblocking` — 3 new tests verifying correct behaviour from a background thread, interrupted-turn skip, and exception containment (+89 lines)

## How to Test

```
python3.11 -m pytest tests/run_agent/test_memory_sync_interrupted.py -v --override-ini="addopts="
```

19 passed (16 pre-existing + 3 new).

## Checklist

- [x] Contributing Guide read | Conventional Commits | Duplicate PR check done
- [x] Single logical change | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A