### PR TITLE
fix: use reasoning_content for reasoning.available event

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14581,6 +14581,8 @@ class AIAgent:
 
                 # Notify progress callback of model's thinking (used by subagent
                 # delegation to relay the child's reasoning to the parent display).
+                raw_reasoning = getattr(assistant_message, 'reasoning_content', None) or getattr(assistant_message, 'reasoning', None)
+                _think_text = ""
                 if (assistant_message.content and self.tool_progress_callback):
                     _think_text = assistant_message.content.strip()
                     # Strip reasoning XML tags that shouldn't leak to parent display
@@ -14588,18 +14590,28 @@ class AIAgent:
                         r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
                     ).strip()
                     # For subagents: relay first line to parent display (existing behaviour).
-                    # For all agents with a structured callback: emit reasoning.available event.
                     first_line = _think_text.split('\n')[0][:80] if _think_text else ""
                     if first_line and getattr(self, '_delegate_depth', 0) > 0:
                         try:
                             self.tool_progress_callback("_thinking", first_line)
                         except Exception:
                             pass
-                    elif _think_text:
-                        try:
-                            self.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
-                        except Exception:
-                            pass
+                # Emit reasoning.available with actual reasoning content when the
+                # model provides it (reasoning_content or reasoning field). Falls
+                # back to stripped content for models without a dedicated reasoning
+                # field. Previously this always read from .content, which caused
+                # reasoning.available to carry the final response text instead of
+                # the model's reasoning.
+                if raw_reasoning:
+                    try:
+                        self.tool_progress_callback("reasoning.available", "_thinking", raw_reasoning[:500], None)
+                    except Exception:
+                        pass
+                elif _think_text:
+                    try:
+                        self.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
+                    except Exception:
+                        pass
                 
                 # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
                 # This means the model ran out of output tokens mid-reasoning — retry up to 2 times


### PR DESCRIPTION
## Problem

When consuming the structured event stream via the api_server (`/v1/runs/{run_id}/events`), the `reasoning.available` event carried the final assistant response text instead of the model's actual reasoning content. This caused external UIs to display the final response twice — once labeled as reasoning, once as the actual reply.

## Root Cause

In `run_agent.py`, the reasoning event emission path read from `assistant_message.content` (the visible assistant text) instead of `assistant_message.reasoning_content` (the model's reasoning). The variable was named `_think_text` but its source was `.content`, not the actual reasoning field.

## Fix

- Added `raw_reasoning = getattr(assistant_message, 'reasoning_content', None) or getattr(assistant_message, 'reasoning', None)` to extract actual reasoning
- Separated the subagent `_thinking` relay (which still uses content for parent display) from the `reasoning.available` event emission
- `reasoning.available` now emits `reasoning_content` when the model provides it, falling back to stripped content only for models without a dedicated reasoning field
- Initialized `_think_text` outside the conditional block to avoid NameError in the fallback path

## Testing

Syntax verified with py_compile. The change is backward compatible — models without reasoning_content continue to use the content fallback.

## Result

The `reasoning.available` event now carries actual model reasoning when available, fixing the duplicate display issue in consuming UIs.

Closes #24518