### PR TITLE
fix(cli): align /cron slash handler with cron parser

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6933,6 +6933,9 @@ class HermesCLI:
                 "all": False,
                 "prompt": None,
                 "schedule": None,
+                "script": None,
+                "workdir": None,
+                "no_agent": None,
                 "positionals": [],
             }
             i = 0
@@ -6972,6 +6975,18 @@ class HermesCLI:
                 elif token == "--schedule" and i + 1 < len(tokens):
                     opts["schedule"] = tokens[i + 1]
                     i += 2
+                elif token == "--script" and i + 1 < len(tokens):
+                    opts["script"] = tokens[i + 1]
+                    i += 2
+                elif token == "--workdir" and i + 1 < len(tokens):
+                    opts["workdir"] = tokens[i + 1]
+                    i += 2
+                elif token == "--no-agent":
+                    opts["no_agent"] = True
+                    i += 1
+                elif token == "--agent":
+                    opts["no_agent"] = False
+                    i += 1
                 else:
                     opts["positionals"].append(token)
                     i += 1
@@ -6996,6 +7011,9 @@ class HermesCLI:
             print("    /cron resume <job_id>")
             print("    /cron run <job_id>")
             print("    /cron remove <job_id>")
+            print("    /cron status")
+            print("    /cron tick")
+            print('    /cron add "every 15m" --script watcher.py --no-agent')
             print()
             result = _cron_api(action="list")
             jobs = result.get("jobs", []) if result.get("success") else []
@@ -7047,13 +7065,13 @@ class HermesCLI:
 
         if subcommand in {"add", "create"}:
             positionals = opts["positionals"]
-            if not positionals:
+            if not positionals and not opts["schedule"]:
                 print("(._.) Usage: /cron add <schedule> <prompt>")
                 return
             schedule = opts["schedule"] or positionals[0]
             prompt = opts["prompt"] or " ".join(positionals[1:])
             skills = _normalize_skills(opts["skills"])
-            if not prompt and not skills:
+            if not prompt and not skills and not opts["no_agent"]:
                 print("(._.) Please provide a prompt or at least one skill")
                 return
             result = _cron_api(
@@ -7064,12 +7082,22 @@ class HermesCLI:
                 deliver=opts["deliver"],
                 repeat=opts["repeat"],
                 skills=skills or None,
+                script=opts["script"],
+                workdir=opts["workdir"],
+                no_agent=opts["no_agent"],
             )
             if result.get("success"):
                 print(f"(^_^)b Created job: {result['job_id']}")
                 print(f"  Schedule: {result['schedule']}")
                 if result.get("skills"):
                     print(f"  Skills: {', '.join(result['skills'])}")
+                job = result.get("job") or {}
+                if job.get("script"):
+                    print(f"  Script: {job['script']}")
+                if job.get("no_agent"):
+                    print("  Mode: no-agent (script stdout delivered directly)")
+                if job.get("workdir"):
+                    print(f"  Workdir: {job['workdir']}")
                 print(f"  Next run: {result['next_run_at']}")
             else:
                 print(f"(x_x) Failed to create job: {result.get('error')}")
@@ -7110,6 +7138,9 @@ class HermesCLI:
                 deliver=opts["deliver"],
                 repeat=opts["repeat"],
                 skills=final_skills,
+                script=opts["script"],
+                workdir=opts["workdir"],
+                no_agent=opts["no_agent"],
             )
             if result.get("success"):
                 job = result["job"]
@@ -7119,6 +7150,12 @@ class HermesCLI:
                     print(f"  Skills: {', '.join(job['skills'])}")
                 else:
                     print("  Skills: none")
+                if job.get("script"):
+                    print(f"  Script: {job['script']}")
+                if job.get("no_agent"):
+                    print("  Mode: no-agent (script stdout delivered directly)")
+                if job.get("workdir"):
+                    print(f"  Workdir: {job['workdir']}")
             else:
                 print(f"(x_x) Failed to update job: {result.get('error')}")
             return
@@ -7147,8 +7184,20 @@ class HermesCLI:
                 print(f"(^_^)b Removed job: {removed.get('name', job_id)} ({job_id})")
             return
 
+        if subcommand == "status":
+            from hermes_cli.cron import cron_status
+
+            cron_status()
+            return
+
+        if subcommand == "tick":
+            from hermes_cli.cron import cron_tick
+
+            cron_tick()
+            return
+
         print(f"(._.) Unknown cron command: {subcommand}")
