### PR TITLE
fix(gateway): paginate Discord model picker options

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4883,6 +4883,8 @@ if DISCORD_AVAILABLE:
         Times out after 2 minutes.
         """
 
+        _MODEL_PAGE_SIZE = 25
+
         def __init__(
             self,
             providers: list,
@@ -4903,6 +4905,7 @@ if DISCORD_AVAILABLE:
             self.allowed_role_ids = allowed_role_ids or set()
             self.resolved = False
             self._selected_provider: str = ""
+            self._model_page: int = 0
 
             self._build_provider_select()
 
@@ -4910,6 +4913,34 @@ if DISCORD_AVAILABLE:
             return _component_check_auth(
                 interaction, self.allowed_user_ids, self.allowed_role_ids,
             )
+
+        def _provider_for_slug(self, provider_slug: str):
+            return next(
+                (p for p in self.providers if p["slug"] == provider_slug), None
+            )
+
+        def _model_select_description(self, provider: dict) -> str:
+            pname = provider.get("name", provider.get("slug", "provider"))
+            models = provider.get("models", [])
+            loaded_total = len(models)
+            reported_total = provider.get("total_models", loaded_total) or loaded_total
+
+            lines = [f"Provider: **{pname}**"]
+            if loaded_total:
+                start = self._model_page * self._MODEL_PAGE_SIZE
+                end = min(start + self._MODEL_PAGE_SIZE, loaded_total)
+                lines.append(f"Select a model (showing {start + 1}-{end} of {loaded_total}):")
+                if loaded_total > self._MODEL_PAGE_SIZE:
+                    lines.append("Use Next/Prev to browse more models.")
+            else:
+                lines.append("Select a model:")
+
+            if reported_total > loaded_total:
+                lines.append(
+                    f"*{reported_total - loaded_total} more available — "
+                    "type `/model <name>` directly*"
+                )
+            return "\n".join(lines)
 
         def _build_provider_select(self):
             """Build the provider dropdown menu."""
@@ -4943,18 +4974,24 @@ if DISCORD_AVAILABLE:
             cancel_btn.callback = self._on_cancel
             self.add_item(cancel_btn)
 
-        def _build_model_select(self, provider_slug: str):
+        def _build_model_select(self, provider_slug: str, page: int = 0):
             """Build the model dropdown for a specific provider."""
             self.clear_items()
-            provider = next(
-                (p for p in self.providers if p["slug"] == provider_slug), None
-            )
+            provider = self._provider_for_slug(provider_slug)
             if not provider:
                 return
 
             models = provider.get("models", [])
+            if models:
+                last_page = max((len(models) - 1) // self._MODEL_PAGE_SIZE, 0)
+                self._model_page = max(0, min(page, last_page))
+            else:
+                self._model_page = 0
+
+            start = self._model_page * self._MODEL_PAGE_SIZE
+            end = start + self._MODEL_PAGE_SIZE
             options = []
-            for model_id in models[:25]:
+            for model_id in models[start:end]:
                 short = model_id.split("/")[-1] if "/" in model_id else model_id
                 options.append(
                     discord.SelectOption(
@@ -4972,6 +5009,25 @@ if DISCORD_AVAILABLE:
             )
             select.callback = self._on_model_selected
             self.add_item(select)
+
+            if len(models) > self._MODEL_PAGE_SIZE:
+                prev_btn = discord.ui.Button(
+                    label="◀ Prev",
+                    style=discord.ButtonStyle.grey,
+                    custom_id="model_prev",
+                    disabled=self._model_page <= 0,
+                )
+                prev_btn.callback = self._on_model_prev
+                self.add_item(prev_btn)
+
+                next_btn = discord.ui.Button(
+                    label="Next ▶",
+                    style=discord.ButtonStyle.grey,
+                    custom_id="model_next",
+                    disabled=(self._model_page + 1) * self._MODEL_PAGE_SIZE >= len(models),
+                )
+                next_btn.callback = self._on_model_next
+                self.add_item(next_btn)
 
             back_btn = discord.ui.Button(
                 label="◀ Back", style=discord.ButtonStyle.grey, custom_id="model_back"
@@ -4994,21 +5050,50 @@ if DISCORD_AVAILABLE:
 
             provider_slug = interaction.data["values"][0]
             self._selected_provider = provider_slug
-            provider = next(
-                (p for p in self.providers if p["slug"] == provider_slug), None
-            )
+            self._model_page = 0
+            provider = self._provider_for_slug(provider_slug)
             pname = provider.get("name", provider_slug) if provider else provider_slug
 
-            self._build_model_select(provider_slug)
-
-            total = provider.get("total_models", 0) if provider else 0
-            shown = min(len(provider.get("models", [])), 25) if provider else 0
-            extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
+            self._build_model_select(provider_slug, page=0)
 
             await interaction.response.edit_message(
                 embed=discord.Embed(
                     title="⚙ Model Configuration",
-                    description=f"Provider: **{pname}**\nSelect a model:{extra}",
+                    description=(
+                        self._model_select_description(provider)
+                        if provider else f"Provider: **{pname}**\nSelect a model:"
+                    ),
+                    color=discord.Color.blue(),
+                ),
+                view=self,
+            )
+
+        async def _on_model_prev(self, interaction: discord.Interaction):
+            await self._turn_model_page(interaction, -1)
+
+        async def _on_model_next(self, interaction: discord.Interaction):
+            await self._turn_model_page(interaction, 1)
+
+        async def _turn_model_page(self, interaction: discord.Interaction, delta: int):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+
+            provider_slug = self._selected_provider
+            provider = self._provider_for_slug(provider_slug)
+            if not provider:
+                await interaction.response.send_message(
+                    "Provider no longer available~", ephemeral=True
+                )
+                return
+
+            self._build_model_select(provider_slug, page=self._model_page + delta)
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="⚙ Model Configuration",
+                    description=self._model_select_description(provider),
                     color=discord.Color.blue(),
                 ),
                 view=self,

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -14,6 +14,48 @@ import pytest
 from gateway.platforms.discord import ModelPickerView
 
 
+def _make_view(models: list[str], *, allowed_user_ids: set[int] | None = None) -> ModelPickerView:
+    view = ModelPickerView(
+        providers=[
+            {
+                "slug": "ollama-cloud",
+                "name": "Ollama Cloud",
+                "models": models,
+                "total_models": len(models),
+                "is_current": False,
+            }
+        ],
+        current_model="gpt-5.5",
+        current_provider="openai-codex",
+        session_key="session-1",
+        on_model_selected=AsyncMock(return_value="Model switched"),
+        allowed_user_ids=allowed_user_ids or set(),
+    )
+    view._selected_provider = "ollama-cloud"
+    return view
+
+
+def _child(view: ModelPickerView, custom_id: str):
+    return next(
+        child for child in view.children
+        if getattr(child, "custom_id", "") == custom_id
+    )
+
+
+def _model_values(view: ModelPickerView) -> list[str]:
+    return [option.value for option in _child(view, "model_model_select").options]
+
+
+def _page_interaction(user_id: int = 123) -> SimpleNamespace:
+    return SimpleNamespace(
+        user=SimpleNamespace(id=user_id),
+        response=SimpleNamespace(
+            send_message=AsyncMock(),
+            edit_message=AsyncMock(),
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_model_picker_clears_controls_before_running_switch_callback():
     events: list[object] = []
@@ -80,3 +122,63 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
     interaction.response.edit_message.assert_awaited_once()
     interaction.response.defer.assert_not_called()
     interaction.edit_original_response.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_picker_paginates_provider_models_past_discord_select_limit():
+    """Models after Discord's 25-option select cap must still be reachable."""
+    models = [f"model-{i:02d}" for i in range(1, 33)] + ["kimi-k2.6"]
+    view = _make_view(models)
+
+    view._build_model_select("ollama-cloud")
+
+    assert _model_values(view) == models[:25]
+    next_button = _child(view, "model_next")
+    assert next_button.disabled is False
+
+    interaction = _page_interaction()
+    await next_button.callback(interaction)
+
+    assert _model_values(view) == models[25:]
+    assert "kimi-k2.6" in _model_values(view)
+    interaction.response.edit_message.assert_awaited_once()
+
+
+def test_model_picker_omits_pagination_controls_at_discord_select_limit():
+    models = [f"model-{i:02d}" for i in range(1, 26)]
+    view = _make_view(models)
+
+    view._build_model_select("ollama-cloud")
+
+    assert _model_values(view) == models
+    custom_ids = {getattr(child, "custom_id", "") for child in view.children}
+    assert "model_prev" not in custom_ids
+    assert "model_next" not in custom_ids
+
+
+def test_model_picker_clamps_out_of_range_model_page():
+    models = [f"model-{i:02d}" for i in range(1, 54)]
+    view = _make_view(models)
+
+    view._build_model_select("ollama-cloud", page=999)
+
+    assert view._model_page == 2
+    assert _model_values(view) == models[50:]
+    assert _child(view, "model_prev").disabled is False
+    assert _child(view, "model_next").disabled is True
+
+
+@pytest.mark.asyncio
+async def test_model_picker_rejects_unauthorized_model_page_turn():
+    models = [f"model-{i:02d}" for i in range(1, 28)]
+    view = _make_view(models, allowed_user_ids={999})
+    view._build_model_select("ollama-cloud")
+
+    interaction = _page_interaction(user_id=123)
+    await _child(view, "model_next").callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "You're not authorized~", ephemeral=True
+    )
+    interaction.response.edit_message.assert_not_called()
+    assert _model_values(view) == models[:25]


