### PR TITLE
feat(config): per-model context_length and provider_routing overrides

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -55,6 +55,19 @@ model:
   #
   # context_length: 131072
   #
+  # Per-model overrides: `models.<id>.context_length` wins over the flat
+  # `context_length` above when `model.model` resolves to <id>. Useful when
+  # one model needs a non-default context window (e.g. a provider that only
+  # serves the model with a smaller window than the model's native size) and
+  # you don't want to remember to flip the flat value every time you switch
+  # models.
+  #
+  # models:
+  #   moonshotai/kimi-k2.6:
+  #     context_length: 256000
+  #   anthropic/claude-opus-4.6:
+  #     context_length: 200000
+  #
   # max_tokens: OUTPUT cap — maximum tokens the model may generate per response.
   #   Unrelated to how long your conversation history can be.
   #   The OpenAI-standard name "max_tokens" is a misnomer; Anthropic's native
@@ -120,6 +133,19 @@ model:
 #
 #   # Data policy: "allow" (default) or "deny" to exclude providers that may store data
 #   # data_collection: "deny"
+#
+#   # Per-model overrides: `models.<id>.<key>` wins over the flat keys above
+#   # when the active model is <id>. Unspecified per-model keys fall through
+#   # to the flat defaults. Useful when one specific model needs provider
+#   # pinning (e.g. some OpenRouter providers serve a model with a smaller
+#   # context window than the model's native size — pin to providers that
+#   # serve the full window) without affecting routing for other models.
+#   #
+#   # models:
+#   #   moonshotai/kimi-k2.6:
+#   #     only: ["together", "groq"]
+#   #   anthropic/claude-opus-4.6:
+#   #     order: ["anthropic", "google"]
 
 # =============================================================================
 # OpenRouter Response Caching (only applies when using OpenRouter)

--- a/cli.py
+++ b/cli.py
@@ -2504,14 +2504,27 @@ class HermesCLI:
             CLI_CONFIG["agent"].get("service_tier", "")
         )
         
-        # OpenRouter provider routing preferences
+        # OpenRouter provider routing preferences.
+        # Per-model overlay: provider_routing.models.<active_model> overrides
+        # flat keys when the active model has its own entry. Unspecified
+        # per-model keys fall through to the flat defaults — useful when a
+        # specific model needs e.g. `only: [...]` provider pinning but the
+        # rest of the config still applies.
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
-        self._provider_sort = pr.get("sort")
-        self._providers_only = pr.get("only")
-        self._providers_ignore = pr.get("ignore")
-        self._providers_order = pr.get("order")
-        self._provider_require_params = pr.get("require_parameters", False)
-        self._provider_data_collection = pr.get("data_collection")
+        if not isinstance(pr, dict):
+            pr = {}
+        _pr_models = pr.get("models") if isinstance(pr.get("models"), dict) else {}
+        _pr_per_model = _pr_models.get(self.model) if isinstance(_pr_models.get(self.model), dict) else {}
+        def _pr(key, default=None):
+            if key in _pr_per_model:
+                return _pr_per_model[key]
+            return pr.get(key, default)
+        self._provider_sort = _pr("sort")
+        self._providers_only = _pr("only")
+        self._providers_ignore = _pr("ignore")
+        self._providers_order = _pr("order")
+        self._provider_require_params = _pr("require_parameters", False)
+        self._provider_data_collection = _pr("data_collection")
 
         # OpenRouter Pareto Code router knob — coding-score floor (0.0-1.0).
         # Only applied when model.model == "openrouter/pareto-code".

--- a/run_agent.py
+++ b/run_agent.py
@@ -2107,28 +2107,62 @@ class AIAgent:
                     )
         self._session_init_model_config["max_tokens"] = self.max_tokens
 
