### PR TITLE
feat: add read-only Google Messages checker

### DIFF
--- a/tests/tools/test_google_messages.py
+++ b/tests/tools/test_google_messages.py
@@ -1,4 +1,6 @@
 import json
+import sys
+import types
 from pathlib import Path
 
 from tools import google_messages
@@ -55,6 +57,45 @@ def test_classify_status_pairing_required_when_qr_hint_and_no_conversations():
     assert status["ready"] is False
 
 
+def test_classify_status_pairing_required_wins_over_setup_list_items():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Messages for web Pair with QR code Scan the code on your phone",
+        [
+            {"text": "Set up Messages\nChoose an account\nContinue"},
+            {"text": "Keep your phone connected\nLearn more"},
+        ],
+    )
+
+    assert status["state"] == "pairing_required"
+    assert status["pairing_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_login_required_for_google_sign_in_url():
+    status = google_messages._classify_status(
+        "https://accounts.google.com/signin/v2/identifier",
+        "Sign in with your Google Account to continue to Messages",
+        [],
+    )
+
+    assert status["state"] == "login_required"
+    assert status["login_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_login_required_for_sign_in_page_text():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Choose an account Sign in Google Account",
+        [],
+    )
+
+    assert status["state"] == "login_required"
+    assert status["login_required"] is True
+    assert status["ready"] is False
+
+
 def test_classify_status_ready_when_conversation_candidates_parse():
     status = google_messages._classify_status(
         "https://messages.google.com/web/conversations",
@@ -66,6 +107,19 @@ def test_classify_status_ready_when_conversation_candidates_parse():
     assert status["pairing_required"] is False
     assert status["ready"] is True
     assert status["conversation_candidates"] == 1
+
+
+def test_parse_conversation_item_does_not_treat_month_name_contact_as_timestamp():
+    item = google_messages._parse_conversation_item(
+        {"text": "May Flowers\nToday\nGarden party?"}
+    )
+
+    assert item == {
+        "sender": "May Flowers",
+        "timestamp": "Today",
+        "snippet": "Garden party?",
+        "unread": False,
+    }
 
 
 def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatch, tmp_path):
@@ -81,3 +135,53 @@ def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatc
     assert "no browser goblin" in payload["error"]
     assert payload["profile_path"] == str(tmp_path / "browser-profiles" / "google-messages")
     assert "python -m playwright install chromium" in payload["setup_hint"]
+
+
+def test_with_page_cleans_up_context_and_playwright_when_goto_fails(monkeypatch, tmp_path):
+    calls = []
+
+    class FakePage:
+        def set_default_timeout(self, timeout_ms):
+            calls.append(("timeout", timeout_ms))
+
+        def goto(self, *args, **kwargs):
+            calls.append(("goto", args, kwargs))
+            raise RuntimeError("navigation exploded")
+
+    class FakeContext:
+        pages = [FakePage()]
+
+        def close(self):
+            calls.append(("context.close",))
+
+    class FakeChromium:
+        def launch_persistent_context(self, *args, **kwargs):
+            calls.append(("launch", args, kwargs))
+            return FakeContext()
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+        def stop(self):
+            calls.append(("pw.stop",))
+
+    class FakeSyncPlaywright:
+        def start(self):
+            calls.append(("start",))
+            return FakePlaywright()
+
+    fake_playwright_pkg = types.ModuleType("playwright")
+    fake_sync_api = types.ModuleType("playwright.sync_api")
+    fake_sync_api.sync_playwright = lambda: FakeSyncPlaywright()
+    monkeypatch.setitem(sys.modules, "playwright", fake_playwright_pkg)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_sync_api)
+
+    try:
+        google_messages._with_page(tmp_path / "profile", headless=True, timeout_ms=1234)
+    except RuntimeError as exc:
+        assert "navigation exploded" in str(exc)
+    else:
+        raise AssertionError("_with_page should re-raise navigation failures")
+
+    assert ("context.close",) in calls
+    assert ("pw.stop",) in calls

--- a/tests/tools/test_google_messages.py
+++ b/tests/tools/test_google_messages.py
@@ -96,6 +96,19 @@ def test_classify_status_login_required_for_sign_in_page_text():
     assert status["ready"] is False
 
 
