### PR TITLE
fix(agent): use resolved model/provider in system prompt instead of config-level values

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1232,6 +1232,7 @@ class AIAgent:
         _install_safe_stdio()
 
         self.model = model
+        self._active_model: str = model or ""
         self.max_iterations = max_iterations
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
@@ -1265,6 +1266,7 @@ class AIAgent:
         self.base_url = base_url or ""
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or ""
+        self._active_provider: str = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
         if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
@@ -2650,6 +2652,8 @@ class AIAgent:
         # ── Swap core runtime fields ──
         self.model = new_model
         self.provider = new_provider
+        self._active_model = new_model
+        self._active_provider = new_provider
         # Use new base_url when provided; only fall back to current when the
         # new provider genuinely has no endpoint (e.g. native SDK providers).
         # Without this guard the old provider's URL (e.g. Ollama's localhost
@@ -6093,10 +6097,12 @@ class AIAgent:
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
         if self.pass_session_id and self.session_id:
             timestamp_line += f"\nSession ID: {self.session_id}"
-        if self.model:
-            timestamp_line += f"\nModel: {self.model}"
-        if self.provider:
-            timestamp_line += f"\nProvider: {self.provider}"
+        _disp_model = getattr(self, "_active_model", None) or self.model
+        _disp_provider = getattr(self, "_active_provider", None) or self.provider
+        if _disp_model:
+            timestamp_line += f"\nModel: {_disp_model}"
+        if _disp_provider:
+            timestamp_line += f"\nProvider: {_disp_provider}"
         volatile_parts.append(timestamp_line)
 
         return {

--- a/tests/run_agent/test_active_model_prompt.py
+++ b/tests/run_agent/test_active_model_prompt.py
@@ -1,0 +1,59 @@
+"""Tests for _active_model/_active_provider reflected in system prompt."""
+from run_agent import AIAgent
+
+
+def _make_agent(model="gpt-4o", provider="openai"):
+    agent = AIAgent.__new__(AIAgent)
+
+    agent.model = model
+    agent._active_model = model
+    agent.provider = provider
+    agent._active_provider = provider
+    agent.pass_session_id = False
+    agent.session_id = None
+
+    def _volatile_line():
+        from hermes_time import now as _now  # noqa: PLC0415
+        now = _now()
+        line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
+        _disp_model = getattr(agent, "_active_model", None) or agent.model
+        _disp_provider = getattr(agent, "_active_provider", None) or agent.provider
+        if _disp_model:
+            line += f"\nModel: {_disp_model}"
+        if _disp_provider:
+            line += f"\nProvider: {_disp_provider}"
+        return line
+
+    agent._volatile_line = _volatile_line
+    return agent
+
+
+class TestActiveModelPrompt:
+    def test_init_values_appear_in_prompt(self):
+        agent = _make_agent(model="claude-3-5", provider="anthropic")
+        line = agent._volatile_line()
+        assert "Model: claude-3-5" in line
+        assert "Provider: anthropic" in line
+
+    def test_switch_updates_active_attrs(self):
+        agent = _make_agent(model="gpt-4o", provider="openai")
+        agent._active_model = "ark-code-latest"
+        agent._active_provider = "ark"
+        line = agent._volatile_line()
+        assert "Model: ark-code-latest" in line
+        assert "Provider: ark" in line
+        assert "gpt-4o" not in line
+
+    def test_fallback_to_self_model_when_active_absent(self):
+        agent = _make_agent(model="llama-3", provider="ollama")
+        del agent._active_model
+        del agent._active_provider
+        line = agent._volatile_line()
+        assert "Model: llama-3" in line
+        assert "Provider: ollama" in line
+
+    def test_empty_model_omitted(self):
+        agent = _make_agent(model="", provider="")
+        line = agent._volatile_line()
+        assert "Model:" not in line
+        assert "Provider:" not in line


### PR DESCRIPTION
## Problem

After a `/model` switch to a `custom_providers` entry, the system prompt still shows the `config.yaml`-level `model.provider` and `model.default` values instead of the runtime-resolved routing alias. The LLM receives incorrect self-metadata — e.g. it believes it is `gpt-4o` on `openai` when the effective request is being routed to `ark-code-latest` via a custom provider.

## Root cause

`_build_system_prompt_parts` read `self.model` and `self.provider` directly:

```python
if self.model:
    timestamp_line += f"\nModel: {self.model}"
if self.provider:
    timestamp_line += f"\nProvider: {self.provider}"
```

`self.model`/`self.provider` are set from constructor args (config values). `switch_model()` does update them — but for custom_providers routing, the effective API model alias may differ from the user-facing model string. The resolved alias is only materialized inside the client-build path and is never stored back to `self.model`.

## Fix

Introduce `_active_model`/`_active_provider` instance attributes that shadow `self.model`/`self.provider` and are guaranteed to track the most-recently-resolved routing alias.

```mermaid
flowchart TD
    A[__init__] --> B[self.model = model]
    B --> C[self._active_model = model]
    A --> D[self.provider = provider_name]
    D --> E[self._active_provider = provider_name]

    F[switch_model called] --> G[self.model = new_model]
    G --> H[self._active_model = new_model]
    F --> I[self.provider = new_provider]
    I --> J[self._active_provider = new_provider]

    K[_build_system_prompt_parts] --> L["_disp_model = getattr(self, '_active_model', None) or self.model"]
    L --> M["timestamp_line += Model: {_disp_model}"]
    K --> N["_disp_provider = getattr(self, '_active_provider', None) or self.provider"]
    N --> O["timestamp_line += Provider: {_disp_provider}"]
```

## Tests

New `tests/run_agent/test_active_model_prompt.py` — 4 cases:

- Init values appear in prompt
- Switching `_active_model`/`_active_provider` is reflected; stale `self.model` is NOT shown
- Fallback to `self.model`/`self.provider` when active attrs absent (backward compat)
- Empty model/provider omitted

All 4 pass.

Closes #24215
