### PR TITLE
fix(auxiliary): pass cfg_base_url and cfg_api_key when resolving task provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3828,7 +3828,7 @@ def _resolve_task_provider_model(
             # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
             return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
-            return cfg_provider, resolved_model, None, None, resolved_api_mode
+            return cfg_provider, resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
 
         return "auto", resolved_model, None, None, resolved_api_mode
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -145,6 +145,7 @@ AUTHOR_MAP = {
     "ahmetosrak@Ahmet-MacBook-Air.local": "Osraka",
     "98612432+Osraka@users.noreply.github.com": "Osraka",
     "112634774+ryptotalent@users.noreply.github.com": "ryptotalent",
+    "270097726+hookinglau@users.noreply.github.com": "hookinglau",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",


### PR DESCRIPTION
Salvage of #24455 by @hookinglau onto current main.

## Verified bug
On current main, `agent/auxiliary_client.py:_resolve_task_provider_model()` at line 3830 silently drops the user's `auxiliary.<task>.api_key` (and `base_url`) when they specify a named provider WITHOUT also specifying base_url. Repro:

```
task_config = {'provider': 'openrouter', 'api_key': 'sk-or-test-12345'}
BEFORE FIX: returns provider='openrouter', base_url=None, api_key=None  ← api_key dropped!
AFTER FIX:  returns provider='openrouter', base_url=None, api_key='sk-or-test-12345'  ✓
```

User-visible impact: anyone setting `auxiliary.<task>.provider: openrouter` with an explicit `auxiliary.<task>.api_key` (and no base_url) silently has their api_key discarded; the task then falls back to env-var resolution (`OPENROUTER_API_KEY` etc.), which may not exist or may be a different key.

## Tests
```
scripts/run_tests.sh tests/agent/test_auxiliary_client.py
155 passed in 1.60s
```

Authorship preserved via cherry-pick + AUTHOR_MAP entry. Original commit had a placeholder `macbook <macbook@users.noreply.github.com>` author — re-authored to canonical noreply form during salvage.