### PR TITLE
fix(fallback): respect explicit api_mode on fallback_providers entries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -768,7 +768,17 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        # Respect explicit api_mode on the fallback entry. Without this,
+        # a custom_providers entry that speaks a non-default protocol but
+        # whose provider name / base URL doesn't match any heuristic below
+        # activates with chat_completions and routes to /chat/completions
+        # on a backend that doesn't serve it. The primary resolution path
+        # in hermes_cli/main.py already reads custom_providers[x].api_mode
+        # correctly — this restores parity on the fallback path.
+        _explicit_fb_api_mode = (fb.get("api_mode") or "").strip()
+        if _explicit_fb_api_mode:
+            fb_api_mode = _explicit_fb_api_mode
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
             fb_api_mode = "anthropic_messages"

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -305,3 +305,94 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+# ── Explicit api_mode on fallback entries ──────────────────────────────────
+
+
+class TestExplicitFallbackApiMode:
+    """An ``api_mode`` declared on a fallback entry must override heuristics.
+
+    The fallback activation path determined api_mode from a hardcoded
+    heuristic chain (provider name, base URL suffix, model pattern) and
+    never consulted the fallback entry's own ``api_mode`` field. For a
+    custom_providers entry that speaks a non-default protocol but whose
+    provider name / base URL doesn't match any heuristic (e.g. an
+    Anthropic-speaking local shim whose base URL doesn't end in
+    /anthropic), the fallback activated with ``chat_completions`` and
+    routed to /chat/completions on a backend that only serves /v1/messages.
+
+    Same bug class as the auxiliary-client gap (#10814) and the model
+    validator gap (#9146).
+    """
+
+    def test_explicit_api_mode_respected(self):
+        """Explicit api_mode on a custom-shim entry resolves to that mode."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom:anthropic-shim",
+                "model": "claude-sonnet-4.6",
+                "api_mode": "anthropic_messages",
+            },
+        )
+        mock_client = _mock_client(
+            api_key="shim-key",
+            base_url="http://127.0.0.1:9000",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "claude-sonnet-4.6"),
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+            assert agent.provider == "custom:anthropic-shim"
+            assert agent.model == "claude-sonnet-4.6"
+
+    def test_explicit_api_mode_overrides_heuristics(self):
+        """Explicit api_mode wins over URL / model heuristics."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom:anthropic-shim",
+                "model": "claude-sonnet-4.6",
+                "api_mode": "anthropic_messages",
+            },
+        )
+        mock_client = _mock_client(
+            api_key="shim-key",
+            base_url="http://127.0.0.1:4000/chat",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "claude-sonnet-4.6"),
+        ), patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "anthropic_messages"
+
+    def test_absent_api_mode_falls_through_to_heuristics(self):
+        """No explicit api_mode → existing heuristics resolve normally.
+
+        Regression guard that the explicit-mode shortcut doesn't change
+        URL / name based resolution.
+        """
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        )
+        mock_client = _mock_client(
+            api_key="sk-or-key",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "anthropic/claude-sonnet-4"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
The fallback activation path in _try_activate_fallback() determined api_mode from a hardcoded heuristic chain (provider name, base URL suffix, model pattern) and never consulted the fallback entry's own api_mode field.

For custom_providers that speak Anthropic but whose URL doesn't happen to end in /anthropic (e.g. a local custom gateway at http://127.0.0.1:9000 that serves /v1/messages), the fallback is activated with api_mode='chat_completions', then Hermes hits/chat/completions on a messages-only backend and gets 404s on every retry before falling through to the next entry.

The primary resolution path in hermes_cli/main.py:3714 already correctly reads custom_providers[x].api_mode. This restores parity on the fallback path: if the fallback entry sets api_mode explicitly, use it; otherwise, the existing heuristics still apply unchanged.

Same bug class as the auxiliary-client gap fixed in #10814 and the model validator gap fixed in #9146.

Tests:
- test_explicit_api_mode_respected, custom provider at arbitrary URL honours declared api_mode
- test_explicit_api_mode_overrides_heuristics, explicit mode wins over URL pattern heuristics
- test_absent_api_mode_falls_through_to_heuristics, regression guard that no-api_mode entries still resolve via the existing chain
