### PR TITLE
feat(gateway): add Slack profile visual identities

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16993,6 +16993,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if team_id:
                 metadata = dict(metadata or {})
                 metadata["slack_team_id"] = str(team_id)
+        profile = str(getattr(source, "profile", "") or "").strip()
+        if profile:
+            metadata = dict(metadata or {})
+            metadata["profile"] = profile
         return metadata
 
     def _thread_metadata_for_target(

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -81,6 +81,7 @@ def _build_full_manifest(
         "channels:history",
         "channels:read",
         "chat:write",
+        "chat:write.customize",
         "commands",
         "files:read",
         "files:write",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -712,6 +712,57 @@ _SLACK_PROXY_HOSTS = (
     "wss-primary.slack.com",
 )
 
+_SLACK_PROFILE_IDENTITY_FIELDS = ("username", "icon_url", "icon_emoji")
+
+
+def _resolve_slack_sender_profile(metadata: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the profile whose optional Slack identity should be used."""
+    if isinstance(metadata, dict):
+        profile = str(metadata.get("profile") or "").strip()
+        if profile:
+            return profile
+
+    profile = os.getenv("HERMES_PROFILE", "").strip()
+    if profile:
+        return profile
+
+    hermes_home = os.getenv("HERMES_HOME", "").strip()
+    if hermes_home:
+        try:
+            home_path = _Path(hermes_home)
+            if home_path.parent.name == "profiles" and home_path.name:
+                return home_path.name
+        except (OSError, ValueError):
+            pass
+
+    return "default"
+
+
+def resolve_slack_profile_identity(
+    config_extra: Optional[Dict[str, Any]],
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Return safe, configured Slack identity fields for this delivery.
+
+    Invalid configuration is deliberately ignored: profile presentation must
+    never prevent a message from reaching Slack.
+    """
+    if not isinstance(config_extra, dict):
+        return {}
+    identities = config_extra.get("profile_identities")
+    if not isinstance(identities, dict):
+        return {}
+
+    identity = identities.get(_resolve_slack_sender_profile(metadata))
+    if not isinstance(identity, dict):
+        return {}
+
+    return {
+        key: value
+        for key in _SLACK_PROFILE_IDENTITY_FIELDS
+        if (value := str(identity.get(key) or "").strip())
+    }
+
 
 def _resolve_slack_proxy_url() -> Optional[str]:
     """Resolve a proxy URL that Slack SDK clients can safely use."""
@@ -2544,6 +2595,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": chunk,
                     "mrkdwn": True,
                 }
+                kwargs.update(self._profile_identity_kwargs(metadata))
                 if blocks and i == 0:
                     kwargs["blocks"] = blocks
                 if thread_ts:
@@ -2619,6 +2671,12 @@ class SlackAdapter(BasePlatformAdapter):
                 retryable=_retryable,
                 retry_after=_retry_after,
             )
+
+    def _profile_identity_kwargs(
+        self, metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, str]:
+        """Resolve optional per-message Slack profile presentation."""
+        return resolve_slack_profile_identity(self.config.extra, metadata)
 
     async def send_private_notice(
         self,
@@ -6427,6 +6485,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
                 "blocks": sanitize_blocks(blocks),
             }
+            kwargs.update(self._profile_identity_kwargs(metadata))
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
@@ -6516,6 +6575,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "text": f"{title or 'Confirm'}: {body[:100]}",
                 "blocks": sanitize_blocks(blocks),
             }
+            kwargs.update(self._profile_identity_kwargs(metadata))
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
 
@@ -8670,6 +8730,9 @@ async def _standalone_send(
 
     formatted = _format_mrkdwn(message) if message else message
     formatted_caption = _format_mrkdwn(caption) if caption else caption
+    profile_identity = resolve_slack_profile_identity(
+        getattr(pconfig, "extra", None)
+    )
 
     # --- Media path: AsyncWebClient.files_upload_v2 (+ optional text) ---
     if media_files:
@@ -8698,6 +8761,7 @@ async def _standalone_send(
                 "text": text_to_send,
                 "mrkdwn": True,
             }
+            post_kwargs.update(profile_identity)
             if thread_id:
                 post_kwargs["thread_ts"] = thread_id
             try:
@@ -8727,6 +8791,7 @@ async def _standalone_send(
                             "text": formatted_caption,
                             "mrkdwn": True,
                         }
+                        fallback_kwargs.update(profile_identity)
                         if thread_id:
                             fallback_kwargs["thread_ts"] = thread_id
                         fb = await client.chat_postMessage(**fallback_kwargs)
@@ -8811,6 +8876,7 @@ async def _standalone_send(
             timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
         ) as session:
             payload = {"channel": chat_id, "text": formatted, "mrkdwn": True}
+            payload.update(profile_identity)
             if thread_id:
                 payload["thread_ts"] = thread_id
             for tok in tokens:
@@ -8969,8 +9035,9 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
     existing env-driven model and owns the YAML→env translation here, next to
     the adapter that consumes it. Env vars take precedence over YAML — every
     assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    survive a config.yaml update. ``profile_identities`` is message behavior,
+    not a secret, so it is returned for ``PlatformConfig.extra`` instead of
+    being flattened into environment variables.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -9022,7 +9089,14 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ic, list):
             ic = ",".join(str(v) for v in ic)
         os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
