### PR TITLE
fix(tts): report configured TTS backends accurately in setup and status surfaces

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import importlib.util
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Set
 
@@ -153,10 +154,52 @@ def _tts_label(current_provider: str) -> str:
         "elevenlabs": "ElevenLabs",
         "edge": "Edge TTS",
         "xai": "xAI TTS",
+        "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
+        "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
+        "kittentts": "KittenTTS",
+        "piper": "Piper",
     }
     return mapping.get(current_provider or "edge", current_provider or "Edge TTS")
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except Exception:
+        return False
+
+
+def _tts_provider_available(
+    provider: str,
+    *,
+    managed_tts_available: bool,
+    direct_openai_tts: bool,
+    direct_elevenlabs: bool,
+) -> bool:
+    provider = provider or "edge"
+    if provider == "edge":
+        return True
+    if provider == "openai":
+        return bool(managed_tts_available or direct_openai_tts)
+    if provider == "elevenlabs":
+        return bool(direct_elevenlabs)
+    if provider == "xai":
+        return bool(get_env_value("XAI_API_KEY"))
+    if provider == "minimax":
+        return bool(get_env_value("MINIMAX_API_KEY"))
+    if provider == "gemini":
+        return bool(get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY"))
+    if provider == "mistral":
+        return bool(get_env_value("MISTRAL_API_KEY"))
+    if provider == "neutts":
+        return _module_available("neutts")
+    if provider == "kittentts":
+        return _module_available("kittentts")
+    if provider == "piper":
+        return _module_available("piper")
+    return False
 
 
 def _resolve_browser_feature_state(
@@ -353,11 +396,11 @@ def get_nous_subscription_features(
         and managed_tts_available
         and not direct_openai_tts
     )
-    tts_available = bool(
-        tts_current_provider in {"edge", "neutts"}
-        or (tts_current_provider == "openai" and (managed_tts_available or direct_openai_tts))
-        or (tts_current_provider == "elevenlabs" and direct_elevenlabs)
-        or (tts_current_provider == "mistral" and bool(get_env_value("MISTRAL_API_KEY")))
+    tts_available = _tts_provider_available(
+        tts_current_provider,
+        managed_tts_available=managed_tts_available,
+        direct_openai_tts=direct_openai_tts,
+        direct_elevenlabs=direct_elevenlabs,
     )
     tts_active = bool(tts_tool_enabled and tts_available)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -464,6 +464,8 @@ def _print_setup_summary(config: dict, hermes_home):
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
         tool_status.append(("Text-to-Speech (OpenAI)", True, None))
+    elif tts_provider == "xai" and get_env_value("XAI_API_KEY"):
+        tool_status.append(("Text-to-Speech (xAI)", True, None))
     elif tts_provider == "minimax" and get_env_value("MINIMAX_API_KEY"):
         tool_status.append(("Text-to-Speech (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -507,3 +507,35 @@ def test_setup_summary_does_not_mark_incomplete_browserbase_as_available(tmp_pat
     assert "Browser Automation (Browserbase)" not in output
     assert "Browser Automation" in output
     assert "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID" in output
+
+
+def test_setup_summary_shows_xai_tts_when_configured(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("XAI_API_KEY", "xai-key")
+
+    cfg = load_config()
+    cfg["tts"] = {"provider": "xai"}
+    save_config(cfg)
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_nous_subscription_features",
+        lambda config: NousSubscriptionFeatures(
+            subscribed=False,
+            nous_auth_present=False,
+            provider_is_nous=False,
+            features={
+                "web": NousFeatureState("web", "Web tools", True, False, False, False, False, True, ""),
+                "image_gen": NousFeatureState("image_gen", "Image generation", True, False, False, False, False, True, ""),
+                "tts": NousFeatureState("tts", "xAI TTS", True, True, True, False, True, True, "xAI TTS"),
+                "browser": NousFeatureState("browser", "Browser automation", True, False, False, False, False, True, ""),
+                "modal": NousFeatureState("modal", "Modal execution", False, False, False, False, False, True, "local"),
+            },
+        ),
+    )
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    _print_setup_summary(load_config(), tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Text-to-Speech (xAI)" in output

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -2,7 +2,11 @@
 
 from types import SimpleNamespace
 
-from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
+from hermes_cli.nous_subscription import (
+    NousFeatureState,
+    NousSubscriptionFeatures,
+    get_nous_subscription_features,
+)
 
 
 def _patch_common_status_deps(monkeypatch, status_mod, tmp_path, *, openai_base_url=""):
@@ -153,3 +157,63 @@ def test_show_status_reports_empty_lmstudio_listing_as_reachable(monkeypatch, ca
     out = capsys.readouterr().out
     assert "LM Studio" in out
     assert "reachable (0 model(s)) at http://127.0.0.1:1234/v1" in out
+
+
+def test_nous_subscription_tts_feature_detects_xai_provider(monkeypatch):
+    monkeypatch.setattr("hermes_cli.nous_subscription.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.nous_subscription.get_nous_auth_status", lambda: {})
+    monkeypatch.setattr("hermes_cli.nous_subscription.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription._toolset_enabled", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("hermes_cli.nous_subscription.resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr("hermes_cli.nous_subscription.fal_key_is_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.is_managed_tool_gateway_ready", lambda _name: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.normalize_browser_cloud_provider", lambda value: value or "local")
+    monkeypatch.setattr("hermes_cli.nous_subscription.normalize_modal_mode", lambda value: value)
+    monkeypatch.setattr(
+        "hermes_cli.nous_subscription.resolve_modal_backend_state",
+        lambda *_args, **_kwargs: {"selected_backend": "local"},
+    )
+    monkeypatch.setattr("hermes_cli.nous_subscription._has_agent_browser", lambda: False)
+
+    env = {"XAI_API_KEY": "xai-key"}
+
+    def fake_get_env_value(name: str):
+        return env.get(name, "")
+
+    monkeypatch.setattr("hermes_cli.nous_subscription.get_env_value", fake_get_env_value)
+
+    features = get_nous_subscription_features({"tts": {"provider": "xai"}})
+
+    assert features.tts.available is True
+    assert features.tts.active is True
+    assert features.tts.current_provider == "xAI TTS"
+
+
+def test_nous_subscription_tts_feature_requires_local_engine_for_kittentts(monkeypatch):
+    monkeypatch.setattr("hermes_cli.nous_subscription.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.nous_subscription.get_nous_auth_status", lambda: {})
+    monkeypatch.setattr("hermes_cli.nous_subscription.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription._toolset_enabled", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("hermes_cli.nous_subscription.resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr("hermes_cli.nous_subscription.fal_key_is_configured", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.is_managed_tool_gateway_ready", lambda _name: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.normalize_browser_cloud_provider", lambda value: value or "local")
+    monkeypatch.setattr("hermes_cli.nous_subscription.normalize_modal_mode", lambda value: value)
+    monkeypatch.setattr(
+        "hermes_cli.nous_subscription.resolve_modal_backend_state",
+        lambda *_args, **_kwargs: {"selected_backend": "local"},
+    )
+    monkeypatch.setattr("hermes_cli.nous_subscription._has_agent_browser", lambda: False)
+    monkeypatch.setattr("hermes_cli.nous_subscription.get_env_value", lambda _name: "")
+    monkeypatch.setattr(
+        "hermes_cli.nous_subscription.importlib.util.find_spec",
+        lambda name: object() if name == "neutts" else None,
+    )
+
+    features = get_nous_subscription_features({"tts": {"provider": "kittentts"}})
+
+    assert features.tts.available is False
+    assert features.tts.active is False
+    assert features.tts.current_provider == "KittenTTS"


### PR DESCRIPTION
## What does this PR do?

Fixes inaccurate TTS capability reporting in setup and status-related surfaces.

Hermes already supports several TTS providers beyond the small subset that the
subscription/status helper was treating as available. As a result, valid
configurations such as `tts.provider: xai` could be shown as unavailable or be
misreported in the setup summary.

This PR aligns TTS provider detection with the providers that are already
supported by configuration and runtime flow, and adds focused regression tests
to keep that behavior stable.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/nous_subscription.py`
  - Expanded TTS provider labeling to cover supported providers such as xAI,
    MiniMax, Gemini, KittenTTS, and Piper.
  - Introduced centralized provider-specific TTS availability checks so feature
    status reflects the actual configured backend more accurately.

- `hermes_cli/setup.py`
  - Updated setup summary reporting so configured xAI TTS is displayed
    correctly instead of falling back to the generic Edge TTS label.

- `tests/hermes_cli/test_status_model_provider.py`
  - Added regression coverage for xAI TTS detection.
  - Added regression coverage ensuring local-engine-backed providers are only
    reported available when their runtime dependency is actually present.

- `tests/hermes_cli/test_setup_model_provider.py`
  - Added regression coverage for xAI TTS setup summary output.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/hermes_cli/test_status_model_provider.py tests/hermes_cli/test_setup_model_provider.py`
2. Confirm both targeted test files pass.
3. Optionally configure `tts.provider: xai` with `XAI_API_KEY` set and verify
   the setup summary shows `Text-to-Speech (xAI)`.

## Checklist Notes

- Contributing guide considered: yes
- Conventional commit title: `fix(tts): report configured TTS backends accurately in setup and status surfaces`
- Duplicate PR search: checked against provided forbidden/DONE list
- Scope: single-purpose
- Tests added/updated: yes
- Platform tested: Windows
- Docs updated or N/A: N/A
- cli-config.yaml.example updated or N/A: N/A
- AGENTS.md/CONTRIBUTING.md updated or N/A: N/A
- Cross-platform impact considered: yes
- Tool schema/description updated or N/A: N/A
