### PR TITLE
feat: add Telegram inline project intake

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1743,6 +1743,24 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def send_project_intake_prompt(
+        self,
+        chat_id: str,
+        title: str,
+        state: Dict[str, Any],
+        session_key: str,
+        on_intake_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a narrow project-intake prompt when the platform supports it.
+
+        The default implementation deliberately does not render generic
+        arbitrary buttons. Platform adapters may override this for a fixed,
+        gateway-owned project-intake state machine and route the final submit
+        through ``on_intake_selected``.
+        """
+        return SendResult(success=False, error="Not supported")
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import secrets
 import tempfile
 import html as _html
 import re
@@ -343,6 +344,51 @@ class TelegramAdapter(BasePlatformAdapter):
     _TEXT_BATCH_SHORT_LEN = 1024
     _TEXT_BATCH_SHORT_DELAY_S = 0.24
 
+    _PROJECT_INTAKE_STEP_ORDER = ("kind", "board", "scope", "risk", "confirm")
+    _PROJECT_INTAKE_CHOICES = {
+        "kind": (
+            ("feature", "Feature / UX improvement"),
+            ("bug", "Bug / regression"),
+            ("research", "Research / investigation"),
+            ("ops", "Operations / workflow"),
+            ("cancel", "Cancel"),
+        ),
+        "board": (
+            ("control", "hermes-kanban-control"),
+            ("triage", "Ask operator / triage only"),
+            ("new", "Needs a new board later"),
+            ("back", "Back"),
+            ("cancel", "Cancel"),
+        ),
+        "scope": (
+            ("spec", "Spec only"),
+            ("impl_after_spec", "Implementation after approved spec"),
+            ("triage_only", "Triage card only"),
+            ("back", "Back"),
+            ("cancel", "Cancel"),
+        ),
+        "risk": (
+            ("safe", "No source/config/gateway changes without approval"),
+            ("normal", "Source changes allowed after clean preflight + tests"),
+            ("manual", "Human review before any dispatch"),
+            ("back", "Back"),
+            ("cancel", "Cancel"),
+        ),
+        "confirm": (
+            ("preview", "Preview only"),
+            ("create", "Create triage card"),
+            ("back", "Back"),
+            ("cancel", "Cancel"),
+        ),
+    }
+    _PROJECT_INTAKE_PROMPTS = {
+        "kind": "What is this?",
+        "board": "Where should it land?",
+        "scope": "How far should automation go?",
+        "risk": "Stop-gate sensitivity?",
+        "confirm": "Final action",
+    }
+
     @staticmethod
     def _env_float_clamped(
         name: str,
@@ -427,6 +473,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Project-intake inline button state: flow_id → fixed questionnaire state.
+        self._project_intake_state: Dict[str, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -2215,6 +2263,322 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_slash_confirm failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    @staticmethod
+    def _base36(num: int) -> str:
+        alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+        if num <= 0:
+            return "0"
+        chars: List[str] = []
+        while num:
+            num, rem = divmod(num, 36)
+            chars.append(alphabet[rem])
+        return "".join(reversed(chars))
+
+    def _new_project_intake_flow_id(self) -> str:
+        for _ in range(8):
+            flow_id = secrets.token_urlsafe(9)
+            if flow_id and flow_id not in self._project_intake_state:
+                return flow_id
+        return secrets.token_hex(8)
+
+    @classmethod
+    def _project_intake_label(cls, step: str, choice: str) -> str:
+        for token, label in cls._PROJECT_INTAKE_CHOICES.get(step, ()):  # pragma: no branch - tiny lookup
+            if token == choice:
+                return label
+        return choice.replace("_", " ")
+
+    def _build_project_intake_keyboard(
+        self,
+        flow_id: str,
+        step: str,
+        answers: Optional[Dict[str, str]] = None,
+    ) -> InlineKeyboardMarkup:
+        del answers  # server-side state owns answers; callback data stays compact.
+        buttons = [
+            InlineKeyboardButton(label, callback_data=f"pi:{flow_id}:{step}:{choice}")
+            for choice, label in self._PROJECT_INTAKE_CHOICES.get(step, ())
+        ]
+        return InlineKeyboardMarkup([buttons[i : i + 2] for i in range(0, len(buttons), 2)])
+
+    def _project_intake_step_text(self, state: Dict[str, Any], step: str) -> str:
+        title = str(state.get("title") or "Project intake").strip() or "Project intake"
+        description = str(state.get("description") or "No description provided.").strip()
+        answers = state.get("answers") or {}
+        lines = [f"📋 Project intake: {title}"]
+        if description:
+            lines.extend(["", description])
+        if answers:
+            lines.append("")
+            lines.append("Current selections:")
+            for key in self._PROJECT_INTAKE_STEP_ORDER:
+                if key in answers:
+                    lines.append(f"• {self._PROJECT_INTAKE_PROMPTS[key]} {self._project_intake_label(key, answers[key])}")
+        lines.extend(["", self._PROJECT_INTAKE_PROMPTS.get(step, step)])
+        return "\n".join(lines)
+
+    def _project_intake_preview_text(self, state: Dict[str, Any]) -> str:
+        answers = state.get("answers") or {}
+        lines = [
+            "Project intake preview",
+            "",
+            f"Title: {state.get('title') or 'Project intake'}",
+            f"Description: {state.get('description') or 'No description provided.'}",
+            "",
+            "Selections:",
+        ]
+        for key in self._PROJECT_INTAKE_STEP_ORDER[:-1]:
+            value = answers.get(key, "unset")
+            lines.append(f"• {key}: {self._project_intake_label(key, value)}")
+        return "\n".join(lines)
+
+    def _project_intake_payload(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        metadata = dict(state.get("metadata") or {})
+        source: Dict[str, Any] = {"platform": "telegram"}
+        if state.get("chat_id") is not None:
+            source["chat_id"] = str(state.get("chat_id"))
+        if metadata.get("thread_id") is not None:
+            source["thread_id"] = str(metadata.get("thread_id"))
+        if metadata.get("telegram_dm_topic_reply_fallback"):
+            source["telegram_dm_topic_reply_fallback"] = True
+        return {
+            "title": str(state.get("title") or "Project intake").strip() or "Project intake",
+            "description": str(state.get("description") or "").strip(),
+            "answers": dict(state.get("answers") or {}),
+            "source": source,
+        }
+
+    @staticmethod
+    def _project_intake_context_value(value: Optional[Any]) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _project_intake_context_matches(
+        self,
+        state: Dict[str, Any],
+        *,
+        chat_id: Optional[Any],
+        thread_id: Optional[str],
+    ) -> bool:
+        expected_chat_id = self._project_intake_context_value(state.get("chat_id"))
+        actual_chat_id = self._project_intake_context_value(chat_id)
+        if expected_chat_id != actual_chat_id:
+            return False
+
+        metadata = dict(state.get("metadata") or {})
+        expected_thread_id = self._project_intake_context_value(metadata.get("thread_id"))
+        actual_thread_id = self._project_intake_context_value(thread_id)
+        return expected_thread_id == actual_thread_id
+
+    def _project_intake_prompt_matches(
+        self,
+        state: Dict[str, Any],
+        *,
+        message_id: Optional[Any],
+    ) -> bool:
+        expected_message_id = self._project_intake_context_value(state.get("prompt_message_id"))
+        if expected_message_id is None:
+            return True
+        actual_message_id = self._project_intake_context_value(message_id)
+        return expected_message_id == actual_message_id
+
+    def _project_intake_missing_required_step(self, state: Dict[str, Any]) -> Optional[str]:
+        answers = dict(state.get("answers") or {})
+        for required_step in self._PROJECT_INTAKE_STEP_ORDER[:-1]:
+            allowed = {
+                token
+                for token, _ in self._PROJECT_INTAKE_CHOICES.get(required_step, ())
+                if token not in {"back", "cancel"}
+            }
+            if answers.get(required_step) not in allowed:
+                return required_step
+        return None
+
+    async def send_project_intake_prompt(
+        self,
+        chat_id: str,
+        title: str,
+        state: Dict[str, Any],
+        session_key: str,
+        on_intake_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send Telegram inline buttons for the fixed project-intake flow."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        flow_id = self._new_project_intake_flow_id()
+        intake_state: Dict[str, Any] = {
+            "session_key": session_key,
+            "chat_id": str(chat_id),
+            "title": str(title or "Project intake").strip() or "Project intake",
+            "description": str((state or {}).get("description") or title or "").strip(),
+            "step": "kind",
+            "answers": {},
+            "metadata": dict(metadata or {}),
+            "on_intake_selected": on_intake_selected,
+        }
+
+        try:
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text=self._project_intake_step_text(intake_state, "kind"),
+                reply_markup=self._build_project_intake_keyboard(flow_id, "kind", {}),
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            intake_state["prompt_message_id"] = str(msg.message_id)
+            self._project_intake_state[flow_id] = intake_state
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_project_intake_prompt failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _edit_project_intake_message(
+        self,
+        query,
+        *,
+        text: str,
+        reply_markup=None,
+    ) -> None:
+        try:
+            await query.edit_message_text(text=text, reply_markup=reply_markup)
+        except Exception:
+            logger.debug("[%s] project-intake message edit failed", self.name, exc_info=True)
+
+    async def _handle_project_intake_callback(
+        self,
+        query,
+        data: str,
+        *,
+        chat_id: Optional[Any] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        message_id: Optional[Any] = None,
+        user_name: Optional[str] = None,
+    ) -> None:
+        parts = data.split(":", 3)
+        if len(parts) != 4:
+            await query.answer(text="Invalid project intake data.")
+            return
+        _, flow_id, step, choice = parts
+        state = self._project_intake_state.get(flow_id)
+        if not state:
+            await query.answer(text="Project intake expired — use /project again.")
+            return
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+            user_name=user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to answer this intake prompt.")
+            return
+
+        if not self._project_intake_context_matches(state, chat_id=chat_id, thread_id=thread_id):
+            await query.answer(text="Project intake belongs to a different chat/thread.")
+            return
+        if not self._project_intake_prompt_matches(state, message_id=message_id):
+            await query.answer(text="Project intake belongs to a different prompt.")
+            return
+
+        if step not in self._PROJECT_INTAKE_STEP_ORDER:
+            await query.answer(text="Invalid project intake step.")
+            return
+        if step != state.get("step"):
+            await query.answer(text="Project intake moved on — use the latest buttons.")
+            return
+        if choice not in {token for token, _ in self._PROJECT_INTAKE_CHOICES.get(step, ())}:
+            await query.answer(text="Invalid project intake choice.")
+            return
+
+        if choice == "cancel":
+            self._project_intake_state.pop(flow_id, None)
+            await self._edit_project_intake_message(
+                query,
+                text="Project intake cancelled.",
+                reply_markup=None,
+            )
+            await query.answer(text="Cancelled")
+            return
+
+        if choice == "back":
+            idx = max(self._PROJECT_INTAKE_STEP_ORDER.index(step) - 1, 0)
+            previous = self._PROJECT_INTAKE_STEP_ORDER[idx]
+            state["answers"].pop(previous, None)
+            state["step"] = previous
+            await self._edit_project_intake_message(
+                query,
+                text=self._project_intake_step_text(state, previous),
+                reply_markup=self._build_project_intake_keyboard(flow_id, previous, state.get("answers")),
+            )
+            await query.answer()
+            return
+
+        if step == "confirm":
+            missing_step = self._project_intake_missing_required_step(state)
+            if missing_step:
+                state["step"] = missing_step
+                await self._edit_project_intake_message(
+                    query,
+                    text=self._project_intake_step_text(state, missing_step),
+                    reply_markup=self._build_project_intake_keyboard(flow_id, missing_step, state.get("answers")),
+                )
+                await query.answer(text="Project intake is incomplete — choose missing answers first.")
+                return
+            if choice == "preview":
+                self._project_intake_state.pop(flow_id, None)
+                await self._edit_project_intake_message(
+                    query,
+                    text=self._project_intake_preview_text(state),
+                    reply_markup=None,
+                )
+                await query.answer(text="Preview ready")
+                return
+            if choice == "create":
+                callback = state.get("on_intake_selected")
+                payload = self._project_intake_payload(state)
+                result_text = "Project intake submitted."
+                self._project_intake_state.pop(flow_id, None)
+                if callable(callback):
+                    result = callback(payload)
+                    if asyncio.iscoroutine(result):
+                        result = await result
+                    if result:
+                        result_text = str(result)
+                await self._edit_project_intake_message(
+                    query,
+                    text=result_text,
+                    reply_markup=None,
+                )
+                await query.answer(text="Submitted")
+                return
+
+        answers = state.setdefault("answers", {})
+        answers[step] = choice
+        next_idx = min(self._PROJECT_INTAKE_STEP_ORDER.index(step) + 1, len(self._PROJECT_INTAKE_STEP_ORDER) - 1)
+        next_step = self._PROJECT_INTAKE_STEP_ORDER[next_idx]
+        state["step"] = next_step
+        await self._edit_project_intake_message(
+            query,
+            text=self._project_intake_step_text(state, next_step),
+            reply_markup=self._build_project_intake_keyboard(flow_id, next_step, answers),
+        )
+        await query.answer()
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -2531,7 +2895,21 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat = getattr(query_message, "chat", None)
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
+        query_message_id = getattr(query_message, "message_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Project intake callbacks (pi:flow:step:choice) ---
+        if data.startswith("pi:"):
+            await self._handle_project_intake_callback(
+                query,
+                data,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                message_id=query_message_id,
+                user_name=query_user_name,
+            )
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6405,6 +6405,9 @@ class GatewayRunner:
         if canonical == "kanban":
             return await self._handle_kanban_command(event)
 
+        if canonical == "project":
+            return await self._handle_project_command(event)
+
         if canonical == "retry":
             return await self._handle_retry_command(event)
         
@@ -8414,6 +8417,54 @@ class GatewayRunner:
         if len(output) > 3800:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
+
+    async def _handle_project_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /project — render the gateway-owned project-intake prompt when supported."""
+        source = event.source
+        adapter = self.adapters.get(source.platform) if source is not None else None
+        prompt = getattr(adapter, "send_project_intake_prompt", None) if adapter else None
+
+        raw_title = (event.get_command_args() or "").strip()
+        title = " ".join(raw_title.split()) or "Project intake"
+        description = title
+        metadata = self._thread_metadata_for_source(
+            source,
+            self._reply_anchor_for_event(event),
+        ) if source is not None else None
+        session_key = self._session_key_for_source(source) if source is not None else ""
+
+        async def _preview_only_project_intake(payload: Dict[str, Any]) -> str:
+            payload_title = str(payload.get("title") or title).strip() or "Project intake"
+            return (
+                f"Project intake preview saved for: {payload_title}\n\n"
+                "Card creation is not enabled from this button yet. "
+                "Reply with /kanban create when you are ready to create a board card."
+            )
+
+        fallback = (
+            "Project intake buttons are unavailable on this platform. "
+            "Please reply with /project <title or short description> from Telegram to use the mobile intake buttons."
+        )
+
+        if not callable(prompt) or source is None:
+            return fallback
+
+        try:
+            result = await prompt(
+                chat_id=str(source.chat_id),
+                title=title,
+                state={"description": description},
+                session_key=session_key,
+                on_intake_selected=_preview_only_project_intake,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            logger.debug("send_project_intake_prompt failed for /project: %s", exc)
+            return fallback
+
+        if result and getattr(result, "success", False):
+            return None
+        return fallback
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -105,6 +105,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | pause | resume | clear | status]"),
     CommandDef("status", "Show session info", "Session"),
+    CommandDef("project", "Start a Telegram project-intake questionnaire", "Session",
+               gateway_only=True, args_hint="[title or short description]"),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/tests/gateway/test_telegram_project_intake_buttons.py
+++ b/tests/gateway/test_telegram_project_intake_buttons.py
@@ -1,0 +1,556 @@
+"""Tests for Telegram project-intake inline keyboard buttons."""
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeInlineKeyboardButton:
+    def __init__(self, text, callback_data=None, **kwargs):
+        self.text = text
+        self.callback_data = callback_data
+        self.kwargs = kwargs
+
+
+class _FakeInlineKeyboardMarkup:
+    def __init__(self, inline_keyboard):
+        self.inline_keyboard = inline_keyboard
+
+
+class _FakeBadRequest(Exception):
+    pass
+
+
+_fake_telegram = types.ModuleType("telegram")
+_fake_telegram.Update = object
+_fake_telegram.Bot = object
+_fake_telegram.Message = object
+_fake_telegram.InlineKeyboardButton = _FakeInlineKeyboardButton
+_fake_telegram.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+_fake_telegram_error = types.ModuleType("telegram.error")
+_fake_telegram_error.NetworkError = OSError
+_fake_telegram_error.BadRequest = _FakeBadRequest
+_fake_telegram_error.TimedOut = OSError
+_fake_telegram.error = _fake_telegram_error
+_fake_telegram_constants = types.ModuleType("telegram.constants")
+_fake_telegram_constants.ParseMode = SimpleNamespace(
+    MARKDOWN_V2="MarkdownV2",
+    MARKDOWN="Markdown",
+    HTML="HTML",
+)
+_fake_telegram_constants.ChatType = SimpleNamespace(
+    GROUP="group",
+    SUPERGROUP="supergroup",
+    CHANNEL="channel",
+    PRIVATE="private",
+)
+_fake_telegram.constants = _fake_telegram_constants
+_fake_telegram_ext = types.ModuleType("telegram.ext")
+_fake_telegram_ext.Application = object
+_fake_telegram_ext.CommandHandler = object
+_fake_telegram_ext.CallbackQueryHandler = object
+_fake_telegram_ext.MessageHandler = object
+_fake_telegram_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
+_fake_telegram_ext.filters = object
+_fake_telegram_request = types.ModuleType("telegram.request")
+_fake_telegram_request.HTTPXRequest = object
+
+for _name, _module in {
+    "telegram": _fake_telegram,
+    "telegram.error": _fake_telegram_error,
+    "telegram.constants": _fake_telegram_constants,
+    "telegram.ext": _fake_telegram_ext,
+    "telegram.request": _fake_telegram_request,
+}.items():
+    sys.modules[_name] = _module
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+import gateway.platforms.telegram as telegram_platform
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.session import SessionSource
+
+# Other Telegram gateway tests may import gateway.platforms.telegram before this
+# file's fake telegram modules are installed. Patch the module globals too so
+# this test remains order-independent in larger pytest invocations.
+telegram_platform.InlineKeyboardButton = _FakeInlineKeyboardButton
+telegram_platform.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=77))
+    )
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _button_callback_data(markup):
+    return [
+        button.callback_data
+        for row in markup.inline_keyboard
+        for button in row
+        if button.callback_data
+    ]
+
+
+def _seed_flow(adapter, flow_id="abc123", *, step="kind", answers=None, callback=None):
+    adapter._project_intake_state[flow_id] = {
+        "session_key": "agent:main:telegram:dm:12345",
+        "chat_id": "12345",
+        "title": "Mobile Telegram intake",
+        "description": "Buttons are hidden on Telegram mobile",
+        "step": step,
+        "answers": dict(answers or {}),
+        "metadata": {},
+        "on_intake_selected": callback or AsyncMock(return_value="Created t_test"),
+    }
+    return adapter._project_intake_state[flow_id]
+
+
+def _make_callback_update(
+    data,
+    *,
+    user_id="12345",
+    chat_id=12345,
+    chat_type="private",
+    thread_id=None,
+    message_id=55,
+):
+    query = SimpleNamespace(
+        data=data,
+        message=SimpleNamespace(
+            chat_id=chat_id,
+            chat=SimpleNamespace(type=chat_type),
+            message_thread_id=thread_id,
+            message_id=message_id,
+        ),
+        from_user=SimpleNamespace(id=user_id, first_name="Tester"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+    return SimpleNamespace(callback_query=query), query
+
+
+@pytest.mark.asyncio
+async def test_send_project_intake_prompt_renders_inline_keyboard():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Created t_test")
+
+    result = await adapter.send_project_intake_prompt(
+        chat_id="12345",
+        title="Mobile Telegram intake",
+        state={"description": "Buttons are hidden on Telegram mobile"},
+        session_key="agent:main:telegram:dm:12345",
+        on_intake_selected=callback,
+    )
+
+    assert result.success is True
+    assert result.message_id == "77"
+    send_kwargs = adapter._bot.send_message.call_args.kwargs
+    assert send_kwargs["chat_id"] == 12345
+    assert "Mobile Telegram intake" in send_kwargs["text"]
+    markup = send_kwargs["reply_markup"]
+    assert isinstance(markup, _FakeInlineKeyboardMarkup)
+    callback_data = _button_callback_data(markup)
+    assert callback_data
+    assert all(value.startswith("pi:") for value in callback_data)
+    assert all(len(value.encode("utf-8")) <= 64 for value in callback_data)
+
+    flow_ids = {value.split(":")[1] for value in callback_data}
+    assert len(flow_ids) == 1
+    flow_id = flow_ids.pop()
+    stored = adapter._project_intake_state[flow_id]
+    assert stored["session_key"] == "agent:main:telegram:dm:12345"
+    assert stored["step"] == "kind"
+    assert stored["answers"] == {}
+    assert stored["prompt_message_id"] == "77"
+    assert stored["on_intake_selected"] is callback
+
+
+@pytest.mark.asyncio
+async def test_project_intake_flow_id_uses_random_nonce(monkeypatch):
+    values = iter(["nonce_one", "nonce_two"])
+    monkeypatch.setattr(telegram_platform.secrets, "token_urlsafe", lambda nbytes: next(values))
+    adapter = _make_adapter()
+
+    assert adapter._new_project_intake_flow_id() == "nonce_one"
+    assert adapter._new_project_intake_flow_id() == "nonce_two"
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_rejects_wrong_prompt_message_id():
+    adapter = _make_adapter()
+    state = _seed_flow(
+        adapter,
+        step="board",
+        answers={"kind": "feature"},
+        callback=AsyncMock(),
+    )
+    state["prompt_message_id"] = "55"
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update(
+        "pi:abc123:board:control",
+        chat_id=12345,
+        message_id=999,
+    )
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(text="Project intake belongs to a different prompt.")
+    query.edit_message_text.assert_not_called()
+    assert state["step"] == "board"
+    assert state["answers"] == {"kind": "feature"}
+
+
+@pytest.mark.asyncio
+async def test_send_project_intake_prompt_uses_dm_topic_reply_fallback():
+    adapter = _make_adapter()
+
+    await adapter.send_project_intake_prompt(
+        chat_id="12345",
+        title="Mobile Telegram intake",
+        state={"description": "Buttons are hidden on Telegram mobile"},
+        session_key="agent:main:telegram:dm:12345:20197",
+        on_intake_selected=AsyncMock(),
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    send_kwargs = adapter._bot.send_message.call_args.kwargs
+    assert send_kwargs["reply_to_message_id"] == 462
+    assert send_kwargs["message_thread_id"] == 20197
+    assert "direct_messages_topic_id" not in send_kwargs
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_rejects_unauthorized_user():
+    adapter = _make_adapter()
+    callback = AsyncMock()
+    _seed_flow(adapter, callback=callback)
+    adapter._is_callback_user_authorized = MagicMock(return_value=False)
+    update, query = _make_callback_update("pi:abc123:kind:feature", user_id="999")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(
+        text="⛔ You are not authorized to answer this intake prompt."
+    )
+    query.edit_message_text.assert_not_called()
+    callback.assert_not_called()
+    assert adapter._project_intake_state["abc123"]["answers"] == {}
+    assert adapter._project_intake_state["abc123"]["step"] == "kind"
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_advances_step_and_edits_message():
+    adapter = _make_adapter()
+    _seed_flow(adapter)
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update("pi:abc123:kind:feature")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    state = adapter._project_intake_state["abc123"]
+    assert state["answers"] == {"kind": "feature"}
+    assert state["step"] == "board"
+    query.edit_message_text.assert_called_once()
+    edit_kwargs = query.edit_message_text.call_args.kwargs
+    assert "Where should it land" in edit_kwargs["text"]
+    assert isinstance(edit_kwargs["reply_markup"], _FakeInlineKeyboardMarkup)
+    assert any(data == "pi:abc123:board:control" for data in _button_callback_data(edit_kwargs["reply_markup"]))
+    query.answer.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_submit_preview_does_not_create_card():
+    adapter = _make_adapter()
+    callback = AsyncMock()
+    _seed_flow(
+        adapter,
+        step="confirm",
+        answers={
+            "kind": "feature",
+            "board": "control",
+            "scope": "impl_after_spec",
+            "risk": "safe",
+        },
+        callback=callback,
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update("pi:abc123:confirm:preview")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    callback.assert_not_called()
+    query.edit_message_text.assert_called_once()
+    edit_kwargs = query.edit_message_text.call_args.kwargs
+    assert "Project intake preview" in edit_kwargs["text"]
+    assert "Feature / UX improvement" in edit_kwargs["text"]
+    assert edit_kwargs["reply_markup"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_submit_create_invokes_callback_once():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Created triage card t_abc123")
+    _seed_flow(
+        adapter,
+        step="confirm",
+        answers={
+            "kind": "feature",
+            "board": "control",
+            "scope": "impl_after_spec",
+            "risk": "safe",
+        },
+        callback=callback,
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update("pi:abc123:confirm:create")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    callback.assert_awaited_once()
+    payload = callback.await_args.args[0]
+    assert payload["title"] == "Mobile Telegram intake"
+    assert payload["description"] == "Buttons are hidden on Telegram mobile"
+    assert payload["answers"] == {
+        "kind": "feature",
+        "board": "control",
+        "scope": "impl_after_spec",
+        "risk": "safe",
+    }
+    assert payload["source"]["platform"] == "telegram"
+    assert "token" not in repr(payload).lower()
+    assert "abc123" not in adapter._project_intake_state
+    edit_kwargs = query.edit_message_text.call_args.kwargs
+    assert "Created triage card t_abc123" in edit_kwargs["text"]
+    assert edit_kwargs["reply_markup"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_rejects_stale_step_buttons():
+    adapter = _make_adapter()
+    state = _seed_flow(
+        adapter,
+        step="board",
+        answers={"kind": "bug"},
+        callback=AsyncMock(),
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update("pi:abc123:kind:feature")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(text="Project intake moved on — use the latest buttons.")
+    query.edit_message_text.assert_not_called()
+    assert state["step"] == "board"
+    assert state["answers"] == {"kind": "bug"}
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_rejects_wrong_chat_or_thread():
+    adapter = _make_adapter()
+    state = _seed_flow(
+        adapter,
+        step="board",
+        answers={"kind": "feature"},
+        callback=AsyncMock(),
+    )
+    state["metadata"] = {"thread_id": "20197"}
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update(
+        "pi:abc123:board:control",
+        chat_id=54321,
+        thread_id="20197",
+    )
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(text="Project intake belongs to a different chat/thread.")
+    query.edit_message_text.assert_not_called()
+    assert state["step"] == "board"
+    assert state["answers"] == {"kind": "feature"}
+
+    update, query = _make_callback_update(
+        "pi:abc123:board:control",
+        chat_id=12345,
+        thread_id="99999",
+    )
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(text="Project intake belongs to a different chat/thread.")
+    query.edit_message_text.assert_not_called()
+    assert state["step"] == "board"
+    assert state["answers"] == {"kind": "feature"}
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_submit_create_requires_complete_answers():
+    adapter = _make_adapter()
+    callback = AsyncMock(return_value="Created triage card t_abc123")
+    state = _seed_flow(
+        adapter,
+        step="confirm",
+        answers={
+            "kind": "feature",
+            "board": "control",
+            "scope": "impl_after_spec",
+        },
+        callback=callback,
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update, query = _make_callback_update("pi:abc123:confirm:create")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    callback.assert_not_called()
+    query.answer.assert_called_once_with(text="Project intake is incomplete — choose missing answers first.")
+    query.edit_message_text.assert_called_once()
+    edit_kwargs = query.edit_message_text.call_args.kwargs
+    assert "Stop-gate sensitivity" in edit_kwargs["text"]
+    assert isinstance(edit_kwargs["reply_markup"], _FakeInlineKeyboardMarkup)
+    assert state["step"] == "risk"
+    assert "abc123" in adapter._project_intake_state
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_submit_create_reserves_flow_before_await():
+    adapter = _make_adapter()
+    callback_calls = []
+    callback_entered = asyncio.Event()
+    callback_release = asyncio.Event()
+
+    async def slow_create(payload):
+        callback_calls.append(payload)
+        callback_entered.set()
+        await callback_release.wait()
+        return "Created triage card t_abc123"
+
+    _seed_flow(
+        adapter,
+        step="confirm",
+        answers={
+            "kind": "feature",
+            "board": "control",
+            "scope": "impl_after_spec",
+            "risk": "safe",
+        },
+        callback=slow_create,
+    )
+    adapter._is_callback_user_authorized = MagicMock(return_value=True)
+    update1, query1 = _make_callback_update("pi:abc123:confirm:create")
+    first_task = asyncio.create_task(adapter._handle_callback_query(update1, SimpleNamespace()))
+
+    try:
+        await asyncio.wait_for(callback_entered.wait(), timeout=1)
+        assert "abc123" not in adapter._project_intake_state
+
+        update2, query2 = _make_callback_update("pi:abc123:confirm:create")
+        await asyncio.wait_for(adapter._handle_callback_query(update2, SimpleNamespace()), timeout=1)
+
+        query2.answer.assert_called_once_with(text="Project intake expired — use /project again.")
+        query2.edit_message_text.assert_not_called()
+        assert len(callback_calls) == 1
+    finally:
+        callback_release.set()
+        await asyncio.wait_for(first_task, timeout=1)
+
+    query1.answer.assert_called_once_with(text="Submitted")
+    assert len(callback_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_project_intake_callback_expired_flow_is_harmless():
+    adapter = _make_adapter()
+    update, query = _make_callback_update("pi:expired:kind:feature")
+
+    await adapter._handle_callback_query(update, SimpleNamespace())
+
+    query.answer.assert_called_once_with(text="Project intake expired — use /project again.")
+    query.edit_message_text.assert_not_called()
+
+
+class _FakeProjectAdapter:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    async def send_project_intake_prompt(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.result
+
+
+def test_project_command_is_gateway_known():
+    from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+    assert is_gateway_known_command("project") is True
+    assert resolve_command("project").name == "project"
+
+
+@pytest.mark.asyncio
+async def test_project_command_calls_adapter_with_thread_metadata():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    adapter = _FakeProjectAdapter(SendResult(success=True, message_id="77"))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._session_key_for_source = lambda source: "session-key"
+
+    event = MessageEvent(
+        text="/project mobile buttons hidden",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            thread_id="20197",
+            user_id="12345",
+        ),
+        message_id="462",
+    )
+
+    result = await runner._handle_project_command(event)
+
+    assert result is None
+    assert len(adapter.calls) == 1
+    call = adapter.calls[0]
+    assert call["chat_id"] == "12345"
+    assert call["title"] == "mobile buttons hidden"
+    assert call["state"]["description"] == "mobile buttons hidden"
+    assert call["session_key"] == "session-key"
+    assert call["metadata"] == {
+        "thread_id": "20197",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "462",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_command_returns_text_fallback_when_adapter_unsupported():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: _FakeProjectAdapter(SendResult(success=False, error="Not supported"))}
+    runner._session_key_for_source = lambda source: "session-key"
+
+    event = MessageEvent(
+        text="/project",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+    )
+
+    result = await runner._handle_project_command(event)
+
+    assert result is not None
+    assert "Project intake" in result
+    assert "reply with /project" in result


### PR DESCRIPTION
## Summary

- Add `/project` as a gateway-known command for Telegram project intake.
- Add a Telegram inline-keyboard questionnaire for mobile-friendly project intake using compact callback data and server-side state.
- Preserve Telegram DM topic/thread metadata when launching the prompt.
- Harden callback handling: random flow nonces, chat/thread and prompt message binding, stale-step rejection, required-answer validation, and duplicate-submit prevention before awaiting the create callback.

## Tests / Verification

- `python -m py_compile gateway/platforms/base.py gateway/platforms/telegram.py gateway/run.py hermes_cli/commands.py`
- `python -m pytest tests/gateway/test_telegram_project_intake_buttons.py -q -o 'addopts='` — 16 passed
- `python -m pytest tests/gateway/test_telegram*.py -q -o 'addopts='` — 425 passed
- `git diff --check`
- Added-line static scan for obvious hardcoded secrets / shell / eval / pickle / SQL issues
- Independent pre-push review after fixes: PASS

## Safety / Scope

- No Hermes runtime config changes.
- No gateway restart.
- No worker dispatch.
- Branch contains one feature commit on top of `origin/main` and touches only Telegram project-intake wiring/tests.
