### PR TITLE
fix(docker): remove corrupted sandbox dir before credential bind-mount

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -512,3 +512,46 @@ def test_run_as_host_user_warns_and_skips_when_no_posix_ids(monkeypatch, caplog)
         "does not expose POSIX uid/gid" in rec.getMessage()
         for rec in caplog.records
     ), "expected a warning when POSIX ids are unavailable"
+
+
+def test_persistent_credential_dir_corruption_cleaned_up(monkeypatch, tmp_path, caplog):
+    """When persistent=True and a credential's destination inside the sandbox home
+    is a directory (corrupted from a previous failed run), DockerEnvironment must
+    remove it before building the -v mount arg — otherwise Docker exits 125.
+
+    Regression test for issue #24483: Docker sandbox fails with exit 125 when
+    container_persistent=true and credential files are registered.
+    """
+    import tools.environments.base as base_env
+    import tools.credential_files as cred_mod
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+
+    # Simulate corrupted sandbox home: google_token.json is a directory instead
+    # of a file (Docker auto-creates source paths as directories on failed runs).
+    sandbox_home = tmp_path / "sandboxes" / "docker" / "cred-corruption-test" / "home"
+    sandbox_home.mkdir(parents=True)
+    corrupted_dir = sandbox_home / ".hermes" / "google_token.json"
+    corrupted_dir.mkdir(parents=True)
+    assert corrupted_dir.is_dir()
+
+    monkeypatch.setattr(base_env, "get_sandbox_dir", lambda: tmp_path / "sandboxes")
+
+    fake_cred = tmp_path / "google_token.json"
+    fake_cred.write_text("{}")
+
+    monkeypatch.setattr(
+        cred_mod,
+        "get_credential_file_mounts",
+        lambda: [{"host_path": str(fake_cred), "container_path": "/root/.hermes/google_token.json"}],
+    )
+    monkeypatch.setattr(cred_mod, "get_skills_directory_mount", lambda: [])
+    monkeypatch.setattr(cred_mod, "get_cache_directory_mounts", lambda: [])
+
+    with caplog.at_level(logging.WARNING):
+        _make_dummy_env(persistent_filesystem=True, task_id="cred-corruption-test")
+
+    assert not corrupted_dir.exists(), (
+        "DockerEnvironment must remove corrupted sandbox directory before credential bind-mount"
+    )

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -410,6 +410,23 @@ class DockerEnvironment(BaseEnvironment):
             )
 
             for mount_entry in get_credential_file_mounts():
+                # When persistent, container_path maps into self._home_dir on
+                # disk (/root -> home_dir). Guard against a corrupted sandbox
+                # home where a credential filename was auto-created as a
+                # directory by Docker on a prior failed run — Docker cannot
+                # bind-mount a file over a directory and will exit 125.
+                if self._persistent and self._home_dir:
+                    rel = mount_entry["container_path"].removeprefix("/root/")
+                    if rel != mount_entry["container_path"]:
+                        host_dest = os.path.join(self._home_dir, rel)
+                        if os.path.isdir(host_dest):
+                            logger.warning(
+                                "Docker: removing corrupted sandbox path %s "
+                                "(directory where credential file expected)",
+                                host_dest,
+                            )
+                            shutil.rmtree(host_dest, ignore_errors=True)
+
                 volume_args.extend([
                     "-v",
                     f"{mount_entry['host_path']}:{mount_entry['container_path']}:ro",


### PR DESCRIPTION
## Problem

When `container_persistent: true` is set and credential files are registered (e.g. `google-workspace`), the Docker sandbox fails with exit 125:

```
docker: error mounting "...google_client_secret.json" to rootfs: not a directory
```

## Root cause

With `persistent_filesystem=True`, `DockerEnvironment` binds `self._home_dir` as `/root` inside the container. Credential files are then mounted at paths like `/root/.hermes/google_token.json`. If a previous failed run caused Docker to auto-create `<home_dir>/.hermes/google_token.json` as a **directory** on disk, subsequent bind-mount attempts fail because Docker cannot mount a file over an existing directory.

## Fix

Before building each `-v` arg for a credential file, check whether the corresponding destination path inside `self._home_dir` is a directory. If so, remove it with `shutil.rmtree` and log a warning.

```python
if self._persistent and self._home_dir:
    rel = mount_entry["container_path"].removeprefix("/root/")
    if rel != mount_entry["container_path"]:
        host_dest = os.path.join(self._home_dir, rel)
        if os.path.isdir(host_dest):
            shutil.rmtree(host_dest, ignore_errors=True)
```

Only `tools/environments/docker.py` is modified.

## Tests

New regression test `test_persistent_credential_dir_corruption_cleaned_up` in `tests/tools/test_docker_environment.py`:
- Creates a corrupted sandbox home with `google_token.json` as a directory
- Confirms it is removed by `DockerEnvironment.__init__` before the `-v` arg is built

```
53 passed in 3.73s
```

## Visual

```mermaid
flowchart LR
    BUG["❌ Bug path\npersistent + cred dir corrupted as dir"] --> ERR["docker run exit 125\n'not a directory'"]
    FIX["✅ Fixed path\nshutil.rmtree corrupted dir\nbefore -v arg"] --> OK["docker run succeeds\ncredential file mounted :ro"]
```

Closes #24483