### PR TITLE
fix(api_server): stream reasoning deltas via reasoning_callback (closes #24518)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -803,6 +803,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         gateway_session_key: Optional[str] = None,
     ) -> Any:
         """
@@ -851,6 +852,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            reasoning_callback=reasoning_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -2790,12 +2792,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "error": kwargs.get("is_error", False),
                 })
             elif event_type == "reasoning.available":
-                _push({
-                    "event": "reasoning.available",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "text": preview or "",
-                })
+                # NOTE: This path fires from assistant_message.content after
+                # completion (run_agent.py:14406), which is the WRONG source —
+                # it's the final response text, not reasoning. We suppress it
+                # here and rely on the streaming reasoning_callback wired in
+                # _handle_runs to deliver correct deltas from
+                # reasoning_content. (See NousResearch/hermes-agent#24518.)
+                return
             # _thinking and subagent_progress are intentionally not forwarded
 
         return _callback
@@ -2905,6 +2908,24 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
+        # Wire reasoning_callback so reasoning.available deltas flow into the
+        # SSE stream from the correct source (reasoning_content field via
+        # _fire_reasoning_delta), matching how Telegram and other streaming
+        # gateways render reasoning. Streams char-by-char alongside
+        # message.delta.
+        def _reasoning_cb(delta: Optional[str]) -> None:
+            if not delta:
+                return
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, {
+                    "event": "reasoning.available",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "text": delta,
+                })
+            except Exception:
+                pass
+
         self._set_run_status(
             run_id,
             "queued",
@@ -2921,6 +2942,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    reasoning_callback=_reasoning_cb,
                     gateway_session_key=gateway_session_key,
                 )
                 self._active_run_agents[run_id] = agent


### PR DESCRIPTION
## Fix: stream reasoning deltas via reasoning_callback in api_server

Closes #24518.

### Problem

When external consumers subscribe to `/v1/runs/{run_id}/events`, every run emits a single `reasoning.available` event followed by `run.completed`. The `text` payload on `reasoning.available` is **identical** to the `output` payload on `run.completed` — the post-completion callback in `run_agent.py:14406` reads from `assistant_message.content` (the final response), not `reasoning_content` (the actual reasoning block).

This causes UIs that render reasoning and response in separate surfaces (e.g. a collapsible "thinking" pane above the message bubble) to show duplicate content. The wider this UX class spreads, the more visible the duplication becomes.

### Why Telegram doesn't show this bug

Telegram (and other streaming gateways) wire `reasoning_callback`, which `_fire_reasoning_delta` (run_agent.py:7610) calls from `reasoning_content` deltas as they stream — the correct source. The api_server platform just wasn't passing this callback through to `AIAgent`.

### Fix

Three localized changes in `gateway/platforms/api_server.py`:

1. **`_create_agent` accepts `reasoning_callback`** and forwards it to `AIAgent(...)` alongside the existing callback parameters.
2. **`_handle_runs` defines `_reasoning_cb`** symmetric with the existing `_text_cb`: when the agent emits a reasoning delta, push it onto the SSE queue as a `reasoning.available` event with `text` set to the delta. Pass the callback into `_create_agent`.
3. **The existing `tool_progress_callback` branch for `reasoning.available` is suppressed** (with a clear comment) so we don't double-emit from the wrong source.

```diff
 def _create_agent(
     self,
     ...
     tool_complete_callback=None,
+    reasoning_callback=None,
     gateway_session_key: Optional[str] = None,
 ) -> Any:
     ...
     agent = AIAgent(
         ...
         tool_complete_callback=tool_complete_callback,
+        reasoning_callback=reasoning_callback,
         ...
     )
```

```diff
 elif event_type == "reasoning.available":
-    _push({
-        "event": "reasoning.available",
-        "run_id": run_id,
-        "timestamp": ts,
-        "text": preview or "",
-    })
+    # NOTE: This path fires from assistant_message.content after
+    # completion (run_agent.py:14406), which is the WRONG source —
+    # it's the final response text, not reasoning. We suppress it
+    # here and rely on the streaming reasoning_callback wired in
+    # _handle_runs to deliver correct deltas from reasoning_content.
+    return
```

```diff
+def _reasoning_cb(delta: Optional[str]) -> None:
+    if not delta:
+        return
+    try:
+        loop.call_soon_threadsafe(q.put_nowait, {
+            "event": "reasoning.available",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "text": delta,
+        })
+    except Exception:
+        pass
```

### Smoke (verified)

Tested end-to-end against a real chat surface (janus-ui v17 chat) hitting the patched gateway. Sent a message; consumed `/v1/runs/{id}/events`. Result:

- **REASONING text** (concatenated from `reasoning.available` deltas): *"I'll just say hello briefly here."*
- **OUTPUT text** (from `run.completed.output`): *"\*metal rings\*\n\nHello, brother. The vents are open. ⚒️"*
- `reasoning == output? **False**`

The two streams now carry different content from different sources — matching how Telegram has been rendering this for months.

### Impact

External consumers of `/v1/runs/{id}/events` that render reasoning and response in distinct UI surfaces will now show distinct content. No change to consumers that don't render reasoning separately (the `run.completed.output` field is unchanged). No new events introduced; only the source of the existing `reasoning.available` event changes.

### Notes

The single post-completion `reasoning.available` emission in `tool_progress_callback` (still present in `run_agent.py:14406` for backward compat with subagent-delegation paths that consume it differently) is now ignored at the api_server boundary. Other platforms that don't wire `reasoning_callback` are unaffected by this change — they continue to see the post-completion event as before.

⚒️
