### PR TITLE
fix: add hardcoded fallback path in _resolve_hermes_bin for symlink environments  

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3895,10 +3895,14 @@ def _resolve_hermes_argv() -> list[str]:
 
     hermes_bin = shutil.which("hermes")
     if hermes_bin:
-        return [hermes_bin]
-    # Fallback to the module form. ``hermes_cli.main`` is the actual
-    # console-script target declared in pyproject.toml, NOT a top-level
-    # ``hermes`` package — there is no ``hermes`` package to import.
+         return [hermes_bin]
+    # Second fallback: hardcoded well-known path for environments where
+    # shutil.which() fails to resolve symlinks (e.g. /usr/local/bin/hermes
+    # → /root/.local/bin/hermes) despite PATH being correct.
+    _HARDCODED_FALLBACK = "/usr/local/bin/hermes"
+    if os.path.isfile(_HARDCODED_FALLBACK) and os.access(_HARDCODED_FALLBACK, os.X_OK):
+        return [_HARDCODED_FALLBACK]
+    # Final fallback: module form for venv setups without hermes shim on PATH.
     return [sys.executable, "-m", "hermes_cli.main"]
 
 


### PR DESCRIPTION
…nvs   #24491

## What does this PR do?


Fixes #24491

shutil.which("hermes") returns None in certain environments where the binary
is installed as a symlink (e.g. /usr/local/bin/hermes → /root/.local/bin/hermes)
despite PATH being correctly set.

Added a hardcoded fallback path check before falling back to sys.executable,
preventing the dispatcher from deadlocking when shutil.which() fails silently.