+def test_classify_status_login_required_wins_over_generic_pairing_hint():
+    status = google_messages._classify_status(
+        "https://accounts.google.com/signin/v2/identifier",
+        "Choose an account Sign in with your Google Account to use Messages on the web",
+        [],
+    )
+
+    assert status["state"] == "login_required"
+    assert status["login_required"] is True
+    assert status["pairing_required"] is True
+    assert status["ready"] is False
+
+
 def test_classify_status_ready_when_conversation_candidates_parse():
     status = google_messages._classify_status(
         "https://messages.google.com/web/conversations",

--- a/tests/tools/test_google_messages.py
+++ b/tests/tools/test_google_messages.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from tools import google_messages
+
+
+def test_default_profile_path_uses_dedicated_google_messages_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert google_messages._default_profile_path() == (
+        Path(tmp_path) / "browser-profiles" / "google-messages"
+    )
+
+
+def test_parse_conversation_item_extracts_sender_timestamp_snippet_and_unread():
+    item = google_messages._parse_conversation_item(
+        {
+            "text": "Alice\nYesterday\nCan you grab tomatoes?",
+            "aria_label": "Unread conversation with Alice",
+            "class_name": "conversation unread",
+        }
+    )
+
+    assert item == {
+        "sender": "Alice",
+        "timestamp": "Yesterday",
+        "snippet": "Can you grab tomatoes?",
+        "unread": True,
+    }
+
+
+def test_parse_conversation_items_deduplicates_and_limits():
+    raw = [
+        {"text": "Alice\n10:34 AM\nFirst"},
+        {"text": "Alice\n10:34 AM\nFirst"},
+        {"text": "Bob\nTue\nSecond"},
+    ]
+
+    conversations = google_messages._parse_conversation_items(raw, limit=1)
+
+    assert conversations == [
+        {"sender": "Alice", "timestamp": "10:34 AM", "snippet": "First", "unread": False}
+    ]
+
+
+def test_classify_status_pairing_required_when_qr_hint_and_no_conversations():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Messages for web Pair with QR code Scan the code on your phone",
+        [],
+    )
+
+    assert status["state"] == "pairing_required"
+    assert status["pairing_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_ready_when_conversation_candidates_parse():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web/conversations",
+        "Messages",
+        [{"text": "Alice\nToday\nHello"}],
+    )
+
+    assert status["state"] == "ready"
+    assert status["pairing_required"] is False
+    assert status["ready"] is True
+    assert status["conversation_candidates"] == 1
+
+
+def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatch, tmp_path):
+    def boom(profile_path, headless, timeout_ms):
+        raise RuntimeError("no browser goblin installed")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(google_messages, "_with_page", boom)
+
+    payload = json.loads(google_messages.google_messages_status(headless=True))
+
+    assert payload["ok"] is False
+    assert "no browser goblin" in payload["error"]
+    assert payload["profile_path"] == str(tmp_path / "browser-profiles" / "google-messages")
+    assert "python -m playwright install chromium" in payload["setup_hint"]

--- a/tools/google_messages.py
+++ b/tools/google_messages.py
@@ -29,13 +29,20 @@ _TIMESTAMP_RE = re.compile(
     r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
     r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?|"
     r"(?:Yesterday|Today)|"
-    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b.*"
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|"
+    r"Nov(?:ember)?|Dec(?:ember)?)\.?\s+\d{1,2}(?:,?\s+\d{4})?"
     r")$",
     re.IGNORECASE,
 )
 
 _PAIRING_HINT_RE = re.compile(
     r"(qr code|pair(?:ing)?|scan the code|use messages on the web)",
+    re.IGNORECASE,
+)
+
+_LOGIN_REQUIRED_RE = re.compile(
+    r"(sign in|google account|choose an account|accounts\.google\.com/(?:.*signin|.*sign-in))",
     re.IGNORECASE,
 )
 
