### PR TITLE
docs(models): update DeepSeek provider picker description to V4 models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -917,7 +917,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
+    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V4 Pro, V4 Flash, R1 — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),


### PR DESCRIPTION
## Problem

The `hermes model` provider picker shows:

```
DeepSeek (DeepSeek-V3, R1, coder — direct API)
```

This is stale — the direct DeepSeek provider now exposes first-class V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) as its primary offerings.

## Root cause

`CANONICAL_PROVIDERS` in `hermes_cli/models.py` line 920 had a hardcoded `tui_desc` string that was never updated when V4 models were added to the `DEEPSEEK_MODELS` list.

## Fix

Single-line change to `tui_desc` of the `"deepseek"` `ProviderEntry`:

```
Before: "DeepSeek (DeepSeek-V3, R1, coder — direct API)"
After:  "DeepSeek (V4 Pro, V4 Flash, R1 — direct API)"
```

No behavior change — only the display string shown in the interactive provider picker.

## Tests

- `tests/hermes_cli/test_models.py`
- `tests/hermes_cli/test_model_catalog.py`
- `tests/hermes_cli/test_model_validation.py`

177 passed, 0 failed.

## Visual

```mermaid
graph LR
    A[CANONICAL_PROVIDERS] -->|tui_desc| B[hermes model picker]
    B -->|was| C["DeepSeek-V3, R1, coder"]
    B -->|now| D["V4 Pro, V4 Flash, R1"]
```

Closes #24471