### PR TITLE
fix(url_safety): fix TOCTOU race in _global_allow_private_urls lazy-init

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -345,6 +345,83 @@ class TestAllowPrivateUrlsIntegration:
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
         assert is_safe_url("http://metadata.google.internal/computeMetadata/v1/") is False
 
+
+class TestAllowPrivateUrlsConcurrency:
+    """Regression tests for the TOCTOU race in _global_allow_private_urls (#24623).
+
+    The old implementation published _allow_private_resolved=True before
+    _cached_allow_private was fully computed.  A concurrent caller on the fast
+    path would observe resolved=True and return the stale default False even
+    when the user had opted in.  The fix uses double-checked locking.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        _reset_allow_private_cache()
+        yield
+        _reset_allow_private_cache()
+
+    def test_concurrent_calls_all_agree(self, monkeypatch):
+        """Spawn many threads simultaneously; all must return the same value."""
+        import threading as _threading
+
+        monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+        results: list[bool] = []
+        errors: list[Exception] = []
+        barrier = _threading.Barrier(20)
+
+        def call_it():
+            try:
+                barrier.wait()  # start all threads at once
+                results.append(_global_allow_private_urls())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=call_it) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"thread errors: {errors}"
+        assert all(r is True for r in results), f"inconsistent results: {results}"
+
+    def test_concurrent_false_all_agree(self, monkeypatch):
+        """Same test for the False outcome (default / no toggle)."""
+        import threading as _threading
+
+        monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+        results: list[bool] = []
+        errors: list[Exception] = []
+        barrier = _threading.Barrier(20)
+
+        def call_it():
+            try:
+                barrier.wait()
+                with patch("hermes_cli.config.read_raw_config", return_value={}):
+                    results.append(_global_allow_private_urls())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [_threading.Thread(target=call_it) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"thread errors: {errors}"
+        assert all(r is False for r in results), f"inconsistent results: {results}"
+
+    def test_reset_cache_is_safe_to_call_under_lock(self, monkeypatch):
+        """_reset_allow_private_cache must not deadlock when called after resolution."""
+        monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+        assert _global_allow_private_urls() is True
+        # Must not deadlock
+        _reset_allow_private_cache()
+        monkeypatch.delenv("HERMES_ALLOW_PRIVATE_URLS", raising=False)
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert _global_allow_private_urls() is False
+
     def test_metadata_goog_blocked_even_with_toggle(self, monkeypatch):
         """metadata.goog is ALWAYS blocked."""
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -27,6 +27,7 @@ import ipaddress
 import logging
 import os
 import socket
+import threading
 from urllib.parse import urlparse
 
 from utils import is_truthy_value
@@ -73,8 +74,12 @@ _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 # Global toggle: allow private/internal IP resolution
 # ---------------------------------------------------------------------------
 # Cached after first read so we don't hit the filesystem on every URL check.
+# _allow_private_lock guards the lazy-init to prevent a TOCTOU race where a
+# concurrent caller sees _allow_private_resolved=True while _cached_allow_private
+# still holds the stale default (False) — refs #24623.
 _allow_private_resolved = False
 _cached_allow_private: bool = False
+_allow_private_lock = threading.Lock()
 
 
 def _global_allow_private_urls() -> bool:
@@ -91,48 +96,52 @@ def _global_allow_private_urls() -> bool:
     if _allow_private_resolved:
         return _cached_allow_private
 
-    _allow_private_resolved = True
-    _cached_allow_private = False  # safe default
-
-    # 1. Env var override (highest priority)
-    env_val = os.getenv("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
-    if env_val in {"true", "1", "yes"}:
-        _cached_allow_private = True
-        return _cached_allow_private
-    if env_val in {"false", "0", "no"}:
-        # Explicit false — don't fall through to config
-        return _cached_allow_private
-
-    # 2. Config file
-    try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
-        # security.allow_private_urls (preferred)
-        sec = cfg.get("security", {})
-        if isinstance(sec, dict) and is_truthy_value(
-            sec.get("allow_private_urls"), default=False
-        ):
-            _cached_allow_private = True
+    with _allow_private_lock:
+        # Double-checked: another thread may have finished while we waited.
+        if _allow_private_resolved:
             return _cached_allow_private
-        # browser.allow_private_urls (legacy fallback)
-        browser = cfg.get("browser", {})
-        if isinstance(browser, dict) and is_truthy_value(
-            browser.get("allow_private_urls"), default=False
-        ):
-            _cached_allow_private = True
-            return _cached_allow_private
-    except Exception:
-        # Config unavailable (e.g. tests, early import) — keep default
-        pass
 
-    return _cached_allow_private
+        result = False  # safe default
+
+        # 1. Env var override (highest priority)
+        env_val = os.getenv("HERMES_ALLOW_PRIVATE_URLS", "").strip().lower()
+        if env_val in {"true", "1", "yes"}:
+            result = True
+        elif env_val not in {"false", "0", "no"}:
+            # 2. Config file (only when env var not an explicit false)
+            try:
+                from hermes_cli.config import read_raw_config
+                cfg = read_raw_config()
+                # security.allow_private_urls (preferred)
+                sec = cfg.get("security", {})
+                if isinstance(sec, dict) and is_truthy_value(
+                    sec.get("allow_private_urls"), default=False
+                ):
+                    result = True
+                else:
+                    # browser.allow_private_urls (legacy fallback)
+                    browser = cfg.get("browser", {})
+                    if isinstance(browser, dict) and is_truthy_value(
+                        browser.get("allow_private_urls"), default=False
+                    ):
+                        result = True
+            except Exception:
+                # Config unavailable (e.g. tests, early import) — keep default
+                pass
+
+        # Publish value before the resolved flag so no thread can observe
+        # resolved=True with a stale value.
+        _cached_allow_private = result
+        _allow_private_resolved = True
+        return _cached_allow_private
 
 
 def _reset_allow_private_cache() -> None:
     """Reset the cached toggle — only for tests."""
     global _allow_private_resolved, _cached_allow_private
-    _allow_private_resolved = False
-    _cached_allow_private = False
+    with _allow_private_lock:
+        _allow_private_resolved = False
+        _cached_allow_private = False
 
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:


### PR DESCRIPTION
## Problem

`_global_allow_private_urls()` in `tools/url_safety.py` has a TOCTOU race in its lazy-init pattern. The resolved flag is published **before** the cached value is computed, so a concurrent caller on the fast path returns the stale default `False` even when `allow_private_urls` is configured `true`.

**Timeline of the race:**

```
Thread A: _allow_private_resolved = True   ← published too early
Thread B: sees resolved=True → returns _cached_allow_private = False (stale!)
Thread A: _cached_allow_private = True     ← too late for Thread B
```

## Root cause

```python
_allow_private_resolved = True   # line 94 — published before value is ready
_cached_allow_private = False    # safe default
# ... config reads happen here ...
_cached_allow_private = True     # may still be running when Thread B passes line 91
```

## Fix

Add `_allow_private_lock = threading.Lock()` and apply double-checked locking so `_cached_allow_private` is fully computed before `_allow_private_resolved` is set to `True`. `_reset_allow_private_cache()` (test helper) also holds the lock to prevent teardown races.

```python
with _allow_private_lock:
    if _allow_private_resolved:          # double-check inside lock
        return _cached_allow_private
    # ... compute result ...
    _cached_allow_private = result       # value first
    _allow_private_resolved = True       # flag last
```

## Impact

- The race fires at process start when multiple gateway requests arrive concurrently.
- Failure mode: false-deny — a URL the user explicitly allowed via config is blocked for that call. Silent, no error logged.
- Fixed by ensuring the flag is only published after the value is stable.

## Tests

3 new regression tests in `TestAllowPrivateUrlsConcurrency` appended to `tests/tools/test_url_safety.py`:

| Test | Coverage |
|---|---|
| `test_concurrent_calls_all_agree` | 20 threads race on toggle=True; all must return True |
| `test_concurrent_false_all_agree` | 20 threads race on toggle=False; all must return False |
| `test_reset_cache_is_safe_to_call_under_lock` | reset + re-resolve does not deadlock |

All 100 tests in `test_url_safety.py` pass.

## Visual

```mermaid
sequenceDiagram
    participant A as Thread A (slow path)
    participant B as Thread B (concurrent)
    participant Lock as _allow_private_lock

    Note over A,B: Before fix (race)
    A->>A: _allow_private_resolved = True  ← too early
    B->>B: sees resolved=True → returns False (stale)
    A->>A: _cached_allow_private = True   ← too late

    Note over A,B: After fix (double-checked lock)
    A->>Lock: acquire
    A->>A: compute result
    A->>A: _cached_allow_private = result  ← value first
    A->>A: _allow_private_resolved = True  ← flag last
    A->>Lock: release
    B->>B: sees resolved=True → returns correct value
```

Closes #24623.