@@ -154,11 +161,16 @@ def _parse_conversation_items(raw_items: Iterable[Dict[str, Any]], limit: int = 
 
 def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
     raw_list = list(raw_items)
-    conversations = _parse_conversation_items(raw_list, limit=5)
-    pairing_required = bool(_PAIRING_HINT_RE.search(body_text or "")) and not conversations
-    logged_in = bool(conversations) or "conversations" in (url or "").lower()
+    url_text = url or ""
+    body = body_text or ""
+    pairing_required = bool(_PAIRING_HINT_RE.search(body))
+    login_required = bool(_LOGIN_REQUIRED_RE.search(f"{url_text}\n{body}"))
+    conversations = [] if pairing_required or login_required else _parse_conversation_items(raw_list, limit=5)
+    logged_in = bool(conversations) or "conversations" in url_text.lower()
     if pairing_required:
         state = "pairing_required"
+    elif login_required:
+        state = "login_required"
     elif logged_in:
         state = "ready"
     else:
@@ -166,7 +178,8 @@ def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any
     return {
         "state": state,
         "pairing_required": pairing_required,
-        "ready": logged_in and not pairing_required,
+        "login_required": login_required,
+        "ready": logged_in and not pairing_required and not login_required,
         "conversation_candidates": len(raw_list),
     }
 
@@ -179,7 +192,6 @@ def _conversation_extract_script() -> str:
     'mws-conversation-list-item',
     '[data-e2e-conversation-list-item]',
     'a[href*="/web/conversations"]',
-    '[role="listitem"]',
     'mws-conversation-list [role="button"]',
     'mws-conversation-list a'
   ];
@@ -203,25 +215,45 @@ def _conversation_extract_script() -> str:
 def _with_page(profile_path: Path, headless: bool, timeout_ms: int):
     """Launch Google Messages with a persistent context and return Playwright objects.
 
-    Caller must close the context and stop Playwright.
+    Caller must close the context and stop Playwright after successful return.
+    Partial launch/navigation failures are cleaned up here before re-raising.
     """
     from playwright.sync_api import sync_playwright
 
     profile_path.mkdir(parents=True, exist_ok=True)
-    pw = sync_playwright().start()
-    context = pw.chromium.launch_persistent_context(
-        str(profile_path),
-        headless=headless,
-        viewport={"width": 1280, "height": 900},
-    )
-    page = context.pages[0] if context.pages else context.new_page()
-    page.set_default_timeout(timeout_ms)
-    page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
     try:
-        page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
-    except Exception:
+        profile_path.chmod(0o700)
+    except OSError:
         pass
