### PR TITLE
feat: add read-only Google Messages checker

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -542,54 +542,6 @@ def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
 # calls to the Codex Responses API so callers don't need any changes.
 
 
-def _convert_content_for_responses(content: Any) -> Any:
-    """Convert chat.completions content to Responses API format.
-
-    chat.completions uses:
-      {"type": "text", "text": "..."}
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
-
-    Responses API uses:
-      {"type": "input_text", "text": "..."}
-      {"type": "input_image", "image_url": "data:image/png;base64,..."}
-
-    If content is a plain string, it's returned as-is (the Responses API
-    accepts strings directly for text-only messages).
-    """
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return str(content) if content else ""
-
-    converted: List[Dict[str, Any]] = []
-    for part in content:
-        if not isinstance(part, dict):
-            continue
-        ptype = part.get("type", "")
-        if ptype == "text":
-            converted.append({"type": "input_text", "text": part.get("text", "")})
-        elif ptype == "image_url":
-            # chat.completions nests the URL: {"image_url": {"url": "..."}}
-            image_data = part.get("image_url", {})
-            url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data)
-            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
-            # Preserve detail if specified
-            detail = image_data.get("detail") if isinstance(image_data, dict) else None
-            if detail:
-                entry["detail"] = detail
-            converted.append(entry)
-        elif ptype in {"input_text", "input_image"}:
-            # Already in Responses format — pass through
-            converted.append(part)
-        else:
-            # Unknown content type — try to preserve as text
-            text = part.get("text", "")
-            if text:
-                converted.append({"type": "input_text", "text": text})
-
-    return converted or ""
-
-
 class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
@@ -602,22 +554,24 @@ class _CodexCompletionsAdapter:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
-        # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
+        # Separate system/instructions from conversation messages, then use
+        # the shared Codex conversion path for input. Passing chat-style
+        # {"role": "tool"} messages directly to Responses 400s with
+        # "Invalid value: 'tool'"; the shared adapter converts them into
+        # function_call_output items and also preserves assistant tool calls.
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        input_source: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
-                input_msgs.append({
-                    "role": role,
-                    "content": _convert_content_for_responses(content),
-                })
+                input_source.append(msg)
 
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        input_msgs = _chat_messages_to_responses_input(input_source)
         resp_kwargs: Dict[str, Any] = {
             "model": model,
             "instructions": instructions,
@@ -3977,12 +3931,19 @@ def _build_call_kwargs(
         if _forbids_sampling_params(model):
             temperature = None
 
-    if temperature is not None:
+    is_codex_backend = (
+        provider == "openai-codex"
+        or base_url_host_matches(base_url, "chatgpt.com")
+    )
+
+    if temperature is not None and not is_codex_backend:
         kwargs["temperature"] = temperature
 
-    if max_tokens is not None:
-        # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.
-        # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
+    if max_tokens is not None and not is_codex_backend:
+        # Codex's chatgpt.com Responses endpoint rejects both max_tokens and
+        # max_completion_tokens for auxiliary calls. OpenRouter/Nous use
+        # max_tokens. Direct OpenAI api.openai.com with newer models needs
+        # max_completion_tokens.
         # ZAI vision models (glm-4v-flash, glm-4v-plus, etc.) reject max_tokens with
         # error code 1210 ("API 调用参数有误") on multimodal requests — skip it.
         _model_lower = (model or "").lower()

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -354,17 +354,28 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
                     for tc in tool_calls:
-                        if not isinstance(tc, dict):
-                            continue
-                        fn = tc.get("function", {})
-                        fn_name = fn.get("name")
+                        if isinstance(tc, dict):
+                            fn = tc.get("function", {})
+                            raw_tool_id = tc.get("id")
+                            call_id = tc.get("call_id")
+                        else:
+                            fn = getattr(tc, "function", {})
+                            raw_tool_id = getattr(tc, "id", None)
+                            call_id = getattr(tc, "call_id", None)
+
+                        if isinstance(fn, dict):
+                            fn_name = fn.get("name")
+                            arguments = fn.get("arguments", "{}")
+                        else:
+                            fn_name = getattr(fn, "name", None)
+                            arguments = getattr(fn, "arguments", "{}")
+
                         if not isinstance(fn_name, str) or not fn_name.strip():
                             continue
 
                         embedded_call_id, embedded_response_item_id = _split_responses_tool_id(
-                            tc.get("id")
+                            raw_tool_id
                         )
-                        call_id = tc.get("call_id")
                         if not isinstance(call_id, str) or not call_id.strip():
                             call_id = embedded_call_id
                         if not isinstance(call_id, str) or not call_id.strip():
@@ -375,11 +386,10 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                             ):
                                 call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
                             else:
-                                _raw_args = str(fn.get("arguments", "{}"))
+                                _raw_args = str(arguments)
                                 call_id = _deterministic_call_id(fn_name, _raw_args, len(items))
                         call_id = call_id.strip()
 
-                        arguments = fn.get("arguments", "{}")
                         if isinstance(arguments, dict):
                             arguments = json.dumps(arguments, ensure_ascii=False)
                         elif not isinstance(arguments, str):

--- a/docs/private-repo-workflow.md
+++ b/docs/private-repo-workflow.md
@@ -1,0 +1,58 @@
+# Private Repo Branching & PR Workflow
+
+This repository is now mirrored into the private `Methodician/Hermes` repo.
+Use the following lightweight workflow for future changes:
+
+## 1) Create a feature branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b fix/short-description
+```
+
+Branch naming conventions:
+- `fix/...` for bug fixes
+- `feat/...` for new features
+- `docs/...` for documentation
+- `test/...` for test-only changes
+- `refactor/...` for non-behavioral cleanup
+
+## 2) Commit with a conventional message
+
+```bash
+git add .
+git commit -m "fix(scope): short description"
+```
+
+## 3) Push the branch to the private repo
+
+```bash
+git push -u origin fix/short-description
+```
+
+## 4) Open a pull request into `main`
+
+Use GitHub PRs for review and history tracking.
+
+Suggested PR checklist:
+- What changed and why
+- How you tested it
+- Any caveats or follow-ups
+- Link to related issues if relevant
+
+## 5) Wait for CI
+
+The repo already runs CI on pull requests:
+- `Tests` workflow
+- contributor checks where applicable
+
+## 6) Merge back to `main`
+
+Prefer a merge commit for feature branches so the branch history remains visible.
+
+## Notes
+
+- Keep PRs small and focused.
+- If a change touches gateway, voice, tools, or auth paths, run the relevant targeted tests before opening the PR.
+- This document is the private-repo companion to `CONTRIBUTING.md`.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3007,17 +3007,39 @@ class BasePlatformAdapter(ABC):
                         and text_content
                         and not media_files):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                        from tools.tts_tool import (
+                            DEFAULT_TTS_CHUNK_CHARS,
+                            check_tts_requirements,
+                            chunk_tts_text,
+                            text_to_speech_tool,
+                        )
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content).strip()
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
-                            )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
+                            speech_chunks = chunk_tts_text(speech_text, max_chars=DEFAULT_TTS_CHUNK_CHARS)
+                            if not speech_chunks:
+                                raise ValueError("Empty text after markdown cleanup")
+                            for speech_chunk in speech_chunks:
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_chunk
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                _tts_path = tts_data.get("file_path")
+                                if _tts_path and Path(_tts_path).exists():
+                                    try:
+                                        await self.play_tts(
+                                            chat_id=event.source.chat_id,
+                                            audio_path=_tts_path,
+                                            metadata=_thread_metadata,
+                                        )
+                                    finally:
+                                        try:
+                                            os.remove(_tts_path)
+                                        except OSError:
+                                            pass
+                                    _tts_path = None
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3627,11 +3627,18 @@ class BasePlatformAdapter(ABC):
 
             chunks.append(full_chunk)
 
-        # Append chunk indicators when the response spans multiple messages
+        # Append chunk indicators when the response spans multiple messages.
+        # If a chunk ends with a synthetic closing code fence, keep the marker
+        # on its own line so Markdown parsers still see a valid closing fence.
         if len(chunks) > 1:
             total = len(chunks)
             chunks = [
-                f"{chunk} ({i + 1}/{total})" for i, chunk in enumerate(chunks)
+                (
+                    f"{chunk}\n({i + 1}/{total})"
+                    if chunk.rstrip().endswith("```")
+                    else f"{chunk} ({i + 1}/{total})"
+                )
+                for i, chunk in enumerate(chunks)
             ]
 
         return chunks

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2846,12 +2846,12 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.error(
-                "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
+                "[%s] Failed to send Telegram voice/audio: %s",
                 self.name,
                 e,
                 exc_info=True,
             )