### PR DESCRIPTION
## What does this PR do?

Draft: fixes the Discord `/model` picker truncating provider model lists at Discord's 25-option string-select limit.

Problem: providers can expose more than 25 models (for example Ollama Cloud), but the Discord picker only rendered the first 25. Models beyond that page were not selectable from the picker.

Current draft approach: add Prev/Next controls to page through the provider's loaded model list while keeping each string-select under Discord's 25-option limit.

## Related Issue

No issue found yet. Draft PR while validating approach and tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py`
  - Adds page state to `ModelPickerView`.
  - Shows one page of models per Discord string-select.
  - Adds Prev/Next buttons when a provider has more than 25 models.
- `tests/gateway/test_discord_model_picker.py`
  - Adds regression coverage for models beyond the first 25 entries.
  - Covers exactly-25 boundary behavior, out-of-range page clamping, and unauthorized page-turn rejection.

## How to Test

Manual Discord smoke testing is still pending, so this PR remains draft.

1. Reproduce in Discord with a provider exposing more than 25 models.
2. Open `/model`, choose that provider, and verify only the first page appears initially.
3. Click `Next`, verify later models are selectable, then select one and confirm the model switch succeeds.
4. Run CI-parity tests with `scripts/run_tests.sh`.

Validation so far:

- [x] `scripts/run_tests.sh tests/gateway/test_discord_model_picker.py -q` — 5 passed
- [x] `python -m ruff check gateway/platforms/discord.py tests/gateway/test_discord_model_picker.py` — passed
- [x] `scripts/run_tests.sh tests/gateway/test_discord_*.py -q` — 322 passed, 2 existing coroutine warnings in `test_discord_race_polish`
- [x] `scripts/run_tests.sh --tb=short -q` — attempted full wrapper run locally. It does not pass in this local checkout; failures are outside this PR's modified files.
- [x] Baseline check: reran the local full-run failure list in isolation on both this branch and a clean `origin/main` worktree. Both produced the same isolated result: 10 failed, 32 passed.
- [x] CI note: the upstream `main` Tests workflow is currently red too (same broad failure classes: missing optional deps such as `botocore`/`faster_whisper`/`numpy`, DingTalk/Feishu tests, and `lsp` startup-plugin gating). This PR's failing `test` check is not isolated to the Discord model picker diff.
- [ ] Manual Discord gateway smoke test
- [ ] Clean full-suite pass in CI/local clean environment

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Fedora Linux 44 / Discord gateway manual smoke test pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Pending. This PR stays draft until manual Discord smoke testing and clean full-suite/CI validation are complete.
