### PR TITLE
fix(fallback): eagerly fail over on overloaded providers

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -266,7 +266,12 @@ class PlatformConfig:
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
     home_channel: Optional[HomeChannel] = None
-    
+
+    # Optional dedicated destination for gateway lifecycle notices
+    # (shutdown/restart/startup). When set, these notices are routed here
+    # instead of active/home chats on the same platform.
+    lifecycle_notification_channel: Optional[HomeChannel] = None
+
     # Reply threading mode (Telegram/Slack)
     # - "off": Never thread replies to original message
     # - "first": Only first chunk threads to user's message (default)
@@ -296,6 +301,10 @@ class PlatformConfig:
             result["api_key"] = self.api_key
         if self.home_channel:
             result["home_channel"] = self.home_channel.to_dict()
+        if self.lifecycle_notification_channel:
+            result["lifecycle_notification_channel"] = (
+                self.lifecycle_notification_channel.to_dict()
+            )
         return result
 
     @classmethod
@@ -304,11 +313,18 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        lifecycle_notification_channel = None
+        if "lifecycle_notification_channel" in data:
+            lifecycle_notification_channel = HomeChannel.from_dict(
+                data["lifecycle_notification_channel"]
+            )
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
+            lifecycle_notification_channel=lifecycle_notification_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(
                 data.get("gateway_restart_notification"), True
@@ -517,6 +533,13 @@ class GatewayConfig:
         config = self.platforms.get(platform)
         if config:
             return config.home_channel
+        return None
+
+    def get_lifecycle_notification_channel(self, platform: Platform) -> Optional[HomeChannel]:
+        """Get dedicated lifecycle-notification channel for a platform, if any."""
+        config = self.platforms.get(platform)
+        if config:
+            return config.lifecycle_notification_channel
         return None
     
     def get_reset_policy(
@@ -1216,6 +1239,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=discord_home,
             name=os.getenv("DISCORD_HOME_CHANNEL_NAME", "Home"),
             thread_id=os.getenv("DISCORD_HOME_CHANNEL_THREAD_ID") or None,
+        )
+
+    discord_lifecycle = os.getenv("DISCORD_LIFECYCLE_CHANNEL")
+    if discord_lifecycle and Platform.DISCORD in config.platforms:
+        config.platforms[Platform.DISCORD].lifecycle_notification_channel = HomeChannel(
+            platform=Platform.DISCORD,
+            chat_id=discord_lifecycle,
+            name=os.getenv("DISCORD_LIFECYCLE_CHANNEL_NAME", "System"),
+            thread_id=os.getenv("DISCORD_LIFECYCLE_CHANNEL_THREAD_ID") or None,
         )
     
     # Reply threading mode for Discord (off/first/all)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -628,6 +628,42 @@ from gateway.config import (
     PlatformConfig,
     load_gateway_config,
 )
+
+
+def _target_tuple(
+    platform_value: str,
+    chat_id: str,
+    thread_id: Optional[str],
+) -> tuple[str, str, Optional[str]]:
+    return (
+        platform_value,
+        str(chat_id),
+        str(thread_id) if thread_id else None,
+    )
+
+
+def _resolve_lifecycle_target(
+    config: GatewayConfig,
+    platform: Platform,
+    *,
+    fallback_chat_id: str,
+    fallback_thread_id: Optional[str],
+) -> tuple[str, Optional[dict[str, str]], tuple[str, str, Optional[str]], bool]:
+    """Resolve destination for lifecycle notices on a platform.
+
+    Returns:
+      (chat_id_to_send, metadata, dedup_target, rerouted)
+    where rerouted=True means a dedicated lifecycle channel was used.
+    """
+    channel = config.get_lifecycle_notification_channel(platform)
+    if channel and channel.chat_id:
+        target = _target_tuple(platform.value, str(channel.chat_id), channel.thread_id)
+        metadata = {"thread_id": channel.thread_id} if channel.thread_id else None
+        return str(channel.chat_id), metadata, target, True
+
+    target = _target_tuple(platform.value, fallback_chat_id, fallback_thread_id)
+    metadata = {"thread_id": fallback_thread_id} if fallback_thread_id else None
+    return str(fallback_chat_id), metadata, target, False
 from gateway.session import (
     SessionStore,
     SessionSource,
@@ -2750,13 +2786,6 @@ class GatewayRunner:
                 chat_id = _parsed["chat_id"]
                 thread_id = _parsed.get("thread_id")
 
-            # Deduplicate only identical delivery targets. Thread/topic-aware
-            # platforms can share a parent chat while still routing to distinct
-            # destinations via metadata.
-            dedup_key = (platform_str, chat_id, str(thread_id) if thread_id else None)
-            if dedup_key in notified:
-                continue
-
             try:
                 platform = Platform(platform_str)
                 adapter = self.adapters.get(platform)
@@ -2771,29 +2800,44 @@ class GatewayRunner:
                     )
                     continue
 
