### PR TITLE
fix(anthropic_adapter): override User-Agent for third-party endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -594,13 +594,18 @@ def build_anthropic_client(
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _is_third_party_anthropic_endpoint(base_url):
-        # Third-party proxies (Azure AI Foundry, AWS Bedrock, etc.) use their
-        # own API keys with x-api-key auth. Skip OAuth detection — their keys
-        # don't follow Anthropic's sk-ant-* prefix convention and would be
+        # Third-party proxies (Azure AI Foundry, AWS Bedrock, self-hosted, etc.)
+        # use their own API keys with x-api-key auth. Skip OAuth detection — their
+        # keys don't follow Anthropic's sk-ant-* prefix convention and would be
         # misclassified as OAuth tokens.
+        # Always override the SDK's default User-Agent ("Anthropic/Python X.Y.Z")
+        # with a neutral value. Cloudflare and similar WAFs in front of third-party
+        # proxies block the SDK UA via bot-detection rules (refs #24293).
         kwargs["api_key"] = api_key
+        headers: dict = {"User-Agent": "hermes-agent"}
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            headers["anthropic-beta"] = ",".join(common_betas)
+        kwargs["default_headers"] = headers
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -108,7 +108,8 @@ class TestBuildAnthropicClient:
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
             assert kwargs["default_headers"] == {
-                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+                "User-Agent": "hermes-agent",
+                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
             }
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
@@ -154,6 +155,47 @@ class TestBuildAnthropicClient:
             assert kwargs["default_headers"] == {
                 "anthropic-beta": "interleaved-thinking-2025-05-14"
             }
+
+
+class TestThirdPartyUserAgentOverride:
+    """Third-party endpoints must send User-Agent: hermes-agent (refs #24293).
+
+    The Anthropic Python SDK's default User-Agent ("Anthropic/Python X.Y.Z")
+    triggers Cloudflare WAF bot-detection on self-hosted/proxy endpoints,
+    returning 403.  We always override it to a neutral value for every URL
+    that passes _is_third_party_anthropic_endpoint().
+    """
+
+    def test_third_party_endpoint_sets_neutral_user_agent(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("any-key", base_url="https://my-proxy.example.com/v1")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["User-Agent"] == "hermes-agent"
+
+    def test_third_party_endpoint_user_agent_present_even_without_betas(self):
+        """User-Agent override must appear even when no common_betas are set."""
+        from agent.anthropic_adapter import _COMMON_BETAS
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            with patch("agent.anthropic_adapter._COMMON_BETAS", []):
+                build_anthropic_client("any-key", base_url="https://my-proxy.example.com/v1")
+                kwargs = mock_sdk.Anthropic.call_args[1]
+                assert kwargs["default_headers"]["User-Agent"] == "hermes-agent"
+                assert "anthropic-beta" not in kwargs["default_headers"]
+
+    def test_native_anthropic_endpoint_keeps_sdk_default_user_agent(self):
+        """Native Anthropic endpoints must NOT get the User-Agent override."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-x")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert "User-Agent" not in kwargs.get("default_headers", {})
+
+    def test_third_party_endpoint_keeps_beta_header_alongside_user_agent(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("any-key", base_url="https://selfhosted.corp/anthropic")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            headers = kwargs["default_headers"]
+            assert headers["User-Agent"] == "hermes-agent"
+            assert "anthropic-beta" in headers
 
 
 class TestReadClaudeCodeCredentials:


### PR DESCRIPTION
## What does this PR do?

Self-hosted / proxy Anthropic endpoints (e.g. LiteLLM, vLLM, custom gateways) are commonly put behind Cloudflare or similar WAF services. These WAFs block the Anthropic Python SDK's default `User-Agent` (`Anthropic/Python X.Y.Z`) via bot-detection rules, returning **403**.

## Root cause

Self-hosted / proxy Anthropic endpoints (e.g. LiteLLM, vLLM, custom gateways) are commonly put behind Cloudflare or similar WAF services. These WAFs block the Anthropic Python SDK's default `User-Agent` (`Anthropic/Python X.Y.Z`) via bot-detection rules, returning **403**.

Issue: #24293

## Fix

For every URL that passes `_is_third_party_anthropic_endpoint()`, always set:

```python
default_headers["User-Agent"] = "hermes-agent"
```

The neutral value bypasses WAF bot filters. The existing `anthropic-beta` header is preserved alongside it. Native Anthropic endpoints (`api.anthropic.com`) keep the SDK default — only third-party proxies are affected.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24293

<details>
<summary>Original body</summary>

## Summary

Self-hosted / proxy Anthropic endpoints (e.g. LiteLLM, vLLM, custom gateways) are commonly put behind Cloudflare or similar WAF services. These WAFs block the Anthropic Python SDK's default `User-Agent` (`Anthropic/Python X.Y.Z`) via bot-detection rules, returning **403**.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

Self-hosted / proxy Anthropic endpoints (e.g. LiteLLM, vLLM, custom gateways) are commonly put behind Cloudflare or similar WAF services. These WAFs block the Anthropic Python SDK's default `User-Agent` (`Anthropic/Python X.Y.Z`) via bot-detection rules, returning **403**.

Issue: #24293

## Root cause

In `build_anthropic_client` (`agent/anthropic_adapter.py`), the third-party branch (`_is_third_party_anthropic_endpoint(base_url)` true) only set `default_headers["anthropic-beta"]` when `_COMMON_BETAS` was non-empty. The SDK's auto-generated `User-Agent` was never overridden, so every request from Hermes through a Cloudflare-fronted proxy carried `Anthropic/Python X.Y.Z` and was rejected at the WAF layer before reaching the upstream model.

## Fix

For every URL that passes `_is_third_party_anthropic_endpoint()`, always set:

```python
default_headers["User-Agent"] = "hermes-agent"
```

The neutral value bypasses WAF bot filters. The existing `anthropic-beta` header is preserved alongside it. Native Anthropic endpoints (`api.anthropic.com`) keep the SDK default — only third-party proxies are affected.

## Tests

- Updated `TestBuildAnthropicClient::test_custom_base_url` to assert the new `User-Agent` key in `default_headers`.
- Added `TestThirdPartyUserAgentOverride` (4 tests) covering:
  - Third-party endpoint → `User-Agent: hermes-agent` present
  - Override present even when `_COMMON_BETAS` is empty
  - Native Anthropic endpoint → no `User-Agent` override
  - Beta header survives alongside `User-Agent`

All new tests pass; zero pre-existing test regressions introduced.

## Visual

```mermaid
flowchart LR
    A["Hermes → third-party Anthropic proxy"] --> B{_is_third_party_anthropic_endpoint?}
    B -- yes --> C["default_headers['User-Agent'] = 'hermes-agent'"]
    B -- no (native api.anthropic.com) --> D["SDK default UA preserved"]
    C --> E["Cloudflare WAF allows"]
    E --> F["✅ 200 OK upstream"]
    D --> G["✅ 200 OK native"]
```

Closes #24293

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_