-    return None  # all settings flow through env; nothing to merge into extras
+    identities = slack_cfg.get("profile_identities")
+    if not isinstance(identities, dict):
+        return None
+    return {
+        "profile_identities": {
+            str(profile): identity for profile, identity in identities.items()
+        }
+    }
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1821,6 +1821,35 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_slack_profile_identities_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  profile_identities:\n"
+            "    orchestrator:\n"
+            "      username: Orchestrator\n"
+            "      icon_url: https://example.com/orchestrator.png\n"
+            "    support:\n"
+            "      username: Support Agent\n"
+            "      icon_emoji: ':office:'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["profile_identities"] == {
+            "orchestrator": {
+                "username": "Orchestrator",
+                "icon_url": "https://example.com/orchestrator.png",
+            },
+            "support": {
+                "username": "Support Agent",
+                "icon_emoji": ":office:",
+            },
+        }
+
     def test_bridges_feishu_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -149,6 +149,44 @@ class TestProfileMessageHandler:
         await handler(_Evt())
         assert seen["profile"] == "writer"
 
+    @pytest.mark.asyncio
+    async def test_multiplexed_profile_reaches_slack_delivery_identity(self):
+        """The profile stamped by multiplexing must survive outbound metadata."""
+        from unittest.mock import MagicMock
+
+        from plugins.platforms.slack.adapter import SlackAdapter
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        adapter = SlackAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="xoxb-fake",
+                extra={
+                    "profile_identities": {
+                        "coder": {"username": "Coder"},
+                    }
+                },
+            )
+        )
+        adapter._app = MagicMock()
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "1"})
+
+        class _Source:
+            platform = Platform.SLACK
+            profile = "coder"
+            chat_id = "C123"
+            chat_type = "group"
+            thread_id = None
+            message_id = "171.111"
+            scope_id = "T123"
+
+        metadata = runner._thread_metadata_for_source(_Source())
+        await adapter.send("C123", "profile response", metadata=metadata)
+
+        kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
+        assert metadata["profile"] == "coder"
+        assert kwargs["username"] == "Coder"
+
 
 class _SecondaryRecoveryAdapter:
     platform = Platform.DISCORD

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -213,6 +213,34 @@ def _fake_create_task(coro):
     return loop.create_task(_pending_for_fake_task())
 
 
+class _StandaloneSlackResponse:
+    async def json(self):
+        return {"ok": True, "ts": "171.222"}
+
+
+class _StandaloneSlackPost:
+    async def __aenter__(self):
+        return _StandaloneSlackResponse()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _StandaloneSlackSession:
+    def __init__(self):
+        self.payload = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, _url, **kwargs):
+        self.payload = kwargs["json"]
+        return _StandaloneSlackPost()
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -239,6 +267,51 @@ def adapter():
     # Capture events instead of processing them
     a.handle_message = AsyncMock()
     return a
+
+
+class TestProfileVisualIdentities:
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_profile_identity(self, adapter):
+        adapter.config.extra["profile_identities"] = {
+            "orchestrator": {
+                "username": "Orchestrator",
+                "icon_url": "https://example.com/orchestrator.png",
+            }
+        }
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "171.111"})
+
+        await adapter.send("C123", "hello", metadata={"profile": "orchestrator"})
+
+        kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
+        assert kwargs["username"] == "Orchestrator"
+        assert kwargs["icon_url"] == "https://example.com/orchestrator.png"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_profile_identity(self, monkeypatch):
+        from types import SimpleNamespace
+
+        session = _StandaloneSlackSession()
+        monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = await _slack_mod._standalone_send(
+                SimpleNamespace(
+                    token="xoxb-test",
+                    extra={
+                        "profile_identities": {
+                            "orchestrator": {
+                                "username": "Orchestrator",
+                                "icon_emoji": ":robot_face:",
+                            }
+                        }
+                    },
+                ),
+                "C123",
+                "hello",
+            )
+
+        assert result["success"] is True
+        assert session.payload["username"] == "Orchestrator"
+        assert session.payload["icon_emoji"] == ":robot_face:"
 
 
 @pytest.fixture(autouse=True)
