### PR TITLE
feat(whatsapp): expand bridge features and approvals

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -28,6 +28,7 @@ import subprocess
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
 from typing import Dict, Optional, Any
+from urllib.parse import quote
 
 from hermes_constants import get_hermes_dir
 
@@ -926,6 +927,261 @@ class WhatsAppAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    def _bridge_url(self, path: str) -> str:
+        """Build a loopback URL for the managed WhatsApp bridge."""
+        return f"http://127.0.0.1:{self._bridge_port}{path}"
+
+    async def _post_bridge_json(
+        self,
+        path: str,
+        payload: Dict[str, Any],
+        *,
+        timeout_seconds: int = 30,
+    ) -> SendResult:
+        """POST JSON to the bridge and normalize the response as SendResult."""
+        if not self._running or not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        bridge_exit = await self._check_managed_bridge_exit()
+        if bridge_exit:
+            return SendResult(success=False, error=bridge_exit)
+
+        try:
+            import aiohttp
+
+            async with self._http_session.post(
+                self._bridge_url(path),
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=timeout_seconds),
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    success = data.get("success", True)
+                    return SendResult(
+                        success=bool(success),
+                        message_id=data.get("messageId"),
+                        error=data.get("error") if not success else None,
+                        raw_response=data,
+                    )
+                return SendResult(success=False, error=await resp.text())
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
+    async def _get_bridge_json(
+        self,
+        path: str,
+        *,
+        timeout_seconds: int = 15,
+    ) -> Dict[str, Any]:
+        """GET JSON from the bridge, returning an empty dict on failure."""
+        if not self._running or not self._http_session:
+            return {}
+        if await self._check_managed_bridge_exit():
+            return {}
+
+        try:
+            import aiohttp
+
+            async with self._http_session.get(
+                self._bridge_url(path),
+                timeout=aiohttp.ClientTimeout(total=timeout_seconds),
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+        except Exception as e:
+            logger.debug("Could not fetch WhatsApp bridge path %s: %s", path, e)
+        return {}
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a WhatsApp approval prompt as a poll, with text fallback."""
+        cmd_preview = command[:1200] + "..." if len(command) > 1200 else command
+        approval_id = None
+        if isinstance(metadata, dict):
+            approval_id = metadata.get("approval_id")
+        approve_once_text = f"`/approve {approval_id}`" if approval_id else "`/approve`"
+        deny_text = f"`/deny {approval_id}`" if approval_id else "`/deny`"
+        question = (
+            "*Dangerous command requires approval:*\n"
+            f"```\n{cmd_preview}\n```\n"
+            f"Reason: {description}"
+        )
+        fallback_text = (
+            f"{question}\n\n"
+            f"Reply {approve_once_text} to execute once, "
+            f"`/approve {approval_id} session` to approve for this session, "
+            f"`/approve {approval_id} always` to approve permanently, or "
+            f"{deny_text} to cancel."
+            if approval_id
+            else (
+                f"{question}\n\n"
+                "Reply `/approve` to execute once, `/approve session` to approve "
+                "for this session, `/approve always` to approve permanently, or "
+                "`/deny` to cancel."
+            )
+        )
+        approval_actions = {
+            "Approve once": f"/approve {approval_id}" if approval_id else "/approve",
+            "Approve session": (
+                f"/approve {approval_id} session" if approval_id else "/approve session"
+            ),
+            "Approve always": (
+                f"/approve {approval_id} always" if approval_id else "/approve always"
+            ),
+            "Deny": f"/deny {approval_id}" if approval_id else "/deny",
+        }
+        payload = {
+            "chatId": chat_id,
+            "question": question,
+            "options": list(approval_actions.keys()),
+            "selectableCount": 1,
+            "approvalActions": approval_actions,
+        }
+        if metadata:
+            payload["metadata"] = metadata
+        if session_key:
+            payload["sessionKey"] = session_key
+        poll_result = await self._post_bridge_json("/send-poll", payload, timeout_seconds=30)
+        if poll_result.success:
+            return poll_result
+
+        fallback_result = await self._post_bridge_json(
+            "/send",
+            {"chatId": chat_id, "message": fallback_text},
+            timeout_seconds=30,
+        )
+        if fallback_result.success:
+            return fallback_result
+        return SendResult(
+            success=False,
+            error=(
+                f"Poll approval failed: {poll_result.error}; "
+                f"text fallback failed: {fallback_result.error}"
+            ),
+            raw_response={
+                "poll": poll_result.raw_response,
+                "fallback": fallback_result.raw_response,
+            },
+        )
+
+    async def send_poll(
+        self,
+        chat_id: str,
+        question: str,
+        options: list[str],
+        *,
+        selectable_count: int = 1,
+    ) -> SendResult:
+        """Send a WhatsApp poll through the bridge."""
+        if not question or not options:
+            return SendResult(success=False, error="question and options are required")
+        return await self._post_bridge_json(
+            "/send-poll",
+            {
+                "chatId": chat_id,
+                "question": question,
+                "options": [str(option) for option in options],
+                "selectableCount": selectable_count,
+            },
+            timeout_seconds=30,
+        )
+
+    async def send_buttons(
+        self,
+        chat_id: str,
+        text: str,
+        buttons: list[Dict[str, Any]],
+        *,
+        footer: Optional[str] = None,
+    ) -> SendResult:
+        """Send a WhatsApp button message through the bridge."""
+        return await self._post_bridge_json(
+            "/send-buttons",
+            {
+                "chatId": chat_id,
+                "text": text,
+                "buttons": buttons,
+                "footer": footer,
+            },
+            timeout_seconds=30,
+        )
+
+    async def send_list(
+        self,
+        chat_id: str,
+        text: str,
+        sections: list[Dict[str, Any]],
+        *,
+        button_text: str = "Choose",
+        title: Optional[str] = None,
+        footer: Optional[str] = None,
+    ) -> SendResult:
+        """Send a WhatsApp list message through the bridge."""
+        return await self._post_bridge_json(
+            "/send-list",
+            {
+                "chatId": chat_id,
+                "text": text,
+                "sections": sections,
+                "buttonText": button_text,
+                "title": title,
+                "footer": footer,
+            },
+            timeout_seconds=30,
+        )
+
+    async def send_presence(self, chat_id: str, state: str = "typing") -> SendResult:
+        """Send a WhatsApp presence update through the bridge."""
+        normalized = str(state or "").strip().lower()
+        if normalized not in {"typing", "paused", "recording"}:
+            return SendResult(success=False, error=f"Unsupported presence state: {state}")
+        return await self._post_bridge_json(
+            "/presence",
+            {"chatId": chat_id, "state": normalized},
+            timeout_seconds=5,
+        )
+
+    async def list_groups(self) -> list[Dict[str, Any]]:
+        """Return groups the WhatsApp account participates in."""
+        data = await self._get_bridge_json("/groups", timeout_seconds=20)
+        return data.get("groups", []) if data.get("success", True) else []
+
+    async def get_group_participants(self, chat_id: str) -> list[Dict[str, Any]]:
+        """Return participant metadata for a WhatsApp group."""
+        encoded = quote(str(chat_id), safe="")
+        data = await self._get_bridge_json(
+            f"/groups/{encoded}/participants",
+            timeout_seconds=20,
+        )
+        return data.get("participants", []) if data.get("success", True) else []
+
+    async def get_lid_map(self) -> Dict[str, Any]:
+        """Return the bridge's known LID/phone alias mapping."""
+        data = await self._get_bridge_json("/lid-map", timeout_seconds=10)
+        return {
+            "lidToPhone": data.get("lidToPhone", {}),
+            "phoneToLid": data.get("phoneToLid", {}),
+        }
+
+    async def get_account_info(self) -> Dict[str, Any]:
+        """Return current WhatsApp account identifiers from the bridge."""
+        data = await self._get_bridge_json("/account", timeout_seconds=10)
+        data.pop("success", None)
+        return data
+
+    async def get_labels(self) -> Dict[str, Any]:
+        """Return labels when the active Baileys socket exposes label APIs."""
+        data = await self._get_bridge_json("/labels", timeout_seconds=20)
+        return {
+            "supported": bool(data.get("supported", False)),
+            "labels": data.get("labels", []),
+        }
+
     async def edit_message(
         self,
         chat_id: str,
@@ -1080,15 +1336,21 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Must wrap in `async with` — a bare `await session.post(...)`
-            # leaves the response object alive until GC, holding its TCP
-            # socket in CLOSE_WAIT. See #18451.
+            # Prefer the richer presence endpoint. Must wrap in `async with`
+            # — a bare `await session.post(...)` leaves the response object
+            # alive until GC, holding its TCP socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
-                f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": chat_id},
+                self._bridge_url("/presence"),
+                json={"chatId": chat_id, "state": "typing"},
                 timeout=aiohttp.ClientTimeout(total=5)
-            ):
-                pass
+            ) as resp:
+                if resp.status == 404:
+                    async with self._http_session.post(
+                        self._bridge_url("/typing"),
+                        json={"chatId": chat_id},
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ):
+                        pass
         except Exception:
             pass  # Ignore typing indicator failures
     