-    return pw, context, page
+    pw = None
+    context = None
+    try:
+        pw = sync_playwright().start()
+        context = pw.chromium.launch_persistent_context(
+            str(profile_path),
+            headless=headless,
+            viewport={"width": 1280, "height": 900},
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.set_default_timeout(timeout_ms)
+        page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
+        try:
+            page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
+        except Exception:
+            pass
+        return pw, context, page
+    except Exception:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:
+                pass
+        if pw is not None:
+            try:
+                pw.stop()
+            except Exception:
+                pass
+        raise
 
 
 def google_messages_status(
@@ -315,7 +347,7 @@ registry.register(
         "parameters": {
             "type": "object",
             "properties": {
-                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to the active Hermes profile home under browser-profiles/google-messages."},
                 "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so QR pairing is visible."},
                 "timeout_ms": {"type": "integer", "description": "Navigation/detection timeout in milliseconds."},
             },
@@ -345,7 +377,7 @@ registry.register(
             "type": "object",
             "properties": {
                 "limit": {"type": "integer", "description": "Maximum conversation previews to return, capped at 50."},
-                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to the active Hermes profile home under browser-profiles/google-messages."},
                 "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so pairing problems are visible."},
                 "timeout_ms": {"type": "integer", "description": "Navigation/extraction timeout in milliseconds."},
             },

--- a/tools/google_messages.py
+++ b/tools/google_messages.py
@@ -167,10 +167,10 @@ def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any
     login_required = bool(_LOGIN_REQUIRED_RE.search(f"{url_text}\n{body}"))
     conversations = [] if pairing_required or login_required else _parse_conversation_items(raw_list, limit=5)
     logged_in = bool(conversations) or "conversations" in url_text.lower()
-    if pairing_required:
-        state = "pairing_required"
-    elif login_required:
+    if login_required:
         state = "login_required"
+    elif pairing_required:
+        state = "pairing_required"
     elif logged_in:
         state = "ready"
     else:

--- a/tools/google_messages.py
+++ b/tools/google_messages.py
@@ -1,0 +1,363 @@
+"""Read-only Google Messages for Web checker tools.
+
+Milestone 1 is intentionally conservative:
+
+* use a dedicated persistent browser profile by default;
+* open/navigate only to https://messages.google.com/web;
+* report pairing/login status;
+* extract the visible conversation list only;
+* never open individual threads and never send messages.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+GOOGLE_MESSAGES_URL = "https://messages.google.com/web"
+DEFAULT_PROFILE_SUBDIR = Path("browser-profiles") / "google-messages"
+_TOOLSET = "google_messages"
+
+_TIMESTAMP_RE = re.compile(
+    r"^(?:"
+    r"\d{1,2}:\d{2}(?:\s?[AP]M)?|"
+    r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
+    r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?|"
+    r"(?:Yesterday|Today)|"
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b.*"
+    r")$",
+    re.IGNORECASE,
+)
+
+_PAIRING_HINT_RE = re.compile(
+    r"(qr code|pair(?:ing)?|scan the code|use messages on the web)",
+    re.IGNORECASE,
+)
+
+
+def _default_profile_path() -> Path:
+    """Return the profile directory dedicated to Google Messages for Web."""
+    return get_hermes_home() / DEFAULT_PROFILE_SUBDIR
+
+
+def _resolve_profile_path(profile_path: Optional[str]) -> Path:
+    if profile_path:
+        return Path(profile_path).expanduser()
+    return _default_profile_path()
+
+
+def check_google_messages_requirements() -> bool:
+    """Return True when local Playwright is importable.
+
+    Chromium browser installation is validated lazily by Playwright at runtime so
+    the tool can return a clear setup error instead of disappearing because the
+    Python package is installed but browser bits are missing.
+    """
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _clean_lines(text: str) -> List[str]:
+    seen: set[str] = set()
+    lines: List[str] = []
+    for raw in (text or "").splitlines():
+        line = re.sub(r"\s+", " ", raw).strip()
+        if not line or line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return lines
+
+
+def _looks_like_timestamp(line: str) -> bool:
+    return bool(_TIMESTAMP_RE.match(line.strip()))
+
+
+def _detect_unread(raw: Dict[str, Any], text: str) -> bool:
+    attrs = " ".join(
+        str(raw.get(key) or "")
+        for key in ("aria_label", "class_name", "data_unread", "role")
+    )
+    haystack = f"{attrs}\n{text}".lower()
+    if re.search(r"\bunread\b", haystack):
+        return True
+    if str(raw.get("data_unread") or "").lower() in {"true", "1", "yes"}:
+        return True
+    return False
+
+
+def _parse_conversation_item(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize one raw DOM candidate into a conversation preview.
+
+    The Google Messages Web DOM is private and changes over time, so this parser
+    accepts loose text/ARIA/class candidates and returns best-effort fields.
+    """
+    text = str(raw.get("text") or raw.get("inner_text") or "")
+    aria = str(raw.get("aria_label") or "")
+    lines = _clean_lines(text or aria)
+    if not lines:
+        return None
+
+    sender: Optional[str] = None
+    timestamp: Optional[str] = None
+    snippet_parts: List[str] = []
+
+    for line in lines:
+        lower = line.lower()
+        if lower in {"you", "me", "sent", "delivered", "read"}:
+            snippet_parts.append(line)
+            continue
+        if timestamp is None and _looks_like_timestamp(line):
+            timestamp = line
+            continue
+        if sender is None:
+            sender = line
+            continue
+        snippet_parts.append(line)
+
+    if sender is None and aria:
+        sender = aria.split(",", 1)[0].strip() or None
+
+    snippet = " ".join(snippet_parts).strip() or None
+    return {
+        "sender": sender,
+        "timestamp": timestamp,
+        "snippet": snippet,
+        "unread": _detect_unread(raw, text or aria),
+    }
+
+
+def _parse_conversation_items(raw_items: Iterable[Dict[str, Any]], limit: int = 20) -> List[Dict[str, Any]]:
+    conversations: List[Dict[str, Any]] = []
+    seen: set[tuple[Any, Any, Any]] = set()
+    for raw in raw_items:
+        item = _parse_conversation_item(raw)
+        if not item or not item.get("sender"):
+            continue
+        key = (item.get("sender"), item.get("timestamp"), item.get("snippet"))
+        if key in seen:
+            continue
+        seen.add(key)
+        conversations.append(item)
+        if len(conversations) >= limit:
+            break
+    return conversations
+
+
+def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    raw_list = list(raw_items)
+    conversations = _parse_conversation_items(raw_list, limit=5)
+    pairing_required = bool(_PAIRING_HINT_RE.search(body_text or "")) and not conversations
+    logged_in = bool(conversations) or "conversations" in (url or "").lower()
+    if pairing_required:
+        state = "pairing_required"
+    elif logged_in:
+        state = "ready"
+    else:
+        state = "unknown"
+    return {
+        "state": state,
+        "pairing_required": pairing_required,
+        "ready": logged_in and not pairing_required,
+        "conversation_candidates": len(raw_list),
+    }
+
+
+def _conversation_extract_script() -> str:
+    # Kept as a string so tests can focus on parser logic without Playwright.
+    return r"""
+() => {
+  const selectors = [
+    'mws-conversation-list-item',
+    '[data-e2e-conversation-list-item]',
+    'a[href*="/web/conversations"]',
+    '[role="listitem"]',
+    'mws-conversation-list [role="button"]',
+    'mws-conversation-list a'
+  ];
+  const nodes = [];
+  for (const selector of selectors) {
+    document.querySelectorAll(selector).forEach((node) => {
+      if (!nodes.includes(node)) nodes.push(node);
+    });
+  }
+  return nodes.slice(0, 80).map((node) => ({
+    text: node.innerText || node.textContent || '',
+    aria_label: node.getAttribute('aria-label') || '',
+    class_name: node.getAttribute('class') || '',
+    data_unread: node.getAttribute('data-unread') || node.getAttribute('aria-current') || '',
+    role: node.getAttribute('role') || ''
+  }));
+}
+"""
+
+
+def _with_page(profile_path: Path, headless: bool, timeout_ms: int):
+    """Launch Google Messages with a persistent context and return Playwright objects.
+
+    Caller must close the context and stop Playwright.
+    """
+    from playwright.sync_api import sync_playwright
+
+    profile_path.mkdir(parents=True, exist_ok=True)
+    pw = sync_playwright().start()
+    context = pw.chromium.launch_persistent_context(
+        str(profile_path),
+        headless=headless,
+        viewport={"width": 1280, "height": 900},
+    )
+    page = context.pages[0] if context.pages else context.new_page()
+    page.set_default_timeout(timeout_ms)
+    page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
+    try:
+        page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
+    except Exception:
+        pass
+    return pw, context, page
+
+
+def google_messages_status(
+    profile_path: Optional[str] = None,
+    headless: bool = False,
+    timeout_ms: int = 15000,
+) -> str:
+    """Open Google Messages for Web and report pairing/login status.
+
+    This is read-only. It navigates to the web app but does not click a
+    conversation and does not send or type anything.
+    """
+    resolved_profile = _resolve_profile_path(profile_path)
+    try:
+        pw, context, page = _with_page(resolved_profile, headless, timeout_ms)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": str(exc),
+            "profile_path": str(resolved_profile),
+            "setup_hint": "Install Playwright and Chromium: pip install playwright && python -m playwright install chromium",
+        })
+    try:
+        body_text = page.locator("body").inner_text(timeout=min(timeout_ms, 5000))
+        raw_items = page.evaluate(_conversation_extract_script())
+        status = _classify_status(page.url, body_text, raw_items)
+        return json.dumps({
+            "ok": True,
+            "url": page.url,
+            "profile_path": str(resolved_profile),
+            **status,
+            "safety": "read-only status check; no thread opened and no message sent",
+        })
+    finally:
+        context.close()
+        pw.stop()
+
+
+def google_messages_conversations(
+    limit: int = 20,
+    profile_path: Optional[str] = None,
+    headless: bool = False,
+    timeout_ms: int = 15000,
+) -> str:
+    """Return visible Google Messages conversation-list previews only.
+
+    The tool never opens individual threads. Snippets are whatever the list UI
+    already exposes; opening a thread is deliberately out of scope for milestone 1.
+    """
+    limit = max(1, min(int(limit or 20), 50))
+    resolved_profile = _resolve_profile_path(profile_path)
+    try:
+        pw, context, page = _with_page(resolved_profile, headless, timeout_ms)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": str(exc),
+            "profile_path": str(resolved_profile),
+            "setup_hint": "Install Playwright and Chromium: pip install playwright && python -m playwright install chromium",
+        })
+    try:
+        body_text = page.locator("body").inner_text(timeout=min(timeout_ms, 5000))
+        raw_items = page.evaluate(_conversation_extract_script())
+        status = _classify_status(page.url, body_text, raw_items)
+        conversations = _parse_conversation_items(raw_items, limit=limit)
+        return json.dumps({
+            "ok": True,
+            "url": page.url,
+            "profile_path": str(resolved_profile),
+            **status,
+            "count": len(conversations),
+            "conversations": conversations,
+            "safety": "conversation-list extraction only; no thread opened and no message sent",
+        })
+    finally:
+        context.close()
+        pw.stop()
+
+
+registry.register(
+    name="google_messages_status",
+    toolset=_TOOLSET,
+    schema={
+        "name": "google_messages_status",
+        "description": (
+            "Read-only Google Messages for Web status/pairing check. Opens "
+            "messages.google.com/web using a dedicated persistent profile and "
+            "reports whether manual QR pairing/login appears needed. Does not "
+            "open threads or send messages."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so QR pairing is visible."},
+                "timeout_ms": {"type": "integer", "description": "Navigation/detection timeout in milliseconds."},
+            },
+        },
+    },
+    handler=lambda args, **kw: google_messages_status(
+        profile_path=args.get("profile_path"),
+        headless=bool(args.get("headless", False)),
+        timeout_ms=int(args.get("timeout_ms", 15000)),
+    ),
+    check_fn=check_google_messages_requirements,
+    description="Read-only Google Messages for Web pairing/status check",
+    emoji="💬",
+)
+
+registry.register(
+    name="google_messages_conversations",
+    toolset=_TOOLSET,
+    schema={
+        "name": "google_messages_conversations",
+        "description": (
+            "Read-only Google Messages for Web conversation-list extraction. "
+            "Returns visible sender/name, timestamp, snippet, and defensively "
+            "detected unread-ish flag. Never opens individual threads and never sends messages."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Maximum conversation previews to return, capped at 50."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so pairing problems are visible."},
+                "timeout_ms": {"type": "integer", "description": "Navigation/extraction timeout in milliseconds."},
+            },
+        },
+    },
+    handler=lambda args, **kw: google_messages_conversations(
+        limit=int(args.get("limit", 20)),
+        profile_path=args.get("profile_path"),
+        headless=bool(args.get("headless", False)),
+        timeout_ms=int(args.get("timeout_ms", 15000)),
+    ),
+    check_fn=check_google_messages_requirements,
+    description="Read-only Google Messages for Web conversation previews",
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -158,6 +158,12 @@ TOOLSETS = {
         "tools": ["send_message"],
         "includes": []
     },