-            return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
+            return SendResult(success=False, error=str(e))
 
     async def send_multiple_images(
         self,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1501,19 +1501,30 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
-            # Format and split message if needed
-            formatted = self.format_message(content)
-            chunks = self.truncate_message(
-                formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
-            )
-            if len(chunks) > 1:
-                # truncate_message appends a raw " (1/2)" suffix. Escape the
-                # MarkdownV2-special parentheses so Telegram doesn't reject the
-                # chunk and fall back to plain text.
-                chunks = [
-                    re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
-                    for chunk in chunks
-                ]
+            # Split raw Markdown first, then format each chunk independently.
+            # Formatting the whole response before splitting can leave fenced
+            # code blocks invalid when Telegram parses each chunk on its own.
+            # Because MarkdownV2 escaping can expand text, retry with a smaller
+            # raw budget until every formatted chunk fits Telegram's UTF-16
+            # message limit.
+            raw_limit = self.MAX_MESSAGE_LENGTH
+            for _ in range(8):
+                raw_chunks = self.truncate_message(
+                    content, raw_limit, len_fn=utf16_len,
+                )
+                chunks = [self.format_message(chunk) for chunk in raw_chunks]
+                if all(utf16_len(chunk) <= self.MAX_MESSAGE_LENGTH for chunk in chunks):
+                    break
+                worst_len = max(utf16_len(chunk) for chunk in chunks)
+                next_limit = int(raw_limit * (self.MAX_MESSAGE_LENGTH - 64) / worst_len)
+                raw_limit = max(512, min(raw_limit - 1, next_limit))
+            else:
+                # Extremely escape-heavy text still exceeded the limit after
+                # adaptive shrinking.  Fall back to formatted splitting rather
+                # than sending over-limit text; this path should be rare.
+                chunks = self.truncate_message(
+                    self.format_message(content), self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
+                )
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10064,7 +10064,13 @@ class GatewayRunner:
                         }
                         if thread_meta:
                             send_kwargs["metadata"] = thread_meta
-                        await adapter.send_voice(**send_kwargs)
+                        send_result = await adapter.send_voice(**send_kwargs)
+                        if send_result and not getattr(send_result, "success", True):
+                            logger.warning(
+                                "Auto voice reply send failed: %s",
+                                getattr(send_result, "error", "unknown error"),
+                            )
+                            return None
                 finally:
                     for p in {audio_path, actual_path} - {None}:
                         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1449,9 +1449,25 @@ class GatewayRunner:
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
-    def _voice_key(self, platform: Platform, chat_id: str) -> str:
+    def _voice_key(self, platform: Platform, chat_id: str, thread_id: str | None = None) -> str:
         """Return a platform-namespaced key for voice mode state."""
-        return f"{platform.value}:{chat_id}"
+        base = f"{platform.value}:{chat_id}"
+        return f"{base}:{thread_id}" if thread_id else base
+
+    def _voice_mode_for_source(self, source: SessionSource) -> str:
+        """Return voice mode for a source, preferring topic-specific state."""
+        thread_id = getattr(source, "thread_id", None)
+        if thread_id:
+            topic_key = self._voice_key(source.platform, source.chat_id, str(thread_id))
+            if topic_key in self._voice_mode:
+                return self._voice_mode.get(topic_key, "off")
+        chat_key = self._voice_key(source.platform, source.chat_id)
+        if chat_key in self._voice_mode:
+            return self._voice_mode.get(chat_key, "off")
+        # Some older tests/in-memory callers used raw chat_id keys before
+        # persisted voice mode state became platform-prefixed. Keep this as a
+        # compatibility fallback, but never write new raw keys.
+        return self._voice_mode.get(source.chat_id, "off")
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
@@ -9624,7 +9640,7 @@ class GatewayRunner:
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
-        voice_key = self._voice_key(platform, chat_id)
+        voice_key = self._voice_key(platform, chat_id, event.source.thread_id)
 
         adapter = self.adapters.get(platform)
 
@@ -9903,8 +9919,7 @@ class GatewayRunner:
         if not response or response.startswith("Error:"):
             return False
 
-        chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
+        voice_mode = self._voice_mode_for_source(event.source)
         is_voice_input = (event.message_type == MessageType.VOICE)
 
         should = (
@@ -9951,8 +9966,7 @@ class GatewayRunner:
         """
         if not tts_chunks or len(tts_chunks) <= 1:
             return False
-        chat_id = event.source.chat_id
-        return self._voice_mode.get(chat_id, "off") == "all"
+        return self._voice_mode_for_source(event.source) == "all"
 
     @staticmethod
     def _is_telegram_source(source: SessionSource) -> bool:
@@ -9971,7 +9985,7 @@ class GatewayRunner:
         """
         if not self._is_telegram_source(source):
             return False
-        return self._voice_mode.get(source.chat_id, "off") == "all"
+        return self._voice_mode_for_source(source) == "all"
 
     async def _send_audio_primary_text_chunks(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7836,10 +7836,16 @@ class GatewayRunner:
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
-            # Auto voice reply: send TTS audio before the text response
+            # Auto voice reply: send TTS audio before the text response.
+            # In /voice tts mode, long multi-part replies become audio-primary:
+            # send the voice chunks, then replace the full text wall with a short
+            # control/status message instead of duplicating the entire answer.
             _already_sent = bool(agent_result.get("already_sent"))
+            _voice_reply_meta = None
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
-                await self._send_voice_reply(event, response)
+                _voice_reply_meta = await self._send_voice_reply(event, response)
+                if _voice_reply_meta and _voice_reply_meta.get("audio_primary"):
+                    response = _voice_reply_meta.get("status_text") or None
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -9930,65 +9936,168 @@ class GatewayRunner:
 
         return True
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
-        """Generate TTS audio and send as a voice message before the text reply."""
+    def _should_use_audio_primary_voice_reply(
+        self,
+        event: MessageEvent,
+        tts_chunks: list[str],
+    ) -> bool:
+        """Return True when voice should become the primary artifact.
+
+        Current policy mirrors the OpenClaw-style payload model for `/voice tts`
+        without giving up Hermes' full chunked narration:
+        - only in `/voice tts` mode (`voice_mode == "all"`)
+        - only when the reply is long enough to require multiple TTS chunks
+        - suppress the parallel long-form text wall in favor of a short status blurb
+        """
+        if not tts_chunks or len(tts_chunks) <= 1:
+            return False
+        chat_id = event.source.chat_id
+        return self._voice_mode.get(chat_id, "off") == "all"
+
+    @staticmethod
+    def _is_telegram_source(source: SessionSource) -> bool:
+        platform = getattr(source, "platform", None)
+        value = getattr(platform, "value", platform)
+        return str(value).strip().lower() == "telegram"
+
+    def _should_disable_streaming_for_voice_mode(self, source: SessionSource) -> bool:
+        """Disable token streaming when Telegram auto-TTS should own delivery.
+
+        In `/voice tts` mode on Telegram, progressive text streaming causes the
+        exact duplication the user reported: the full answer is streamed/chunked
+        as text, and then the voice pipeline sends its own chunked audio. For
+        this mode, prefer voice-first delivery and send the aligned text payload
+        after the audio instead of streaming the raw answer live.
+        """
+        if not self._is_telegram_source(source):
+            return False
+        return self._voice_mode.get(source.chat_id, "off") == "all"
+
+    async def _send_audio_primary_text_chunks(
+        self,
+        event: MessageEvent,
+        text_chunks: list[str],
+        adapter,
+    ) -> bool:
+        """Send text chunks that align with audio-primary Telegram voice parts."""
+        if not text_chunks or not adapter or not hasattr(adapter, "send"):
+            return False
+
+        metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        for index, chunk in enumerate(text_chunks):
+            await adapter.send(
+                event.source.chat_id,
+                chunk,
+                reply_to=event.message_id if index == 0 else None,
+                metadata=metadata,
+            )
+        return True
+
+    async def _send_voice_reply(self, event: MessageEvent, text: str) -> dict[str, Any] | None:
+        """Generate TTS audio and send as voice media.
+
+        Returns metadata describing whether the reply should become audio-primary.
+        """
         import uuid as _uuid
-        audio_path = None
-        actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                DEFAULT_TTS_CHUNK_CHARS,
+                _strip_markdown_for_tts,
+                chunk_tts_text,
+                text_to_speech_tool,
+            )
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = _strip_markdown_for_tts(text)
             if not tts_text:
-                return
-
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
-            audio_path = os.path.join(
-                tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
-            )
-            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-
-            result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
-            )
-            result = json.loads(result_json)
-
-            # Use the actual file path from result (may differ after opus conversion)
-            actual_path = result.get("file_path", audio_path)
-            if not result.get("success") or not os.path.isfile(actual_path):
-                logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
-                return
+                return None
 
             adapter = self.adapters.get(event.source.platform)
