### PR TITLE
fix(cli): promote root-level provider when model.provider is default 'auto'

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -436,7 +436,11 @@ def load_cli_config() -> Dict[str, Any]:
             # only used as a FALLBACK when model.provider / model.base_url
             # is not already set — never as an override.  The canonical
             # location is model.provider (written by `hermes model`).
-            if not defaults["model"].get("provider"):
+            # Treat the built-in default "auto" as unset so a root-level
+            # provider written by `hermes config set provider X` is not
+            # silently swallowed (issue #24433).
+            _mp = defaults["model"].get("provider")
+            if not _mp or _mp == "auto":
                 root_provider = file_config.get("provider")
                 if root_provider:
                     defaults["model"]["provider"] = root_provider

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3980,7 +3980,11 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
 
     for key in ("provider", "base_url", "context_length"):
         root_val = config.get(key)
-        if root_val and not model.get(key):
+        model_val = model.get(key)
+        # Treat the built-in default "auto" for provider as unset so a
+        # root-level `provider:` written by `hermes config set provider X`
+        # is promoted correctly (issue #24433).
+        if root_val and (not model_val or (key == "provider" and model_val == "auto")):
             model[key] = root_val
         config.pop(key, None)
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -346,8 +346,9 @@ class TestRootLevelProviderOverride:
 
         assert cfg["model"]["provider"] == "openrouter"
 
-    def test_root_provider_ignored_when_default_model_provider_exists(self, tmp_path, monkeypatch):
-        """Even when model.provider is the default 'auto', root-level provider is ignored."""
+    def test_root_provider_promoted_when_model_provider_is_default_auto(self, tmp_path, monkeypatch):
+        """When model.provider is the built-in default 'auto', root-level provider
+        is promoted so `hermes config set provider X` works under profiles (issue #24433)."""
         import yaml
 
         hermes_home = tmp_path / ".hermes"
@@ -356,9 +357,9 @@ class TestRootLevelProviderOverride:
 
         config_path = hermes_home / "config.yaml"
         config_path.write_text(yaml.safe_dump({
-            "provider": "opencode-go",  # stale root key
+            "provider": "openai-codex",  # root-level key from `hermes config set provider`
             "model": {
-                "default": "google/gemini-3-flash-preview",
+                "default": "gpt-5.5",
                 # no explicit model.provider — defaults provide "auto"
             },
         }))
@@ -367,8 +368,8 @@ class TestRootLevelProviderOverride:
         monkeypatch.setattr(cli, "_hermes_home", hermes_home)
         cfg = cli.load_cli_config()
 
-        # Root-level "opencode-go" must NOT leak through
-        assert cfg["model"]["provider"] != "opencode-go"
+        # Root-level "openai-codex" should be promoted since model.provider is "auto"
+        assert cfg["model"]["provider"] == "openai-codex"
 
     def test_terminal_vercel_runtime_bridged_to_env(self, tmp_path, monkeypatch):
         """Classic CLI must expose terminal.vercel_runtime to terminal_tool.py."""
@@ -470,6 +471,22 @@ class TestRootLevelProviderOverride:
         assert result["model"]["default"] == "my-model"
         assert result["model"]["context_length"] == 128000
         assert "context_length" not in result
+
+    def test_normalize_root_provider_promoted_when_model_provider_is_auto(self):
+        """Root-level provider is promoted when model.provider is the default 'auto'
+        (issue #24433: `hermes config set provider X` writes to root level)."""
+        from hermes_cli.config import _normalize_root_model_keys
+
+        config = {
+            "provider": "openai-codex",
+            "model": {
+                "default": "gpt-5.5",
+                "provider": "auto",
+            },
+        }
+        result = _normalize_root_model_keys(config)
+        assert result["model"]["provider"] == "openai-codex"
+        assert "provider" not in result  # root key cleaned up
 
 
 class TestProviderResolution:


### PR DESCRIPTION
## What does this PR do?

`hermes -p personal chat` reports "No inference provider configured" even when the profile config has `provider: openai-codex` set via `hermes config set provider`. The same profile's `hermes -z "..."` one-shot mode works fine.


### Root Cause

`hermes config set provider X` writes the value at the YAML root level (`provider: X`), not under `model:`. In `cli.py::load_cli_config()`, the root-level provider fallback checks `if not defaults["model"].get("provider")` — but the built-in default is `"auto"`, which is truthy. So the root-level provider is silently ignored.

The same issue exists in `hermes_cli/config.py::_normalize_root_model_keys()` which is used by `load_config()` (used by `-z` mode, gateway, cron).

## Related Issue

Fixes #24433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A