-        # Read explicit context_length override from model config
-        if isinstance(_model_cfg, dict):
-            _config_context_length = _model_cfg.get("context_length")
-        else:
-            _config_context_length = None
-        if _config_context_length is not None:
-            try:
-                _config_context_length = int(_config_context_length)
-            except (TypeError, ValueError):
-                logger.warning(
-                    "Invalid model.context_length in config.yaml: %r — "
-                    "must be a plain integer (e.g. 256000, not '256K'). "
-                    "Falling back to auto-detection.",
-                    _config_context_length,
-                )
-                print(
-                    f"\n⚠ Invalid model.context_length in config.yaml: {_config_context_length!r}\n"
-                    f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                    f"  Falling back to auto-detected context window.\n",
-                    file=sys.stderr,
-                )
-                _config_context_length = None
+        # Read explicit context_length override from model config.
+        # Resolution priority (highest first):
+        #   1. model.models.<active_model>.context_length — per-model override
+        #      (lets a single profile hold one model's settings without
+        #      cross-contaminating others, when used with --model overrides)
+        #   2. model.context_length — flat default
+        #   3. model.custom_providers.<name>.models.<id>.context_length —
+        #      per-(custom_provider, model) override (handled in the
+        #      custom_providers branch further below)
+        if not isinstance(_model_cfg, dict):
+            _model_cfg = {}
+        _config_context_length = None
+
+        # (1) Per-model override
+        _models_overlay = _model_cfg.get("models", {})
+        if isinstance(_models_overlay, dict):
+            _per_model_cfg = _models_overlay.get(self.model, {})
+            if isinstance(_per_model_cfg, dict):
+                _per_model_ctx = _per_model_cfg.get("context_length")
+                if _per_model_ctx is not None:
+                    try:
+                        _config_context_length = int(_per_model_ctx)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Invalid model.models.%r.context_length in config.yaml: %r — "
+                            "must be a plain integer (e.g. 256000, not '256K'). "
+                            "Falling back to flat model.context_length.",
+                            self.model, _per_model_ctx,
+                        )
+                        print(
+                            f"\n⚠ Invalid model.models.{self.model!r}.context_length in config.yaml: {_per_model_ctx!r}\n"
+                            f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+                            f"  Falling back to flat model.context_length.\n",
+                            file=sys.stderr,
+                        )
+
+        # (2) Flat default — only if per-model didn't resolve
+        if _config_context_length is None:
+            _flat_ctx = _model_cfg.get("context_length")
+            if _flat_ctx is not None:
+                try:
+                    _config_context_length = int(_flat_ctx)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Invalid model.context_length in config.yaml: %r — "
+                        "must be a plain integer (e.g. 256000, not '256K'). "
+                        "Falling back to auto-detection.",
+                        _flat_ctx,
+                    )
+                    print(
+                        f"\n⚠ Invalid model.context_length in config.yaml: {_flat_ctx!r}\n"
+                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+                        f"  Falling back to auto-detected context window.\n",
+                        file=sys.stderr,
+                    )
+                    _config_context_length = None
 
         # Resolve custom_providers list once for reuse below (startup
         # context-length override and plugin context-engine init).

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -639,3 +639,82 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+# ---------------------------------------------------------------------------
+# Per-model provider_routing overlay (provider_routing.models.<id>.*).
+# Lets a single config declare different provider routing per model without
+# the user having to remember to swap the flat keys when they switch models.
+# ---------------------------------------------------------------------------
+
+def test_per_model_provider_routing_overrides_flat(monkeypatch):
+    cli = _import_cli()
+    config_copy = dict(cli.CLI_CONFIG)
+    config_copy["provider_routing"] = {
+        "sort": "throughput",
+        "only": ["openai", "anthropic"],  # flat default
+        "models": {
+            "moonshotai/kimi-k2.6": {
+                "only": ["together", "groq"],
+            },
+        },
+    }
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+
+    shell = cli.HermesCLI(model="moonshotai/kimi-k2.6", compact=True, max_turns=1)
+
+    assert shell._providers_only == ["together", "groq"]
+    # Unspecified per-model keys still fall through to the flat default.
+    assert shell._provider_sort == "throughput"
+
+
+def test_per_model_provider_routing_does_not_leak_to_other_models(monkeypatch):
+    """Other models keep the flat routing."""
+    cli = _import_cli()
+    config_copy = dict(cli.CLI_CONFIG)
+    config_copy["provider_routing"] = {
+        "only": ["openai", "anthropic"],
+        "models": {
+            "moonshotai/kimi-k2.6": {"only": ["together"]},
+        },
+    }
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+
+    shell = cli.HermesCLI(model="anthropic/claude-opus-4.6", compact=True, max_turns=1)
+
+    assert shell._providers_only == ["openai", "anthropic"]
+
+
+def test_per_model_provider_routing_empty_list_overrides_flat(monkeypatch):
+    """An explicit empty list at the per-model level is honored (not ignored
+    as 'unspecified'). Important so users can clear a flat default for one
+    specific model."""
+    cli = _import_cli()
+    config_copy = dict(cli.CLI_CONFIG)
+    config_copy["provider_routing"] = {
+        "only": ["openai"],
+        "models": {
+            "moonshotai/kimi-k2.6": {"only": []},
+        },
+    }
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+
+    shell = cli.HermesCLI(model="moonshotai/kimi-k2.6", compact=True, max_turns=1)
+
+    assert shell._providers_only == []
+
+
+def test_no_per_model_overlay_preserves_flat_routing(monkeypatch):
+    """Config without `models:` overlay behaves identically to old config."""
+    cli = _import_cli()
+    config_copy = dict(cli.CLI_CONFIG)
+    config_copy["provider_routing"] = {
+        "sort": "latency",
+        "only": ["openai"],
+    }
+    monkeypatch.setattr(cli, "CLI_CONFIG", config_copy)
+
+    shell = cli.HermesCLI(model="moonshotai/kimi-k2.6", compact=True, max_turns=1)
+
+    assert shell._provider_sort == "latency"
+    assert shell._providers_only == ["openai"]