-
-            # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
-            if (guild_id
-                    and hasattr(adapter, "play_in_voice_channel")
-                    and hasattr(adapter, "is_in_voice_channel")
-                    and adapter.is_in_voice_channel(guild_id)):
-                await adapter.play_in_voice_channel(guild_id, actual_path)
-            elif adapter and hasattr(adapter, "send_voice"):
-                reply_anchor = self._reply_anchor_for_event(event)
-                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
-                send_kwargs: Dict[str, Any] = {
-                    "chat_id": event.source.chat_id,
-                    "audio_path": actual_path,
-                    "reply_to": reply_anchor,
-                }
-                if thread_meta:
-                    send_kwargs["metadata"] = thread_meta
-                await adapter.send_voice(**send_kwargs)
+            chunk_chars = DEFAULT_TTS_CHUNK_CHARS
+            if self._is_telegram_source(event.source):
+                # Keep a safety margin below Telegram's hard text limit while
+                # still approximating the chunk sizes the user sees in-chat.
+                chunk_chars = max(DEFAULT_TTS_CHUNK_CHARS, 3500)
+
+            tts_chunks = chunk_tts_text(tts_text, max_chars=chunk_chars)
+            if not tts_chunks:
+                return None
+
+            audio_primary = self._should_use_audio_primary_voice_reply(event, tts_chunks)
+            reply_anchor = self._reply_anchor_for_event(event)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+
+            for index, chunk in enumerate(tts_chunks, start=1):
+                audio_path = None
+                actual_path = None
+                try:
+                    # Use .mp3 extension so edge-tts conversion to opus works correctly.
+                    # The TTS tool may convert to .ogg — use file_path from result.
+                    audio_path = os.path.join(
+                        tempfile.gettempdir(), "hermes_voice",
+                        f"tts_reply_{_uuid.uuid4().hex[:12]}_{index}.mp3",
+                    )
+                    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+
+                    result_json = await asyncio.to_thread(
+                        text_to_speech_tool, text=chunk, output_path=audio_path
+                    )
+                    result = json.loads(result_json)
+
+                    # Use the actual file path from result (may differ after opus conversion)
+                    actual_path = result.get("file_path", audio_path)
+                    if not result.get("success") or not os.path.isfile(actual_path):
+                        logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
+                        return None
+
+                    # If connected to a voice channel, play there instead of sending a file
+                    if (guild_id
+                            and hasattr(adapter, "play_in_voice_channel")
+                            and hasattr(adapter, "is_in_voice_channel")
+                            and adapter.is_in_voice_channel(guild_id)):
+                        await adapter.play_in_voice_channel(guild_id, actual_path)
+                    elif adapter and hasattr(adapter, "send_voice"):
+                        send_kwargs: Dict[str, Any] = {
+                            "chat_id": event.source.chat_id,
+                            "audio_path": actual_path,
+                            "reply_to": reply_anchor,
+                        }
+                        if thread_meta:
+                            send_kwargs["metadata"] = thread_meta
+                        await adapter.send_voice(**send_kwargs)
+                finally:
+                    for p in {audio_path, actual_path} - {None}:
+                        try:
+                            os.unlink(p)
+                        except OSError:
+                            pass
+
+            mirrored_text = False
+            status_text = None
+            if audio_primary and self._is_telegram_source(event.source):
+                try:
+                    mirrored_text = await self._send_audio_primary_text_chunks(
+                        event,
+                        tts_chunks,
+                        adapter,
+                    )
+                except Exception as send_err:
+                    logger.warning("Failed to send aligned Telegram text chunks for auto voice reply: %s", send_err)
+                    mirrored_text = False
+
+            if not mirrored_text:
+                part_word = "part" if len(tts_chunks) == 1 else "parts"
+                status_text = f"Sent {len(tts_chunks)} voice {part_word}."
+
+            return {
+                "sent_chunks": len(tts_chunks),
+                "audio_primary": audio_primary,
+                "status_text": status_text,
+                "mirrored_text": mirrored_text,
+            }
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
-        finally:
-            for p in {audio_path, actual_path} - {None}:
-                try:
-                    os.unlink(p)
-                except OSError:
-                    pass
+            return None
 
     async def _deliver_media_from_response(
         self,
@@ -13926,6 +14035,8 @@ class GatewayRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
+        if _streaming_enabled and self._should_disable_streaming_for_voice_mode(source):
+            _streaming_enabled = False
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
@@ -14739,6 +14850,8 @@ class GatewayRunner:
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            if _streaming_enabled and self._should_disable_streaming_for_voice_mode(source):
+                _streaming_enabled = False
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -27,6 +27,7 @@ from agent.auxiliary_client import (
     _try_payment_fallback,
     _resolve_auto,
     _CodexCompletionsAdapter,
+    _build_call_kwargs,
 )
 
 
@@ -277,6 +278,76 @@ class TestAnthropicOAuthFlag:
 
 
 class TestBuildCodexClient:
+    def test_codex_backend_omits_unsupported_sampling_kwargs(self):
+        kwargs = _build_call_kwargs(
+            "auto",
+            "gpt-5.5",
+            [{"role": "user", "content": "remember this"}],
+            temperature=0.3,
+            max_tokens=5120,
+            timeout=30,
+            base_url="https://chatgpt.com/backend-api/codex/",
+        )
+
+        assert "temperature" not in kwargs
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_codex_adapter_converts_tool_messages_to_responses_items(self):
+        from types import SimpleNamespace
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        captured = {}
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([])
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        content=[SimpleNamespace(type="output_text", text="ok")],
+                    )],
+                    usage=None,
+                )
+
+        class _FakeResponses:
+            def stream(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeStream()
+
+        fake_client = SimpleNamespace(responses=_FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.2-codex")
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "You are Hermes."},
+                {"role": "assistant", "content": "", "tool_calls": [{
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }]},
+                {"role": "tool", "tool_call_id": "call_abc123", "content": "file contents"},
+                {"role": "user", "content": "remember this"},
+            ],
+        )
+
+        assert captured["instructions"] == "You are Hermes."
+        assert all(item.get("role") != "tool" for item in captured["input"])
+        assert any(item.get("type") == "function_call" for item in captured["input"])
+        function_output = next(
+            item for item in captured["input"] if item.get("type") == "function_call_output"
+        )
+        assert function_output["call_id"] == "call_abc123"
+        assert function_output["output"] == "file contents"
+
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -27,7 +27,6 @@ from agent.auxiliary_client import (
     _try_payment_fallback,
     _resolve_auto,
     _CodexCompletionsAdapter,
-    _build_call_kwargs,
 )
 
 
@@ -346,6 +345,34 @@ class TestBuildCodexClient:
             item for item in captured["input"] if item.get("type") == "function_call_output"
         )
         assert function_output["call_id"] == "call_abc123"
+        assert function_output["output"] == "file contents"
+
+    def test_codex_adapter_converts_object_tool_calls_to_responses_items(self):
+        from types import SimpleNamespace
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [SimpleNamespace(
+                    id="call_obj123",
+                    type="function",
+                    function=SimpleNamespace(name="read_file", arguments="{}"),
+                )],
+            },
+            {"role": "tool", "tool_call_id": "call_obj123", "content": "file contents"},
+        ]
+
+        items = _chat_messages_to_responses_input(messages)
+
+        function_call = next(item for item in items if item.get("type") == "function_call")
+        assert function_call["call_id"] == "call_obj123"
+        assert function_call["name"] == "read_file"
+        function_output = next(
+            item for item in items if item.get("type") == "function_call_output"
+        )
+        assert function_output["call_id"] == "call_obj123"
         assert function_output["output"] == "file contents"
 
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -570,8 +570,29 @@ class TestSendVoice:
         connected_adapter._bot.send_audio.assert_awaited_once()
         connected_adapter._bot.send_document.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_ogg_send_voice_failure_does_not_fall_back_to_text_path(self, connected_adapter, tmp_path):
+        """Telegram voice send failures must not leak local temp paths as fallback text."""
+        audio_file = tmp_path / "clip.ogg"
+        audio_file.write_bytes(b"OggS" + b"\x00" * 32)
 
