### PR TITLE
fix: include arg-taking commands in Telegram menu

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -468,20 +468,23 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
 
     Telegram command names cannot contain hyphens, so they are replaced with
     underscores.  Aliases are skipped -- Telegram shows one menu entry per
-    canonical command. Commands that require arguments are skipped because
-    selecting a Telegram BotCommand sends only ``/command`` and would execute
-    an incomplete command.
+    canonical command.
 
-    Plugin-registered slash commands are included so plugins get native
-    autocomplete in Telegram without touching core code.
+    Built-in commands that require arguments (e.g. /queue, /steer, /background)
+    are **included** because their handlers return usage text when selected
+    without a payload, making them discoverable via autocomplete.
+
+    Plugin-registered slash commands that require arguments are **excluded**
+    because plugins may not provide a no-arg usage fallback.
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        if _requires_argument(cmd.args_hint):
-            continue
+        # Built-in arg-taking commands are included — their handlers show
+        # usage text when invoked without arguments, and hiding them from
+        # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
             result.append((tg_name, cmd.description))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -144,6 +144,7 @@ AUTHOR_MAP = {
     "16263913+zccyman@users.noreply.github.com": "zccyman",
     "ahmetosrak@Ahmet-MacBook-Air.local": "Osraka",
     "98612432+Osraka@users.noreply.github.com": "Osraka",
+    "112634774+ryptotalent@users.noreply.github.com": "ryptotalent",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -242,12 +242,14 @@ class TestTelegramBotCommands:
                 tg_name = cmd.name.replace("-", "_")
                 assert tg_name not in names
 
-    def test_excludes_commands_with_required_args(self):
+    def test_includes_builtin_commands_with_required_args(self):
+        """Built-in arg-taking commands (e.g. /queue, /steer, /background)
+        are now included because their handlers return usage text when
+        invoked without arguments — issue #24312."""
         names = {name for name, _ in telegram_bot_commands()}
-        assert "background" not in names
-        assert "queue" not in names
-        assert "steer" not in names
-        assert "background" in GATEWAY_KNOWN_COMMANDS
+        assert "background" in names
+        assert "queue" in names
+        assert "steer" in names
 
 
 class TestSlackSubcommandMap:


### PR DESCRIPTION
Salvage of #24340 by @ryptotalent onto current main. Supersedes #24312 (also fixes the same gap but with extra unrelated typing refactors).

## Verified bug
On current main, `telegram_bot_commands()` returns 37 commands but excludes 3 that have required `<...>` args yet are gateway-available:
- `/background <prompt>`
- `/queue <prompt>`
- `/steer <prompt>`

All three are in `GATEWAY_KNOWN_COMMANDS` (the gateway happily dispatches them when invoked with a payload), but Telegram users get zero autocomplete discovery. After fix: 40 commands returned, including those three.

## Tests
```
scripts/run_tests.sh tests/hermes_cli/test_commands.py
============================= 142 passed in 1.54s ==============================
```
`test_includes_builtin_commands_with_required_args` (added by the PR) replaces the now-stale `test_excludes_commands_with_required_args`.

Authorship preserved via cherry-pick + AUTHOR_MAP entry for ryptotalent. Original commit had a placeholder `Ubuntu <ubuntu@localhost.localdomain>` author — re-authored to canonical noreply form during salvage.