### PR TITLE
Add scheduled Kanban status for delayed follow-ups

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1,6 +1,6 @@
 """CLI for the Hermes Kanban board — ``hermes kanban …`` subcommand.
 
-Exposes the full 15-verb surface documented in the design spec
+Exposes the full Kanban command surface documented in the design spec
 (``docs/hermes-kanban-v1-spec.pdf``).  All DB work is delegated to
 ``kanban_db``.  This module adds:
 
@@ -34,6 +34,7 @@ _STATUS_ICONS = {
     "todo":     "◻",
     "ready":    "▶",
     "running":  "●",
+    "scheduled":"⏱",
     "blocked":  "⊘",
     "done":     "✓",
     "archived": "—",
@@ -431,7 +432,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_block.add_argument("--ids", nargs="+", default=None,
                          help="Additional task ids to block with the same reason (bulk mode)")
 
-    p_unblock = sub.add_parser("unblock", help="Return one or more blocked tasks to ready")
+    p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
+    p_schedule.add_argument("task_id")
+    p_schedule.add_argument("reason", nargs="*", help="Reason/timing note (also appended as a comment)")
+    p_schedule.add_argument("--ids", nargs="+", default=None,
+                            help="Additional task ids to schedule with the same reason (bulk mode)")
+
+    p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
@@ -724,6 +731,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "complete": _cmd_complete,
         "edit":     _cmd_edit,
         "block":    _cmd_block,
+        "schedule": _cmd_schedule,
         "unblock":  _cmd_unblock,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
@@ -1627,6 +1635,28 @@ def _cmd_block(args: argparse.Namespace) -> int:
     return 0 if not failed else 1
 
 
+def _cmd_schedule(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip() if args.reason else None
+    author = _profile_author()
+    ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    failed: list[str] = []
+    with kb.connect() as conn:
+        for tid in ids:
+            if reason:
+                kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
+            if not kb.schedule_task(
+                conn,
+                tid,
+                reason=reason,
+                expected_run_id=_worker_run_id_for(tid),
+            ):
+                failed.append(tid)
+                print(f"cannot schedule {tid}", file=sys.stderr)
+            else:
+                print(f"Scheduled {tid}" + (f": {reason}" if reason else ""))
+    return 0 if not failed else 1
+
+
 def _cmd_unblock(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     if not ids:
@@ -1637,7 +1667,7 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
         for tid in ids:
             if not kb.unblock_task(conn, tid):
                 failed.append(tid)
-                print(f"cannot unblock {tid} (not blocked?)", file=sys.stderr)
+                print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
                 print(f"Unblocked {tid}")
     return 0 if not failed else 1
@@ -1922,7 +1952,7 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         print(json.dumps(stats, indent=2, ensure_ascii=False))
         return 0
     print("By status:")
-    for k in ("triage", "todo", "ready", "running", "blocked", "done"):
+    for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
     if stats["by_assignee"]:
         print("\nBy assignee:")
@@ -2170,7 +2200,7 @@ Common subcommands:
   `create <title>…`     Create a task (auto-subscribes you to events)
   `comment <id> <msg>`  Append a comment
   `complete <id>…`      Mark task(s) done
-  `block <id> [reason]` Mark blocked; `unblock <id>` to revive
+  `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards
   `assignees`           Known profiles + counts

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,7 +90,7 @@ from toolsets import get_toolset_names
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "done", "archived"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 
@@ -2637,7 +2637,7 @@ def block_task(
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Transition ``blocked -> ready``.
+    """Transition ``blocked``/``scheduled`` -> ready or todo.
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
@@ -2649,7 +2649,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(
-            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'blocked'",
+            "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
         ).fetchone()
         if stale and stale["current_run_id"]:
@@ -2679,7 +2679,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         new_status = "todo" if undone_parents else "ready"
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL "
-            "WHERE id = ? AND status = 'blocked'",
+            "WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (new_status, task_id),
         )
         if cur.rowcount != 1:
