### PR TITLE
feat(tui): add toast notifications

### DIFF
--- a/ui-tui/src/__tests__/toastStore.test.ts
+++ b/ui-tui/src/__tests__/toastStore.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  dismissToast,
+  getToastState,
+  patchToastState,
+  pushToast,
+  resetToastState
+} from '../app/toastStore.js'
+
+describe('toastStore', () => {
+  beforeEach(() => {
+    resetToastState()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts empty', () => {
+    expect(getToastState().toasts).toEqual([])
+  })
+
+  it('adds a toast', () => {
+    pushToast('copy', 'Copied to clipboard')
+
+    expect(getToastState().toasts).toHaveLength(1)
+    expect(getToastState().toasts[0]!.label).toBe('copy')
+    expect(getToastState().toasts[0]!.message).toBe('Copied to clipboard')
+    expect(getToastState().toasts[0]!.tone).toBe('info')
+  })
+
+  it('auto-dismisses after default duration', () => {
+    pushToast('copy', 'Copied to clipboard')
+    expect(getToastState().toasts).toHaveLength(1)
+
+    vi.advanceTimersByTime(3000)
+    expect(getToastState().toasts).toHaveLength(0)
+  })
+
+  it('honors custom duration', () => {
+    pushToast('copy', 'Copied to clipboard', 'info', 5000)
+
+    vi.advanceTimersByTime(3000)
+    expect(getToastState().toasts).toHaveLength(1)
+
+    vi.advanceTimersByTime(2000)
+    expect(getToastState().toasts).toHaveLength(0)
+  })
+
+  it('dedupes by label: replaces existing toast and resets timer', () => {
+    pushToast('copy', 'First copy')
+
+    vi.advanceTimersByTime(2000)
+    expect(getToastState().toasts).toHaveLength(1)
+    expect(getToastState().toasts[0]!.message).toBe('First copy')
+
+    pushToast('copy', 'Second copy')
+    expect(getToastState().toasts).toHaveLength(1)
+    expect(getToastState().toasts[0]!.message).toBe('Second copy')
+
+    vi.advanceTimersByTime(2000)
+    expect(getToastState().toasts).toHaveLength(1)
+
+    vi.advanceTimersByTime(1000)
+    expect(getToastState().toasts).toHaveLength(0)
+  })
+
+  it('keeps distinct labels as separate toasts', () => {
+    pushToast('copy', 'Copied')
+    pushToast('save', 'Saved')
+
+    expect(getToastState().toasts).toHaveLength(2)
+  })
+
+  it('caps toast count at limit and drops oldest', () => {
+    pushToast('a', 'A')
+    pushToast('b', 'B')
+    pushToast('c', 'C')
+    pushToast('d', 'D')
+    pushToast('e', 'E')
+
+    expect(getToastState().toasts).toHaveLength(4)
+    expect(getToastState().toasts.map(t => t.label)).toEqual(['b', 'c', 'd', 'e'])
+  })
+
+  it('manual dismiss removes toast immediately', () => {
+    pushToast('copy', 'Copied')
+    expect(getToastState().toasts).toHaveLength(1)
+
+    dismissToast(getToastState().toasts[0]!.id)
+    expect(getToastState().toasts).toHaveLength(0)
+  })
+
+  it('returned dismiss function removes toast', () => {
+    const dismiss = pushToast('copy', 'Copied')
+    expect(getToastState().toasts).toHaveLength(1)
+
+    dismiss()
+    expect(getToastState().toasts).toHaveLength(0)
+  })
+
+  it('resets to empty', () => {
+    pushToast('a', 'A')
+    pushToast('b', 'B')
+
+    resetToastState()
+    expect(getToastState().toasts).toEqual([])
+  })
+
+  it('supports different tones', () => {
+    pushToast('ok', 'Done', 'success')
+    pushToast('warn', 'Careful', 'warn')
+    pushToast('err', 'Failed', 'error')
+
+    const tones = getToastState().toasts.map(t => t.tone)
+    expect(tones).toEqual(['success', 'warn', 'error'])
+  })
+
+  it('patchToastState merges partial state', () => {
+    patchToastState({ toasts: [{ id: 1, label: 'x', message: 'm', tone: 'info', createdAt: 0 }] })
+    expect(getToastState().toasts).toHaveLength(1)
+  })
+})

