### PR TITLE
fix(holographic): add CJK-aware entity extraction to fix silent retrieval degradation

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -89,6 +89,27 @@ _RE_AKA          = re.compile(
     r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
     re.IGNORECASE,
 )
+# CJK bracket/quote markers — high-signal entity delimiters used in CJK text
+_RE_CJK_BRACKET  = re.compile(
+    r'[「『《“‘]([^」』》”’]{1,40})[」』》”’]'
+)
+# Mixed-script identifiers: Latin start, must contain at least one non-letter
+# character (digit, hyphen, dot, underscore) so plain English words are skipped.
+# Captures "lark-cli", "GPT-5.5", "baitugroup.com", "IHMS_v2", etc.
+_RE_MIXED_IDENT  = re.compile(
+    r'\b([A-Za-z][A-Za-z0-9_.\-]*[0-9_.\-][A-Za-z0-9_.\-]*(?:\s+\d+(?:\.\d+)*)?)\b'
+)
+# Stopwords applied only to pure-CJK candidates to avoid extracting pronouns
+# or generic grammatical particles as entities.
+_CJK_STOPWORDS = frozenset({
+    "的", "了", "和", "与", "或", "在", "是", "有", "也", "都",
+    "我", "你", "他", "她", "它", "我们", "你们", "他们",
+    "这", "那", "哪", "什么", "为", "以", "对", "从", "到",
+    "上", "下", "中", "内", "外", "前", "后", "左", "右",
+    "时", "年", "月", "日", "天", "个", "种", "次", "件",
+    "用", "使", "让", "把", "被", "给", "向", "按", "通过",
+})
+_RE_CJK_CHAR = re.compile(r'[一-鿿぀-ヿ가-힯]')
 
 
 def _clamp_trust(value: float) -> float:
@@ -403,15 +424,27 @@ class MemoryStore:
         2. Double-quoted terms             e.g. "Python"
         3. Single-quoted terms             e.g. 'pytest'
         4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+        5. CJK bracket/quote markers       e.g. 「白兔」《项目》 (high-signal CJK)
