### PR TITLE
fix(daytona): migrate legacy-sandbox lookup to cursor-based list()

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -91,7 +91,7 @@ def make_env(daytona_sdk, monkeypatch):
         if list_return is not None:
             mock_client.list.return_value = list_return
         else:
-            mock_client.list.return_value = SimpleNamespace(items=[])
+            mock_client.list.return_value = iter([])
 
         daytona_sdk.Daytona = MagicMock(return_value=mock_client)
 
@@ -156,13 +156,13 @@ class TestPersistence:
         legacy.process.exec.return_value = _make_exec_response(result="/root")
         env = make_env(
             get_side_effect=daytona_sdk.DaytonaError("not found"),
-            list_return=SimpleNamespace(items=[legacy]),
+            list_return=iter([legacy]),
             persistent=True,
             task_id="mytask",
         )
         legacy.start.assert_called_once()
         env._mock_client.list.assert_called_once_with(
-            labels={"hermes_task_id": "mytask"}, page=1, limit=1)
+            labels={"hermes_task_id": "mytask"}, limit=1)
         env._mock_client.create.assert_not_called()
 
     def test_persistent_creates_new_when_none_found(self, make_env, daytona_sdk):
@@ -176,7 +176,7 @@ class TestPersistence:
         # by checking get() was called with the right sandbox name
         env._mock_client.get.assert_called_with("hermes-mytask")
         env._mock_client.list.assert_called_with(
-            labels={"hermes_task_id": "mytask"}, page=1, limit=1)
+            labels={"hermes_task_id": "mytask"}, limit=1)
 
     def test_non_persistent_skips_lookup(self, make_env):
         env = make_env(persistent=False)

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -101,9 +101,13 @@ class DaytonaEnvironment(BaseEnvironment):
 
             if self._sandbox is None:
                 try:
-                    page = self._daytona.list(labels=labels, page=1, limit=1)
-                    if page.items:
-                        self._sandbox = page.items[0]
+                    # Daytona SDK >=0.108.0 uses cursor-based pagination and
+                    # list() returns an iterator. Offset-based pagination
+                    # (page=1) is removed on June 10, 2026.
+                    results = self._daytona.list(labels=labels, limit=1)
+                    legacy = next(iter(results), None)
+                    if legacy is not None:
+                        self._sandbox = legacy
                         self._sandbox.start()
                         logger.info("Daytona: resumed legacy sandbox %s for task %s",
                                     self._sandbox.id, task_id)


### PR DESCRIPTION
## Summary
Migrates the one offset-paginated Daytona SDK call in our codebase to the new cursor-style API, ahead of Daytona's June 10, 2026 deprecation.

Daytona is removing offset pagination from `Daytona.list()` on June 10, 2026 (announcement May 12). After that date, `list()` returns an iterator instead of a page object with `.items`, and the `page=` parameter is gone.

We pin `daytona==0.155.0` (well above the v0.108.0 May 24 hard-cutoff), so the May 24 break doesn't affect us. The only place we used offset pagination was the legacy-sandbox resume path in `DaytonaEnvironment`.

## Changes
- `tools/environments/daytona.py`: replace `list(labels=..., page=1, limit=1).items[0]` with `next(iter(list(labels=..., limit=1)), None)`
- `tests/tools/test_daytona_environment.py`: drop `page=1` from list() call assertions, switch `SimpleNamespace(items=[...])` mocks to `iter([...])`

We don't shell out to `daytona sandbox` and we don't hit any `/api/workspace` endpoints — both also affected by the announcement but not used here.

## Validation
- `scripts/run_tests.sh tests/tools/test_daytona_environment.py` — 26/26 passing