@@ -1103,7 +1365,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             import aiohttp
 
             async with self._http_session.get(
-                f"http://127.0.0.1:{self._bridge_port}/chat/{chat_id}",
+                self._bridge_url(f"/chat/{quote(str(chat_id), safe='')}"),
                 timeout=aiohttp.ClientTimeout(total=10)
             ) as resp:
                 if resp.status == 200:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5608,23 +5608,6 @@ class GatewayRunner:
 
             timeout = self._restart_drain_timeout
 
-            # Pre-mark sessions as resume_pending BEFORE the drain wait.
-            # If the process is killed by the service manager during the
-            # drain, the durable marker is already written so the next
-            # gateway boot can recover in-flight sessions (#27856).
-            _pre_drain_keys: list[str] = []
-            for _sk, _agent in list(self._running_agents.items()):
-                if _agent is _AGENT_PENDING_SENTINEL:
-                    continue
-                try:
-                    self.session_store.mark_resume_pending(
-                        _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
-                    )
-                    _pre_drain_keys.append(_sk)
-                except Exception as _e:
-                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
-
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)
             logger.info(
@@ -5636,20 +5619,6 @@ class GatewayRunner:
                 len(active_agents),
                 self._running_agent_count(),
             )
-
-            if not timed_out:
-                # Drain completed gracefully — all running sessions finished.
-                # Clear the pre-drain resume_pending markers so sessions that
-                # completed during the drain window don't carry a stale flag.
-                for _sk in _pre_drain_keys:
-                    if _sk not in self._running_agents:
-                        try:
-                            self.session_store.clear_resume_pending(_sk)
-                        except Exception as _e:
-                            logger.debug(
-                                "clear_resume_pending after drain failed for %s: %s",
-                                _sk, _e,
-                            )
 
             if timed_out:
                 logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13427,8 +13427,14 @@ class GatewayRunner:
                 return t("gateway.approval_expired")
             return t("gateway.approve.no_pending")
 
-        # Parse args: support "all", "all session", "all always", "session", "always"
-        args = event.get_command_args().strip().lower().split()
+        # Parse args: support an optional approval id first, then modifiers:
+        # "all", "all session", "all always", "session", "always".
+        raw_args = event.get_command_args().strip().split()
+        known_modifiers = {"all", "always", "permanent", "permanently", "session", "ses"}
+        approval_id = None
+        if raw_args and raw_args[0].lower() not in known_modifiers:
+            approval_id = raw_args.pop(0)
+        args = [a.lower() for a in raw_args]
         resolve_all = "all" in args
         remaining = [a for a in args if a != "all"]
 
@@ -13439,7 +13445,12 @@ class GatewayRunner:
         else:
             choice = "once"
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        count = resolve_gateway_approval(
+            session_key,
+            choice,
+            resolve_all=resolve_all,
+            approval_id=approval_id,
+        )
         if not count:
             return t("gateway.approve.no_pending")
 
@@ -13473,10 +13484,19 @@ class GatewayRunner:
                 return t("gateway.deny.stale")
             return t("gateway.deny.no_pending")
 
-        args = event.get_command_args().strip().lower()
+        raw_args = event.get_command_args().strip().split()
+        approval_id = None
+        if raw_args and raw_args[0].lower() != "all":
+            approval_id = raw_args.pop(0)
+        args = [a.lower() for a in raw_args]
         resolve_all = "all" in args
 
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
+        count = resolve_gateway_approval(
+            session_key,
+            "deny",
+            resolve_all=resolve_all,
+            approval_id=approval_id,
+        )
         if not count:
             return t("gateway.deny.no_pending")
 
@@ -16558,6 +16578,10 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_id = approval_data.get("approval_id")
+                approval_metadata = dict(_status_thread_metadata or {})
+                if approval_id:
+                    approval_metadata["approval_id"] = approval_id
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -16570,7 +16594,7 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_metadata,
                             ),
                             _loop_for_step,
                             logger=logger,
@@ -16604,7 +16628,7 @@ class GatewayRunner:
                         _status_adapter.send(
                             _status_chat_id,
                             msg,
-                            metadata=_status_thread_metadata,
+                            metadata=approval_metadata,
                         ),
                         _loop_for_step,
                         logger=logger,

--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -9,6 +9,12 @@ export function normalizeWhatsAppIdentifier(value) {
     .replace(/^\+/, '');
 }
 
