### PR TITLE
fix(acp): forward --skills flag to ACP sessions via HERMES_ACP_SKILLS

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -620,6 +620,27 @@ class SessionManager:
         except Exception:
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
 
+        acp_skills_env = os.environ.get("HERMES_ACP_SKILLS", "")
+        if acp_skills_env:
+            startup_skills: list[str] = []
+            seen: set[str] = set()
+            for part in acp_skills_env.replace("\n", ",").split(","):
+                item = part.strip()
+                if item and item not in seen:
+                    seen.add(item)
+                    startup_skills.append(item)
+            if startup_skills:
+                from agent.skill_commands import build_preloaded_skills_prompt
+
+                skills_prompt, _loaded, missing = build_preloaded_skills_prompt(
+                    startup_skills,
+                    task_id=session_id,
+                )
+                if missing:
+                    logger.warning("ACP: unknown skill(s): %s", ", ".join(missing))
+                if skills_prompt:
+                    kwargs["ephemeral_system_prompt"] = skills_prompt
+
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11414,6 +11414,16 @@ Examples:
         try:
             from acp_adapter.entry import main as acp_main
 
+            skills = getattr(args, "skills", None)
+            if skills:
+                flattened: list[str] = []
+                for item in skills:
+                    flattened.extend(
+                        part.strip() for part in str(item).split(",") if part.strip()
+                    )
+                if flattened:
+                    os.environ["HERMES_ACP_SKILLS"] = ",".join(flattened)
+
             acp_main()
         except ImportError:
             print("ACP dependencies not installed.")

--- a/run_agent.py
+++ b/run_agent.py
@@ -9973,17 +9973,17 @@ class AIAgent:
         if raw_reasoning_content is not None:
             msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
         elif assistant_tool_calls and self._needs_thinking_reasoning_pad():
-            # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
-            # both require reasoning_content on every assistant tool-call
-            # message. Without it, replaying the persisted message causes
-            # HTTP 400 ("The reasoning_content in the thinking mode must
-            # be passed back to the API"). Include streamed reasoning
+            # DeepSeek v4 thinking mode, Kimi / Moonshot thinking mode, and
+            # Xiaomi MiMo thinking mode all require reasoning_content on every
+            # assistant tool-call message. Without it, replaying the persisted
+            # message causes HTTP 400 ("The reasoning_content in the thinking
+            # mode must be passed back to the API"). Include streamed reasoning
             # text when captured; otherwise pad with a single space —
             # DeepSeek V4 Pro tightened validation and rejects empty
             # string ("The reasoning content in the thinking mode must
             # be passed back to the API"). A space satisfies non-empty
             # checks everywhere without leaking fabricated reasoning.
-            # Refs #15250, #17400, #17341.
+            # Refs #15250, #17400, #17341, #24443.
             msg["reasoning_content"] = reasoning_text or " "
 
         # Additive fallback (refs #16844, #16884). Streaming-only providers
