### PR TITLE
fix(agent): propagate self.user_id in _ensure_db_session instead of hardcoded None

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2528,7 +2528,7 @@ class AIAgent:
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=self.user_id,
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True

--- a/tests/run_agent/test_ensure_db_session_user_id.py
+++ b/tests/run_agent/test_ensure_db_session_user_id.py
@@ -1,0 +1,41 @@
+"""Tests for AIAgent._ensure_db_session — user_id propagation (issue #24321)."""
+
+from unittest.mock import MagicMock
+
+
+def _make_agent(user_id):
+    """Build a minimal AIAgent-like object with _ensure_db_session."""
+    import run_agent
+
+    agent = object.__new__(run_agent.AIAgent)
+    agent.session_id = "test-session-001"
+    agent.user_id = user_id
+    agent.platform = "telegram"
+    agent._session_db = MagicMock()
+    agent._session_db_created = False
+    agent.model = "gpt-4o"
+    agent._session_init_model_config = {}
+    agent._cached_system_prompt = ""
+    agent._parent_session_id = None
+    return agent
+
+
+class TestEnsureDbSessionUserId:
+    def test_user_id_propagated(self):
+        agent = _make_agent("user-123")
+        agent._ensure_db_session()
+        kwargs = agent._session_db.create_session.call_args.kwargs
+        assert kwargs["user_id"] == "user-123"
+
+    def test_none_user_id_flows_through(self):
+        """user_id=None is valid for CLI sessions and must not be replaced."""
+        agent = _make_agent(None)
+        agent._ensure_db_session()
+        kwargs = agent._session_db.create_session.call_args.kwargs
+        assert kwargs["user_id"] is None
+
+    def test_idempotent_when_already_created(self):
+        agent = _make_agent("user-456")
+        agent._session_db_created = True
+        agent._ensure_db_session()
+        agent._session_db.create_session.assert_not_called()


### PR DESCRIPTION
## Problem

Background tasks, cron runs, sub-agent delegations, and oneshot invocations create session rows in `state.db` with `user_id=NULL`, producing unlinkable "orphan" sessions that cannot be attributed to any user. On a 4-day-old install this represented 38% of the sessions table.

## Root cause

`run_agent.py` — `AIAgent._ensure_db_session` (line 2531):

```python
self._session_db.create_session(
    ...
    user_id=None,   # hardcoded; ignores self.user_id
    ...
)
```

`self.user_id` is set at constructor time and is the correct value to pass.

## Fix

Single-line change — replace `user_id=None` with `user_id=self.user_id`:

```python
self._session_db.create_session(
    session_id=self.session_id,
    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
    model=self.model,
    model_config=self._session_init_model_config,
    system_prompt=self._cached_system_prompt,
    user_id=self.user_id,          # was: None
    parent_session_id=self._parent_session_id,
)
```

`None` is still a valid value for CLI sessions where no user ID is set; it flows through unchanged.

```mermaid
flowchart TD
    A[_ensure_db_session called] --> B{_session_db_created or no _session_db?}
    B -- yes --> SKIP[return early]
    B -- no --> C[create_session]
    C --> D{self.user_id?}
    D -- string value --> STORE_ID[store user_id = self.user_id]
    D -- None --> STORE_NULL[store user_id = NULL — valid for CLI]
    STORE_ID --> MARK[_session_db_created = True]
    STORE_NULL --> MARK
```

## Tests

New `tests/run_agent/test_ensure_db_session_user_id.py` — 3 cases:

| Scenario | Expected |
|---|---|
| `self.user_id = "user-123"` | `create_session` called with `user_id="user-123"` |
| `self.user_id = None` (CLI) | `create_session` called with `user_id=None` |
| `_session_db_created = True` | `create_session` not called (idempotent guard) |

All 3 pass.

Closes #24321