### PR TITLE
fix(agent): propagate self._user_id in _ensure_db_session instead of hardcoded None

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2528,7 +2528,7 @@ class AIAgent:
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=self._user_id,
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True

--- a/tests/run_agent/test_ensure_db_session_user_id.py
+++ b/tests/run_agent/test_ensure_db_session_user_id.py
@@ -1,0 +1,54 @@
+"""Tests for _ensure_db_session propagating self._user_id (fixes #24321).
+
+Orphan session rows with user_id=NULL were created because _ensure_db_session
+hardcoded user_id=None instead of forwarding self._user_id.
+"""
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from run_agent import AIAgent
+
+
+def _make_agent(user_id=None, platform="cli"):
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-session-001"
+    agent._user_id = user_id
+    agent.platform = platform
+    agent._session_db = MagicMock()
+    agent._session_db_created = False
+    agent.model = "gpt-4o"
+    agent._session_init_model_config = {}
+    agent._cached_system_prompt = ""
+    agent._parent_session_id = None
+    return agent
+
+
+def test_user_id_propagated_to_create_session():
+    agent = _make_agent(user_id="user-123", platform="telegram")
+    agent._ensure_db_session()
+    kwargs = agent._session_db.create_session.call_args.kwargs
+    assert kwargs["user_id"] == "user-123"
+
+
+def test_none_user_id_still_forwarded():
+    """CLI sessions with user_id=None are valid; None must flow through."""
+    agent = _make_agent(user_id=None, platform="cli")
+    agent._ensure_db_session()
+    kwargs = agent._session_db.create_session.call_args.kwargs
+    assert kwargs["user_id"] is None
+
+
+def test_idempotent_second_call_skipped():
+    """_ensure_db_session must not call create_session twice."""
+    agent = _make_agent(user_id="user-abc")
+    agent._ensure_db_session()
+    agent._ensure_db_session()
+    assert agent._session_db.create_session.call_count == 1


### PR DESCRIPTION
## Problem

Background tasks, cron runs, sub-agent delegations, and oneshot invocations create session rows in `state.db` with `user_id=NULL`, producing orphan sessions that cannot be linked to users. On a multi-day install this represented ~38% of the sessions table.

## Root cause

`run_agent.py` `_ensure_db_session()` hardcoded `user_id=None` in the `create_session()` call despite `self._user_id` being set at constructor time and carrying the correct platform user identifier (set from the `user_id` constructor param at line 1245).

```python
# Before (line 2531)
user_id=None,   # always NULL — ignores self._user_id
```

## Fix

One-line change: pass `self._user_id` instead of the literal `None`.

```python
# After
user_id=self._user_id,
```

`self._user_id` is `None` for CLI sessions (no regression) and carries the platform-provided identifier for gateway sessions (Telegram, Discord, API, etc.).

## Tests

New file `tests/run_agent/test_ensure_db_session_user_id.py` — 3 cases:

- `test_user_id_propagated_to_create_session` — gateway session with a real user id: `create_session` receives the correct value
- `test_none_user_id_still_forwarded` — CLI session with `_user_id=None`: `None` flows through (no regression)
- `test_idempotent_second_call_skipped` — `_ensure_db_session` called twice: `create_session` called exactly once

Stash-verify: test **FAILS** on old code (`assert None == 'user-123'`), **PASSES** after fix.

## Visual

```mermaid
flowchart TD
    A[AIAgent.__init__] -->|user_id param| B[self._user_id = user_id]
    C[_ensure_db_session called] --> D{_session_db_created?}
    D -->|yes| E[return early]
    D -->|no| F[session_db.create_session]
    B -->|Before fix: hardcoded None| G[user_id=NULL in DB]
    B -->|After fix: self._user_id| H[user_id=correct value in DB]
    F --> H
```

Closes #24321