### PR TITLE
docs(gateway): mention Weixin in gateway help and docstrings

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -2,7 +2,7 @@
 Hermes Gateway - Multi-platform messaging integration.
 
 This module provides a unified gateway for connecting the Hermes agent
-to various messaging platforms (Telegram, Discord, WhatsApp) with:
+to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) with:
 - Session management (persistent conversations with reset policies)
 - Dynamic context injection (agent knows where messages come from)
 - Delivery routing (cron job outputs to appropriate channels)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2,7 +2,7 @@
 Gateway configuration management.
 
 Handles loading and validating configuration for:
-- Connected platforms (Telegram, Discord, WhatsApp)
+- Connected platforms (Telegram, Discord, WhatsApp, Weixin, and more)
 - Home channels for each platform
 - Session reset policies
 - Delivery preferences

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1,7 +1,7 @@
 """
 Base platform adapter interface.
 
-All platform adapters (Telegram, Discord, WhatsApp) inherit from this
+All platform adapters (Telegram, Discord, WhatsApp, Weixin, and more) inherit from this
 and implement the required methods.
 """
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9390,7 +9390,7 @@ def main():
     gateway_parser = subparsers.add_parser(
         "gateway",
         help="Messaging gateway management",
-        description="Manage the messaging gateway (Telegram, Discord, WhatsApp)",
+        description="Manage the messaging gateway (Telegram, Discord, WhatsApp, Weixin, and more)",
     )
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
 


### PR DESCRIPTION
Salvage of #21063 by @wuwuzhijing onto current main.

Original branch was severely stale — cherry-pick would have resurrected ~137k lines of removed code (msgraph_webhook, computer_use, lsp/, plugin_llm, etc.). Manually applied just the substantive 4-line docstring change with the contributor as author.

## Change
Adds 'Weixin, and more' to gateway docstrings/help text:
- gateway/__init__.py module docstring
- gateway/config.py module docstring
- gateway/platforms/base.py module docstring
- hermes_cli/main.py 'hermes gateway' subparser description

Authorship preserved + AUTHOR_MAP entries pending in next chore-release commit.