### PR TITLE
fix(webhook): scope idempotency keys by route and disable fallback dedupe

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -34,6 +34,7 @@ import logging
 import re
 import subprocess
 import time
+import uuid
 from typing import Any, Dict, List, Optional
 
 try:
@@ -441,10 +442,11 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+        # Build a delivery identity. Provider/request IDs are suitable for
+        # retry deduplication, but generated fallbacks are not: time-based
+        # IDs can collide across routes or within the same millisecond.
+        delivery_id, dedupe_key = self._resolve_delivery_identity(
+            route_name, request,
         )
 
         # ── Idempotency ─────────────────────────────────────────
@@ -456,15 +458,16 @@ class WebhookAdapter(BasePlatformAdapter):
             for k, v in self._seen_deliveries.items()
             if now - v < self._idempotency_ttl
         }
-        if delivery_id in self._seen_deliveries:
+        if dedupe_key and dedupe_key in self._seen_deliveries:
             logger.info(
-                "[webhook] Skipping duplicate delivery %s", delivery_id
+                "[webhook] Skipping duplicate delivery %s", dedupe_key
             )
             return web.json_response(
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
+        if dedupe_key:
+            self._seen_deliveries[dedupe_key] = now
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
@@ -581,6 +584,32 @@ class WebhookAdapter(BasePlatformAdapter):
             },
             status=202,
         )
+
+    def _resolve_delivery_identity(
+        self, route_name: str, request: "web.Request"
+    ) -> tuple[str, Optional[str]]:
+        """Return ``(delivery_id, dedupe_key)`` for the incoming request.
+
+        ``delivery_id`` is always unique enough to identify the run/session and
+        is returned to the caller. ``dedupe_key`` is only populated when the
+        request carried a caller-controlled retry token that is safe to use for
+        idempotency suppression.
+
+        Route scope is part of the dedupe key so two independent webhook routes
+        can legitimately reuse the same upstream request ID without suppressing
+        each other.
+        """
+        explicit_delivery_id = (
+            request.headers.get("X-GitHub-Delivery")
+            or request.headers.get("X-Request-ID")
+        )
+        if explicit_delivery_id:
+            explicit_delivery_id = str(explicit_delivery_id).strip()
+            if explicit_delivery_id:
+                return explicit_delivery_id, f"{route_name}:{explicit_delivery_id}"
+
+        generated_id = f"auto-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
+        return generated_id, None
 
     # ------------------------------------------------------------------
     # Signature validation

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -427,10 +427,54 @@ class TestIdempotency:
             assert resp1.status == 202
 
             # Backdate the cache entry so it appears expired
-            adapter._seen_deliveries["delivery-456"] = time.time() - 3700
+            adapter._seen_deliveries["idem:delivery-456"] = time.time() - 3700
 
             resp2 = await cli.post("/webhooks/idem", json={"x": 1}, headers=headers)
             assert resp2.status == 202  # re-accepted
+
+    @pytest.mark.asyncio
+    async def test_same_request_id_on_different_routes_is_not_deduped(self):
+        """Route scope must be part of the idempotency key.
+
+        Different webhook routes can legitimately reuse the same upstream
+        request ID; suppressing the second route would drop a real event.
+        """
+        routes = {
+            "route-a": {"secret": _INSECURE_NO_AUTH, "prompt": "a"},
+            "route-b": {"secret": _INSECURE_NO_AUTH, "prompt": "b"},
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-Request-ID": "shared-req-id"}
+
+            resp1 = await cli.post("/webhooks/route-a", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/route-b", json={"b": 2}, headers=headers)
+            assert resp2.status == 202
+
+    @pytest.mark.asyncio
+    async def test_generated_fallback_ids_are_not_deduped(self):
+        """Headerless requests must not be deduped by time-based fallback IDs."""
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        with patch("gateway.platforms.webhook.time.time", return_value=1234.567):
+            async with TestClient(TestServer(app)) as cli:
+                resp1 = await cli.post("/webhooks/idem", json={"n": 1})
+                assert resp1.status == 202
+                data1 = await resp1.json()
+
+                resp2 = await cli.post("/webhooks/idem", json={"n": 2})
+                assert resp2.status == 202
+                data2 = await resp2.json()
+
+        assert data1["delivery_id"] != data2["delivery_id"]
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Fixes false duplicate suppression in the webhook adapter's idempotency cache.

Previously, webhook deduplication used a global `delivery_id` key and also fell back to a millisecond timestamp when no upstream request ID was provided. That caused two real correctness bugs:

1. Different webhook routes could suppress each other if they reused the same `X-Request-ID`.
2. Headerless requests arriving in the same millisecond could be incorrectly treated as duplicates.

This change scopes explicit dedupe keys by route and disables dedupe for generated fallback IDs.

## Problem

| Case | Previous behavior | Why it was wrong |
| --- | --- | --- |
| Same `X-Request-ID` reused across different routes | Second route could return `duplicate` | Route A and Route B are independent delivery surfaces and should not cross-dedupe |
| No upstream delivery/request ID present | Fallback used `int(time.time() * 1000)` | Two real requests in the same millisecond could collide and get dropped |
| Explicit retry from the same route | Correctly deduped | This behavior should be preserved |

## What Changed

| Area | Change |
| --- | --- |
| `gateway/platforms/webhook.py` | Added `_resolve_delivery_identity(route_name, request)` |
| Idempotency keying | Explicit upstream IDs now dedupe as `"{route_name}:{delivery_id}"` |
| Fallback identity | Generated IDs remain unique for session/run tracking, but are not inserted into the dedupe cache |
| Existing behavior preserved | Explicit duplicate retries on the same route still return `status=duplicate` |

## Why This Fix Is Safe

| Property | Result |
| --- | --- |
| Scope | Narrow, webhook-only |
| Backward compatibility | Preserves existing duplicate suppression for explicit upstream IDs |
| Behavior change | Only removes false-positive duplicate suppression |
| Session isolation | Still uses `delivery_id` in per-request session chat IDs |

## Tests

Added regression coverage in `tests/gateway/test_webhook_adapter.py` for:

| Test | Purpose |
| --- | --- |
| `test_same_request_id_on_different_routes_is_not_deduped` | Ensures route scope is part of the dedupe key |
| `test_generated_fallback_ids_are_not_deduped` | Ensures headerless requests are not falsely deduped |
| Updated expired-entry test | Aligns cache expectations with route-scoped dedupe keys |

## Validation

| Command | Result |
| --- | --- |
| `uv run --extra messaging --extra dev pytest tests/gateway/test_webhook_adapter.py -q` | `56 passed in 5.16s` |
| `uv run --extra messaging --extra dev pytest tests/gateway/test_webhook_adapter.py -q -k "idempotency or request_id or fallback"` | `4 passed in 2.61s` |


