### PR TITLE
feat(cache): enable Anthropic cache_control for DeepSeek on OpenCode (#24617)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3567,11 +3567,19 @@ class AIAgent:
         # rewards them with real cache hits.  Without this branch
         # qwen3.6-plus on opencode-go reports 0% cached tokens and burns
         # through the subscription on every turn.
+        #
+        # DeepSeek on OpenCode (Zen/Go) routes through the same gateway,
+        # which implements cache_control at the gateway level (not per
+        # model). The model switcher reports `$0.01/M cache read` pricing
+        # for deepseek-v4-pro on opencode-go, confirming gateway-side
+        # cache support — but without markers Hermes serves 0% cache hits.
+        # Issue #24617.
         model_is_qwen = "qwen" in model_lower
+        model_is_deepseek = "deepseek" in model_lower
         provider_is_alibaba_family = provider_lower in {
             "opencode", "opencode-zen", "opencode-go", "alibaba",
         }
-        if provider_is_alibaba_family and model_is_qwen:
+        if provider_is_alibaba_family and (model_is_qwen or model_is_deepseek):
             # Envelope layout (native_anthropic=False): markers on inner
             # content parts, not top-level tool messages.  Matches
             # pi-mono's "alibaba" cacheControlFormat.

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -246,6 +246,40 @@ class TestQwenAlibabaFamily:
         )
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_deepseek_on_opencode_go_caches_with_envelope_layout(self):
+        # Issue #24617: deepseek-v4-pro on opencode-go reports
+        # `$0.01/M cache read` pricing — gateway-side cache_control is
+        # supported but never engaged without markers.
+        agent = _make_agent(
+            provider="opencode-go",
+            base_url="https://opencode.ai/v1",
+            api_mode="chat_completions",
+            model="deepseek-v4-pro",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True, "DeepSeek on opencode-go must cache"
+        assert native is False, "opencode-go is OpenAI-wire; envelope layout"
+
+    def test_deepseek_on_opencode_zen_caches(self):
+        agent = _make_agent(
+            provider="opencode",
+            base_url="https://opencode.ai/v1",
+            api_mode="chat_completions",
+            model="deepseek-v3.5",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_deepseek_on_openrouter_not_affected(self):
+        # DeepSeek via OpenRouter falls through — same as Qwen, OpenRouter
+        # has its own upstream caching arrangement.
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="deepseek/deepseek-chat",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
     def test_qwen_on_openrouter_not_affected(self):
         # Qwen via OpenRouter falls through — OpenRouter has its own
         # upstream caching arrangement for Qwen (provider-dependent).


### PR DESCRIPTION
## Summary

OpenCode Go is a gateway that implements `cache_control` at its own level, not per model — the same envelope-layout marker injection that makes Qwen on `opencode-go` pay the cached-read rate also works for DeepSeek models on the same gateway. The model switcher reports `\$0.01/M cache read` pricing for `deepseek-v4-pro` on `opencode-go`, confirming gateway-side cache support. Without markers Hermes serves 0% cache hits and re-bills the full prompt on every turn.

## Fix

Extend the alibaba-family branch in `_anthropic_prompt_cache_policy` (run_agent.py:3570) to accept DeepSeek models alongside Qwen on the four `opencode` / `opencode-zen` / `opencode-go` / `alibaba` providers. The wire format (OpenAI chat completions) and marker layout (envelope, not native) are identical to the existing Qwen path — this is purely an expansion of the model whitelist.

```python
model_is_qwen = "qwen" in model_lower
model_is_deepseek = "deepseek" in model_lower
provider_is_alibaba_family = provider_lower in {
    "opencode", "opencode-zen", "opencode-go", "alibaba",
}
if provider_is_alibaba_family and (model_is_qwen or model_is_deepseek):
    return True, False
```

## Test plan

- [x] `test_deepseek_on_opencode_go_caches_with_envelope_layout` — the reported case (`deepseek-v4-pro` on `opencode-go`) returns `(True, False)`.
- [x] `test_deepseek_on_opencode_zen_caches` — same marker layout on `opencode-zen`.
- [x] `test_deepseek_on_openrouter_not_affected` — DeepSeek via OpenRouter still falls through to its own caching arrangement (no regression for non-alibaba-family providers).
- [x] All 39 existing tests in `tests/run_agent/test_anthropic_prompt_cache_policy.py` still pass.

## Risk

Zero. If the gateway doesn't honor cache for a specific DeepSeek model, the markers are silently ignored. Non-DeepSeek/non-Qwen models on opencode-go (GLM, Kimi) keep falling through to `(False, False)` as before — verified by the existing `test_non_qwen_on_opencode_go_does_not_cache` and `test_kimi_on_opencode_go_does_not_cache`.

Fixes #24617