### PR TITLE
fix(gateway): consult lock record argv when cmdline unreadable in scoped-lock stale check

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -613,15 +613,20 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     stale = True
                 # When start_time comparison is unavailable (macOS / Windows
                 # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  If the PID was
-                # reused by an unrelated process the lock is stale.
+                # checking the live process command line.  When cmdline is
+                # also unreadable (Windows has no ps), consult the lock
+                # record's own argv — the gateway writes it at startup and
+                # it's the only identity signal on platforms without ps.
+                # Both oracles must indicate "not a gateway" to mark stale.
                 if (
                     not stale
                     and existing.get("start_time") is None
                     and current_start is None
                     and not _looks_like_gateway_process(existing_pid)
                 ):
-                    stale = True
+                    live_cmdline = _read_process_cmdline(existing_pid)
+                    if live_cmdline is not None or not _record_looks_like_gateway(existing):
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still appear alive to _pid_exists but are not
                 # actually running. Treat them as stale so --replace works.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "treydong.zh@gmail.com": "TreyDong",
     "kyanam.preetham@gmail.com": "pkyanam",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "147827411+EloquentBrush@users.noreply.github.com": "AhmetArif0",
     "hugosequier@gmail.com": "Hugo-SEQUIER",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -468,6 +468,9 @@ class TestScopedLocks:
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
         monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        # On macOS ``ps`` is available, so _read_process_cmdline returns the
+        # unrelated process's name.  This confirms the PID was reused.
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/usr/libexec/bluetoothuserd")
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
@@ -475,6 +478,37 @@ class TestScopedLocks:
         payload = json.loads(lock_path.read_text())
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway(self, tmp_path, monkeypatch):
+        """Windows regression: ps unavailable so cmdline cannot be read.
+
+        When start_time is None on both sides and _looks_like_gateway_process
+        returns False because ps is missing (not because the PID belongs to an
+        unrelated process), the stale check must not delete a valid gateway
+        lock.  Fall back to the lock record's own argv — written by the
+        gateway at startup — before declaring the lock stale.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "argv": ["hermes_cli/main.py", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        # Windows: ps not available, so _read_process_cmdline returns None
+        # and _looks_like_gateway_process returns False for every process.
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is False
+        assert existing["pid"] == 99999
 
     def test_acquire_scoped_lock_keeps_lock_when_pid_reused_by_gateway(self, tmp_path, monkeypatch):
         """When start_time is None but the live PID still looks like a gateway, keep the lock."""


### PR DESCRIPTION
Salvages PR #24600 onto current main. Authorship preserved via cherry-pick.

## Summary
On Windows, scoped-lock stale check now consults the lock record's own argv when the live cmdline can't be read, instead of evicting every valid Windows gateway lock.

## Root cause
PR #24500 added stale-lock detection. When start_time is None on both sides (macOS/Windows have no /proc), the code falls back to `_looks_like_gateway_process`. On Windows there's no `/proc` and no `ps`, so cmdline always returns None and the helper always returns False — every Windows gateway lock got evicted immediately.

## Fix
After `_looks_like_gateway_process` returns False, call `_read_process_cmdline` directly:
- Non-None → live cmdline confirms PID reuse → mark stale (macOS path)
- None → fall back to `_record_looks_like_gateway(existing)` which validates the argv the gateway wrote at startup. If the record identifies as a gateway, keep the lock.

Same two-oracle pattern already used in `get_running_pid` (line 941).

## Validation
50/50 tests pass in tests/gateway/test_status.py. New test `test_acquire_scoped_lock_keeps_lock_when_cmdline_unreadable_but_record_is_gateway` exercises the Windows path; existing test updated to mock `_read_process_cmdline` for the macOS path.

Closes #24600.

Co-authored-by: AhmetArif0 <147827411+EloquentBrush@users.noreply.github.com>