### PR TITLE
fix(cli): @-file completion crash on Windows when paths aren't cp1252-decodable

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1362,9 +1362,9 @@ class SlashCommandCompleter(Completer):
             try:
                 proc = subprocess.run(
                     cmd, capture_output=True, text=True, timeout=2,
-                    cwd=cwd,
+                    cwd=cwd, encoding="utf-8", errors="replace",
                 )
-                if proc.returncode == 0 and proc.stdout.strip():
+                if proc.returncode == 0 and proc.stdout and proc.stdout.strip():
                     raw = proc.stdout.strip().split("\n")
                     # Store relative paths
                     for p in raw[:5000]:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -154,6 +154,8 @@ AUTHOR_MAP = {
     "laoli_no1@163.com": "laoli-no1",
     "39730900+NorethSea@users.noreply.github.com": "NorethSea",
     "963979204@qq.com": "NorethSea",
+    "2283389+JamesX88@users.noreply.github.com": "JamesX88",
+    "JamesX88@users.noreply.github.com": "JamesX88",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",


### PR DESCRIPTION
Salvage of #24106 by @JamesX88 onto current main.

## Verified bug (static-verified — Linux env, no live Windows repro)
`SlashCommandCompleter` at `hermes_cli/commands.py:1359-1364` runs `subprocess.run([rg, --files], ..., text=True)` without specifying `encoding=`. CPython falls back to `locale.getpreferredencoding(False)`, which is the active Windows ANSI code page (cp1252 on en-US installs).

ripgrep on Windows emits filesystem paths as **UTF-8** (uses OsString → UTF-8 for stdout). Decoding those bytes through cp1252 with the default `strict` errors handler raises `UnicodeDecodeError` whenever a path contains a byte that's undefined in cp1252.

cp1252 has 5 undefined byte values: 0x81, 0x8D, 0x8F, 0x90, 0x9D. Many extremely common CJK ideographs encode to UTF-8 sequences containing these bytes:
```
U+4E01 丁 → e4 b8 81  (0x81 undefined)
U+4E0D 不 → e4 b8 8d  (0x8D undefined)
U+4E0F 丏 → e4 b8 8f  (0x8F undefined)
U+4E10 丐 → e4 b8 90  (0x90 undefined)
U+4E1D 丝 → e4 b8 9d  (0x9D undefined)
```

The except clause is `except (subprocess.TimeoutExpired, OSError)` — `UnicodeDecodeError` is **not** caught. It propagates out of `_get_project_files` into the @-completion handler and crashes prompt_toolkit's input loop. Matches the reported symptom.

## Fix
Adds `encoding="utf-8", errors="replace"` to the subprocess.run call (matches what ripgrep actually emits, on every platform), plus a `proc.stdout and …` None guard. The change applies inside the for-loop covering all three commands (rg, fd, find), so the fix covers the entire fallback chain.

Linux behavior unchanged (locale already UTF-8).

## Tests
```
scripts/run_tests.sh tests/hermes_cli/test_commands.py
142 passed in 1.31s
```

Authorship preserved via cherry-pick + AUTHOR_MAP entries (re-authored from legacy noreply form to canonical `<id>+JamesX88@` form).