### PR TITLE
fix(dashboard): display real config path on Config page

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -148,6 +148,8 @@ AUTHOR_MAP = {
     "270097726+hookinglau@users.noreply.github.com": "hookinglau",
     "5029547+AllynSheep@users.noreply.github.com": "AllynSheep",
     "allyn0306@gmail.com": "AllynSheep",
+    "46887634+aqilaziz@users.noreply.github.com": "aqilaziz",
+    "gonzes7@gmail.com": "aqilaziz",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -118,6 +118,7 @@ export default function ConfigPage() {
   const [yamlText, setYamlText] = useState("");
   const [yamlLoading, setYamlLoading] = useState(false);
   const [yamlSaving, setYamlSaving] = useState(false);
+  const [configPath, setConfigPath] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState<string>("");
   const [confirmReset, setConfirmReset] = useState(false);
   const { toast, showToast } = useToast();
@@ -176,6 +177,10 @@ export default function ConfigPage() {
     api
       .getDefaults()
       .then(setDefaults)
+      .catch(() => {});
+    api
+      .getStatus()
+      .then((resp) => setConfigPath(resp.config_path))
       .catch(() => {});
   }, []);
 
@@ -416,7 +421,7 @@ export default function ConfigPage() {
         <div className="flex items-center gap-2">
           <Settings2 className="h-4 w-4 text-muted-foreground" />
           <code className="text-xs text-muted-foreground bg-muted/50 px-2 py-0.5">
-            {t.config.configPath}
+            {configPath ?? t.config.configPath}
           </code>
         </div>
         <div className="flex items-center gap-1.5">


### PR DESCRIPTION
Salvage of #24044 by @aqilaziz onto current main.

## Verified bug
`web/src/pages/ConfigPage.tsx:413-415` on main rendered `<code>{t.config.configPath}</code>`. `t.config.configPath` is hardcoded to the string `"~/.hermes/config.yaml"` in **every locale** (verified in all 16 i18n files: en, zh, de, es, fr, ja, ko, ru, uk, it, pt, af, tr, ga, hu, zh-hant — all line 323; type at `i18n/types.ts:343`). So users with HERMES_HOME overrides or custom config paths saw a misleading placeholder.

`/api/status` already returns the real path (verified: `status_code: 200, config_path value: /tmp/hermes-test-config/config.yaml` from `hermes_cli/web_server.py:614`). The UI just never read it.

## Fix
Adds a `configPath` state, fetches it via the existing `useEffect` chain, renders `configPath ?? t.config.configPath` (i18n string preserved as fallback during load / on API failure).

## Tests
```
$ cd web && npx tsc --noEmit
(no errors, exit 0)
```

The `config_path` field is already on the `getStatus` response type at `web/src/lib/api.ts:368`, so no type churn needed.

Authorship preserved via cherry-pick + AUTHOR_MAP entries. Title rephrased to `fix(dashboard): ...` convention; body co-authored to original email.