### PR TITLE
feat: add hard task orchestration and Discord controls

### DIFF
--- a/agent/hard_task_orchestrator.py
+++ b/agent/hard_task_orchestrator.py
@@ -1,0 +1,46 @@
+"""Prompt helpers for plan-first hard-task orchestration.
+
+This module is intentionally pure: it does not spawn workers or call external
+CLIs. Slash commands can use it to queue an execution-ready prompt into the
+normal Hermes loop, preserving existing tool approval, model routing, and
+platform behavior.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MAX_SLUG_LEN = 72
+
+
+def slugify_task(task: str) -> str:
+    """Return a stable, filesystem-friendly slug for a task description."""
+    words = re.findall(r"[a-z0-9]+", task.lower())
+    slug = "-".join(words)[:_MAX_SLUG_LEN].strip("-")
+    return slug or "hard-task"
+
+
+def build_orchestration_prompt(task: str) -> str:
+    """Build a prompt that makes Hermes run the hard-task orchestration workflow."""
+    task = task.strip()
+    slug = slugify_task(task)
+    plan_path = f".hermes/plans/{slug}.md"
+
+    return f"""Run this as a hard-task orchestrator mission.
+
+Task:
+{task}
+
+Required workflow:
+1. Gather prerequisite context first: repo status, relevant files, existing tests, failure logs, and acceptance criteria that can be inferred from the task.
+2. Create a plan document at `{plan_path}` before implementation. Do not implement before the plan document exists.
+3. The plan must include: refined spec, objectives and scope, acceptance criteria, file map, worker assignments, integration plan, verification commands, risks and assumptions, rollback plan, and checkpoint cadence.
+4. Prefer Claude Code Opus as planner when available. Request `claude-opus-4-7[1m]` first, then fall back to `claude-opus-4-7`, `opus[1m]`, then `opus`. Do not claim a model was used unless command output confirms it.
+5. Use independent implementation/review workers where useful: Claude/Sonnet workers with `claude-sonnet-4-6` or `claude-sonnet-4-6[1m]`, and a GPT/Hermes worker using `gpt-5.5` where appropriate.
+6. For long-running tasks, monitor worker progress with objective signals: git diff, logs, checkpoint notes, test output, and changed files. Do not trust worker self-reports without verifying.
+7. Keep diffs minimal and reversible. Do not broaden scope beyond the task.
+8. Integrate under the parent Hermes session: inspect final diff, run agreed tests/linters/builds, and verify external side effects yourself.
+9. Final report should be short: what changed, what was verified, and any unresolved risk.
+
+Start now by creating `{plan_path}` and then proceed through the workflow without asking for confirmation unless a destructive, paid, credential, or external publishing action is required.
+"""

--- a/cli.py
+++ b/cli.py
@@ -7545,6 +7545,8 @@ class HermesCLI:
             self._handle_agents_command()
         elif canonical == "background":
             self._handle_background_command(cmd_original)
+        elif canonical == "orchestrate":
+            self._handle_orchestrate_command(cmd_original)
         elif canonical == "queue":
             # Extract prompt after "/queue " or "/q "
             parts = cmd_original.split(None, 1)
@@ -7699,6 +7701,24 @@ class HermesCLI:
         
         return True
     
+    def _handle_orchestrate_command(self, cmd: str):
+        """Handle /orchestrate <task> by queueing a plan-first orchestration prompt."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /orchestrate <task>")
+            _cprint("  Example: /orchestrate Refactor gateway routing with tests")
+            return
+
+        from agent.hard_task_orchestrator import build_orchestration_prompt
+
+        task = parts[1].strip()
+        prompt = build_orchestration_prompt(task)
+        self._pending_input.put(prompt)
+        if getattr(self, "_agent_running", False):
+            _cprint(f"  Queued hard-task orchestrator for next turn: {task[:80]}{'...' if len(task) > 80 else ''}")
+        else:
+            _cprint(f"  Starting hard-task orchestrator: {task[:80]}{'...' if len(task) > 80 else ''}")
+
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -779,6 +779,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "require_mention_in_threads" in platform_cfg:
+                    bridged["require_mention_in_threads"] = platform_cfg["require_mention_in_threads"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -852,6 +854,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "require_mention_in_threads" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION_IN_THREADS"):
+                    os.environ["DISCORD_REQUIRE_MENTION_IN_THREADS"] = str(discord_cfg["require_mention_in_threads"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1330,8 +1330,23 @@ class APIServerAdapter(BasePlatformAdapter):
             }
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
+            buffered_text_chunks: List[str] = []
 
             # Helper — route a queue item to the correct SSE event.
+            fallback_filter_agent = None
+
+            def _filter_public_delta(text: str) -> str:
+                nonlocal fallback_filter_agent
+                agent = agent_ref[0] if agent_ref else None
+                if agent is None:
+                    if fallback_filter_agent is None:
+                        from run_agent import AIAgent
+                        fallback_filter_agent = AIAgent.__new__(AIAgent)
+                    agent = fallback_filter_agent
+                if hasattr(agent, "_filter_public_stream_scaffolding"):
+                    return agent._filter_public_stream_scaffolding(text)
+                return text
+
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
@@ -1348,12 +1363,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    if not isinstance(item, str):
+                        item = str(item)
+                    if item:
+                        buffered_text_chunks.append(item)
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
@@ -1388,6 +1401,22 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
+                final_text = result.get("final_response", "") if isinstance(result, dict) else ""
+                if not final_text and buffered_text_chunks:
+                    fallback_agent = fallback_filter_agent
+                    if fallback_agent is None:
+                        from run_agent import AIAgent
+                        fallback_agent = AIAgent.__new__(AIAgent)
+                    final_text = fallback_agent._strip_public_response_scaffolding(
+                        "".join(buffered_text_chunks)
+                    ).strip()
+                if final_text:
+                    content_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{"index": 0, "delta": {"content": final_text}, "finish_reason": None}],
+                    }
+                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
             except Exception as exc:
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
 
