### PR TITLE
fix(gateway): consult lock record argv when cmdline is unreadable in scoped-lock stale check

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -613,15 +613,20 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     stale = True
                 # When start_time comparison is unavailable (macOS / Windows
                 # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  If the PID was
-                # reused by an unrelated process the lock is stale.
+                # checking the live process command line.  When cmdline is
+                # also unreadable (Windows has no ps), consult the lock
+                # record's own argv — the gateway writes it at startup and
+                # it's the only identity signal on platforms without ps.
+                # Both oracles must indicate "not a gateway" to mark stale.
                 if (
                     not stale
                     and existing.get("start_time") is None
                     and current_start is None
                     and not _looks_like_gateway_process(existing_pid)
                 ):
-                    stale = True
+                    live_cmdline = _read_process_cmdline(existing_pid)
+                    if live_cmdline is not None or not _record_looks_like_gateway(existing):
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still appear alive to _pid_exists but are not
                 # actually running. Treat them as stale so --replace works.

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -468,6 +468,9 @@ class TestScopedLocks:
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
         monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        # On macOS ``ps`` is available, so _read_process_cmdline returns the
+        # unrelated process's name.  This confirms the PID was reused.
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/usr/libexec/bluetoothuserd")
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
@@ -475,6 +478,37 @@ class TestScopedLocks:
         payload = json.loads(lock_path.read_text())
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway(self, tmp_path, monkeypatch):
+        """Windows regression: ps unavailable so cmdline cannot be read.
+
+        When start_time is None on both sides and _looks_like_gateway_process
+        returns False because ps is missing (not because the PID belongs to an
+        unrelated process), the stale check must not delete a valid gateway
+        lock.  Fall back to the lock record's own argv — written by the
+        gateway at startup — before declaring the lock stale.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        # Windows: ps not available, so _read_process_cmdline returns None
+        # and _looks_like_gateway_process returns False for every process.
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is False
+        assert existing["pid"] == 99999
 
     def test_acquire_scoped_lock_keeps_lock_when_pid_reused_by_gateway(self, tmp_path, monkeypatch):
         """When start_time is None but the live PID still looks like a gateway, keep the lock."""


### PR DESCRIPTION
## Problem

PR #24500 introduced stale-lock detection for `acquire_scoped_lock`. When `start_time` is unavailable on both sides (macOS / Windows have no `/proc`), the code falls back to `_looks_like_gateway_process` to confirm the running PID is still a gateway process:

```python
if (
    not stale
    and existing.get("start_time") is None
    and current_start is None
    and not _looks_like_gateway_process(existing_pid)
):
    stale = True
```

On **Windows**, neither `/proc` nor `ps` is available, so `_read_process_cmdline` always returns `None` and `_looks_like_gateway_process` always returns `False` — regardless of what process is actually running. This causes every valid Windows gateway lock to be immediately evicted as stale, making scoped locking effectively non-functional on Windows.

## Fix

After `_looks_like_gateway_process` returns `False`, call `_read_process_cmdline` directly:

- **Non-`None` result** → the live cmdline was readable and confirms the PID is a foreign process → mark stale (macOS behaviour, existing test updated to reflect this).
- **`None` result** → cmdline is unreadable (Windows without `ps`). Fall back to `_record_looks_like_gateway`, which validates the `argv` the gateway wrote into the lock file at startup. If the record identifies as a gateway, **keep the lock**.

This is the same two-oracle pattern already used in `get_running_pid` (line 941):

```python
if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
```

Both oracles must indicate "not a gateway" before the lock is evicted.

## Changes

- **`gateway/status.py`** — 5-line change inside `acquire_scoped_lock`'s stale-detection block.
- **`tests/gateway/test_status.py`**:
  - Updated `test_acquire_scoped_lock_replaces_pid_reused_by_unrelated_process` to mock `_read_process_cmdline` returning a non-`None` value (simulating macOS where `ps` confirms PID reuse).
  - Added `test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway` — simulates a Windows host where `_looks_like_gateway_process` is always `False` and `_read_process_cmdline` is always `None`, confirms the lock is preserved when the record argv identifies it as a gateway.

## Test

```
50 passed in 0.47s
```