-# ---------------------------------------------------------------------------
+        connected_adapter._bot.send_voice = AsyncMock(side_effect=RuntimeError("telegram rejected voice"))
+        connected_adapter._bot.send_audio = AsyncMock()
+        connected_adapter._bot.send_document = AsyncMock()
+        connected_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text-fallback"))
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+        )
+
+        assert result.success is False
+        assert "telegram rejected voice" in result.error
+        connected_adapter._bot.send_voice.assert_awaited_once()
+        connected_adapter.send.assert_not_awaited()
+        connected_adapter._bot.send_audio.assert_not_awaited()
+        connected_adapter._bot.send_document.assert_not_awaited()
+
 # TestSendDocument — outbound file attachment delivery
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -178,6 +178,50 @@ class TestFormatMessageCodeBlocks:
         assert r"`\\\\server\\share`" in result
 
 
+@pytest.mark.asyncio
+async def test_send_chunks_raw_markdown_before_formatting_code_blocks(adapter):
+    """Chunked Telegram sends keep fenced code blocks valid per chunk."""
+    sent_messages = []
+
+    async def mock_send_message(**kwargs):
+        sent_messages.append(kwargs)
+        return MagicMock(message_id=len(sent_messages))
+
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = mock_send_message
+
+    code_lines = [
+        f"print('line_{i:03d}')  # `backtick` \\ path_(x)"
+        for i in range(1, 180)
+    ]
+    content = (
+        "Before code\n"
+        "```python\n"
+        + "\n".join(code_lines)
+        + "\n```\n"
+        "After code\n"
+        "GROUP_TOPIC_FORMATTING_TEST_COMPLETE"
+    )
+
+    result = await adapter.send("123", content)
+
+    assert result.success is True
+    assert len(sent_messages) > 1
+    first_text = sent_messages[0]["text"]
+    all_text = "\n".join(message["text"] for message in sent_messages)
+
+    from gateway.platforms.base import utf16_len
+    assert all(utf16_len(message["text"]) <= adapter.MAX_MESSAGE_LENGTH for message in sent_messages)
+    assert "line_001" in first_text
+    assert "line_080" in first_text
+    assert "GROUP\\_TOPIC\\_FORMATTING\\_TEST\\_COMPLETE" in all_text
+    # If the continuation marker is appended to the closing fence line,
+    # Telegram MarkdownV2 may parse the chunk as an unterminated code block and
+    # hide/drop the visible code block in the delivered message.
+    assert "``` \\" not in first_text
+    assert re.search(r"\n```\n\\\(1/\d+\\\)", first_text)
+
+
 # =========================================================================
 # format_message - bold and italic
 # =========================================================================

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -51,7 +51,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.platforms.base import MessageEvent, MessageType, SendResult, SessionSource
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +463,25 @@ class TestSendVoiceReply:
             "telegram_dm_topic_reply_fallback": True,
             "telegram_reply_to_message_id": "462",
         }
