### PR TITLE
fix(acp): plumb --skills through to ACP session preload (#24466)

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -107,8 +107,42 @@ def _load_env() -> None:
         )
 
 
-def main() -> None:
-    """Entry point: load env, configure logging, run the ACP agent."""
+def _resolve_default_skills(skills, logger: logging.Logger) -> list[str]:
+    """Normalize and validate ``--skills`` for the ACP entry point.
+
+    Accepts the same argparse shapes as the CLI (None, string, or list of
+    strings; comma-separated values inside each entry are split). Unknown
+    skills cause a clean ``sys.exit(1)`` so editor clients see a startup
+    failure instead of a silently-ignored flag.
+    """
+    # Ensure the project root is on sys.path so the cli/agent imports below
+    # work when entry.main is invoked as a console script (``hermes-acp``).
+    project_root = str(Path(__file__).resolve().parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    from cli import _parse_skills_argument
+    from agent.skill_commands import build_preloaded_skills_prompt
+
+    parsed = _parse_skills_argument(skills)
+    if not parsed:
+        return []
+
+    _, loaded, missing = build_preloaded_skills_prompt(parsed)
+    if missing:
+        print(f"Unknown skill(s): {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+    logger.info("Preloading skills for ACP sessions: %s", ", ".join(loaded))
+    return parsed
+
+
+def main(skills=None) -> None:
+    """Entry point: load env, configure logging, run the ACP agent.
+
+    ``skills`` mirrors the global ``-s/--skills`` CLI flag. When provided,
+    each new ACP session is created with those skills preloaded into its
+    system prompt, matching ``hermes -s <skill> chat`` behavior (#24466).
+    """
     _setup_logging()
     _load_env()
 
@@ -119,6 +153,8 @@ def main() -> None:
     project_root = str(Path(__file__).resolve().parent.parent)
     if project_root not in sys.path:
         sys.path.insert(0, project_root)
+
+    default_skills = _resolve_default_skills(skills, logger)
 
     import acp
     from .server import HermesACPAgent
@@ -134,7 +170,7 @@ def main() -> None:
     except Exception:
         logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
 
-    agent = HermesACPAgent()
+    agent = HermesACPAgent(default_skills=default_skills or None)
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
     except KeyboardInterrupt:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -499,9 +499,16 @@ class HermesACPAgent(acp.Agent):
         },
     )
 
-    def __init__(self, session_manager: SessionManager | None = None):
+    def __init__(
+        self,
+        session_manager: SessionManager | None = None,
+        *,
+        default_skills: list[str] | None = None,
+    ):
         super().__init__()
-        self.session_manager = session_manager or SessionManager()
+        self.session_manager = session_manager or SessionManager(
+            default_skills=default_skills,
+        )
         self._conn: Optional[acp.Client] = None
 
     # ---- Connection lifecycle -----------------------------------------------

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -191,7 +191,7 @@ class SessionManager:
     via ``session_search``.
     """
 
-    def __init__(self, agent_factory=None, db=None):
+    def __init__(self, agent_factory=None, db=None, *, default_skills=None):
         """
         Args:
             agent_factory: Optional callable that creates an AIAgent-like object.
@@ -199,11 +199,15 @@ class SessionManager:
                            using the current Hermes runtime provider configuration.
             db:            Optional SessionDB instance. When omitted, the default
                            SessionDB (``~/.hermes/state.db``) is lazily created.
