### PR TITLE
fix(dashboard): skip browser-open on headless Linux to prevent process exit

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4432,11 +4432,33 @@ def start_server(
     if open_browser:
         import webbrowser
 
-        def _open():
-            time.sleep(1.0)
-            webbrowser.open(f"http://{host}:{port}")
+        # On headless Linux (no DISPLAY or WAYLAND_DISPLAY) some registered
+        # browsers are TUI programs (links, lynx, www-browser) that try to
+        # take over the terminal.  That can send SIGHUP to the server process
+        # and cause an immediate exit even though uvicorn bound successfully.
+        # Skip the auto-open attempt on headless systems and let the user
+        # open the URL manually.  macOS and Windows are always considered
+        # display-capable.
+        _has_display = (
+            sys.platform != "linux"
+            or bool(os.environ.get("DISPLAY"))
+            or bool(os.environ.get("WAYLAND_DISPLAY"))
+        )
 
-        threading.Thread(target=_open, daemon=True).start()
+        if _has_display:
+            def _open():
+                try:
+                    time.sleep(1.0)
+                    webbrowser.open(f"http://{host}:{port}")
+                except Exception:
+                    pass
+
+            threading.Thread(target=_open, daemon=True).start()
+        else:
+            _log.debug(
+                "Skipping browser-open: no DISPLAY or WAYLAND_DISPLAY detected "
+                "(headless Linux). Pass --no-open to suppress this detection."
+            )
 
     print(f"  Hermes Web UI → http://{host}:{port}")
     uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -146,6 +146,8 @@ AUTHOR_MAP = {
     "98612432+Osraka@users.noreply.github.com": "Osraka",
     "112634774+ryptotalent@users.noreply.github.com": "ryptotalent",
     "270097726+hookinglau@users.noreply.github.com": "hookinglau",
+    "5029547+AllynSheep@users.noreply.github.com": "AllynSheep",
+    "allyn0306@gmail.com": "AllynSheep",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",


### PR DESCRIPTION
Salvage of #24129 by @AllynSheep onto current main.

## Verified bug
On current main `hermes_cli/web_server.py:start_server()`, `webbrowser.open()` fires unconditionally on headless Linux. `webbrowser.GenericBrowser.open()` shells out via `subprocess.Popen(...)` then `p.wait()`s — when DISPLAY/WAYLAND_DISPLAY are unset and the registered browser is a TUI program (links/lynx/www-browser), the child takes over the controlling tty and SIGHUP propagates back, killing the dashboard server.

## Repro (PTY harness in /tmp)
```
$ BROWSER_OVERRIDE=/tmp/.../links_aggressive python3 run_in_pty.py buggy
… 1538928 Hangup    BROWSER_OVERRIDE=… python3 … buggy
exit_code: 129     # 128 + SIGHUP — server killed

$ BROWSER_OVERRIDE=… python3 run_in_pty.py fixed
[fixed] DISPLAY=None WAYLAND_DISPLAY=None
[fixed] skipped browser-open: headless
[fixed] tick 0 … tick 5
[fixed] EXIT_CLEAN
```

Fix gates the auto-open behind `sys.platform != 'linux' or DISPLAY or WAYLAND_DISPLAY` (macOS/Windows always open) and wraps the `webbrowser.open` call in try/except. Headless Linux gets a debug log instead.

## Tests
```
scripts/run_tests.sh tests/hermes_cli -k web_server
152 passed in 6.53s
```

Authorship preserved via cherry-pick + AUTHOR_MAP entry. Original commit had a placeholder `allyn <allyn0306@gmail.com>` author — re-authored to canonical noreply form during salvage.