### PR TITLE
fix(agent): preserve reasoning_content for Xiaomi MiMo thinking mode (#24443)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -440,6 +440,61 @@ def _is_kimi_family_endpoint(base_url: str | None, model: str | None = None) -> 
     return False
 
 
+_XIAOMI_MIMO_BARE_PREFIXES = ("mimo-",)
+_XIAOMI_MIMO_CATALOG_PREFIXES = ("xiaomi/",)
+
+
+def _model_name_is_xiaomi_mimo(model: str | None) -> bool:
+    """Return True for Xiaomi MiMo model identifiers.
+
+    Detection covers three slot shapes so third-party catalogs (OpenRouter,
+    Nous Portal, private gateways) match alongside the native MiMo API:
+
+    1. Catalog prefix ``xiaomi/`` (e.g. ``xiaomi/mimo-v2.5-pro``).
+    2. Bare prefix ``mimo-`` (e.g. ``mimo-v2.5-pro``).
+    3. Embedded ``/mimo-`` for namespaced third-party slots
+       (e.g. ``openrouter/mimo-v2.5-pro``).
+
+    The match is intentionally narrow: ``mimo_`` and ``xiaomi-mimo-`` are
+    not accepted because no published MiMo catalog uses those forms, and
+    accepting them risks false positives on lookalikes (e.g. ``mimowave``,
+    ``mistral-mimo``-style internal prototypes).  Negative guards are
+    asserted in the test suite (MiniMax, Mistral, Phi-4, ``mimowave``).
+    Refs hermes-agent#24443.
+    """
+    if not isinstance(model, str):
+        return False
+    m = model.strip().lower()
+    if not m:
+        return False
+    if m.startswith(_XIAOMI_MIMO_CATALOG_PREFIXES):
+        return True
+    if m.startswith(_XIAOMI_MIMO_BARE_PREFIXES):
+        return True
+    return "/mimo-" in m
+
+
+def _is_xiaomi_mimo_anthropic_endpoint(
+    base_url: str | None, model: str | None = None
+) -> bool:
+    """Return True for Xiaomi MiMo Anthropic-Messages-speaking endpoints.
+
+    MiMo thinking mode follows the same replay contract as Kimi / Moonshot
+    and DeepSeek's ``/anthropic`` route: when conversation history contains
+    an assistant tool call, the prior ``reasoning_content`` must round-trip
+    on subsequent turns.  In the Anthropic Messages protocol this is
+    represented as an unsigned ``thinking`` block before the ``tool_use``
+    block.  Without preservation the next request fails with HTTP 400
+    ("The reasoning_content in the thinking mode must be passed back to
+    the API.").  Refs hermes-agent#24443.
+    """
+    if _model_name_is_xiaomi_mimo(model):
+        return True
+    if base_url_host_matches(base_url or "", "xiaomimimo.com"):
+        return True
+    return False
+
+
 def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for DeepSeek's Anthropic-compatible endpoint.
 
@@ -1480,11 +1535,12 @@ def convert_messages_to_anthropic(
     Anthropic-proprietary — third-party endpoints cannot validate them and will
     reject them with HTTP 400 "Invalid signature in thinking block".
 
-    When *model* is provided and matches the Kimi / Moonshot family (or
-    *base_url* is a Kimi / Moonshot host), unsigned thinking blocks
-    synthesised from ``reasoning_content`` are preserved on replayed
-    assistant tool-call messages — Kimi requires the field to exist, even
-    if empty.
+    When *model* / *base_url* identifies a provider with strict thinking
+    replay validation (Kimi / Moonshot, DeepSeek ``/anthropic``, Xiaomi
+    MiMo), unsigned thinking blocks synthesised from ``reasoning_content``
+    are preserved on replayed assistant tool-call messages.  These
+    providers require the prior reasoning payload to round-trip when
+    thinking mode is enabled.
     """
     system = None
     result = []
@@ -1533,15 +1589,18 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
-            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
-            # tool-call messages to carry reasoning_content when thinking is
-            # enabled server-side.  Preserve it as a thinking block so Kimi
-            # can validate the message history.  See hermes-agent#13848.
+            # Strict thinking-replay endpoints (Kimi /coding, DeepSeek
+            # /anthropic, Xiaomi MiMo) speak the Anthropic Messages protocol
+            # but require assistant tool-call messages to carry the prior
+            # reasoning payload when thinking is enabled server-side.
+            # Preserve Hermes's provider-facing reasoning_content as an
+            # unsigned thinking block so upstream can validate the message
+            # history.  See hermes-agent#13848 (Kimi), #16748 (DeepSeek),
+            # #24443 (MiMo).
             #
-            # Accept empty string "" — _copy_reasoning_content_for_api()
-            # injects "" as a tier-3 fallback for Kimi tool-call messages
-            # that had no reasoning.  Kimi requires the field to exist, even
-            # if empty.
+            # Accept empty/blank strings — _copy_reasoning_content_for_api()
+            # injects a single-space fallback for strict thinking providers
+            # when stale or cross-provider history lacks real reasoning.
             #
             # Prepend (not append): Anthropic protocol requires thinking
             # blocks before text and tool_use blocks.
@@ -1746,15 +1805,17 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
-    # Anthropic Messages protocol upstream but require that thinking blocks
-    # synthesised from reasoning_content round-trip on subsequent turns when
-    # thinking is enabled.  Signed Anthropic blocks still have to be stripped
-    # (neither endpoint can validate Anthropic's signatures); unsigned blocks
-    # are preserved.  See hermes-agent#13848 (Kimi) and #16748 (DeepSeek).
+    # Kimi /coding, DeepSeek /anthropic and Xiaomi MiMo share a contract:
+    # all three speak the Anthropic Messages protocol upstream but require
+    # that thinking blocks synthesised from reasoning_content round-trip on
+    # subsequent turns when thinking is enabled.  Signed Anthropic blocks
+    # still have to be stripped (none of these endpoints can validate
+    # Anthropic's signatures); unsigned blocks are preserved.  See
+    # hermes-agent#13848 (Kimi), #16748 (DeepSeek), #24443 (MiMo).
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_mimo_anthropic_endpoint(base_url, model)
     )
 
     last_assistant_idx = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -9973,17 +9973,17 @@ class AIAgent:
         if raw_reasoning_content is not None:
             msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
         elif assistant_tool_calls and self._needs_thinking_reasoning_pad():
-            # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
-            # both require reasoning_content on every assistant tool-call
-            # message. Without it, replaying the persisted message causes
-            # HTTP 400 ("The reasoning_content in the thinking mode must
-            # be passed back to the API"). Include streamed reasoning
+            # DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+            # thinking all require reasoning_content on every assistant
+            # tool-call message. Without it, replaying the persisted message
+            # causes HTTP 400 ("The reasoning_content in the thinking mode
+            # must be passed back to the API"). Include streamed reasoning
             # text when captured; otherwise pad with a single space —
             # DeepSeek V4 Pro tightened validation and rejects empty
             # string ("The reasoning content in the thinking mode must
             # be passed back to the API"). A space satisfies non-empty
             # checks everywhere without leaking fabricated reasoning.
-            # Refs #15250, #17400, #17341.
+            # Refs #15250, #17400, #17341, #24443.
             msg["reasoning_content"] = reasoning_text or " "
 
         # Additive fallback (refs #16844, #16884). Streaming-only providers
@@ -10095,13 +10095,14 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that omit
+        ``reasoning_content`` (refs #15250, #17400, #24443).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10131,6 +10132,39 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the active provider is Xiaomi MiMo thinking mode.
+
+        MiMo's OpenAI-compatible API requires ``reasoning_content`` on every
+        prior assistant message in thinking mode; omitting it causes HTTP 400
+        ("The reasoning_content in the thinking mode must be passed back to
+        the API.") on the next replay. Detection covers four signals so it
+        works regardless of how the session was configured:
+
+        1. Hermes provider id ``xiaomi`` (set by ``hermes_cli/auth.py`` for
+           native MiMo sessions).
+        2. The MiMo API host ``xiaomimimo.com`` (custom-provider setups
+           pointing at MiMo directly).
+        3. Catalog model names starting with ``xiaomi/`` (e.g. OpenRouter
+           and Nous Portal slots).
+        4. Bare model names starting with ``mimo-`` or any catalog slot
+           containing ``/mimo-`` (third-party hosted MiMo).
+
+        Known gap: sessions routed through a proxy or institutional gateway
+        with a custom hostname AND no Hermes provider id set will not be
+        detected. Users in that configuration should set ``provider: xiaomi``
+        explicitly. Refs #24443.
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
+            or model.startswith("xiaomi/")
+            or model.startswith("mimo-")
+            or "/mimo-" in model
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
@@ -10165,9 +10199,9 @@ class AIAgent:
         # shape (reasoning set, reasoning_content absent, tool_calls present)
         # is unreachable from same-provider DeepSeek history after this fix.
         # Inject a single space to satisfy the API without leaking another
-        # provider's chain of thought to DeepSeek/Kimi. Space (not "")
+        # provider's chain of thought to DeepSeek/Kimi/MiMo. Space (not "")
         # because DeepSeek V4 Pro rejects empty-string reasoning_content
-        # in thinking mode (refs #17341).
+        # in thinking mode (refs #17341, #24443).
         normalized_reasoning = source_msg.get("reasoning")
         if (
             needs_thinking_pad
@@ -10187,14 +10221,14 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        # 4. DeepSeek / Kimi thinking mode: all assistant messages need
-        # reasoning_content. Inject a single space to satisfy the provider's
-        # requirement when no explicit reasoning content is present. Covers
-        # both tool-call turns (already-poisoned history with no reasoning
-        # at all) and plain text turns. Space (not "") because DeepSeek V4
-        # Pro tightened validation and rejects empty string with HTTP 400
-        # ("The reasoning content in the thinking mode must be passed back
-        # to the API"). Refs #17341.
+        # 4. DeepSeek / Kimi / MiMo thinking mode: all assistant messages
+        # need reasoning_content. Inject a single space to satisfy the
+        # provider's requirement when no explicit reasoning content is
+        # present. Covers both tool-call turns (already-poisoned history
+        # with no reasoning at all) and plain text turns. Space (not "")
+        # because DeepSeek V4 Pro tightened validation and rejects empty
+        # string with HTTP 400 ("The reasoning content in the thinking
+        # mode must be passed back to the API"). Refs #17341, #24443.
         if needs_thinking_pad:
             api_msg["reasoning_content"] = " "
             return

--- a/tests/agent/test_mimo_anthropic_thinking.py
+++ b/tests/agent/test_mimo_anthropic_thinking.py
@@ -1,0 +1,314 @@
+"""Regression guard: preserve thinking blocks for Xiaomi MiMo (Anthropic path).
+
+MiMo's API requires the prior ``reasoning_content`` to round-trip on every
+replayed assistant turn when thinking mode is enabled (same contract as
+Kimi / Moonshot and DeepSeek's ``/anthropic`` route).  Without preservation
+the next request fails with HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the
+    API.
+
+Detection in the Anthropic adapter is intentionally narrow: ``xiaomi/`` /
+``mimo-`` model prefixes plus the embedded ``/mimo-`` third-party catalog
+shape and the ``xiaomimimo.com`` host.  Lookalike model families
+(MiniMax, Mistral, Microsoft Phi-4, ``mimowave`` substrings) must NOT
+trigger the carve-out — they are negative-guarded below.
+
+See hermes-agent#24443.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestModelNameIsXiaomiMimo:
+    """``_model_name_is_xiaomi_mimo`` — three-shape positive matrix + negatives."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "xiaomi/mimo-v2.5-pro",
+            "xiaomi/mimo-v2.5-pro-thinking",
+            "XIAOMI/MIMO-V2.5",
+            "mimo-v2.5-pro",
+            "mimo-v2",
+            "MIMO-V2",
+            "openrouter/mimo-v2.5-pro",
+            "nous-portal/mimo-v2",
+            "vendor/sub/mimo-v3",
+            "  mimo-v2.5-pro  ",
+        ],
+    )
+    def test_positive_signals(self, model: str) -> None:
+        from agent.anthropic_adapter import _model_name_is_xiaomi_mimo
+
+        assert _model_name_is_xiaomi_mimo(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Lookalike families — must NOT match
+            "minimax-text-01",
+            "minimax/abab-7-chat",
+            "mistral-large",
+            "mistralai/mistral-medium",
+            "microsoft/phi-4",
+            "phi-4-mimo-style",  # contains 'mimo' but not '/mimo-' or prefix
+            "mimowave-7b",       # substring; must not match
+            "openrouter/mimowave",
+            # Underscore variants explicitly excluded (no published catalog)
+            "mimo_v2",
+            "xiaomi-mimo-v2",
+            # Empty / non-string
+            "",
+            "   ",
+            None,
+            123,
+        ],
+    )
+    def test_negative_signals(self, model) -> None:
+        from agent.anthropic_adapter import _model_name_is_xiaomi_mimo
+
+        assert _model_name_is_xiaomi_mimo(model) is False
+
+
+class TestIsXiaomiMimoAnthropicEndpoint:
+    """``_is_xiaomi_mimo_anthropic_endpoint`` — host + model combinatorics."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.xiaomimimo.com",
+            "https://api.xiaomimimo.com/anthropic",
+            "https://API.XiaomiMiMo.com/v1",
+        ],
+    )
+    def test_host_signal(self, base_url: str) -> None:
+        from agent.anthropic_adapter import _is_xiaomi_mimo_anthropic_endpoint
+
+        assert _is_xiaomi_mimo_anthropic_endpoint(base_url) is True
+
+    def test_model_signal_without_host(self) -> None:
+        from agent.anthropic_adapter import _is_xiaomi_mimo_anthropic_endpoint
+
+        assert _is_xiaomi_mimo_anthropic_endpoint(
+            "https://openrouter.ai/api/v1/messages",
+            "openrouter/mimo-v2.5-pro",
+        ) is True
+
+    def test_neither_host_nor_model(self) -> None:
+        from agent.anthropic_adapter import _is_xiaomi_mimo_anthropic_endpoint
+
+        assert _is_xiaomi_mimo_anthropic_endpoint(
+            "https://api.minimax.io/anthropic", "minimax-text-01"
+        ) is False
+        assert _is_xiaomi_mimo_anthropic_endpoint(None, None) is False
+
+
+class TestMimoAnthropicPreservesThinking:
+    """convert_messages_to_anthropic must replay MiMo thinking blocks."""
+
+    @pytest.mark.parametrize(
+        "base_url, model",
+        [
+            ("https://api.xiaomimimo.com/anthropic", None),
+            (None, "xiaomi/mimo-v2.5-pro"),
+            (None, "mimo-v2.5-pro"),
+            (None, "openrouter/mimo-v2.5-pro"),
+        ],
+    )
+    def test_unsigned_thinking_block_survives_replay(
+        self, base_url: str | None, model: str | None
+    ) -> None:
+        """Unsigned thinking (synthesised from reasoning_content) must be preserved."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "planning the tool call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "skill_view", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url=base_url, model=model
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1, (
+            f"MiMo (base_url={base_url!r}, model={model!r}) must preserve "
+            "unsigned thinking blocks synthesised from reasoning_content — "
+            "upstream rejects replayed tool-call messages without them."
+        )
+        assert thinking_blocks[0]["thinking"] == "planning the tool call"
+        assert "signature" not in thinking_blocks[0]
+
+    def test_unsigned_thinking_preserved_on_non_latest_assistant_turn(self) -> None:
+        """MiMo validates every prior assistant turn, not just the last."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r1",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "user", "content": "q2"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r2",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+
+        assistants = [m for m in converted if m["role"] == "assistant"]
+        assert len(assistants) == 2
+        for assistant, expected in zip(assistants, ("r1", "r2")):
+            thinking = [
+                b for b in assistant["content"]
+                if isinstance(b, dict) and b.get("type") == "thinking"
+            ]
+            assert len(thinking) == 1
+            assert thinking[0]["thinking"] == expected
+
+    def test_signed_anthropic_thinking_block_is_stripped(self) -> None:
+        """Anthropic-signed blocks must still be stripped on MiMo.
+
+        MiMo cannot validate Anthropic's proprietary signatures — strip
+        signed blocks, preserve unsigned ones (Hermes-synthesised).
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "anthropic-signed payload",
+                        "signature": "anthropic-sig-xyz",
+                    },
+                    {"type": "text", "text": "hello"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == [], (
+            "Signed Anthropic thinking blocks must be stripped on MiMo — "
+            "MiMo cannot validate Anthropic-proprietary signatures."
+        )
+
+    def test_cache_control_stripped_from_thinking_block(self) -> None:
+        """cache_control on thinking blocks must still be stripped on MiMo."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r1",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+        for m in converted:
+            if not isinstance(m.get("content"), list):
+                continue
+            for b in m["content"]:
+                if isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking"):
+                    assert "cache_control" not in b
+
+    def test_minimax_lookalike_still_strips_all_thinking(self) -> None:
+        """MiniMax (lookalike provider) must keep the generic strip-all path.
+
+        Regression guard: a too-liberal MiMo matcher could accidentally
+        enable MiMo's preserve-unsigned-thinking branch for MiniMax, which
+        rejects unsigned blocks outright.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r1",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.minimax.io/anthropic",
+            model="minimax-text-01",
+        )
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == [], (
+            "MiniMax must keep the generic strip-all-thinking behaviour — "
+            "a too-liberal MiMo matcher would break MiniMax replays."
+        )

--- a/tests/run_agent/test_mimo_reasoning_content_echo.py
+++ b/tests/run_agent/test_mimo_reasoning_content_echo.py
@@ -1,0 +1,420 @@
+"""Regression test: Xiaomi MiMo thinking mode reasoning_content echo.
+
+MiMo's OpenAI-compatible API requires ``reasoning_content`` on every prior
+assistant message in thinking mode. When a persisted session replays an
+assistant turn that was recorded without the field, MiMo rejects the next
+request with HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the API.
+
+Fix covers three paths (mirroring the DeepSeek / Kimi fix):
+
+1. ``_build_assistant_message`` — new tool-call messages without raw
+   ``reasoning_content`` get ``" "`` pinned at creation time so nothing gets
+   persisted poisoned.
+2. ``_copy_reasoning_content_for_api`` — already-poisoned history replays
+   with ``reasoning_content=" "`` injected defensively, ``""`` placeholders
+   upgrade to ``" "``, and cross-provider history doesn't leak another
+   provider's chain of thought.
+3. Detection covers four signals: ``provider == "xiaomi"``, the
+   ``xiaomimimo.com`` API host, model names starting with ``xiaomi/`` (catalog
+   form), and bare names starting with ``mimo-`` (config form).
+
+Refs #24443.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+_ATTR_ABSENT = object()
+_EXPECT_NOT_PRESENT = object()
+
+
+def _sdk_tool_call(call_id: str = "c1", name: str = "terminal", arguments: str = "{}"):
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+        extra_content=None,
+    )
+
+
+def _build_sdk_message(reasoning_content=_ATTR_ABSENT, **extra):
+    kwargs = {"content": "", **extra}
+    if reasoning_content is not _ATTR_ABSENT:
+        kwargs["reasoning_content"] = reasoning_content
+    return SimpleNamespace(**kwargs)
+
+
+class TestNeedsMimoToolReasoning:
+    """_needs_mimo_tool_reasoning() recognises all four detection signals."""
+
+    def test_provider_xiaomi(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_provider_case_insensitive(self) -> None:
+        agent = _make_agent(provider="Xiaomi", model="")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_base_url_host(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="some-aliased-name",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_catalog_model_prefix(self) -> None:
+        agent = _make_agent(provider="openrouter", model="xiaomi/mimo-v2.5-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_bare_model_prefix(self) -> None:
+        agent = _make_agent(provider="custom", model="mimo-v2-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_bare_model_prefix_dotted(self) -> None:
+        agent = _make_agent(provider="custom", model="mimo-v2.5")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_third_party_catalog_form(self) -> None:
+        """Some hosted catalogs surface MiMo as ``vendor/mimo-…``."""
+        agent = _make_agent(provider="openrouter", model="nous/mimo-v2-flash")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_non_mimo_provider(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    def test_empty_everything(self) -> None:
+        agent = _make_agent()
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    def test_deepseek_not_flagged_as_mimo(self) -> None:
+        """Cross-provider guard: DeepSeek must not trip MiMo detection."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url",
+        [
+            # MiniMax — name contains "mi" but is not MiMo
+            ("minimax", "minimax/abab6-chat", ""),
+            ("minimax-cn", "MiniMax-M2.7", ""),
+            # Mistral models — must not be confused with MiMo
+            ("custom", "mistral/mistral-large", ""),
+            # Microsoft Phi-4 mini — startswith "mi" but no "mimo-" segment
+            ("openrouter", "microsoft/phi-4-mini-instruct", ""),
+            # Plain ``mimo`` substring without dash separator must not match
+            ("custom", "vendor-mimowave-1", ""),
+        ],
+    )
+    def test_lookalike_model_names_not_flagged(
+        self, provider: str, model: str, base_url: str
+    ) -> None:
+        """Substring-based detection must not over-match neighbouring vendors."""
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        assert agent._needs_mimo_tool_reasoning() is False
+
+
+class TestThinkingPadGateIncludesMimo:
+    """_needs_thinking_reasoning_pad() must OR in the MiMo detector."""
+
+    def test_xiaomi_provider_enables_pad(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_mimo_base_url_enables_pad(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="whatever",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_existing_deepseek_path_unaffected(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_existing_kimi_path_unaffected(self) -> None:
+        agent = _make_agent(provider="kimi-coding", model="kimi-k2.6")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_unrelated_provider_still_false(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_thinking_reasoning_pad() is False
+
+
+class TestCopyReasoningContentForApiMimo:
+    """_copy_reasoning_content_for_api pads reasoning_content for MiMo turns."""
+
+    def test_mimo_tool_call_poisoned_history_gets_space_placeholder(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_mimo_assistant_no_tool_call_gets_padded(self) -> None:
+        """MiMo thinking mode pads ALL assistant turns, mirroring DeepSeek."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {"role": "assistant", "content": "hello"}
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_mimo_explicit_reasoning_content_preserved(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "reasoning_content": "<think>real chain of thought</think>",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "<think>real chain of thought</think>"
+
+    def test_mimo_stale_empty_placeholder_upgraded_to_space(self) -> None:
+        """Pre-fix sessions with reasoning_content="" upgrade to " " on replay."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_mimo_reasoning_field_promoted(self) -> None:
+        """When only 'reasoning' is set, promote to reasoning_content."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "thought trace",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "thought trace"
+
+    def test_mimo_poisoned_cross_provider_history_padded(self) -> None:
+        """Cross-provider tool-call turn: prior provider's reasoning must NOT
+        leak into the MiMo request; inject " " instead.
+        """
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "MiniMax chain of thought from a prior turn",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_mimo_base_url_path(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="mimo-v2-flash",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_non_thinking_provider_not_padded(self) -> None:
+        """Identical inputs under a non-enforcing provider stay untouched."""
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+
+class TestBuildAssistantMessageMimo:
+    """_build_assistant_message pins replay-safe MiMo tool-call state."""
+
+    def test_mimo_tool_call_reasoning_is_backfilled_into_reasoning_content(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assistant_message = SimpleNamespace(
+            content=None,
+            reasoning="MiMo tool-call reasoning",
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+        assert msg["reasoning_content"] == "MiMo tool-call reasoning"
+        assert msg["tool_calls"][0]["id"] == "call_1"
+
+    def test_mimo_model_extra_reasoning_content_preserved(self) -> None:
+        """OpenAI SDK stores unknown provider fields in model_extra."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assistant_message = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            reasoning_content=None,
+            model_extra={"reasoning_content": "MiMo model_extra reasoning"},
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+        assert msg["reasoning_content"] == "MiMo model_extra reasoning"
+
+    def test_mimo_tool_call_without_raw_reasoning_content_gets_space_placeholder(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assistant_message = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+        assert msg["reasoning_content"] == " "
+        assert msg["tool_calls"][0]["id"] == "call_1"
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url,sdk_reasoning_content,expected",
+        [
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                None, " ",
+                id="xiaomi-attr-none",
+            ),
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                _ATTR_ABSENT, " ",
+                id="xiaomi-attr-absent",
+            ),
+            pytest.param(
+                "custom", "mimo-v2-pro", "https://api.xiaomimimo.com/v1",
+                _ATTR_ABSENT, " ",
+                id="mimo-base-url",
+            ),
+            pytest.param(
+                "openrouter", "xiaomi/mimo-v2.5-pro", "https://openrouter.ai/api/v1",
+                _ATTR_ABSENT, " ",
+                id="openrouter-xiaomi-catalog",
+            ),
+            pytest.param(
+                "openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1",
+                _ATTR_ABSENT, _EXPECT_NOT_PRESENT,
+                id="openrouter-non-mimo-no-pad",
+            ),
+        ],
+    )
+    def test_tool_call_reasoning_content_pad(
+        self, provider, model, base_url, sdk_reasoning_content, expected,
+    ) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        msg_in = _build_sdk_message(
+            reasoning_content=sdk_reasoning_content,
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        if expected is _EXPECT_NOT_PRESENT:
+            assert "reasoning_content" not in msg
+        else:
+            assert msg["reasoning_content"] == expected
+
+    def test_streamed_reasoning_text_promoted_over_pad(self) -> None:
+        """When .reasoning carries streamed thinking, promote it rather than
+        overwriting with the empty pad."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        msg_in = _build_sdk_message(
+            reasoning="streamed thoughts",
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        assert msg["reasoning_content"] == "streamed thoughts"
+
+    def test_build_assistant_message_text_only_turn_no_pad_at_creation_time(self) -> None:
+        """Plain-text turns must NOT be padded at creation time — the
+        tool-call pad branch in ``_build_assistant_message`` only fires when
+        ``assistant_tool_calls`` is truthy. Replay-time padding for text
+        turns happens later in ``_copy_reasoning_content_for_api`` Tier 4
+        (covered by ``test_mimo_assistant_no_tool_call_gets_padded``); the
+        boundary between creation-time and replay-time pad is intentional.
+        """
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        msg_in = SimpleNamespace(content="hello", tool_calls=None)
+        msg = agent._build_assistant_message(msg_in, finish_reason="stop")
+        assert "tool_calls" not in msg
+        assert "reasoning_content" not in msg


### PR DESCRIPTION
## What

Enrol Xiaomi MiMo into the `reasoning_content` echo-back enforcement set on **both** the OpenAI-compatible path (`run_agent.py`) and the Anthropic-Messages path (`agent/anthropic_adapter.py`) so multi-turn MiMo conversations stop failing with HTTP 400.

## Why

MiMo's OpenAI-compatible API requires `reasoning_content` on every prior assistant message in thinking mode (see [MiMo docs](https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content)). Without it, the next replay returns:

```
Error code: 400 - {"error": {"message": "Param Incorrect",
  "param": "The reasoning_content in the thinking mode must be passed back to the API."}}
```

Hermes already ships the echo-back pattern for DeepSeek V4 thinking and Kimi / Moonshot thinking on **both** protocol paths; MiMo was simply not in either enforcement gate. That double omission produced four failure modes:

1. **Tool-call turns without SDK-exposed `reasoning_content`** — when MiMo streams reasoning via deltas only, the assembled `ChatCompletionMessage` has no top-level attribute, so the build-time pad never fired. Persisted history then lacked the field and the next request 400'd.
2. **Cross-provider history** — sessions opened under another provider and then `/model`-switched to MiMo bypassed the tier-2 leak guard, so prior chain-of-thought either leaked or was dropped.
3. **Legacy `reasoning_content=""` sessions** (pre-#17341) replayed the empty string verbatim instead of upgrading it to `" "`.
4. **Anthropic-Messages path** — MiMo running through an Anthropic-Messages-compatible gateway (`xiaomimimo.com`, OpenRouter `mimo-` slots, private proxies) had no carve-out: unsigned thinking blocks synthesised from `reasoning_content` were stripped along with signed Anthropic blocks, and the next replay 400'd.

Fixes #24443.

## How

### `run_agent.py` (OpenAI-compatible path)

- New `_needs_mimo_tool_reasoning()`, modelled on `_needs_kimi_tool_reasoning()`. Detection covers four signals:
  - `provider == "xiaomi"` (Hermes-internal id from `hermes_cli/auth.py`)
  - `base_url` host matches `xiaomimimo.com`
  - model starts with `xiaomi/` (catalog form)
  - model starts with `mimo-` or contains `/mimo-` (bare + third-party catalog form)
- `_needs_thinking_reasoning_pad()` ORs the new detector in. All four existing tiers of `_copy_reasoning_content_for_api` and the tool-call pad branch in `_build_assistant_message` activate for MiMo automatically.
- Inline comments at the three pad sites updated to mention MiMo alongside DeepSeek / Kimi (refs #24443).

### `agent/anthropic_adapter.py` (Anthropic-Messages path)

- New `_model_name_is_xiaomi_mimo()` covering three slot shapes: catalog `xiaomi/`, bare `mimo-`, and embedded `/mimo-` for namespaced third-party slots (e.g. `openrouter/mimo-v2.5-pro`). Intentionally narrow — does **not** accept `mimo_` / `xiaomi-mimo-` (no published catalog uses those) so lookalikes are not misdetected.
- New `_is_xiaomi_mimo_anthropic_endpoint()`, ORed into `_preserve_unsigned_thinking` alongside `_is_kimi_family_endpoint` and `_is_deepseek_anthropic_endpoint`. MiMo now uses the same strip-signed / keep-unsigned policy as Kimi `/coding` and DeepSeek `/anthropic`.
- Comment block at the thinking-block synthesis site updated to mention all three strict-replay providers.

DeepSeek / Kimi / Anthropic-native / MiniMax behaviour is untouched — the three detectors are OR-combined and mutually exclusive in practice. No schema or state migration.

A known gap is documented in the new docstring: sessions routed through a proxy or institutional gateway with a custom hostname AND no Hermes provider id set will not auto-detect; users in that configuration should set `provider: xiaomi` explicitly.

## How to test

```bash
pytest tests/run_agent/test_mimo_reasoning_content_echo.py \
       tests/run_agent/test_deepseek_reasoning_content_echo.py \
       tests/agent/test_mimo_anthropic_thinking.py \
       tests/agent/test_deepseek_anthropic_thinking.py \
       tests/agent/test_kimi_coding_anthropic_thinking.py -q
```

### `run_agent.py` suite

38 hermetic tests in `tests/run_agent/test_mimo_reasoning_content_echo.py` mirroring the DeepSeek echo suite:

- **Detection (`_needs_mimo_tool_reasoning`)**: all four positive signals, case-insensitive provider id, third-party catalog form, plus negative guards for lookalike model names (MiniMax, Mistral, Microsoft Phi-4, `mimowave` substring).
- **Pad gate**: `_needs_thinking_reasoning_pad` flips on under MiMo and remains off for unrelated providers; pre-existing DeepSeek / Kimi paths unaffected.
- **`_copy_reasoning_content_for_api`**: all four tiers exercised under MiMo (tool-call pad, `""` → `" "` upgrade, explicit content preserved, `reasoning` field promoted, cross-provider leak guard injects `" "`).
- **`_build_assistant_message`**: `reasoning` → `reasoning_content` backfill, `model_extra` preservation, tool-call pad with no raw `reasoning_content`, parametrised matrix covering attr-none / attr-absent / base-url / catalog / negative-non-mimo cases, streamed-reasoning promotion over pad, creation-time pad boundary for text-only turns.

### `agent/anthropic_adapter.py` suite

37 hermetic tests in `tests/agent/test_mimo_anthropic_thinking.py` mirroring the DeepSeek/Kimi Anthropic-path suites:

- **Detection (`_model_name_is_xiaomi_mimo`)**: catalog / bare / `/mimo-` shapes; case-insensitive; whitespace-tolerant.
- **Negative guards**: MiniMax, Mistral, Microsoft Phi-4, `mimowave`, `phi-4-mimo-style`, `mimo_v2`, `xiaomi-mimo-v2`, empty/non-string inputs — all must NOT match.
- **Endpoint detection (`_is_xiaomi_mimo_anthropic_endpoint`)**: host-only, model-only, neither-signal cases.
- **`convert_messages_to_anthropic`**: unsigned thinking blocks preserved on tool-call replay (parametrised over four detection routes); preservation across non-latest assistant turns; signed Anthropic blocks stripped; `cache_control` stripped from thinking blocks; **MiniMax regression guard** (a too-liberal MiMo matcher would break MiniMax — explicit negative test).

Result: 101 tests pass across the new file and the pre-existing DeepSeek / Kimi / MiMo echo suites, 0 regressions. `ruff check agent/anthropic_adapter.py tests/agent/test_mimo_anthropic_thinking.py run_agent.py tests/run_agent/test_mimo_reasoning_content_echo.py` clean.

## Platforms tested

- macOS 15 / Python 3.12 (local)

Hermetic test suite — no platform-specific code paths.