--- a/ui-tui/src/app/toastStore.ts
+++ b/ui-tui/src/app/toastStore.ts
@@ -1,0 +1,75 @@
+import { atom } from 'nanostores'
+
+export type ToastTone = 'error' | 'info' | 'success' | 'warn'
+
+export interface ToastItem {
+  createdAt: number
+  id: number
+  label: string
+  message: string
+  tone: ToastTone
+}
+
+interface ToastState {
+  toasts: ToastItem[]
+}
+
+const buildToastState = (): ToastState => ({ toasts: [] })
+
+export const $toastState = atom<ToastState>(buildToastState())
+
+export const getToastState = () => $toastState.get()
+
+export const patchToastState = (next: Partial<ToastState> | ((state: ToastState) => ToastState)) =>
+  $toastState.set(typeof next === 'function' ? next($toastState.get()) : { ...$toastState.get(), ...next })
+
+export const resetToastState = () => $toastState.set(buildToastState())
+
+let toastIdCounter = 0
+const timers = new Map<number, ReturnType<typeof setTimeout>>()
+
+const DEFAULT_TOAST_DURATION_MS = 3000
+const TOAST_LIMIT = 4
+
+export function dismissToast(id: number) {
+  const t = timers.get(id)
+
+  if (t) {
+    clearTimeout(t)
+    timers.delete(id)
+  }
+
+  patchToastState(state => ({ ...state, toasts: state.toasts.filter(item => item.id !== id) }))
+}
+
+export function pushToast(
+  label: string,
+  message: string,
+  tone: ToastTone = 'info',
+  durationMs = DEFAULT_TOAST_DURATION_MS
+): () => void {
+  const now = Date.now()
+  const existing = getToastState().toasts.find(t => t.label === label)
+  const id = existing ? existing.id : ++toastIdCounter
+
+  if (existing) {
+    const oldTimer = timers.get(id)
+
+    if (oldTimer) {
+      clearTimeout(oldTimer)
+    }
+  }
+
+  patchToastState(state => {
+    const base = state.toasts.filter(t => t.label !== label)
+    const next = [...base, { id, label, message, tone, createdAt: now }].slice(-TOAST_LIMIT)
+
+    return { ...state, toasts: next }
+  })
+
+  const timer = setTimeout(() => dismissToast(id), durationMs)
+
+  timers.set(id, timer)
+
+  return () => dismissToast(id)
+}

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -22,6 +22,7 @@ import { resetFlowOverlays } from './overlayStore.js'
 import { pushSnapshot } from './spawnHistoryStore.js'
 import { archiveDoneTodos, getTurnState, patchTurnState, resetTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
+import { pushToast, type ToastTone } from './toastStore.js'
 
 const INTERRUPT_COOLDOWN_MS = 1500
 const ACTIVITY_LIMIT = 8
@@ -416,6 +417,10 @@ class TurnController {
 
       return { ...state, turnTrail: next }
     })