-                # Include thread_id if present so the message lands in the
-                # correct forum topic / thread.
-                metadata = {"thread_id": thread_id} if thread_id else None
+                resolved_chat_id, metadata, dedup_key, rerouted = _resolve_lifecycle_target(
+                    self.config,
+                    platform,
+                    fallback_chat_id=chat_id,
+                    fallback_thread_id=thread_id,
+                )
+                if dedup_key in notified:
+                    continue
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                result = await adapter.send(resolved_chat_id, msg, metadata=metadata)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
                         platform_str,
-                        chat_id,
+                        resolved_chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
 
                 notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to active chat %s:%s",
-                    platform_str, chat_id,
-                )
+                if rerouted:
+                    logger.info(
+                        "Sent shutdown notification to lifecycle channel %s:%s",
+                        platform_str,
+                        resolved_chat_id,
+                    )
+                else:
+                    logger.info(
+                        "Sent shutdown notification to active chat %s:%s",
+                        platform_str,
+                        resolved_chat_id,
+                    )
             except Exception as e:
                 logger.debug(
                     "Failed to send shutdown notification to %s:%s: %s",
-                    platform_str, chat_id, e,
+                    platform_str,
+                    chat_id,
+                    e,
                 )
 
         # Snapshot adapters up front: adapter.send() can hit a fatal error
@@ -2814,36 +2858,47 @@ class GatewayRunner:
                 )
                 continue
 
-            dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+            resolved_chat_id, metadata, dedup_key, rerouted = _resolve_lifecycle_target(
+                self.config,
+                platform,
+                fallback_chat_id=str(home.chat_id),
+                fallback_thread_id=home.thread_id,
+            )
             if dedup_key in notified:
                 continue
 
             try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await adapter.send(resolved_chat_id, msg, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await adapter.send(resolved_chat_id, msg)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
                         platform.value,
-                        home.chat_id,
+                        resolved_chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
 
                 notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
+                if rerouted:
+                    logger.info(
+                        "Sent shutdown notification to lifecycle channel %s:%s",
+                        platform.value,
+                        resolved_chat_id,
+                    )
+                else:
+                    logger.info(
+                        "Sent shutdown notification to home channel %s:%s",
+                        platform.value,
+                        resolved_chat_id,
+                    )
             except Exception as e:
                 logger.debug(
                     "Failed to send shutdown notification to home channel %s:%s: %s",
                     platform.value,
-                    home.chat_id,
+                    resolved_chat_id,
                     e,
                 )
 
@@ -12774,12 +12829,23 @@ class GatewayRunner:
                 )
                 return None
 
