### PR TITLE
fix(kanban): allow running parents to not block child task promotion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1362,7 +1362,7 @@ def create_task(
                             "(" + ",".join("?" * len(parents)) + ")",
                             parents,
                         ).fetchall()
-                        if any(r["status"] != "done" for r in rows):
+                        if any(r["status"] not in {"done", "running"} for r in rows):
                             initial_status = "todo"
                 # Even in triage mode we still need to validate parent ids
                 # so the eventual link rows don't dangle.
@@ -1529,7 +1529,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
-        if parent_status != "done":
+        if parent_status not in {"done", "running"}:
             conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
@@ -1826,7 +1826,7 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote ``todo`` tasks to ``ready`` when all parents are ``done``, ``archived``, or ``running``.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
@@ -1844,7 +1844,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in {"done", "archived"} for p in parents):
+            if all(p["status"] in {"done", "archived", "running"} for p in parents):
                 conn.execute(
                     "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                     (task_id,),
@@ -1885,7 +1885,7 @@ def claim_task(
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived', 'running') LIMIT 1",
             (task_id,),
         ).fetchone()
         if undone:
@@ -2673,7 +2673,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         undone_parents = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'running') LIMIT 1",
             (task_id,),
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1230,11 +1230,12 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
         a = kb.create_task(conn, title="parent-done")
         kb.complete_task(conn, a)
 
-        # C is running (not done) — blocks child B.
-        c = kb.create_task(conn, title="parent-running")
-        kb.claim_task(conn, c, claimer="worker:1")
+        # C is todo (blocked by its own unsatisfied parent) — blocks child B.
+        c_grandparent = kb.create_task(conn, title="c-grandparent")
+        c = kb.create_task(conn, title="parent-blocked", parents=[c_grandparent])
+        assert kb.get_task(conn, c).status == "todo"
 
-        # B depends on both A (done) and C (running) → stays todo.
+        # B depends on both A (done) and C (todo) → stays todo.
         b = kb.create_task(conn, title="child", parents=[a, c])
         assert kb.get_task(conn, b).status == "todo"
 
