### PR TITLE
fix(gateway): dedup tool-progress on raw preview, not truncated display string

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14331,6 +14331,7 @@ class GatewayRunner:
             # "all" / "new" modes: short preview, respects tool_preview_length
             # config (defaults to 40 chars when unset to keep gateway messages
             # compact — unlike CLI spinners, these persist as permanent messages).
+            _raw_preview = preview or ""  # save before truncation for dedup key
             if preview:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
@@ -14340,17 +14341,20 @@ class GatewayRunner:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."
-            
+
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same
             # code (same boilerplate imports → identical previews).
-            if msg == last_progress_msg[0]:
+            # Use raw (pre-truncation) preview as key so two calls that share
+            # a long common prefix but differ in their tail are not collapsed.
+            _dedup_key = f"{tool_name}\x00{_raw_preview}"
+            if _dedup_key == last_progress_msg[0]:
                 repeat_count[0] += 1
                 # Update the last line in progress_lines with a counter
                 # via a special "dedup" queue message.
                 progress_queue.put(("__dedup__", msg, repeat_count[0]))
                 return
-            last_progress_msg[0] = msg
+            last_progress_msg[0] = _dedup_key
             repeat_count[0] = 0
             
             progress_queue.put(msg)

--- a/tests/gateway/test_progress_dedup.py
+++ b/tests/gateway/test_progress_dedup.py
@@ -1,0 +1,68 @@
+"""Tests for gateway progress-callback dedup key using raw preview (fixes #24298).
+
+Before the fix, truncation happened before the dedup comparison, so two distinct
+tool calls with a long shared prefix collapsed to a false (×N) bubble.
+"""
+
+
+def _simulate_dedup(calls, cap=40):
+    """Reproduce the dedup logic from gateway/run.py progress_callback.
+
+    Returns a list of queued items — plain strings for new messages,
+    ("__dedup__", msg, count) tuples for collapsed repeats.
+    """
+    last = [None]
+    count = [0]
+    queued = []
+    for tool_name, preview in calls:
+        raw = preview or ""
+        display = (preview[:cap - 3] + "...") if len(preview) > cap else preview
+        msg = f"⚙️ {tool_name}: \"{display}\"" if preview else f"⚙️ {tool_name}..."
+        key = f"{tool_name}\x00{raw}"
+        if key == last[0]:
+            count[0] += 1
+            queued.append(("__dedup__", msg, count[0]))
+        else:
+            last[0] = key
+            count[0] = 0
+            queued.append(msg)
+    return queued
+
+
+def test_distinct_long_prefix_not_collapsed():
+    """Two calls sharing a 37-char prefix but different tails must not collapse."""
+    prefix = "cd /home/agent/coding/my-project && "
+    calls = [
+        ("terminal", prefix + "git log -1"),
+        ("terminal", prefix + "git status -s"),
+    ]
+    result = _simulate_dedup(calls)
+    new_msgs = [q for q in result if isinstance(q, str)]
+    assert len(new_msgs) == 2, f"Expected 2 distinct messages, got: {result}"
+    assert not any(
+        isinstance(q, tuple) and q[0] == "__dedup__" for q in result
+    ), f"No dedup expected, got: {result}"
+
+
+def test_identical_calls_collapsed():
+    """Two calls with exactly the same tool and preview must collapse."""
+    calls = [("terminal", "echo hello"), ("terminal", "echo hello")]
+    result = _simulate_dedup(calls)
+    assert any(isinstance(q, tuple) and q[0] == "__dedup__" for q in result), (
+        f"Expected dedup, got: {result}"
+    )
+
+
+def test_different_tools_same_preview_not_collapsed():
+    """Same preview on different tools must not collapse."""
+    calls = [("read_file", "README.md"), ("write_file", "README.md")]
+    result = _simulate_dedup(calls)
+    new_msgs = [q for q in result if isinstance(q, str)]
+    assert len(new_msgs) == 2
+
+
+def test_empty_preview_same_tool_collapses():
+    """Two calls with no preview on the same tool collapse."""
+    calls = [("terminal", ""), ("terminal", "")]
+    result = _simulate_dedup(calls)
+    assert any(isinstance(q, tuple) and q[0] == "__dedup__" for q in result)


### PR DESCRIPTION
## Problem

The gateway's tool-progress dedup collapses distinct tool calls into `(×N)` when they share a long common prefix. Five different shell commands all truncated to the same 40-char display string appear as one `(×5)` bubble. This misleads users and triggers false-positive stall detectors.

## Root cause

In `gateway/run.py` `progress_callback`, truncation occurs **before** the dedup comparison:

```python
if len(preview) > _cap:
    preview = preview[:_cap - 3] + "..."   # truncation destroys the tail
msg = f"{emoji} {tool_name}: \"{preview}\""

if msg == last_progress_msg[0]:            # compare already-truncated string
    repeat_count[0] += 1
    ...
```

Two calls with the same 37-char prefix but different tails produce identical `msg` → false dedup.

## Fix

Save the raw (pre-truncation) preview before any truncation, then use `f"{tool_name}\x00{_raw_preview}"` as the dedup key. The display string continues to use the truncated form.

```python
_raw_preview = preview or ""  # save before truncation
...
_dedup_key = f"{tool_name}\x00{_raw_preview}"
if _dedup_key == last_progress_msg[0]:
    ...
last_progress_msg[0] = _dedup_key
```

## Tests

New file `tests/gateway/test_progress_dedup.py` — 4 cases:

- `test_distinct_long_prefix_not_collapsed` — two calls sharing a 37-char prefix with different tails: no collapse
- `test_identical_calls_collapsed` — two identical calls: collapse to dedup tuple
- `test_different_tools_same_preview_not_collapsed` — same preview, different tool names: no collapse
- `test_empty_preview_same_tool_collapses` — two no-preview calls on the same tool: collapse

## Visual

```mermaid
flowchart TD
    A[progress_callback called] --> B[save _raw_preview = preview]
    B --> C{len preview > cap?}
    C -->|yes| D[preview = preview truncated]
    C -->|no| E[preview unchanged]
    D --> F[build display msg]
    E --> F
    F --> G[_dedup_key = tool_name + NUL + _raw_preview]
    G --> H{key == last_progress_msg?}
    H -->|yes, truly identical| I[emit __dedup__ counter]
    H -->|no, different tail| J[emit new message]
```

Closes #24298