### PR TITLE
fix(agent): add MiMo to reasoning_content echo-back providers in _needs_thinking_reasoning_pad

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10095,13 +10095,27 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo all
+        reject replays of assistant tool-call messages that omit
+        ``reasoning_content`` (refs #15250, #17400, #24443).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
+        )
+
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the active provider is Xiaomi MiMo thinking mode.
+
+        MiMo requires reasoning_content to be echoed back on every assistant
+        turn (same contract as DeepSeek/Kimi).  Detected by base_url matching
+        xiaomimimo.com or "mimo" appearing in the model name.
+        """
+        model = (self.model or "").lower()
+        return (
+            base_url_host_matches(self.base_url, "xiaomimimo.com")
+            or "mimo" in model
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:

--- a/tests/run_agent/test_mimo_reasoning_content_echo.py
+++ b/tests/run_agent/test_mimo_reasoning_content_echo.py
@@ -1,0 +1,62 @@
+"""Regression tests: MiMo reasoning_content echo-back detection.
+
+MiMo (Xiaomi) thinking-mode models require ``reasoning_content`` to be
+echoed back on every assistant turn that carried tool_calls, identical to
+the existing DeepSeek / Kimi contract.  Without it the API rejects the
+replay with HTTP 400:
+
+    The reasoning_content in the thinking mode must be passed back to the API.
+
+Detection signals: base_url matches ``xiaomimimo.com`` OR ``"mimo"``
+appears in the model name.
+
+Refs #24443.
+"""
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    return agent
+
+
+class TestNeedsMimoToolReasoning:
+    def test_mimo_base_url_detected(self):
+        agent = _make_agent(base_url="https://api.xiaomimimo.com/v1")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_mimo_in_model_name_detected(self):
+        agent = _make_agent(model="mimo-7b-thinking")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_mimo_uppercase_model_name_detected(self):
+        agent = _make_agent(model="MiMo-VL-7B-RL")
+        assert agent._needs_mimo_tool_reasoning() is True
+
+    def test_unrelated_provider_not_detected(self):
+        agent = _make_agent(provider="openai", model="gpt-4o", base_url="https://api.openai.com/v1")
+        assert agent._needs_mimo_tool_reasoning() is False
+
+    def test_deepseek_not_detected_as_mimo(self):
+        agent = _make_agent(provider="deepseek", base_url="https://api.deepseek.com/v1")
+        assert agent._needs_mimo_tool_reasoning() is False
+
+
+class TestNeedsThinkingReasoningPadIncludesMimo:
+    def test_mimo_url_triggers_pad(self):
+        agent = _make_agent(base_url="https://api.xiaomimimo.com/v1")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_mimo_model_triggers_pad(self):
+        agent = _make_agent(model="mimo-7b")
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    def test_unrelated_provider_skips_pad(self):
+        agent = _make_agent(provider="anthropic", model="claude-3-5", base_url="https://api.anthropic.com")
+        assert agent._needs_thinking_reasoning_pad() is False


### PR DESCRIPTION
## Problem

Multi-turn MiMo (Xiaomi) reasoning-model conversations fail with HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

Hermes already handles this requirement for DeepSeek and Kimi, but MiMo (`api.xiaomimimo.com`, model names containing `mimo`) was absent from the predicate, so `_copy_reasoning_content_for_api` never injected the required `reasoning_content` placeholder on replayed assistant turns.

## Root cause

`_needs_thinking_reasoning_pad()` at line ~10101 only ORs DeepSeek and Kimi:

```python
def _needs_thinking_reasoning_pad(self) -> bool:
    return (
        self._needs_deepseek_tool_reasoning()
        or self._needs_kimi_tool_reasoning()
    )
```

MiMo was never included.

## Fix

Add `_needs_mimo_tool_reasoning()` and include it in the combined predicate.

```mermaid
flowchart TD
    A[_needs_thinking_reasoning_pad] --> B[_needs_deepseek_tool_reasoning]
    A --> C[_needs_kimi_tool_reasoning]
    A --> D[_needs_mimo_tool_reasoning]
    D --> E{base_url matches xiaomimimo.com?}
    E -- yes --> TRUE[return True]
    D --> F{"'mimo' in model.lower()?"}
    F -- yes --> TRUE
    E -- no --> F
    F -- no --> FALSE[return False]
```

Detection mirrors the DeepSeek/Kimi pattern: match on base URL hostname OR model name substring, covering both direct API access and custom-provider setups.

## Tests

New `tests/run_agent/test_mimo_reasoning_content_echo.py` — 8 cases:

- Base URL `api.xiaomimimo.com` detected
- `mimo-7b-thinking` model name detected
- `MiMo-VL-7B-RL` (mixed-case) detected
- Unrelated provider not detected
- DeepSeek not detected as MiMo
- MiMo URL triggers `_needs_thinking_reasoning_pad`
- MiMo model name triggers `_needs_thinking_reasoning_pad`
- Unrelated provider skips pad

All 8 pass.

Closes #24443
