### PR TITLE
fix(bedrock): route Claude through Converse API when bearer token auth

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -62,9 +62,23 @@ def _get_bedrock_runtime_client(region: str):
     """Get or create a cached ``bedrock-runtime`` client for the given region.
 
     Uses the default AWS credential chain (env vars → profile → instance role).
+    When ``AWS_BEARER_TOKEN_BEDROCK`` is set (Bedrock API Key auth), it is
+    promoted to the standard ``AWS_BEARER_TOKEN`` env var so boto3's credential
+    chain picks it up via httpBearerAuth (requires boto3 >=1.35).
+
+    Without this promotion, boto3's default chain cannot resolve credentials
+    and raises "could not resolve credentials from session" — even though
+    runtime_provider.py correctly routed the call to bedrock_converse mode.
     """
     if region not in _bedrock_runtime_client_cache:
         boto3 = _require_boto3()
+
+        # Promote Hermes-specific bearer token to the standard boto3 env var
+        # so the default credential chain can resolve it automatically.
+        _bearer = os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+        if _bearer and not os.environ.get("AWS_BEARER_TOKEN", "").strip():
+            os.environ["AWS_BEARER_TOKEN"] = _bearer
+
         _bedrock_runtime_client_cache[region] = boto3.client(
             "bedrock-runtime", region_name=region,
         )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1261,8 +1261,22 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
+        #
+        # Exception — AWS_BEARER_TOKEN_BEDROCK auth: the AnthropicBedrock SDK
+        # only speaks SigV4 (IAM access key + secret) and cannot send the
+        # ``Authorization: Bearer <token>`` header that Bedrock API Keys
+        # require.  Routing Claude through it with a bearer token produces
+        # ``could not resolve credentials from session``.  boto3 >=1.35
+        # natively supports ``smithy.api#httpBearerAuth`` for Bedrock, so
+        # fall back to the Converse API in that case.  The trade-off is no
+        # prompt caching / thinking budgets, but that's a strict improvement
+        # over a total-failure path.
         _current_model = str(model_cfg.get("default") or "").strip()
-        if is_anthropic_bedrock_model(_current_model):
+        _bearer_auth = auth_source == "AWS_BEARER_TOKEN_BEDROCK"
+        _use_anthropic_sdk = (
+            is_anthropic_bedrock_model(_current_model) and not _bearer_auth
+        )
+        if _use_anthropic_sdk:
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1462,3 +1462,64 @@ class TestCallConverseInvalidatesOnStaleError:
         )
 
         assert _bedrock_runtime_client_cache.get("us-east-1") is live_client
