### PR TITLE
test: guard bare import grp with module-level pytest.importorskip

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 pwd = pytest.importorskip("pwd")
+grp = pytest.importorskip("grp")
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status
@@ -1339,8 +1340,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        import grp
-
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "root")
         monkeypatch.setenv("LOGNAME", "root")
@@ -1350,8 +1349,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        import grp
-
         root_info = pwd.getpwnam("root")
         root_group = grp.getgrgid(root_info.pw_gid).gr_name
 
@@ -1361,8 +1358,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        import grp
-
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "nobody")
         monkeypatch.setenv("LOGNAME", "nobody")


### PR DESCRIPTION
## Problem

Three test methods in `TestSystemServiceIdentityRootHandling` contain inline `import grp` with no platform guard:

- `test_auto_detected_root_is_rejected` (line 1342)
- `test_explicit_root_is_allowed` (line 1353)
- `test_non_root_user_passes_through` (line 1364)

`grp` is UNIX-only and raises `ModuleNotFoundError` on Windows. The inline pattern is inconsistent with the existing module-level guard for `pwd`.

## Root cause

`grp` was imported lazily inside each test body instead of being guarded at module level alongside `pwd = pytest.importorskip("pwd")` (line 10). If the `pwd` guard is ever removed or tests are run in isolation, the inline imports have no fallback.

## Fix

Added `grp = pytest.importorskip("grp")` at module level (line 11) to match the existing `pwd` guard pattern. Removed the three redundant inline `import grp` statements.

```diff
 pwd = pytest.importorskip("pwd")
+grp = pytest.importorskip("grp")
```

## Tests

```
tests/hermes_cli/test_gateway_service.py::TestSystemServiceIdentityRootHandling::test_auto_detected_root_is_rejected PASSED
tests/hermes_cli/test_gateway_service.py::TestSystemServiceIdentityRootHandling::test_explicit_root_is_allowed PASSED
tests/hermes_cli/test_gateway_service.py::TestSystemServiceIdentityRootHandling::test_non_root_user_passes_through PASSED

3 passed
```

## Visual

```mermaid
graph LR
    A[module load] --> B{pwd available?}
    B -->|no| C[skip entire module]
    B -->|yes| D{grp available?}
    D -->|no| C
    D -->|yes| E[tests run normally]
```

Closes #24531