### PR TITLE
fix: increment retrieval_count in FactRetriever (closes #17899)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -106,6 +106,8 @@ class FactRetriever:
         # Sort by score descending, return top limit
         scored.sort(key=lambda x: x["score"], reverse=True)
         results = scored[:limit]
+        # Track retrieval for usage metrics
+        self.store.touch_facts([f["fact_id"] for f in results])
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
@@ -147,9 +149,11 @@ class FactRetriever:
                 bank_vec = hrr.bytes_to_phases(bank_row["vector"])
                 extracted = hrr.unbind(bank_vec, probe_key)
                 # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
+                results = self._score_facts_by_vector(
                     extracted, category=category, limit=limit
                 )
+                self.store.touch_facts([f["fact_id"] for f in results])
+                return results
 
         # Score against individual fact vectors directly
         where = "WHERE hrr_vector IS NOT NULL"
@@ -187,7 +191,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self.store.touch_facts([f["fact_id"] for f in results])
+        return results
 
     def related(
         self,
@@ -255,7 +261,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self.store.touch_facts([f["fact_id"] for f in results])
+        return results
 
     def reason(
         self,
@@ -333,7 +341,9 @@ class FactRetriever:
             scored.append(fact)
 
         scored.sort(key=lambda x: x["score"], reverse=True)
-        return scored[:limit]
+        results = scored[:limit]
+        self.store.touch_facts([f["fact_id"] for f in results])
+        return results
 
     def contradict(
         self,

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -391,6 +391,23 @@ class MemoryStore:
                 "helpful_count": row["helpful_count"] + helpful_increment,
             }
 
+    def touch_facts(self, fact_ids: list[int]) -> None:
+        """Increment retrieval_count for the given fact IDs (usage tracking).
+
+        Called by FactRetriever after each successful retrieval so that
+        trust scoring and usage metrics reflect actual access patterns.
+        """
+        if not fact_ids:
+            return
+        with self._lock:
+            placeholders = ",".join("?" * len(fact_ids))
+            self._conn.execute(
+                f"UPDATE facts SET retrieval_count = retrieval_count + 1 "
+                f"WHERE fact_id IN ({placeholders})",
+                fact_ids,
+            )
+            self._conn.commit()
+
     # ------------------------------------------------------------------
     # Entity helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `retrieval_count` column in the `facts` table is never incremented during normal operation, making it useless as a usage metric. All 44 facts in my store show `retrieval_count = 0` despite weeks of active use.

## Root Cause

Two search paths exist, but only `store.search_facts()` increments the counter — and nothing calls it:

- **`store.search_facts()`** (`store.py:191`) — has `UPDATE facts SET retrieval_count = retrieval_count + 1`. **Nobody calls this method.**
- **`FactRetriever.search/probe/related/reason()`** (`retrieval.py`) — the actual retrieval layer used by `prefetch()` and `fact_store` tool calls. Queries the DB directly, **never increments the counter.**

Reported in #17899.

## Fix

- Add `store.touch_facts(fact_ids)` as a shared helper that increments `retrieval_count` for given fact IDs (with lock, noop on empty list).
- Call `touch_facts()` in all 5 return paths across the 4 retrieval methods: `search()`, `probe()` (2 paths — bank-hit and direct), `related()`, and `reason()`.

The existing `search_facts()` increment logic in `store.py` is untouched — no behavior change for any code that does call it directly.

## Testing

- Verified `touch_facts` exists on `MemoryStore` and is referenced in all 4 retrieval methods via `inspect.getsource()`.
- The fix is minimal and additive — no existing code paths are modified, only extended with a post-retrieval counter bump.

## Files Changed

- `plugins/memory/holographic/store.py` — add `touch_facts()` method
- `plugins/memory/holographic/retrieval.py` — call `touch_facts()` after scoring in all return paths