+
+
+# ---------------------------------------------------------------------------
+# Bearer token promotion
+# ---------------------------------------------------------------------------
+
+class TestBearerTokenPromotion:
+    """Verify _get_bedrock_runtime_client promotes AWS_BEARER_TOKEN_BEDROCK
+    to the standard AWS_BEARER_TOKEN env var for boto3's credential chain."""
+
+    def test_promotes_bearer_token_to_standard_env_var(self, monkeypatch):
+        """When AWS_BEARER_TOKEN_BEDROCK is set and AWS_BEARER_TOKEN is not,
+        the client factory must promote it so boto3 can resolve credentials."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+
+        reset_client_cache()
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKTestToken123")
+        monkeypatch.delenv("AWS_BEARER_TOKEN", raising=False)
+
+        with patch("boto3.client") as mock_client:
+            mock_client.return_value = MagicMock()
+            _get_bedrock_runtime_client("us-east-1")
+
+        assert os.environ.get("AWS_BEARER_TOKEN") == "ABSKTestToken123"
+
+    def test_does_not_overwrite_existing_bearer_token(self, monkeypatch):
+        """If AWS_BEARER_TOKEN is already set, don't clobber it."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+
+        reset_client_cache()
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKHermesToken")
+        monkeypatch.setenv("AWS_BEARER_TOKEN", "ExistingToken")
+
+        with patch("boto3.client") as mock_client:
+            mock_client.return_value = MagicMock()
+            _get_bedrock_runtime_client("us-west-2")
+
+        assert os.environ.get("AWS_BEARER_TOKEN") == "ExistingToken"
+
+    def test_no_promotion_when_bearer_token_bedrock_absent(self, monkeypatch):
+        """Without AWS_BEARER_TOKEN_BEDROCK, don't touch AWS_BEARER_TOKEN."""
+        from agent.bedrock_adapter import (
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+
+        reset_client_cache()
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN", raising=False)
+
+        with patch("boto3.client") as mock_client:
+            mock_client.return_value = MagicMock()
+            _get_bedrock_runtime_client("eu-west-1")
+
+        assert os.environ.get("AWS_BEARER_TOKEN") is None

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -203,6 +203,63 @@ class TestRuntimeProvider:
         assert result["provider"] == "bedrock"
         assert result["api_mode"] == "bedrock_converse"
 
+    def test_bedrock_claude_with_bearer_token_uses_converse(self, monkeypatch):
+        """When AWS_BEARER_TOKEN_BEDROCK is the auth source, Claude models must
+        route through the Converse API (boto3) rather than the AnthropicBedrock
+        SDK.  The AnthropicBedrock SDK only supports SigV4 and cannot send the
+        ``Authorization: Bearer <token>`` header Bedrock API Keys require —
+        routing Claude through it with a bearer token fails with
+        ``could not resolve credentials from session``.
+        """
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        # Clear SigV4 credentials so bearer token is the only auth source
+        for var in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_PROFILE"]:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ABSKTestBearerTokenValue")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        model_cfg = {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-opus-4-7",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value=model_cfg):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["provider"] == "bedrock"
+        # Claude + bearer → Converse (not anthropic_messages)
+        assert result["api_mode"] == "bedrock_converse"
+        # The bedrock_anthropic signal must NOT be set (that triggers the
+        # AnthropicBedrock client which can't speak bearer auth).
+        assert not result.get("bedrock_anthropic")
+        assert result["source"] == "AWS_BEARER_TOKEN_BEDROCK"
+
+    def test_bedrock_claude_with_sigv4_still_uses_anthropic_sdk(self, monkeypatch):
+        """Regression guard: Claude models with SigV4 credentials must continue
+        to route through AnthropicBedrock SDK for prompt caching / thinking
+        budgets.  The bearer-token fallback must not affect the SigV4 path.
+        """
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        model_cfg = {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-opus-4-7",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value=model_cfg):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["provider"] == "bedrock"
+        assert result["api_mode"] == "anthropic_messages"
+        assert result.get("bedrock_anthropic") is True
+        assert result["source"] == "AWS_ACCESS_KEY_ID"
+
 
 # ---------------------------------------------------------------------------
 # providers.py integration


### PR DESCRIPTION
## Problem

Users authenticating to AWS Bedrock with `AWS_BEARER_TOKEN_BEDROCK` (Bedrock API Keys — short-term or long-term — introduced by AWS in 2025) hit a fatal error on every Claude request:

```
Could not resolve credentials from session
```

### Root cause (two-part)

Hermes' Bedrock runtime uses a dual-path design:

- **Claude models** → `AnthropicBedrock` SDK (`api_mode=anthropic_messages`) — gives us prompt caching, thinking budgets, adaptive thinking.
- **Everything else** (Nova, DeepSeek, Llama, etc.) → boto3 Converse API (`api_mode=bedrock_converse`).

**Issue 1 (routing):** The `AnthropicBedrock` SDK signs requests with **SigV4 only** — it cannot send the `Authorization: Bearer <token>` header that Bedrock API Keys require. So when a user has only a bearer token in their environment (no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), the SDK's SigV4 signer finds no credentials and the call dies before it ever hits Bedrock.

**Issue 2 (credential resolution):** Even after routing to the Converse API (boto3), the `_get_bedrock_runtime_client()` factory creates a vanilla boto3 client that still can't resolve credentials. `AWS_BEARER_TOKEN_BEDROCK` is a Hermes-specific env var — boto3's credential chain only recognizes the standard `AWS_BEARER_TOKEN`. Without promoting to the standard name, boto3 raises the same "could not resolve credentials" error.

boto3 ≥ 1.35 natively supports Bedrock's `smithy.api#httpBearerAuth` trait and handles bearer auth correctly — it just needs the right env var name.

## Fix

### Commit 1: Route Claude through Converse API for bearer auth

When `auth_source == "AWS_BEARER_TOKEN_BEDROCK"`, route Claude models through the Converse API path (boto3) instead of the AnthropicBedrock SDK.

```python
_bearer_auth = auth_source == "AWS_BEARER_TOKEN_BEDROCK"
_use_anthropic_sdk = (
    is_anthropic_bedrock_model(_current_model) and not _bearer_auth
)
if _use_anthropic_sdk:
    # Claude + SigV4 → AnthropicBedrock SDK (unchanged)
    ...
else:
    # Claude + bearer OR non-Claude → Converse API
    ...
```

### Commit 2: Promote bearer token for boto3 credential chain

`_get_bedrock_runtime_client()` now promotes `AWS_BEARER_TOKEN_BEDROCK` to the standard `AWS_BEARER_TOKEN` env var before creating the boto3 client. This is guarded: only promotes when `AWS_BEARER_TOKEN` is not already set.

```python
_bearer = os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
if _bearer and not os.environ.get("AWS_BEARER_TOKEN", "").strip():
    os.environ["AWS_BEARER_TOKEN"] = _bearer
```

Without this second fix, the routing change alone still fails — cron jobs and subagents that don't inherit the TUI session's full environment all hit the same error.

### Trade-off

The Converse path doesn't expose Anthropic-specific features (prompt caching, thinking budgets, adaptive thinking). This is a strict improvement over the current total-failure behavior, and users who want those features can switch to SigV4 credentials.

**SigV4 auth path is unchanged** — Claude + `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` still routes to the `AnthropicBedrock` SDK exactly as before.

## Tests

5 new tests covering both commits:

| Test | Validates |
|------|-----------|
| `test_bedrock_claude_with_bearer_token_uses_converse` | Claude + bearer → Converse API |
| `test_bedrock_claude_with_sigv4_still_uses_anthropic_sdk` | SigV4 path untouched |
| `test_promotes_bearer_token_to_standard_env_var` | Token promotion works |
| `test_does_not_overwrite_existing_bearer_token` | Won't clobber existing env |
| `test_no_promotion_when_bearer_token_bedrock_absent` | No-op without token |

```
$ pytest tests/agent/test_bedrock_adapter.py::TestBearerTokenPromotion \
         tests/agent/test_bedrock_integration.py::TestRuntimeProvider::test_bedrock_claude_with_bearer_token_uses_converse \
         tests/agent/test_bedrock_integration.py::TestRuntimeProvider::test_bedrock_claude_with_sigv4_still_uses_anthropic_sdk -v
5 passed in 1.03s
```

## Context

Hit this personally on macOS after AWS issued me a Bedrock API Key. The first commit fixed the interactive TUI session, but cron jobs and subagents still failed because they don't inherit the TUI's environment — they load `.env` fresh and create new boto3 clients that can't find credentials. The second commit completes the fix for all execution contexts.

Happy to tweak the approach (e.g. warn when downgrading from anthropic_messages → converse, or gate behind a flag) if preferred.