-            metadata = {"thread_id": thread_id} if thread_id else None
-            result = await adapter.send(
-                str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
-                metadata=metadata,
+            resolved_chat_id, metadata, delivered_target, rerouted = _resolve_lifecycle_target(
+                self.config,
+                platform,
+                fallback_chat_id=str(chat_id),
+                fallback_thread_id=thread_id,
             )
+            if metadata:
+                result = await adapter.send(
+                    resolved_chat_id,
+                    "♻ Gateway restarted successfully. Your session continues.",
+                    metadata=metadata,
+                )
+            else:
+                result = await adapter.send(
+                    resolved_chat_id,
+                    "♻ Gateway restarted successfully. Your session continues.",
+                )
             # adapter.send() catches provider errors (e.g. "Chat not found")
             # and returns SendResult(success=False) rather than raising, so
             # we must inspect the result before claiming success — otherwise
@@ -12788,17 +12854,24 @@ class GatewayRunner:
                 logger.warning(
                     "Restart notification to %s:%s was not delivered: %s",
                     platform_str,
-                    chat_id,
+                    resolved_chat_id,
                     getattr(result, "error", "send returned success=False"),
                 )
                 return None
 
-            logger.info(
-                "Sent restart notification to %s:%s",
-                platform_str,
-                chat_id,
-            )
-            return str(platform_str), str(chat_id), str(thread_id) if thread_id else None
+            if rerouted:
+                logger.info(
+                    "Sent restart notification to lifecycle channel %s:%s",
+                    platform_str,
+                    resolved_chat_id,
+                )
+            else:
+                logger.info(
+                    "Sent restart notification to %s:%s",
+                    platform_str,
+                    resolved_chat_id,
+                )
+            return delivered_target
         except Exception as e:
             logger.warning("Restart notification failed: %s", e)
             return None
@@ -12833,36 +12906,47 @@ class GatewayRunner:
                 )
                 continue
 
-            target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
+            resolved_chat_id, metadata, target, rerouted = _resolve_lifecycle_target(
+                self.config,
+                platform,
+                fallback_chat_id=str(home.chat_id),
+                fallback_thread_id=home.thread_id,
+            )
             if target in skipped or target in delivered:
                 continue
 
             try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), message, metadata=metadata)
+                    result = await adapter.send(resolved_chat_id, message, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), message)
+                    result = await adapter.send(resolved_chat_id, message)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",
                         platform.value,
-                        home.chat_id,
+                        resolved_chat_id,
                         getattr(result, "error", "send returned success=False"),
                     )
                     continue
 
                 delivered.add(target)