@@ -1247,6 +1248,105 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
             "child should promote to ready immediately after unlink_tasks "
             "removes its last blocking dependency"
         )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator pattern: running parents allow children (issue #24489)
+# ---------------------------------------------------------------------------
+
+def test_running_parent_does_not_block_child_promotion(kanban_home):
+    """Children must be promotable to ready while a parent is still running.
+
+    Regression test for issue #24489: the orchestrator pattern requires
+    a parent task to stay 'running' while coordinating child tasks in
+    parallel. Before the fix, children were permanently stuck in 'todo'
+    because only 'done' and 'archived' parents were considered non-blocking.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="orchestrator")
+        kb.claim_task(conn, parent, claimer="orch:1")
+        assert kb.get_task(conn, parent).status == "running"
+
+        child = kb.create_task(conn, title="review-task", parents=[parent])
+        assert kb.get_task(conn, child).status == "ready", (
+            "child should be ready when parent is running (orchestrator pattern)"
+        )
+
+
+def test_link_keeps_ready_child_when_parent_is_running(kanban_home):
+    """link_tasks must not demote a ready child when the parent is running.
+
+    Regression test for issue #24489: link_tasks previously demoted children
+    to 'todo' whenever the parent was not 'done'. With the orchestrator pattern,
+    'running' parents must also allow children to remain ready.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="orchestrator")
+        kb.claim_task(conn, parent, claimer="orch:1")
+        assert kb.get_task(conn, parent).status == "running"
+
+        child = kb.create_task(conn, title="child")
+        assert kb.get_task(conn, child).status == "ready"
+
+        kb.link_tasks(conn, parent, child)
+        assert kb.get_task(conn, child).status == "ready", (
+            "child should remain ready when linked to a running parent"
+        )
+
+
+def test_child_claimable_while_parent_is_running(kanban_home):
+    """Children must be claimable while a parent is still running.
+
+    Regression test for issue #24489: claim_task previously rejected claims
+    when any parent was not 'done' or 'archived'. With the orchestrator
+    pattern, 'running' parents must not block child claiming.
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="orchestrator")
+        kb.claim_task(conn, parent, claimer="orch:1")
+        assert kb.get_task(conn, parent).status == "running"
+
+        child = kb.create_task(conn, title="review-task", parents=[parent])
+        assert kb.get_task(conn, child).status == "ready"
+
+        claimed = kb.claim_task(conn, child, claimer="worker:1")
+        assert claimed is not None, (
+            "child should be claimable while parent is running"
+        )
+        assert claimed.status == "running"
+
+
+def test_orchestrator_full_lifecycle(kanban_home):
+    """Full orchestrator lifecycle: parent runs, children execute, parent completes.
+
+    Regression test for issue #24489: verifies the complete orchestrator
+    workflow where a running parent coordinates children in parallel.
+    """
+    with kb.connect() as conn:
+        # Create orchestrator and claim it.
+        parent = kb.create_task(conn, title="orchestrator")
+        kb.claim_task(conn, parent, claimer="orch:1")
+
+        # Create two child tasks linked to the running parent.
+        c1 = kb.create_task(conn, title="review-1", parents=[parent])
+        c2 = kb.create_task(conn, title="review-2", parents=[parent])
+        assert kb.get_task(conn, c1).status == "ready"
+        assert kb.get_task(conn, c2).status == "ready"
+
+        # Claim and complete children while parent is running.
+        kb.claim_task(conn, c1, claimer="worker:1")
+        kb.complete_task(conn, c1, result="approved")
+        assert kb.get_task(conn, c1).status == "done"
+
+        kb.claim_task(conn, c2, claimer="worker:2")
+        kb.complete_task(conn, c2, result="approved")
+        assert kb.get_task(conn, c2).status == "done"
+
+        # Parent can now complete.
+        kb.complete_task(conn, parent, result="all reviews done")
+        assert kb.get_task(conn, parent).status == "done"
+
+
 # ---------------------------------------------------------------------------
 # _add_column_if_missing / _migrate_add_optional_columns idempotency (#21708)
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -591,7 +591,7 @@ def test_create_happy_path(worker_env):
     d = json.loads(out)
     assert d["ok"] is True
     assert d["task_id"]
-    assert d["status"] == "todo"  # parent isn't done yet
+    assert d["status"] == "ready"  # running parent no longer blocks promotion
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:


### PR DESCRIPTION
## Summary

Allow `running` parent tasks to not block child task promotion, enabling the orchestrator pattern where a parent stays `running` while coordinating child tasks in parallel.

## Root Cause

The kanban dispatcher only promoted children from `todo` to `ready` when ALL parents were `done` or `archived`. This blocked the War Room orchestration workflow where an orchestrator parent task stays `running` while coordinating child review tasks in parallel — children were permanently stuck in `todo`.

## Fix

Updated 5 locations in `hermes_cli/kanban_db.py` to treat `running` parents as non-blocking:

| Function | Before | After |
|----------|--------|-------|
| `create_task` | `status != "done"` | `status not in {"done", "running"}` |
| `link_tasks` | `parent_status != "done"` | `parent_status not in {"done", "running"}` |
| `recompute_ready` | `{"done", "archived"}` | `{"done", "archived", "running"}` |
| `claim_task` | `NOT IN ('done', 'archived')` | `NOT IN ('done', 'archived', 'running')` |
| `unblock_task` | `status != 'done'` | `status NOT IN ('done', 'running')` |

## Regression Coverage

4 new tests in `tests/hermes_cli/test_kanban_db.py`:

- `test_running_parent_does_not_block_child_promotion` — child is `ready` when parent is `running`
- `test_link_keeps_ready_child_when_parent_is_running` — `link_tasks` doesn't demote children for `running` parents
- `test_child_claimable_while_parent_is_running` — `claim_task` succeeds when parent is `running`
- `test_orchestrator_full_lifecycle` — end-to-end: parent runs → children execute → parent completes

Updated 1 existing test to use a `todo` parent (instead of `running`) to test the `unlink_tasks` → `recompute_ready` flow.

## Testing

```
85 passed (tests/hermes_cli/test_kanban_db.py)
```

Fixes [kanban: parent-child deadlock blocks parallel War Room orchestration #24489](https://github.com/NousResearch/hermes-agent/issues/24489)
