### PR TITLE
fix(google_chat): restore google chat placeholders in reverse order

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2028,7 +2028,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         counter = [0]
 
         def _ph(value: str) -> str:
-            key = f"\x00GC{counter[0]}\x00"
+            key = f"\x00HGC{counter[0]}\x00"
             counter[0] += 1
             placeholders[key] = value
             return key
@@ -2077,9 +2077,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Collapse double spaces left over from stripped chars.
         text = re.sub(r"  +", " ", text)
 
-        # Restore protected regions.
-        for key, value in placeholders.items():
-            text = text.replace(key, value)
+        # Restore protected regions in reverse order so that nested
+        # placeholders (e.g. code inside a header) are resolved correctly.
+        for key in reversed(placeholders):
+            text = text.replace(key, placeholders[key])
 
         return text
 


### PR DESCRIPTION
Corrects #24567


## What does this PR do?

The bug was caused by the GoogleChatAdapter.format_message function restoring placeholders in the same order they were created (forward order). This caused problems when placeholders were nested—for example, if a code block was inside a header, the header's placeholder would be created after the code block's placeholder. In the restoration phase, the code block's placeholder would be looked for in the main text before the header had been restored, so it wouldn't be found. When the header was finally restored, it would still contain the inner placeholder (e.g., \x00GC0\x00).

Google Chat's API also might use \x00GC{index}\x00 for its own internal annotations. When the bot sent these un-restored placeholders, Google Chat's API stripped the null bytes because it couldn't find a matching annotation, leaving the user with the literal text GC0 instead of the intended content.




## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #24567

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

A two-part fix in plugins/platforms/google_chat/adapter.py:
1. Reversed restoration order: The placeholder loop now uses reversed(placeholders), ensuring that outer placeholders are restored first, exposing any inner placeholders for the subsequent iterations of the loop. This matches the correct logic used in the Slack and Telegram adapters.

2. Updated placeholder prefix: I've changed the placeholder prefix from GC to HGC (Hermes Google Chat) to avoid any
potential collision or confusion with Google Chat's own internal markers.


## How to Test


1.  use google chat
2. have hermes do some background task with multiple things to report later
3. observe GC0/GC1/... in the result, observe correct with patch

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

