### PR TITLE
fix(transports): propagate provider routing prefs to custom providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -314,13 +314,14 @@ class ChatCompletionsTransport(ProviderTransport):
         extra_body: dict[str, Any] = {}
 
         is_openrouter = params.get("is_openrouter", False)
+        is_custom_provider = params.get("is_custom_provider", False)
         is_nous = params.get("is_nous", False)
         is_github_models = params.get("is_github_models", False)
         provider_name = str(params.get("provider_name") or "").strip().lower()
         base_url = params.get("base_url")
 
         provider_prefs = params.get("provider_preferences")
-        if provider_prefs and is_openrouter:
+        if provider_prefs and (is_openrouter or is_custom_provider):
             extra_body["provider"] = provider_prefs
 
         # Pareto Code router plugin — model-gated. Same shape as the

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -83,6 +83,29 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["provider"] == {"only": ["openai"]}
 
+    def test_custom_provider_gets_provider_prefs(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            provider_preferences={"only": ["openai"]},
+            is_custom_provider=True,
+        )
+        assert kw["extra_body"]["provider"] == {"only": ["openai"]}
+    
+    def test_non_openrouter_non_custom_provider_skips_provider_prefs(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            provider_preferences={"only": ["openai"]},
+            is_openrouter=False,
+            is_custom_provider=False,
+        )
+        assert "provider" not in kw.get("extra_body", {})
+
     def test_openrouter_pareto_min_coding_score(self, transport):
         """Profile path: model=openrouter/pareto-code + score → plugins block."""
         from providers import get_provider_profile


### PR DESCRIPTION
## What does this PR do?

Custom providers like Polza.ai support OpenRouter-style `provider` routing fields (`only`, `ignore`, `order`, `sort`) in the request body, but Hermes was silently dropping them. The `build_kwargs` function only injected `extra_body["provider"]` for OpenRouter, leaving custom providers with no way to pin upstream providers.

This PR extends that condition to include custom providers too — a one-line change that aligns the legacy path with `_build_kwargs_from_profile`, which already handles this correctly.

**Fixes #24450**

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` — extended `provider_prefs` condition from `is_openrouter` to `(is_openrouter or is_custom_provider)`
- `tests/agent/transports/test_chat_completions.py` — added 2 tests covering the custom provider path and the negative case

## How to Test

```bash
python -m pytest tests/agent/transports/test_chat_completions.py -v
```

- `test_custom_provider_gets_provider_prefs` — verifies custom providers now receive `provider` in `extra_body`
- `test_non_openrouter_non_custom_provider_skips_provider_prefs` — verifies other providers are still unaffected

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicates found
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
