### PR TITLE
fix(gateway): add threading.Lock to progress_callback dedup state (closes #24604)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14222,6 +14222,7 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        _progress_dedup_lock = threading.Lock()
 
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
@@ -14301,9 +14302,10 @@ class GatewayRunner:
                 pass
 
             # "new" mode: only report when tool changes
-            if progress_mode == "new" and tool_name == last_tool[0]:
-                return
-            last_tool[0] = tool_name
+            with _progress_dedup_lock:
+                if progress_mode == "new" and tool_name == last_tool[0]:
+                    return
+                last_tool[0] = tool_name
             
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
@@ -14344,14 +14346,15 @@ class GatewayRunner:
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same
             # code (same boilerplate imports → identical previews).
-            if msg == last_progress_msg[0]:
-                repeat_count[0] += 1
-                # Update the last line in progress_lines with a counter
-                # via a special "dedup" queue message.
-                progress_queue.put(("__dedup__", msg, repeat_count[0]))
-                return
-            last_progress_msg[0] = msg
-            repeat_count[0] = 0
+            with _progress_dedup_lock:
+                if msg == last_progress_msg[0]:
+                    repeat_count[0] += 1
+                    # Update the last line in progress_lines with a counter
+                    # via a special "dedup" queue message.
+                    progress_queue.put(("__dedup__", msg, repeat_count[0]))
+                    return
+                last_progress_msg[0] = msg
+                repeat_count[0] = 0
             
             progress_queue.put(msg)
         

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,7 +14,7 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __release_date__ = "2026.5.7"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.13.0"
+version = "0.13.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import importlib
+import queue
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -12,6 +14,8 @@ import pytest
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource
+
+_REAL_QUEUE_CLS = queue.Queue
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -116,6 +120,90 @@ class DelayedProgressAgent:
         time.sleep(0.45)
         self.tool_progress_callback("tool.started", "terminal", "second command", {})
         time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RecordingQueue:
+    def __init__(self):
+        self._queue = _REAL_QUEUE_CLS()
+        self.items = []
+        self._lock = threading.Lock()
+
+    def put(self, item, *args, **kwargs):
+        with self._lock:
+            self.items.append(item)
+        return self._queue.put(item, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._queue, name)
+
+
+class FirstQueueCaptureFactory:
+    def __init__(self, observed_queue):
+        self._observed_queue = observed_queue
+        self._used_observed_queue = False
+
+    def __call__(self, *args, **kwargs):
+        if not self._used_observed_queue:
+            self._used_observed_queue = True
+            return self._observed_queue
+        return _REAL_QUEUE_CLS(*args, **kwargs)
+
+
+class ConcurrentDedupAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        barrier = threading.Barrier(2)
+
+        def worker():
+            barrier.wait()
+            cb("tool.started", "web_search", "duplicate preview one", {})
+            barrier.wait()
+            cb("tool.started", "web_search", "duplicate preview two", {})
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ConcurrentNewModeAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        barrier = threading.Barrier(2)
+
+        def worker(preview):
+            barrier.wait()
+            cb("tool.started", "terminal", preview, {})
+
+        threads = [
+            threading.Thread(target=worker, args=("first concurrent command",)),
+            threading.Thread(target=worker, args=("second concurrent command",)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        time.sleep(0.35)
         return {
             "final_response": "done",
             "messages": [],
@@ -345,6 +433,51 @@ async def test_run_agent_feishu_progress_replies_inside_existing_thread(monkeypa
     assert adapter.sent[0]["metadata"] == {"thread_id": "topic_17585"}
     assert adapter.edits
     assert adapter.edits[0]["message_id"] == "progress-1"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_dedup_is_serialized_under_concurrency(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    observed_queue = RecordingQueue()
+    monkeypatch.setattr(queue, "Queue", FirstQueueCaptureFactory(observed_queue))
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ConcurrentDedupAgent,
+        session_id="sess-progress-dedup-race",
+    )
+
+    assert result["final_response"] == "done"
+    non_dedup_entries = [item for item in observed_queue.items if isinstance(item, str)]
+    assert len(non_dedup_entries) == 2
+    assert sum("duplicate preview one" in item for item in non_dedup_entries) == 1
+    assert sum("duplicate preview two" in item for item in non_dedup_entries) == 1
+    dedup_entries = [item for item in observed_queue.items if isinstance(item, tuple)]
+    assert len(dedup_entries) == 2
+    assert adapter.sent
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_new_mode_serializes_last_tool_check(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "new")
+
+    observed_queue = RecordingQueue()
+    monkeypatch.setattr(queue, "Queue", FirstQueueCaptureFactory(observed_queue))
+
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ConcurrentNewModeAgent,
+        session_id="sess-progress-new-race",
+    )
+
+    assert result["final_response"] == "done"
+    non_dedup_entries = [item for item in observed_queue.items if isinstance(item, str)]
+    assert len(non_dedup_entries) == 1
+    assert "concurrent command" in non_dedup_entries[0]
+    assert adapter.sent
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`progress_callback` in `gateway/run.py` reads and writes three shared closure
variables — `last_progress_msg[0]`, `repeat_count[0]`, `last_tool[0]` — without
any synchronization. The callback is passed as `tool_progress_callback` to the
agent, which calls it from **concurrent** `ThreadPoolExecutor` workers inside
`_execute_tool_calls_concurrent`.

Races observed:
1. Both workers read `last_progress_msg[0] = None` before either writes → both
   emit their message as "new" (dedup window lost)
2. `repeat_count[0] += 1` is a non-atomic read-modify-write → lost increments
   (the `×N` counter shows wrong values)
3. `last_tool[0]` in "new" mode has the same check-then-write race

## Root cause

No lock protecting the dedup check-and-update sequence in `progress_callback`.

## Fix

Add one `threading.Lock()` (`_progress_dedup_lock`) alongside the shared state.
Hold it for the full read-check-write block in both the "new" mode guard and the
dedup section. `threading` was already imported at line 38.

```python
_progress_dedup_lock = threading.Lock()

# "new" mode guard
with _progress_dedup_lock:
    if progress_mode == "new" and tool_name == last_tool[0]:
        return
    last_tool[0] = tool_name

# dedup block
with _progress_dedup_lock:
    if msg == last_progress_msg[0]:
        repeat_count[0] += 1
        progress_queue.put(("__dedup__", msg, repeat_count[0]))
        return
    last_progress_msg[0] = msg
    repeat_count[0] = 0
```

## Tests

Added two concurrent tests to `tests/gateway/test_run_progress_topics.py`:

- `test_run_agent_progress_dedup_is_serialized_under_concurrency` — two threads
  fire identical previews simultaneously; asserts exactly 1 non-dedup + 1 dedup
  entry per unique message
- `test_run_agent_progress_new_mode_serializes_last_tool_check` — two threads
  fire different commands in "new" mode simultaneously; asserts exactly 1 entry
  reaches the queue

## Visual

```mermaid
flowchart LR
    A["❌ Bug\n(no lock)"] --> B["Race on\nlast_progress_msg\nrepeat_count\nlast_tool"]
    C["✅ Fixed\n(_progress_dedup_lock)"] --> D["Atomic dedup\ncheck-and-update"]
```

Closes #24604