+            default_skills: Optional list of skill identifiers to preload into
+                            every session's system prompt. Set from the global
+                            ``-s/--skills`` flag of ``hermes ... acp`` (#24466).
         """
         self._sessions: Dict[str, SessionState] = {}
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        self._default_skills: List[str] = list(default_skills or [])
 
     # ---- public API ---------------------------------------------------------
 
@@ -560,6 +564,30 @@ class SessionManager:
 
     # ---- internal -----------------------------------------------------------
 
+    def _build_default_skills_prompt(self, session_id: str) -> str:
+        """Return the preloaded-skills system prompt for a new ACP session.
+
+        Unknown skills are silently dropped here — startup validation in
+        ``acp_adapter.entry.main`` is the authoritative gate for fail-fast.
+        We re-resolve per session so each new AIAgent gets its own
+        ``task_id`` recorded by the skill-usage tracker.
+        """
+        if not self._default_skills:
+            return ""
+        try:
+            from agent.skill_commands import build_preloaded_skills_prompt
+        except Exception:
+            logger.debug("skill_commands import failed; skipping skill preload", exc_info=True)
+            return ""
+        try:
+            prompt, _loaded, _missing = build_preloaded_skills_prompt(
+                self._default_skills, task_id=session_id,
+            )
+        except Exception:
+            logger.debug("Failed to build preloaded skills prompt", exc_info=True)
+            return ""
+        return prompt or ""
+
     def _make_agent(
         self,
         *,
@@ -604,6 +632,10 @@ class SessionManager:
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+
+        skills_prompt = self._build_default_skills_prompt(session_id)
+        if skills_prompt:
+            kwargs["ephemeral_system_prompt"] = skills_prompt
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11414,7 +11414,7 @@ Examples:
         try:
             from acp_adapter.entry import main as acp_main
 
-            acp_main()
+            acp_main(skills=getattr(args, "skills", None))
         except ImportError:
             print("ACP dependencies not installed.")
             print("Install them with:  pip install -e '.[acp]'")

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,9 @@
 """Tests for acp_adapter.entry startup wiring."""
 
+import logging
+
 import acp
+import pytest
 
 from acp_adapter import entry
 
@@ -18,3 +21,63 @@ def test_main_enables_unstable_protocol(monkeypatch):
     entry.main()
 
     assert calls["kwargs"]["use_unstable_protocol"] is True
+
+
+def test_main_forwards_skills_to_agent(monkeypatch):
+    """``hermes -s foo,bar acp`` reaches ``HermesACPAgent`` as default_skills."""
+    captured = {}
+
+    async def fake_run_agent(agent, **_kwargs):
+        captured["agent"] = agent
+
+    def fake_resolve(skills, _logger):
+        captured["raw_skills"] = skills
+        return ["foo", "bar"]
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry, "_resolve_default_skills", fake_resolve)
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main(skills=["foo,bar"])
+
+    assert captured["raw_skills"] == ["foo,bar"]
+    agent = captured["agent"]
+    assert agent.session_manager._default_skills == ["foo", "bar"]
+
+
+def test_main_passes_none_skills_when_unused(monkeypatch):
+    """Default invocation must still produce a SessionManager with no skills."""
+    captured = {}
+
+    async def fake_run_agent(agent, **_kwargs):
+        captured["agent"] = agent
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main()
+
+    assert captured["agent"].session_manager._default_skills == []
+
+
+def test_resolve_default_skills_returns_empty_for_none():
+    assert entry._resolve_default_skills(None, logging.getLogger("test")) == []
+    assert entry._resolve_default_skills("", logging.getLogger("test")) == []
+
+
+def test_resolve_default_skills_exits_on_unknown_skill(monkeypatch, capsys):
+    """Unknown skill names cause sys.exit(1) so editor clients see the error."""
+    monkeypatch.setattr(
+        "agent.skill_commands.build_preloaded_skills_prompt",
+        lambda parsed, task_id=None: ("", [], ["does-not-exist"]),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        entry._resolve_default_skills("does-not-exist", logging.getLogger("test"))
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "Unknown skill(s)" in err
+    assert "does-not-exist" in err

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -596,3 +596,156 @@ class TestPersistence:
 
         assert stdout_buf.getvalue() == ""
         assert stderr_buf.getvalue() == "ACP noise\n"
+
+
+# ---------------------------------------------------------------------------
+# default_skills preload (#24466)
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultSkillsPreload:
+    """``hermes -s X acp`` must preload skill prompts into every ACP session."""
+
+    def test_default_skills_stored_on_manager(self):
+        manager = SessionManager(
+            agent_factory=_mock_agent, default_skills=["skill-a", "skill-b"],
+        )
+        assert manager._default_skills == ["skill-a", "skill-b"]
+
+    def test_default_skills_defaults_to_empty_list(self):
+        manager = SessionManager(agent_factory=_mock_agent)
+        assert manager._default_skills == []
+
+    def test_default_skills_accepts_none(self):
+        manager = SessionManager(agent_factory=_mock_agent, default_skills=None)
+        assert manager._default_skills == []
+
+    def test_build_default_skills_prompt_returns_empty_without_skills(self):
+        manager = SessionManager(agent_factory=_mock_agent)
+        assert manager._build_default_skills_prompt("sess-1") == ""
+
+    def test_build_default_skills_prompt_calls_skill_loader(self, monkeypatch):
+        calls = {}
+
+        def fake_build(identifiers, task_id=None):
+            calls["identifiers"] = identifiers
+            calls["task_id"] = task_id
+            return ("PRELOADED SKILL PROMPT", list(identifiers), [])
+
+        monkeypatch.setattr(
+            "agent.skill_commands.build_preloaded_skills_prompt", fake_build,
+        )
+        manager = SessionManager(
+            agent_factory=_mock_agent, default_skills=["skill-a"],
+        )
+
+        prompt = manager._build_default_skills_prompt("sess-xyz")
+
+        assert prompt == "PRELOADED SKILL PROMPT"
+        assert calls["identifiers"] == ["skill-a"]
+        assert calls["task_id"] == "sess-xyz"
+
+    def test_build_default_skills_prompt_swallows_loader_errors(self, monkeypatch):
+        """Skill-loader failures must not crash ACP session creation."""
+        def boom(identifiers, task_id=None):
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(
+            "agent.skill_commands.build_preloaded_skills_prompt", boom,
+        )
+        manager = SessionManager(
+            agent_factory=_mock_agent, default_skills=["skill-a"],
+        )
+
+        assert manager._build_default_skills_prompt("sess-1") == ""
+
+    def test_make_agent_injects_ephemeral_system_prompt(self, tmp_path, monkeypatch):
+        """The AIAgent constructed for an ACP session must receive the
+        preloaded-skills prompt as ``ephemeral_system_prompt``, matching the
+        CLI's injection mechanism (cli.py:4152)."""
+        captured_kwargs = {}
+
+        def fake_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), _print_fn=None)
+
+        def fake_build(identifiers, task_id=None):
+            return (
+                f"[SKILL CONTENT for {','.join(identifiers)} session={task_id}]",
+                list(identifiers),
+                [],
+            )
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "test-key",
+                "command": None,
+                "args": [],
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        monkeypatch.setattr(
+            "agent.skill_commands.build_preloaded_skills_prompt", fake_build,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db, default_skills=["skill-x"])
+            state = manager.create_session(cwd="/work")
+
+        injected = captured_kwargs.get("ephemeral_system_prompt")
+        assert injected is not None
+        assert "SKILL CONTENT for skill-x" in injected
+        assert state.session_id in injected
+
+    def test_make_agent_omits_ephemeral_prompt_without_skills(self, tmp_path, monkeypatch):
+        """When ``--skills`` is absent, the AIAgent must NOT receive an
+        ``ephemeral_system_prompt`` kwarg — that channel is reserved for the
+        preloaded-skills payload here, and a stray empty value would mask
+        callers downstream that test for ``if ephemeral_system_prompt``."""
+        captured_kwargs = {}
+
+        def fake_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            return SimpleNamespace(model=kwargs.get("model"), _print_fn=None)
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "test-key",
+                "command": None,
+                "args": [],
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "test-model"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            manager.create_session(cwd="/work")
+
+        assert "ephemeral_system_prompt" not in captured_kwargs
+
+    def test_default_skills_propagated_from_acp_agent(self):
+        """``HermesACPAgent(default_skills=...)`` must reach SessionManager."""
+        from acp_adapter.server import HermesACPAgent
+
+        agent = HermesACPAgent(default_skills=["skill-a", "skill-b"])
+        assert agent.session_manager._default_skills == ["skill-a", "skill-b"]