-                logger.info(
-                    "Sent home-channel startup notification to %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
+                if rerouted:
+                    logger.info(
+                        "Sent startup notification to lifecycle channel %s:%s",
+                        platform.value,
+                        resolved_chat_id,
+                    )
+                else:
+                    logger.info(
+                        "Sent home-channel startup notification to %s:%s",
+                        platform.value,
+                        resolved_chat_id,
+                    )
             except Exception as exc:
                 logger.warning(
                     "Home-channel startup notification failed for %s:%s: %s",
                     platform.value,
-                    home.chat_id,
+                    resolved_chat_id,
                     exc,
                 )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -13956,16 +13956,26 @@ class AIAgent:
                     is_rate_limited = classified.reason in {
                         FailoverReason.rate_limit,
                         FailoverReason.billing,
+                        FailoverReason.overloaded,
                     }
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  See _pool_may_recover_from_rate_limit
                         # for the single-credential-pool and CloudCode-quota
                         # exceptions.  Fixes #11314 and #13636.
-                        pool_may_recover = _pool_may_recover_from_rate_limit(
-                            self._credential_pool,
-                            provider=self.provider,
-                            base_url=getattr(self, "base_url", None),
+                        #
+                        # Important: credential rotation is useless when the
+                        # provider itself is overloaded (503/529) — a different
+                        # API key hits the same overloaded backend.  Skip the
+                        # pool-recovery gate so we fall back immediately instead
+                        # of burning all retries on an unrecoverable state.
+                        pool_may_recover = (
+                            classified.reason != FailoverReason.overloaded
+                            and _pool_may_recover_from_rate_limit(
+                                self._credential_pool,
+                                provider=self.provider,
+                                base_url=getattr(self, "base_url", None),
+                            )
                         )
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,22 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_lifecycle_notification_channel_roundtrip(self):
+        pc = PlatformConfig(
+            enabled=True,
+            lifecycle_notification_channel=HomeChannel(
+                platform=Platform.DISCORD,
+                chat_id="1504054464678596618",
+                name="system",
+                thread_id="topic-7",
+            ),
+        )
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.lifecycle_notification_channel is not None
+        assert restored.lifecycle_notification_channel.chat_id == "1504054464678596618"
+        assert restored.lifecycle_notification_channel.name == "system"
+        assert restored.lifecycle_notification_channel.thread_id == "topic-7"
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -622,3 +638,21 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+    def test_discord_lifecycle_channel_env_override(self):
+        config = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True)})
+        env = {
+            "DISCORD_BOT_TOKEN": "token",
+            "DISCORD_LIFECYCLE_CHANNEL": "1504054464678596618",
+            "DISCORD_LIFECYCLE_CHANNEL_NAME": "system",
+            "DISCORD_LIFECYCLE_CHANNEL_THREAD_ID": "topic-7",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            _apply_env_overrides(config)
+
+        lifecycle = config.platforms[Platform.DISCORD].lifecycle_notification_channel
+        assert lifecycle is not None
+        assert lifecycle.chat_id == "1504054464678596618"
+        assert lifecycle.name == "system"
+        assert lifecycle.thread_id == "topic-7"

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -210,6 +210,29 @@ async def test_shutdown_notification_says_restarting_when_restart_requested():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notification_routes_to_lifecycle_channel_when_configured():
+    """Lifecycle channel overrides active-chat/home destinations for shutdown notices."""
+    from gateway.config import HomeChannel, Platform
+
+    runner, adapter = make_restart_runner()
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_notification_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="sys-42",
+        name="System",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    test_adapter = adapter
+    assert len(test_adapter.sent_calls) == 1
+    chat_id, content, metadata = test_adapter.sent_calls[0]
+    assert chat_id == "sys-42"
+    assert "Gateway shutting down" in content
+    assert metadata is None
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_deduplicates_per_chat():
     """Multiple sessions in the same chat only get one notification."""
     runner, adapter = make_restart_runner()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -249,6 +249,35 @@ async def test_send_home_channel_startup_notification_to_configured_home(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_uses_lifecycle_channel_when_configured(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_notification_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="sys-42",
+        name="System",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="sys"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "sys-42", None)}
+    adapter.send.assert_called_once_with(
+        "sys-42",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_preserves_thread_metadata(
     tmp_path, monkeypatch
 ):
@@ -544,6 +573,35 @@ async def test_send_home_channel_startup_notification_default_flag_true(
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_reroutes_to_lifecycle_channel(
+    tmp_path, monkeypatch
+):
+    """When lifecycle channel is configured, startup ping goes there instead of home."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_notification_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="sys-42",
+        name="System",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="sys"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "sys-42", None)}
+    adapter.send.assert_called_once_with(
+        "sys-42",
+        "♻️ Gateway online — Hermes is back and ready.",
+    )
+
+
+@pytest.mark.asyncio
 async def test_send_restart_notification_skipped_when_flag_disabled(
     tmp_path, monkeypatch
 ):
@@ -601,6 +659,37 @@ async def test_send_restart_notification_logs_info_on_sendresult_success(
     assert success_lines, (
         "Expected INFO 'Sent restart notification' when send succeeded; "
         f"got records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_reroutes_to_lifecycle_channel(
+    tmp_path, monkeypatch
+):
+    """Restart completion notice follows lifecycle channel when configured."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].lifecycle_notification_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="sys-42",
+        name="System",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target == ("telegram", "sys-42", None)
+    adapter.send.assert_called_once_with(
+        "sys-42",
+        "♻ Gateway restarted successfully. Your session continues.",
     )
     assert not notify_path.exists()
 


### PR DESCRIPTION
## Summary
- treat `FailoverReason.overloaded` as an eager-fallback trigger
- bypass credential-pool recovery gating for overloaded backends

## Why
For provider overload states (e.g. 503/529), rotating API keys in the same provider pool usually cannot recover because all keys hit the same overloaded backend. In that case, retrying the same provider burns retries and delays recovery.

## Changes
- `run_agent.py`
  - include `FailoverReason.overloaded` in eager-fallback classification
  - skip `_pool_may_recover_from_rate_limit(...)` gate when reason is overloaded

## Validation
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/agent/test_error_classifier.py tests/agent/test_gemini_fast_fallback.py -q`
- Result: `158 passed`

## Scope
This PR only adjusts fallback behavior for overloaded-provider errors; rate-limit/billing behavior remains unchanged.
