### PR TITLE
fix(gateway): fail-close Telegram auth when TELEGRAM_ALLOWED_USERS is empty; warn on ALLOW_ALL

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -496,7 +496,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
         allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
         if not allowed_csv:
-            return True
+            _global_open = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+            _tg_open = os.getenv("TELEGRAM_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+            return _global_open or _tg_open
         allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3363,6 +3363,13 @@ class GatewayRunner:
                 "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "
                 "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id)."
             )
+        elif _allow_all:
+            logger.warning(
+                "SECURITY WARNING: Gateway is open to ALL users (*_ALLOW_ALL_USERS=true). "
+                "Any user who finds this bot can interact with your local agent "
+                "(filesystem, terminal, credentials). "
+                "Set TELEGRAM_ALLOWED_USERS / DISCORD_ALLOWED_USERS etc. to restrict access."
+            )
         
         # Discover Python plugins before shell hooks so plugin block
         # decisions take precedence in tie cases.  The CLI startup path

--- a/tests/gateway/test_telegram_auth_fail_closed.py
+++ b/tests/gateway/test_telegram_auth_fail_closed.py
@@ -1,0 +1,42 @@
+"""Tests for Telegram _is_authorized_user failing closed when no allowlist is set."""
+
+
+def _simulate_is_authorized(user_id: str, env: dict) -> bool:
+    """Replicate the env-based auth logic from TelegramAdapter._is_authorized_user."""
+    allowed_csv = env.get("TELEGRAM_ALLOWED_USERS", "").strip()
+    if not allowed_csv:
+        _global_open = env.get("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+        _tg_open = env.get("TELEGRAM_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+        return _global_open or _tg_open
+    allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+    return "*" in allowed_ids or user_id in allowed_ids
+
+
+class TestTelegramAuthFailClosed:
+    def test_no_allowlist_no_allow_all_denies(self):
+        result = _simulate_is_authorized("999", {})
+        assert result is False
+
+    def test_no_allowlist_gateway_allow_all_true_permits(self):
+        result = _simulate_is_authorized("999", {"GATEWAY_ALLOW_ALL_USERS": "true"})
+        assert result is True
+
+    def test_no_allowlist_telegram_allow_all_true_permits(self):
+        result = _simulate_is_authorized("999", {"TELEGRAM_ALLOW_ALL_USERS": "1"})
+        assert result is True
+
+    def test_no_allowlist_allow_all_false_string_denies(self):
+        result = _simulate_is_authorized("999", {"GATEWAY_ALLOW_ALL_USERS": "false"})
+        assert result is False
+
+    def test_known_user_in_allowlist_permits(self):
+        result = _simulate_is_authorized("123456", {"TELEGRAM_ALLOWED_USERS": "123456,789012"})
+        assert result is True
+
+    def test_unknown_user_in_allowlist_denies(self):
+        result = _simulate_is_authorized("000000", {"TELEGRAM_ALLOWED_USERS": "123456,789012"})
+        assert result is False
+
+    def test_wildcard_in_allowlist_permits_anyone(self):
+        result = _simulate_is_authorized("999999", {"TELEGRAM_ALLOWED_USERS": "*"})
+        assert result is True


### PR DESCRIPTION
## Problem

When `TELEGRAM_ALLOWED_USERS` is unset, `TelegramAdapter._is_authorized_user()` returns `True` unconditionally — any Telegram account that discovers the bot gets full local agent access (filesystem, terminal, GitHub). The `gateway/run.py` startup log also emits **no warning** when `GATEWAY_ALLOW_ALL_USERS=true` is set, the most dangerous open state.

## Root cause

`gateway/platforms/telegram.py` line 498–499:
```python
allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
if not allowed_csv:
    return True    # fails OPEN when env var is absent
```

`gateway/run.py` line 3360–3365 only warns when neither allowlist nor allow-all is set; it is silent when `_allow_all=True`.

## Fix

**`gateway/platforms/telegram.py`** — fail closed when no allowlist is configured; permit only when an explicit allow-all flag is set:
```python
if not allowed_csv:
    _global_open = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
    _tg_open = os.getenv("TELEGRAM_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
    return _global_open or _tg_open
```

**`gateway/run.py`** — add a loud `SECURITY WARNING` log when `*_ALLOW_ALL_USERS=true` is active, so operators are never silently in the open state.

```mermaid
flowchart TD
    A[Telegram update received] --> B{auth_fn available?}
    B -- yes --> C[auth_fn result]
    B -- no / raises --> D{TELEGRAM_ALLOWED_USERS set?}
    D -- yes --> E{user_id in allowlist or wildcard?}
    E -- yes --> PERMIT
    E -- no --> DENY
    D -- no --> F{GATEWAY_ALLOW_ALL_USERS or TELEGRAM_ALLOW_ALL_USERS = true?}
    F -- yes --> PERMIT
    F -- no --> DENY
```

## Tests

New `tests/gateway/test_telegram_auth_fail_closed.py` — 7 cases:

| Scenario | Expected |
|---|---|
| No allowlist, no allow-all flags | `False` (deny) |
| No allowlist, `GATEWAY_ALLOW_ALL_USERS=true` | `True` (permit) |
| No allowlist, `TELEGRAM_ALLOW_ALL_USERS=1` | `True` (permit) |
| No allowlist, `GATEWAY_ALLOW_ALL_USERS=false` | `False` (deny) |
| Known user in `TELEGRAM_ALLOWED_USERS` | `True` (permit) |
| Unknown user in `TELEGRAM_ALLOWED_USERS` | `False` (deny) |
| Wildcard `*` in allowlist | `True` (permit) |

All 7 pass.

Closes #24457