### PR TITLE
fix(gateway): use psutil for cross-platform process start_time + cmdline detection

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -14,6 +14,7 @@ concurrently under distinct configurations).
 import hashlib
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -109,12 +110,31 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
-    stat_path = Path(f"/proc/{pid}/stat")
+    """Return a stable process-start identifier when available.
+
+    Uses ``psutil.Process(pid).create_time()`` so the kernel-reported boot
+    time of the PID is available on Linux, macOS, and Windows alike — the
+    legacy ``/proc/<pid>/stat`` path only worked on Linux, which silently
+    disabled stale-lock detection everywhere else.
+
+    Result is rounded to milliseconds so it serialises cleanly to JSON and
+    compares with `==` across restarts.  Returns ``None`` when the process
+    no longer exists, when access is denied, or when psutil itself is
+    unavailable (scaffold phase before ``psutil`` is pip-installed) — in
+    that case callers fall back to the cmdline identity check.
+
+    Format change vs. previous releases: old PID/lock files stored Linux
+    jiffies; new files store milliseconds.  Mixed values self-heal
+    because the stale-detection branch compares for equality and treats
+    any mismatch as stale.
+    """
     try:
-        # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text(encoding="utf-8").split()[21])
-    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        import psutil  # type: ignore
+    except ImportError:
+        return None
+    try:
+        return int(psutil.Process(int(pid)).create_time() * 1000)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError, ValueError):
         return None
 
 
