### PR TITLE
feat(anthropic-adapter): preserve unsigned thinking blocks on MiniMax round-trip

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2272,10 +2272,10 @@ def _manage_thinking_signatures(
 
     Signatures are Anthropic-proprietary.  Third-party endpoints (MiniMax,
     Azure AI Foundry, AWS Bedrock, self-hosted proxies) cannot validate them
-    and will reject them outright.  Kimi's /coding and DeepSeek's /anthropic
-    endpoints speak the Anthropic protocol upstream but require unsigned
-    thinking blocks (synthesised from ``reasoning_content``) to round-trip on
-    replayed assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
+    and will reject them outright.  Kimi's /coding, DeepSeek's /anthropic,
+    and MiniMax's Anthropic-compatible endpoints require unsigned thinking
+    blocks (synthesised from ``reasoning_content``) to round-trip on replayed
+    assistant tool-call messages.  See hermes-agent#13848 (Kimi) and
     hermes-agent#16748 (DeepSeek).
 
     Mutates ``result`` in place.
@@ -2297,8 +2297,11 @@ def _manage_thinking_signatures(
             # Kimi does not enforce thinking signatures — replay as-is
             # (shared cleanup below still strips cache markers + the internal flag).
             pass
-        elif _is_deepseek_anthropic_endpoint(base_url):
-            # DeepSeek: strip signed, preserve unsigned.
+        elif (
+            _is_deepseek_anthropic_endpoint(base_url)
+            or _is_minimax_anthropic_endpoint(base_url)
+        ):
+            # DeepSeek and MiniMax: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -207,10 +207,8 @@ class TestDeepSeekAnthropicPreservesThinking:
         assert _is_deepseek_anthropic_endpoint("https://api.deepseek.com/anthropic") is True
         assert _is_deepseek_anthropic_endpoint("https://api.deepseek.com/anthropic/v1") is True
 
-    def test_non_deepseek_third_party_still_strips_all_thinking(self) -> None:
-        """MiniMax and other third-party Anthropic endpoints must keep the
-        generic strip-all behaviour (they reject unsigned blocks outright).
-        """
+    def test_azure_third_party_still_strips_all_thinking(self) -> None:
+        """Azure must not inherit the DeepSeek/MiniMax unsigned replay policy."""
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
         messages = [
@@ -229,7 +227,8 @@ class TestDeepSeekAnthropicPreservesThinking:
             {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
         ]
         _system, converted = convert_messages_to_anthropic(
-            messages, base_url="https://api.minimax.io/anthropic"
+            messages,
+            base_url="https://example.services.ai.azure.com/anthropic",
         )
         assistant_msg = next(m for m in converted if m["role"] == "assistant")
         thinking_blocks = [
@@ -237,6 +236,6 @@ class TestDeepSeekAnthropicPreservesThinking:
             if isinstance(b, dict) and b.get("type") == "thinking"
         ]
         assert thinking_blocks == [], (
-            "Non-DeepSeek third-party endpoints must keep the generic "
-            "strip-all-thinking behaviour — unsigned blocks get rejected."
+            "Azure must keep the generic strip-all-thinking behavior instead "
+            "of being classified as MiniMax merely because both use Bearer auth."
         )

--- a/tests/agent/test_minimax_anthropic_thinking.py
+++ b/tests/agent/test_minimax_anthropic_thinking.py
@@ -1,0 +1,78 @@
+"""Regression coverage for MiniMax Anthropic-compatible thinking replay."""
+
+from __future__ import annotations
+
+import pytest
+
+
+MINIMAX_ANTHROPIC_ENDPOINTS = (
+    "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/anthropic",
+)
+
+
+@pytest.mark.parametrize("base_url", MINIMAX_ANTHROPIC_ENDPOINTS)
+def test_minimax_preserves_unsigned_thinking_on_replay(base_url: str) -> None:
+    """Both MiniMax hosts require reasoning_content-derived blocks to round-trip."""
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "reasoning_content": "planning the tool call",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "skill_view", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+
+    _system, converted = convert_messages_to_anthropic(
+        messages,
+        base_url=base_url,
+    )
+
+    assistant_msg = next(m for m in converted if m["role"] == "assistant")
+    thinking_blocks = [
+        block
+        for block in assistant_msg["content"]
+        if isinstance(block, dict) and block.get("type") == "thinking"
+    ]
+    assert thinking_blocks == [
+        {"type": "thinking", "thinking": "planning the tool call"}
+    ]
+
+
+@pytest.mark.parametrize("base_url", MINIMAX_ANTHROPIC_ENDPOINTS)
+def test_minimax_strips_anthropic_signed_thinking(base_url: str) -> None:
+    """MiniMax cannot validate Anthropic-proprietary thinking signatures."""
+    from agent.anthropic_adapter import convert_messages_to_anthropic
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "anthropic-signed payload",
+                    "signature": "anthropic-sig-xyz",
+                },
+                {"type": "text", "text": "hello"},
+            ],
+        },
+        {"role": "user", "content": "again"},
+    ]
+
+    _system, converted = convert_messages_to_anthropic(
+        messages,
+        base_url=base_url,
+    )
+
+    assistant_msg = next(m for m in converted if m["role"] == "assistant")
+    assert assistant_msg["content"] == [{"type": "text", "text": "hello"}]


### PR DESCRIPTION
## Summary

MiniMax's Anthropic-compatible endpoints require unsigned thinking blocks derived from `reasoning_content` to round-trip in replayed assistant tool-call history. Hermes already synthesizes those blocks, but the generic third-party signature-management path removed them on subsequent turns.

This PR updates `_manage_thinking_signatures` to reuse the existing `_is_minimax_anthropic_endpoint` predicate. For both supported MiniMax Anthropic endpoints, Hermes now:

- preserves unsigned thinking blocks synthesized from `reasoning_content`;
- strips Anthropic-signed thinking blocks that MiniMax cannot validate; and
- continues stripping `cache_control` from retained thinking blocks through the shared cleanup path.

Azure remains on the generic third-party strip-all path, preventing the broader Bearer-auth matcher from accidentally opting Azure into MiniMax behavior.

## Endpoints covered

- `https://api.minimax.io/anthropic`
- `https://api.minimaxi.com/anthropic`

## Tests

Added direct regression coverage showing that both MiniMax hosts:

- preserve unsigned thinking blocks during replay; and
- strip Anthropic-signed thinking blocks.

The previous MiniMax strip-all assertion was replaced with an Azure negative case.

Validation completed:

- `scripts/run_tests.sh -j 2 tests/agent/test_minimax_anthropic_thinking.py tests/agent/test_deepseek_anthropic_thinking.py` — 13 passed
- `ruff check agent/anthropic_adapter.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_minimax_anthropic_thinking.py` — passed
- `python -m py_compile agent/anthropic_adapter.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_minimax_anthropic_thinking.py` — passed

## Review note

The branch has been rebased onto current `main`. The upstream CI workflow is awaiting maintainer approval before jobs can start.
