### PR TITLE
fix(cli): exit with clear message when ui-tui/ is missing in packaged installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1150,6 +1150,15 @@ def _launch_tui(
 ):
     """Replace current process with the TUI."""
     tui_dir = PROJECT_ROOT / "ui-tui"
+    if not tui_dir.is_dir() and not os.environ.get("HERMES_TUI_DIR"):
+        print(
+            "✗ The TUI is not available in this install — ui-tui/ was not packaged.\n"
+            "  Options:\n"
+            "    • Use a source checkout (git clone + uv pip install -e .)\n"
+            "    • Set HERMES_TUI_DIR to a pre-built ui-tui/dist directory",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     import tempfile
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,6 +1,7 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -120,3 +121,19 @@ def test_no_install_prebuilt_bundle_mode(tmp_path: Path, main_mod) -> None:
     """dist/entry.js present and no package-lock.json → prebuilt bundle, skip npm install."""
     _touch_tui_entry(tmp_path)
     assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_launch_tui_missing_ui_dir_exits_with_message(
+    monkeypatch, main_mod, tmp_path, capsys
+) -> None:
+    """_launch_tui exits with a clear message when ui-tui/ doesn't exist and HERMES_TUI_DIR is unset."""
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._launch_tui()
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "ui-tui" in captured.err
+    assert "not available" in captured.err or "not packaged" in captured.err


### PR DESCRIPTION
## What does this PR do?

`hermes --tui` crashes with an unhandled `FileNotFoundError` on Homebrew and other packaged installs because `ui-tui/` is not included in the Python wheel:

## Root cause

`hermes --tui` crashes with an unhandled `FileNotFoundError` on Homebrew and other packaged installs because `ui-tui/` is not included in the Python wheel:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/opt/homebrew/Cellar/hermes-agent/2026.5.7/libexec/lib/python3.14/site-packages/ui-tui'
```

The traceback is confusing — users have no idea whether the problem is Node.js, npm, their PATH, or the install itself.

## Fix

Add an early guard at the top of `_launch_tui` that checks for the missing directory before any subprocess is attempted:

```python
if not tui_dir.is_dir() and not os.environ.get("HERMES_TUI_DIR"):
    print(
        "✗ The TUI is not available in this install — ui-tui/ was not packaged.
"
        "  Options:
"
        "    • Use a source checkout (git clone + uv pip install -e .)
"
        "    • Set HERMES_TUI_DIR to a pre-built ui-tui/dist directory",
        file=sys.stderr,
    )
    sys.exit(1)
```

`HERMES_TUI_DIR` pointing to a pre-built dist is still supported — the guard only fires when neither source nor a prebuilt path is available.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24544

<details>
<summary>Original body</summary>

## Summary

`hermes --tui` crashes with an unhandled `FileNotFoundError` on Homebrew and other packaged installs because `ui-tui/` is not included in the Python wheel:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`hermes --tui` crashes with an unhandled `FileNotFoundError` on Homebrew and other packaged installs because `ui-tui/` is not included in the Python wheel:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/opt/homebrew/Cellar/hermes-agent/2026.5.7/libexec/lib/python3.14/site-packages/ui-tui'
```

The traceback is confusing — users have no idea whether the problem is Node.js, npm, their PATH, or the install itself.

## Root cause

`_launch_tui()` in `hermes_cli/main.py` sets `tui_dir = PROJECT_ROOT / "ui-tui"` and then calls `_make_tui_argv(tui_dir, ...)`, which internally calls `subprocess.run(..., cwd=str(tui_dir))`. When `tui_dir` doesn't exist (packaged install), Python raises `FileNotFoundError` from `subprocess.run`, not a user-friendly message.

The code has a fast-path for prebuilt bundles via `HERMES_TUI_DIR` env var, but that path is never taken when the variable isn't set — so packaged installs without `ui-tui/` fall straight into the crash.

## Fix

Add an early guard at the top of `_launch_tui` that checks for the missing directory before any subprocess is attempted:

```python
if not tui_dir.is_dir() and not os.environ.get("HERMES_TUI_DIR"):
    print(
        "✗ The TUI is not available in this install — ui-tui/ was not packaged.
"
        "  Options:
"
        "    • Use a source checkout (git clone + uv pip install -e .)
"
        "    • Set HERMES_TUI_DIR to a pre-built ui-tui/dist directory",
        file=sys.stderr,
    )
    sys.exit(1)
```

`HERMES_TUI_DIR` pointing to a pre-built dist is still supported — the guard only fires when neither source nor a prebuilt path is available.

## Tests

New test `test_launch_tui_missing_ui_dir_exits_with_message` in `test_tui_npm_install.py`:
- patches `PROJECT_ROOT` to a tmp directory (so `ui-tui/` doesn't exist)
- asserts `SystemExit(1)` is raised
- asserts stderr contains actionable guidance

All 11 tests in `test_tui_npm_install.py` and 19 tests in `test_tui_resume_flow.py` pass.

## Visual

```mermaid
flowchart LR
    A["hermes --tui"] --> B["_launch_tui()"]
    B --> C{{"ui-tui/ exists
or HERMES_TUI_DIR set?"}}
    C -- "before fix: no check
→ FileNotFoundError" --> D["❌ cryptic traceback"]
    C -- "after fix: missing" --> E["✗ clear error + sys.exit(1)"]
    C -- "present" --> F["_make_tui_argv() → TUI starts"]
```

Closes #24544

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24544

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_