### PR TITLE
fix(ci): install ripgrep in e2e job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 


### PR DESCRIPTION
Salvage of #22219 by @wesleysimplicio onto current main.

Adds `apt-get install -y ripgrep` step to the e2e GHA job (mirrors the existing step in the main test job). Without it, e2e tests that shell out to `rg` fail in CI.