### PR TITLE
fix(ci): bump e2e job timeout to 15 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
Salvage of #22220 by @wesleysimplicio onto current main.

Bumps e2e GHA job timeout from 10→15 minutes; the existing window was tight enough to flake on slow runners. Pairs with #24648 (ripgrep install) so e2e tests have both the deps and the headroom they need.