### PR TITLE
fix(compressor): save compressor_api_mode in the init snapshot

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2488,6 +2488,7 @@ class AIAgent:
             "compressor_base_url": getattr(_cc, "base_url", self.base_url),
             "compressor_api_key": getattr(_cc, "api_key", ""),
             "compressor_provider": getattr(_cc, "provider", self.provider),
+            "compressor_api_mode": getattr(_cc, "api_mode", self.api_mode),
             "compressor_context_length": _cc.context_length,
             "compressor_threshold_tokens": _cc.threshold_tokens,
         }
@@ -2773,6 +2774,7 @@ class AIAgent:
             "compressor_base_url": getattr(_cc, "base_url", self.base_url) if _cc else self.base_url,
             "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
             "compressor_provider": getattr(_cc, "provider", self.provider) if _cc else self.provider,
+            "compressor_api_mode": getattr(_cc, "api_mode", self.api_mode) if _cc else self.api_mode,
             "compressor_context_length": _cc.context_length if _cc else 0,
             "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
         }
@@ -9002,6 +9004,7 @@ class AIAgent:
                 base_url=rt["compressor_base_url"],
                 api_key=rt["compressor_api_key"],
                 provider=rt["compressor_provider"],
+                api_mode=rt.get("compressor_api_mode", ""),
             )
 
             # ── Reset fallback chain for the new turn ──

--- a/run_agent.py
+++ b/run_agent.py
@@ -8912,6 +8912,7 @@ class AIAgent:
                     base_url=self.base_url,
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
+                    api_mode=self.api_mode,
                 )
 
             self._emit_status(


### PR DESCRIPTION
## What does this PR do?

`_primary_runtime` is built in `agent/agent_init.py` without `compressor_api_mode`, so `_restore_primary_runtime` falls back to `""` (`agent/agent_runtime_helpers.py`, `rt.get("compressor_api_mode", "")`). After a primary → fallback → primary round trip, the compressor is left with an empty `api_mode`: the fallback had moved it to `chat_completions`, and restore doesn't put it back on the primary's wire.

`switch_model()` already records the field in its snapshot; this adds the same one line to the init snapshot.

Reworked per the sweeper review: the fallback-propagation and restore-consumption halves of the original PR are already on `main` (from the runtime-helper extraction), so the branch now carries **only** the missing init-snapshot field plus the requested round-trip test.

## Related Issue

None filed. Found while tracing compressor transport state in a Codex-primary deployment with a cross-provider fallback chain.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py`: save `compressor_api_mode` in the init `_primary_runtime` snapshot
- `tests/agent/test_primary_runtime_restore.py`: new `test_compressor_api_mode_survives_fallback_round_trip` (anthropic_messages primary → openrouter fallback → restore), plus an assertion in `test_snapshot_includes_compressor_state`

## How to Test

1. `pytest tests/agent/test_primary_runtime_restore.py -q` → 36 passed
2. Remove the one-line fix and re-run: the round-trip test fails with `AssertionError: assert '' == 'anthropic_messages'` (and the snapshot test fails), which is the bug

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the affected tests and they pass (`tests/agent/test_primary_runtime_restore.py`, in the Docker image)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Docker (Debian image) on Windows 11 / Docker Desktop

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python state)