+        6. Mixed-script identifiers        e.g. "lark-cli", "GPT-5.5"
+
+        Pure-CJK candidates extracted by rule 5 are filtered against a small
+        stopword list (_CJK_STOPWORDS) to suppress pronouns and particles.
 
         Returns a deduplicated list preserving first-seen order.
         """
         seen: set[str] = set()
         candidates: list[str] = []
 
-        def _add(name: str) -> None:
+        def _add(name: str, cjk_candidate: bool = False) -> None:
             stripped = name.strip()
-            if stripped and stripped.lower() not in seen:
+            if not stripped:
+                return
+            if cjk_candidate and _RE_CJK_CHAR.search(stripped):
+                # Strip surrounding CJK punctuation that may bleed into the match
+                stripped = stripped.strip("，。！？、；：")
+                if stripped in _CJK_STOPWORDS:
+                    return
+            if stripped.lower() not in seen:
                 seen.add(stripped.lower())
                 candidates.append(stripped)
 
@@ -427,6 +460,12 @@ class MemoryStore:
         for m in _RE_AKA.finditer(text):
             _add(m.group(1))
             _add(m.group(2))
+
+        for m in _RE_CJK_BRACKET.finditer(text):
+            _add(m.group(1), cjk_candidate=True)
+
+        for m in _RE_MIXED_IDENT.finditer(text):
+            _add(m.group(1))
 
         return candidates
 

--- a/tests/plugins/memory/test_holographic_store.py
+++ b/tests/plugins/memory/test_holographic_store.py
@@ -1,0 +1,156 @@
+"""Tests for holographic memory plugin's _extract_entities.
+
+Covers the four original English rules plus the two CJK-aware rules added
+to fix issue #24416 (ASCII-only extraction silently breaks non-English users).
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract(text: str) -> list[str]:
+    """Call _extract_entities without a real DB."""
+    store = MemoryStore.__new__(MemoryStore)
+    return store._extract_entities(text)
+
+
+# ---------------------------------------------------------------------------
+# Original English rules — must remain fully intact
+# ---------------------------------------------------------------------------
+
+class TestEnglishRules:
+    def test_capitalized_multi_word(self):
+        result = _extract("John Doe joined the team today.")
+        assert "John Doe" in result
+
+    def test_double_quoted(self):
+        result = _extract('She uses "Python" daily.')
+        assert "Python" in result
+
+    def test_single_quoted(self):
+        result = _extract("Run 'pytest' before merging.")
+        assert "pytest" in result
+
+    def test_aka_pattern(self):
+        # AKA group 1 captures the left side; group 2 captures greedily to end
+        result = _extract("Guido aka BDFL")
+        assert "Guido" in result
+        assert "BDFL" in result
+
+    def test_dedup_preserves_first_seen_order(self):
+        result = _extract('"Alpha" and "alpha" are the same.')
+        assert result.count("Alpha") == 1
+        assert result[0] == "Alpha"
+
+    def test_empty_string(self):
+        assert _extract("") == []
+
+    def test_no_entities(self):
+        # Pure lowercase English words with no special chars yield no entities
+        assert _extract("nothing here to extract at all today") == []
+
+
+# ---------------------------------------------------------------------------
+# CJK bracket / quote rule (rule 5)
+# ---------------------------------------------------------------------------
+
+class TestCjkBracketRule:
+    def test_japanese_corner_brackets(self):
+        result = _extract("「白兔」App已接入完成。")
+        assert "白兔" in result
+
+    def test_double_corner_brackets(self):
+        result = _extract("『Coco香港插班』计划已启动。")
+        assert "Coco香港插班" in result
+
+    def test_book_title_marks(self):
+        result = _extract("参见《项目规划》文档。")
+        assert "项目规划" in result
+
+    def test_fullwidth_double_quote(self):
+        result = _extract("“白兔控股”是正式名称。")
+        assert "白兔控股" in result
+
+    def test_fullwidth_single_quote(self):
+        result = _extract("‘IHMS’系统已上线。")
+        assert "IHMS" in result
+
+    def test_stopword_inside_brackets_is_filtered(self):
+        result = _extract("「的」这是一个测试。")
+        assert "的" not in result
+
+    def test_mixed_cjk_english_in_brackets(self):
+        result = _extract("「lark-bot v2.1」已部署。")
+        assert "lark-bot v2.1" in result
+
+    def test_long_cjk_content_over_40_chars_not_matched(self):
+        # CJK bracket pattern caps at 40 chars; 41-char CJK run should not match
+        long = "白" * 41
+        result = _extract(f"「{long}」")
+        assert long not in result
+
+    def test_multiple_brackets_in_one_sentence(self):
+        result = _extract("「白兔」和「Kanban」项目合并。")
+        assert "白兔" in result
+        assert "Kanban" in result
+
+
+# ---------------------------------------------------------------------------
+# Mixed-script identifier rule (rule 6)
+# ---------------------------------------------------------------------------
+
+class TestMixedIdentRule:
+    def test_hyphenated_tool_name(self):
+        result = _extract("The lark-cli tool is used daily.")
+        assert "lark-cli" in result
+
+    def test_model_with_version(self):
+        result = _extract("We migrated from GPT-5.5 last week.")
+        assert "GPT-5.5" in result
+
+    def test_domain_name(self):
+        result = _extract("Check baitugroup.com for details.")
+        assert "baitugroup.com" in result
+
+    def test_versioned_acronym(self):
+        # Pure-alpha acronyms need a non-letter char to be picked up by _RE_MIXED_IDENT
+        result = _extract("IHMS-v2 handles hospital management.")
+        assert "IHMS-v2" in result
+
+
+# ---------------------------------------------------------------------------
+# CJK context integration — issue #24416 reproduction scenario
+# ---------------------------------------------------------------------------
+
+class TestCjkIntegration:
+    def test_chinese_fact_yields_entities(self):
+        facts = [
+            "飞书白兔 App 已于 2026-5-10 接入完成",
+            "Coco 香港插班项目计划",
+            "用户公司日常用「白兔」/「白兔控股」，不要用工商执照名「成都抖咖」",
+        ]
+        all_entities: list[str] = []
+        for f in facts:
+            all_entities.extend(_extract(f))
+        assert len(all_entities) > 0, (
+            "No entities extracted from Chinese facts (regression of #24416)"
+        )
+
+    def test_bracketed_entities_from_issue_example(self):
+        text = "用户公司日常用「白兔」/「白兔控股」，不要用工商执照名「成都抖咖」"
+        result = _extract(text)
+        assert "白兔" in result
+        assert "白兔控股" in result
+        assert "成都抖咖" in result
+
+    def test_english_behavior_unchanged_with_cjk_present(self):
+        text = 'John Doe uses "pytest" and 「白兔」 daily.'
+        result = _extract(text)
+        assert "John Doe" in result
+        assert "pytest" in result
+        assert "白兔" in result


