### PR TITLE
fix(runtime): exchange Copilot raw OAuth token in pool resolution path

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -229,6 +229,20 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
+        # Exchange the raw GitHub OAuth token (gho_/ghu_) for a short-lived
+        # Copilot API Bearer (tid=...).  Without this, sending the raw token to
+        # /chat/completions makes GitHub map it to whatever integrator the
+        # originating OAuth app declared as default — typically
+        # ``copilot-language-server`` for Business seats — which has a
+        # restricted model allowlist that excludes Claude.  The sibling
+        # ``resolve_api_key_provider_credentials("copilot")`` path does this
+        # exchange; the pool path was the only one skipping it.
+        if api_key and not api_key.startswith("tid="):
+            try:
+                from hermes_cli.copilot_auth import get_copilot_api_token
+                api_key = get_copilot_api_token(api_key)
+            except Exception:
+                pass
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()


### PR DESCRIPTION
## Problem

`_resolve_runtime_from_pool_entry`'s Copilot branch returns `getattr(entry, "runtime_api_key", "")` directly. The sibling api-key path (`resolve_api_key_provider_credentials("copilot")` in `hermes_cli/auth.py`) correctly calls `get_copilot_api_token()` to exchange the raw `gho_*` / `ghu_*` GitHub OAuth token via `/copilot_internal/v2/token` for the short-lived `tid=...` Bearer that Copilot's `/chat/completions` endpoint actually requires.

When the gateway-init fallback path picks Copilot via the pool branch, the raw token goes on the wire. GitHub then maps the raw OAuth grant to whatever integrator the originating OAuth app declared as default — typically `copilot-language-server` for Business/Enterprise seats — which has a restricted model allowlist that excludes Claude:

```
HTTP 400: The requested model is not available for integrator
"copilot-language-server"
```

even though `copilot_request_headers()` correctly advertises `Copilot-Integration-Id: vscode-chat` (verified by adding an `httpx.Client.send` wrapper and inspecting outgoing headers). The header is ignored when the Bearer is a raw OAuth token rather than an exchanged Copilot API token.

The bug is partially masked because the secondary `_try_activate_fallback` path constructs its own client via `resolve_provider_client()` which DOES exchange — so the next-tier fallback (e.g. `gpt-4.1`) succeeds, hiding the first-attempt failure.

## Fix

When the pool branch resolves Copilot, run the same `get_copilot_api_token()` exchange before assigning the returned `api_key`. Guarded against a string already in exchanged form (`tid=...`) so a future caller that pre-exchanges the token is not double-exchanged.

Strictly additive — no signature changes, only adds the missing exchange step to one specific provider branch. Other providers (`openai-codex`, `anthropic`, `nous`, etc.) are unaffected.

## Reproduction

1. Configure `fallback_providers:`:
   ```yaml
   fallback_providers:
     - provider: copilot
       model: claude-sonnet-4.6
   ```
2. Force the primary to fail at gateway init (e.g. remove Codex auth so the gateway falls back at `_resolve_runtime_agent_kwargs`).
3. Send any inbound message.
4. Without the fix: chat-completions request fails with `HTTP 400: The requested model is not available for integrator "copilot-language-server"`. With the fix: the request succeeds.

The 40-character `ghu_*` vs ~400-character `tid=...` Bearer-token length difference is observable in `httpx.Client.send` if you wrap it temporarily.

## Test plan

- [ ] Existing `_resolve_runtime_from_pool_entry` tests pass.
- [ ] Add a test asserting that `_resolve_runtime_from_pool_entry({provider: "copilot", runtime_api_key: "gho_..."})` returns an `api_key` that starts with `tid=` (mocking `get_copilot_api_token` to return a sentinel exchanged token).
- [ ] Add a test asserting double-exchange is skipped when the entry's `runtime_api_key` already starts with `tid=`.

## Note

This is a separate root cause from [#17622](https://github.com/NousResearch/hermes-agent/pull/17622) (which targets the same function for the `api_mode` calculation but doesn't touch the returned `api_key`). The two fixes are complementary; both are needed for the gateway-init Copilot fallback to work for Claude on Business seats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
