### PR TITLE
docs: + 分支策略段

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,15 @@ scripts/run_tests.sh
 MIT — see [LICENSE](LICENSE).
 
 Built by [Nous Research](https://nousresearch.com).
+
+---
+
+## 分支策略 (yarnovo fork · akong 团队用)
+
+- `main` = 主分支 (我们 fork 后只用 main · upstream sync 时 merge NousResearch/hermes-agent main)
+- 临时分支: `feat/<name>` · `fix/<name>` · base 永远 `origin/main`
+- PR target = `main` · CI pass + mergeable + 无 conflict 才合
+- lead merge 不 auto · subagent 不自合
+- subagent 创 worktree 干活前必读本 README
+
+详见 `~/.claude/memories/feedback_lead_main_branch_only.md`


### PR DESCRIPTION
## Summary

加 "## 分支策略" 段 (yarnovo fork · akong 团队用) 到 README 末尾。

5-13 老板拍 · 每仓 README 必含分支策略段 (subagent / maintainer 干活前必读)。

## Test plan

- [x] README.md 末尾追加 "## 分支策略" 段
- [x] 不动 NousResearch upstream 内容 (仅 append)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>