### PR DESCRIPTION
## Summary

- Forward the inherited top-level \`-s/--skills\` flag from \`cmd_acp\` into \`acp_adapter.entry.main\` so \`hermes -s <skill> acp\` actually preloads the skill.
- Validate skill identifiers once at ACP startup and \`sys.exit(1)\` with a clear message on unknown names — matches the \`ValueError\` raised by \`cli.main\`.
- Inject the resolved preload prompt as \`ephemeral_system_prompt=\` on each session's AIAgent, the same channel \`cli.py:4152\` uses, with per-session \`task_id\` so skill-usage tracking is preserved.

## The bug

\`cmd_acp(args)\` ignored its argparse namespace entirely:

\`\`\`python
def cmd_acp(args):
    from acp_adapter.entry import main as acp_main
    acp_main()   # args.skills dropped on the floor
\`\`\`

\`-s/--skills\` is registered as an \`_inherited_flag\` on the top-level parser, so \`args.skills\` is populated for every subcommand including \`acp\`. The ACP entry point just never read it. Result: \`hermes -s my-skill chat\` preloads the skill, \`hermes -s my-skill acp\` silently doesn't.

## The fix

1. \`hermes_cli/main.py\` — \`cmd_acp\` reads \`getattr(args, \"skills\", None)\` and forwards it to \`acp_main(skills=...)\`.
2. \`acp_adapter/entry.py\` — new \`_resolve_default_skills\` normalizes the argparse shape (None / string / list, comma-splitting inside each entry), validates via \`build_preloaded_skills_prompt\`, and \`sys.exit(1)\`s with \`Unknown skill(s): ...\` on miss.
3. \`acp_adapter/server.py\` — \`HermesACPAgent\` accepts \`default_skills\` and threads it to \`SessionManager\`.
4. \`acp_adapter/session.py\` — \`SessionManager\` stores \`_default_skills\`; \`_make_agent\` re-resolves the prompt per session and passes \`ephemeral_system_prompt=\` to \`AIAgent\`. All three session-creation paths (\`create_session\`, \`fork_session\`, \`_restore\`) flow through \`_make_agent\`, so newly-created **and** DB-restored ACP sessions both inherit the preload on subsequent launches with the same \`--skills\` flag.

## Test plan

- [x] \`tests/acp/test_entry.py\` — new tests covering the entry-point wiring (skills forwarded, no-skills default still produces a clean SessionManager, unknown-skill exits non-zero).
- [x] \`tests/acp/test_session.py\` — new \`TestDefaultSkillsPreload\` class verifying \`default_skills\` plumbing, \`ephemeral_system_prompt\` injection (positive case), absence of the kwarg when no skills are configured (negative case), and resilience to skill-loader failures.
- [x] Regression guard: full \`tests/acp/\` and \`tests/acp_adapter/\` pass (235 passed) with no changes elsewhere.

\`\`\`
uv run --with pytest --with pytest-xdist --with pytest-asyncio \\
       --with 'agent-client-protocol==0.9.0' \\
       python3 -m pytest tests/acp/ tests/acp_adapter/ -v
# 235 passed in 2.96s
\`\`\`

## Related / Positioning

| PR | Approach | Skill content lands as | Validation |
|----|----------|------------------------|------------|
| #24474 (luyao618) | params plumbed via \`SessionManager(skills=...)\` | \`prefill_messages=[{role: user, content: ...}]\` | silent fallback on errors |
| #24521 (shanewas) | env-var bridge \`HERMES_ACP_SKILLS\` + extra \`-s\` on \`acp_parser\` | \`ephemeral_system_prompt\` | silent skip on errors |
| this PR | params plumbed via \`SessionManager(default_skills=...)\` | \`ephemeral_system_prompt\` (matches \`cli.py:4152\`) | fail-fast \`sys.exit(1)\` with message |

Concrete differences:

- **\`ephemeral_system_prompt\` is the correct channel.** The activation note built by \`build_preloaded_skills_prompt\` reads *\"The user launched this CLI session with the \"X\" skill preloaded. Treat its instructions as active guidance...\"* — it's authored as system guidance. #24474 routes it through \`prefill_messages\` (run_agent.py:1161), which surfaces the skill payload as a synthetic **user-role** message in conversation history. That changes what the model sees and is inconsistent with how \`cli.py:4152\` handles the same content.
- **Fail-fast validation.** The CLI raises \`ValueError(f\"Unknown skill(s): ...\")\` at \`cli.py:13400\`. Editor clients launching ACP can't see Python exceptions cleanly, but they do see process exit codes and stderr. This PR matches the CLI semantics; #24474 and #24521 silently drop unknown skills.
- **No global state.** #24521 writes \`HERMES_ACP_SKILLS\` to \`os.environ\` and re-adds \`-s/--skills\` on \`acp_parser\` even though it's already inherited from the top-level parser. This PR keeps the wiring as plain function parameters.

> Sibling code paths that may need the same fix: the \`hermes-acp\` console-script entry point declared in \`pyproject.toml\` (\`hermes-acp = \"acp_adapter.entry:main\"\`) bypasses the \`hermes\` CLI's argparse entirely. Intentionally left out of this PR's scope to keep the diff small — happy to widen to add argparse there if preferred.

Fixes #24466.