### PR TITLE
fix(hermes_state): acquire lock in get_last_init_error() to match setter

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -98,8 +98,13 @@ def get_last_init_error() -> Optional[str]:
     call this to surface the underlying cause in their error messages when
     ``_session_db is None``.  Returns ``None`` if SessionDB initialized
     successfully (or hasn't been attempted).
+
+    Thread-safe: acquires ``_last_init_error_lock`` symmetrically with the
+    setter so readers never observe a partially-written value on non-GIL
+    runtimes (issue #24613).
     """
-    return _last_init_error
+    with _last_init_error_lock:
+        return _last_init_error
 
 
 def format_session_db_unavailable(prefix: str = "Session database not available") -> str:


### PR DESCRIPTION
## What does this PR do?

`get_last_init_error()` reads `_last_init_error` without acquiring `_last_init_error_lock`, while `_set_last_init_error()` correctly holds the lock. The setter's docstring explicitly documents: *"Thread-safe via _last_init_error_lock"* — but the getter ignores it.

## Root cause

`get_last_init_error()` reads `_last_init_error` without acquiring `_last_init_error_lock`, while `_set_last_init_error()` correctly holds the lock. The setter's docstring explicitly documents: *"Thread-safe via _last_init_error_lock"* — but the getter ignores it.

```python
# setter — correctly locked
def _set_last_init_error(msg):
    global _last_init_error
    with _last_init_error_lock:   # ✓
        _last_init_error = msg

# getter — NOT locked
def get_last_init_error():
    return _last_init_error       # ✗ races with any concurrent setter call
```

## Fix

Add `with _last_init_error_lock:` to the getter — one line:

```python
def get_last_init_error() -> Optional[str]:
    with _last_init_error_lock:
        return _last_init_error
```

No signature change. In CPython with the GIL the behaviour is identical; on free-threaded CPython (`--disable-gil`) and other runtimes the race is now properly closed.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24613

<details>
<summary>Original body</summary>

## Summary

`get_last_init_error()` reads `_last_init_error` without acquiring `_last_init_error_lock`, while `_set_last_init_error()` correctly holds the lock. The setter's docstring explicitly documents: *"Thread-safe via _last_init_error_lock"* — but the getter ignores it.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`get_last_init_error()` reads `_last_init_error` without acquiring `_last_init_error_lock`, while `_set_last_init_error()` correctly holds the lock. The setter's docstring explicitly documents: *"Thread-safe via _last_init_error_lock"* — but the getter ignores it.

```python
# setter — correctly locked
def _set_last_init_error(msg):
    global _last_init_error
    with _last_init_error_lock:   # ✓
        _last_init_error = msg

# getter — NOT locked
def get_last_init_error():
    return _last_init_error       # ✗ races with any concurrent setter call
```

## Root cause

The lock was introduced on the setter to prevent concurrent `SessionDB()` initialisations from clobbering each other in the gateway, but the getter was not updated to match. The API contract is half-implemented.

## Fix

Add `with _last_init_error_lock:` to the getter — one line:

```python
def get_last_init_error() -> Optional[str]:
    with _last_init_error_lock:
        return _last_init_error
```

No signature change. In CPython with the GIL the behaviour is identical; on free-threaded CPython (`--disable-gil`) and other runtimes the race is now properly closed.

## Tests

All 212 existing `tests/test_hermes_state.py` tests pass unchanged.

## Visual

```
Before:
  Gateway thread A ──[lock]── write(_last_init_error="err") ──[unlock]──▶
  CLI thread B                         read(_last_init_error) ← may tear on non-GIL

After:
  Gateway thread A ──[lock]── write ──[unlock]──▶
  CLI thread B          ──[lock]── read ──[unlock]──▶  ✓ always consistent
```

Closes #24613

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_