@@ -2877,6 +2877,51 @@ def set_workspace_path(
 
 
 # ---------------------------------------------------------------------------
+def schedule_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Park a task in ``scheduled`` so it is waiting on time, not human input.
+
+    ``scheduled`` tasks are intentionally not dispatchable; an external cron,
+    human action, or automation can later call ``unblock_task`` to re-gate them
+    to ``ready`` (or ``todo`` if parents are still incomplete).
+    """
+    with write_txn(conn):
+        params: list[Any] = [task_id]
+        sql = """
+            UPDATE tasks
+               SET status       = 'scheduled',
+                   claim_lock   = NULL,
+                   claim_expires= NULL,
+                   worker_pid   = NULL
+             WHERE id = ?
+               AND status IN ('todo', 'ready', 'running', 'blocked')
+        """
+        if expected_run_id is not None:
+            sql += " AND current_run_id = ?"
+            params.append(int(expected_run_id))
+        cur = conn.execute(sql, params)
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="scheduled", status="scheduled",
+            summary=reason,
+        )
+        if run_id is None and reason:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="scheduled",
+                summary=reason,
+            )
+        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        return True
+
+
 # Dispatcher (one-shot pass)
 # ---------------------------------------------------------------------------
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,47 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _resolve_dispatcher_github_auth_bridge(env: dict, profile_hermes_home: str | None) -> tuple[str, str] | None:
+    """Return ``(auth_home, gh_config_dir)`` for Kanban worker GitHub auth.
+
+    The dispatcher process often has working ``gh`` auth in the operator's real
+    HOME, while worker terminal commands run with ``HOME={profile}/home`` for
+    profile isolation.  On macOS that isolated HOME cannot see the operator
+    keychain-backed gh token.  If the target profile does not already have its
+    own gh auth config, expose the dispatcher's authenticated HOME to the
+    worker via non-secret env vars; the terminal backend wraps only ``gh`` and
+    ``git`` commands with that HOME.
+    """
+    disabled = str(env.get("HERMES_KANBAN_GITHUB_AUTH_BRIDGE") or "").strip().lower()
+    if disabled in {"0", "false", "no", "off"}:
+        return None
+
+    profile_home = None
+    if profile_hermes_home:
+        profile_home = Path(profile_hermes_home).expanduser() / "home"
+        if (profile_home / ".config" / "gh" / "hosts.yml").is_file():
+            # Profile-specific gh auth wins; no cross-profile bridge needed.
+            return None
+
+    auth_home_raw = str(env.get("HOME") or "").strip()
+    if not auth_home_raw:
+        return None
+    auth_home = Path(auth_home_raw).expanduser()
+    if profile_home is not None:
+        try:
+            if auth_home.resolve() == profile_home.resolve():
+                return None
+        except OSError:
+            if str(auth_home) == str(profile_home):
+                return None
+
+    gh_config_raw = str(env.get("GH_CONFIG_DIR") or "").strip()
+    gh_config = Path(gh_config_raw).expanduser() if gh_config_raw else auth_home / ".config" / "gh"
+    if not (gh_config / "hosts.yml").is_file():
+        return None
+    return (str(auth_home), str(gh_config))
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3941,14 +3982,23 @@ def _default_spawn(
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
     from hermes_cli.profiles import resolve_profile_env
+    profile_hermes_home: str | None = None
     try:
-        env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+        profile_hermes_home = resolve_profile_env(profile_arg)
+        env["HERMES_HOME"] = profile_hermes_home
     except FileNotFoundError:
         # Profile dir doesn't exist — defer resolution to the CLI's
         # _apply_profile_override() via HERMES_PROFILE (set below).
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+
+    github_bridge = _resolve_dispatcher_github_auth_bridge(env, profile_hermes_home)
+    if github_bridge:
+        auth_home, gh_config_dir = github_bridge
+        env["HERMES_KANBAN_GITHUB_AUTH_HOME"] = auth_home
+        env["HERMES_KANBAN_GITHUB_CONFIG_DIR"] = gh_config_dir
+
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -52,13 +52,14 @@
   }
 
   // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
@@ -68,6 +69,7 @@
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Waiting on a known time delay or scheduled follow-up",
     ready: "Assigned and waiting for a dispatcher tick",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",
@@ -78,6 +80,7 @@
     done: "Mark this task as done? The worker's claim is released and dependent children become ready.",
     archived: "Archive this task? It disappears from the default board view.",
     blocked: "Mark this task as blocked? The worker's claim is released.",
+    scheduled: "Move this task to Scheduled? Use this for known time delays rather than human blockers.",
   };
   const FALLBACK_DIAGNOSTIC_EVENT_LABELS = {
     completion_blocked_hallucination: "⚠ Completion blocked — phantom card ids",
@@ -91,6 +94,7 @@
     done: "confirmDone",
     archived: "confirmArchive",
     blocked: "confirmBlocked",
+    scheduled: "confirmScheduled",
   };
 
   function getColumnLabel(t, status) {
@@ -115,6 +119,7 @@
     todo: "hermes-kanban-dot-todo",
     ready: "hermes-kanban-dot-ready",
     running: "hermes-kanban-dot-running",
+    scheduled: "hermes-kanban-dot-scheduled",
     blocked: "hermes-kanban-dot-blocked",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
@@ -3061,6 +3066,8 @@
       h("div", { className: "hermes-kanban-actions" },
         specifyButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),
+        b("→ scheduled", { status: "scheduled" }, task.status !== "scheduled",
+          getDestructiveConfirm(t, "scheduled")),
         b("→ ready",   { status: "ready" },    task.status !== "ready"),
         // No direct → running button: /tasks/:id PATCH rejects status=running
         // with 400 (issue #19535). Tasks enter running only through the
@@ -3069,9 +3076,9 @@
         b(tx(t, "block", "Block"),     { status: "blocked" },
           task.status === "running" || task.status === "ready",
           getDestructiveConfirm(t, "blocked")),
-        b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked"),
+        b(tx(t, "unblock", "Unblock"),   { status: "ready" },    task.status === "blocked" || task.status === "scheduled"),
         b(tx(t, "complete", "Complete"),  { status: "done" },
-          task.status === "running" || task.status === "ready" || task.status === "blocked",
+          task.status === "running" || task.status === "ready" || task.status === "blocked" || task.status === "scheduled",
           getDestructiveConfirm(t, "done")),
         b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
           getDestructiveConfirm(t, "archived")),

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -162,6 +162,7 @@
 .hermes-kanban-dot-todo     { background: var(--color-muted-foreground); }
 .hermes-kanban-dot-ready    { background: #d4b348; }  /* amber */
 .hermes-kanban-dot-running  { background: #3fb97d; }  /* green */
+.hermes-kanban-dot-scheduled{ background: #7aa2f7; }  /* clock blue */
 .hermes-kanban-dot-blocked  { background: var(--color-destructive, #d14a4a); }
 .hermes-kanban-dot-done     { background: #4a8cd1; }  /* blue */
 .hermes-kanban-dot-archived { background: var(--color-border); }

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -130,7 +130,7 @@ def _conn(board: Optional[str] = None):
 # Columns shown by the dashboard, in left-to-right order. "archived" is
 # available via a filter toggle rather than a visible column.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "ready", "running", "blocked", "done",
+    "triage", "todo", "scheduled", "ready", "running", "blocked", "done",
 ]
 
 
@@ -613,10 +613,12 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 )
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+            elif s == "scheduled":
+                ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
             elif s == "ready":
-                # Re-open a blocked task, or just an explicit status set.
+                # Re-open a blocked/scheduled task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status == "blocked":
+                if current and current.status in ("blocked", "scheduled"):
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
@@ -628,7 +630,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     status_code=400,
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
-            elif s in ("todo", "triage"):
+            elif s in ("todo", "triage", "scheduled"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
@@ -864,10 +866,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         ok = kanban_db.block_task(conn, tid)
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status == "blocked":
+                        if cur and cur.status in ("blocked", "scheduled"):
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             ok = _set_status_direct(conn, tid, "ready")
+                    elif s == "scheduled":
+                        ok = kanban_db.schedule_task(conn, tid)
                     elif s in ("todo", "running", "triage"):
                         ok = _set_status_direct(conn, tid, s)
                     else:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -215,6 +215,34 @@ def test_claim_fails_on_non_ready(kanban_home):
         assert kb.claim_task(conn, t) is None
 
 
+def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="delayed recheck", assignee="ops")
+        assert kb.schedule_task(conn, t, reason="run next week") is True
+        task = kb.get_task(conn, t)
+        assert task.status == "scheduled"
+        assert kb.claim_task(conn, t) is None
+
+        events = kb.list_events(conn, t)
+        assert any(e.kind == "scheduled" and e.payload == {"reason": "run next week"} for e in events)
+
+
+def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.schedule_task(conn, child, reason="wait until tomorrow") is True
+
+        assert kb.unblock_task(conn, child) is True
+        assert kb.get_task(conn, child).status == "todo"
+
+        kb.complete_task(conn, parent)
+        assert kb.schedule_task(conn, child, reason="second timer") is True
+        assert kb.unblock_task(conn, child) is True
+        assert kb.get_task(conn, child).status == "ready"
+
+
 def test_stale_claim_reclaimed(kanban_home, monkeypatch):
     import signal
     import hermes_cli.kanban_db as _kb

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -80,6 +80,53 @@ def test_workspace_kind_validation(kanban_home):
         kb.create_task(conn, title="bad ws", workspace_kind="cloud")
 
 
+class TestDispatcherGithubAuthBridge:
+    def test_uses_dispatcher_home_when_profile_lacks_gh_auth(self, tmp_path):
+        operator_home = tmp_path / "operator"
+        operator_gh = operator_home / ".config" / "gh"
+        operator_gh.mkdir(parents=True)
+        (operator_gh / "hosts.yml").write_text("github.com: {}\n")
+        profile_home = tmp_path / "profiles" / "ops"
+        (profile_home / "home").mkdir(parents=True)
+
+        bridge = kb._resolve_dispatcher_github_auth_bridge(
+            {"HOME": str(operator_home)},
+            str(profile_home),
+        )
+
+        assert bridge == (str(operator_home), str(operator_gh))
+
+    def test_profile_specific_gh_auth_wins(self, tmp_path):
+        operator_home = tmp_path / "operator"
+        operator_gh = operator_home / ".config" / "gh"
+        operator_gh.mkdir(parents=True)
+        (operator_gh / "hosts.yml").write_text("github.com: {}\n")
+        profile_home = tmp_path / "profiles" / "ops"
+        profile_gh = profile_home / "home" / ".config" / "gh"
+        profile_gh.mkdir(parents=True)
+        (profile_gh / "hosts.yml").write_text("github.com: {}\n")
+
+        bridge = kb._resolve_dispatcher_github_auth_bridge(
+            {"HOME": str(operator_home)},
+            str(profile_home),
+        )
+
+        assert bridge is None
+
+    def test_bridge_can_be_disabled(self, tmp_path):
+        operator_home = tmp_path / "operator"
+        operator_gh = operator_home / ".config" / "gh"
+        operator_gh.mkdir(parents=True)
+        (operator_gh / "hosts.yml").write_text("github.com: {}\n")
+
+        bridge = kb._resolve_dispatcher_github_auth_bridge(
+            {"HOME": str(operator_home), "HERMES_KANBAN_GITHUB_AUTH_BRIDGE": "off"},
+            str(tmp_path / "profile"),
+        )
+
+        assert bridge is None
+
+
 # ---------------------------------------------------------------------------
 # Links + dependency resolution
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -238,6 +238,28 @@ def test_patch_block_then_unblock(client):
     assert r.json()["task"]["status"] == "ready"
 
 
+def test_patch_schedule_then_unblock(client):
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "x"}).json()["task"]
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "scheduled", "block_reason": "run tomorrow"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task"]["status"] == "scheduled"
+
+    columns = client.get("/api/plugins/kanban/board").json()["columns"]
+    assert "scheduled" in [c["name"] for c in columns]
+    scheduled = next(c for c in columns if c["name"] == "scheduled")
+    assert any(x["id"] == t["id"] for x in scheduled["tasks"])
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}",
+        json={"status": "ready"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task"]["status"] == "ready"
+
+
 def test_patch_drag_drop_move_todo_to_ready(client):
     """Direct status write: the drag-drop path for statuses without a
     dedicated verb (e.g. manually promoting todo -> ready).

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -7,12 +7,14 @@ tests verify the config-driven prelude that fixes that.
 """
 
 import os
+import shlex
 from unittest.mock import patch
 
 import pytest
 
 from tools.environments.local import (
     LocalEnvironment,
+    _prepend_github_auth_bridge,
     _prepend_shell_init,
     _read_terminal_shell_init_config,
     _resolve_shell_init_files,
@@ -179,8 +181,50 @@ class TestPrependShellInit:
     def test_escapes_single_quotes(self):
         wrapped = _prepend_shell_init("echo hi", ["/tmp/o'malley.sh"])
         # The path must survive as the shell receives it; embedded single
-        # quote is escaped as '\'' rather than breaking the outer quoting.
-        assert "o'\\''malley" in wrapped
+        # quote is escaped by shlex.quote rather than breaking the outer quoting.
+        assert shlex.quote("/tmp/o'malley.sh") in wrapped
+
+
+class TestPrependGithubAuthBridge:
+    def test_returns_command_unchanged_without_bridge_env(self):
+        assert _prepend_github_auth_bridge("gh auth status", {}) == "gh auth status"
+
+    def test_returns_command_unchanged_when_hosts_file_missing(self, tmp_path):
+        auth_home = tmp_path / "operator"
+        auth_home.mkdir()
+
+        wrapped = _prepend_github_auth_bridge(
+            "gh auth status",
+            {"HERMES_KANBAN_GITHUB_AUTH_HOME": str(auth_home)},
+        )
+
+        assert wrapped == "gh auth status"
+
+    def test_wraps_gh_and_git_when_bridge_config_exists(self, tmp_path, monkeypatch):
+        auth_home = tmp_path / "operator home"
+        gh_config = auth_home / ".config" / "gh"
+        gh_config.mkdir(parents=True)
+        (gh_config / "hosts.yml").write_text("github.com: {}\n")
+        fake_gh = tmp_path / "bin" / "gh"
+        fake_gh.parent.mkdir()
+        fake_gh.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("tools.environments.local.shutil.which", lambda *a, **k: str(fake_gh))
+
+        wrapped = _prepend_github_auth_bridge(
+            "gh auth status && git push --dry-run",
+            {
+                "HERMES_KANBAN_GITHUB_AUTH_HOME": str(auth_home),
+                "HERMES_KANBAN_GITHUB_CONFIG_DIR": str(gh_config),
+                "PATH": str(fake_gh.parent),
+            },
+        )
+
+        assert "gh()" in wrapped
+        assert "git()" in wrapped
+        assert f"__hermes_gh_auth_home={shlex.quote(str(auth_home))}" in wrapped
+        assert "credential.https://github.com.helper" in wrapped
+        assert "auth git-credential" in wrapped
+        assert wrapped.endswith("gh auth status && git push --dry-run")
 
 
 @pytest.mark.skipif(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -4,6 +4,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -351,12 +352,65 @@ def _prepend_shell_init(cmd_string: str, files: list[str]) -> str:
 
     prelude_parts = ["set +e"]
     for path in files:
-        # shlex.quote isn't available here without an import; the files list
-        # comes from os.path.expanduser output so it's a concrete absolute
-        # path.  Escape single quotes defensively anyway.
-        safe = path.replace("'", "'\\''")
-        prelude_parts.append(f"[ -r '{safe}' ] && . '{safe}' 2>/dev/null || true")
+        # The files list comes from os.path.expanduser output so it's a
+        # concrete absolute path.  Quote defensively anyway.
+        prelude_parts.append(
+            f"[ -r {shlex.quote(path)} ] && . {shlex.quote(path)} 2>/dev/null || true"
+        )
     prelude = "\n".join(prelude_parts) + "\n"
+    return prelude + cmd_string
+
+
+def _prepend_github_auth_bridge(cmd_string: str, env: dict) -> str:
+    """Let Kanban workers use dispatcher GitHub auth without copying tokens.
+
+    Profile subprocess HOME isolation is normally desirable: git/ssh/gh/npm
+    configs stay inside ``{HERMES_HOME}/home``. On macOS, though, GitHub CLI
+    tokens stored in the operator keychain are tied to the real login HOME; a
+    Kanban worker with ``HOME={profile}/home`` sees ``gh auth status`` as
+    unauthenticated even though the gateway/operator session is authenticated.
+
+    The dispatcher may set ``HERMES_KANBAN_GITHUB_AUTH_HOME`` to the operator
+    HOME that already has gh auth. When present, wrap only the ``gh`` and
+    ``git`` shell commands so those tools run with the authenticated HOME while
+    every other subprocess still uses the profile-isolated HOME. No token is
+    copied into env or onto disk.
+    """
+    if _IS_WINDOWS:
+        return cmd_string
+
+    auth_home = str(env.get("HERMES_KANBAN_GITHUB_AUTH_HOME") or "").strip()
+    if not auth_home or not os.path.isdir(auth_home):
+        return cmd_string
+
+    config_dir = str(
+        env.get("HERMES_KANBAN_GITHUB_CONFIG_DIR")
+        or os.path.join(auth_home, ".config", "gh")
+    ).strip()
+    if not config_dir or not os.path.isfile(os.path.join(config_dir, "hosts.yml")):
+        return cmd_string
+
+    gh_bin = shutil.which("gh", path=env.get("PATH") or os.environ.get("PATH") or "") or "gh"
+    helper = f"!{shlex.quote(gh_bin)} auth git-credential"
+    prelude = "\n".join([
+        f"__hermes_gh_auth_home={shlex.quote(auth_home)}",
+        f"__hermes_gh_config_dir={shlex.quote(config_dir)}",
+        f"__hermes_gh_bin={shlex.quote(gh_bin)}",
+        f"__hermes_git_credential_helper={shlex.quote(helper)}",
+        "gh() {",
+        "  HOME=\"$__hermes_gh_auth_home\" GH_CONFIG_DIR=\"$__hermes_gh_config_dir\" command \"$__hermes_gh_bin\" \"$@\"",
+        "}",
+        "git() {",
+        "  local __hermes_git_config_count=\"${GIT_CONFIG_COUNT:-0}\"",
+        "  case \"$__hermes_git_config_count\" in ''|*[!0-9]*) __hermes_git_config_count=0 ;; esac",
+        "  env HOME=\"$__hermes_gh_auth_home\" GH_CONFIG_DIR=\"$__hermes_gh_config_dir\" \\",
+        "    GIT_CONFIG_COUNT=\"$((__hermes_git_config_count + 1))\" \\",
+        "    \"GIT_CONFIG_KEY_${__hermes_git_config_count}=credential.https://github.com.helper\" \\",
+        "    \"GIT_CONFIG_VALUE_${__hermes_git_config_count}=$__hermes_git_credential_helper\" \\",
+        "    git \"$@\"",
+        "}",
+        "",
+    ])
     return prelude + cmd_string
 
 
@@ -436,8 +490,9 @@ class LocalEnvironment(BaseEnvironment):
             init_files = _resolve_shell_init_files()
             if init_files:
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
-        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
+        cmd_string = _prepend_github_auth_bridge(cmd_string, run_env)
+        args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -655,6 +655,7 @@ export const en: Translations = {
     columnLabels: {
       triage: "Triage",
       todo: "Todo",
+      scheduled: "Scheduled",
       ready: "Ready",
       running: "In Progress",
       blocked: "Blocked",
@@ -664,6 +665,7 @@ export const en: Translations = {
     columnHelp: {
       triage: "Raw ideas — a specifier will flesh out the spec",
       todo: "Waiting on dependencies or unassigned",
+      scheduled: "Waiting on a known time delay or scheduled follow-up",
       ready: "Assigned and waiting for a dispatcher tick",
       running: "Claimed by a worker — in-flight",
       blocked: "Worker asked for human input",
@@ -676,6 +678,8 @@ export const en: Translations = {
       "Archive this task? It disappears from the default board view.",
     confirmBlocked:
       "Mark this task as blocked? The worker's claim is released.",
+    confirmScheduled:
+      "Move this task to Scheduled? Use this for known time delays rather than human blockers.",
     completionSummary:
       "Completion summary for {label}. This is stored as the task result.",
     completionSummaryRequired:

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -682,6 +682,7 @@ export interface Translations {
     confirmDone: string;
     confirmArchive: string;
     confirmBlocked: string;
+    confirmScheduled?: string;
     completionSummary: string;
     completionSummaryRequired: string;
     triagePlaceholder: string;

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -375,8 +375,9 @@ Multi-profile, multi-project collaboration board. Each install can host many boa
 | `claim <id>` | Atomically claim a ready task. Prints resolved workspace path. |
 | `comment <id> "<text>"` | Append a comment. The next worker that claims the task reads it as part of its `kanban_show()` response. |
 | `complete <id>` | Mark task done. Flags: `--result`, `--summary`, `--metadata`. |
-| `block <id> "<reason>"` | Mark task blocked. Also appends the reason as a comment. |
-| `unblock <id>` | Return a blocked task to ready. |
+| `block <id> "<reason>"` | Mark task blocked for human input. Also appends the reason as a comment. |
+| `schedule <id> "<reason>"` | Park time-delay/follow-up work in `scheduled` so it is not shown as a human blocker. |
+| `unblock <id>` | Return a blocked or scheduled task to ready (or `todo` if dependencies are still open). |
 | `archive <id>` | Hide from default list. `gc` will remove scratch workspaces. |
 | `tail <id>` | Follow a task's event stream. |
 | `dispatch` | One dispatcher pass on the active board. Flags: `--dry-run`, `--max N`, `--json`. |


### PR DESCRIPTION
## Summary
- Add a first-class `scheduled` Kanban status/column for time-delay follow-ups that are not waiting on human input.
- Add `hermes kanban schedule <task_id> [reason]` and allow dashboard/API transitions to/from Scheduled.
- Keep `unblock` as the release path; it re-checks parent dependencies before moving to `ready`/`todo`.
- Update dashboard labels/styles, i18n fallbacks, docs, and tests.

## Validation
- `python -m pytest tests/hermes_cli/test_kanban_db.py::test_schedule_task_parks_time_delay_without_dispatching tests/hermes_cli/test_kanban_db.py::test_unblock_scheduled_rechecks_parent_gate tests/plugins/test_kanban_dashboard_plugin.py::test_patch_schedule_then_unblock` — 3 passed
- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/plugins/test_kanban_dashboard_plugin.py` — 322 passed, 1 skipped
- `git diff --check`
- `python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py`
- `node --check plugins/kanban/dashboard/dist/index.js`

## Operational note
- Converted existing delayed Vercel recheck card `t_8b167bd2` from `blocked` to `scheduled` locally with the existing cron timing note.