+export function normalizeWhatsAppJid(value) {
+  return String(value || '')
+    .trim()
+    .replace(/:.*@/, '@');
+}
+
 export function parseAllowedUsers(rawValue) {
   return new Set(
     String(rawValue || '')

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -8,6 +8,7 @@ import {
   expandWhatsAppIdentifiers,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
+  normalizeWhatsAppJid,
   parseAllowedUsers,
 } from './allowlist.js';
 
@@ -15,6 +16,11 @@ test('normalizeWhatsAppIdentifier strips jid syntax and plus prefix', () => {
   assert.equal(normalizeWhatsAppIdentifier('+19175395595@s.whatsapp.net'), '19175395595');
   assert.equal(normalizeWhatsAppIdentifier('267383306489914@lid'), '267383306489914');
   assert.equal(normalizeWhatsAppIdentifier('19175395595:12@s.whatsapp.net'), '19175395595');
+});
+
+test('normalizeWhatsAppJid strips device suffix without corrupting jid domain', () => {
+  assert.equal(normalizeWhatsAppJid('19175395595:12@s.whatsapp.net'), '19175395595@s.whatsapp.net');
+  assert.equal(normalizeWhatsAppJid('267383306489914:3@lid'), '267383306489914@lid');
 });
 
 test('expandWhatsAppIdentifiers resolves phone and lid aliases from session files', () => {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -10,8 +10,17 @@
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
- *   POST /typing         - Send typing indicator { chatId }
+ *   POST /send-buttons   - Send buttons or safe text fallback { chatId, text, buttons[], footer? }
+ *   POST /send-list      - Send list or safe text fallback { chatId, text, sections[] }
+ *   POST /send-poll      - Send poll { chatId, question, options[], selectableCount? }
+ *   POST /presence       - Send presence { chatId, state: typing|paused|recording }
+ *   POST /typing         - Back-compat typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
+ *   GET  /groups         - List participating groups
+ *   GET  /groups/:id/participants - List group participants
+ *   GET  /lid-map        - Get known LID/phone aliases
+ *   GET  /account        - Get current account identifiers
+ *   GET  /labels         - Get labels when supported by Baileys
  *   GET  /health         - Health check
  *
  * Usage:
@@ -28,7 +37,7 @@ import { randomBytes } from 'crypto';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedUser, normalizeWhatsAppJid, parseAllowedUsers } from './allowlist.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -120,8 +129,29 @@ function trackSentMessageId(sent) {
 }
 
 function normalizeWhatsAppId(value) {
-  if (!value) return '';
-  return String(value).replace(':', '@');
+  return normalizeWhatsAppJid(value);
+}
+
+const HERMES_APPROVAL_ACTIONS = {
+  hermes_approve_once: '/approve',
+  hermes_approve_session: '/approve session',
+  hermes_approve_always: '/approve always',
+  hermes_deny: '/deny',
+};
+
+function approvalActionText(rawId) {
+  const value = String(rawId || '');
+  const separator = value.indexOf(':');
+  const actionId = separator === -1 ? value : value.slice(0, separator);
+  const approvalId = separator === -1 ? '' : value.slice(separator + 1);
+  const command = HERMES_APPROVAL_ACTIONS[actionId];
+  if (!command) return null;
+  if (!approvalId) return command;
+  if (command === '/approve') return `/approve ${approvalId}`;
+  if (command === '/approve session') return `/approve ${approvalId} session`;
+  if (command === '/approve always') return `/approve ${approvalId} always`;
+  if (command === '/deny') return `/deny ${approvalId}`;
+  return command;
 }
 
 function getMessageContent(msg) {
@@ -146,6 +176,117 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+function getInteractiveResponse(messageContent) {
+  const buttonResponse = messageContent.buttonsResponseMessage;
+  if (buttonResponse) {
+    const id = buttonResponse.selectedButtonId || '';
+    return {
+      eventType: 'button.response',
+      id,
+      title: buttonResponse.selectedDisplayText || id,
+      text: approvalActionText(id) || buttonResponse.selectedDisplayText || id,
+    };
+  }
+
+  const templateResponse = messageContent.templateButtonReplyMessage;
+  if (templateResponse) {
+    const id = templateResponse.selectedId || '';
+    return {
+      eventType: 'button.response',
+      id,
+      title: templateResponse.selectedDisplayText || id,
+      text: approvalActionText(id) || templateResponse.selectedDisplayText || id,
+    };
+  }
+
+  const listResponse = messageContent.listResponseMessage;
+  if (listResponse) {
+    const id = listResponse.singleSelectReply?.selectedRowId || '';
+    return {
+      eventType: 'list.response',
+      id,
+      title: listResponse.title || id,
+      description: listResponse.description || '',
+      text: approvalActionText(id) || listResponse.title || id,
+    };
+  }
+
+  const nativeFlow = messageContent.interactiveResponseMessage?.nativeFlowResponseMessage;
+  if (nativeFlow) {
+    let id = nativeFlow.name || '';
+    let title = id;
+    try {
+      const params = JSON.parse(nativeFlow.paramsJson || '{}');
+      id = params.id || params.rowId || params.button_id || id;
+      title = params.title || params.display_text || params.name || title;
+    } catch {}
+    return {
+      eventType: 'interactive.response',
+      id,
+      title,
+      text: approvalActionText(id) || title || id,
+    };
+  }
+
+  return null;
+}
+
+function getPollCreation(messageContent) {
+  return (
+    messageContent.pollCreationMessage ||
+    messageContent.pollCreationMessageV2 ||
+    messageContent.pollCreationMessageV3 ||
+    null
+  );
+}
+
+function parsePollCreation(poll) {
+  if (!poll) return null;
+  return {
+    question: poll.name || poll.question || '',
+    options: (poll.options || [])
+      .map(option => option.optionName || option.name || option.text || '')
+      .filter(Boolean),
+    selectableCount: poll.selectableOptionsCount || poll.selectableCount || 1,
+  };
+}
+
+function extractPollSelectedOptions(pollUpdateMessage) {
+  const vote = pollUpdateMessage?.vote || pollUpdateMessage || {};
+  if (Array.isArray(vote.selectedOptions)) return vote.selectedOptions;
+  if (Array.isArray(vote.selectedOptionNames)) return vote.selectedOptionNames;
+  if (Array.isArray(vote.selectedOptionHashes)) return vote.selectedOptionHashes;
+  if (vote.selectedOptionName) return [vote.selectedOptionName];
+  if (vote.selectedOption) return [vote.selectedOption];
+  return [];
+}
+
+function rememberPollApproval(sent, approvalActions) {
+  const messageId = sent?.key?.id;
+  if (!messageId || !approvalActions || typeof approvalActions !== 'object') return;
+  pollApprovalActions.set(messageId, approvalActions);
+  if (pollApprovalActions.size > MAX_POLL_APPROVALS) {
+    pollApprovalActions.delete(pollApprovalActions.keys().next().value);
+  }
+}
+
+function pollCreationMessageId(pollUpdateMessage) {
+  const key = pollUpdateMessage?.pollCreationMessageKey || pollUpdateMessage?.pollCreationKey || {};
+  return key.id || key.key?.id || '';
+}
+
+function resolvePollApprovalAction(pollUpdateMessage, selectedOptions) {
+  const pollId = pollCreationMessageId(pollUpdateMessage);
+  const actions = pollId ? pollApprovalActions.get(pollId) : null;
+  for (const option of selectedOptions || []) {
+    const key = String(option || '');
+    if (actions?.[key]) return actions[key];
+    const direct = approvalActionText(key);
+    if (direct) return direct;
+  }
+  return null;
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -164,6 +305,14 @@ function buildLidMap() {
 }
 let lidToPhone = buildLidMap();
 
+function buildPhoneToLidMap() {
+  const map = {};
+  for (const [lid, phone] of Object.entries(buildLidMap())) {
+    map[phone] = lid;
+  }
+  return map;
+}
+
 const logger = pino({ level: 'warn' });
 
 // Message queue for polling
@@ -173,6 +322,11 @@ const MAX_QUEUE_SIZE = 100;
 // Track recently sent message IDs to prevent echo-back loops with media
 const recentlySentIds = new Set();
 const MAX_RECENT_IDS = 50;
+
+// Track approval polls so a vote can become the same slash command text that
+// the gateway already authorizes and dispatches.
+const pollApprovalActions = new Map();
+const MAX_POLL_APPROVALS = 100;
 
 let sock = null;
 let connectionState = 'disconnected';
@@ -318,17 +472,35 @@ async function startSocket() {
       const contextInfo = getContextInfo(messageContent);
       const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
       const quotedMessageId = contextInfo?.stanzaId || null;
-      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
+      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || contextInfo?.remoteJid || '') || null;
       const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
       const hasQuotedMessage = !!contextInfo?.quotedMessage;
+      const interactiveResponse = getInteractiveResponse(messageContent);
+      const pollCreation = parsePollCreation(getPollCreation(messageContent));
+      const pollUpdateMessage = messageContent.pollUpdateMessage;
 
       // Extract message body
       let body = '';
       let hasMedia = false;
       let mediaType = '';
+      let eventType = 'message.received';
+      let selectedOptions = [];
       const mediaUrls = [];
 
-      if (messageContent.conversation) {
+      if (interactiveResponse) {
+        body = interactiveResponse.text;
+        eventType = interactiveResponse.eventType;
+      } else if (pollCreation) {
+        body = `[poll] ${pollCreation.question}`;
+        eventType = 'poll.created';
+      } else if (pollUpdateMessage) {
+        selectedOptions = extractPollSelectedOptions(pollUpdateMessage);
+        const approvalAction = resolvePollApprovalAction(pollUpdateMessage, selectedOptions);
+        body = approvalAction || (selectedOptions.length
+          ? `[poll vote] ${selectedOptions.join(', ')}`
+          : '[poll vote received]');
+        eventType = 'poll.vote';
+      } else if (messageContent.conversation) {
         body = messageContent.conversation;
       } else if (messageContent.extendedTextMessage?.text) {
         body = messageContent.extendedTextMessage.text;
@@ -421,6 +593,7 @@ async function startSocket() {
       }
 
       const event = {
+        eventType,
         messageId: msg.key.id,
         chatId,
         senderId,
@@ -436,6 +609,9 @@ async function startSocket() {
         quotedParticipant,
         quotedRemoteJid,
         hasQuotedMessage,
+        interactive: interactiveResponse,
+        poll: pollCreation,
+        selectedOptions,
         botIds,
         timestamp: msg.messageTimestamp,
       };
@@ -652,6 +828,186 @@ app.post('/send-media', async (req, res) => {
   }
 });
 
+function normalizeButton(button, index) {
+  const rawId = button?.id || button?.buttonId || button?.rowId || `button_${index + 1}`;
+  const rawText = button?.text || button?.title || button?.displayText || rawId;
+  return {
+    id: String(rawId),
+    text: String(rawText).slice(0, 60),
+    description: button?.description ? String(button.description).slice(0, 72) : undefined,
+  };
+}
+
+function formatFallbackOptions(buttons) {
+  return buttons
+    .map((button, index) => {
+      const actionText = approvalActionText(button.id);
+      const command = actionText ? ` (${actionText})` : '';
+      return `${index + 1}. ${button.text}${command}`;
+    })
+    .join('\n');
+}
+
+async function sendTextFallback(chatId, text, optionText = '', footer = '') {
+  const fallbackText = [text, optionText, footer].filter(Boolean).join('\n\n');
+  const sent = await sock.sendMessage(chatId, { text: formatOutgoingMessage(fallbackText) });
+  trackSentMessageId(sent);
+  return sent;
+}
+
+app.post('/send-buttons', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, text, buttons, footer } = req.body;
+  if (!chatId || !text || !Array.isArray(buttons) || buttons.length === 0) {
+    return res.status(400).json({ error: 'chatId, text, and buttons[] are required' });
+  }
+
+  const normalizedButtons = buttons.map(normalizeButton).slice(0, 10);
+  const nativeButtons = normalizedButtons.map(button => ({
+    buttonId: button.id,
+    buttonText: { displayText: button.text },
+    type: 1,
+  }));
+
+  try {
+    const sent = await sock.sendMessage(chatId, {
+      text: formatOutgoingMessage(text),
+      footer: footer || undefined,
+      buttons: nativeButtons,
+      headerType: 1,
+    });
+    trackSentMessageId(sent);
+    res.json({ success: true, messageId: sent?.key?.id, native: true });
+  } catch (err) {
+    try {
+      const sent = await sendTextFallback(
+        chatId,
+        text,
+        formatFallbackOptions(normalizedButtons),
+        footer || '',
+      );
+      res.json({
+        success: true,
+        messageId: sent?.key?.id,
+        native: false,
+        warning: err.message,
+      });
+    } catch (fallbackErr) {
+      res.status(500).json({ error: fallbackErr.message || err.message });
+    }
+  }
+});
+
+app.post('/send-list', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, text, sections, buttonText, title, footer } = req.body;
+  if (!chatId || !text || !Array.isArray(sections) || sections.length === 0) {
+    return res.status(400).json({ error: 'chatId, text, and sections[] are required' });
+  }
+
+  const normalizedSections = sections.map((section, sectionIndex) => ({
+    title: String(section?.title || `Section ${sectionIndex + 1}`),
+    rows: (section?.rows || section?.items || []).map((row, rowIndex) => {
+      const button = normalizeButton(row, rowIndex);
+      return {
+        title: button.text,
+        rowId: button.id,
+        description: button.description,
+      };
+    }),
+  })).filter(section => section.rows.length > 0);
+
+  if (normalizedSections.length === 0) {
+    return res.status(400).json({ error: 'At least one list row is required' });
+  }
+
+  try {
+    const sent = await sock.sendMessage(chatId, {
+      text: formatOutgoingMessage(text),
+      title: title || undefined,
+      footer: footer || undefined,
+      buttonText: buttonText || 'Choose',
+      sections: normalizedSections,
+    });
+    trackSentMessageId(sent);
+    res.json({ success: true, messageId: sent?.key?.id, native: true });
+  } catch (err) {
+    try {
+      const rows = normalizedSections.flatMap(section => section.rows.map(row => ({
+        id: row.rowId,
+        text: `${section.title}: ${row.title}`,
+      })));
+      const sent = await sendTextFallback(chatId, text, formatFallbackOptions(rows), footer || '');
+      res.json({
+        success: true,
+        messageId: sent?.key?.id,
+        native: false,
+        warning: err.message,
+      });
+    } catch (fallbackErr) {
+      res.status(500).json({ error: fallbackErr.message || err.message });
+    }
+  }
+});
+
+app.post('/send-poll', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { chatId, question, options, selectableCount, approvalActions } = req.body;
+  if (!chatId || !question || !Array.isArray(options) || options.length < 2) {
+    return res.status(400).json({ error: 'chatId, question, and at least two options are required' });
+  }
+
+  try {
+    const sent = await sock.sendMessage(chatId, {
+      poll: {
+        name: String(question),
+        values: options.map(option => String(option)).slice(0, 12),
+        selectableCount: Number.isInteger(selectableCount) ? selectableCount : 1,
+      },
+    });
+    trackSentMessageId(sent);
+    rememberPollApproval(sent, approvalActions);
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/presence', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  const { chatId, state } = req.body;
+  if (!chatId) return res.status(400).json({ error: 'chatId required' });
+
+  const presence = {
+    typing: 'composing',
+    paused: 'paused',
+    recording: 'recording',
+  }[String(state || 'typing').toLowerCase()];
+
+  if (!presence) {
+    return res.status(400).json({ error: 'state must be typing, paused, or recording' });
+  }
+
+  try {
+    await sock.sendPresenceUpdate(presence, chatId);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Typing indicator
 app.post('/typing', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
@@ -669,9 +1025,32 @@ app.post('/typing', async (req, res) => {
   }
 });
 
+function formatParticipant(participant) {
+  const id = normalizeWhatsAppId(participant?.id || '');
+  const bare = id.replace(/@.*/, '');
+  return {
+    id,
+    phone: id.endsWith('@lid') ? lidToPhone[id] || lidToPhone[bare] || null : bare || null,
+    lid: id.endsWith('@lid') ? id : null,
+    admin: participant?.admin || null,
+  };
+}
+
+function formatGroupMetadata(metadata) {
+  return {
+    id: metadata.id,
+    name: metadata.subject,
+    owner: normalizeWhatsAppId(metadata.owner || ''),
+    description: metadata.desc || '',
+    participants: (metadata.participants || []).map(formatParticipant),
+    participantCount: (metadata.participants || []).length,
+    createdAt: metadata.creation || null,
+  };
+}
+
 // Chat info
 app.get('/chat/:id', async (req, res) => {
-  const chatId = req.params.id;
+  const chatId = decodeURIComponent(req.params.id);
   const isGroup = chatId.endsWith('@g.us');
 
   if (isGroup && sock) {
@@ -680,7 +1059,7 @@ app.get('/chat/:id', async (req, res) => {
       return res.json({
         name: metadata.subject,
         isGroup: true,
-        participants: metadata.participants.map(p => p.id),
+        participants: metadata.participants.map(formatParticipant),
       });
     } catch {
       // Fall through to default
@@ -692,6 +1071,89 @@ app.get('/chat/:id', async (req, res) => {
     isGroup,
     participants: [],
   });
+});
+
+// List groups for directory/picker UX
+app.get('/groups', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  try {
+    const participating = await sock.groupFetchAllParticipating();
+    const groups = Object.values(participating || {}).map(formatGroupMetadata);
+    res.json({ success: true, groups });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// List participants for a single group
+app.get('/groups/:id/participants', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  try {
+    const chatId = decodeURIComponent(req.params.id);
+    const metadata = await sock.groupMetadata(chatId);
+    res.json({
+      success: true,
+      groupId: chatId,
+      participants: (metadata.participants || []).map(formatParticipant),
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Known LID/phone aliases discovered from Baileys auth state files
+app.get('/lid-map', (req, res) => {
+  lidToPhone = buildLidMap();
+  res.json({
+    success: true,
+    lidToPhone,
+    phoneToLid: buildPhoneToLidMap(),
+  });
+});
+
+// Current WhatsApp account identity
+app.get('/account', (req, res) => {
+  res.json({
+    success: true,
+    status: connectionState,
+    id: normalizeWhatsAppId(sock?.user?.id),
+    lid: normalizeWhatsAppId(sock?.user?.lid),
+    name: sock?.user?.name || '',
+    phone: normalizeWhatsAppId(sock?.user?.id).replace(/@.*/, ''),
+  });
+});
+
+// Labels are available only on some Baileys/WhatsApp app-state surfaces.
+app.get('/labels', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  try {
+    if (typeof sock.getLabels === 'function') {
+      const labels = await sock.getLabels();
+      return res.json({ success: true, supported: true, labels: labels || [] });
+    }
+    if (typeof sock.fetchLabels === 'function') {
+      const labels = await sock.fetchLabels();
+      return res.json({ success: true, supported: true, labels: labels || [] });
+    }
+  } catch (err) {
+    return res.json({
+      success: true,
+      supported: false,
+      labels: [],
+      error: err.message,
+    });
+  }
+
+  res.json({ success: true, supported: false, labels: [] });
 });
 
 // Health check

--- a/scripts/whatsapp-bridge/features.test.mjs
+++ b/scripts/whatsapp-bridge/features.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(join(here, 'bridge.js'), 'utf8');
+
+function assertSourceContains(token) {
+  assert.match(bridgeSource, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+}
+
+test('bridge exposes expanded WhatsApp feature endpoints', () => {
+  for (const endpoint of [
+    "app.post('/send-buttons'",
+    "app.post('/send-list'",
+    "app.post('/send-poll'",
+    "app.post('/presence'",
+    "app.get('/groups'",
+    "app.get('/groups/:id/participants'",
+    "app.get('/lid-map'",
+    "app.get('/account'",
+    "app.get('/labels'",
+  ]) {
+    assertSourceContains(endpoint);
+  }
+});
+
+test('button and list replies are converted into slash-command text', () => {
+  for (const token of [
+    'buttonsResponseMessage',
+    'templateButtonReplyMessage',
+    'listResponseMessage',
+    'approvalActionText',
+    'hermes_approve_once',
+    '/approve ${approvalId}',
+    '/approve session',
+    '/deny',
+  ]) {
+    assertSourceContains(token);
+  }
+});
+
+test('poll creation and poll update messages are represented in bridge events', () => {
+  for (const token of [
+    'pollCreationMessage',
+    'pollCreationMessageV3',
+    'pollUpdateMessage',
+    'poll.vote',
+    'selectedOptions',
+    'approvalActions',
+    'resolvePollApprovalAction',
+  ]) {
+    assertSourceContains(token);
+  }
+});

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",

--- a/tests/gateway/test_whatsapp_features.py
+++ b/tests/gateway/test_whatsapp_features.py
@@ -1,0 +1,328 @@
+"""Tests for expanded WhatsApp bridge feature wrappers."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class _AsyncCM:
+    """Minimal async context manager returning a fixed value."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_adapter():
+    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter._bridge_port = 3000
+    adapter._bridge_script = "/tmp/test-bridge.js"
+    adapter._session_path = MagicMock()
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._running = True
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = MagicMock()
+    adapter._mention_patterns = []
+    return adapter
+
+
+def _json_response(status=200, data=None, text=""):
+    resp = MagicMock(status=status)
+    resp.json = AsyncMock(return_value=data or {})
+    resp.text = AsyncMock(return_value=text)
+    return resp
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+
+
+def _make_whatsapp_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.WHATSAPP: PlatformConfig(enabled=True, token="")}
+    )
+    adapter = MagicMock()
+    adapter.resume_typing_for_chat = MagicMock()
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner.session_store = None
+    runner._pending_approvals = {}
+    return runner
+
+
+def _make_whatsapp_event(text="/approve"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.WHATSAPP,
+            user_id="15551234567@s.whatsapp.net",
+            chat_id="15551234567@s.whatsapp.net",
+            user_name="operator",
+            chat_type="dm",
+        ),
+        message_id="wa-msg-1",
+    )
+
+
+class TestWhatsAppExecApproval:
+    """send_exec_approval should use the bridge's rich approval surface."""
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    def teardown_method(self):
+        _clear_approval_state()
+
+    def test_send_exec_approval_is_class_method(self):
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+
+        assert getattr(WhatsAppAdapter, "send_exec_approval", None) is not None
+
+    @pytest.mark.asyncio
+    async def test_sends_poll_approval_prompt(self):
+        adapter = _make_adapter()
+        resp = _json_response(data={"success": True, "messageId": "wa-msg-1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send_exec_approval(
+            chat_id="15551234567@s.whatsapp.net",
+            command="rm -rf /important",
+            session_key="agent:main:whatsapp:dm:15551234567",
+            description="dangerous deletion",
+        )
+
+        assert result.success is True
+        assert result.message_id == "wa-msg-1"
+
+        url = adapter._http_session.post.call_args.args[0]
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert url.endswith("/send-poll")
+        assert payload["chatId"] == "15551234567@s.whatsapp.net"
+        assert "rm -rf /important" in payload["question"]
+        assert "dangerous deletion" in payload["question"]
+        assert payload["options"] == [
+            "Approve once",
+            "Approve session",
+            "Approve always",
+            "Deny",
+        ]
+        assert payload["approvalActions"] == {
+            "Approve once": "/approve",
+            "Approve session": "/approve session",
+            "Approve always": "/approve always",
+            "Deny": "/deny",
+        }
+
+    @pytest.mark.asyncio
+    async def test_poll_error_falls_back_to_text_approval(self):
+        adapter = _make_adapter()
+        poll_resp = _json_response(status=501, text="polls unsupported")
+        text_resp = _json_response(data={"success": True, "messageId": "text-fallback"})
+        adapter._http_session.post = MagicMock(
+            side_effect=[_AsyncCM(poll_resp), _AsyncCM(text_resp)]
+        )
+
+        result = await adapter.send_exec_approval(
+            chat_id="chat",
+            command="ls",
+            session_key="session",
+        )
+
+        assert result.success is True
+        assert result.message_id == "text-fallback"
+        first_call, second_call = adapter._http_session.post.call_args_list
+        assert first_call.args[0].endswith("/send-poll")
+        assert second_call.args[0].endswith("/send")
+        assert "Reply `/approve`" in second_call.kwargs["json"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_approval_id_is_embedded_in_poll_actions(self):
+        adapter = _make_adapter()
+        resp = _json_response(data={"success": True, "messageId": "wa-msg-2"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send_exec_approval(
+            chat_id="15551234567@s.whatsapp.net",
+            command="rm -rf /important",
+            session_key="agent:main:whatsapp:dm:15551234567",
+            metadata={"approval_id": "abc123"},
+        )
+
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert payload["options"] == ["Approve once", "Approve session", "Approve always", "Deny"]
+        assert payload["approvalActions"] == {
+            "Approve once": "/approve abc123",
+            "Approve session": "/approve abc123 session",
+            "Approve always": "/approve abc123 always",
+            "Deny": "/deny abc123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_interactive_approve_session_routes_through_gateway_queue(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_whatsapp_runner()
+        event = _make_whatsapp_event("/approve session")
+        session_key = runner._session_key_for_source(event.source)
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/demo"})
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_approve_command(event)
+
+        assert "session" in result.lower()
+        assert entry.event.is_set()
+        assert entry.result == "session"
+        runner.adapters[Platform.WHATSAPP].resume_typing_for_chat.assert_called_once_with(
+            "15551234567@s.whatsapp.net"
+        )
+
+    @pytest.mark.asyncio
+    async def test_interactive_approval_id_resolves_matching_queue_entry(self):
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        runner = _make_whatsapp_runner()
+        event = _make_whatsapp_event("/approve approval-new session")
+        session_key = runner._session_key_for_source(event.source)
+        old_entry = _ApprovalEntry({"approval_id": "approval-old", "command": "first"})
+        new_entry = _ApprovalEntry({"approval_id": "approval-new", "command": "second"})
+        _gateway_queues[session_key] = [old_entry, new_entry]
+
+        result = await runner._handle_approve_command(event)
+
+        assert "session" in result.lower()
+        assert not old_entry.event.is_set()
+        assert new_entry.event.is_set()
+        assert new_entry.result == "session"
+        assert _gateway_queues[session_key] == [old_entry]
+
+
+class TestWhatsAppFeatureWrappers:
+    """Python adapter wrappers should call stable bridge endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_send_poll(self):
+        adapter = _make_adapter()
+        resp = _json_response(data={"success": True, "messageId": "poll-1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send_poll(
+            "120363000000000000@g.us",
+            "Deploy?",
+            ["yes", "no"],
+            selectable_count=1,
+        )
+
+        assert result.success is True
+        assert result.message_id == "poll-1"
+        url = adapter._http_session.post.call_args.args[0]
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert url.endswith("/send-poll")
+        assert payload == {
+            "chatId": "120363000000000000@g.us",
+            "question": "Deploy?",
+            "options": ["yes", "no"],
+            "selectableCount": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_presence(self):
+        adapter = _make_adapter()
+        resp = _json_response(data={"success": True})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.send_presence("chat", "recording")
+
+        assert result.success is True
+        url = adapter._http_session.post.call_args.args[0]
+        payload = adapter._http_session.post.call_args.kwargs["json"]
+        assert url.endswith("/presence")
+        assert payload == {"chatId": "chat", "state": "recording"}
+
+    @pytest.mark.asyncio
+    async def test_list_groups(self):
+        adapter = _make_adapter()
+        groups = [{"id": "120363@g.us", "name": "Ops"}]
+        resp = _json_response(data={"success": True, "groups": groups})
+        adapter._http_session.get = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.list_groups()
+
+        assert result == groups
+        assert adapter._http_session.get.call_args.args[0].endswith("/groups")
+
+    @pytest.mark.asyncio
+    async def test_get_group_participants(self):
+        adapter = _make_adapter()
+        participants = [{"id": "15551234567@s.whatsapp.net", "admin": "admin"}]
+        resp = _json_response(data={"success": True, "participants": participants})
+        adapter._http_session.get = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.get_group_participants("120363@g.us")
+
+        assert result == participants
+        assert adapter._http_session.get.call_args.args[0].endswith(
+            "/groups/120363%40g.us/participants"
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_lid_map(self):
+        adapter = _make_adapter()
+        mapping = {
+            "lidToPhone": {"111@lid": "15551234567"},
+            "phoneToLid": {"15551234567": "111@lid"},
+        }
+        resp = _json_response(data={"success": True, **mapping})
+        adapter._http_session.get = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.get_lid_map()
+
+        assert result == mapping
+        assert adapter._http_session.get.call_args.args[0].endswith("/lid-map")
+
+    @pytest.mark.asyncio
+    async def test_get_labels_preserves_supported_flag(self):
+        adapter = _make_adapter()
+        data = {"success": True, "supported": False, "labels": []}
+        resp = _json_response(data=data)
+        adapter._http_session.get = MagicMock(return_value=_AsyncCM(resp))
+
+        result = await adapter.get_labels()
+
+        assert result == {"supported": False, "labels": []}
+        assert adapter._http_session.get.call_args.args[0].endswith("/labels")

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -30,6 +30,7 @@ from tools.send_message_tool import (
     _send_signal,
     _send_telegram,
     _send_to_platform,
+    _send_whatsapp,
     send_message_tool,
 )
 
@@ -701,6 +702,49 @@ class TestSendToPlatformWhatsapp:
 
         assert result["success"] is True
         async_mock.assert_awaited_once_with({"bridge_port": 3000}, chat_id, "hello from hermes")
+
+    def test_whatsapp_media_routes_via_local_bridge_sender(self, tmp_path):
+        chat_id = "test-user@lid"
+        image_path = tmp_path / "proof.jpg"
+        image_path.write_bytes(b"fake image")
+        media_files = [(str(image_path), False)]
+        async_mock = AsyncMock(return_value={"success": True, "platform": "whatsapp", "chat_id": chat_id, "message_id": "media123"})
+
+        with patch("tools.send_message_tool._send_whatsapp", async_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token=None, extra={"bridge_port": 3000}),
+                    chat_id,
+                    "photo caption",
+                    media_files=media_files,
+                )
+            )
+
+        assert result["success"] is True
+        async_mock.assert_awaited_once_with(
+            {"bridge_port": 3000},
+            chat_id,
+            "photo caption",
+            media_files=media_files,
+        )
+
+    def test_whatsapp_missing_media_without_text_returns_clear_error(self):
+        missing_path = "/nonexistent/whatsapp-proof.jpg"
+
+        result = asyncio.run(
+            _send_whatsapp(
+                {"bridge_port": 3000},
+                "test-user@lid",
+                "",
+                media_files=[(missing_path, False)],
+            )
+        )
+
+        assert result["error"] == "No deliverable text or media remained after processing"
+        assert result["warnings"] == [
+            f"WhatsApp media file not found, skipping: {missing_path}"
+        ]
 
 
 class TestSendTelegramHtmlDetection:
@@ -2569,4 +2613,3 @@ class TestSendTelegramThreadNotFoundRetry:
         finally:
             if media_path and os.path.exists(media_path):
                 os.unlink(media_path)
-

--- a/tests/tools/test_whatsapp_tool.py
+++ b/tests/tools/test_whatsapp_tool.py
@@ -1,0 +1,71 @@
+"""Tests for tools/whatsapp_tool.py."""
+
+import json
+
+
+def test_send_poll_posts_bridge_payload(monkeypatch):
+    from tools import whatsapp_tool as mod
+
+    calls = []
+
+    def fake_request(method, path, payload=None, timeout=20):
+        calls.append((method, path, payload, timeout))
+        return {"success": True, "messageId": "poll-1"}
+
+    monkeypatch.setattr(mod, "_request_bridge", fake_request)
+
+    result = json.loads(mod.whatsapp_tool({
+        "action": "send_poll",
+        "chat_id": "120363@g.us",
+        "question": "Deploy?",
+        "options": ["yes", "no"],
+        "selectable_count": 1,
+    }))
+
+    assert result == {"success": True, "messageId": "poll-1"}
+    assert calls == [(
+        "POST",
+        "/send-poll",
+        {
+            "chatId": "120363@g.us",
+            "question": "Deploy?",
+            "options": ["yes", "no"],
+            "selectableCount": 1,
+        },
+        20,
+    )]
+
+
+def test_group_participants_encodes_chat_id(monkeypatch):
+    from tools import whatsapp_tool as mod
+
+    calls = []
+
+    def fake_request(method, path, payload=None, timeout=20):
+        calls.append((method, path, payload, timeout))
+        return {"success": True, "participants": []}
+
+    monkeypatch.setattr(mod, "_request_bridge", fake_request)
+
+    result = json.loads(mod.whatsapp_tool({
+        "action": "group_participants",
+        "chat_id": "120363@g.us",
+    }))
+
+    assert result == {"success": True, "participants": []}
+    assert calls == [("GET", "/groups/120363%40g.us/participants", None, 20)]
+
+
+def test_buttons_require_buttons_array(monkeypatch):
+    from tools import whatsapp_tool as mod
+
+    monkeypatch.setattr(mod, "_request_bridge", lambda *_args, **_kwargs: {"success": True})
+
+    result = json.loads(mod.whatsapp_tool({
+        "action": "send_buttons",
+        "chat_id": "15551234567@s.whatsapp.net",
+        "text": "Pick one",
+        "buttons": [],
+    }))
+
+    assert "buttons" in result["error"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -16,6 +16,7 @@ import sys
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -539,13 +540,18 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
-def resolve_gateway_approval(session_key: str, choice: str,
-                             resolve_all: bool = False) -> int:
+def resolve_gateway_approval(
+    session_key: str,
+    choice: str,
+    resolve_all: bool = False,
+    approval_id: Optional[str] = None,
+) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
     waiting agent thread(s).
 
     When *resolve_all* is True every pending approval in the session is
-    resolved at once (``/approve all``).  Otherwise only the oldest one
+    resolved at once (``/approve all``).  When *approval_id* is supplied,
+    only that matching approval is resolved.  Otherwise only the oldest one
     is resolved (FIFO).
 
     Returns the number of approvals resolved (0 means nothing was pending).
@@ -557,6 +563,17 @@ def resolve_gateway_approval(session_key: str, choice: str,
         if resolve_all:
             targets = list(queue)
             queue.clear()
+        elif approval_id:
+            target_index = next(
+                (
+                    index for index, entry in enumerate(queue)
+                    if str(entry.data.get("approval_id", "")) == str(approval_id)
+                ),
+                None,
+            )
+            if target_index is None:
+                return 0
+            targets = [queue.pop(target_index)]
         else:
             targets = [queue.pop(0)]
         if not queue:
@@ -1193,6 +1210,7 @@ def check_all_command_guards(command: str, env_type: str,
             # Each call gets its own _ApprovalEntry so parallel subagents
             # and execute_code threads can block concurrently.
             approval_data = {
+                "approval_id": uuid.uuid4().hex[:12],
                 "command": command,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -599,6 +599,43 @@ class ShellFileOperations(FileOperations):
             return non_printable / min(len(content_sample), 1000) > 0.30
         
         return False
+
+    def _check_git_baseline(self, path: str) -> Optional[str]:
+        """Return a warning if the target starts in a dirty git worktree."""
+        workdir = os.path.dirname(path) or None
+
+        try:
+            git_result = self._exec("command -v git", cwd=workdir)
+            if git_result.exit_code != 0:
+                return None
+
+            repo_result = self._exec(
+                "git rev-parse --is-inside-work-tree",
+                cwd=workdir,
+            )
+            if repo_result.exit_code != 0 or repo_result.stdout.strip().lower() != "true":
+                return None
+
+            branch_result = self._exec(
+                "git rev-parse --abbrev-ref HEAD",
+                cwd=workdir,
+            )
+            branch = (
+                branch_result.stdout.strip()
+                if branch_result.exit_code == 0 and branch_result.stdout.strip()
+                else "unknown"
+            )
+
+            status_result = self._exec("git status --porcelain", cwd=workdir)
+            if status_result.exit_code == 0 and status_result.stdout.strip():
+                return (
+                    f"Git working tree is dirty (branch: {branch}); "
+                    "uncommitted changes existed before this write."
+                )
+        except Exception:
+            return None
+
+        return None
     
     def _is_image(self, path: str) -> bool:
         """Check if file is an image we can return as base64."""
@@ -909,6 +946,8 @@ class ShellFileOperations(FileOperations):
         if _is_write_denied(path):
             return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
 
+        git_warning = self._check_git_baseline(path)
+
         # Capture pre-write content.  Two consumers want it:
         #
         #   1. The lint-delta layer (for in-process linters like ast.parse
@@ -993,6 +1032,7 @@ class ShellFileOperations(FileOperations):
             dirs_created=dirs_created,
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
+            warning=git_warning,
         )
     
     # =========================================================================

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -692,6 +692,22 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- WhatsApp: native attachment support via local Baileys bridge ---
+    if platform == Platform.WHATSAPP and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_whatsapp(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Yuanbao: native media attachment support via running gateway adapter ---
     if platform == Platform.YUANBAO and media_files:
         last_result = None
@@ -728,7 +744,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -736,7 +752,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, whatsapp, yuanbao and feishu"
         )
 
     last_result = None
@@ -1270,7 +1286,7 @@ async def _send_slack(token, chat_id, message):
         return _error(f"Slack send failed: {e}")
 
 
-async def _send_whatsapp(extra, chat_id, message):
+async def _send_whatsapp(extra, chat_id, message, media_files=None):
     """Send via the local WhatsApp bridge HTTP API."""
     try:
         import aiohttp
@@ -1278,7 +1294,64 @@ async def _send_whatsapp(extra, chat_id, message):
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
         bridge_port = extra.get("bridge_port", 3000)
+        warnings = []
+        valid_media = []
+        for media_path, is_voice in media_files or []:
+            if os.path.exists(media_path):
+                valid_media.append((media_path, is_voice))
+            else:
+                warning = f"WhatsApp media file not found, skipping: {media_path}"
+                logger.warning(warning)
+                warnings.append(warning)
+
+        if not valid_media and not message.strip():
+            error = "No deliverable text or media remained after processing"
+            if warnings:
+                return {"error": error, "warnings": warnings}
+            return {"error": error}
+
         async with aiohttp.ClientSession() as session:
+            if valid_media:
+                last_data = None
+                for index, (media_path, is_voice) in enumerate(valid_media):
+                    ext = os.path.splitext(media_path)[1].lower()
+                    media_type = None
+                    if ext in _IMAGE_EXTS:
+                        media_type = "image"
+                    elif ext in _VIDEO_EXTS:
+                        media_type = "video"
+                    elif ext in _AUDIO_EXTS or is_voice:
+                        media_type = "audio"
+                    payload = {
+                        "chatId": chat_id,
+                        "filePath": media_path,
+                    }
+                    if media_type:
+                        payload["mediaType"] = media_type
+                    if index == 0 and message.strip():
+                        payload["caption"] = message
+                    async with session.post(
+                        f"http://localhost:{bridge_port}/send-media",
+                        json=payload,
+                        timeout=aiohttp.ClientTimeout(total=120),
+                    ) as resp:
+                        if resp.status != 200:
+                            body = await resp.text()
+                            error = _error(f"WhatsApp bridge error ({resp.status}): {body}")
+                            if warnings:
+                                error["warnings"] = warnings
+                            return error
+                        last_data = await resp.json()
+                result = {
+                    "success": True,
+                    "platform": "whatsapp",
+                    "chat_id": chat_id,
+                    "message_id": (last_data or {}).get("messageId"),
+                }
+                if warnings:
+                    result["warnings"] = warnings
+                return result
+
             async with session.post(
                 f"http://localhost:{bridge_port}/send",
                 json={"chatId": chat_id, "message": message},
@@ -1292,8 +1365,14 @@ async def _send_whatsapp(extra, chat_id, message):
                         "chat_id": chat_id,
                         "message_id": data.get("messageId"),
                     }
+                    if warnings:
+                        result["warnings"] = warnings
+                    return result
                 body = await resp.text()
-                return _error(f"WhatsApp bridge error ({resp.status}): {body}")
+                error = _error(f"WhatsApp bridge error ({resp.status}): {body}")
+                if warnings:
+                    error["warnings"] = warnings
+                return error
     except Exception as e:
         return _error(f"WhatsApp send failed: {e}")
 

--- a/tools/whatsapp_tool.py
+++ b/tools/whatsapp_tool.py
@@ -1,0 +1,242 @@
+"""WhatsApp bridge tool -- rich WhatsApp operations via the local bridge."""
+
+import json
+import os
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+WHATSAPP_SCHEMA = {
+    "name": "whatsapp",
+    "description": (
+        "Use the local WhatsApp bridge for rich WhatsApp features: polls, "
+        "buttons, lists, presence, group discovery, participants, LID map, "
+        "account info, and labels. Use send_message for plain text/media."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "send_poll",
+                    "send_buttons",
+                    "send_list",
+                    "set_presence",
+                    "list_groups",
+                    "group_participants",
+                    "lid_map",
+                    "account",
+                    "labels",
+                ],
+                "description": "WhatsApp bridge action to perform.",
+            },
+            "chat_id": {
+                "type": "string",
+                "description": "WhatsApp chat JID, e.g. 15551234567@s.whatsapp.net or 120363...@g.us.",
+            },
+            "text": {
+                "type": "string",
+                "description": "Message body for button/list sends.",
+            },
+            "question": {
+                "type": "string",
+                "description": "Poll question.",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Poll options.",
+            },
+            "selectable_count": {
+                "type": "integer",
+                "description": "Poll selectable option count. Defaults to 1.",
+            },
+            "buttons": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "Button objects: [{id, text}] or [{id, title}].",
+            },
+            "sections": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": "List sections: [{title, rows:[{id, title, description?}]}].",
+            },
+            "button_text": {
+                "type": "string",
+                "description": "List open button text. Defaults to Choose.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional list title.",
+            },
+            "footer": {
+                "type": "string",
+                "description": "Optional footer.",
+            },
+            "state": {
+                "type": "string",
+                "enum": ["typing", "paused", "recording"],
+                "description": "Presence state. Defaults to typing.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _error(message: str) -> dict:
+    return {"error": message}
+
+
+def _load_whatsapp_extra() -> Dict[str, Any]:
+    from gateway.config import Platform, load_gateway_config
+
+    config = load_gateway_config()
+    pconfig = config.platforms.get(Platform.WHATSAPP)
+    if not pconfig or not pconfig.enabled:
+        raise RuntimeError("WhatsApp platform is not enabled in gateway config.")
+    return dict(pconfig.extra or {})
+
+
+def _bridge_port(extra: Optional[Dict[str, Any]] = None) -> int:
+    value = (extra or {}).get("bridge_port") or os.getenv("WHATSAPP_BRIDGE_PORT") or 3000
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 3000
+
+
+def _request_bridge(method: str, path: str, payload: Optional[Dict[str, Any]] = None, timeout: int = 20) -> dict:
+    extra = _load_whatsapp_extra()
+    url = f"http://127.0.0.1:{_bridge_port(extra)}{path}"
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        url,
+        data=body,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            return json.loads(raw) if raw else {"success": True}
+    except HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = {"error": raw or str(exc)}
+        data.setdefault("status", exc.code)
+        return data
+    except (URLError, TimeoutError, OSError) as exc:
+        return _error(f"WhatsApp bridge request failed: {exc}")
+
+
+def _require(value: Any, name: str) -> Optional[dict]:
+    if value:
+        return None
+    return _error(f"{name} is required")
+
+
+def whatsapp_tool(args, **_kw):
+    action = str(args.get("action", "")).strip()
+    chat_id = str(args.get("chat_id", "")).strip()
+
+    try:
+        if action == "send_poll":
+            missing = _require(chat_id, "chat_id") or _require(args.get("question"), "question")
+            options = args.get("options") or []
+            if missing:
+                return json.dumps(missing)
+            if not isinstance(options, list) or len(options) < 2:
+                return json.dumps(_error("options must contain at least two strings"))
+            return json.dumps(_request_bridge("POST", "/send-poll", {
+                "chatId": chat_id,
+                "question": str(args.get("question")),
+                "options": [str(option) for option in options],
+                "selectableCount": int(args.get("selectable_count") or 1),
+            }))
+
+        if action == "send_buttons":
+            missing = _require(chat_id, "chat_id") or _require(args.get("text"), "text")
+            buttons = args.get("buttons") or []
+            if missing:
+                return json.dumps(missing)
+            if not isinstance(buttons, list) or not buttons:
+                return json.dumps(_error("buttons must be a non-empty array"))
+            return json.dumps(_request_bridge("POST", "/send-buttons", {
+                "chatId": chat_id,
+                "text": str(args.get("text")),
+                "buttons": buttons,
+                "footer": args.get("footer") or None,
+            }))
+
+        if action == "send_list":
+            missing = _require(chat_id, "chat_id") or _require(args.get("text"), "text")
+            sections = args.get("sections") or []
+            if missing:
+                return json.dumps(missing)
+            if not isinstance(sections, list) or not sections:
+                return json.dumps(_error("sections must be a non-empty array"))
+            return json.dumps(_request_bridge("POST", "/send-list", {
+                "chatId": chat_id,
+                "text": str(args.get("text")),
+                "sections": sections,
+                "buttonText": args.get("button_text") or "Choose",
+                "title": args.get("title") or None,
+                "footer": args.get("footer") or None,
+            }))
+
+        if action == "set_presence":
+            missing = _require(chat_id, "chat_id")
+            if missing:
+                return json.dumps(missing)
+            return json.dumps(_request_bridge("POST", "/presence", {
+                "chatId": chat_id,
+                "state": args.get("state") or "typing",
+            }, timeout=5))
+
+        if action == "list_groups":
+            return json.dumps(_request_bridge("GET", "/groups"))
+
+        if action == "group_participants":
+            missing = _require(chat_id, "chat_id")
+            if missing:
+                return json.dumps(missing)
+            return json.dumps(_request_bridge("GET", f"/groups/{quote(chat_id, safe='')}/participants"))
+
+        if action == "lid_map":
+            return json.dumps(_request_bridge("GET", "/lid-map"))
+
+        if action == "account":
+            return json.dumps(_request_bridge("GET", "/account"))
+
+        if action == "labels":
+            return json.dumps(_request_bridge("GET", "/labels"))
+
+        return json.dumps(_error(f"Unknown WhatsApp action: {action}"))
+    except Exception as exc:
+        return json.dumps(_error(f"WhatsApp tool failed: {exc}"))
+
+
+def check_whatsapp_tool_requirements() -> bool:
+    try:
+        _load_whatsapp_extra()
+        return True
+    except Exception:
+        return False
+
+
+from tools.registry import registry
+
+registry.register(
+    name="whatsapp",
+    toolset="whatsapp",
+    schema=WHATSAPP_SCHEMA,
+    handler=whatsapp_tool,
+    check_fn=check_whatsapp_tool_requirements,
+    emoji="WA",
+)


### PR DESCRIPTION
## What does this PR do?

Expands the WhatsApp gateway from basic text/media coverage into a richer Baileys-backed Hermes transport.

This adds outbound bridge endpoints for polls, buttons, lists, presence, group metadata, account info, labels, and LID mapping. It also makes WhatsApp approval prompts poll-first, with plain-text `/approve` and `/deny` fallback when polls are unavailable.

The approval path now carries targeted approval IDs through `tools/approval.py` and `gateway/run.py`, so poll/button/list replies can resolve the matching pending approval instead of relying only on oldest-pending FIFO behavior.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`: adds rich outbound endpoints, inbound interactive/poll parsing, approval poll vote mapping, group/account/label endpoints, presence support, media event payloads, and quote metadata.
- `scripts/whatsapp-bridge/allowlist.js`: adds safe WhatsApp JID normalization for device-suffixed IDs.
- `gateway/platforms/whatsapp.py`: adds rich bridge wrappers and poll-first `send_exec_approval()` with text fallback.
- `tools/approval.py` and `gateway/run.py`: add optional `approval_id` support for exact approval resolution.
- `tools/send_message_tool.py`: routes WhatsApp media attachments through `/send-media`.
- `tools/whatsapp_tool.py`: registers the new `whatsapp` toolset for polls, buttons, lists, presence, groups, participants, LID map, account info, and labels.
- Tests cover adapter behavior, approval routing, bridge source coverage, JID normalization, media delegation, registry discovery, and the new WhatsApp tool.
- Merged latest `upstream/main` and resolved conflicts in `scripts/whatsapp-bridge/bridge.js` and `tests/tools/test_registry.py`.

## How to Test

1. Create/update a local venv with required extras:
   `python3 -m venv .venv && uv pip install --python .venv/bin/python -e '.[dev,messaging]'`
2. Run the affected Python suite:
   `scripts/run_tests.sh tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_reply_prefix.py tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_whatsapp_features.py tests/gateway/test_approve_deny_commands.py tests/tools/test_send_message_tool.py::TestSendToPlatformWhatsapp tests/tools/test_whatsapp_tool.py tests/tools/test_registry.py`
3. Run bridge Node checks:
   `node --check scripts/whatsapp-bridge/bridge.js`
   `node --test scripts/whatsapp-bridge/*.test.mjs`
4. Run syntax/static checks:
   `python3 -m py_compile gateway/run.py gateway/platforms/whatsapp.py tools/approval.py tools/send_message_tool.py tools/whatsapp_tool.py`
   `python3 scripts/check-windows-footguns.py scripts/whatsapp-bridge/bridge.js gateway/run.py gateway/platforms/whatsapp.py tools/approval.py tools/send_message_tool.py tools/whatsapp_tool.py tests/gateway/test_whatsapp_features.py tests/gateway/test_approve_deny_commands.py tests/tools/test_send_message_tool.py tests/tools/test_whatsapp_tool.py tests/tools/test_registry.py`
   `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local worktree, Python 3.11.4, Node 25.9.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No UI screenshots. This was tested with mocked bridge calls, local Python/Node tests, and source-level bridge checks. I did not pair a live WhatsApp QR session in this environment.

Validation on 2026-05-19:

- `scripts/run_tests.sh ...` affected Python suite: 187 passed, 1 existing RuntimeWarning.
- `node --check scripts/whatsapp-bridge/bridge.js`: passed.
- `node --test scripts/whatsapp-bridge/*.test.mjs`: 9 passed.
- `python3 -m py_compile ...`: passed.
- `python3 scripts/check-windows-footguns.py ...` on PR files: passed.
- `git diff --check`: passed.
