### PR TITLE
fix: add platform guard for grp import in test_gateway_service.py

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 pwd = pytest.importorskip("pwd")
+grp = pytest.importorskip("grp")
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status
@@ -1339,7 +1340,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "root")
@@ -1350,7 +1350,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        import grp
 
         root_info = pwd.getpwnam("root")
         root_group = grp.getgrgid(root_info.pw_gid).gr_name
@@ -1361,7 +1360,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "nobody")


### PR DESCRIPTION
## Problem

Three test methods in `tests/hermes_cli/test_gateway_service.py` use inline `import grp` without a platform guard:

- `TestSystemServiceIdentityRootHandling.test_auto_detected_root_is_rejected`
- `TestSystemServiceIdentityRootHandling.test_explicit_root_is_allowed`
- `TestSystemServiceIdentityRootHandling.test_non_root_user_passes_through`

The `grp` module is UNIX-only (not available on Windows). While the module already has `pwd = pytest.importorskip("pwd")` at line 10 which effectively skips the entire module on Windows, the inline `import grp` statements are inconsistent with the established pattern and will cause `ModuleNotFoundError` if the module-level guard is ever removed or the tests are isolated.

## Root Cause

`grp` imported lazily inside test bodies with no `pytest.importorskip` guard, unlike `pwd` which is already guarded at module level.

## Fix

- Added `grp = pytest.importorskip("grp")` at module level (line 11), consistent with the existing `pwd` pattern
- Removed the three inline `import grp` statements from the test methods

## Testing

Ran the affected test class:

```
.venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py::TestSystemServiceIdentityRootHandling -v
============================= test session starts ==============================
collected 3 items

test_auto_detected_root_is_rejected PASSED
test_explicit_root_is_allowed PASSED
test_non_root_user_passes_through PASSED

============================== 3 passed in 1.27s ===============================
```

## Result

`grp` is now guarded at module level alongside `pwd`, making the skip intent explicit and defensive against future refactors. No behavioral change on Linux/UNIX systems.

Closes #24531