+
+    @pytest.mark.asyncio
+    async def test_send_voice_failure_returns_none_without_success_status(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock(return_value=SendResult(success=False, error="telegram rejected voice"))
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            result = await runner._send_voice_reply(event, "Hello world")
+
+        assert result is None
+        mock_adapter.send_voice.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_empty_text_after_strip_skips(self, runner):

--- a/tests/gateway/test_voice_reply_chunking.py
+++ b/tests/gateway/test_voice_reply_chunking.py
@@ -1,0 +1,72 @@
+"""Tests for chunked gateway voice replies."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.gateway.test_voice_command import _make_event, _make_runner
+
+
+class TestChunkedSendVoiceReply:
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_reply_sends_multiple_audio_chunks(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+        runner._voice_mode[event.source.chat_id] = "all"
+
+        first_sentence = "A" * 2000 + "."
+        second_sentence = "B" * 2000 + "."
+        text = f"{first_sentence} {second_sentence}"
+
+        tts_results = [
+            json.dumps({"success": True, "file_path": "/tmp/test_part1.ogg"}),
+            json.dumps({"success": True, "file_path": "/tmp/test_part2.ogg"}),
+        ]
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=tts_results) as mock_tts, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda value: value), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            meta = await runner._send_voice_reply(event, text)
+
+        assert mock_tts.call_count == 2
+        assert mock_adapter.send_voice.await_count == 2
+        assert mock_adapter.send.await_count == 2
+        assert meta == {
+            "sent_chunks": 2,
+            "audio_primary": True,
+            "status_text": None,
+            "mirrored_text": True,
+        }
+
+    def test_audio_primary_requires_voice_tts_mode_and_multiple_chunks(self, runner):
+        event = _make_event()
+
+        runner._voice_mode[event.source.chat_id] = "all"
+        assert runner._should_use_audio_primary_voice_reply(event, ["chunk 1", "chunk 2"]) is True
+
+        runner._voice_mode[event.source.chat_id] = "voice_only"
+        assert runner._should_use_audio_primary_voice_reply(event, ["chunk 1", "chunk 2"]) is False
+
+        runner._voice_mode[event.source.chat_id] = "all"
+        assert runner._should_use_audio_primary_voice_reply(event, ["single chunk"]) is False
+
+    def test_disables_streaming_for_telegram_voice_tts_mode(self, runner):
+        event = _make_event(chat_id="chat-1")
+        event.source.platform = MagicMock()
+        event.source.platform.value = "telegram"
+
+        runner._voice_mode[event.source.chat_id] = "all"
+        assert runner._should_disable_streaming_for_voice_mode(event.source) is True
+
+        runner._voice_mode[event.source.chat_id] = "voice_only"
+        assert runner._should_disable_streaming_for_voice_mode(event.source) is False

--- a/tests/tools/test_google_messages.py
+++ b/tests/tools/test_google_messages.py
@@ -1,4 +1,6 @@
 import json
+import sys
+import types
 from pathlib import Path
 
 from tools import google_messages
@@ -55,6 +57,45 @@ def test_classify_status_pairing_required_when_qr_hint_and_no_conversations():
     assert status["ready"] is False
 
 
+def test_classify_status_pairing_required_wins_over_setup_list_items():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Messages for web Pair with QR code Scan the code on your phone",
+        [
+            {"text": "Set up Messages\nChoose an account\nContinue"},
+            {"text": "Keep your phone connected\nLearn more"},
+        ],
+    )
+
+    assert status["state"] == "pairing_required"
+    assert status["pairing_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_login_required_for_google_sign_in_url():
+    status = google_messages._classify_status(
+        "https://accounts.google.com/signin/v2/identifier",
+        "Sign in with your Google Account to continue to Messages",
+        [],
+    )
+
+    assert status["state"] == "login_required"
+    assert status["login_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_login_required_for_sign_in_page_text():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Choose an account Sign in Google Account",
+        [],
+    )
+
+    assert status["state"] == "login_required"
+    assert status["login_required"] is True
+    assert status["ready"] is False
+
+
 def test_classify_status_ready_when_conversation_candidates_parse():
     status = google_messages._classify_status(
         "https://messages.google.com/web/conversations",
@@ -66,6 +107,19 @@ def test_classify_status_ready_when_conversation_candidates_parse():
     assert status["pairing_required"] is False
     assert status["ready"] is True
     assert status["conversation_candidates"] == 1
+
+
+def test_parse_conversation_item_does_not_treat_month_name_contact_as_timestamp():
+    item = google_messages._parse_conversation_item(
+        {"text": "May Flowers\nToday\nGarden party?"}
+    )
+
+    assert item == {
+        "sender": "May Flowers",
+        "timestamp": "Today",
+        "snippet": "Garden party?",
+        "unread": False,
+    }
 
 
 def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatch, tmp_path):
@@ -81,3 +135,53 @@ def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatc
     assert "no browser goblin" in payload["error"]
     assert payload["profile_path"] == str(tmp_path / "browser-profiles" / "google-messages")
     assert "python -m playwright install chromium" in payload["setup_hint"]
+
+
+def test_with_page_cleans_up_context_and_playwright_when_goto_fails(monkeypatch, tmp_path):
+    calls = []
+
+    class FakePage:
+        def set_default_timeout(self, timeout_ms):
+            calls.append(("timeout", timeout_ms))
+
+        def goto(self, *args, **kwargs):
+            calls.append(("goto", args, kwargs))
+            raise RuntimeError("navigation exploded")
+
+    class FakeContext:
+        pages = [FakePage()]
+
+        def close(self):
+            calls.append(("context.close",))
+
+    class FakeChromium:
+        def launch_persistent_context(self, *args, **kwargs):
+            calls.append(("launch", args, kwargs))
+            return FakeContext()
+
+    class FakePlaywright:
+        chromium = FakeChromium()
+
+        def stop(self):
+            calls.append(("pw.stop",))
+
+    class FakeSyncPlaywright:
+        def start(self):
+            calls.append(("start",))
+            return FakePlaywright()
+
+    fake_playwright_pkg = types.ModuleType("playwright")
+    fake_sync_api = types.ModuleType("playwright.sync_api")
+    fake_sync_api.sync_playwright = lambda: FakeSyncPlaywright()
+    monkeypatch.setitem(sys.modules, "playwright", fake_playwright_pkg)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_sync_api)
+
+    try:
+        google_messages._with_page(tmp_path / "profile", headless=True, timeout_ms=1234)
+    except RuntimeError as exc:
+        assert "navigation exploded" in str(exc)
+    else:
+        raise AssertionError("_with_page should re-raise navigation failures")
+
+    assert ("context.close",) in calls
+    assert ("pw.stop",) in calls

--- a/tests/tools/test_google_messages.py
+++ b/tests/tools/test_google_messages.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+from tools import google_messages
+
+
+def test_default_profile_path_uses_dedicated_google_messages_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert google_messages._default_profile_path() == (
+        Path(tmp_path) / "browser-profiles" / "google-messages"
+    )
+
+
+def test_parse_conversation_item_extracts_sender_timestamp_snippet_and_unread():
+    item = google_messages._parse_conversation_item(
+        {
+            "text": "Alice\nYesterday\nCan you grab tomatoes?",
+            "aria_label": "Unread conversation with Alice",
+            "class_name": "conversation unread",
+        }
+    )
+
+    assert item == {
+        "sender": "Alice",
+        "timestamp": "Yesterday",
+        "snippet": "Can you grab tomatoes?",
+        "unread": True,
+    }
+
+
+def test_parse_conversation_items_deduplicates_and_limits():
+    raw = [
+        {"text": "Alice\n10:34 AM\nFirst"},
+        {"text": "Alice\n10:34 AM\nFirst"},
+        {"text": "Bob\nTue\nSecond"},
+    ]
+
+    conversations = google_messages._parse_conversation_items(raw, limit=1)
+
+    assert conversations == [
+        {"sender": "Alice", "timestamp": "10:34 AM", "snippet": "First", "unread": False}
+    ]
+
+
+def test_classify_status_pairing_required_when_qr_hint_and_no_conversations():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web",
+        "Messages for web Pair with QR code Scan the code on your phone",
+        [],
+    )
+
+    assert status["state"] == "pairing_required"
+    assert status["pairing_required"] is True
+    assert status["ready"] is False
+
+
+def test_classify_status_ready_when_conversation_candidates_parse():
+    status = google_messages._classify_status(
+        "https://messages.google.com/web/conversations",
+        "Messages",
+        [{"text": "Alice\nToday\nHello"}],
+    )
+
+    assert status["state"] == "ready"
+    assert status["pairing_required"] is False
+    assert status["ready"] is True
+    assert status["conversation_candidates"] == 1
+
+
+def test_tool_handlers_return_setup_hint_when_playwright_launch_fails(monkeypatch, tmp_path):
+    def boom(profile_path, headless, timeout_ms):
+        raise RuntimeError("no browser goblin installed")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(google_messages, "_with_page", boom)
+
+    payload = json.loads(google_messages.google_messages_status(headless=True))
+
+    assert payload["ok"] is False
+    assert "no browser goblin" in payload["error"]
+    assert payload["profile_path"] == str(tmp_path / "browser-profiles" / "google-messages")
+    assert "python -m playwright install chromium" in payload["setup_hint"]

--- a/tests/tools/test_tts_chunking.py
+++ b/tests/tools/test_tts_chunking.py
@@ -1,0 +1,40 @@
+"""Tests for sentence-aware TTS chunking helpers."""
+
+from tools import tts_tool
+
+
+class TestChunkTtsText:
+    def test_short_text_returns_single_chunk(self):
+        chunks = tts_tool.chunk_tts_text("A short answer.", max_chars=50)
+
+        assert chunks == ["A short answer."]
+
+    def test_prefers_sentence_boundaries(self):
+        text = "First sentence. Second sentence is a little longer. Third sentence."
+
+        chunks = tts_tool.chunk_tts_text(text, max_chars=45)
+
+        assert chunks == [
+            "First sentence.",
+            "Second sentence is a little longer.",
+            "Third sentence.",
+        ]
+
+    def test_combines_short_paragraphs_instead_of_flushing_every_break(self):
+        text = "First short paragraph.\n\nSecond short paragraph.\n\nThird short paragraph."
+
+        chunks = tts_tool.chunk_tts_text(text, max_chars=60)
+
+        assert chunks == [
+            "First short paragraph.\n\nSecond short paragraph.",
+            "Third short paragraph.",
+        ]
+
+    def test_splits_long_sentence_at_word_boundaries(self):
+        text = "word " * 30
+
+        chunks = tts_tool.chunk_tts_text(text, max_chars=40)
+
+        assert len(chunks) > 1
+        assert all(len(chunk) <= 40 for chunk in chunks)
+        assert " ".join(chunk.strip() for chunk in chunks).strip() == text.strip()

--- a/tools/google_messages.py
+++ b/tools/google_messages.py
@@ -29,13 +29,20 @@ _TIMESTAMP_RE = re.compile(
     r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
     r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?|"
     r"(?:Yesterday|Today)|"
-    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b.*"
+    r"(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|"
+    r"Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|"
+    r"Nov(?:ember)?|Dec(?:ember)?)\.?\s+\d{1,2}(?:,?\s+\d{4})?"
     r")$",
     re.IGNORECASE,
 )
 
 _PAIRING_HINT_RE = re.compile(
     r"(qr code|pair(?:ing)?|scan the code|use messages on the web)",
+    re.IGNORECASE,
+)
+
+_LOGIN_REQUIRED_RE = re.compile(
+    r"(sign in|google account|choose an account|accounts\.google\.com/(?:.*signin|.*sign-in))",
     re.IGNORECASE,
 )
 
@@ -154,11 +161,16 @@ def _parse_conversation_items(raw_items: Iterable[Dict[str, Any]], limit: int = 
 
 def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
     raw_list = list(raw_items)
-    conversations = _parse_conversation_items(raw_list, limit=5)
-    pairing_required = bool(_PAIRING_HINT_RE.search(body_text or "")) and not conversations
-    logged_in = bool(conversations) or "conversations" in (url or "").lower()
+    url_text = url or ""
+    body = body_text or ""
+    pairing_required = bool(_PAIRING_HINT_RE.search(body))
+    login_required = bool(_LOGIN_REQUIRED_RE.search(f"{url_text}\n{body}"))
+    conversations = [] if pairing_required or login_required else _parse_conversation_items(raw_list, limit=5)
+    logged_in = bool(conversations) or "conversations" in url_text.lower()
     if pairing_required:
         state = "pairing_required"
+    elif login_required:
+        state = "login_required"
     elif logged_in:
         state = "ready"
     else:
@@ -166,7 +178,8 @@ def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any
     return {
         "state": state,
         "pairing_required": pairing_required,
-        "ready": logged_in and not pairing_required,
+        "login_required": login_required,
+        "ready": logged_in and not pairing_required and not login_required,
         "conversation_candidates": len(raw_list),
     }
 
@@ -179,7 +192,6 @@ def _conversation_extract_script() -> str:
     'mws-conversation-list-item',
     '[data-e2e-conversation-list-item]',
     'a[href*="/web/conversations"]',
-    '[role="listitem"]',
     'mws-conversation-list [role="button"]',
     'mws-conversation-list a'
   ];
@@ -203,25 +215,45 @@ def _conversation_extract_script() -> str:
 def _with_page(profile_path: Path, headless: bool, timeout_ms: int):
     """Launch Google Messages with a persistent context and return Playwright objects.
 
-    Caller must close the context and stop Playwright.
+    Caller must close the context and stop Playwright after successful return.
+    Partial launch/navigation failures are cleaned up here before re-raising.
     """
     from playwright.sync_api import sync_playwright
 
     profile_path.mkdir(parents=True, exist_ok=True)
-    pw = sync_playwright().start()
-    context = pw.chromium.launch_persistent_context(
-        str(profile_path),
-        headless=headless,
-        viewport={"width": 1280, "height": 900},
-    )
-    page = context.pages[0] if context.pages else context.new_page()
-    page.set_default_timeout(timeout_ms)
-    page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
     try:
-        page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
-    except Exception:
+        profile_path.chmod(0o700)
+    except OSError:
         pass
-    return pw, context, page
+    pw = None
+    context = None
+    try:
+        pw = sync_playwright().start()
+        context = pw.chromium.launch_persistent_context(
+            str(profile_path),
+            headless=headless,
+            viewport={"width": 1280, "height": 900},
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.set_default_timeout(timeout_ms)
+        page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
+        try:
+            page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
+        except Exception:
+            pass
+        return pw, context, page
+    except Exception:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:
+                pass
+        if pw is not None:
+            try:
+                pw.stop()
+            except Exception:
+                pass
+        raise
 
 
 def google_messages_status(
@@ -315,7 +347,7 @@ registry.register(
         "parameters": {
             "type": "object",
             "properties": {
-                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to the active Hermes profile home under browser-profiles/google-messages."},
                 "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so QR pairing is visible."},
                 "timeout_ms": {"type": "integer", "description": "Navigation/detection timeout in milliseconds."},
             },
@@ -345,7 +377,7 @@ registry.register(
             "type": "object",
             "properties": {
                 "limit": {"type": "integer", "description": "Maximum conversation previews to return, capped at 50."},
-                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to the active Hermes profile home under browser-profiles/google-messages."},
                 "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so pairing problems are visible."},
                 "timeout_ms": {"type": "integer", "description": "Navigation/extraction timeout in milliseconds."},
             },

--- a/tools/google_messages.py
+++ b/tools/google_messages.py
@@ -1,0 +1,363 @@
+"""Read-only Google Messages for Web checker tools.
+
+Milestone 1 is intentionally conservative:
+
+* use a dedicated persistent browser profile by default;
+* open/navigate only to https://messages.google.com/web;
+* report pairing/login status;
+* extract the visible conversation list only;
+* never open individual threads and never send messages.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+GOOGLE_MESSAGES_URL = "https://messages.google.com/web"
+DEFAULT_PROFILE_SUBDIR = Path("browser-profiles") / "google-messages"
+_TOOLSET = "google_messages"
+
+_TIMESTAMP_RE = re.compile(
+    r"^(?:"
+    r"\d{1,2}:\d{2}(?:\s?[AP]M)?|"
+    r"\d{1,2}/\d{1,2}(?:/\d{2,4})?|"
+    r"(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?|"
+    r"(?:Yesterday|Today)|"
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b.*"
+    r")$",
+    re.IGNORECASE,
+)
+
+_PAIRING_HINT_RE = re.compile(
+    r"(qr code|pair(?:ing)?|scan the code|use messages on the web)",
+    re.IGNORECASE,
+)
+
+
+def _default_profile_path() -> Path:
+    """Return the profile directory dedicated to Google Messages for Web."""
+    return get_hermes_home() / DEFAULT_PROFILE_SUBDIR
+
+
+def _resolve_profile_path(profile_path: Optional[str]) -> Path:
+    if profile_path:
+        return Path(profile_path).expanduser()
+    return _default_profile_path()
+
+
+def check_google_messages_requirements() -> bool:
+    """Return True when local Playwright is importable.
+
+    Chromium browser installation is validated lazily by Playwright at runtime so
+    the tool can return a clear setup error instead of disappearing because the
+    Python package is installed but browser bits are missing.
+    """
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _clean_lines(text: str) -> List[str]:
+    seen: set[str] = set()
+    lines: List[str] = []
+    for raw in (text or "").splitlines():
+        line = re.sub(r"\s+", " ", raw).strip()
+        if not line or line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return lines
+
+
+def _looks_like_timestamp(line: str) -> bool:
+    return bool(_TIMESTAMP_RE.match(line.strip()))
+
+
+def _detect_unread(raw: Dict[str, Any], text: str) -> bool:
+    attrs = " ".join(
+        str(raw.get(key) or "")
+        for key in ("aria_label", "class_name", "data_unread", "role")
+    )
+    haystack = f"{attrs}\n{text}".lower()
+    if re.search(r"\bunread\b", haystack):
+        return True
+    if str(raw.get("data_unread") or "").lower() in {"true", "1", "yes"}:
+        return True
+    return False
+
+
+def _parse_conversation_item(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize one raw DOM candidate into a conversation preview.
+
+    The Google Messages Web DOM is private and changes over time, so this parser
+    accepts loose text/ARIA/class candidates and returns best-effort fields.
+    """
+    text = str(raw.get("text") or raw.get("inner_text") or "")
+    aria = str(raw.get("aria_label") or "")
+    lines = _clean_lines(text or aria)
+    if not lines:
+        return None
+
+    sender: Optional[str] = None
+    timestamp: Optional[str] = None
+    snippet_parts: List[str] = []
+
+    for line in lines:
+        lower = line.lower()
+        if lower in {"you", "me", "sent", "delivered", "read"}:
+            snippet_parts.append(line)
+            continue
+        if timestamp is None and _looks_like_timestamp(line):
+            timestamp = line
+            continue
+        if sender is None:
+            sender = line
+            continue
+        snippet_parts.append(line)
+
+    if sender is None and aria:
+        sender = aria.split(",", 1)[0].strip() or None
+
+    snippet = " ".join(snippet_parts).strip() or None
+    return {
+        "sender": sender,
+        "timestamp": timestamp,
+        "snippet": snippet,
+        "unread": _detect_unread(raw, text or aria),
+    }
+
+
+def _parse_conversation_items(raw_items: Iterable[Dict[str, Any]], limit: int = 20) -> List[Dict[str, Any]]:
+    conversations: List[Dict[str, Any]] = []
+    seen: set[tuple[Any, Any, Any]] = set()
+    for raw in raw_items:
+        item = _parse_conversation_item(raw)
+        if not item or not item.get("sender"):
+            continue
+        key = (item.get("sender"), item.get("timestamp"), item.get("snippet"))
+        if key in seen:
+            continue
+        seen.add(key)
+        conversations.append(item)
+        if len(conversations) >= limit:
+            break
+    return conversations
+
+
+def _classify_status(url: str, body_text: str, raw_items: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    raw_list = list(raw_items)
+    conversations = _parse_conversation_items(raw_list, limit=5)
+    pairing_required = bool(_PAIRING_HINT_RE.search(body_text or "")) and not conversations
+    logged_in = bool(conversations) or "conversations" in (url or "").lower()
+    if pairing_required:
+        state = "pairing_required"
+    elif logged_in:
+        state = "ready"
+    else:
+        state = "unknown"
+    return {
+        "state": state,
+        "pairing_required": pairing_required,
+        "ready": logged_in and not pairing_required,
+        "conversation_candidates": len(raw_list),
+    }
+
+
+def _conversation_extract_script() -> str:
+    # Kept as a string so tests can focus on parser logic without Playwright.
+    return r"""
+() => {
+  const selectors = [
+    'mws-conversation-list-item',
+    '[data-e2e-conversation-list-item]',
+    'a[href*="/web/conversations"]',
+    '[role="listitem"]',
+    'mws-conversation-list [role="button"]',
+    'mws-conversation-list a'
+  ];
+  const nodes = [];
+  for (const selector of selectors) {
+    document.querySelectorAll(selector).forEach((node) => {
+      if (!nodes.includes(node)) nodes.push(node);
+    });
+  }
+  return nodes.slice(0, 80).map((node) => ({
+    text: node.innerText || node.textContent || '',
+    aria_label: node.getAttribute('aria-label') || '',
+    class_name: node.getAttribute('class') || '',
+    data_unread: node.getAttribute('data-unread') || node.getAttribute('aria-current') || '',
+    role: node.getAttribute('role') || ''
+  }));
+}
+"""
+
+
+def _with_page(profile_path: Path, headless: bool, timeout_ms: int):
+    """Launch Google Messages with a persistent context and return Playwright objects.
+
+    Caller must close the context and stop Playwright.
+    """
+    from playwright.sync_api import sync_playwright
+
+    profile_path.mkdir(parents=True, exist_ok=True)
+    pw = sync_playwright().start()
+    context = pw.chromium.launch_persistent_context(
+        str(profile_path),
+        headless=headless,
+        viewport={"width": 1280, "height": 900},
+    )
+    page = context.pages[0] if context.pages else context.new_page()
+    page.set_default_timeout(timeout_ms)
+    page.goto(GOOGLE_MESSAGES_URL, wait_until="domcontentloaded", timeout=timeout_ms)
+    try:
+        page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 5000))
+    except Exception:
+        pass
+    return pw, context, page
+
+
+def google_messages_status(
+    profile_path: Optional[str] = None,
+    headless: bool = False,
+    timeout_ms: int = 15000,
+) -> str:
+    """Open Google Messages for Web and report pairing/login status.
+
+    This is read-only. It navigates to the web app but does not click a
+    conversation and does not send or type anything.
+    """
+    resolved_profile = _resolve_profile_path(profile_path)
+    try:
+        pw, context, page = _with_page(resolved_profile, headless, timeout_ms)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": str(exc),
+            "profile_path": str(resolved_profile),
+            "setup_hint": "Install Playwright and Chromium: pip install playwright && python -m playwright install chromium",
+        })
+    try:
+        body_text = page.locator("body").inner_text(timeout=min(timeout_ms, 5000))
+        raw_items = page.evaluate(_conversation_extract_script())
+        status = _classify_status(page.url, body_text, raw_items)
+        return json.dumps({
+            "ok": True,
+            "url": page.url,
+            "profile_path": str(resolved_profile),
+            **status,
+            "safety": "read-only status check; no thread opened and no message sent",
+        })
+    finally:
+        context.close()
+        pw.stop()
+
+
+def google_messages_conversations(
+    limit: int = 20,
+    profile_path: Optional[str] = None,
+    headless: bool = False,
+    timeout_ms: int = 15000,
+) -> str:
+    """Return visible Google Messages conversation-list previews only.
+
+    The tool never opens individual threads. Snippets are whatever the list UI
+    already exposes; opening a thread is deliberately out of scope for milestone 1.
+    """
+    limit = max(1, min(int(limit or 20), 50))
+    resolved_profile = _resolve_profile_path(profile_path)
+    try:
+        pw, context, page = _with_page(resolved_profile, headless, timeout_ms)
+    except Exception as exc:
+        return json.dumps({
+            "ok": False,
+            "error": str(exc),
+            "profile_path": str(resolved_profile),
+            "setup_hint": "Install Playwright and Chromium: pip install playwright && python -m playwright install chromium",
+        })
+    try:
+        body_text = page.locator("body").inner_text(timeout=min(timeout_ms, 5000))
+        raw_items = page.evaluate(_conversation_extract_script())
+        status = _classify_status(page.url, body_text, raw_items)
+        conversations = _parse_conversation_items(raw_items, limit=limit)
+        return json.dumps({
+            "ok": True,
+            "url": page.url,
+            "profile_path": str(resolved_profile),
+            **status,
+            "count": len(conversations),
+            "conversations": conversations,
+            "safety": "conversation-list extraction only; no thread opened and no message sent",
+        })
+    finally:
+        context.close()
+        pw.stop()
+
+
+registry.register(
+    name="google_messages_status",
+    toolset=_TOOLSET,
+    schema={
+        "name": "google_messages_status",
+        "description": (
+            "Read-only Google Messages for Web status/pairing check. Opens "
+            "messages.google.com/web using a dedicated persistent profile and "
+            "reports whether manual QR pairing/login appears needed. Does not "
+            "open threads or send messages."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so QR pairing is visible."},
+                "timeout_ms": {"type": "integer", "description": "Navigation/detection timeout in milliseconds."},
+            },
+        },
+    },
+    handler=lambda args, **kw: google_messages_status(
+        profile_path=args.get("profile_path"),
+        headless=bool(args.get("headless", False)),
+        timeout_ms=int(args.get("timeout_ms", 15000)),
+    ),
+    check_fn=check_google_messages_requirements,
+    description="Read-only Google Messages for Web pairing/status check",
+    emoji="💬",
+)
+
+registry.register(
+    name="google_messages_conversations",
+    toolset=_TOOLSET,
+    schema={
+        "name": "google_messages_conversations",
+        "description": (
+            "Read-only Google Messages for Web conversation-list extraction. "
+            "Returns visible sender/name, timestamp, snippet, and defensively "
+            "detected unread-ish flag. Never opens individual threads and never sends messages."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Maximum conversation previews to return, capped at 50."},
+                "profile_path": {"type": "string", "description": "Optional persistent browser profile path. Defaults to ~/.hermes/browser-profiles/google-messages."},
+                "headless": {"type": "boolean", "description": "Run browser headlessly. Defaults to false so pairing problems are visible."},
+                "timeout_ms": {"type": "integer", "description": "Navigation/extraction timeout in milliseconds."},
+            },
+        },
+    },
+    handler=lambda args, **kw: google_messages_conversations(
+        limit=int(args.get("limit", 20)),
+        profile_path=args.get("profile_path"),
+        headless=bool(args.get("headless", False)),
+        timeout_ms=int(args.get("timeout_ms", 15000)),
+    ),
+    check_fn=check_google_messages_requirements,
+    description="Read-only Google Messages for Web conversation previews",
+    emoji="💬",
+)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -182,12 +182,13 @@ def _get_default_output_dir() -> str:
     return str(get_hermes_dir("cache/audio", "audio_cache"))
 
 DEFAULT_OUTPUT_DIR = _get_default_output_dir()
+DEFAULT_TTS_CHUNK_CHARS = 3000
 
 # ---------------------------------------------------------------------------
 # Per-provider input-character limits (from official provider docs).
 # A single global cap was wrong: OpenAI is 4096, xAI is 15k, MiniMax is 10k,
 # ElevenLabs is model-dependent (5k / 10k / 30k / 40k), Gemini caps at ~8k
-# input tokens.  Users can override any of these via
+# input tokens. Users can override any of these via
 # ``tts.<provider>.max_text_length`` in config.yaml.
 # ---------------------------------------------------------------------------
 PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
@@ -197,7 +198,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 5000,       # Gemini TTS caps at ~8k input tokens / ~655s audio
-    "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
+    "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
@@ -1918,6 +1919,7 @@ def _has_openai_audio_backend() -> bool:
 # ===========================================================================
 # Sentence boundary pattern: punctuation followed by space or newline
 _SENTENCE_BOUNDARY_RE = re.compile(r'(?<=[.!?])(?:\s|\n)|(?:\n\n)')
+_CLAUSE_BOUNDARY_RE = re.compile(r'(?<=[,;:])\s+|(?<=—)\s*|(?<=-)\s+')
 
 # Markdown stripping patterns (same as cli.py _voice_speak_response)
 _MD_CODE_BLOCK = re.compile(r'```[\s\S]*?```')
@@ -1945,6 +1947,115 @@ def _strip_markdown_for_tts(text: str) -> str:
     text = _MD_HR.sub('', text)
     text = _MD_EXCESS_NL.sub('\n\n', text)
     return text.strip()
+
+
+def _split_tts_fragment_at_words(text: str, max_chars: int) -> list[str]:
+    """Split an oversized fragment on word boundaries."""
+    words = text.split()
+    if not words:
+        return []
+
+    chunks: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = word
+            continue
+        if len(word) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            for i in range(0, len(word), max_chars):
+                chunks.append(word[i:i + max_chars])
+            continue
+        current = candidate
+
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_tts_unit(text: str, max_chars: int) -> list[str]:
+    """Split a single oversized unit using clause, then word boundaries."""
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+
+    clause_parts = [part.strip() for part in _CLAUSE_BOUNDARY_RE.split(text) if part.strip()]
+    if len(clause_parts) > 1:
+        chunks: list[str] = []
+        current = ""
+        for part in clause_parts:
+            if len(part) > max_chars:
+                if current:
+                    chunks.append(current)
+                    current = ""
+                chunks.extend(_split_tts_fragment_at_words(part, max_chars))
+                continue
+
+            candidate = f"{current} {part}".strip()
+            if current and len(candidate) > max_chars:
+                chunks.append(current)
+                current = part
+            else:
+                current = candidate
+
+        if current:
+            chunks.append(current)
+        return chunks
+
+    return _split_tts_fragment_at_words(text, max_chars)
+
+
+def chunk_tts_text(text: str, max_chars: int = DEFAULT_TTS_CHUNK_CHARS) -> list[str]:
+    """Split long TTS text into sentence-aware chunks.
+
+    Paragraph breaks are preserved when possible, but they do *not* force a new
+    chunk by themselves. This avoids pathological cases where story-like prose
+    becomes dozens of tiny voice notes simply because the source has many short
+    paragraphs.
+    """
+    normalized = text.replace("\r\n", "\n").strip()
+    if not normalized:
+        return []
+    if len(normalized) <= max_chars:
+        return [normalized]
+
+    paragraphs = [p.strip() for p in re.split(r'\n{2,}', normalized) if p.strip()]
+    if not paragraphs:
+        paragraphs = [normalized]
+
+    chunks: list[str] = []
+    current = ""
+
+    for paragraph in paragraphs:
+        sentences = [s.strip() for s in _SENTENCE_BOUNDARY_RE.split(paragraph) if s.strip()]
+        units = sentences or [paragraph]
+
+        for unit in units:
+            if len(unit) > max_chars:
+                if current:
+                    chunks.append(current)
+                    current = ""
+                chunks.extend(_split_tts_unit(unit, max_chars))
+                continue
+
+            separator = "\n\n" if current else ""
+            candidate = f"{current}{separator}{unit}" if current else unit
+            if current and len(candidate) > max_chars:
+                chunks.append(current)
+                current = unit
+            else:
+                current = candidate
+
+    if current:
+        chunks.append(current)
+
+    return chunks
 
 
 def stream_tts_to_speaker(

--- a/toolsets.py
+++ b/toolsets.py
@@ -158,6 +158,12 @@ TOOLSETS = {
         "tools": ["send_message"],
         "includes": []
     },
+
+    "google_messages": {
+        "description": "Read-only Google Messages for Web status and conversation-list previews",
+        "tools": ["google_messages_status", "google_messages_conversations"],
+        "includes": []
+    },
     
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",

--- a/website/docs/user-guide/messaging/google-messages.md
+++ b/website/docs/user-guide/messaging/google-messages.md
@@ -1,0 +1,75 @@
+---
+title: Google Messages for Web
+---
+
+# Google Messages for Web checker
+
+Hermes can inspect Jake's existing Pixel/Android text-message inbox through Google Messages for Web using a local Playwright browser profile. This is separate from the Twilio-backed SMS gateway: Twilio lets people text a Hermes-owned number, while this checker previews the inbox already paired to Google Messages on the phone.
+
+Milestone 1 is intentionally read-only and boring in the best possible way:
+
+- open `https://messages.google.com/web` in a dedicated persistent browser profile;
+- report whether manual QR pairing/login appears needed;
+- extract only the visible conversation list: sender/name, timestamp if visible, snippet, and a defensive unread-ish flag;
+- never open individual threads by default;
+- never type, draft, or send messages.
+
+## Setup
+
+Install Playwright if it is not already available in the Hermes environment:
+
+```bash
+pip install playwright
+python -m playwright install chromium
+```
+
+Enable or request the `google_messages` toolset for the Hermes session/profile that should use it. The toolset exposes:
+
+- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, or `unknown`.
+- `google_messages_conversations` — returns visible conversation-list previews only.
+
+By default both tools use this persistent profile:
+
+```text
+~/.hermes/browser-profiles/google-messages
+```
+
+That dedicated profile keeps Google Messages cookies/session state away from the normal browser automation profile and makes it easier to revoke, inspect, or delete the pairing later.
+
+## Manual QR pairing
+
+The first status check should usually run non-headless so the QR code can be seen:
+
+```text
+google_messages_status(headless=false)
+```
+
+On the Pixel:
+
+1. Open Google Messages.
+2. Open device pairing / Messages for web.
+3. Scan the QR code shown in the Hermes-controlled browser window.
+
+After pairing, future checks can reuse the persistent profile. If the profile is deleted, if Google expires the session, or if the phone unpairs the browser, `google_messages_status` should report that pairing appears needed again.
+
+## Privacy and read-status caveats
+
+This checker is for preview triage, not durable archiving.
+
+Important caveats:
+
+- Conversation-list snippets may still contain private message text and may enter Hermes transcripts/logs if an agent includes them in a response. Do not store more than necessary.
+- Opening an individual conversation may mark it read. Milestone 1 does not open threads for exactly this reason.
+- Google can change the Messages Web DOM at any time. Selectors and unread detection are defensive best-effort, not a contract.
+- RCS/SMS/MMS behavior depends on what Google Messages exposes through the paired web UI.
+- Sending is out of scope. Future reply support should stay draft-only/manual until read-status and consent boundaries are proven.
+
+## Removing local state
+
+To force a fresh pairing, close any checker browser window and remove the dedicated profile directory:
+
+```bash
+rm -rf ~/.hermes/browser-profiles/google-messages
+```
+
+Also unpair the browser from the Pixel's Google Messages device-pairing screen when you no longer want Hermes to have access.

--- a/website/docs/user-guide/messaging/google-messages.md
+++ b/website/docs/user-guide/messaging/google-messages.md
@@ -25,14 +25,16 @@ python -m playwright install chromium
 
 Enable or request the `google_messages` toolset for the Hermes session/profile that should use it. The toolset exposes:
 
-- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, or `unknown`.
+- `google_messages_status` — opens Google Messages for Web and reports `ready`, `pairing_required`, `login_required`, or `unknown`.
 - `google_messages_conversations` — returns visible conversation-list previews only.
 
-By default both tools use this persistent profile:
+By default both tools use this persistent profile under the active Hermes profile home:
 
 ```text
 ~/.hermes/browser-profiles/google-messages
 ```
+
+For named Hermes profiles, replace `~/.hermes` with that profile's home directory. The checker creates the browser-profile directory with owner-only permissions (`0700`) where the platform allows it, because the profile contains paired Google session state.
 
 That dedicated profile keeps Google Messages cookies/session state away from the normal browser automation profile and makes it easier to revoke, inspect, or delete the pairing later.
 
@@ -71,5 +73,7 @@ To force a fresh pairing, close any checker browser window and remove the dedica
 ```bash
 rm -rf ~/.hermes/browser-profiles/google-messages
 ```
+
+For named Hermes profiles, remove the same `browser-profiles/google-messages` subdirectory from that profile's Hermes home instead.
 
 Also unpair the browser from the Pixel's Google Messages device-pairing screen when you no longer want Hermes to have access.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -128,6 +128,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/signal',
         'user-guide/messaging/email',
         'user-guide/messaging/sms',
+        'user-guide/messaging/google-messages',
         'user-guide/messaging/homeassistant',
         'user-guide/messaging/mattermost',
         'user-guide/messaging/matrix',


### PR DESCRIPTION
## Problem

No way to triage Google Messages (SMS/RCS) conversations from within Hermes without leaving the assistant context. Users with Pixel phones or Chrome's Messages for Web integration had no passive read-only status check.

## Root Cause

No `google_messages` toolset existed. The feature requires a persistent browser profile (QR pairing survives restarts) and read-only guards to prevent accidental message sends or thread opens.

## Fix

Adds `tools/google_messages.py` with two tools behind an opt-in `google_messages` toolset:

| Tool | Description |
|---|---|
| `google_messages_status` | Check whether Messages for Web is paired and active |
| `google_messages_list` | Preview unread conversation list (no thread open, no send) |

Implementation details:
- Dedicated persistent browser profile at `~/.hermes/browser-profiles/google-messages` (survives restarts across the QR pairing lifetime)
- Manual QR pairing documented in `website/docs/user-guide/messaging/google-messages.md`
- Privacy caveat: checking message list marks conversations as "read" on the phone — documented prominently
- No-send / no-thread-open enforced as hard milestones in the tool

Also includes companion fixes rebased from the same branch:
- `fix: chunk auto-TTS voice replies` — chunked TTS for long Telegram voice replies with audio-primary mirroring
- `fix(auxiliary): sanitize Codex memory flush requests` — prevent Codex Responses endpoint from receiving `max_tokens`/`max_completion_tokens` on memory flush calls
- `fix(codex): preserve object-shaped auxiliary tool calls` — handle `SimpleNamespace` tool_call objects in the Codex responses adapter
- `fix(gateway): stop Telegram voice failures leaking paths` — return `SendResult(success=False)` instead of falling back to base adapter on voice send error
- `fix(gateway): preserve Telegram code blocks when chunking` — code block continuity across chunk boundaries
- `fix(gateway): respect Telegram topic voice mode` — topic voice mode routing

## Tests

- `tests/tools/test_google_messages.py` — 6 unit tests covering status detection, list parsing, pairing state, and error handling
- `tests/tools/test_tts_chunking.py` — TTS chunking edge cases
- `tests/gateway/test_voice_reply_chunking.py` — voice reply chunking integration tests
- `tests/gateway/test_voice_command.py` — two new tests: thread metadata routing and failure-returns-None guard

## Visual

```mermaid
flowchart LR
    A[Hermes] -->|opt-in toolset| B[google_messages_status]
    A -->|opt-in toolset| C[google_messages_list]
    B --> D[Persistent browser profile\n~/.hermes/browser-profiles/google-messages]
    C --> D
    D -->|QR paired| E[Messages for Web]
    E -->|read-only| F[SMS/RCS conversations]
```

---

Salvages and completes #24514 (rebased onto main; 5 conflicts resolved across `gateway/run.py`, `gateway/platforms/telegram.py`, `agent/auxiliary_client.py`, and `tests/agent/test_auxiliary_client.py`).