### PR TITLE
feat(api): expose truthful slash command registry

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8,6 +8,8 @@ Exposes an HTTP server with endpoints:
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
+- GET  /v1/commands                — machine-readable gateway slash command registry
+- POST /v1/commands/{name}         — parity-safe slash command dispatch/results
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
@@ -947,6 +949,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events_sse": True,
                 "run_stop": True,
                 "run_approval_response": True,
+                "slash_command_registry": True,
+                "slash_command_dispatch": "metadata_and_read_only_subset",
                 "tool_progress_events": True,
                 "approval_events": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -957,6 +961,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "health": {"method": "GET", "path": "/health"},
                 "health_detailed": {"method": "GET", "path": "/health/detailed"},
                 "models": {"method": "GET", "path": "/v1/models"},
+                "commands": {"method": "GET", "path": "/v1/commands"},
+                "command_execute": {"method": "POST", "path": "/v1/commands/{name}"},
                 "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
                 "responses": {"method": "POST", "path": "/v1/responses"},
                 "runs": {"method": "POST", "path": "/v1/runs"},
@@ -966,6 +972,174 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
             },
         })
+
+    async def _handle_commands(self, request: "web.Request") -> "web.Response":
+        """GET /v1/commands — machine-readable gateway slash command registry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            from hermes_cli.commands import gateway_command_records
+            commands = gateway_command_records()
+        except Exception as exc:
+            logger.warning("Failed to build command registry: %s", exc)
+            return web.json_response(_openai_error("Command registry unavailable"), status=503)
+        enabled_count = sum(1 for command in commands if command.get("enabled"))
+        return web.json_response({
+            "object": "hermes.gateway.commands",
+            "surface": "api_server",
+            "commands": commands,
+            "data": commands,
+            "count": len(commands),
+            "enabled_count": enabled_count,
+        })
+
+    async def _handle_command_execute(self, request: "web.Request") -> "web.Response":
+        """POST /v1/commands/{name} — parity-safe slash command dispatch.
+
+        Full gateway command execution mutates live session/gateway state and is
+        progressively exposed. This endpoint is deliberately truthful: it uses
+        the same registry as the gateway, executes read-only/status commands,
+        and returns requires_confirmation for mutating/dangerous commands.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        raw_name = (request.match_info.get("name") or "").strip().lower().lstrip("/")
+        if not raw_name or not re.match(r"^[a-z0-9_-]{1,64}$", raw_name):
+            return web.json_response(_openai_error("Invalid command name"), status=400)
+        try:
+            body = await request.json() if request.can_read_body else {}
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("Command body must be an object"), status=400)
+        try:
+            from hermes_cli.commands import gateway_command_records, gateway_help_lines, resolve_command
+            cmd = resolve_command(raw_name)
+            records = gateway_command_records()
+        except Exception as exc:
+            logger.warning("Failed to resolve command %s: %s", raw_name, exc)
+            return web.json_response(_openai_error("Command registry unavailable"), status=503)
+        record = next(
+            (item for item in records if item.get("name") == (cmd.name if cmd else raw_name)
+             or raw_name in item.get("aliases", [])),
+            None,
+        )
+        if not cmd:
+            if record:
+                if record.get("source") == "skill":
+                    return web.json_response({
+                        "command": raw_name,
+                        "status": "requires_run",
+                        "message": record.get("disabled_reason") or f"/{raw_name} requires a Hermes agent run.",
+                        "risk": record.get("risk"),
+                        "execution_mode": record.get("execution_mode"),
+                        "effects": {},
+                    }, status=409)
+                return web.json_response({
+                    "command": raw_name,
+                    "status": "unsupported",
+                    "message": record.get("disabled_reason") or f"/{raw_name} is not exposed through the API command executor.",
+                    "risk": record.get("risk"),
+                    "execution_mode": record.get("execution_mode"),
+                    "effects": {},
+                }, status=409)
+            return web.json_response({
+                "command": raw_name,
+                "status": "unsupported",
+                "message": f"/{raw_name} is not a supported Hermes gateway command.",
+                "effects": {},
+            }, status=404)
+        if not record:
+            return web.json_response({
+                "command": raw_name,
+                "status": "unsupported",
+                "message": f"/{raw_name} is not a supported Hermes gateway command.",
+                "effects": {},
+            }, status=404)
+        canonical = cmd.name
+        if not record.get("supported"):
+            return web.json_response({
+                "command": canonical,
+                "status": "unsupported",
+                "message": record.get("disabled_reason") or f"/{canonical} is not available in this gateway.",
+                "effects": {},
+            }, status=409)
+        if record.get("risk") != "read_only":
+            return web.json_response({
+                "command": canonical,
+                "status": "requires_confirmation",
+                "message": (
+                    f"/{canonical} is registered in the Hermes gateway, but API execution "
+                    "for mutating or dangerous slash commands is confirmation-gated and not enabled yet."
+                ),
+                "risk": record.get("risk"),
+                "effects": {
+                    "session_reset": False,
+                    "transcript_mutated": False,
+                    "config_written": False,
+                    "agent_cache_evicted": False,
+                },
+            }, status=409)
+        args = str(body.get("args") or body.get("text") or "").strip()
+        if args:
+            return web.json_response({
+                "command": canonical,
+                "status": "rejected",
+                "message": f"/{canonical} is available through the API as a read-only status command without arguments.",
+                "effects": {},
+            }, status=400)
+        message = self._read_only_command_message(canonical, records, gateway_help_lines())
+        return web.json_response({
+            "command": canonical,
+            "status": "succeeded",
+            "message": message,
+            "session_id": None,
+            "effects": {
+                "session_reset": False,
+                "transcript_mutated": False,
+                "config_written": False,
+                "agent_cache_evicted": False,
+            },
+        })
+
+    def _read_only_command_message(self, command: str, records: list[dict[str, Any]], help_lines: list[str]) -> str:
+        if command == "help":
+            return "Available gateway commands:\n" + "\n".join(help_lines[:30])
+        if command == "commands":
+            return f"{len(records)} gateway slash commands are registered; {sum(1 for r in records if r.get('enabled'))} are read-only API-enabled."
+        if command == "status":
+            return f"Hermes API server is running. model={self._model_name}; active_runs={len(self._active_run_tasks)}"
+        if command == "profile":
+            return "API server surface: api_server. Profile details are intentionally not exposed here."
+        if command == "whoami":
+            return "Authenticated API client with bearer access to this Hermes API server."
+        if command == "agents":
+            return f"Active API runs: {len(self._active_run_tasks)}."
+        if command == "model":
+            return f"Current API server model: {self._model_name}."
+        if command == "title":
+            return "API server command surface has no active gateway conversation title."
+        if command == "goal":
+            return "Goal state belongs to gateway/CLI sessions and is not exposed read-only through the API yet."
+        if command == "usage":
+            return "Usage details are not exposed through this API command surface yet."
+        if command == "insights":
+            return "Insights are not exposed through this API command surface yet."
+        if command == "sessions":
+            return "Session browsing is not exposed through this API command surface yet."
+        if command == "resume":
+            return "Resume requires session selection and is not executed through this read-only API surface."
+        if command == "reasoning":
+            return "Reasoning status is provider/session-specific and not exposed through this API command surface yet."
+        if command == "footer":
+            return "Gateway footer status is not exposed through this API command surface yet."
+        if command == "fast":
+            return "Fast-mode status is not exposed through this API command surface yet."
+        if command == "voice":
+            return "Voice status is not exposed through this API command surface yet."
+        return f"/{command} is registered as a read-only command."
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -3340,6 +3514,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
+            self._app.router.add_get("/v1/commands", self._handle_commands)
+            self._app.router.add_post("/v1/commands/{name}", self._handle_command_execute)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -431,6 +431,182 @@ def gateway_help_lines() -> list[str]:
     return lines
 
 
