### PR TITLE
fix(agent): reject stale 32k metadata for MiniMax

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1079,6 +1079,22 @@ def _model_name_suggests_kimi(model: str) -> bool:
     return lower.startswith("kimi") or "moonshot" in lower
 
 
+def _model_name_suggests_minimax(model: str) -> bool:
+    """Return True if the model name looks like a MiniMax-family model.
+
+    Catches ``MiniMax-M2.7``, ``minimax-m2.5``, ``MiniMaxAI/MiniMax-M2.5``,
+    and similar variants. Used as a guard against stale 32K metadata that
+    underreports the MiniMax M2 family, whose real context window is 204.8K.
+    """
+    lower = model.lower()
+    return lower.startswith("minimax") or "minimaxai/" in lower
+
+
+def _model_name_suggests_stale_32k_underreport(model: str) -> bool:
+    """Return True for model families known to be wrongly underreported as 32K."""
+    return _model_name_suggests_kimi(model) or _model_name_suggests_minimax(model)
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx
@@ -1364,13 +1380,18 @@ def _resolve_nous_context_length(
     metadata = fetch_model_metadata()
 
     def _safe_ctx(or_id: str, entry: dict) -> Optional[int]:
+        """Return context length, but reject known stale 32K underreports.
+
+        Apply the same guard used for the generic OpenRouter path (step 6 in
+        resolve_context_length) so the Nous portal path does not short-circuit it.
+        """
         ctx = entry.get("context_length")
         if ctx is None:
             return None
-        if ctx <= 32768 and _model_name_suggests_kimi(or_id):
+        if ctx <= 32768 and _model_name_suggests_stale_32k_underreport(or_id):
             logger.info(
                 "Rejecting OpenRouter metadata context=%s for %r "
-                "(Kimi-family underreport, Nous path); falling through to hardcoded defaults",
+                "(known 32K underreport, Nous path); falling through to hardcoded defaults",
                 ctx, or_id,
             )
             return None
@@ -1482,10 +1503,11 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale 32k cache entries for Kimi-family models.
-            elif cached <= 32768 and _model_name_suggests_kimi(model):
+            # Invalidate stale 32k cache entries for model families known to
+            # be underreported by stale third-party metadata.
+            elif cached <= 32768 and _model_name_suggests_stale_32k_underreport(model):
                 logger.info(
-                    "Dropping stale Kimi cache entry %s@%s -> %s (OpenRouter underreport); "
+                    "Dropping stale cached context entry %s@%s -> %s (known 32K underreport); "
                     "re-resolving via hardcoded defaults",
                     model, base_url, f"{cached:,}",
                 )
@@ -1651,11 +1673,12 @@ def get_model_context_length(
         metadata = fetch_model_metadata()
         if model in metadata:
             or_ctx = metadata[model].get("context_length", DEFAULT_FALLBACK_CONTEXT)
-            # Guard against stale OpenRouter metadata for Kimi-family models.
-            if or_ctx == 32768 and _model_name_suggests_kimi(model):
+            # Guard against stale OpenRouter metadata for model families
+            # known to be underreported as 32K.
+            if or_ctx == 32768 and _model_name_suggests_stale_32k_underreport(model):
                 logger.info(
                     "Rejecting OpenRouter metadata context=%s for %r "
-                    "(Kimi-family underreport); falling through to hardcoded defaults",
+                    "(known 32K underreport); falling through to hardcoded defaults",
                     or_ctx, model,
                 )
             else:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -781,6 +781,48 @@ class TestGetModelContextLength:
             assert result == CONTEXT_PROBE_TIERS[0]
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    def test_stale_minimax_cache_32k_is_invalidated(self, mock_models_dev, mock_fetch, tmp_path):
+        """Stale 32K cache entries for MiniMax must not keep tripping the 64K floor."""
+        mock_fetch.return_value = {}
+        cache_file = tmp_path / "cache.yaml"
+        base_url = "https://api.minimax.io/anthropic"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("MiniMax-M2.7", base_url, 32768)
+            result = get_model_context_length(
+                "MiniMax-M2.7",
+                base_url=base_url,
+                provider="minimax",
+            )
+            assert result == 204800
+            assert get_cached_context_length("MiniMax-M2.7", base_url) is None
+
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_openrouter_32k_underreport_for_minimax_falls_through_to_default(self, mock_fetch, mock_models_dev):
+        """Unknown-provider fallback must reject stale OpenRouter 32K for MiniMax."""
+        mock_fetch.return_value = {
+            "MiniMax-M2.7": {"context_length": 32768}
+        }
+        result = get_model_context_length("MiniMax-M2.7")
+        assert result == 204800
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    def test_non_minimax_32k_cache_is_still_respected(self, mock_models_dev, mock_fetch, tmp_path):
+        """The stale-32K invalidation must stay narrow and not touch unrelated models."""
+        mock_fetch.return_value = {}
+        cache_file = tmp_path / "cache.yaml"
+        base_url = "http://local"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("qwen3.5:27b", base_url, 32768)
+            result = get_model_context_length(
+                "qwen3.5:27b",
+                base_url=base_url,
+            )
+            assert result == 32768
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     def test_custom_endpoint_metadata_beats_fuzzy_default(self, mock_endpoint_fetch, mock_fetch):
         mock_fetch.return_value = {}


### PR DESCRIPTION
## Problem

MiniMax M2-family models (real context: 204,800 tokens) were sometimes resolved to 32,768 tokens, causing Telegram and cron setups to fail Hermes' existing 64K minimum-context guard even though the models fully support it.

## Root Cause

`get_model_context_length()` had a targeted guard for Kimi/Moonshot models that were wrongly underreported as `32768` by stale OpenRouter metadata. MiniMax models lacked the equivalent protection, leaving two failure paths:

1. A stale persisted `32768` cache entry for `MiniMax-M2.7` / `MiniMax-M2.5` would win before any provider fallback.
2. The unknown-provider OpenRouter fallback could still accept stale `32768` metadata for MiniMax models.

## Fix

- Add `_model_name_suggests_minimax()` mirroring the existing `_model_name_suggests_kimi()`.
- Introduce `_model_name_suggests_stale_32k_underreport()` that covers both families — a single predicate used in all three guard sites.
- Replace every call to `_model_name_suggests_kimi()` in the guard paths with the new combined predicate so adding future model families requires touching only one function.

## Tests

Three new regression tests in `tests/agent/test_model_metadata.py`:

| Test | Scenario |
|---|---|
| `test_stale_minimax_cache_32k_is_invalidated` | Stale 32K on-disk cache entry is dropped; falls through to 204800 hardcoded default |
| `test_openrouter_32k_underreport_for_minimax_falls_through_to_default` | OpenRouter reporting 32768 for MiniMax is rejected; 204800 returned |
| `test_non_minimax_32k_cache_is_still_respected` | Guard stays narrow — a genuine 32K Ollama model is not affected |

## Visual

```mermaid
flowchart TD
    A[get_model_context_length] --> B{cached <= 32768?}
    B -- yes --> C{_model_name_suggests_stale_32k_underreport?}
    C -- Kimi / MiniMax --> D[invalidate cache, re-resolve]
    C -- other --> E[use cached value]
    D --> F[hardcoded defaults → 204800]
```

---

Salvages and completes #24436 (rebased onto main, conflict in `_safe_ctx` docstring resolved).