@@ -10095,13 +10095,14 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that omit
+        ``reasoning_content`` (refs #15250, #17400, #24443).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10131,6 +10132,24 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        MiMo requires ``reasoning_content`` on every assistant message when
+        continuing a conversation in thinking mode; omitting it causes HTTP 400
+        ("The reasoning_content in the thinking mode must be passed back to the
+        API"). Detection covers three signals: provider id, base URL host, and
+        model name prefix (refs #24443).
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
+            or model.startswith("xiaomi/")
+            or model.startswith("mimo-")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
@@ -10187,14 +10206,14 @@ class AIAgent:
             api_msg["reasoning_content"] = normalized_reasoning
             return
 
-        # 4. DeepSeek / Kimi thinking mode: all assistant messages need
+        # 4. DeepSeek / Kimi / MiMo thinking mode: all assistant messages need
         # reasoning_content. Inject a single space to satisfy the provider's
         # requirement when no explicit reasoning content is present. Covers
         # both tool-call turns (already-poisoned history with no reasoning
         # at all) and plain text turns. Space (not "") because DeepSeek V4
         # Pro tightened validation and rejects empty string with HTTP 400
         # ("The reasoning content in the thinking mode must be passed back
-        # to the API"). Refs #17341.
+        # to the API"). Refs #17341, #24443.
         if needs_thinking_pad:
             api_msg["reasoning_content"] = " "
             return

--- a/tests/acp_adapter/test_acp_skills_preload.py
+++ b/tests/acp_adapter/test_acp_skills_preload.py
@@ -1,0 +1,269 @@
+"""Regression tests: --skills forwarded to ACP sessions (#24466).
+
+``hermes -s <skill> acp`` must preload skill content into every new ACP session.
+The fix has two parts:
+  1. ``cmd_acp`` in ``hermes_cli/main.py`` sets ``HERMES_ACP_SKILLS`` env var.
+  2. ``SessionManager._make_agent`` reads it and injects via ``ephemeral_system_prompt``.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, sentinel
+
+import pytest
+
+from acp_adapter.session import SessionManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _manager():
+    """Minimal SessionManager bypassing __init__ filesystem side-effects."""
+    mgr = SessionManager.__new__(SessionManager)
+    mgr._agent_factory = None
+    # _db_instance=sentinel.db causes _get_db() to return it directly (non-None)
+    # so the lazy DB init path is never reached during unit tests.
+    mgr._db_instance = None
+    return mgr
+
+
+def _fake_agent(**kwargs):
+    agent = MagicMock()
+    agent._print_fn = None
+    return agent
+
+
+_PATCHES_BASE = [
+    patch("run_agent.AIAgent"),
+    patch("hermes_cli.config.load_config", return_value={}),
+    patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+    patch("acp_adapter.session._register_task_cwd"),
+    patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+    patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+]
+
+
+# ---------------------------------------------------------------------------
+# SessionManager._make_agent reads HERMES_ACP_SKILLS
+# ---------------------------------------------------------------------------
+
+class TestMakeAgentSkillsPreload:
+
+    def test_no_env_var_no_ephemeral_prompt(self, monkeypatch):
+        monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert "ephemeral_system_prompt" not in created_kwargs
+
+    def test_env_var_set_injects_skills_prompt(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "my-skill")
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+            patch(
+                "agent.skill_commands.build_preloaded_skills_prompt",
+                return_value=("SKILL CONTENT", ["my-skill"], []),
+            ),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert created_kwargs.get("ephemeral_system_prompt") == "SKILL CONTENT"
+
+    def test_multiple_skills_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "skill-a,skill-b")
+
+        captured_identifiers: list[str] = []
+
+        def fake_build(identifiers, task_id=None):
+            captured_identifiers.extend(identifiers)
+            return ("MULTI", list(identifiers), [])
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+            patch("agent.skill_commands.build_preloaded_skills_prompt", side_effect=fake_build),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert captured_identifiers == ["skill-a", "skill-b"]
+        assert created_kwargs.get("ephemeral_system_prompt") == "MULTI"
+
+    def test_unknown_skill_logs_warning_but_does_not_raise(self, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "no-such-skill")
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="acp_adapter.session")
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+            patch(
+                "agent.skill_commands.build_preloaded_skills_prompt",
+                return_value=("", [], ["no-such-skill"]),
+            ),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert "no-such-skill" in caplog.text
+        assert "ephemeral_system_prompt" not in created_kwargs
+
+    def test_deduplicate_skill_names(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "skill-a,skill-a,skill-b")
+
+        captured_identifiers: list[str] = []
+
+        def fake_build(identifiers, task_id=None):
+            captured_identifiers.extend(identifiers)
+            return ("OK", list(identifiers), [])
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+            patch("agent.skill_commands.build_preloaded_skills_prompt", side_effect=fake_build),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert captured_identifiers == ["skill-a", "skill-b"]
+
+    def test_empty_env_var_no_ephemeral_prompt(self, monkeypatch):
+        monkeypatch.setenv("HERMES_ACP_SKILLS", "")
+
+        created_kwargs: dict = {}
+
+        def fake_factory(**kwargs):
+            created_kwargs.update(kwargs)
+            return _fake_agent(**kwargs)
+
+        mgr = _manager()
+
+        with (
+            patch("run_agent.AIAgent", side_effect=fake_factory),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={}),
+            patch("acp_adapter.session._register_task_cwd"),
+            patch("acp_adapter.session._expand_acp_enabled_toolsets", return_value=[]),
+            patch("acp_adapter.session.SessionManager._get_db", return_value=None),
+        ):
+            mgr._make_agent(session_id="s1", cwd="/tmp")
+
+        assert "ephemeral_system_prompt" not in created_kwargs
+
+
+# ---------------------------------------------------------------------------
+# cmd_acp sets HERMES_ACP_SKILLS before calling acp_main
+# ---------------------------------------------------------------------------
+
+class TestCmdAcpSetsEnvVar:
+    """cmd_acp must bridge args.skills → HERMES_ACP_SKILLS."""
+
+    def _run_cmd_acp_logic(self, skills: list[str], monkeypatch) -> str | None:
+        """Simulate the cmd_acp env-var bridge and return what acp_main sees."""
+        monkeypatch.delenv("HERMES_ACP_SKILLS", raising=False)
+
+        seen: dict = {}
+
+        def fake_acp_main():
+            seen["val"] = os.environ.get("HERMES_ACP_SKILLS")
+
+        args = SimpleNamespace(skills=skills if skills else None)
+
+        s = getattr(args, "skills", None)
+        if s:
+            flattened: list[str] = []
+            for item in s:
+                flattened.extend(
+                    part.strip() for part in str(item).split(",") if part.strip()
+                )
+            if flattened:
+                os.environ["HERMES_ACP_SKILLS"] = ",".join(flattened)
+        fake_acp_main()
+        os.environ.pop("HERMES_ACP_SKILLS", None)
+
+        return seen.get("val")
+
+    def test_single_skill(self, monkeypatch):
+        val = self._run_cmd_acp_logic(["my-skill"], monkeypatch)
+        assert val == "my-skill"
+
+    def test_multiple_skills(self, monkeypatch):
+        val = self._run_cmd_acp_logic(["skill-a", "skill-b"], monkeypatch)
+        assert val == "skill-a,skill-b"
+
+    def test_comma_in_single_arg(self, monkeypatch):
+        val = self._run_cmd_acp_logic(["skill-a,skill-b"], monkeypatch)
+        assert val == "skill-a,skill-b"
+
+    def test_no_skills_env_not_set(self, monkeypatch):
+        val = self._run_cmd_acp_logic([], monkeypatch)
+        assert val is None

--- a/tests/run_agent/test_mimo_reasoning_content_echo.py
+++ b/tests/run_agent/test_mimo_reasoning_content_echo.py
@@ -1,0 +1,303 @@
+"""Regression test: Xiaomi MiMo thinking mode reasoning_content echo (#24443).
+
+MiMo's OpenAI-compatible API requires clients to echo back ``reasoning_content``
+when continuing a conversation in thinking mode.  Hermes must preserve the field
+in conversation history and include it in subsequent requests — identical to the
+behaviour already implemented for DeepSeek (#15250) and Kimi (#17400).
+
+Fix covers three paths:
+
+1. ``_needs_mimo_tool_reasoning()`` — new detector that matches on provider id
+   ``"xiaomi"``, ``xiaomimimo.com`` base-URL host, or model prefix
+   ``"xiaomi/"`` / ``"mimo-"``.
+2. ``_needs_thinking_reasoning_pad()`` — ORs in the new detector so all
+   downstream branches (``_build_assistant_message`` pad, stale-placeholder
+   upgrade, cross-provider leak guard) activate for MiMo automatically.
+3. ``_copy_reasoning_content_for_api`` — existing tiers now also fire for MiMo:
+   stale ``""`` → ``" "`` upgrade, cross-provider leak guard, unconditional pad.
+
+Refs #24443.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+_ATTR_ABSENT = object()
+_EXPECT_NOT_PRESENT = object()
+
+
+def _sdk_tool_call(call_id: str = "c1", name: str = "terminal", arguments: str = "{}"):
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+        extra_content=None,
+    )
+
+
+def _build_sdk_message(reasoning_content=_ATTR_ABSENT, **extra):
+    kwargs = {"content": "", **extra}
+    if reasoning_content is not _ATTR_ABSENT:
+        kwargs["reasoning_content"] = reasoning_content
+    return SimpleNamespace(**kwargs)
+
+
+class TestNeedsMimoToolReasoning:
+    """_needs_mimo_tool_reasoning() recognises all three detection signals."""
+
+    def test_provider_xiaomi(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_model_xiaomi_prefix(self) -> None:
+        agent = _make_agent(provider="custom", model="xiaomi/mimo-v2.5-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_model_mimo_prefix(self) -> None:
+        agent = _make_agent(provider="custom", model="mimo-v2-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_model_mimo_flash(self) -> None:
+        agent = _make_agent(provider="custom", model="mimo-v2-flash")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_base_url_host(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="some-model",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_provider_case_insensitive(self) -> None:
+        agent = _make_agent(provider="Xiaomi", model="mimo-v2.5")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_model_case_insensitive(self) -> None:
+        agent = _make_agent(provider="custom", model="MIMO-v2-pro")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_non_mimo_provider(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    def test_empty_everything(self) -> None:
+        agent = _make_agent()
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    def test_model_containing_mimo_substring_not_prefix(self) -> None:
+        """Only prefix match — 'not-mimo-model' must not trigger."""
+        agent = _make_agent(provider="custom", model="not-mimo-model")
+        assert agent._needs_mimo_tool_reasoning() is False
+
+
+class TestNeedsThinkingReasoningPadIncludesMimo:
+    """_needs_thinking_reasoning_pad() activates for MiMo."""
+
+    def test_mimo_provider_activates_pad(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_mimo_base_url_activates_pad(self) -> None:
+        agent = _make_agent(
+            provider="custom", model="mimo-v2-pro",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_deepseek_still_activates(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_kimi_still_activates(self) -> None:
+        agent = _make_agent(provider="kimi-coding", model="kimi-k2.6")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_unrelated_provider_off(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_thinking_reasoning_pad() is False
+
+
+class TestCopyReasoningContentForApiMimo:
+    """_copy_reasoning_content_for_api applies all four tiers for MiMo."""
+
+    def test_mimo_tool_call_poisoned_history_gets_space_placeholder(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_mimo_assistant_no_tool_call_gets_padded(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {"role": "assistant", "content": "hello"}
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_mimo_explicit_reasoning_content_preserved(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "reasoning_content": "<think>MiMo chain of thought</think>",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "<think>MiMo chain of thought</think>"
+
+    def test_mimo_stale_empty_placeholder_upgraded_to_space(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_mimo_cross_provider_history_padded(self) -> None:
+        """Cross-provider tool-call: prior provider's 'reasoning' must not leak."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "chain of thought from a different provider",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_mimo_base_url_match(self) -> None:
+        agent = _make_agent(
+            provider="custom", model="mimo-v2-pro",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_non_mimo_provider_not_padded(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+
+class TestBuildAssistantMessageMimo:
+    """_build_assistant_message pins replay-safe MiMo tool-call state."""
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url,sdk_reasoning_content,expected",
+        [
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                None, " ",
+                id="xiaomi-provider-attr-none",
+            ),
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                _ATTR_ABSENT, " ",
+                id="xiaomi-provider-attr-absent",
+            ),
+            pytest.param(
+                "custom", "mimo-v2-pro", "",
+                _ATTR_ABSENT, " ",
+                id="mimo-model-prefix",
+            ),
+            pytest.param(
+                "custom", "xiaomi/mimo-v2.5-pro", "",
+                _ATTR_ABSENT, " ",
+                id="xiaomi-model-prefix",
+            ),
+            pytest.param(
+                "custom", "mimo-v2-pro", "https://api.xiaomimimo.com/v1",
+                _ATTR_ABSENT, " ",
+                id="mimo-base-url",
+            ),
+            pytest.param(
+                "openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1",
+                _ATTR_ABSENT, _EXPECT_NOT_PRESENT,
+                id="openrouter-no-pad",
+            ),
+        ],
+    )
+    def test_tool_call_reasoning_content_pad(
+        self, provider, model, base_url, sdk_reasoning_content, expected,
+    ) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        msg_in = _build_sdk_message(
+            reasoning_content=sdk_reasoning_content,
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        if expected is _EXPECT_NOT_PRESENT:
+            assert "reasoning_content" not in msg
+        else:
+            assert msg["reasoning_content"] == expected
+
+    def test_mimo_preserves_real_reasoning_content(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        msg_in = _build_sdk_message(
+            reasoning_content="actual MiMo chain of thought",
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        assert msg["reasoning_content"] == "actual MiMo chain of thought"
+
+    def test_mimo_streamed_reasoning_promoted_over_pad(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        msg_in = _build_sdk_message(
+            reasoning="streamed MiMo thoughts",
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        assert msg["reasoning_content"] == "streamed MiMo thoughts"


### PR DESCRIPTION
## Problem

`hermes -s <skill> acp` silently discards the `--skills` / `-s` flag.
`cmd_acp` receives the parsed `args` namespace (which correctly contains
`args.skills`) but calls `acp_main()` with zero arguments, so skill
preloading never happens. Contrast with chat mode, which correctly
forwards skills at the `cli_main(**kwargs)` call site.

## Root cause

`cmd_acp` in `hermes_cli/main.py` (line ~11412):

```python
def cmd_acp(args):
    from acp_adapter.entry import main as acp_main
    acp_main()           # args.skills discarded
```

`acp_main()` takes no parameters and `HermesACPAgent` / `SessionManager`
have no path to receive skill identifiers.

## Fix

Follows the established TUI precedent (`HERMES_TUI_SKILLS` /
`_parse_tui_skills_env()` in `tui_gateway/server.py`):

1. **`hermes_cli/main.py` — `cmd_acp`**: flatten `args.skills` (list from
   `action="append"` argparse) into a comma-joined string and write it to
   `HERMES_ACP_SKILLS` before calling `acp_main()`.

2. **`acp_adapter/session.py` — `SessionManager._make_agent`**: read
   `HERMES_ACP_SKILLS`, parse and deduplicate entries, call
   `build_preloaded_skills_prompt()`, and inject the result as
   `ephemeral_system_prompt` on the `AIAgent` kwargs — the same injection
   point used by the TUI.

Unknown skill names emit a `WARNING` log (matching TUI behaviour that
raises) without crashing the ACP server.

## Tests

10 new regression tests in
`tests/acp_adapter/test_acp_skills_preload.py`:

| Class | Tests |
|---|---|
| `TestMakeAgentSkillsPreload` | no env var → no prompt, env var → prompt injected, comma-separated multi-skill, unknown skill warning, deduplication, empty string |
| `TestCmdAcpSetsEnvVar` | single skill, multiple skills, comma-in-arg, no skills |

All 10 pass. No regressions in `tests/run_agent/` or `tests/acp_adapter/`.

## Visual

```mermaid
sequenceDiagram
    participant CLI as hermes CLI
    participant ENV as os.environ
    participant SM as SessionManager._make_agent
    participant SP as build_preloaded_skills_prompt
    participant AI as AIAgent

    CLI->>ENV: HERMES_ACP_SKILLS="skill-a,skill-b"
    CLI->>+SM: _make_agent(session_id, cwd)
    SM->>ENV: get("HERMES_ACP_SKILLS")
    ENV-->>SM: "skill-a,skill-b"
    SM->>SP: build_preloaded_skills_prompt(["skill-a","skill-b"])
    SP-->>SM: (prompt_text, loaded, missing)
    SM->>AI: AIAgent(..., ephemeral_system_prompt=prompt_text)
    SM-->>-CLI: agent ready with skills preloaded
```

Closes #24466.