### PR TITLE
fix(telegram): reset sticky fallback IP on connect failure

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -76,6 +76,8 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
         sticky_ip = self._sticky_ip
         attempt_order: list[Optional[str]] = [sticky_ip] if sticky_ip else [None]
+        if sticky_ip:
+            attempt_order.append(None)  # retry primary DNS after sticky failure
         for ip in self._fallback_ips:
             if ip != sticky_ip:
                 attempt_order.append(ip)
@@ -99,6 +101,14 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                 last_error = exc
                 if not _is_retryable_connect_error(exc):
                     raise
+                if ip is not None and ip == self._sticky_ip:
+                    async with self._sticky_lock:
+                        if self._sticky_ip == ip:
+                            self._sticky_ip = None
+                            logger.warning(
+                                "[Telegram] Sticky fallback IP %s failed; resetting to primary DNS path",
+                                ip,
+                            )
                 if ip is None:
                     logger.warning(
                         "[Telegram] Primary api.telegram.org connection failed (%s); trying fallback IPs %s",


### PR DESCRIPTION
When a sticky fallback IP (from DoH discovery) becomes unreachable, the transport got stuck trying only the dead IP, leaving the gateway unable to recover until restart.

**Changes:**
- Always include primary DNS path (`None`) after the sticky IP in `attempt_order`, so a primary-path retry happens when the sticky IP fails.
- Reset `self._sticky_ip` to `None` on connect timeout / connect error, allowing the next request to retry from scratch.

**Impact:** Prevents silent Telegram disconnection when discovered fallback IPs are transiently or permanently unreachable.

Fixes the root cause of `Telegram Fallback IP ... failed` loops that persist until service restart.