### PR TITLE
fix(acp): pass --skills arg through to ACP session preloader

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -620,6 +620,27 @@ class SessionManager:
         except Exception:
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
 
+        # Inject preloaded skills via HERMES_ACP_SKILLS env var (mirrors TUI pattern).
+        import os as _os
+
+        _skills_raw = _os.environ.get("HERMES_ACP_SKILLS", "")
+        if _skills_raw:
+            try:
+                from agent.skill_commands import build_preloaded_skills_prompt
+
+                _skills_list = [
+                    p.strip()
+                    for p in _skills_raw.replace("\n", ",").split(",")
+                    if p.strip()
+                ]
+                _skills_prompt, _loaded, _missing = build_preloaded_skills_prompt(
+                    _skills_list, task_id=session_id
+                )
+                if _skills_prompt:
+                    kwargs["ephemeral_system_prompt"] = _skills_prompt
+            except Exception:
+                logger.debug("Failed to load ACP preloaded skills", exc_info=True)
+
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11388,10 +11388,37 @@ Examples:
         help="Run Hermes Agent as an ACP (Agent Client Protocol) server",
         description="Start Hermes Agent in ACP mode for editor integration (VS Code, Zed, JetBrains)",
     )
+    acp_parser.add_argument(
+        "-s",
+        "--skills",
+        action="append",
+        default=None,
+        metavar="SKILL",
+        help="Preload one or more skills into the ACP session (can be passed multiple times)",
+    )
     _add_accept_hooks_flag(acp_parser)
 
     def cmd_acp(args):
         """Launch Hermes Agent as an ACP server."""
+        import os
+
+        skills = getattr(args, "skills", None)
+        if skills:
+            # Mirror the same env-var bridge that TUI mode uses (tui_gateway/server.py).
+            # Flatten nested list-of-lists (action="append" can produce [[a,b], [c]]).
+            seen: set[str] = set()
+            flat: list[str] = []
+            for item in skills:
+                for part in str(item).replace("\n", ",").split(","):
+                    part = part.strip()
+                    if part and part not in seen:
+                        seen.add(part)
+                        flat.append(part)
+            if flat:
+                os.environ["HERMES_ACP_SKILLS"] = ",".join(flat)
+        else:
+            os.environ.pop("HERMES_ACP_SKILLS", None)
+
         try:
             from acp_adapter.entry import main as acp_main
 

