### PR TITLE
fix(security): suppress false-positive Tirith lookalike_tld warning for benign gTLD

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1221,3 +1221,83 @@ class TestSpawnWarningDedup:
             if "tirith path resolved to None" in rec.message
         ]
         assert len(none_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for benign lookalike_tld suppression (issue #24461)
+# ---------------------------------------------------------------------------
+
+class TestBenignTldSuppression:
+
+    def test_app_only_finding_is_benign(self):
+        from tools.tirith_security import _is_benign_tld_only
+        findings = [
+            {"rule_id": "lookalike_tld", "detail": "Domain uses '.app' TLD which can be confused with file extensions"}
+        ]
+        assert _is_benign_tld_only(findings) is True
+
+    def test_mixed_findings_not_benign(self):
+        from tools.tirith_security import _is_benign_tld_only
+        findings = [
+            {"rule_id": "lookalike_tld", "detail": "Domain uses '.app' TLD which can be confused with file extensions"},
+            {"rule_id": "pipe_to_interpreter", "detail": "Pipe to shell"},
+        ]
+        assert _is_benign_tld_only(findings) is False
+
+    def test_non_app_tld_not_benign(self):
+        from tools.tirith_security import _is_benign_tld_only
+        findings = [
+            {"rule_id": "lookalike_tld", "detail": "Domain uses '.zip' TLD which can be confused with file extensions"}
+        ]
+        assert _is_benign_tld_only(findings) is False
+
+    def test_empty_findings(self):
+        from tools.tirith_security import _is_benign_tld_only
+        assert _is_benign_tld_only([]) is False
+
+    def test_multiple_app_findings_benign(self):
+        from tools.tirith_security import _is_benign_tld_only
+        findings = [
+            {"rule_id": "lookalike_tld", "detail": "Domain uses '.app' TLD"},
+            {"rule_id": "lookalike_tld", "detail": "Domain uses '.app' TLD"},
+        ]
+        assert _is_benign_tld_only(findings) is True
+
+    @patch("tools.tirith_security._load_security_config", return_value={
+        "tirith_enabled": True, "tirith_path": "/usr/bin/tirith",
+        "tirith_timeout": 5, "tirith_fail_open": True,
+    })
+    @patch("tools.tirith_security._resolve_tirith_path", return_value="/usr/bin/tirith")
+    @patch("subprocess.run")
+    def test_check_command_downgrades_app_warn(self, mock_run, _rtp, _cfg):
+        from tools.tirith_security import check_command_security
+        mock_run.return_value = MagicMock(
+            returncode=2,
+            stdout=json.dumps({
+                "findings": [{"rule_id": "lookalike_tld", "detail": "Domain uses .app TLD"}],
+                "summary": "lookalike TLD",
+            }),
+        )
+        result = check_command_security("curl https://test.local")
+        assert result["action"] == "allow"
+
+    @patch("tools.tirith_security._load_security_config", return_value={
+        "tirith_enabled": True, "tirith_path": "/usr/bin/tirith",
+        "tirith_timeout": 5, "tirith_fail_open": True,
+    })
+    @patch("tools.tirith_security._resolve_tirith_path", return_value="/usr/bin/tirith")
+    @patch("subprocess.run")
+    def test_check_command_preserves_mixed_warn(self, mock_run, _rtp, _cfg):
+        from tools.tirith_security import check_command_security
+        mock_run.return_value = MagicMock(
+            returncode=2,
+            stdout=json.dumps({
+                "findings": [
+                    {"rule_id": "lookalike_tld", "detail": "Domain uses .app TLD"},
+                    {"rule_id": "homograph_url", "detail": "URL homograph"},
+                ],
+                "summary": "warnings",
+            }),
+        )
+        result = check_command_security("curl https://test.local")
+        assert result["action"] == "warn"

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -21,6 +21,7 @@ never blocks.
 """
 
 import hashlib
+import re
 import json
 import logging
 import os
@@ -669,11 +670,46 @@ def ensure_installed(*, log_failures: bool = True):
 
 
 # ---------------------------------------------------------------------------
+# Benign-TLD suppression
+# ---------------------------------------------------------------------------
+
+
+def _is_benign_tld_only(findings: list) -> bool:
+    """Return True if every finding is a lookalike_tld for a benign TLD.
+
+    A finding matches when its rule_id is ``lookalike_tld`` and its detail
+    text references only TLDs listed in ``_BENIGN_LOOKALIKE_TLDS``.
+    """
+    if not findings:
+        return False
+    for f in findings:
+        if not isinstance(f, dict):
+            return False
+        if f.get("rule_id") != "lookalike_tld":
+            return False
+        # Extract the TLD from the detail string.  Tirith formats it as e.g.
+        # "Domain uses '.app' TLD which can be confused with file extensions"
+        detail = f.get("detail", "") or f.get("description", "") or ""
+        tld_match = _BENIGN_TLD_RE.search(detail)
+        if not tld_match or tld_match.group(0) not in _BENIGN_LOOKALIKE_TLDS:
+            return False
+    return True
+
+
+_BENIGN_TLD_RE = re.compile(r"\.[a-z]{2,}")
+
+
+# ---------------------------------------------------------------------------
 # Main API
 # ---------------------------------------------------------------------------
 
 _MAX_FINDINGS = 50
 _MAX_SUMMARY_LEN = 500
+
+# Benign TLDs that tirith flags as lookalike_tld but are legitimate ICANN
+# gTLDs widely used by real services.  When *every* finding in a scan is a
+# lookalike_tld for one of these TLDs the verdict is downgraded to "allow".
+_BENIGN_LOOKALIKE_TLDS = frozenset({".app"})
 
 
 def check_command_security(command: str) -> dict:
@@ -770,5 +806,13 @@ def check_command_security(command: str) -> dict:
             summary = "security issue detected (details unavailable)"
         elif action == "warn":
             summary = "security warning detected (details unavailable)"
+
+    # Suppress false-positive warnings for benign TLDs (e.g. .app).
+    # When the only findings are lookalike_tld for a benign TLD, the warning
+    # is noise — downgrade to allow so the command proceeds without an
+    # unnecessary approval prompt.  Mixed findings are preserved as-is.
+    if action == "warn" and findings and _is_benign_tld_only(findings):
+        logger.debug("suppressing benign lookalike_tld-only warning")
+        action = "allow"
 
     return {"action": action, "findings": findings, "summary": summary}


### PR DESCRIPTION
## Summary

Fixes #24461

## Problem

Tirith reports a lookalike_tld finding for dot-app domains, triggering an unnecessary approval prompt. dot-app is a legitimate ICANN gTLD widely used by real services.

## Solution

Added post-processing in check_command_security() that downgrades the verdict from warn to allow when all findings are lookalike_tld for a benign TLD (dot-app).

Key design decisions:
- Narrow scope: Only dot-app is in the benign set. Other confusable TLDs like dot-zip are NOT suppressed.
- Mixed findings preserved: If a command has dot-app + any other finding, the original warn/block verdict is kept.
- Extensible: _BENIGN_LOOKALIKE_TLDS frozenset can be expanded if needed.

## Changes

- tools/tirith_security.py: Added _is_benign_tld_only() helper and post-processing logic
- tests/tools/test_tirith_security.py: 7 new tests covering benign-only, mixed, non-app, empty, and e2e scenarios

## Testing

All 7 new tests pass. Existing tirith tests unaffected.