+_READ_ONLY_GATEWAY_COMMANDS: frozenset[str] = frozenset({
+    "help", "commands", "whoami", "status", "profile", "agents",
+    "usage", "insights", "model", "reasoning", "title", "footer",
+    "fast", "voice", "goal",
+})
+
+_SESSION_MUTATION_GATEWAY_COMMANDS: frozenset[str] = frozenset({
+    "title", "model", "personality", "reasoning", "fast", "footer",
+    "voice", "queue", "steer", "goal", "reload-skills", "reload-mcp",
+    "sethome", "branch", "compress", "retry", "background", "kanban",
+    "curator", "resume",
+})
+
+_HIGH_RISK_GATEWAY_COMMANDS: frozenset[str] = frozenset({
+    "new", "undo", "rollback", "stop", "restart", "update", "approve",
+    "deny", "yolo", "debug",
+})
+
+
+def _gateway_command_risk(cmd: CommandDef) -> str:
+    """Return a coarse risk class for Homebase/API command surfaces."""
+    if cmd.name in _HIGH_RISK_GATEWAY_COMMANDS:
+        return "dangerous"
+    if cmd.name in _SESSION_MUTATION_GATEWAY_COMMANDS:
+        return "safe_mutation"
+    if cmd.name in _READ_ONLY_GATEWAY_COMMANDS:
+        return "read_only"
+    if cmd.gateway_only:
+        return "safe_mutation"
+    return "safe_mutation"
+
+
+def _gateway_command_mid_run(cmd: CommandDef) -> str:
+    if cmd.name in ACTIVE_SESSION_BYPASS_COMMANDS:
+        return "allowed"
+    return "busy_if_running"
+
+
+def _gateway_command_input_mode(args_hint: str, subcommands: list[str] | tuple[str, ...] | None = None) -> str:
+    """Classify how a command expects input for API/Homebase UIs."""
+    if subcommands:
+        return "subcommand"
+    hint = (args_hint or "").strip()
+    if not hint:
+        return "none"
+    if hint.startswith("{") or "json" in hint.lower():
+        return "structured"
+    return "text"
+
+
+def _gateway_command_execution_mode(*, api_supported: bool, risk: str, source: str) -> str:
+    """Return a truthful execution class for external command surfaces."""
+    if source == "plugin":
+        return "metadata_only"
+    if source == "skill":
+        return "run"
+    if api_supported and risk == "read_only":
+        return "sync"
+    return "confirmation_required"
+
+
+def gateway_command_records(*, include_plugins: bool = True, include_skills: bool = True) -> list[dict[str, Any]]:
+    """Return structured gateway slash-command metadata.
+
+    This is the machine-readable sibling of :func:`gateway_help_lines` and is
+    intentionally safe for API/Homebase exposure: it returns command names,
+    aliases, descriptions, risk labels, and disabled reasons, but never raw
+    config values, platform allowlists, tokens, or handler internals.
+    """
+    overrides = _resolve_config_gates()
+    records: list[dict[str, Any]] = []
+    for cmd in COMMAND_REGISTRY:
+        gateway_known = (not cmd.cli_only) or bool(cmd.gateway_config_gate)
+        available = _is_gateway_available(cmd, overrides)
+        if not gateway_known and not available:
+            continue
+        disabled_reason = None
+        if not available:
+            disabled_reason = "disabled by gateway configuration"
+        risk = _gateway_command_risk(cmd)
+        api_supported = available and risk == "read_only"
+        if available and not api_supported:
+            disabled_reason = "requires confirmation or agent/session context; API execution is not enabled yet"
+        records.append({
+            "name": cmd.name,
+            "aliases": list(cmd.aliases),
+            "description": cmd.description,
+            "category": cmd.category,
+            "args_hint": cmd.args_hint,
+            "subcommands": list(cmd.subcommands),
+            "risk": risk,
+            "gateway_supported": available,
+            "api_supported": api_supported,
+            "supported": available,
+            "enabled": api_supported,
+            "disabled_reason": disabled_reason if available else disabled_reason or "not available in gateway",
+            "mid_run": _gateway_command_mid_run(cmd),
+            "source": "builtin",
+            "input_mode": _gateway_command_input_mode(cmd.args_hint, cmd.subcommands),
+            "execution_mode": _gateway_command_execution_mode(
+                api_supported=api_supported,
+                risk=risk,
+                source="builtin",
+            ),
+        })
+
+    if include_plugins:
+        for name, description, args_hint in _iter_plugin_command_entries():
+            records.append({
+                "name": name,
+                "aliases": [],
+                "description": description,
+                "category": "Plugin",
+                "args_hint": args_hint,
+                "subcommands": [],
+                "risk": "unknown",
+                "gateway_supported": True,
+                "api_supported": False,
+                "supported": False,
+                "enabled": False,
+                "disabled_reason": "plugin command execution is not exposed through the API yet",
+                "mid_run": "busy_if_running",
+                "source": "plugin",
+                "input_mode": _gateway_command_input_mode(args_hint),
+                "execution_mode": "metadata_only",
+            })
+    if include_skills:
+        for record in _iter_skill_command_records():
+            records.append(record)
+    return records
+
+
+def _iter_skill_command_records() -> list[dict[str, Any]]:
+    """Return safe metadata records for skill slash commands.
+
+    The skill scanner keeps local paths so the runtime can load the skill. The
+    API/Homebase registry must not expose those paths or skill contents.
+    """
+    try:
+        from agent.skill_commands import get_skill_commands
+    except Exception:
+        return []
+    try:
+        commands = get_skill_commands() or {}
+    except Exception:
+        return []
+    records: list[dict[str, Any]] = []
+    for slash_name, meta in commands.items():
+        if not isinstance(slash_name, str) or not isinstance(meta, dict):
+            continue
+        name = slash_name.strip().lstrip("/").lower().replace("_", "-")
+        if not name:
+            continue
+        skill_name = str(meta.get("name") or name)
+        description = f"Invoke the {skill_name} skill"
+        records.append({
+            "name": name,
+            "aliases": [],
+            "description": description,
+            "category": "Skill",
+            "args_hint": "[instruction]",
+            "subcommands": [],
+            "risk": "agent_execution",
+            "gateway_supported": True,
+            "api_supported": False,
+            "supported": True,
+            "enabled": False,
+            "disabled_reason": "skill commands require an agent run and are not executed as read-only API commands yet",
+            "mid_run": "busy_if_running",
+            "source": "skill",
+            "input_mode": "text",
+            "execution_mode": "run",
+        })
+    return records
+
+
 def _iter_plugin_command_entries() -> list[tuple[str, str, str]]:
     """Yield (name, description, args_hint) tuples for all plugin slash commands.
 

--- a/tests/gateway/test_api_server_commands.py
+++ b/tests/gateway/test_api_server_commands.py
@@ -1,0 +1,127 @@
+import pytest
+
+from hermes_cli.commands import gateway_command_records
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+def _record(name: str, records: list[dict]):
+    return next(record for record in records if record["name"] == name)
+
+
+async def test_gateway_command_records_include_gateway_commands():
+    records = gateway_command_records(include_plugins=False)
+    names = {record["name"] for record in records}
+    assert "help" in names
+    assert "status" in names
+    assert "model" in names
+    assert "approve" in names
+    assert "clear" not in names
+    status = _record("status", records)
+    assert status["enabled"] is True
+    assert status["risk"] == "read_only"
+    approve = _record("approve", records)
+    assert approve["supported"] is True
+    assert approve["enabled"] is False
+    assert approve["risk"] == "dangerous"
+    background = _record("background", records)
+    assert "bg" in background["aliases"]
+
+
+def test_gateway_command_records_have_phase1_schema():
+    records = gateway_command_records(include_plugins=False)
+    required = {
+        "name",
+        "aliases",
+        "description",
+        "category",
+        "args_hint",
+        "subcommands",
+        "source",
+        "risk",
+        "gateway_supported",
+        "api_supported",
+        "enabled",
+        "disabled_reason",
+        "mid_run",
+        "input_mode",
+        "execution_mode",
+    }
+    assert records
+    for record in records:
+        assert required.issubset(record), record
+    assert _record("status", records)["input_mode"] == "none"
+    assert _record("status", records)["execution_mode"] == "sync"
+    assert _record("new", records)["execution_mode"] == "confirmation_required"
+    assert _record("new", records)["disabled_reason"]
+
+
+def test_gateway_command_records_include_plugin_commands_as_metadata_only(monkeypatch):
+    import hermes_cli.commands as commands_mod
+
+    monkeypatch.setattr(
+        commands_mod,
+        "_iter_plugin_command_entries",
+        lambda: [("example-plugin", "Example plugin command", "<target>")],
+    )
+
+    records = gateway_command_records(include_plugins=True)
+    plugin = _record("example-plugin", records)
+    assert plugin["source"] == "plugin"
+    assert plugin["gateway_supported"] is True
+    assert plugin["api_supported"] is False
+    assert plugin["enabled"] is False
+    assert plugin["execution_mode"] == "metadata_only"
+    assert plugin["input_mode"] == "text"
+    assert "not exposed" in plugin["disabled_reason"]
+
+
+def test_gateway_command_records_include_skill_commands_without_paths(monkeypatch):
+    import agent.skill_commands as skill_commands
+
+    monkeypatch.setattr(
+        skill_commands,
+        "get_skill_commands",
+        lambda: {
+            "/demo-skill": {
+                "name": "Demo Skill",
+                "description": "Invoke demo skill",
+                "skill_md_path": "/tmp/secret/SKILL.md",
+                "skill_dir": "/tmp/secret",
+            }
+        },
+    )
+
+    records = gateway_command_records(include_plugins=False, include_skills=True)
+    skill = _record("demo-skill", records)
+    assert skill["source"] == "skill"
+    assert skill["risk"] == "agent_execution"
+    assert skill["gateway_supported"] is True
+    assert skill["api_supported"] is False
+    assert skill["enabled"] is False
+    assert skill["execution_mode"] == "run"
+    assert skill["input_mode"] == "text"
+    assert "skill_md_path" not in skill
+    assert "skill_dir" not in skill
+    assert "/tmp/secret" not in repr(skill)
+    assert "Invoke demo skill" not in skill["description"]
+    assert skill["description"] == "Invoke the Demo Skill skill"
+
+
+async def test_api_server_exposes_command_routes_in_capabilities():
+    import json
+    from types import SimpleNamespace
+
+    from gateway.config import PlatformConfig
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": ""}))
+    response = await adapter._handle_capabilities(SimpleNamespace(headers={}))
+    payload = json.loads(response.text)
+
+    assert payload["features"]["slash_command_registry"] is True
+    assert payload["features"]["slash_command_dispatch"] == "metadata_and_read_only_subset"
+    assert payload["endpoints"]["commands"] == {"method": "GET", "path": "/v1/commands"}
+    assert payload["endpoints"]["command_execute"] == {"method": "POST", "path": "/v1/commands/{name}"}
+    assert hasattr(adapter, "_handle_commands")
+    assert hasattr(adapter, "_handle_command_execute")


### PR DESCRIPTION
## Summary
- Adds a structured gateway slash-command registry for the API server
- Exposes GET /v1/commands and POST /v1/commands/{name} with truthful api_supported/enabled/risk metadata
- Preserves unsupported / confirmation-gated command responses instead of fake success

## Test plan
- /home/agastya/.hermes/hermes-agent/.venv/bin/python -m pytest -q -o addopts="" tests/gateway/test_api_server_commands.py

## Homebase dependency
This makes Luna Homebase command palette / slash-command execution durable instead of relying on a local-only Hermes patch.