### PR TITLE
fix(prompt_builder): make HERMES_AGENT_HELP_GUIDANCE respect env var override

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -141,10 +141,11 @@ DEFAULT_AGENT_IDENTITY = (
     "Be targeted and efficient in your exploration and investigations."
 )
 
-HERMES_AGENT_HELP_GUIDANCE = (
+HERMES_AGENT_HELP_GUIDANCE = os.environ.get(
+    "HERMES_AGENT_HELP_GUIDANCE",
     "If the user asks about configuring, setting up, or using Hermes Agent "
     "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "before answering. Docs: https://hermes-agent.nousresearch.com/docs"
+    "before answering. Docs: https://hermes-agent.nousresearch.com/docs",
 )
 
 MEMORY_GUIDANCE = (

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1188,4 +1188,37 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 
 
+# =========================================================================
+# HERMES_AGENT_HELP_GUIDANCE env-var override (issue #24438)
+# =========================================================================
 
+
+class TestHermesAgentHelpGuidanceEnvVar:
+    def test_default_contains_skill_view_instruction(self):
+        import importlib
+        import agent.prompt_builder as pb
+        importlib.reload(pb)
+        assert "skill_view" in pb.HERMES_AGENT_HELP_GUIDANCE
+        assert "hermes-agent" in pb.HERMES_AGENT_HELP_GUIDANCE
+
+    def test_env_var_empty_string_disables_guidance(self, monkeypatch):
+        import importlib
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "")
+        import agent.prompt_builder as pb
+        importlib.reload(pb)
+        assert pb.HERMES_AGENT_HELP_GUIDANCE == ""
+
+    def test_env_var_custom_value_overrides_default(self, monkeypatch):
+        import importlib
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "Custom guidance text.")
+        import agent.prompt_builder as pb
+        importlib.reload(pb)
+        assert pb.HERMES_AGENT_HELP_GUIDANCE == "Custom guidance text."
+        assert "skill_view" not in pb.HERMES_AGENT_HELP_GUIDANCE
+
+    def test_empty_guidance_filtered_from_prompt_parts(self):
+        # Mirrors run_agent._build_stable_system_prompt join logic:
+        # prompt_parts joined with `if p.strip()` — empty string is dropped.
+        parts = ["identity block", "", "another block"]
+        result = "\n\n".join(p.strip() for p in parts if p.strip())
+        assert result == "identity block\n\nanother block"


### PR DESCRIPTION
## Problem

`HERMES_AGENT_HELP_GUIDANCE` is unconditionally injected into the system prompt on every session. Users had no way to disable it despite documentation claiming the env var could be set.

## Root cause

`agent/prompt_builder.py` defined `HERMES_AGENT_HELP_GUIDANCE` as a hardcoded Python string constant. The code never called `os.environ.get(...)`, so setting `HERMES_AGENT_HELP_GUIDANCE=` in the shell had zero effect — the documented behaviour was silently a no-op.

## Fix

Change the constant to read from the environment at module import time:

```python
HERMES_AGENT_HELP_GUIDANCE = os.environ.get(
    "HERMES_AGENT_HELP_GUIDANCE",
    "If the user asks about configuring, setting up, or using Hermes Agent "
    "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
    "before answering. Docs: https://hermes-agent.nousresearch.com/docs",
)
```

`run_agent._build_stable_system_prompt` already filters empty strings via `"\n\n".join(p.strip() for p in prompt_parts if p.strip())`, so setting `HERMES_AGENT_HELP_GUIDANCE=""` silently drops the block without touching `run_agent.py`.

## Tests

Four new tests in `tests/agent/test_prompt_builder.py::TestHermesAgentHelpGuidanceEnvVar`:

- default constant contains `skill_view` and `hermes-agent`
- env var `""` sets guidance to empty string
- env var custom value fully overrides the default
- empty string is filtered from prompt_parts (mirrors `run_agent` join logic)

All 4 pass; 421 existing agent tests continue to pass.

## Visual

```mermaid
sequenceDiagram
    participant E as Environment
    participant PB as agent/prompt_builder.py
    participant RA as run_agent.py

    Note over PB: module import
    E->>PB: os.environ.get("HERMES_AGENT_HELP_GUIDANCE", default)
    PB-->>RA: HERMES_AGENT_HELP_GUIDANCE (str, may be "")

    RA->>RA: prompt_parts.append(HERMES_AGENT_HELP_GUIDANCE)
    RA->>RA: join(p for p in parts if p.strip())
    Note over RA: empty string → silently dropped
```

Closes #24438