### PR TITLE
fix(tui): clear scrollback buffer on startup to prevent tmux scrollback leakage

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -150,6 +150,8 @@ AUTHOR_MAP = {
     "allyn0306@gmail.com": "AllynSheep",
     "46887634+aqilaziz@users.noreply.github.com": "aqilaziz",
     "gonzes7@gmail.com": "aqilaziz",
+    "6966326+laoli-no1@users.noreply.github.com": "laoli-no1",
+    "laoli_no1@163.com": "laoli-no1",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -20,6 +20,12 @@ if (!process.stdin.isTTY) {
 // terminal tab can still have mouse/focus/paste modes enabled.
 resetTerminalModes()
 
+// Clear visible screen + scrollback buffer. Without this, tmux may retain
+// stale TUI output in its scrollback buffer from the previous session,
+// which is visible when the user scrolls up or briefly before AlternateScreen
+// takes over on restart. See entry.tsx → AlternateScreen flow.
+process.stdout.write('\x1b[2J\x1b[H\x1b[3J')
+
 const gw = new GatewayClient()
 
 gw.start()


### PR DESCRIPTION
Salvage of #24440 by @laoli-no1 onto current main.

## Verified bug
On TUI startup inside tmux, prior session output remained in the scrollback buffer; user-visible when scrolling up or briefly before AlternateScreen took over on restart. Fix writes the standard ECMA-48/xterm scrollback-clear sequence `\x1b[2J\x1b[H\x1b[3J` to stdout AFTER `resetTerminalModes()` and BEFORE `new GatewayClient()`.

## Sequence audit
```
\x1b[2J  Erase In Display (visible screen) — ECMA-48
\x1b[H   Cursor home (1,1)                  — ECMA-48
\x1b[3J  Erase saved lines (scrollback)     — xterm extension, honored by tmux

$ infocmp xterm-256color | grep clear
  clear=\E[H\E[2J,
$ tput E3 | xxd
  1b5b 334a       # \x1b[3J exactly
```
Same pair GNU `clear -x` and `tput clear; tput E3` emit.

## Live tmux repro (this env, tmux 3.5a)
- Filled tmux pane with 30 echoed LINE markers.
- Before: `capture-pane -S -200` shows 60 LINE entries.
- After sending `\x1b[2J\x1b[H\x1b[3J`: 0 LINE entries.

## Tests
```
cd ui-tui && npx tsc --noEmit -p tsconfig.json
(no errors)
```

Authorship preserved via cherry-pick + AUTHOR_MAP entries (re-authored from `Li Lao <laoli_no1@163.com>` to canonical noreply form).