### PR DESCRIPTION
## What does this PR do?

`holographic` memory plugin's `_extract_entities` was ASCII-only. For users whose facts are predominantly Chinese, Japanese, Korean, Cyrillic, etc., **zero entities were ever extracted**. This silently degraded `probe` / `related` / `reason` from compositional HRR retrieval to FTS5 keyword fallback with no warning or log line.

## Root cause

`holographic` memory plugin's `_extract_entities` was ASCII-only. For users whose facts are predominantly Chinese, Japanese, Korean, Cyrillic, etc., **zero entities were ever extracted**. This silently degraded `probe` / `related` / `reason` from compositional HRR retrieval to FTS5 keyword fallback with no warning or log line.

Reproduction from the issue:
```
entities:      0  ← bug
fact_entities: 0  ← bug
```

## Fix

Added two new extraction rules alongside the existing four (original rules untouched):

| Rule | Pattern | Captures |
|------|---------|----------|
| `_RE_CJK_BRACKET` | `[「『《"']...[」』》"']` (≤40 chars) | High-signal CJK bracket/quote markers |
| `_RE_MIXED_IDENT` | Latin-start ident with ≥1 non-letter char | `lark-cli`, `GPT-5.5`, `baitugroup.com` |

Added `_CJK_STOPWORDS` (~30 common Chinese pronouns/particles) applied only to pure-CJK candidates so `的`/`了`/`在` are suppressed.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24416

<details>
<summary>Original body</summary>

## Summary

`holographic` memory plugin's `_extract_entities` was ASCII-only. For users whose facts are predominantly Chinese, Japanese, Korean, Cyrillic, etc., **zero entities were ever extracted**. This silently degraded `probe` / `related` / `reason` from compositional HRR retrieval to FTS5 keyword fallback with no warning or log line.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`holographic` memory plugin's `_extract_entities` was ASCII-only. For users whose facts are predominantly Chinese, Japanese, Korean, Cyrillic, etc., **zero entities were ever extracted**. This silently degraded `probe` / `related` / `reason` from compositional HRR retrieval to FTS5 keyword fallback with no warning or log line.

Reproduction from the issue:
```
entities:      0  ← bug
fact_entities: 0  ← bug
```

## Root cause

The four patterns in `store.py:84–91` only handle:
- Latin capitalized multi-word phrases
- ASCII `"..."` and `'...'` quotes
- English AKA idiom

For CJK input, all four rules produce zero candidates, the entity graph stays empty, and HRR vectors are encoded with `entities=[]`.

## Fix

Added two new extraction rules alongside the existing four (original rules untouched):

| Rule | Pattern | Captures |
|------|---------|----------|
| `_RE_CJK_BRACKET` | `[「『《"']...[」』》"']` (≤40 chars) | High-signal CJK bracket/quote markers |
| `_RE_MIXED_IDENT` | Latin-start ident with ≥1 non-letter char | `lark-cli`, `GPT-5.5`, `baitugroup.com` |

Added `_CJK_STOPWORDS` (~30 common Chinese pronouns/particles) applied only to pure-CJK candidates so `的`/`了`/`在` are suppressed.

## Tests

New file: `tests/plugins/memory/test_holographic_store.py` (23 tests)

- `TestEnglishRules` — all 7 original-behaviour tests pass
- `TestCjkBracketRule` — 9 tests: corner brackets, book marks, fullwidth quotes, stopword filter, 40-char limit
- `TestMixedIdentRule` — 4 tests: hyphenated names, versioned models, domain names
- `TestCjkIntegration` — 3 tests: exact reproduction from issue report, mixed CJK+English

```
23 passed in 19s
```

## Visual

```mermaid
graph LR
    A[fact text] --> B{_extract_entities}
    B --> C[_RE_CAPITALIZED]
    B --> D[_RE_DOUBLE_QUOTE]
    B --> E[_RE_SINGLE_QUOTE]
    B --> F[_RE_AKA]
    B --> G["_RE_CJK_BRACKET (new)"]
    B --> H["_RE_MIXED_IDENT (new)"]
    G --> I{pure-CJK candidate?}
    I -->|yes| J{in _CJK_STOPWORDS?}
    J -->|no| K[entity list]
    J -->|yes| L[dropped]
    I -->|no| K
    C & D & E & F & H --> K
```

Closes #24416

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24416

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_