### PR TITLE
feat(cli): show reasoning effort in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4534,6 +4534,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return f"{emoji} {time_str}"
 
     @staticmethod
+    def _status_bar_reasoning_effort_label(reasoning_config: Any) -> str:
+        """Return the compact reasoning-effort suffix for the status bar."""
+        from hermes_constants import reasoning_effort_label
+
+        return reasoning_effort_label(reasoning_config)
+
+    @staticmethod
+    def _status_bar_model_label(snapshot: Dict[str, Any]) -> str:
+        effort = snapshot.get("reasoning_effort")
+        if effort:
+            return f"{snapshot['model_short']} {effort}"
+        return snapshot["model_short"]
+
+    @staticmethod
+    def _status_bar_model_fragments(snapshot: Dict[str, Any]):
+        fragments = [("class:status-bar-strong", snapshot["model_short"])]
+        effort = snapshot.get("reasoning_effort")
+        if effort:
+            fragments.append(("class:status-bar-dim", f" {effort}"))
+        return fragments
+
+    @staticmethod
     def _format_idle_since(last_finished_at: Optional[float], turn_live: bool) -> str:
         """Format time since the last final agent response for the status bar.
 
@@ -4559,10 +4581,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if len(model_short) > 26:
             model_short = f"{model_short[:23]}..."
 
+        reasoning_config = getattr(agent, "reasoning_config", None)
+        if not isinstance(reasoning_config, dict):
+            reasoning_config = getattr(self, "reasoning_config", None)
+        reasoning_effort = self._status_bar_reasoning_effort_label(reasoning_config)
+
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "reasoning_effort": reasoning_effort,
             "duration": format_duration_compact(elapsed_seconds),
             "prompt_elapsed": self._format_prompt_elapsed(
                 getattr(self, "_prompt_start_time", None),
@@ -5069,15 +5097,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            model_label = self._status_bar_model_label(snapshot)
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {model_label} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {model_label}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5103,7 +5132,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {model_label}", context_label, percent_label]
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5145,7 +5174,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
-                    ("class:status-bar-strong", snapshot["model_short"]),
+                    *self._status_bar_model_fragments(snapshot),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
@@ -5163,7 +5192,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        *self._status_bar_model_fragments(snapshot),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
@@ -5202,7 +5231,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
+                        *self._status_bar_model_fragments(snapshot),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -823,6 +823,32 @@ def parse_reasoning_effort(effort) -> dict | None:
     return None
 
 
+def reasoning_effort_label(reasoning_config: object) -> str:
+    """Return the compact display label for a reasoning config.
+
+    Classic CLI status bars intentionally hide default reasoning noise
+    (unset, ``medium``, ``normal``, ``default``), while still surfacing
+    explicit non-default states and explicit disabled reasoning as ``none``.
+    Malformed configs and unknown effort values render blank instead of
+    advertising invalid settings in the status bar.
+
+    The Ink TUI already filters default efforts client-side in
+    ``ui-tui``; this helper is the shared Python-side equivalent for the
+    classic CLI (and any other Python caller that needs the same compact
+    label without reimplementing the rules).
+    """
+    if not isinstance(reasoning_config, dict):
+        return ""
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    effort = str(reasoning_config.get("effort", "") or "").strip().lower()
+    if effort in {"", "medium", "normal", "default"}:
+        return ""
+    if effort in VALID_REASONING_EFFORTS:
+        return effort
+    return ""
+
+
 def is_termux() -> bool:
     """Return True when running inside a Termux (Android) environment.
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1767,7 +1767,10 @@ AUTHOR_MAP = {
     "ambuj@dodopayments.com": "that-ambuj",  # PR #26582 (preserve underscores)
     "zccyman@163.com": "zccyman",  # PR #25294 (custom provider api_key_env alias)
     # xAI cluster batch salvage (May 2026)
-    "lgndscntn@gmail.com": "Fewmanism",  # PR #27420 (threaded xAI OAuth callback)
+    # Fewmanism: canonical author email is lgndscntn@googlemail.com.
+    # lgndscntn@gmail.com is historical mis-set author email on older commits.
+    "lgndscntn@googlemail.com": "Fewmanism",  # canonical
+    "lgndscntn@gmail.com": "Fewmanism",  # historical mis-set author email; PR #27420 era
     "slimydog@Faisals-Mac-mini.local": "Slimydog21",  # PR #28021 (strip slash enums xAI Responses)
     "194121339+Slimydog21@users.noreply.github.com": "Slimydog21",  # PR #28021 salvage (noreply form)
     "bitkyc08@gmail.com": "lidge-jun",  # PR #26814 (api server browser security headers)

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -82,6 +82,111 @@ class TestCLIStatusBar:
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
 
+    def test_status_bar_text_shows_non_default_reasoning_effort(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.5 xhigh" in text
+
+    def test_status_bar_text_shows_reasoning_effort_for_non_gpt_models(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="anthropic/claude-sonnet-4-20250514"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "high"}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "claude-sonnet-4-20250514 high" in text
+
+    def test_status_bar_text_hides_default_but_shows_disabled_reasoning_effort(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+
+        cli_obj.reasoning_config = {"enabled": True, "effort": "medium"}
+        assert "gpt-5.5 medium" not in cli_obj._build_status_bar_text(width=120)
+
+        cli_obj.reasoning_config = {"enabled": False}
+        assert "gpt-5.5 none" in cli_obj._build_status_bar_text(width=120)
+
+    def test_status_bar_text_hides_invalid_reasoning_effort(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "turbo"}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "turbo" not in text
+        assert "gpt-5.5 │" in text
+
+    def test_status_bar_text_prefers_agent_reasoning_config(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "low"}
+        cli_obj.agent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "gpt-5.5 xhigh" in text
+        assert "gpt-5.5 low" not in text
+
+    def test_status_bar_fragments_include_reasoning_effort_next_to_model(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="openai/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        cli_obj._status_bar_visible = True
+        mock_app = MagicMock()
+        mock_app.output.get_size.return_value = MagicMock(columns=120)
+
+        with patch("prompt_toolkit.application.get_app", return_value=mock_app):
+            frags = cli_obj._get_status_bar_fragments()
+
+        text = "".join(fragment_text for _, fragment_text in frags)
+        assert "gpt-5.5 xhigh" in text
+
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1
         sentinel until the next API call reports real usage. The status bar

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -22,6 +22,7 @@ from hermes_constants import (
     is_container,
     node_tool_runnable,
     parse_reasoning_effort,
+    reasoning_effort_label,
     secure_parent_dir,
     with_hermes_node_path,
 )
@@ -488,6 +489,33 @@ class TestParseReasoningEffort:
         """
         documented = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
+
+
+class TestReasoningEffortLabel:
+    """Compact reasoning labels for classic CLI status bars."""
+
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            (None, ""),
+            ({}, ""),
+            ({"enabled": True}, ""),
+            ({"enabled": True, "effort": "medium"}, ""),
+            ({"enabled": True, "effort": "normal"}, ""),
+            ({"enabled": True, "effort": "default"}, ""),
+            ({"enabled": False}, "none"),
+            ({"enabled": True, "effort": "minimal"}, "minimal"),
+            ({"enabled": True, "effort": "HIGH"}, "high"),
+            ({"enabled": True, "effort": " xhigh "}, "xhigh"),
+            ({"enabled": True, "effort": "max"}, "max"),
+            ({"enabled": True, "effort": "ultra"}, "ultra"),
+            ({"enabled": True, "effort": "turbo"}, ""),
+            ({"enabled": True, "effort": object()}, ""),
+            ("high", ""),
+        ],
+    )
+    def test_compact_display_label(self, config, expected):
+        assert reasoning_effort_label(config) == expected
 
 
 class TestSecureParentDir:

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -68,7 +68,7 @@ A persistent status bar sits above the input area, updating in real time:
 
 | Element | Description |
 |---------|-------------|
-| Model name | Current model (truncated if longer than 26 chars) |
+| Model name | Current model (truncated if longer than 26 chars). Explicit non-default reasoning effort, or `none` when reasoning is disabled, appears next to the model. |
 | Token count | Context tokens used / max context window |
 | Context bar | Visual fill indicator with color-coded thresholds |
 | Cost | Estimated session cost (or `n/a` for unknown/zero-priced models) |


### PR DESCRIPTION
## Summary
- Show compact non-default reasoning effort next to the model name in the classic CLI status bar (text + prompt_toolkit fragments).
- Prefer live `agent.reasoning_config`, hide default `medium`/`normal`/`default`, surface explicit `none`, and ignore invalid effort values via shared `reasoning_effort_label`.
- Leave the current TUI gateway session-scoped reasoning path alone; Ink TUI already filters default efforts client-side.

## Review response
Addresses https://github.com/NousResearch/hermes-agent/pull/24488#pullrequestreview-4681638707:
1. Salvaged classic-CLI label/rendering + focused status-bar tests onto current main.
2. Dropped the old `tui_gateway/server.py` config/session rewrite that would regress `create_reasoning_override` / live runtime persistence / `session.info` emit.
3. Kept only non-duplicated Python-side normalization (`reasoning_effort_label`) for classic CLI after comparing against `ui-tui` `appChrome.tsx` effortLabel.

## Test Plan
- `python -m pytest tests/cli/test_cli_status_bar.py tests/test_hermes_constants.py::TestReasoningEffortLabel tests/test_hermes_constants.py::TestParseReasoningEffort -q` (97 passed)
- `git diff --check`