### PR TITLE
fix(transports): parse Kimi K2 inline tool-call tokens from chat-completions content

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import logging
 from typing import Any, Dict, List, Optional
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -17,6 +18,19 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+logger = logging.getLogger(__name__)
+
+# Kimi K2 emits tool calls as inline tokens (see
+# environments/tool_call_parsers/kimi_k2_parser.py) and some upstreams,
+# notably OpenRouter when the request exposes a sparse toolset, pass these
+# through as plain assistant content instead of populating the structured
+# ``tool_calls`` field.  We detect the section-begin marker (singular or
+# plural variant) in ``content`` as a fallback trigger.  See #?? for repro.
+_KIMI_K2_TOOL_CALL_MARKERS = (
+    "<|tool_calls_section_begin|>",
+    "<|tool_call_section_begin|>",
+)
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -547,6 +561,43 @@ class ChatCompletionsTransport(ProviderTransport):
                     )
                 )
 
+        # Fallback: parse Kimi K2 inline tool-call tokens out of ``content``
+        # when the structured ``tool_calls`` field is empty.  K2 sometimes
+        # emits its native ``<|tool_calls_section_begin|>...`` format as
+        # plain assistant text — observed with K2.6 via OpenRouter when the
+        # exposed toolset is sparse (1-2 tools).  Without this fallback the
+        # tokens are returned to the agent as final assistant content and
+        # the requested tool call never executes.
+        content = msg.content
+        if (
+            not tool_calls
+            and isinstance(content, str)
+            and any(marker in content for marker in _KIMI_K2_TOOL_CALL_MARKERS)
+        ):
+            try:
+                from environments.tool_call_parsers.kimi_k2_parser import KimiK2ToolCallParser
+                parsed_content, parsed_calls = KimiK2ToolCallParser().parse(content)
+                if parsed_calls:
+                    tool_calls = [
+                        ToolCall(
+                            id=tc.id,
+                            name=tc.function.name,
+                            arguments=tc.function.arguments,
+                        )
+                        for tc in parsed_calls
+                    ]
+                    content = parsed_content  # tokens stripped from content
+                    # The upstream reported finish_reason="stop" because it
+                    # treated the tokens as plain text — correct it so the
+                    # agent loop dispatches tool execution.
+                    if finish_reason == "stop":
+                        finish_reason = "tool_calls"
+            except Exception as exc:
+                logger.warning(
+                    "Failed to parse inline K2 tool-call tokens from content: %s",
+                    exc,
+                )
+
         usage = None
         if hasattr(response, "usage") and response.usage:
             u = response.usage
