### PR TITLE
fix(dashboard): rescan plugins when cached directory is removed

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4021,6 +4021,9 @@ def _get_dashboard_plugins(force_rescan: bool = False) -> list:
     global _dashboard_plugins_cache
     if _dashboard_plugins_cache is None or force_rescan:
         _dashboard_plugins_cache = _discover_dashboard_plugins()
+    elif _dashboard_plugins_cache:
+        if any(not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache):
+            _dashboard_plugins_cache = _discover_dashboard_plugins()
     return _dashboard_plugins_cache
 
 


### PR DESCRIPTION
Salvage of #24224 by @liuhao1024 onto current main.

## Verified bug
`_get_dashboard_plugins` (`hermes_cli/web_server.py:4021-4023`) on main only rebuilds the cache when it's `None` or `force_rescan=True`. Removing a plugin directory after first scan leaves stale entries pointing at non-existent `_dir`s — `/api/dashboard/plugins`, plugin asset routes, and registered API mounts then 404 when the frontend tries to fetch their `entry`/`css`/`api`.

Direct repro:
```
HERMES_HOME=/tmp/hermes-test-plugins → put manifest.json under plugins/myplugin/dashboard/
First call:  myplugin in result
shutil.rmtree(plugins/myplugin/dashboard)
Second call: myplugin STILL in result, _dir pointing at deleted path
STALE? True
```

After fix:
```
First call:  myplugin in result
remove dir
Second call: myplugin gone, only real plugins remain
STALE? False
```

## Tweak during salvage
Dropped the inline `from pathlib import Path as _Path` — `Path` is already imported at module level (line 25). 4-line addition becomes 3-line.

## Tests
```
scripts/run_tests.sh tests/hermes_cli -k web_server
152 passed in 3.88s
```

Authorship preserved via cherry-pick (email already in AUTHOR_MAP).