### PR TITLE
fix(cli): use display-width for response box header label to support CJK

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3669,7 +3669,7 @@ class HermesCLI:
             if self.show_timestamps:
                 label = f"{label} {datetime.now().strftime('%H:%M')}"
             w = shutil.get_terminal_size().columns
-            fill = w - 2 - len(label)
+            fill = w - 2 - HermesCLI._status_bar_display_width(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
         self._stream_buf += text
@@ -10393,7 +10393,7 @@ class HermesCLI:
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
                             label = f"{label}{datetime.now().strftime('%H:%M')} "
-                        fill = w - 2 - len(label)
+                        fill = w - 2 - HermesCLI._status_bar_display_width(label)
                         _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -152,6 +152,8 @@ AUTHOR_MAP = {
     "gonzes7@gmail.com": "aqilaziz",
     "6966326+laoli-no1@users.noreply.github.com": "laoli-no1",
     "laoli_no1@163.com": "laoli-no1",
+    "39730900+NorethSea@users.noreply.github.com": "NorethSea",
+    "963979204@qq.com": "NorethSea",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",


### PR DESCRIPTION
Salvage of #24236 by @NorethSea onto current main.

## Verified bug
`cli.py` lines 3672 and 10371 sized the response-box top border with `len(label)`, which counts every char as 1 cell. CJK chars occupy 2 cells in terminal, so the box top overshoots into the next line.

Repro (terminal width = 40, ASCII path unchanged):
```
label=' ⚕ 哈哈哈 '    len=7   cwidth=10
  BEFORE: ╭─ ⚕ 哈哈哈 ──────────────────────────────╮   ← 3 cells too wide
  AFTER : ╭─ ⚕ 哈哈哈 ───────────────────────────╮       ← matches closer
  closer: ╰──────────────────────────────────────╯

label=' ⚕ 你好世界 12:34 '   len=14  cwidth=18
  BEFORE: ╭─ ⚕ 你好世界 12:34 ───────────────────────╮  ← 4 cells too wide
  AFTER : ╭─ ⚕ 你好世界 12:34 ───────────────────╮      ← matches closer
```

Fix uses the existing `HermesCLI._status_bar_display_width` helper (already in cli.py at line 2881; uses `prompt_toolkit.utils.get_cwidth`, East-Asian-Width-aware).

## Tests
```
scripts/run_tests.sh tests/cli/test_cli_status_bar.py
34 passed in 1.91s
```

Authorship preserved via cherry-pick + AUTHOR_MAP entries.