--- a/tests/run_agent/test_per_model_context_length.py
+++ b/tests/run_agent/test_per_model_context_length.py
@@ -1,0 +1,118 @@
+"""Per-model context_length override resolution.
+
+Tests the `model.models.<id>.context_length` config schema: a per-model
+override that wins over the flat `model.context_length`. Motivating case:
+on OpenRouter some providers serve a model with a smaller context window
+than its native size — pinning providers fixes routing, and a per-model
+context_length override pins the harness's expectations without mutating
+the flat default that other models inherit.
+"""
+
+from unittest.mock import patch
+
+
+def _build_agent(model_cfg, model="moonshotai/kimi-k2.6"):
+    cfg = {"model": model_cfg}
+    base_url = model_cfg.get("base_url", "")
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=64_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+        return AIAgent(
+            model=model,
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def test_per_model_override_wins_over_flat():
+    """model.models.<active>.context_length wins over flat model.context_length."""
+    agent = _build_agent({
+        "default": "moonshotai/kimi-k2.6",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "context_length": 64_000,  # flat default — what other models would get
+        "models": {
+            "moonshotai/kimi-k2.6": {"context_length": 256_000},
+        },
+    })
+    assert agent._config_context_length == 256_000
+
+
+def test_flat_wins_when_no_per_model_entry():
+    """Active model with no per-model entry falls through to the flat default."""
+    agent = _build_agent({
+        "default": "anthropic/claude-opus-4.6",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "context_length": 64_000,
+        "models": {
+            "moonshotai/kimi-k2.6": {"context_length": 256_000},
+        },
+    }, model="anthropic/claude-opus-4.6")
+    assert agent._config_context_length == 64_000
+
+
+def test_per_model_override_with_no_flat():
+    """Per-model override works even when flat context_length is unset."""
+    agent = _build_agent({
+        "default": "moonshotai/kimi-k2.6",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "models": {
+            "moonshotai/kimi-k2.6": {"context_length": 256_000},
+        },
+    })
+    assert agent._config_context_length == 256_000
+
+
+def test_invalid_per_model_value_falls_back_to_flat():
+    """An invalid per-model value warns and falls back to the flat default."""
+    with patch("run_agent.logger") as mock_logger:
+        agent = _build_agent({
+            "default": "moonshotai/kimi-k2.6",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "context_length": 64_000,
+            "models": {
+                "moonshotai/kimi-k2.6": {"context_length": "256K"},
+            },
+        })
+    assert agent._config_context_length == 64_000
+    warning_calls = [
+        c for c in mock_logger.warning.call_args_list
+        if "Invalid model.models." in str(c) and "256K" in str(c)
+    ]
+    assert len(warning_calls) == 1
+
+
+def test_missing_models_dict_is_noop():
+    """No `models:` key at all — behaves identically to old config."""
+    agent = _build_agent({
+        "default": "moonshotai/kimi-k2.6",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "context_length": 64_000,
+    })
+    assert agent._config_context_length == 64_000
+
+
+def test_string_integer_per_model_value():
+    """Quoted integers should parse fine (YAML quirk: '256000' string)."""
+    agent = _build_agent({
+        "default": "moonshotai/kimi-k2.6",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "context_length": 64_000,
+        "models": {
+            "moonshotai/kimi-k2.6": {"context_length": "256000"},
+        },
+    })
+    assert agent._config_context_length == 256_000


### PR DESCRIPTION
## What does this PR do?

Adds two opt-in, fully backward-compatible overlay schemas that let a single config declare model-specific profile-globals without mutating the flat defaults other models inherit:

- **`model.models.<id>.context_length`** — wins over flat `model.context_length` when the active model is `<id>`. Resolution order: per-model override → flat → `custom_providers` per-model → auto-detect.
- **`provider_routing.models.<id>.<key>`** — wins over flat `provider_routing.<key>` when the active model is `<id>`. Unspecified per-model keys fall through to flat defaults.

### Why this approach

On OpenRouter, some providers serve a given model with a smaller context window than its native size — e.g. certain providers ship Kimi K2.6 with a 32K window despite the model's native 256K. The workaround is two profile-global settings travelling together:

1. `provider_routing.only: [...]` to pin providers that serve the full window.
2. `model.context_length: <native>` so the harness's expectation matches.

Both are flat in the current schema, so switching the active model without flipping both yields sporadic tool-call failures when the harness's context check runs against the larger flat default. With this patch the two settings travel together per model:

```yaml
model:
  default: moonshotai/kimi-k2.6
  context_length: 128000           # default for unmatched models
  models:
    moonshotai/kimi-k2.6:
      context_length: 256000

provider_routing:
  sort: throughput
  models:
    moonshotai/kimi-k2.6:
      only: ["together", "groq"]
```

The overlay shape is consistent with precedent already in the codebase: `model.custom_providers.<name>.models.<id>.context_length` and `providers.<name>.models.<id>.timeout_seconds`.

## Related Issues and PRs

Fixes #24493.

Also searched open issues + PRs; this PR is related to the following but not a duplicate of any:

- **#24268 (P1)** — *Wrong context length for kimi-k2.6 family: OpenRouter returns 32K, overrides correct hardcoded 256K default.* This PR is a complementary fix: #24268 proposes hardcoded defaults in `model_metadata.py` for the specific kimi models; this PR adds a user-configurable per-model override that works for any model OpenRouter mis-reports, plus the provider-pinning angle (`provider_routing.models.<id>.only`) which #24268 doesn't address. Both could land independently.
- **#24140 (P1)**, **#24000 (P2)** — broader manifestations of "context window below minimum 64K" failures. This PR doesn't fix the underlying detection bugs but gives users a clean per-model workaround without polluting flat defaults.
- **#24072 (P2)** + companion PR **#24079** — mid-session `/model` switching doesn't re-resolve `_config_context_length`. This is exactly the scope-note below: this PR resolves overlays at agent-init time only; #24079 addresses the live-switch path and is complementary, not conflicting.
- **#24460 (PR, open)** — fixes a bug in the existing `model.custom_providers.<name>.models.<id>.context_length` resolution order. Different code path; no conflict with this PR's new `model.models.<id>` overlay.
- **#15037 (P3 feature)** — per-model `max_tokens` in custom_providers. Adjacent: the overlay pattern introduced here naturally extends to `max_tokens` and other model-globals as future work.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `run_agent.py`: per-model `model.models.<id>.context_length` resolved before flat `model.context_length`; existing custom_providers branch and warning behavior preserved.
- `cli.py`: per-model `provider_routing.models.<id>.*` overlay on top of flat keys; unspecified per-model keys fall through.
- `cli-config.yaml.example`: schema docs for both new overlays with motivating examples.
- `tests/run_agent/test_per_model_context_length.py` (new): 6 tests covering per-model wins, flat fallback, invalid-value warns + falls back, missing `models:` no-op, string-int parsing.
- `tests/cli/test_cli_provider_resolution.py`: 4 new tests covering per-model overlay wins, no-leak to other models, empty-list honored, no-overlay no-op.

## How to Test

1. Apply the patch.
2. Write a config with both flat and per-model entries (see example above).
3. Run `pytest tests/run_agent/test_per_model_context_length.py tests/cli/test_cli_provider_resolution.py -q` — all 10 new tests pass.
4. Regression sweep: `pytest tests/run_agent/test_invalid_context_length_warning.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py tests/cli/test_cli_provider_resolution.py tests/agent/test_model_metadata.py -q` — all 146 tests pass (10 new + 136 pre-existing).
5. End-to-end: start Hermes with a config whose active model has a per-model `context_length` override, and verify via `/info` (or equivalent) that the effective context_length reflects the override, not the flat default.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(config): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` on the touched modules and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (Linux 6.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] N/A — no architecture/workflow changes
- [x] N/A — pure config schema addition, no platform-specific code
- [x] N/A — no tool description/schema changes

## Scope note

Both overlays resolve at agent-init time, so the active value is correct from container/process start. Mid-session `/model` switching does *not* currently re-resolve these overlays (would require touching the `switch_model` path) — happy to follow up if maintainers want it.