+
+    "google_messages": {
+        "description": "Read-only Google Messages for Web status and conversation-list previews",
+        "tools": ["google_messages_status", "google_messages_conversations"],
+        "includes": []
+    },
     
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",

--- a/website/docs/user-guide/messaging/google-messages.md
+++ b/website/docs/user-guide/messaging/google-messages.md
@@ -1,0 +1,75 @@
+---
+title: Google Messages for Web
+---
+
+# Google Messages for Web checker
+
+Hermes can inspect Jake's existing Pixel/Android text-message inbox through Google Messages for Web using a local Playwright browser profile. This is separate from the Twilio-backed SMS gateway: Twilio lets people text a Hermes-owned number, while this checker previews the inbox already paired to Google Messages on the phone.
+
+Milestone 1 is intentionally read-only and boring in the best possible way:
+
+- open `https://messages.google.com/web` in a dedicated persistent browser profile;
+- report whether manual QR pairing/login appears needed;
+- extract only the visible conversation list: sender/name, timestamp if visible, snippet, and a defensive unread-ish flag;
+- never open individual threads by default;
+- never type, draft, or send messages.
+
+## Setup
+
+Install Playwright if it is not already available in the Hermes environment:
+
+```bash
+pip install playwright
+python -m playwright install chromium
+```
+
+Enable or request the `google_messages` toolset for the Hermes session/profile that should use it. The toolset exposes:
+
+- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, or `unknown`.
+- `google_messages_conversations` — returns visible conversation-list previews only.
+
+By default both tools use this persistent profile:
+
+```text
+~/.hermes/browser-profiles/google-messages
+```
+
+That dedicated profile keeps Google Messages cookies/session state away from the normal browser automation profile and makes it easier to revoke, inspect, or delete the pairing later.
+
+## Manual QR pairing
+
+The first status check should usually run non-headless so the QR code can be seen:
+
+```text
+google_messages_status(headless=false)
+```
+
+On the Pixel:
+
+1. Open Google Messages.
+2. Open device pairing / Messages for web.
+3. Scan the QR code shown in the Hermes-controlled browser window.
+
+After pairing, future checks can reuse the persistent profile. If the profile is deleted, if Google expires the session, or if the phone unpairs the browser, `google_messages_status` should report that pairing appears needed again.
+
+## Privacy and read-status caveats
+
+This checker is for preview triage, not durable archiving.
+
+Important caveats:
+
+- Conversation-list snippets may still contain private message text and may enter Hermes transcripts/logs if an agent includes them in a response. Do not store more than necessary.
+- Opening an individual conversation may mark it read. Milestone 1 does not open threads for exactly this reason.
+- Google can change the Messages Web DOM at any time. Selectors and unread detection are defensive best-effort, not a contract.
+- RCS/SMS/MMS behavior depends on what Google Messages exposes through the paired web UI.
+- Sending is out of scope. Future reply support should stay draft-only/manual until read-status and consent boundaries are proven.
+
+## Removing local state
+
+To force a fresh pairing, close any checker browser window and remove the dedicated profile directory:
+
+```bash
+rm -rf ~/.hermes/browser-profiles/google-messages
+```
+
+Also unpair the browser from the Pixel's Google Messages device-pairing screen when you no longer want Hermes to have access.

