### PR TITLE
fix(gateway): print absolute hermes path in sudo install hint

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -1824,6 +1825,22 @@ def _default_system_service_user() -> str | None:
     return None
 
 
+def _hermes_invocation_for_help() -> str:
+    """Return a copy-pasteable hermes command for messages we print to the user.
+
+    Resolves to the absolute path of the ``hermes`` console-script shim so
+    ``sudo`` works under restrictive ``secure_path`` (the default on Arch,
+    Debian, Fedora, etc., where ``/home/<user>/.local/bin`` and other pipx /
+    uv / cargo install dirs are not on root's PATH). Falls back to
+    ``<sys.executable> -m hermes_cli.main`` when the shim isn't on PATH
+    (e.g. when launched via ``python -m`` from inside a venv).
+    """
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        return shlex.quote(hermes_bin)
+    return f"{shlex.quote(sys.executable)} -m hermes_cli.main"
+
+
 def prompt_linux_gateway_install_scope() -> str | None:
     choice = prompt_choice(
         "  Choose how the gateway should run in the background:",
@@ -1846,11 +1863,10 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
         run_as_user = _default_system_service_user()
         if os.geteuid() != 0:  # windows-footgun: ok — Linux systemd install wizard, never invoked on Windows
             print_warning("  System service install requires sudo, so Hermes can't create it from this user session.")
-            if run_as_user:
-                print_info(f"  After setup, run: sudo hermes gateway install --system --run-as-user {run_as_user}")
-            else:
-                print_info("  After setup, run: sudo hermes gateway install --system --run-as-user <your-user>")
-            print_info("  Then start it with: sudo hermes gateway start --system")
+            hermes_cmd = _hermes_invocation_for_help()
+            target_user = run_as_user or "<your-user>"
+            print_info(f"  After setup, run: sudo {hermes_cmd} gateway install --system --run-as-user {target_user}")
+            print_info(f"  Then start it with: sudo {hermes_cmd} gateway start --system")
             return scope, False
 
         if not run_as_user:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -386,14 +386,47 @@ def test_install_linux_gateway_from_setup_system_choice_without_root_prints_foll
     monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
     monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000)
     monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "alice")
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "/home/alice/.local/bin/hermes" if name == "hermes" else None)
     monkeypatch.setattr(gateway, "systemd_install", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not install")))
 
     scope, did_install = gateway.install_linux_gateway_from_setup(force=False)
 
     out = capsys.readouterr().out
     assert (scope, did_install) == ("system", False)
-    assert "sudo hermes gateway install --system --run-as-user alice" in out
-    assert "sudo hermes gateway start --system" in out
+    # Absolute path — bare `sudo hermes` fails under secure_path when the
+    # shim lives in ~/.local/bin (pipx/uv) or another dir not on root's PATH.
+    assert "sudo /home/alice/.local/bin/hermes gateway install --system --run-as-user alice" in out
+    assert "sudo /home/alice/.local/bin/hermes gateway start --system" in out
+
+
+def test_install_linux_gateway_from_setup_falls_back_to_python_module_when_shim_missing(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
+    monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "alice")
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: None)
+    monkeypatch.setattr(gateway.sys, "executable", "/opt/venv/bin/python")
+    monkeypatch.setattr(gateway, "systemd_install", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not install")))
+
+    scope, did_install = gateway.install_linux_gateway_from_setup(force=False)
+
+    out = capsys.readouterr().out
+    assert (scope, did_install) == ("system", False)
+    assert "sudo /opt/venv/bin/python -m hermes_cli.main gateway install --system --run-as-user alice" in out
+    assert "sudo /opt/venv/bin/python -m hermes_cli.main gateway start --system" in out
+
+
+def test_install_linux_gateway_from_setup_quotes_paths_with_spaces(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
+    monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "bob")
+    monkeypatch.setattr(gateway.shutil, "which", lambda name: "/home/bob/My Tools/hermes" if name == "hermes" else None)
+    monkeypatch.setattr(gateway, "systemd_install", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not install")))
+
+    scope, did_install = gateway.install_linux_gateway_from_setup(force=False)
+
+    out = capsys.readouterr().out
+    assert (scope, did_install) == ("system", False)
+    assert "sudo '/home/bob/My Tools/hermes' gateway install --system --run-as-user bob" in out
 
 
 def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeypatch):


### PR DESCRIPTION
## Summary

The systemd setup wizard tells users to run `sudo hermes gateway install --system --run-as-user <user>` when they pick the system-scope option from a non-root session. On most distros (Arch, Debian, Fedora, …) sudo's `secure_path` strips `~/.local/bin` and other pipx / uv / cargo install dirs, so `sudo hermes` resolves to **command not found** — the suggested command is guaranteed to fail for anyone who installed via a user-scope shim.

Repro on Arch with pipx-installed hermes:

```
$ hermes gateway setup
… "Install the gateway as a systemd service?" [Y/n]: y
⚠   System service install requires sudo, so Hermes can't create it from this user session.
    After setup, run: sudo hermes gateway install --system --run-as-user tiny
$ sudo hermes gateway install --system --run-as-user tiny
sudo: hermes: command not found
$ sudo env | grep PATH
PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
```

### Fix

- Added `_hermes_invocation_for_help()` in `hermes_cli/gateway.py` that resolves the `hermes` shim with `shutil.which("hermes")` and returns its absolute path (shell-quoted via `shlex.quote`), falling back to `<sys.executable> -m hermes_cli.main` when the shim isn't on PATH (e.g. when launched via `python -m` from a venv).
- `install_linux_gateway_from_setup` now uses that helper to build the printed `sudo …` commands, so they work under restrictive `secure_path` regardless of install method (pipx, uv tool, cargo, manual venv).
- Updated the existing test to assert on the resolved path, plus two new tests covering the `python -m` fallback and shell-quoting of paths with spaces.

After the fix:

```
After setup, run: sudo /home/tiny/.local/bin/hermes gateway install --system --run-as-user tiny
Then start it with: sudo /home/tiny/.local/bin/hermes gateway start --system
```

### Out of scope

A separate, more opinionated change worth discussing in an issue: invert the default so user-service + linger is the recommended path on single-user dev workstations and `--system` becomes an explicit opt-in flag (matching how `tailscaled`, `syncthing`, etc. handle it). Kept out of this PR so it doesn't get blocked on UX bikeshedding — happy to open an issue if of interest.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway.py` — 29 passed (1 updated existing test + 2 new)
- [x] Smoke-tested `_hermes_invocation_for_help()` in the local venv — returns `/home/tiny/.local/bin/hermes`
- [ ] Manual verification on Arch with pipx-installed hermes that the printed command pastes cleanly into `sudo` and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)