### PR TITLE
fix(auxiliary_client): consult ProviderProfile.api_mode in _resolve_task_provider_model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3812,6 +3812,26 @@ def _resolve_task_provider_model(
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
 
+    # When an explicit provider is given and no task-config api_mode override,
+    # fall back to the provider profile's declared api_mode. Without this,
+    # plugin providers that declare api_mode="anthropic_messages" (i.e. their
+    # upstream speaks the Anthropic Messages API, not OpenAI Chat Completions)
+    # silently land on the OpenAI-wire transport and 404 from
+    # `chat/completions` calls. The URL-suffix detection in
+    # `_endpoint_speaks_anthropic_messages` only catches /anthropic-suffixed
+    # gateways; it misses plain-base-URL Anthropic-API endpoints (e.g. local
+    # proxies on 127.0.0.1:PORT). Reading the profile here closes the gap so
+    # any provider plugin can declare api_mode and have it honored regardless
+    # of upstream URL shape.
+    if provider and not resolved_api_mode:
+        try:
+            from providers import get_provider_profile as _gpf_resolve
+            _profile = _gpf_resolve(provider)
+            if _profile and getattr(_profile, "api_mode", None):
+                resolved_api_mode = _profile.api_mode
+        except Exception:
+            pass
+
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:


### PR DESCRIPTION
## Summary

`_resolve_task_provider_model` returns `api_mode=None` when an explicit provider is given without a task-level `auxiliary.<task>.api_mode` override, **even when the provider's profile declares `api_mode`**. This causes any plugin provider that upstreams to an Anthropic-Messages-API endpoint (vs OpenAI Chat Completions) to silently land on the OpenAI-wire transport and 404 on `chat/completions` calls.

## Reproduction

```python
from providers import register_provider
from providers.base import ProviderProfile

_p = ProviderProfile(
    name="my-anthropic-plugin",
    api_mode="anthropic_messages",  # ← honored only via URL-suffix detection
    base_url="http://127.0.0.1:18801",  # plain base URL, no /anthropic suffix
    auth_type="api_key",
)
register_provider(_p)

from agent.auxiliary_client import _resolve_task_provider_model
prov, model, base, key, mode = _resolve_task_provider_model(
    task=None, provider="my-anthropic-plugin",
    model="some-model", base_url=None, api_key=None,
)
print(mode)  # → None (pre-fix), should be 'anthropic_messages'
```

Downstream consequence: `call_llm` constructs a plain OpenAI client that fails with `openai.NotFoundError: 404` because the upstream speaks `/v1/messages`, not `/chat/completions`.

The existing escape hatch — having the upstream advertise a URL ending in `/anthropic` so `_endpoint_speaks_anthropic_messages` matches — works but is a workaround for the missing profile plumbing. Plugins that don't control their upstream's URL shape (e.g. they wrap a third-party local proxy) have no clean option today.

## Fix

When an explicit provider is given AND no task-level `api_mode` override is configured, fall back to the provider profile's declared `api_mode`. Task config still wins (preserving the existing override semantics).

The change is a small block of code inside `_resolve_task_provider_model`, wrapped in `try/except` so a future refactor of `providers.get_provider_profile` can't crash the resolver.

```diff
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode

+    if provider and not resolved_api_mode:
+        try:
+            from providers import get_provider_profile as _gpf_resolve
+            _profile = _gpf_resolve(provider)
+            if _profile and getattr(_profile, "api_mode", None):
+                resolved_api_mode = _profile.api_mode
+        except Exception:
+            pass
+
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
```

## Test plan

Verification script (asserts the proximate behavior AND that override semantics are preserved):

```
[PASS] resolver reads api_mode from provider profile: anthropic_messages
[PASS] task-config api_mode still wins over profile: chat_completions
[PASS] bundled 'anthropic' provider profile honored: anthropic_messages
```

All three assertions cover scenarios:

1. Plugin provider declares `api_mode="anthropic_messages"` → resolver now returns it (the bug case).
2. Task config explicitly sets `api_mode="chat_completions"` → override still wins (regression guard).
3. Bundled `anthropic` provider (whose profile already declared `api_mode="anthropic_messages"`) → behavior unchanged.

Downstream symptom: with this fix, the call path `call_llm → _get_cached_client → resolve_provider_client → _wrap_if_needed → _maybe_wrap_anthropic` now sees the correct `api_mode` and wraps the OpenAI client in `AnthropicAuxiliaryClient` for plugin providers, even when the upstream URL has no `/anthropic` suffix.

## Scope

- **IN:** the one resolver-internal fallback. Smallest possible change to close the gap.
- **OUT:** any change to `_endpoint_speaks_anthropic_messages` or how `_wrap_if_needed` consumes the `api_mode`. Those already do the right thing once `api_mode` is plumbed through correctly.
- **OUT:** model-name normalization. A separate concern — provider plugins that need their namespace prefix stripped (e.g. `claude-api-proxy/claude-haiku-4-5` → `claude-haiku-4-5`) still need an entry in `hermes_cli/model_normalize.py`'s buckets. That could be a follow-up PR making the normalizer profile-aware, but is out of scope here.

## Risk

Low. The change is additive (a fallback that only fires when the result was previously `None`), wrapped in `try/except`, and gated on `provider and not resolved_api_mode` so the existing precedence (explicit task config > nothing) is preserved. Bundled providers that already declared `api_mode` in their profile now get that field honored — no behavior change for them since the existing URL-suffix detection was already routing them correctly.
