### PR TITLE
fix(auxiliary_client): _get_cached_client honors normalize_resolved_model on caller-passed model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3773,7 +3773,18 @@ def _get_cached_client(
                 _client_cache[cache_key] = (client, default_model, bound_loop)
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    # Re-apply model name normalization on the raw caller-passed `model` so
+    # the caller's explicit override still wins (preserving existing
+    # caller-wins semantics) but the namespace-stripping that
+    # `resolve_provider_client` performed via `_normalize_resolved_model`
+    # isn't silently bypassed. Without this, namespaced model names like
+    # "my-provider/claude-haiku-4-5" leak past the resolver's normalization
+    # and arrive at the wire unstripped — the Anthropic API rejects them
+    # with a 404 "model not found". `default_model` is the resolver's
+    # already-normalized `final_model`, so any normalization failure falls
+    # back to it safely.
+    normalized_caller_model = _normalize_resolved_model(model, provider) if model else None
+    return client, normalized_caller_model or default_model
 
 
 def _resolve_task_provider_model(


### PR DESCRIPTION
## Summary

`_get_cached_client` returns `model or default_model` as the second tuple element. When the caller passes a model name (always truthy, e.g. from a `fallback_model` entry, a `_PROVIDER_MODELS` namespaced ID, or any explicit `call_llm(model=...)`), the raw caller input wins — **bypassing the namespace stripping that `resolve_provider_client` performed via `_normalize_resolved_model`**.

For providers in `_DOT_TO_HYPHEN_PROVIDERS` (`anthropic` is the bundled one — third-party plugin providers extending the set hit this too), this means namespaced model IDs like `anthropic/claude-haiku-4-5` leak past the resolver's normalization and arrive at the wire unstripped. `api.anthropic.com` then 404s with `model not found: anthropic/claude-haiku-4-5`.

The reason this hasn't been noticed broadly is most callers happen to pass already-normalized names. But any caller passing the namespaced form (which `_PROVIDER_MODELS` advertises for some providers, and which fallback chains routinely produce) silently fails — for Anthropic-wire providers the failure is fatal.

## Reproduction

```python
import providers; providers._discover_providers()
from agent.auxiliary_client import _get_cached_client

client, model = _get_cached_client("anthropic", "anthropic/claude-haiku-4-5")
print(model)  # → 'anthropic/claude-haiku-4-5' (pre-fix), should be 'claude-haiku-4-5'
```

The inner call to `resolve_provider_client` correctly normalizes `default_model` to `claude-haiku-4-5`, but `return client, model or default_model` then echoes the raw caller input.

Downstream: `call_llm` passes `'anthropic/claude-haiku-4-5'` into `_build_call_kwargs` → `_AnthropicCompletionsAdapter.create` → `anthropic.NotFoundError: 404 model: anthropic/claude-haiku-4-5`.

## Fix

Re-apply `_normalize_resolved_model` on the raw caller-passed `model` before falling back to `default_model`. Preserves the existing **caller-wins** semantics (caller's explicit override still wins over the provider's default) but no longer bypasses namespace stripping.

```diff
             else:
                 client, default_model, _ = _client_cache[cache_key]
-    return client, model or default_model
+    normalized_caller_model = _normalize_resolved_model(model, provider) if model else None
+    return client, normalized_caller_model or default_model
```

When `model` is `None` (no caller override), behavior is unchanged — `default_model` (the resolver's `final_model`, already normalized) is returned. When `model` is truthy, it now runs through the same normalizer the resolver used, so cache-hit and cache-miss paths agree on the canonical form.

## Test plan

Verification script asserts the proximate behavior AND that the `model=None` fallback path is unchanged:

```
[PASS] _get_cached_client honors normalization: 'claude-haiku-4-5'
[PASS] _get_cached_client(model=None) returns normalized default: 'claude-haiku-4-5'
[PASS] _get_cached_client handles weird namespaces without crashing: 'claude-haiku-4-5'
```

Downstream symptom: with this fix applied, `call_llm(provider='anthropic', model='anthropic/claude-haiku-4-5', ...)` succeeds end-to-end against `api.anthropic.com`. Without the fix it raises `anthropic.NotFoundError: 404`.

## Companion PR

This composes with [#24586](https://github.com/NousResearch/hermes-agent/pull/24586) (resolver consults `ProviderProfile.api_mode`). Either can land first:

- **#24586** makes `api_mode="anthropic_messages"` work for plugin providers without URL-suffix hacks.
- **This PR** makes the namespace stripping the resolver performs survive through the cache layer.

Together they fully enable third-party plugin providers that target Anthropic-Messages-API endpoints (local proxies, gateways) to work via `call_llm` without per-call workarounds.

## Scope

- **IN:** One-line behavioral fix in `_get_cached_client`. Re-applies an existing normalizer; introduces no new logic.
- **OUT:** Changes to `_normalize_resolved_model`, `_compat_model`, or the dispatch table itself. Those are working as intended.
- **OUT:** Provider-specific behaviors. The fix is universal.

## Risk

Low. The normalizer is idempotent — running it twice (once in the resolver, once here) produces the same output. For callers passing already-normalized names (the current dominant case), behavior is identical. For callers passing namespaced names, the bug is fixed.

The `_normalize_resolved_model` wrapper at line 2622 already has `try/except` returning the original name on any error, so an unfamiliar provider hitting the normalizer can't break anything.