@@ -126,9 +146,24 @@ def get_process_start_time(pid: int) -> Optional[int]:
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
-    On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
-    platforms without /proc, falls back to ``ps -p <pid> -o command=``.
+    Prefers ``psutil.Process(pid).cmdline()`` because it works identically
+    on Linux, macOS, and Windows without spawning a subprocess.  Falls back
+    to ``/proc/<pid>/cmdline`` (Linux) and finally to ``ps -p <pid> -o
+    command=`` (gated by ``shutil.which("ps")``) so the function still
+    yields something useful if psutil raises ``AccessDenied`` for a
+    privileged Apple daemon or is unavailable during the install scaffold.
     """
+    try:
+        import psutil  # type: ignore
+        try:
+            parts = psutil.Process(int(pid)).cmdline()
+            if parts:
+                return " ".join(parts)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            pass
+    except ImportError:
+        pass
+
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
         raw = cmdline_path.read_bytes()
@@ -138,23 +173,46 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         if raw:
             return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
 
-    try:
-        result = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "command="],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (OSError, subprocess.TimeoutExpired):
-        pass
+    ps_path = shutil.which("ps")
+    if ps_path:
+        try:
+            result = subprocess.run(
+                [ps_path, "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
 
     return None
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
-    """Return True when the live PID still looks like the Hermes gateway."""
+    """Return True when the live PID still looks like the Hermes gateway.
+
+    Fast-rejects system daemons (CloudDocs / FileProvider / launchd children
+    on macOS, svchost on Windows) via ``psutil.Process(pid).name()`` before
+    doing any cmdline string matching — that prefilter is what flips the
+    macOS PID-reuse case (issue #24067) from "process exists" to "process
+    is clearly not us".  Falls through to cmdline pattern matching when
+    the name check is inconclusive or unavailable.
+    """
+    try:
+        import psutil  # type: ignore
+        try:
+            proc_name = (psutil.Process(int(pid)).name() or "").lower()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            proc_name = ""
+        if proc_name:
+            allowed_prefixes = ("python", "hermes", "pythonw", "uv")
+            if not any(proc_name.startswith(prefix) for prefix in allowed_prefixes):
+                return False
+    except ImportError:
+        pass
+
     cmdline = _read_process_cmdline(pid)
     if not cmdline:
         return False
@@ -605,23 +663,26 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
-                if (
-                    existing.get("start_time") is not None
-                    and current_start is not None
-                    and current_start != existing.get("start_time")
-                ):
-                    stale = True
-                # When start_time comparison is unavailable (macOS / Windows
-                # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  If the PID was
-                # reused by an unrelated process the lock is stale.
-                if (
-                    not stale
-                    and existing.get("start_time") is None
-                    and current_start is None
-                    and not _looks_like_gateway_process(existing_pid)
-                ):
-                    stale = True
+                existing_start = existing.get("start_time")
+                if existing_start is not None and current_start is not None:
+                    # Both sides have a kernel start-time.  Equality means
+                    # this is still the same process; any mismatch (incl.
+                    # legacy jiffies vs. new milliseconds after the psutil
+                    # migration) signals PID reuse.
+                    if existing_start != current_start:
+                        stale = True
+                else:
+                    # At least one side is unknown — either psutil could
+                    # not read create_time (AccessDenied on a privileged
+                    # daemon, or an older lock file with start_time=None
+                    # from the pre-psutil era), or both platforms have no
+                    # /proc.  Fall back to the cmdline identity check:
+                    # if the live PID does not look like the gateway,
+                    # treat the lock as stale.  Closes the cross-platform
+                    # lockfile edge case (one side has start_time, other
+                    # does not).
+                    if not _looks_like_gateway_process(existing_pid):
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still appear alive to _pid_exists but are not
                 # actually running. Treat them as stale so --replace works.

--- a/tests/gateway/test_macos_stale_lock.py
+++ b/tests/gateway/test_macos_stale_lock.py
@@ -1,0 +1,462 @@
+"""Cross-platform stale-scoped-lock detection (issue #24067).
+
+These tests pin down the psutil-backed root-cause fix for the long-standing
+"macOS PID reused by a system process keeps the Telegram/Feishu/WeChat scoped
+lock alive" bug.  They are deliberately hermetic — they mock psutil so they
+run identically on Linux/macOS/Windows CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+import pytest
+
+from gateway import status
+
+
+_LOCK_HASH = "2bb80d537b1da3e3"  # sha256("secret")[:16] — matches existing fixtures
+
+
+def _write_lock(lock_dir, payload: dict[str, Any]):
+    lock_path = lock_dir / f"telegram-bot-token-{_LOCK_HASH}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(json.dumps(payload))
+    return lock_path
+
+
+class _FakeProc:
+    """Minimal stand-in for ``psutil.Process``.
+
+    Each attribute is either a value (returned) or a callable raising an
+    exception so individual accessors can be selectively denied.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: Any = "python",
+        cmdline: Any = None,
+        create_time: Any = 1_700_000.0,
+    ) -> None:
+        self._name = name
+        self._cmdline = cmdline if cmdline is not None else []
+        self._create_time = create_time
+
+    def name(self) -> str:
+        if isinstance(self._name, type) and issubclass(self._name, BaseException):
+            raise self._name()
+        return self._name
+
+    def cmdline(self) -> list[str]:
+        if isinstance(self._cmdline, type) and issubclass(self._cmdline, BaseException):
+            raise self._cmdline()
+        return list(self._cmdline)
+
+    def create_time(self) -> float:
+        if isinstance(self._create_time, type) and issubclass(self._create_time, BaseException):
+            raise self._create_time()
+        return float(self._create_time)
+
+
+def _install_fake_psutil(monkeypatch, *, proc_factory, pid_exists: bool = True):
+    """Replace cached ``psutil`` module with a fake exposing only what we use."""
+    import psutil
+
+    class _Module:
+        NoSuchProcess = psutil.NoSuchProcess
+        AccessDenied = psutil.AccessDenied
+        ZombieProcess = psutil.ZombieProcess
+
+        @staticmethod
+        def Process(pid):  # noqa: N802 — psutil API name
+            return proc_factory(pid)
+
+        @staticmethod
+        def pid_exists(pid):
+            return pid_exists
+
+    monkeypatch.setitem(sys.modules, "psutil", _Module)
+    return _Module
+
+
+class TestGetProcessStartTime:
+    def test_returns_milliseconds_int(self, monkeypatch):
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(create_time=1_700_000.123),
+        )
+        assert status._get_process_start_time(4242) == int(1_700_000.123 * 1000)
+
+    def test_returns_none_when_process_missing(self, monkeypatch):
+        import psutil
+
+        def _missing(_pid):
+            raise psutil.NoSuchProcess(_pid)
+
+        _install_fake_psutil(monkeypatch, proc_factory=_missing)
+        assert status._get_process_start_time(4242) is None
+
+    def test_returns_none_on_access_denied(self, monkeypatch):
+        import psutil
+
+        def _denied(_pid):
+            raise psutil.AccessDenied(_pid)
+
+        _install_fake_psutil(monkeypatch, proc_factory=_denied)
+        assert status._get_process_start_time(4242) is None
+
+    def test_returns_none_on_zombie(self, monkeypatch):
+        import psutil
+
+        def _zombie(_pid):
+            raise psutil.ZombieProcess(_pid)
+
+        _install_fake_psutil(monkeypatch, proc_factory=_zombie)
+        assert status._get_process_start_time(4242) is None
+
+    def test_self_returns_positive_value(self):
+        """End-to-end against the real psutil — works without /proc."""
+        value = status._get_process_start_time(os.getpid())
+        assert isinstance(value, int)
+        assert value > 0
+
+
+class TestReadProcessCmdline:
+    def test_prefers_psutil_cmdline(self, monkeypatch):
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"]
+            ),
+        )
+        assert (
+            status._read_process_cmdline(4242)
+            == "python -m hermes_cli.main gateway run"
+        )
+
+    def test_falls_back_to_ps_when_psutil_denies(self, monkeypatch):
+        import psutil
+
+        def _denied(_pid):
+            raise psutil.AccessDenied(_pid)
+
+        _install_fake_psutil(monkeypatch, proc_factory=_denied)
+
+        class _Result:
+            returncode = 0
+            stdout = "  /opt/hermes/bin/hermes gateway run --replace\n"
+
+        monkeypatch.setattr(status.shutil, "which", lambda name: "/bin/ps")
+        monkeypatch.setattr(status.subprocess, "run", lambda *a, **kw: _Result())
+        assert (
+            status._read_process_cmdline(4242)
+            == "/opt/hermes/bin/hermes gateway run --replace"
+        )
+
+    def test_skips_ps_when_not_on_path(self, monkeypatch):
+        import psutil
+
+        def _denied(_pid):
+            raise psutil.AccessDenied(_pid)
+
+        _install_fake_psutil(monkeypatch, proc_factory=_denied)
+        monkeypatch.setattr(status.shutil, "which", lambda name: None)
+
+        def _explode(*_a, **_kw):
+            raise AssertionError("subprocess.run must not be invoked when ps is absent")
+
+        monkeypatch.setattr(status.subprocess, "run", _explode)
+        assert status._read_process_cmdline(99_999_991) is None
+
+
+class TestLooksLikeGatewayProcess:
+    def test_rejects_non_python_name(self, monkeypatch):
+        """macOS PID reuse: name='FileProvider' must short-circuit to False."""
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="FileProvider",
+                cmdline=["com.apple.CloudDocs.iCloudDriveFileProvider"],
+            ),
+        )
+        assert status._looks_like_gateway_process(4242) is False
+
+    def test_accepts_python_name_and_matching_cmdline(self, monkeypatch):
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="python3.11",
+                cmdline=[
+                    "/opt/python/bin/python3.11",
+                    "-m",
+                    "hermes_cli.main",
+                    "gateway",
+                    "run",
+                ],
+            ),
+        )
+        assert status._looks_like_gateway_process(4242) is True
+
+    def test_python_name_but_unrelated_cmdline(self, monkeypatch):
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="python3.11",
+                cmdline=["python3.11", "-m", "pip", "install", "something"],
+            ),
+        )
+        assert status._looks_like_gateway_process(4242) is False
+
+    def test_accepts_hermes_binary_name(self, monkeypatch):
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="hermes-gateway",
+                cmdline=["/usr/local/bin/hermes-gateway"],
+            ),
+        )
+        assert status._looks_like_gateway_process(4242) is True
+
+    def test_access_denied_falls_through_to_cmdline_check(self, monkeypatch):
+        """If psutil cannot read name(), still trust cmdline."""
+        import psutil
+
+        class _PartialDenied(_FakeProc):
+            def name(self) -> str:  # type: ignore[override]
+                raise psutil.AccessDenied(0)
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _PartialDenied(
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"]
+            ),
+        )
+        assert status._looks_like_gateway_process(4242) is True
+
+
+class TestAcquireScopedLockStaleDetection:
+    def _setup_lock_dir(self, tmp_path, monkeypatch):
+        lock_dir = tmp_path / "locks"
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(lock_dir))
+        return lock_dir
+
+    def test_pid_reuse_by_system_process_releases_lock(self, tmp_path, monkeypatch):
+        """Issue #24067: macOS recycled PID, system daemon, no start_time."""
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        lock_path = _write_lock(
+            lock_dir,
+            {
+                "pid": 873,
+                "start_time": None,
+                "kind": "hermes-gateway",
+                "argv": [
+                    "/Users/u/.hermes/hermes-agent/hermes_cli/main.py",
+                    "gateway",
+                    "run",
+                    "--replace",
+                ],
+            },
+        )
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="FileProvider",
+                cmdline=["com.apple.CloudDocs.iCloudDriveFileProvider"],
+                create_time=2_100_000.0,
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_same_hermes_process_keeps_lock(self, tmp_path, monkeypatch):
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        _write_lock(
+            lock_dir,
+            {
+                "pid": 99999,
+                "start_time": int(1_700_000.123 * 1000),
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            },
+        )
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="python3.11",
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"],
+                create_time=1_700_000.123,
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is False
+        assert existing["pid"] == 99999
+
+    def test_pid_alive_but_start_time_mismatch_is_stale(self, tmp_path, monkeypatch):
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        lock_path = _write_lock(
+            lock_dir,
+            {
+                "pid": 99999,
+                "start_time": 1_000_000_000,
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            },
+        )
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="python3.11",
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"],
+                create_time=2_000_000.0,
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+    def test_legacy_jiffies_lock_is_replaced(self, tmp_path, monkeypatch):
+        """Locks with old Linux jiffies values self-heal under the psutil ms world."""
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        _write_lock(
+            lock_dir,
+            {
+                "pid": 99999,
+                "start_time": 4242,  # old Linux jiffies
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            },
+        )
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _FakeProc(
+                name="python3.11",
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"],
+                create_time=1_700_000.0,
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is True
+
+    def test_cross_platform_lockfile_one_sided_start_time_hermes(
+        self, tmp_path, monkeypatch
+    ):
+        """Lock has start_time, live process has None — fall back to cmdline (matches)."""
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        _write_lock(
+            lock_dir,
+            {
+                "pid": 99999,
+                "start_time": 1_700_000_000,
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            },
+        )
+
+        import psutil
+
+        class _CreateTimeDenied(_FakeProc):
+            def create_time(self) -> float:  # type: ignore[override]
+                raise psutil.AccessDenied(0)
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _CreateTimeDenied(
+                name="python3.11",
+                cmdline=["python", "-m", "hermes_cli.main", "gateway", "run"],
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is False
+        assert existing["pid"] == 99999
+
+    def test_cross_platform_lockfile_one_sided_start_time_other_process(
+        self, tmp_path, monkeypatch
+    ):
+        """Lock has start_time, live process has None, cmdline says NOT us → stale."""
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        _write_lock(
+            lock_dir,
+            {
+                "pid": 99999,
+                "start_time": 1_700_000_000,
+                "kind": "hermes-gateway",
+                "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            },
+        )
+
+        import psutil
+
+        class _CreateTimeDenied(_FakeProc):
+            def create_time(self) -> float:  # type: ignore[override]
+                raise psutil.AccessDenied(0)
+
+        _install_fake_psutil(
+            monkeypatch,
+            proc_factory=lambda pid: _CreateTimeDenied(
+                name="FileProvider",
+                cmdline=["com.apple.CloudDocs.iCloudDriveFileProvider"],
+            ),
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is True
+
+    def test_pid_gone_short_circuits_to_stale(self, tmp_path, monkeypatch):
+        lock_dir = self._setup_lock_dir(tmp_path, monkeypatch)
+        _write_lock(
+            lock_dir,
+            {"pid": 99999, "start_time": None, "kind": "hermes-gateway"},
+        )
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+
+        acquired, _existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+        assert acquired is True
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Smoke test inspects POSIX psutil behavior",
+)
+def test_real_process_start_time_is_stable_across_calls():
+    a = status._get_process_start_time(os.getpid())
+    b = status._get_process_start_time(os.getpid())
+    assert a is not None
+    assert a == b


### PR DESCRIPTION
## What

Replaces the `/proc/<pid>/stat`-based implementation of `_get_process_start_time()` with a `psutil.Process.create_time()`-based one, and extends the staleness detection in `acquire_scoped_lock()` to fall back to the cmdline identity check whenever either side of the start-time comparison is unavailable. Also adds a `psutil.Process.name()` prefilter to `_looks_like_gateway_process()` so system daemons are rejected without subprocess overhead.

## Why

Issue #24067: on macOS, when the gateway dies and the kernel recycles its PID to an unrelated system process (e.g. `com.apple.CloudDocs.iCloudDriveFileProvider`), the per-platform scoped lock (`gateway-locks/<scope>-<hash>.lock`) keeps blocking Telegram/Feishu/WeChat startup with `bot token already in use (PID XXX)`.

Root cause: `_get_process_start_time()` read `/proc/<pid>/stat` field 22 only, which returns `None` on macOS and Windows because `/proc` does not exist there. That silently disabled the precise start-time stale-check on two of three supported platforms. PR #24500 added a cmdline fallback that addressed the most common symptom, but left the root cause in place along with a cross-platform lockfile edge case: when one side of the comparison has a `start_time` and the other has `None` (e.g. WSL2 / NFS / container HERMES_HOME mounts, or psutil `AccessDenied`), neither branch of the previous staleness logic triggered.

`psutil` is already a hard dependency (`pyproject.toml: psutil==7.2.2`), so the cleanest fix is to lift the implementation onto it.

## How

- `_get_process_start_time(pid)` now uses `psutil.Process(pid).create_time()` rounded to milliseconds (int) for stable JSON serialisation. Returns `None` on `NoSuchProcess` / `AccessDenied` / `ZombieProcess` / `OSError` / `ValueError` / `ImportError`.
- `_read_process_cmdline(pid)` prefers `psutil.Process.cmdline()`, falls back to `/proc/<pid>/cmdline` (Linux fast path), then `ps -p <pid> -o command=` (gated by `shutil.which(\"ps\")`).
- `_looks_like_gateway_process(pid)` adds a `psutil.Process.name()` prefilter — if the lowered name does not start with `python` / `hermes` / `pythonw` / `uv`, return `False` fast. Cmdline pattern matching remains the authoritative check.
- `acquire_scoped_lock()` stale branch simplified: if both `existing.start_time` and `current_start` are non-`None`, compare for equality; otherwise fall through to `_looks_like_gateway_process()`. Closes the cross-platform lockfile edge case in both directions.

### Lock-file format migration

The `start_time` field's unit changes from Linux jiffies to milliseconds-since-epoch. The change is safe because every existing reader of the field uses strict equality (`==`) — no arithmetic, no range checks. Concretely audited in:

- `acquire_scoped_lock` self-takeover guard
- `acquire_scoped_lock` stale check
- `release_scoped_lock`
- `release_all_scoped_locks`
- `_consume_pid_marker_for_self`
- `gateway/run.py` `existing_start_time` → `release_all_scoped_locks(owner_start_time=...)`

A pre-existing lock with a jiffies value (small int) cannot equal the new milliseconds value (~1e12), so the equality check trips and the lock is treated as stale on next acquire — self-healing without migration.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_macos_stale_lock.py tests/gateway/test_status.py
```

The new `tests/gateway/test_macos_stale_lock.py` contains 21 hermetic tests (psutil mocked via `sys.modules` injection so they run identically on Linux/macOS/Windows CI):

- `_get_process_start_time` return shape, `NoSuchProcess` / `AccessDenied` / `ZombieProcess` paths, real-psutil smoke test
- `_read_process_cmdline` psutil preference, `ps` fallback gating, missing-`ps` path
- `_looks_like_gateway_process` non-Python-name short-circuit, Python+matching-cmdline accept, Python+unrelated-cmdline reject, hermes-binary accept, `name()` AccessDenied fall-through
- `acquire_scoped_lock` end-to-end: macOS PID-reuse-by-system-process, same-Hermes-keeps-lock, start-time-mismatch, legacy-jiffies self-heal, cross-platform-lockfile both directions, PID-gone short-circuit
- Two-call stability on real psutil

Manual reproduction of the original bug on macOS:

1. `hermes gateway run`
2. Note the gateway PID
3. `kill -9 <pid>` (no graceful shutdown → lock files remain)
4. Wait for macOS to recycle the PID to a system daemon (or use `ps` to find a PID matching a CloudDocs/FileProvider process)
5. `hermes gateway restart` — without this fix, Telegram/Feishu/WeChat fail with \"already in use (PID XXX)\". With this fix, the lock is detected as stale and replaced.

## Platforms tested

- macOS 26 (Apple M3 Max, Python 3.12)
- Test suite verified hermetically — Linux/Windows paths exercised via mocked psutil

## Related issues / PRs

- Closes #24067
- Closes #16376 (duplicate root cause)
- Closes #16586 (tracker)
- Supersedes the cmdline-only approach in open PRs #23925, #12448, #20492, #21018, #16423
- Builds on the merged cmdline fallback from #24500 (kept as a defence-in-depth layer)