### PR TITLE
Fix kanban worker task skill preloading

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,45 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _resolve_worker_skill_identifier(skill_name: str) -> Optional[str]:
+    """Return the child-safe ``--skills`` identifier for a task skill.
+
+    Kanban worker children usually run with their task workspace as CWD and
+    may be launched through an installed ``hermes`` shim rather than the source
+    checkout that hosts the dispatcher.  If the dispatcher can resolve a skill,
+    pass the absolute skill directory to the child so skill preloading does not
+    depend on the child's CWD/PYTHONPATH/profile-specific skill lookup.
+    """
+    try:
+        from agent.skill_commands import _load_skill_payload
+
+        loaded = _load_skill_payload(skill_name)
+        if not loaded:
+            return None
+        _loaded_skill, skill_dir, _display_name = loaded
+        return str(skill_dir) if skill_dir is not None else skill_name
+    except Exception:
+        return None
+
+
+def _filter_worker_extra_skills(skills: Optional[Iterable[Any]]) -> tuple[list[str], list[str]]:
+    """Split task-declared worker skills into (child-safe identifiers, missing)."""
+    valid: list[str] = []
+    missing: list[str] = []
+    seen = {"kanban-worker"}
+    for raw in skills or []:
+        name = str(raw or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        resolved = _resolve_worker_skill_identifier(name)
+        if resolved:
+            valid.append(resolved)
+        else:
+            missing.append(name)
+    return valid, missing
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3996,10 +4035,10 @@ def _default_spawn(
     # quoting ambiguity if a skill name ever contains unusual chars.
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
-    if task.skills:
-        for sk in task.skills:
-            if sk and sk != "kanban-worker":
-                cmd.extend(["--skills", sk])
+    extra_skills, missing_extra_skills = _filter_worker_extra_skills(task.skills)
+    if extra_skills:
+        for sk in extra_skills:
+            cmd.extend(["--skills", sk])
     cmd.extend([
         "chat",
         "-q", prompt,
@@ -4015,6 +4054,14 @@ def _default_spawn(
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    if missing_extra_skills:
+        warning = (
+            "Warning: skipped unknown kanban task skill(s): "
+            + ", ".join(missing_extra_skills)
+            + "\n"
+        )
+        log_f.write(warning.encode("utf-8", errors="replace"))
+        log_f.flush()
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -402,6 +402,54 @@ class TestWorkerSpawnEnv:
         assert env["HERMES_KANBAN_BOARD"] == "default"
         assert env["HERMES_KANBAN_DB"] == str(fresh_home / "kanban.db")
 
+    def test_default_spawn_filters_missing_optional_task_skills(self, fresh_home, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            pid = 99
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            captured["stdout"] = kwargs.get("stdout")
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(
+            kb,
+            "_resolve_worker_skill_identifier",
+            lambda name: "/abs/github-auth" if name == "github-auth" else None,
+        )
+        task = kb.Task(
+            id="t_skills",
+            title="",
+            body=None,
+            assignee="teknium",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            skills=["blueprint", "github-auth", "kanban-worker", "architect"],
+        )
+
+        kb._default_spawn(task, str(fresh_home / "ws"), board=None)
+
+        cmd = captured["cmd"]
+        assert cmd.count("--skills") == 2
+        assert "kanban-worker" in cmd
+        assert "/abs/github-auth" in cmd
+        assert "github-auth" not in cmd
+        assert "blueprint" not in cmd
+        assert "architect" not in cmd
+        log_path = fresh_home / "kanban" / "logs" / "t_skills.log"
+        assert "skipped unknown kanban task skill(s): blueprint, architect" in log_path.read_text()
+
 
 # ---------------------------------------------------------------------------
 # CLI surface


### PR DESCRIPTION
## Summary
- resolve task-declared kanban worker skills in the dispatcher before spawn
- pass resolved skill directories to worker children so CWD/PYTHONPATH/profile lookup does not break preloading
- skip only missing optional task skills with a worker-log warning instead of letting the worker exit before reading the task

## Verification
- python -m pytest tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py -q
- manually unblocked/redispatched t_a983849c; new run is continuing past the prior immediate Unknown skill(s) crash