--- a/website/docs/user-guide/messaging/google-messages.md
+++ b/website/docs/user-guide/messaging/google-messages.md
@@ -25,14 +25,16 @@ python -m playwright install chromium
 
 Enable or request the `google_messages` toolset for the Hermes session/profile that should use it. The toolset exposes:
 
-- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, or `unknown`.
+- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, `login_required`, or `unknown`.
 - `google_messages_conversations` — returns visible conversation-list previews only.
 
-By default both tools use this persistent profile:
+By default both tools use this persistent profile under the active Hermes profile home:
 
 ```text
 ~/.hermes/browser-profiles/google-messages
 ```
+
+For named Hermes profiles, replace `~/.hermes` with that profile's home directory. The checker creates the browser-profile directory with owner-only permissions (`0700`) where the platform allows it, because the profile contains paired Google session state.
 
 That dedicated profile keeps Google Messages cookies/session state away from the normal browser automation profile and makes it easier to revoke, inspect, or delete the pairing later.
 
@@ -71,5 +73,7 @@ To force a fresh pairing, close any checker browser window and remove the dedica
 ```bash
 rm -rf ~/.hermes/browser-profiles/google-messages
 ```
+
+For named Hermes profiles, remove the same `browser-profiles/google-messages` subdirectory from that profile's Hermes home instead.
 
 Also unpair the browser from the Pixel's Google Messages device-pairing screen when you no longer want Hermes to have access.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -129,6 +129,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/signal',
         'user-guide/messaging/email',
         'user-guide/messaging/sms',
+        'user-guide/messaging/google-messages',
         'user-guide/messaging/homeassistant',
         'user-guide/messaging/mattermost',
         'user-guide/messaging/matrix',


### PR DESCRIPTION
## Summary
- add opt-in google_messages toolset with read-only Google Messages for Web status and conversation-list preview tools
- use a dedicated persistent browser profile at ~/.hermes/browser-profiles/google-messages by default
- document manual QR pairing, privacy/read-status caveats, and no-send/no-thread-opening milestone boundaries

## Tests
- scripts/run_tests.sh tests/tools/test_google_messages.py (fails before pytest: shared venv has no pip while wrapper tries to install pytest-split)
- source /home/methodician/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_google_messages.py -q (6 passed in 2.16s)
- source /home/methodician/.hermes/hermes-agent/venv/bin/activate && python -m py_compile tools/google_messages.py tests/tools/test_google_messages.py
