### PR TITLE
fix(gateway): suppress empty-response lifecycle status in chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1047,6 +1047,22 @@ def _normalize_empty_agent_response(
     return response
 
 
+def _should_suppress_gateway_status(event_type: str, message: str) -> bool:
+    """Return True for backend lifecycle diagnostics chat gateways keep silent.
+
+    Gateway turns can intentionally produce an empty response as a no-op
+    (for example quiet-by-default group bots). Empty-response retry diagnostics
+    are useful in CLI logs but must not leak into user chat channels.
+    """
+    if event_type != "lifecycle" or not isinstance(message, str):
+        return False
+    msg = message.strip()
+    return (
+        msg.startswith("⚠️ Empty response from model — retrying")
+        or msg.startswith("❌ Model returned no content after all retries")
+    )
+
+
 def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
     """Return True only when a gateway turn really completed successfully.
 
@@ -13913,6 +13929,9 @@ class GatewayRunner:
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
+                return
+            if _should_suppress_gateway_status(event_type, message):
+                logger.debug("suppressed empty-response lifecycle status for gateway chat")
                 return
             try:
                 _fut = asyncio.run_coroutine_threadsafe(

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -417,6 +417,28 @@ class TestGatewaySurfacesNullResponse:
 
         assert result == "Hello!"
 
+    def test_gateway_suppresses_empty_response_lifecycle_status(self):
+        """Gateway should not leak empty-response retry diagnostics into chat."""
+        from gateway.run import _should_suppress_gateway_status
+
+        assert _should_suppress_gateway_status(
+            "lifecycle", "⚠️ Empty response from model — retrying (1/3)"
+        )
+        assert _should_suppress_gateway_status(
+            "lifecycle",
+            "❌ Model returned no content after all retries. No fallback providers configured.",
+        )
+
+    def test_gateway_keeps_other_status_messages_visible(self):
+        """Only empty-response diagnostics are suppressed."""
+        from gateway.run import _should_suppress_gateway_status
+
+        assert not _should_suppress_gateway_status("lifecycle", "Compacting context…")
+        assert not _should_suppress_gateway_status(
+            "warn", "⚠️ Empty response from model — retrying (1/3)"
+        )
+        assert not _should_suppress_gateway_status("lifecycle", None)
+
 
 # ===========================================================================
 # Prune: finalize_orphaned_compression_sessions


### PR DESCRIPTION
## Summary
- suppress empty-response retry/final lifecycle status messages before gateway adapters send them to chat
- keep other lifecycle/status messages visible
- complements #23672, which handles final empty response normalization but not status_callback diagnostics

## Why
Quiet-by-default group bots can intentionally return an empty response as a no-op. Today the final response can be silent, but lifecycle diagnostics like:

```text
⚠️ Empty response from model — retrying (1/3)
❌ Model returned no content after all retries. No fallback providers configured.
```

still leak into Telegram/other chat gateways via the lifecycle status callback.

## Test Plan
```bash
docker run --rm -v /usr/local/lib/hermes-agent:/src -w /src hermes-agent \
  /opt/hermes/.venv/bin/python -m pytest \
  tests/test_lazy_session_regressions.py -q \
  -k GatewaySurfacesNullResponse -o addopts=
```

Result: `7 passed, 12 deselected`.
