### PR TITLE
fix(agent): fall back to non-streaming on JSONDecodeError

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8501,14 +8501,29 @@ class AIAgent:
                                 "stream" in _err_lower
                                 and "not supported" in _err_lower
                             )
-                            if _is_stream_unsupported:
+                            # Some providers (e.g. custom:llmgateway) return
+                            # malformed or empty SSE responses when streaming
+                            # tool-call turns, raising json.JSONDecodeError
+                            # ("Expecting value: line 1 column 1 (char 0)").
+                            # Treat this the same as "stream not supported" so
+                            # the session automatically falls back to
+                            # non-streaming for subsequent requests.
+                            _is_json_decode_err = isinstance(e, json.JSONDecodeError)
+                            if _is_stream_unsupported or _is_json_decode_err:
                                 self._disable_streaming = True
-                                self._safe_print(
-                                    "\n⚠  Streaming is not supported for this "
-                                    "model/provider. Switching to non-streaming.\n"
-                                    "   To avoid this delay, set display.streaming: false "
-                                    "in config.yaml\n"
-                                )
+                                if _is_stream_unsupported:
+                                    self._safe_print(
+                                        "\n⚠  Streaming is not supported for this "
+                                        "model/provider. Switching to non-streaming.\n"
+                                        "   To avoid this delay, set display.streaming: false "
+                                        "in config.yaml\n"
+                                    )
+                                else:
+                                    logger.warning(
+                                        "Streaming returned malformed response "
+                                        "(JSONDecodeError) — falling back to "
+                                        "non-streaming for this session: %s", e,
+                                    )
                             logger.info(
                                 "Streaming failed before delivery: %s",
                                 e,

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -510,6 +510,42 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_json_decode_error_sets_disable_streaming(self, mock_close, mock_create):
+        """JSONDecodeError during streaming sets _disable_streaming.
+
+        Some providers (e.g. custom:llmgateway) return malformed or empty
+        SSE responses when streaming tool-call turns, raising
+        json.JSONDecodeError ("Expecting value: line 1 column 1 (char 0)").
+        The agent should fall back to non-streaming for subsequent requests.
+        """
+        import json as _json
+        from run_agent import AIAgent
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _json.JSONDecodeError(
+            "Expecting value", "", 0
+        )
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.com/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(_json.JSONDecodeError):
+            agent._interruptible_streaming_api_call({})
+
+        # The flag should be set so the main retry loop switches to non-streaming
+        assert agent._disable_streaming is True
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_non_transport_error_propagates(self, mock_close, mock_create):
         """Non-transport streaming errors propagate to the main retry loop."""
         from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

When using `custom:llmgateway` (or similar providers) with streaming enabled, tool-call turns can fail with `json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`. The agent retries the same streaming path multiple times, then the tool workflow fails entirely.


### Root Cause

The streaming error handling in `_interruptible_streaming_api_call` only recognizes `"stream not supported"` as a signal to fall back to non-streaming. When a provider returns malformed or empty SSE responses for tool-call turns (raising `json.JSONDecodeError`), the error is treated as a generic failure and retried with the same streaming path — which fails identically each time.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A