### PR TITLE
test: guard bare import grp with pytest.importorskip at module level

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 pwd = pytest.importorskip("pwd")
+grp = pytest.importorskip("grp")
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status
@@ -1339,8 +1340,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        import grp
-
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "root")
         monkeypatch.setenv("LOGNAME", "root")
@@ -1350,8 +1349,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        import grp
-
         root_info = pwd.getpwnam("root")
         root_group = grp.getgrgid(root_info.pw_gid).gr_name
 
@@ -1361,8 +1358,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        import grp
-
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "nobody")
         monkeypatch.setenv("LOGNAME", "nobody")


### PR DESCRIPTION
## What does this PR do?

Three test methods in `tests/hermes_cli/test_gateway_service.py` use bare `import grp` inside the test body with no platform guard:

## Root cause

Three test methods in `tests/hermes_cli/test_gateway_service.py` use bare `import grp` inside the test body with no platform guard:

- `test_auto_detected_root_is_rejected` (line 1342)
- `test_explicit_root_is_allowed` (line 1353)
- `test_non_root_user_passes_through` (line 1364)

On Windows (or any non-POSIX platform without `grp`), these raise `ModuleNotFoundError` instead of being skipped.

## Fix

Add `grp = pytest.importorskip("grp")` at module level alongside the existing `pwd` guard, and remove the three redundant inline `import grp` statements. This matches the established pattern in the file and makes the skip intent explicit.

```python
# before (module level)
pwd = pytest.importorskip("pwd")

# after
pwd = pytest.importorskip("pwd")
grp = pytest.importorskip("grp")
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24531

<details>
<summary>Original body</summary>

## Summary

Three test methods in `tests/hermes_cli/test_gateway_service.py` use bare `import grp` inside the test body with no platform guard:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

Three test methods in `tests/hermes_cli/test_gateway_service.py` use bare `import grp` inside the test body with no platform guard:

- `test_auto_detected_root_is_rejected` (line 1342)
- `test_explicit_root_is_allowed` (line 1353)
- `test_non_root_user_passes_through` (line 1364)

On Windows (or any non-POSIX platform without `grp`), these raise `ModuleNotFoundError` instead of being skipped.

## Root cause

`grp` was imported lazily inside test bodies, inconsistent with `pwd` which already uses `pytest.importorskip` at module level (line 10). The module-level `pwd` guard currently causes the entire module to be skipped on Windows, but that is an implicit dependency — if the `pwd` guard is ever removed or tests are isolated, the bare `import grp` would surface as a hard error.

## Fix

Add `grp = pytest.importorskip("grp")` at module level alongside the existing `pwd` guard, and remove the three redundant inline `import grp` statements. This matches the established pattern in the file and makes the skip intent explicit.

```python
# before (module level)
pwd = pytest.importorskip("pwd")

# after
pwd = pytest.importorskip("pwd")
grp = pytest.importorskip("grp")
```

## Tests

- `TestSystemServiceIdentityRootHandling` — 3 tests pass on macOS (POSIX).
- On a non-POSIX platform the entire module is now explicitly skipped via the module-level `grp` guard, consistent with `pwd`.

## Visual

```mermaid
flowchart LR
    A[pytest collects test_gateway_service.py] --> B{grp available?}
    B -- yes --> C[run TestSystemServiceIdentityRootHandling tests]
    B -- no --> D[skip entire module]
```

Closes #24531

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24531

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_