-        print("  Available: list, add, edit, pause, resume, run, remove")
+        print("  Available: list, add, edit, pause, resume, run, remove, status, tick")
 
     def _handle_curator_command(self, cmd: str):
         """Handle /curator slash command.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -162,7 +162,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("search", "browse", "inspect", "install")),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
-               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
+               subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove", "status", "tick")),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),

--- a/tests/cli/test_cli_cron_command.py
+++ b/tests/cli/test_cli_cron_command.py
@@ -1,0 +1,113 @@
+"""Tests for the /cron CLI slash command."""
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+def _printed_text(mock_print) -> str:
+    return " ".join(" ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list)
+
+
+class TestCronSlashCommand(unittest.TestCase):
+    def test_create_forwards_script_no_agent_and_workdir(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace()
+        payload = {
+            "success": True,
+            "job_id": "job-1",
+            "schedule": "every 15m",
+            "skills": [],
+            "next_run_at": "2026-05-13T10:15:00Z",
+            "job": {
+                "script": "watcher.py",
+                "no_agent": True,
+                "workdir": "/tmp/project",
+            },
+        }
+
+        with (
+            patch("tools.cronjob_tools.cronjob", return_value=json.dumps(payload)) as mock_tool,
+            patch("builtins.print") as mock_print,
+        ):
+            cli_mod.HermesCLI._handle_cron_command(
+                stub,
+                '/cron add "every 15m" --script watcher.py --no-agent --workdir /tmp/project',
+            )
+
+        kwargs = mock_tool.call_args.kwargs
+        self.assertEqual(kwargs["action"], "create")
+        self.assertEqual(kwargs["schedule"], "every 15m")
+        self.assertEqual(kwargs["script"], "watcher.py")
+        self.assertEqual(kwargs["workdir"], "/tmp/project")
+        self.assertIs(kwargs["no_agent"], True)
+
+        printed = _printed_text(mock_print)
+        self.assertIn("Created job", printed)
+        self.assertIn("Script: watcher.py", printed)
+        self.assertIn("Mode: no-agent", printed)
+        self.assertIn("Workdir: /tmp/project", printed)
+
+    def test_edit_forwards_agent_toggle_and_script_clear(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace()
+        payload = {
+            "success": True,
+            "job": {
+                "job_id": "job-1",
+                "schedule": "every 2h",
+                "skills": [],
+                "workdir": "/tmp/project",
+            },
+        }
+
+        with (
+            patch.object(cli_mod, "get_job", return_value={"id": "job-1", "skills": [], "script": "watcher.py"}),
+            patch("tools.cronjob_tools.cronjob", return_value=json.dumps(payload)) as mock_tool,
+            patch("builtins.print"),
+        ):
+            cli_mod.HermesCLI._handle_cron_command(
+                stub,
+                '/cron edit job-1 --script "" --agent --workdir /tmp/project',
+            )
+
+        kwargs = mock_tool.call_args.kwargs
+        self.assertEqual(kwargs["action"], "update")
+        self.assertEqual(kwargs["job_id"], "job-1")
+        self.assertEqual(kwargs["script"], "")
+        self.assertEqual(kwargs["workdir"], "/tmp/project")
+        self.assertIs(kwargs["no_agent"], False)
+
+    def test_status_dispatches_to_shared_cron_helper(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace()
+
+        with patch("hermes_cli.cron.cron_status") as mock_status:
+            cli_mod.HermesCLI._handle_cron_command(stub, "/cron status")
+
+        mock_status.assert_called_once_with()
+
+    def test_tick_dispatches_to_shared_cron_helper(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace()
+
+        with patch("hermes_cli.cron.cron_tick") as mock_tick:
+            cli_mod.HermesCLI._handle_cron_command(stub, "/cron tick")
+
+        mock_tick.assert_called_once_with()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -622,6 +622,8 @@ class TestSubcommands:
         assert "/cron" in SUBCOMMANDS
         assert "list" in SUBCOMMANDS["/cron"]
         assert "add" in SUBCOMMANDS["/cron"]
+        assert "status" in SUBCOMMANDS["/cron"]
+        assert "tick" in SUBCOMMANDS["/cron"]
 
     def test_commands_without_subcommands_not_in_dict(self):
         """Plain commands should not appear in SUBCOMMANDS."""


### PR DESCRIPTION
## What does this PR do?

Fixes the interactive `/cron` slash command so it matches the real cron CLI surface more closely.

It now forwards `--script`, `--workdir`, `--no-agent`, and `--agent` correctly, and adds `/cron status` and `/cron tick` support. This prevents script-backed cron jobs from losing important options when created or edited from chat.

## Related Issue

--

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor

## Changes Made

- updated `/cron` slash parsing in `cli.py`
- added `status` and `tick` to cron subcommand metadata
- added regression tests for slash-command forwarding and dispatch

## How to Test

1. `uv run pytest tests/cli/test_cli_cron_command.py tests/hermes_cli/test_commands.py`
2. `uv run ruff check cli.py hermes_cli/commands.py tests/cli/test_cli_cron_command.py tests/hermes_cli/test_commands.py`