+  }
+
+  pushToast(label: string, message: string, tone?: ToastTone, durationMs?: number) {
+    return pushToast(label, message, tone, durationMs)
   }
 
   recordError() {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -27,6 +27,7 @@ import { MessageLine } from './messageLine.js'
 import { QueuedMessages } from './queuedMessages.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
+import { ToastLayer } from './toastLayer.js'
 
 const PromptPrefix = memo(function PromptPrefix({
   bold = false,
@@ -390,7 +391,7 @@ export const AppLayout = memo(function AppLayout({
 
   return (
     <Shell {...shellProps}>
-      <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="column" flexGrow={1} position="relative">
         <Box flexDirection="row" flexGrow={1}>
           {overlay.agents ? (
             <PerfPane id="agents">
@@ -426,6 +427,8 @@ export const AppLayout = memo(function AppLayout({
             )}
           </>
         )}
+
+        <ToastLayer cols={composer.cols} />
       </Box>
     </Shell>
   )

--- a/ui-tui/src/components/toastLayer.tsx
+++ b/ui-tui/src/components/toastLayer.tsx
@@ -1,0 +1,85 @@
+import { Box, Text } from '@hermes/ink'
+import { useStore } from '@nanostores/react'
+import { memo } from 'react'
+
+import { $toastState, dismissToast, type ToastTone } from '../app/toastStore.js'
+import { $uiState } from '../app/uiStore.js'
+import type { Theme } from '../theme.js'
+
+const NARROW_COLS_THRESHOLD = 30
+
+const toneIcon = (tone: ToastTone): string => {
+  switch (tone) {
+    case 'success':
+      return '✓ '
+    case 'error':
+      return '✗ '
+    case 'warn':
+      return '⚠ '
+    case 'info':
+    default:
+      return 'ℹ '
+  }
+}
+
+const toneColor = (tone: ToastTone, t: Theme): string => {
+  switch (tone) {
+    case 'success':
+      return t.color.ok
+    case 'error':
+      return t.color.error
+    case 'warn':
+      return t.color.warn
+    case 'info':
+    default:
+      return t.color.primary
+  }
+}
+
+const ToastItemView = memo(function ToastItemView({
+  message,
+  tone,
+  t
+}: {
+  message: string
+  tone: ToastTone
+  t: Theme
+}) {
+  return (
+    <Box
+      alignSelf="flex-end"
+      borderColor={toneColor(tone, t)}
+      borderStyle="round"
+      flexDirection="row"
+      marginBottom={1}
+      opaque
+      paddingX={1}
+    >
+      <Text bold color={toneColor(tone, t)}>
+        {toneIcon(tone)}
+      </Text>
+      <Text color={t.color.text} wrap="truncate-end">
+        {message}
+      </Text>
+    </Box>
+  )
+})
+
+export const ToastLayer = memo(function ToastLayer({ cols }: { cols: number }) {
+  const { toasts } = useStore($toastState)
+  const ui = useStore($uiState)
+
+  if (cols < NARROW_COLS_THRESHOLD || !toasts.length) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="column" position="absolute" right={1} top={1} zIndex={10}>
+      {toasts.map(item => (
+        <Box key={item.id} onClick={() => dismissToast(item.id)}>
+          <ToastItemView message={item.message} tone={item.tone} t={ui.theme} />
+        </Box>
+      ))}
+    </Box>
+  )
+})


### PR DESCRIPTION
## Summary
Implements a generic, reusable toast notification system for the Hermes TUI. This is the reusable toast parent for stacked PR #24585. No selectioncopy-specific behavior is included here.

## Changes
- Add `toastStore`: nanostores atom with `pushToast` / `dismissToast` / auto-dismiss timers
- Add dedupe/replace behavior: repeated same-label toasts replace the prior one and reset the timer
- Add `ToastLayer` component: top-right floating, theme-aware, transient with auto-dismiss
- Add narrow-terminal handling: layer hides when terminal width < 30 cols
- Mount `ToastLayer` in `AppLayout` via absolute positioning on a relative parent
- Add `turnController.pushToast()` convenience wrapper
- Add 12 focused Vitest tests covering push, dismiss, dedupe, timer reset, tone variants, and limits

## Validation

```
> hermes-tui@0.0.1 type-check
> tsc --noEmit -p tsconfig.json

> hermes-tui@0.0.1 test
> vitest run src/__tests__/toastStore.test.ts

 RUN  v4.1.4 /home/eloklam/Schreibtisch/Apps/hermes-agent/ui-tui

 ✓ src/__tests__/toastStore.test.ts (12 tests) 30ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  01:08:38
   Duration  500ms (transform 105ms, setup 0ms, import 157ms, tests 30ms, environment 0ms)

> hermes-tui@0.0.1 build
> node scripts/build.mjs

built /home/eloklam/Schreibtisch/Apps/hermes-agent/ui-tui/dist/entry.js
```

## Scope
Purely additive. No existing behavior is modified in this PR. The stacked selectioncopy PR (#24585) consumes this toast API.