@@ -575,7 +626,7 @@ class ChatCompletionsTransport(ProviderTransport):
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -753,6 +753,95 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": "model-extra scratchpad"}
 
 
+class TestChatCompletionsKimiK2InlineTokens:
+    """Kimi K2 emits tool calls as inline ``<|tool_calls_section_begin|>``
+    tokens.  Some upstreams (notably OpenRouter when only 1-2 tools are
+    exposed) pass these through as assistant text instead of populating
+    ``tool_calls`` — the transport must parse them as a fallback or the
+    requested tool call never runs."""
+
+    _K2_CONTENT = (
+        '<|tool_calls_section_begin|>'
+        '<|tool_call_begin|>functions.web_search:0'
+        '<|tool_call_argument_begin|>{"query": "hello world"}'
+        '<|tool_call_end|>'
+        '<|tool_calls_section_end|>'
+    )
+
+    def test_parses_inline_tokens_when_structured_tool_calls_empty(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=self._K2_CONTENT, tool_calls=None, reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls is not None
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "web_search"
+        assert nr.tool_calls[0].arguments == '{"query": "hello world"}'
+        # finish_reason promoted from "stop" → "tool_calls" so the agent
+        # loop dispatches the parsed call.
+        assert nr.finish_reason == "tool_calls"
+        # Inline tokens are stripped from content.
+        assert "<|tool_call" not in (nr.content or "")
+
+    def test_strips_tokens_but_preserves_leading_prose(self, transport):
+        prose = "I'll search for that now."
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=prose + self._K2_CONTENT,
+                    tool_calls=None, reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls and nr.tool_calls[0].name == "web_search"
+        assert nr.content == prose
+
+    def test_structured_tool_calls_take_precedence(self, transport):
+        # When the upstream did populate tool_calls properly, leave them
+        # alone even if content happens to also contain the markers.
+        tc = SimpleNamespace(
+            id="call_real",
+            function=SimpleNamespace(name="terminal", arguments='{"command": "ls"}'),
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=self._K2_CONTENT, tool_calls=[tc], reasoning_content=None,
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "terminal"
+        assert nr.tool_calls[0].id == "call_real"
+
+    def test_no_markers_no_change(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="Plain text answer.", tool_calls=None, reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls is None
+        assert nr.content == "Plain text answer."
+        assert nr.finish_reason == "stop"
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):


### PR DESCRIPTION

## What does this PR do?

`ChatCompletionsTransport.normalize_response` extracts tool calls only from the structured `message.tool_calls` field. When the upstream returns Kimi K2's native tool-call format — `<|tool_calls_section_begin|>...<|tool_calls_section_end|>` — as plain assistant `content`, the transport returns the tokens to the agent loop verbatim. The requested tool call never executes; the leaked tokens are delivered to the user as if they were the final answer.

This PR adds a fallback: when `tool_calls` is empty and `content` contains a K2 section-begin marker, parse the content with the existing `KimiK2ToolCallParser` (`environments/tool_call_parsers/kimi_k2_parser.py`, adapted from VLLM's `KimiK2ToolParser`), surface the extracted calls, strip the tokens from `content`, and promote `finish_reason` from `"stop"` to `"tool_calls"` so the agent loop dispatches.

### Why this approach

The K2 text parser already exists in-tree, fully tested, modeled on VLLM's reference implementation. It just wasn't wired into the agent runtime — `kimi_k2_parser.py` is only registered in the RL `environments/` registry. This PR is the smallest possible change: import the parser at the only call site that observed leakage in practice, and gate it on a content-marker check (no model-name detection needed, no kwarg threading through `normalize_response`, no behavior change for messages that don't contain the markers).

Marker-based gating beats model-name gating for two reasons: (1) it's robust against new K2-family endpoints / aggregator slugs where name detection would silently miss the bug, and (2) the markers are specific enough (literal `<|tool_calls_section_begin|>` token sequences) that false positives on non-K2 models are effectively impossible.

Most user-visible failure mode today is cron jobs with sparse toolsets (`enabled_toolsets=["web","search"]` and similar — feature shipped in #21538), which reliably push K2 via OpenRouter into the inline-tokens emission path. The leakage hits the Discord/Telegram/etc. delivery raw.

## Related Issues and PRs

Fixes #24534.

Searched open issues + PRs for K2/tool-call related context; this PR is related to the following but not a duplicate of any:

- **#18742 (P3)** — *Kimi K2.5 via aggregators (synthetic.new, OpenRouter) gets no max_tokens/reasoning_effort → empty response.* Same area (K2-via-aggregator handling under `_is_kimi`), different symptom. That issue is about request shaping; this PR is about response normalization. Independent code paths.
- **#23997 (P1)** — *enabled_toolsets silently rejects MCP server names — MCP tools absent in cron sessions.* The cron-side trigger for this PR is the same configuration shape (sparse `enabled_toolsets` in cron jobs). Different bug — that one is toolset resolution silently dropping items, this one is transport response handling. Independent fixes.
- **#16388 (closed)** — *DeepSeek tool-calling turns missing reasoning_content cause HTTP 400 — Kimi-only compensation should generalise.* Precedent for adding Kimi-specific compensation in the transport layer. This PR generalises in the same spirit: a parser that already exists for one provider's emission format, exposed via a narrow opt-in.
- **#21538 (closed, duplicate of merged work)** — *per-job enabled_toolsets for cron scheduler.* The feature that makes the cron failure mode reachable in practice. Doesn't cause the bug, but is the most common path that exposes it.
- **#13473 (open, tracking)** — *provider transport refactor (`agent/transports/`).* Cycle 1 (PRs 1–7) was pure code movement: `normalize_response` shape unchanged, no new fallback paths. This PR lands at the chat_completions transport where it already lives post-Cycle 1.

  More interesting: Cycle 2's planned `providers/<name>.py` consolidation covers *request* quirks (temperature, max_tokens, headers, message normalization, extra_body, …) — every entry in the design's "Current quirk distribution" table is request-side. The K2-marker fallback this PR adds is the first concrete *response*-side provider quirk surfaced in the refactor's scope, and doesn't fit any existing category.

  Once Cycle 2 lands a Kimi provider module, the natural home for this fix is a per-provider response hook called by the transport after the existing extraction:

  ```python
  # providers/kimi.py
  from dataclasses import replace

  class KimiProvider:
      ...
      def post_normalize(self, nr: NormalizedResponse) -> NormalizedResponse:
          if (not nr.tool_calls
                  and nr.content
                  and any(m in nr.content for m in _KIMI_K2_TOOL_CALL_MARKERS)):
              content, calls = KimiK2ToolCallParser().parse(nr.content)
              if calls:
                  return replace(
                      nr,
                      content=content,
                      tool_calls=[
                          ToolCall(id=c.id,
                                   name=c.function.name,
                                   arguments=c.function.arguments)
                          for c in calls
                      ],
                      finish_reason=("tool_calls" if nr.finish_reason == "stop"
                                     else nr.finish_reason),
                  )
          return nr
  ```

  …with the transport invoking `provider.post_normalize(nr)` after the existing `msg.tool_calls` extraction. Migration would be a ~30-line move with no behavior change — the logic in this PR is self-contained and portable. Adding a `post_normalize` hook (or equivalent response-side callback) to Cycle 2's per-provider interface seems like the right extension; this PR may be useful concrete grounding for that interface decision when Cycle 2's design firms up.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py`:
  - Added module-level `logger = logging.getLogger(__name__)` and `_KIMI_K2_TOOL_CALL_MARKERS` constants.
  - In `normalize_response`, after the existing `msg.tool_calls` extraction, added a marker-gated fallback that calls `KimiK2ToolCallParser().parse(content)`, surfaces extracted calls as `ToolCall` entries, strips tokens from `content`, and promotes `finish_reason` from `"stop"` → `"tool_calls"`.
  - Return now passes the (possibly stripped) local `content` instead of `msg.content` directly — identical when no markers were present.
- `tests/agent/transports/test_chat_completions.py`:
  - New `TestChatCompletionsKimiK2InlineTokens` class with 4 tests: parses tokens when `tool_calls` is empty; preserves leading prose while stripping tokens; structured `tool_calls` takes precedence when both are present; no-op when no markers present.

No changes to call sites, no signature changes, no new kwargs to thread through. 53+/1- in production code, 89+ in tests.

## How to Test

1. Apply the patch.
2. Unit tests: `pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsKimiK2InlineTokens -q` — all 4 new tests pass.
3. Regression sweep on the normalize path: `pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsNormalize -q` — all 6 pre-existing tests pass.
4. End-to-end reproduction (requires K2.6 + OpenRouter access):
   - Configure a profile with `model.default: moonshotai/kimi-k2.6`, `model.provider: openrouter`.
   - `hermes cron create "every 2m" "Use web_search to search for 'hermes nousresearch'. Respond with only the top URL." --toolsets web,search --deliver local`
   - Wait one tick. Inspect `~/.hermes/cron/output/<job_id>/<timestamp>.md` — before the patch, `## Response` contains literal `<|tool_calls_section_begin|>...` tokens; after, it contains the URL.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(transports): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py -q` on the touched module and all tests in the affected classes pass (2 pre-existing failures in `TestChatCompletionsBuildKwargs` are unrelated — `ModuleNotFoundError: No module named 'providers'`, present on `main` independent of this patch)
- [x] I've added tests for my changes (4 new tests)
- [x] I've tested on my platform: Debian 13 (Linux 6.12) inside `hermes-agent:local` Docker image

### Documentation & Housekeeping

- [x] N/A — no user-facing config keys or commands changed; behavior change is invisible when not present in upstream responses
- [x] N/A — no new config keys
- [x] N/A — no architecture / workflow changes
- [x] N/A — pure transport-layer fix, no platform-specific code
- [x] N/A — no tool descriptions / schemas changed

## Scope note

This PR fixes the **token-leakage** failure mode only. Sparse-toolset K2-via-OR also exhibits two separate failure modes — natural-language stubs ("I'll search for...") with no tool call attempted, and hallucinated tool names (e.g. `list_available_tools` for a toolset that doesn't expose it). Those are upstream/model-side issues with sparse toolsets and out of scope for this transport-layer fix.

## Screenshots / Logs

Before (cron output, `enabled_toolsets=["web","search"]`):

```
## Response

<|tool_calls_section_begin|><|tool_call_begin|>functions.web_search:0<|tool_call_argument_begin|>{"query": "hermes nousresearch"}<|tool_call_end|><|tool_calls_section_end|>
```

After (same job config, patched transport):

```
## Response

https://hermes-agent.nousresearch.com/
```