--- a/tests/acp_adapter/test_acp_skills_preload.py
+++ b/tests/acp_adapter/test_acp_skills_preload.py
@@ -1,0 +1,228 @@
+"""Tests for ACP skills preloading via HERMES_ACP_SKILLS env var (fixes #24466)."""
+import sys
+from types import ModuleType
+
+import pytest
+from acp.schema import TextContentBlock
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+class FakeAgent:
+    def __init__(self):
+        self.model = "fake-model"
+        self.provider = "fake-provider"
+        self.enabled_toolsets = ["hermes-acp"]
+        self.disabled_toolsets = []
+        self.tools = []
+        self.valid_tool_names = set()
+        self.steers = []
+        self.runs = []
+
+    def steer(self, text):
+        self.steers.append(text)
+        return True
+
+    def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        self.runs.append(user_message)
+        messages = list(conversation_history or [])
+        messages.append({"role": "user", "content": user_message})
+        final = f"ran: {user_message}"
+        messages.append({"role": "assistant", "content": final})
+        return {"final_response": final, "messages": messages}
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+def _patch_module(monkeypatch, patches, name, **attrs):
+    """Register a minimal fake module via monkeypatch — same pattern as test_acp_real_agent_gets_session_db_for_recall."""
+    module = ModuleType(name)
+    for k, v in attrs.items():
+        setattr(module, k, v)
+    patches[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+class TestAcpSkillsPreload:
+    """Test HERMES_ACP_SKILLS env var → ephemeral_system_prompt flow in _make_agent."""
+
+    def test_skills_env_var_injects_ephemeral_system_prompt(self, monkeypatch):
+        """When HERMES_ACP_SKILLS is set, _make_agent passes it as ephemeral_system_prompt."""
+        captured = {}
+        sentinel_db = NoopDb()
+        fake_skills_prompt = "[IMPORTANT: test-skill is preloaded]"
+        called_with = {}
+
+        def fake_build(skill_list, task_id=None):
+            called_with["skill_list"] = skill_list
+            called_with["task_id"] = task_id
+            return (fake_skills_prompt, ["test-skill"], [])
+
+        class CapturingAgent(FakeAgent):
+            def __init__(self, **kwargs):
+                super().__init__()
+                captured.update(kwargs)
+
+        patches = {}
+        _patch_module(
+            monkeypatch, patches, "run_agent",
+            AIAgent=CapturingAgent,
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kw: {
+                "provider": "p", "api_mode": "chat_completions",
+                "base_url": "u", "api_key": "***", "command": None, "args": [],
+            },
+        )
+        _patch_module(
+            monkeypatch, patches, "agent.skill_commands",
+            build_preloaded_skills_prompt=fake_build,
+        )
+
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "test-skill")
+        try:
+            manager = SessionManager(db=sentinel_db)
+            agent = manager._make_agent(session_id="acp-skills-session", cwd=".")
+
+            assert isinstance(agent, CapturingAgent)
+            assert captured.get("ephemeral_system_prompt") == fake_skills_prompt
+            assert called_with["skill_list"] == ["test-skill"]
+            assert called_with["task_id"] == "acp-skills-session"
+        finally:
+            monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)
+
+    def test_no_skills_without_env_var(self, monkeypatch):
+        """When HERMES_ACP_SKILLS is absent, no ephemeral_system_prompt is set."""
+        captured = {}
+
+        class CapturingAgent(FakeAgent):
+            def __init__(self, **kwargs):
+                super().__init__()
+                captured.update(kwargs)
+
+        patches = {}
+        _patch_module(
+            monkeypatch, patches, "run_agent",
+            AIAgent=CapturingAgent,
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kw: {
+                "provider": "p", "api_mode": "chat_completions",
+                "base_url": "u", "api_key": "***", "command": None, "args": [],
+            },
+        )
+
+        monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)
+
+        manager = SessionManager(db=NoopDb())
+        agent = manager._make_agent(session_id="acp-no-skills-session", cwd=".")
+
+        assert isinstance(agent, CapturingAgent)
+        assert "ephemeral_system_prompt" not in captured
+
+    def test_comma_separated_skills_parsed_into_list(self, monkeypatch):
+        """Comma-separated values in HERMES_ACP_SKILLS are parsed into a list."""
+        called_with = {}
+
+        def fake_build(skill_list, task_id=None):
+            called_with["skill_list"] = skill_list
+            return ("[skills loaded]", skill_list, [])
+
+        class CapturingAgent(FakeAgent):
+            def __init__(self, **kwargs):
+                super().__init__()
+
+        patches = {}
+        _patch_module(
+            monkeypatch, patches, "run_agent",
+            AIAgent=CapturingAgent,
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kw: {
+                "provider": "p", "api_mode": "chat_completions",
+                "base_url": "u", "api_key": "***", "command": None, "args": [],
+            },
+        )
+        _patch_module(
+            monkeypatch, patches, "agent.skill_commands",
+            build_preloaded_skills_prompt=fake_build,
+        )
+
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "skill-a,skill-b,skill-c")
+        try:
+            manager = SessionManager(db=NoopDb())
+            agent = manager._make_agent(session_id="acp-comma-session", cwd=".")
+
+            assert called_with["skill_list"] == ["skill-a", "skill-b", "skill-c"]
+        finally:
+            monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)
+
+    def test_missing_skills_log_at_debug_only(self, monkeypatch):
+        """If build_preloaded_skills_prompt raises, it logs at DEBUG and does not crash."""
+        captured = {}
+        sentinel_db = NoopDb()
+
+        def fake_build_fail(skill_list, task_id=None):
+            raise RuntimeError("skill load failed")
+
+        class CapturingAgent(FakeAgent):
+            def __init__(self, **kwargs):
+                super().__init__()
+                captured.update(kwargs)
+
+        patches = {}
+        _patch_module(
+            monkeypatch, patches, "run_agent",
+            AIAgent=CapturingAgent,
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+        )
+        _patch_module(
+            monkeypatch, patches, "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kw: {
+                "provider": "p", "api_mode": "chat_completions",
+                "base_url": "u", "api_key": "***", "command": None, "args": [],
+            },
+        )
+        _patch_module(
+            monkeypatch, patches, "agent.skill_commands",
+            build_preloaded_skills_prompt=fake_build_fail,
+        )
+
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "broken-skill")
+        try:
+            manager = SessionManager(db=sentinel_db)
+            # Should not raise — failure is caught at DEBUG
+            agent = manager._make_agent(session_id="acp-fail-session", cwd=".")
+            assert isinstance(agent, CapturingAgent)
+            # ephemeral_system_prompt should NOT be set on failure
+            assert "ephemeral_system_prompt" not in captured
+        finally:
+            monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)


### PR DESCRIPTION
## Fixes #24466

Skills passed via `-s` / `--skills` on the `hermes acp` command were silently discarded because `cmd_acp()` called `acp_main()` with no arguments.

### Changes

**hermes_cli/main.py** — `cmd_acp()` now reads `args.skills` and writes `HERMES_ACP_SKILLS=<comma-separated>` into the environment before calling `acp_main()`. The argument uses `action='append'` so multiple `-s foo -s bar` or comma-separated values both work.

**acp_adapter/session.py** — `_make_agent()` now reads `HERMES_ACP_SKILLS` at session-creation time, calls `build_preloaded_skills_prompt()` (same function TUI and CLI chat mode use), and injects the result as `ephemeral_system_prompt` on the `AIAgent`. Failures are logged at DEBUG so they never crash the ACP server.

### Validation

```bash
hermes -s <skillname> acp    # skill should be preloaded into session
hermes acp                    # no skill loaded
hermes -s foo -s bar acp      # multiple skills work
hermes -s foo,bar acp         # comma-separated also works
```