@@ -1635,7 +1664,24 @@ class APIServerAdapter(BasePlatformAdapter):
                     "item": item,
                 })
 
+            fallback_filter_agent = None
+
+            def _filter_public_delta(delta_text: str) -> str:
+                nonlocal fallback_filter_agent
+                agent = agent_ref[0] if agent_ref else None
+                if agent is None:
+                    if fallback_filter_agent is None:
+                        from run_agent import AIAgent
+                        fallback_filter_agent = AIAgent.__new__(AIAgent)
+                    agent = fallback_filter_agent
+                if hasattr(agent, "_filter_public_stream_scaffolding"):
+                    return agent._filter_public_stream_scaffolding(delta_text)
+                return delta_text
+
             async def _emit_text_delta(delta_text: str) -> None:
+                delta_text = _filter_public_delta(delta_text)
+                if not delta_text:
+                    return
                 await _open_message_item()
                 final_text_parts.append(delta_text)
                 await _write_event("response.output_text.delta", {

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3477,8 +3477,9 @@ class DiscordAdapter(BasePlatformAdapter):
         link = f"<#{thread_id}>" if thread_id else f"**{thread_name}**"
         await interaction.followup.send(f"Created thread {link}", ephemeral=True)
 
-        # Track thread participation so follow-ups don't require @mention
-        if thread_id:
+        # Track thread participation so follow-ups don't require @mention,
+        # unless this install is configured to require mentions in threads.
+        if thread_id and not self._discord_require_mention_in_threads():
             self._threads.mark(thread_id)
 
         # If a message was provided, kick off a new Hermes session in the thread
@@ -3553,6 +3554,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 return configured.lower() not in {"false", "0", "no", "off"}
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
+
+    def _discord_require_mention_in_threads(self) -> bool:
+        """Return whether participated Discord threads still require a bot mention."""
+        configured = self.config.extra.get("require_mention_in_threads")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("DISCORD_REQUIRE_MENTION_IN_THREADS", "false").lower() in ("true", "1", "yes", "on")
 
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
@@ -4210,7 +4220,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
-            in_bot_thread = is_thread and thread_id in self._threads
+            in_bot_thread = (
+                is_thread
+                and thread_id in self._threads
+                and not self._discord_require_mention_in_threads()
+            )
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
@@ -4233,7 +4247,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     is_thread = True
                     thread_id = str(thread.id)
                     auto_threaded_channel = thread
-                    self._threads.mark(thread_id)
+                    if not self._discord_require_mention_in_threads():
+                        self._threads.mark(thread_id)
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -4422,7 +4437,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         # Track thread participation so the bot won't require @mention for
         # follow-up messages in threads it has already engaged in.
-        if thread_id:
+        if thread_id and not self._discord_require_mention_in_threads():
             self._threads.mark(thread_id)
 
         # Only batch plain text messages — commands, media, etc. dispatch

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -251,6 +251,7 @@ class ThreadParticipationTracker:
 
     def mark(self, thread_id: str) -> None:
         """Mark *thread_id* as participated and persist."""
+        thread_id = str(thread_id)
         if thread_id not in self._threads:
             self._threads[thread_id] = None
             self._save()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -96,6 +96,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
+    CommandDef("orchestrate", "Run a plan-first hard-task orchestration prompt", "Session",
+               aliases=("orch",), args_hint="<task>"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1227,6 +1227,7 @@ DEFAULT_CONFIG = {
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
+        "require_mention_in_threads": False,  # Also require @mention in participated Discord threads
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3813,6 +3813,161 @@ class AIAgent:
         )
         return content
 
+    def _strip_public_response_scaffolding(self, content: str) -> str:
+        """Remove internal planning/refinement preambles from public replies."""
+        if not content:
+            return ""
+
+        content = self._strip_think_blocks(content).strip()
+        content = re.sub(
+            r"\A((?:#{1,6}\s*)?(?:\*\*)?Refined\s+"
+            r"(?:Prompt|Spec|Specification)(?:\*\*)?:?)"
+            r"(?=[ \t]*[-*][ \t]*(?:\*\*)?(?:Objective|Scope|Constraints|Acceptance criteria)\b)",
+            r"\1\n",
+            content,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        content = re.sub(
+            r"\A\s*(?:[^\w\s]{1,3}\s*)?\*\*Reasoning:\*\*\s*```.*?```\s*",
+            "",
+            content,
+            flags=re.DOTALL | re.IGNORECASE,
+        ).lstrip()
+
+        lines = content.splitlines()
+        start = 0
+        while start < len(lines) and not lines[start].strip():
+            start += 1
+        if start >= len(lines):
+            return ""
+
+        heading = re.sub(r"^[#>\s-]*", "", lines[start]).strip()
+        heading = heading.strip("*_` ").rstrip(":").strip().lower()
+        if heading not in {
+            "refined prompt",
+            "refined spec",
+            "refined specification",
+        }:
+            return content
+
+        preamble_start = start + 1
+        while preamble_start < len(lines) and not lines[preamble_start].strip():
+            preamble_start += 1
+
+        end = preamble_start
+        while end < len(lines) and lines[end].strip():
+            end += 1
+        if end >= len(lines):
+            return content
+
+        preamble = "\n".join(lines[preamble_start:end]).lower()
+        expected_fields = (
+            "objective",
+            "scope",
+            "constraints",
+            "acceptance criteria",
+            "risks/assumptions",
+            "validation",
+            "planned tests",
+            "minimal diffs",
+        )
+        if not any(field in preamble for field in expected_fields):
+            return content
+
+        return "\n".join(lines[end + 1:]).lstrip()
+
+    def _strip_public_response_scaffolding_from_codex_items(self, items):
+        """Clean Codex Responses message items before transcript persistence."""
+        if not isinstance(items, list):
+            return items
+
+        changed = False
+        cleaned_items = []
+        for item in items:
+            new_item = item
+            if isinstance(item, dict) and isinstance(item.get("content"), list):
+                new_content = []
+                item_changed = False
+                for part in item["content"]:
+                    new_part = part
+                    if (
+                        isinstance(part, dict)
+                        and part.get("type") == "output_text"
+                        and isinstance(part.get("text"), str)
+                    ):
+                        cleaned_text = self._strip_public_response_scaffolding(part["text"]).strip()
+                        if cleaned_text != part["text"]:
+                            new_part = dict(part)
+                            new_part["text"] = cleaned_text
+                            item_changed = True
+                    new_content.append(new_part)
+                if item_changed:
+                    new_item = dict(item)
+                    new_item["content"] = new_content
+                    changed = True
+            cleaned_items.append(new_item)
+
+        return cleaned_items if changed else items
+
+    def _filter_public_stream_scaffolding(self, text: str) -> str:
+        """Suppress leading internal scaffolding while streaming public text."""
+        if not text:
+            return ""
+        if getattr(self, "_public_stream_scaffolding_done", False):
+            return text
+
+        buffered = getattr(self, "_public_stream_scaffolding_buffer", "") + text
+        stripped = buffered.lstrip()
+        if not stripped:
+            self._public_stream_scaffolding_buffer = buffered
+            return ""
+
+        first_line = stripped.splitlines()[0] if stripped.splitlines() else stripped
+        heading = re.sub(r"^[#>\s-]*", "", first_line).strip()
+        heading = heading.strip("*_` ").rstrip(":").strip().lower()
+        valid_headings = (
+            "refined prompt",
+            "refined spec",
+            "refined specification",
+        )
+
+        if not any(candidate.startswith(heading) or heading.startswith(candidate) for candidate in valid_headings):
+            self._public_stream_scaffolding_done = True
+            self._public_stream_scaffolding_buffer = ""
+            return buffered
+
+        cleaned = self._strip_public_response_scaffolding(buffered)
+        if cleaned != buffered.strip():
+            self._public_stream_scaffolding_done = True
+            self._public_stream_scaffolding_buffer = ""
+            return cleaned
+
+        expected_fields = (
+            "objective",
+            "scope",
+            "constraints",
+            "acceptance criteria",
+            "risks/assumptions",
+            "validation",
+            "planned tests",
+            "minimal diffs",
+        )
+        body_lines = stripped.splitlines()[1:]
+        first_body_line = next((line.strip().lower() for line in body_lines if line.strip()), "")
+        if first_body_line and not any(field in first_body_line for field in expected_fields):
+            self._public_stream_scaffolding_done = True
+            self._public_stream_scaffolding_buffer = ""
+            return buffered
+
+        if len(buffered) > 4096:
+            self._public_stream_scaffolding_done = True
+            self._public_stream_scaffolding_buffer = ""
+            return buffered
+
+        self._public_stream_scaffolding_buffer = buffered
+        return ""
+
     @staticmethod
     def _has_natural_response_ending(content: str) -> bool:
         """Heuristic: does visible assistant text look intentionally finished?"""
@@ -7655,6 +7810,8 @@ class AIAgent:
                 if ctx_scrubber is not None:
                     think_tail = ctx_scrubber.feed(think_tail)
                 if think_tail:
+                    think_tail = self._filter_public_stream_scaffolding(think_tail)
+                if think_tail:
                     callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
                     for cb in callbacks:
                         try:
@@ -7669,6 +7826,8 @@ class AIAgent:
         if scrubber is not None:
             tail = scrubber.flush()
             if tail:
+                tail = self._filter_public_stream_scaffolding(tail)
+            if tail:
                 callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
                 for cb in callbacks:
                     try:
@@ -7677,6 +7836,8 @@ class AIAgent:
                         pass
                 self._record_streamed_assistant_text(tail)
         self._current_streamed_assistant_text = ""
+        self._public_stream_scaffolding_buffer = ""
+        self._public_stream_scaffolding_done = False
 
     def _record_streamed_assistant_text(self, text: str) -> None:
         """Accumulate visible assistant text emitted through stream callbacks."""
@@ -7757,6 +7918,7 @@ class AIAgent:
                 self, "_current_streamed_assistant_text", ""
             ):
                 text = text.lstrip("\n")
+            text = self._filter_public_stream_scaffolding(text)
         if not text:
             return
         callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
@@ -9956,7 +10118,7 @@ class AIAgent:
         # API replay, session transcript, gateway delivery, CLI display,
         # compression, title generation.
         if isinstance(_san_content, str) and _san_content:
-            _san_content = self._strip_think_blocks(_san_content).strip()
+            _san_content = self._strip_public_response_scaffolding(_san_content).strip()
 
         msg = {
             "role": "assistant",
@@ -10039,7 +10201,7 @@ class AIAgent:
         # flattening to plain text. This is required for prefix cache hits.
         codex_message_items = getattr(assistant_message, "codex_message_items", None)
         if codex_message_items:
-            msg["codex_message_items"] = codex_message_items
+            msg["codex_message_items"] = self._strip_public_response_scaffolding_from_codex_items(codex_message_items)
 
         if assistant_tool_calls:
             tool_calls = []
@@ -15066,7 +15228,7 @@ class AIAgent:
                             # old code injected "Calling the X tools..." which
                             # poisoned the conversation history.  Just use the
                             # fallback text as the final response and break.
-                            final_response = self._strip_think_blocks(fallback).strip()
+                            final_response = self._strip_public_response_scaffolding(fallback).strip()
                             self._response_was_previewed = True
                             break
 
@@ -15313,7 +15475,7 @@ class AIAgent:
                         truncated_response_prefix = ""
                         length_continue_retries = 0
                     
-                    final_response = self._strip_think_blocks(final_response).strip()
+                    final_response = self._strip_public_response_scaffolding(final_response).strip()
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 

--- a/tests/agent/test_hard_task_orchestrator.py
+++ b/tests/agent/test_hard_task_orchestrator.py
@@ -1,0 +1,28 @@
+"""Tests for hard-task orchestration prompt generation."""
+
+from agent.hard_task_orchestrator import build_orchestration_prompt, slugify_task
+
+
+def test_slugify_task_produces_stable_plan_slug():
+    assert slugify_task("Fix OAuth refresh + webhook retries!!!") == "fix-oauth-refresh-webhook-retries"
+
+
+def test_build_orchestration_prompt_contains_required_plan_first_contract():
+    prompt = build_orchestration_prompt("Refactor gateway routing for WhatsApp and Discord")
+
+    assert "Refactor gateway routing for WhatsApp and Discord" in prompt
+    assert ".hermes/plans/refactor-gateway-routing-for-whatsapp-and-discord.md" in prompt
+    assert "Do not implement before the plan document exists" in prompt
+    assert "acceptance criteria" in prompt.lower()
+    assert "rollback plan" in prompt.lower()
+
+
+def test_build_orchestration_prompt_documents_model_and_worker_policy():
+    prompt = build_orchestration_prompt("Implement a multi-file cache migration")
+
+    assert "claude-opus-4-7[1m]" in prompt
+    assert "claude-sonnet-4-6" in prompt
+    assert "claude-sonnet-4-6[1m]" in prompt
+    assert "gpt-5.5" in prompt
+    assert "checkpoint" in prompt.lower()
+    assert "monitor" in prompt.lower()

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -324,6 +324,25 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
 
 
+def test_config_bridges_require_mention_in_threads(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.require_mention_in_threads to env var."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "require_mention_in_threads": True,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_IN_THREADS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_REQUIRE_MENTION_IN_THREADS") == "true"
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -359,6 +359,7 @@ async def test_discord_auto_thread_can_be_disabled(adapter, monkeypatch):
 async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch):
     """Messages in a thread the bot has participated in should not require @mention."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION_IN_THREADS", raising=False)
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
 
@@ -374,6 +375,48 @@ async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "follow-up without mention"
     assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_can_require_mentions(adapter, monkeypatch):
+    """Strict mode keeps participated threads silent unless the bot is mentioned."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_IN_THREADS", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("456")
+
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(channel=thread, content="follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_strict_mode_allows_direct_mentions(adapter, monkeypatch):
+    """Strict thread mode still accepts explicit bot mentions."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_IN_THREADS", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("456")
+    bot_user = adapter._client.user
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(
+        channel=thread,
+        content=f"<@{bot_user.id}> follow-up with mention",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "follow-up with mention"
 
 
 @pytest.mark.asyncio

--- a/tests/test_hard_task_orchestrate_command.py
+++ b/tests/test_hard_task_orchestrate_command.py
@@ -1,0 +1,55 @@
+"""Tests for the /orchestrate CLI command."""
+
+import queue
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+def test_orchestrate_command_registered():
+    from hermes_cli.commands import resolve_command
+
+    cmd = resolve_command("orchestrate")
+    assert cmd is not None
+    assert cmd.name == "orchestrate"
+    assert cmd.args_hint == "<task>"
+
+
+def test_handle_orchestrate_command_requires_task():
+    cli_mod = _import_cli()
+    stub = SimpleNamespace(_pending_input=queue.Queue(), _agent_running=False)
+
+    with patch.object(cli_mod, "_cprint") as mock_cprint:
+        cli_mod.HermesCLI._handle_orchestrate_command(stub, "/orchestrate")
+
+    assert stub._pending_input.empty()
+    printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+    assert "Usage: /orchestrate <task>" in printed
+
+
+def test_handle_orchestrate_command_queues_generated_prompt():
+    cli_mod = _import_cli()
+    stub = SimpleNamespace(_pending_input=queue.Queue(), _agent_running=False)
+
+    with patch.object(cli_mod, "_cprint"):
+        cli_mod.HermesCLI._handle_orchestrate_command(stub, "/orchestrate Ship durable cron monitoring")
+
+    prompt = stub._pending_input.get_nowait()
+    assert "Ship durable cron monitoring" in prompt
+    assert ".hermes/plans/ship-durable-cron-monitoring.md" in prompt
+    assert "hard-task orchestrator" in prompt.lower()
+    assert stub._pending_input.empty()

--- a/tests/test_public_response_scaffolding.py
+++ b/tests/test_public_response_scaffolding.py
@@ -1,0 +1,102 @@
+from run_agent import AIAgent
+
+
+def _agent():
+    return AIAgent.__new__(AIAgent)
+
+
+def test_strip_refined_prompt_preamble_from_public_response():
+    text = """## Refined Prompt
+- **Objective:** Respond to a greeting.
+- **Scope:** Friendly acknowledgement.
+- **Constraints:** Keep it short.
+- **Acceptance criteria:** User feels greeted.
+- **Risks/assumptions:** Casual hello.
+- **Validation:** Relevant reply.
+- **Minimal diffs:** No changes.
+
+Hey! What can I help you with?"""
+
+    assert _agent()._strip_public_response_scaffolding(text) == "Hey! What can I help you with?"
+
+
+def test_strip_refined_spec_preamble_from_public_response():
+    text = """Refined Spec
+Objective: Answer directly.
+Scope: Discord chat.
+Constraints: No tools.
+Acceptance criteria: Brief response.
+Risks/assumptions: Casual context.
+Validation: Conversational.
+Minimal diffs: None.
+
+Hi aGamingGod"""
+
+    assert _agent()._strip_public_response_scaffolding(text) == "Hi aGamingGod"
+
+
+def test_strip_bold_refined_spec_with_blank_line_after_heading():
+    text = """**Refined Spec**
+
+- **Objective:** Clarify capabilities.
+- **Scope:** Discord chat.
+- **Constraints:** Hide internal scaffolding.
+- **Acceptance criteria:** Only the answer is visible.
+- **Validation:** Public response is direct.
+- **Minimal diffs:** No tool/file changes.
+
+I can help with coding, research, files, and automation."""
+
+    assert (
+        _agent()._strip_public_response_scaffolding(text)
+        == "I can help with coding, research, files, and automation."
+    )
+
+
+def test_strip_thinking_blocks_from_public_response():
+    text = "<think>private reasoning</think>\nVisible answer"
+
+    assert _agent()._strip_public_response_scaffolding(text) == "Visible answer"
+
+
+def test_strip_collapsed_refined_prompt_preamble_from_public_response():
+    text = """## Refined Prompt- **Objective:** Test sanitizer.
+- **Scope:** Public output.
+- **Constraints:** Keep visible answer.
+- **Acceptance criteria:** Only final line remains.
+
+VISIBLE_OK"""
+
+    assert _agent()._strip_public_response_scaffolding(text) == "VISIBLE_OK"
+
+
+def test_preserve_non_scaffolding_refined_prompt_text():
+    text = "Refined Prompt\nThis is a title, not the internal response scaffold."
+
+    assert _agent()._strip_public_response_scaffolding(text) == text
+
+
+def test_stream_filter_buffers_and_strips_refined_prompt_preamble():
+    agent = _agent()
+
+    assert agent._filter_public_stream_scaffolding("## Refined") == ""
+    assert agent._filter_public_stream_scaffolding(" Prompt\n- **Objective:** Test.\n") == ""
+    assert agent._filter_public_stream_scaffolding(
+        "- **Acceptance criteria:** Hide scaffold.\n\nVisible stream"
+    ) == "Visible stream"
+
+
+def test_stream_filter_buffers_blank_line_after_refined_spec_heading():
+    agent = _agent()
+
+    assert agent._filter_public_stream_scaffolding("**Refined Spec**\n\n") == ""
+    assert agent._filter_public_stream_scaffolding(
+        "- **Objective:** Test.\n- **Acceptance criteria:** Hide scaffold.\n\nVisible stream"
+    ) == "Visible stream"
+
+
+def test_stream_filter_passes_normal_text_immediately():
+    agent = _agent()
+
+    assert agent._filter_public_stream_scaffolding("Hello") == "Hello"
+    assert agent._filter_public_stream_scaffolding(" there") == " there"

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -302,6 +302,7 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 # Discord-specific settings
 discord:
   require_mention: true           # Require @mention in server channels
+  require_mention_in_threads: false # Also require @mention in participated threads
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -353,6 +354,12 @@ Free-response channels also **skip auto-threading** — the bot replies inline r
 When enabled, every `@mention` in a regular text channel automatically creates a new thread for the conversation. This keeps the main channel clean and gives each conversation its own isolated session history. Once a thread is created, subsequent messages in that thread don't require `@mention` — the bot knows it's already participating.
 
 Messages sent in existing threads or DMs are unaffected by this setting. Channels listed in `discord.free_response_channels` or `discord.no_thread_channels` also bypass auto-threading and get inline replies instead.
+
+#### `discord.require_mention_in_threads`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, existing Discord threads where the bot has already participated still require a direct `@mention`. This is useful when you want the bot to stay silent unless explicitly addressed, even in threads it created or previously answered in.
 
 #### `discord.reactions`
 


### PR DESCRIPTION
## Summary
- add hard task orchestration support and command wiring
- add public response scaffolding tests
- tighten Discord channel/thread controls and docs

## Test Plan
- DISCORD_REQUIRE_MENTION_IN_THREADS=false ./venv/Scripts/python.exe -m pytest -n 0 --basetemp="/c/Users/lucas/AppData/Local/hermes/hermes-agent/.tmp_pytest" tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_free_response.py tests/agent/test_hard_task_orchestrator.py tests/test_hard_task_orchestrate_command.py tests/test_public_response_scaffolding.py -q