### PR TITLE
fix(skills): inspect installed local skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -78,6 +78,110 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
     return ""
 
 
+
+def _inspect_installed_local_skill(identifier: str) -> Optional[dict]:
+    """Resolve an already-installed local/builtin skill from ~/.hermes/skills.
+
+    `hermes skills list` enumerates installed local skills via tools.skills_tool,
+    but `hermes skills inspect` historically only searched remote/source
+    registries. This helper makes inspect consistent with list/skill_view for
+    personal drop-in skills.
+    """
+    try:
+        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform
+        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    except Exception:
+        return None
+
+    wanted = (identifier or "").strip()
+    if not wanted:
+        return None
+
+    local_category_name = None
+    if ":" in wanted:
+        namespace, _, bare = wanted.partition(":")
+        if namespace and bare:
+            local_category_name = f"{namespace}/{bare}"
+
+    dirs_to_scan = []
+    if SKILLS_DIR.exists():
+        dirs_to_scan.append(SKILLS_DIR)
+    try:
+        dirs_to_scan.extend(get_external_skills_dirs())
+    except Exception:
+        pass
+
+    candidate_paths = []
+    for root in dirs_to_scan:
+        candidate_paths.append(root / wanted / "SKILL.md")
+        if local_category_name:
+            candidate_paths.append(root / local_category_name / "SKILL.md")
+
+    for skill_md in candidate_paths:
+        if skill_md.exists():
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                frontmatter, _body = _parse_frontmatter(content)
+                if not skill_matches_platform(frontmatter):
+                    return None
+                return {"path": skill_md, "frontmatter": frontmatter, "content": content}
+            except Exception:
+                return None
+
+    # Search by frontmatter name or directory name across installed skills.
+    for root in dirs_to_scan:
+        try:
+            iterator = iter_skill_index_files(root, "SKILL.md")
+        except Exception:
+            continue
+        for skill_md in iterator:
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                frontmatter, _body = _parse_frontmatter(content)
+                if not skill_matches_platform(frontmatter):
+                    continue
+                name = str(frontmatter.get("name") or skill_md.parent.name)
+                if name == wanted or skill_md.parent.name == wanted:
+                    return {"path": skill_md, "frontmatter": frontmatter, "content": content}
+            except Exception:
+                continue
+    return None
+
+
+def _local_skill_preview_dict(identifier: str) -> Optional[dict]:
+    """Return inspect-style metadata for an installed local skill."""
+    found = _inspect_installed_local_skill(identifier)
+    if not found:
+        return None
+    fm = found["frontmatter"] or {}
+    content = found["content"]
+    skill_md = found["path"]
+    name = str(fm.get("name") or skill_md.parent.name)
+    description = str(fm.get("description") or "")
+    tags = []
+    try:
+        raw_tags = ((fm.get("metadata") or {}).get("hermes") or {}).get("tags") or fm.get("tags") or []
+        if isinstance(raw_tags, list):
+            tags = [str(t) for t in raw_tags]
+        elif raw_tags:
+            tags = [str(raw_tags)]
+    except Exception:
+        tags = []
+    lines = content.split("\n")
+    preview = "\n".join(lines[:50])
+    if len(lines) > 50:
+        preview += f"\n\n... ({len(lines) - 50} more lines)"
+    return {
+        "name": name,
+        "description": description,
+        "source": "local-installed",
+        "identifier": name,
+        "tags": tags,
+        "skill_md_preview": preview,
+        "path": str(skill_md),
+    }
+
+
 def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
     lines: list[str] = []
     if not extra:
@@ -629,6 +733,29 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
     from tools.skills_hub import GitHubAuth, create_source_router
 
     c = console or _console
+
+    # First inspect already-installed local skills so `skills inspect <name>`
+    # matches `skills list` and `skill_view(<name>)` for drop-in skills under
+    # ~/.hermes/skills/. If no installed skill matches, fall back to hub sources.
+    local = _local_skill_preview_dict(identifier)
+    if local:
+        info_lines = [
+            f"[bold]Name:[/] {local['name']}",
+            f"[bold]Description:[/] {local.get('description', '')}",
+            "[bold]Source:[/] local-installed",
+            "[bold]Trust:[/] [dim]local[/]",
+            f"[bold]Identifier:[/] {local['identifier']}",
+            f"[bold]Path:[/] {local.get('path', '')}",
+        ]
+        if local.get('tags'):
+            info_lines.append(f"[bold]Tags:[/] {', '.join(local['tags'])}")
+        c.print()
+        c.print(Panel("\n".join(info_lines), title=f"Skill: {local['name']}"))
+        if local.get("skill_md_preview"):
+            c.print(Panel(local["skill_md_preview"], title="SKILL.md Preview", subtitle="installed local skill"))
+        c.print()
+        return
+
     auth = GitHubAuth()
     sources = create_source_router(auth)
 
@@ -732,6 +859,9 @@ def inspect_skill(identifier: str) -> Optional[dict]:
     auth = GitHubAuth()
     sources = create_source_router(auth)
     ident = identifier
+    local = _local_skill_preview_dict(ident)
+    if local:
+        return local
     if "/" not in ident:
         ident = _resolve_short_name(ident, sources, c)
         if not ident:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash, inspect_skill
 
 
 class _DummyLockFile:
@@ -524,3 +524,64 @@ def test_existing_categories_returns_empty_when_skills_dir_missing(monkeypatch, 
 
     from hermes_cli.skills_hub import _existing_categories
     assert _existing_categories() == []
+
+
+def test_inspect_skill_resolves_installed_local_skill(monkeypatch, tmp_path):
+    import tools.skills_tool as skills_tool
+    from agent import skill_utils
+
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "local-inspect"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: local-inspect\n"
+        "description: Local skill available only from the installed skills dir.\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    tags: [local, inspect]\n"
+        "---\n\n"
+        "# Local Inspect\n\n"
+        "This skill is not present in any hub source.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+
+    info = inspect_skill("local-inspect")
+
+    assert info is not None
+    assert info["name"] == "local-inspect"
+    assert info["source"] == "local-installed"
+    assert info["identifier"] == "local-inspect"
+    assert info["path"].endswith("local-inspect/SKILL.md")
+    assert "local" in info["tags"]
+    assert "This skill is not present" in info["skill_md_preview"]
+
+
+def test_inspect_skill_resolves_categorized_local_identifier(monkeypatch, tmp_path):
+    import tools.skills_tool as skills_tool
+    from agent import skill_utils
+
+    skills_dir = tmp_path / "skills"
+    skill_dir = skills_dir / "workflow" / "context-hygiene"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: context-hygiene\n"
+        "description: Categorized local skill.\n"
+        "---\n\n"
+        "# Context Hygiene\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+
+    info = inspect_skill("workflow:context-hygiene")
+
+    assert info is not None
+    assert info["name"] == "context-hygiene"
+    assert info["source"] == "local-installed"
+    assert info["path"].endswith("workflow/context-hygiene/SKILL.md")


### PR DESCRIPTION
## Summary
- make `hermes skills inspect <name>` resolve installed local skills from `~/.hermes/skills` before falling back to hub registries
- support categorized local identifiers like `category:skill`
- add tests covering uncategorized and categorized local skill inspection

## Why
`hermes skills list` and `skill_view()` can see drop-in local skills, but `hermes skills inspect` only searched hub/source registries. This made local installed skills appear listable/loadable but not inspectable.

## Test plan
- `python -m pytest tests/hermes_cli/test_skills_hub.py -q`
- `python -m ruff check hermes_cli/skills_hub.py tests/hermes_cli/test_skills_hub.py`