### PR TITLE
fix(install): skip Microsoft Store python.exe stub in Test-Python fallback (#24424)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -175,16 +175,34 @@ function Test-Python {
         } catch { }
     }
 
-    # Fallback: try system python
-    if (Get-Command python -ErrorAction SilentlyContinue) {
-        $sysVer = python --version 2>$null
+    # Fallback: try system python.  Skip the Microsoft Store app-execution
+    # alias (`%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe`) — on fresh
+    # Windows 11 it sits in PATH but is not a real interpreter; invoking it
+    # prints "Python was not found; run without arguments to install from the
+    # Microsoft Store..." and exits non-zero.  Under this script's
+    # `$ErrorActionPreference = "Stop"`, that turns into a terminating
+    # NativeCommandError whose message replaces the script's own friendlier
+    # one, surfacing as `Installation failed: Python was not found...` (#24424).
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($pythonCmd -and ($pythonCmd.Source -notmatch '\\WindowsApps\\')) {
+        try {
+            $sysVer = & $pythonCmd.Source --version 2>&1
+        } catch {
+            $sysVer = ""
+        }
         if ($sysVer -match "3\.(1[0-9]|[1-9][0-9])") {
             Write-Success "Using system Python: $sysVer"
             return $true
         }
     }
-    
+
     Write-Err "Failed to install Python $PythonVersion"
+    if ($pythonCmd -and ($pythonCmd.Source -match '\\WindowsApps\\')) {
+        Write-Info "The 'python.exe' on your PATH is the Microsoft Store app-execution"
+        Write-Info "alias, not a real Python install. Disable it under Settings >"
+        Write-Info "Apps > Advanced app settings > App execution aliases, or install"
+        Write-Info "Python directly using one of the options below."
+    }
     Write-Info "Install Python 3.11 manually, then re-run this script:"
     Write-Info "  https://www.python.org/downloads/"
     Write-Info "  Or: winget install Python.Python.3.11"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -183,8 +183,11 @@ function Test-Python {
     # `$ErrorActionPreference = "Stop"`, that turns into a terminating
     # NativeCommandError whose message replaces the script's own friendlier
     # one, surfacing as `Installation failed: Python was not found...` (#24424).
+    # Match only the specific `\Microsoft\WindowsApps\` alias location so a
+    # legitimate `python.exe` that happens to live under any other
+    # `WindowsApps` directory is not also skipped.
     $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-    if ($pythonCmd -and ($pythonCmd.Source -notmatch '\\WindowsApps\\')) {
+    if ($pythonCmd -and ($pythonCmd.Source -notmatch '\\Microsoft\\WindowsApps\\')) {
         try {
             $sysVer = & $pythonCmd.Source --version 2>&1
         } catch {
@@ -197,7 +200,7 @@ function Test-Python {
     }
 
     Write-Err "Failed to install Python $PythonVersion"
-    if ($pythonCmd -and ($pythonCmd.Source -match '\\WindowsApps\\')) {
+    if ($pythonCmd -and ($pythonCmd.Source -match '\\Microsoft\\WindowsApps\\')) {
         Write-Info "The 'python.exe' on your PATH is the Microsoft Store app-execution"
         Write-Info "alias, not a real Python install. Disable it under Settings >"
         Write-Info "Apps > Advanced app settings > App execution aliases, or install"

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -486,14 +486,20 @@ class TestInstallPs1SkipsStorePythonStub:
 
     def test_test_python_skips_windowsapps_alias(self):
         source = self._source()
-        # The fallback that calls `Get-Command python` must check the resolved
-        # Source path against `\WindowsApps\` and skip the alias rather than
-        # invoking it.
-        assert "WindowsApps" in source, (
-            "scripts/install.ps1 must detect the Microsoft Store python.exe "
+        # Assert on the *executable guard expression*, not just a substring
+        # mention.  A plain `"WindowsApps" in source` would still pass if the
+        # only remaining occurrence sat inside a comment after a regression.
+        # The actual fallback that calls `Get-Command python` must contain a
+        # `Source -notmatch '\Microsoft\WindowsApps\'` check (narrowed to the
+        # specific Microsoft Store alias path so a legitimate python.exe under
+        # any other WindowsApps directory is not also skipped).
+        guard_pattern = r"$pythonCmd.Source -notmatch '\\Microsoft\\WindowsApps\\'"
+        assert guard_pattern in source, (
+            "scripts/install.ps1 must guard the system-python fallback with "
+            f"`{guard_pattern}` so the Microsoft Store python.exe "
             "app-execution alias (under %LOCALAPPDATA%\\Microsoft\\WindowsApps\\) "
-            "and skip invoking it — otherwise a fresh Windows 11 install fails "
-            "with the stub's 'Python was not found' message (see #24424)."
+            "is skipped — otherwise a fresh Windows 11 install fails with the "
+            "stub's 'Python was not found' message (see #24424)."
         )
 
     def test_test_python_invokes_resolved_source_not_bare_python(self):
@@ -504,6 +510,18 @@ class TestInstallPs1SkipsStorePythonStub:
         assert "$pythonCmd.Source --version" in source, (
             "scripts/install.ps1 should invoke the resolved Get-Command Source "
             "path (after filtering out WindowsApps) rather than bare `python`."
+        )
+
+    def test_test_python_explains_store_alias_in_failure_message(self):
+        source = self._source()
+        # When detection of a real python fails AND the only thing on PATH is
+        # the Microsoft Store alias, the script must surface a user-actionable
+        # hint pointing at the App-execution-aliases setting.  This binds the
+        # match-branch error path to the same narrowed regex.
+        hint_pattern = r"$pythonCmd.Source -match '\\Microsoft\\WindowsApps\\'"
+        assert hint_pattern in source, (
+            "scripts/install.ps1 must emit the App-execution-aliases hint when "
+            f"the only python.exe on PATH is the Store stub (`{hint_pattern}`)."
         )
 
 

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -463,6 +463,51 @@ class TestReadmeNoLongerSaysWindowsUnsupported:
 
 
 # ---------------------------------------------------------------------------
+# install.ps1 — Microsoft Store python.exe app-execution alias is skipped
+# ---------------------------------------------------------------------------
+
+
+class TestInstallPs1SkipsStorePythonStub:
+    """`Test-Python` in scripts/install.ps1 must not invoke the Windows Store
+    app-execution alias for ``python.exe``.
+
+    On a fresh Windows 11, ``Get-Command python`` returns
+    ``%LOCALAPPDATA%\\Microsoft\\WindowsApps\\python.exe`` even when no real
+    Python is installed.  Invoking that stub prints "Python was not found;
+    run without arguments to install from the Microsoft Store..." and exits
+    non-zero — and because install.ps1 sets ``$ErrorActionPreference = 'Stop'``,
+    that surfaces as ``✗ Installation failed: Python was not found...``, which
+    is reproducible from #24424.
+    """
+
+    def _source(self) -> str:
+        root = Path(__file__).resolve().parents[2]
+        return (root / "scripts" / "install.ps1").read_text(encoding="utf-8")
+
+    def test_test_python_skips_windowsapps_alias(self):
+        source = self._source()
+        # The fallback that calls `Get-Command python` must check the resolved
+        # Source path against `\WindowsApps\` and skip the alias rather than
+        # invoking it.
+        assert "WindowsApps" in source, (
+            "scripts/install.ps1 must detect the Microsoft Store python.exe "
+            "app-execution alias (under %LOCALAPPDATA%\\Microsoft\\WindowsApps\\) "
+            "and skip invoking it — otherwise a fresh Windows 11 install fails "
+            "with the stub's 'Python was not found' message (see #24424)."
+        )
+
+    def test_test_python_invokes_resolved_source_not_bare_python(self):
+        source = self._source()
+        # Bare `python --version` re-resolves PATH (which would re-pick the
+        # stub) and is wrapped in a try/catch in the patched code.  The
+        # resolved-Source invocation is the marker that the guard landed.
+        assert "$pythonCmd.Source --version" in source, (
+            "scripts/install.ps1 should invoke the resolved Get-Command Source "
+            "path (after filtering out WindowsApps) rather than bare `python`."
+        )
+
+
+# ---------------------------------------------------------------------------
 # pty_bridge graceful import on Windows
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fresh Windows 11 installs of Hermes fail at the python-detection step because the installer invokes the Microsoft Store app-execution alias at `%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe`, which isn't a real interpreter.
- The stub's "Python was not found..." message bubbles up through `$ErrorActionPreference = 'Stop'` and replaces the script's friendlier error.
- Fix: detect the alias by path, skip it in the fallback, and surface a one-line pointer to the Windows toggle when it's the only `python.exe` on PATH.

## The bug

`scripts/install.ps1` runs `Test-Python` with three fallback layers:

1. `uv python find 3.11`
2. `uv python install 3.11` then re-find
3. `uv python find 3.12 / 3.13 / 3.10`
4. **System-Python fallback** — `Get-Command python` then `python --version`

On a clean Windows 11, layer 4 picks up the Store app-execution alias, which prints

> Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Apps > Advanced app settings > App execution aliases.

and exits non-zero. With `$ErrorActionPreference = 'Stop'` set at the top of the script, the NativeCommandError replaces the script's own throw, surfacing to the user as

> ✗ Installation failed: Python was not found...

The reporter's transcript in #24424 shows this exact sequence — `uv python install 3.11` failed with a flaky download, the secondary `uv python find` for 3.10/3.12/3.13 also found nothing, and the bare `python` fallback hit the Store stub.

## The fix

In `Test-Python` (`scripts/install.ps1`):

- Capture `Get-Command python -ErrorAction SilentlyContinue` into `$pythonCmd`.
- Skip when `$pythonCmd.Source -match '\WindowsApps\'` — that's the Store alias directory.
- Invoke `& $pythonCmd.Source --version` via the resolved path inside a try/catch so a broken interpreter can't terminate the script through `Stop` preference.
- When the alias is the **only** `python.exe` on PATH, add a short pointer to the toggle location (`Settings > Apps > Advanced app settings > App execution aliases`) before the existing "install Python 3.11 manually" guidance, so the user doesn't have to copy the path out of the error message and search for it.

No behavior change when the user has a real `python.exe` on PATH — the regex `'\\WindowsApps\\'` only matches the Store alias's install path.

## Test plan

- [x] Focused regression test: `tests/tools/test_windows_native_support.py::TestInstallPs1SkipsStorePythonStub` — source-level lint that the install.ps1 contains the `WindowsApps` skip guard and invokes `$pythonCmd.Source --version` rather than bare `python`. Runs on Linux CI; no Windows runner needed.
- [x] Adjacent suite: full `tests/tools/test_windows_native_support.py` (60 tests) passes locally — no collateral damage to the existing source-level lints.
- [x] Regression guard: the new tests assert presence of strings only introduced in this PR (`"WindowsApps"`, `"$pythonCmd.Source --version"`); reverting `scripts/install.ps1` causes both assertions to fail with the precise scope they're meant to protect.

## Related

- Fixes #24424