@@ -1552,7 +1625,18 @@ class TestStandaloneSendMedia:
         client.files_upload_v2 = AsyncMock(
             return_value={"ok": True, "files": [{"id": "F123"}]}
         )
-        config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake-token",
+            extra={
+                "profile_identities": {
+                    "default": {
+                        "username": "Cron Hermes",
+                        "icon_emoji": ":robot_face:",
+                    }
+                }
+            },
+        )
 
         with (
             _fake_slack_sdk_modules(client),
@@ -1574,6 +1658,8 @@ class TestStandaloneSendMedia:
         assert result["success"] is True
         client.chat_postMessage.assert_awaited_once()
         assert client.chat_postMessage.await_args.kwargs["text"] == "daily report"
+        assert client.chat_postMessage.await_args.kwargs["username"] == "Cron Hermes"
+        assert client.chat_postMessage.await_args.kwargs["icon_emoji"] == ":robot_face:"
         client.files_upload_v2.assert_awaited_once()
         up_kwargs = client.files_upload_v2.await_args.kwargs
         assert up_kwargs["channel"] == "C123"

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -286,6 +286,11 @@ class TestSlackFullManifest:
         bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
         assert "groups:read" in bot_scopes
 
+    def test_custom_profile_identity_scope_is_included(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert "chat:write.customize" in manifest["oauth_config"]["scopes"]["bot"]
+
     def test_group_dm_scopes_and_event_are_included(self):
         """Group DMs (mpim) need message.mpim + mpim:history or Slack never
         delivers them — the adapter classifies mpim as a DM and replies

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -83,6 +83,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | Scope | Purpose |
 |-------|---------|
 | `chat:write` | Send messages as the bot |
+| `chat:write.customize` | Use configured Hermes profile names and avatars on outgoing messages |
 | `app_mentions:read` | Detect when @mentioned in channels |
 | `channels:history` | Read messages in public channels the bot is in |
 | `channels:read` | List and get info about public channels |
@@ -902,6 +903,31 @@ slack:
 ```
 
 Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
+
+## Profile Visual Identities
+
+One Slack app can visually distinguish Hermes profiles without creating a bot
+per profile. Configure a display name and either an avatar URL or emoji for
+each profile whose outgoing messages should have a custom presentation:
+
+```yaml
+slack:
+  profile_identities:
+    orchestrator:
+      username: "Orchestrator"
+      icon_url: "https://example.com/orchestrator.png"
+    support:
+      username: "Support Agent"
+      icon_emoji: ":office:"
+```
+
+Hermes uses the routed multiplexed profile when one is present, otherwise
+`HERMES_PROFILE`, a profile-shaped `HERMES_HOME`, then `default`. An absent or
+invalid matching entry leaves the normal Hermes bot identity unchanged.
+
+This feature requires Slack's `chat:write.customize` bot scope. Reinstall the
+Slack app after adding that scope. Configure profile identities only for Hermes
+profiles, never to impersonate people.
 
 ## Per-Channel Skill Bindings
 


### PR DESCRIPTION
## What

Adds optional Slack profile visual identities so configured Hermes profiles can post Slack messages with a custom `username`, `icon_url`, or `icon_emoji`.

## Why

Hermes already supports named profiles and Kanban-dispatched workers. In Slack, those profiles currently all appear as the same Hermes bot, which makes multi-profile workflows harder to follow. This lets one Slack app visually distinguish profile-originated messages without creating multiple Slack bots.

## How

- Adds `slack.profile_identities` config.
- Resolves the sending profile from `metadata.profile`, `HERMES_PROFILE`, or profile-shaped `HERMES_HOME`.
- Applies configured identity fields to Slack `chat.postMessage` calls.
- Preserves existing behavior when no identity is configured.
- Updates the generated Slack manifest to include Slack's `chat:write.customize` scope.
- Updates Slack user docs to document the `chat:write.customize` requirement, reinstall step, and `profile_identities` config.

## Testing

- `python3 -m py_compile gateway/platforms/slack.py gateway/config.py hermes_cli/slack_cli.py tools/send_message_tool.py`
- `git diff --check`
- `uv run --with pytest --with pytest-xdist --with pytest-asyncio pytest tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py tests/hermes_cli/test_slack_cli.py tests/tools/test_send_message_tool.py tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_slack_profile_identities_from_config_yaml -q`
  - Result: `326 passed`
- Manual Slack smoke test on macOS using an existing Slack app with `chat:write.customize`, verified a configured profile identity rendered in Slack.

## Platforms tested

- macOS, local development checkout.

## Compatibility

No schema changes. No Kanban behavior changes. No routing changes. Existing Slack installs continue to work without this config.
