### PR TITLE
fix(gateway): initialize PluginManager so lifecycle hooks fire in gateway mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3400,6 +3400,15 @@ class GatewayRunner:
         # Discover and load event hooks
         self.hooks.discover_and_load()
 
+        # Initialize plugin system so post_llm_call / pre_llm_call hooks
+        # (e.g. memos_sync, specialist_router) actually fire in gateway mode.
+        # Without this, get_plugin_manager() returns a bare PluginManager
+        # with no loaded plugins — hooks are registered but never invoked.
+        try:
+            from hermes_cli.plugins import get_plugin_manager
+            get_plugin_manager().discover_and_load()
+        except Exception as exc:
+            logger.warning("Plugin system init failed (non-blocking): %s", exc)
         
         # Recover background processes from checkpoint (crash recovery)
         try:


### PR DESCRIPTION
## Summary

The gateway never initializes the `PluginManager` from `hermes_cli/plugins.py`. This means plugins that register `post_llm_call` hooks (e.g. `memos_sync`, `specialist_router`) are **loaded** and log "hook registered" at startup, but the hooks are **never actually invoked** by `run_agent.py`'s `invoke_hook()` call.

**Root cause**: `gateway/run.py` calls `self.hooks.discover_and_load()` (the gateway's own `HookRegistry`) but never calls `discover_and_load()` on the `PluginManager` singleton. When `run_agent.py` later calls:

```python
from hermes_cli.plugins import invoke_hook
invoke_hook("post_llm_call", ...)
```

it gets a bare `PluginManager` with an empty `_hooks` dict — zero callbacks fire.

**Symptom**: In gateway mode, `agent.log` shows plugins registering hooks successfully, but contains **zero** `post_llm_call` invocations. No conversation data is synced to MemOS via `memos_sync`, and no specialist routing occurs via `specialist_router`.

**Fix**: Add `get_plugin_manager().discover_and_load()` after the existing `self.hooks.discover_and_load()` in gateway startup. Wrapped in `try/except` so a plugin load failure cannot break gateway startup.

## Verification

```bash
# After fix, agent.log should show post_llm_call invocations:
grep "memos_sync.*add_message OK" ~/.hermes/logs/agent.log

# Plugin hooks count should be > 0:
python3 -c "
from hermes_cli.plugins import get_plugin_manager
mgr = get_plugin_manager()
mgr.discover_and_load()
print('post_llm_call hooks:', len(mgr._hooks.get('post_llm_call', [])))
"
```

## Related Issues

- #20939 — MemOS bridge lifecycle (same vein: gateway init issues)
- #2670 — Memory flush overwrite (same vein: gateway agent lifecycle)