### PR TITLE
fix(kanban): workspace/parent/bulk-reassign selects revert to default (selectChangeHandler)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1744,11 +1744,10 @@
       ),
       h("div", { className: "hermes-kanban-bulk-reassign",
                  title: "Reassign selected tasks to a different Hermes profile. Pick a profile (or unassign) and click Apply." },
-        h(Select, {
+        h(Select, Object.assign({
           value: assignee,
-          onChange: function (e) { setAssignee(e.target.value); },
           className: "h-7 text-xs",
-        },
+        }, selectChangeHandler(setAssignee)),
           h(SelectOption, { value: "" }, "— reassign —"),
           h(SelectOption, { value: "__none__" }, "(unassign)"),
           props.assignees.map(function (a) {
@@ -2249,12 +2248,11 @@
         className: "h-7 text-xs",
       }),
       h("div", { className: "flex gap-2" },
-        h(Select, {
+        h(Select, Object.assign({
           value: workspaceKind,
-          onChange: function (e) { setWorkspaceKind(e.target.value); },
           title: "scratch: isolated temp dir (default). worktree: git worktree on the assignee profile. dir: exact path (required below).",
           className: "h-7 text-xs w-28",
-        },
+        }, selectChangeHandler(setWorkspaceKind)),
           h(SelectOption, { value: "scratch" }, "scratch"),
           h(SelectOption, { value: "worktree" }, "worktree"),
           h(SelectOption, { value: "dir" }, "dir"),
@@ -2266,12 +2264,11 @@
           className: "h-7 text-xs flex-1",
         }) : null,
       ),
-      h(Select, {
+      h(Select, Object.assign({
         value: parent,
-        onChange: function (e) { setParent(e.target.value); },
         className: "h-7 text-xs",
         title: "Optional parent task. A child stays blocked in its current column until the parent is marked done.",
-      },
+      }, selectChangeHandler(setParent)),
         h(SelectOption, { value: "" }, tx(t, "noParent", "— no parent —")),
         (props.allTasks || []).map(function (task) {
           return h(SelectOption, { key: task.id, value: task.id },


### PR DESCRIPTION
## Problem

In the Kanban dashboard's **InlineCreate** form, selecting `worktree` or `dir` in the workspace dropdown (and selecting a parent task or bulk-reassigning) silently reverts to the default value. Backend always receives `workspace_kind: \"scratch\"` regardless of user choice.

## Root cause

The SDK's `Select` component (from `window.__HERMES_PLUGIN_SDK__.components`) fires `onValueChange(rawValue)` — not a DOM `onChange` event. Three selects in the plugin used the broken pattern:

```js
// BROKEN — e is the raw value string; e.target is undefined
onChange: function (e) { setWorkspaceKind(e.target.value); }
```

`e.target` is `undefined`, so the setter is never called and the state stays at its initial value (`"scratch"`, `""`, `""`).

The plugin already has a `selectChangeHandler(setter)` helper (line ~212) that wires **both** `onValueChange` and a guarded `onChange` for compatibility:

```js
function selectChangeHandler(setter) {
  return {
    onValueChange: function (v) { setter(v == null ? "" : v); },
    onChange: function (e) {
      const v = e && e.target ? e.target.value : e;
      setter(v == null ? "" : v);
    },
  };
}
```

## Fix

Replace all three bare `h(Select, { onChange: ... })` calls with `h(Select, Object.assign({...}, selectChangeHandler(setter)))`:

| Location | Setter fixed |
|---|---|
| `BulkActionBar` | `setAssignee` |
| `InlineCreate` workspace | `setWorkspaceKind` |
| `InlineCreate` parent | `setParent` |

No logic change — purely wiring the correct event hook.

## Tests

- Manually verified pattern against `selectChangeHandler` definition and all existing `Object.assign(..., selectChangeHandler(...))` usages (board switcher, filter bar).
- No JS tests exist for this plugin (plain IIFE, no build step).

## Visual

```mermaid
sequenceDiagram
    participant User
    participant Select (SDK)
    participant Handler
    participant State

    Note over Select (SDK): fires onValueChange("worktree"), NOT onChange(event)

    rect rgb(255,80,80)
        Note over Handler,State: BEFORE — broken
        Select (SDK)->>Handler: onChange(e="worktree")
        Handler->>Handler: e.target → undefined → crash/noop
        State-->>State: stays "scratch"
    end

    rect rgb(80,200,80)
        Note over Handler,State: AFTER — fixed
        Select (SDK)->>Handler: onValueChange("worktree")
        Handler->>State: setWorkspaceKind("worktree")
        State-->>State: "worktree" ✓
    end
```

Closes #24520