### PR TITLE
fix: disable streaming on JSONDecodeError when tools are present

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8501,7 +8501,20 @@ class AIAgent:
                                 "stream" in _err_lower
                                 and "not supported" in _err_lower
                             )
-                            if _is_stream_unsupported:
+                            # Detect custom providers (e.g. LLM Gateway) that
+                            # fail streaming when tools are present, returning
+                            # empty/invalid responses (JSONDecodeError with
+                            # "Expecting value" on empty body).  Disable
+                            # streaming so the next attempt uses the
+                            # non-streaming path which succeeds.
+                            _has_tools = bool(api_kwargs.get("tools"))
+                            _is_json_decode = (
+                                "jsondecodeerror" in _err_lower
+                                or "expecting value" in _err_lower
+                                or "expecting ':' delimiter" in _err_lower
+                            )
+                            _is_stream_tool_failure = _has_tools and _is_json_decode
+                            if _is_stream_unsupported or _is_stream_tool_failure:
                                 self._disable_streaming = True
                                 self._safe_print(
                                     "\n⚠  Streaming is not supported for this "


### PR DESCRIPTION
## Problem

Custom providers like LLM Gateway (`custom:llmgateway`) fail streaming requests that include tools, returning empty/invalid responses:

```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The error was not detected as a streaming incompatibility, so Hermes retried the streaming path 3 times and the tool workflow failed. The same workflow succeeds when using the non-streaming path.

## Root Cause

The existing `_disable_streaming` mechanism only detected "stream not supported" error messages. The JSONDecodeError from custom providers that can't handle streaming with tools was not recognized as a streaming incompatibility trigger.

## Fix

Extended the streaming error detection in `_interruptible_streaming_api_call` to also disable streaming when:
- The request includes tools (`api_kwargs.get("tools")`)
- The error contains JSONDecodeError patterns (`jsondecodeerror`, `expecting value`, `expecting ':' delimiter`)

When both conditions are met, streaming is disabled for the session and the next attempt uses the non-streaming path which succeeds. The existing warning message tells users to set `display.streaming: false` to avoid the initial delay.

## Testing

Syntax verified. The fix is narrow and defensive — it only triggers when BOTH tools are present AND a JSON decode error occurs during streaming, minimizing the risk of false positives.

## Result

Custom providers that can't handle streaming with tools now gracefully fall back to non-streaming on the next attempt, matching the behavior already in place for providers that explicitly signal "stream not supported".

Closes #24523