### PR TITLE
fix(gateway): skip non-existent paths in extract_media to stop spurious warnings

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2072,7 +2072,10 @@ class BasePlatformAdapter(ABC):
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+                expanded = os.path.expanduser(path)
+                if not os.path.isfile(expanded):
+                    continue
+                media.append((expanded, has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -258,6 +258,13 @@ class TestExtractImages:
 
 
 class TestExtractMedia:
+    @pytest.fixture(autouse=True)
+    def _mock_isfile(self):
+        # Existing tests use synthetic paths that don't exist on disk.
+        # Patch isfile so the new validation gate doesn't filter them out.
+        with patch("gateway.platforms.base.os.path.isfile", return_value=True):
+            yield
+
     def test_no_media(self):
         media, cleaned = BasePlatformAdapter.extract_media("Just text.")
         assert media == []
@@ -359,6 +366,49 @@ class TestExtractMedia:
         # Both directives stripped from cleaned text
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
+
+
+# ---------------------------------------------------------------------------
+# extract_media — non-existent path guard (regression for greedy \S+ fallback)
+# ---------------------------------------------------------------------------
+
+class TestExtractMediaNonExistentPath:
+    r"""The \S+ fallback regex matched URLs and instructional text, producing
+    spurious 'File not found' warnings.  Paths that don't exist on disk must
+    be silently dropped from the media list."""
+
+    def test_nonexistent_path_not_in_media(self, tmp_path):
+        content = "MEDIA:/nonexistent/path/audio.ogg"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_real_file_is_returned(self, tmp_path):
+        real = tmp_path / "speech.ogg"
+        real.write_bytes(b"")
+        content = f"MEDIA:{real}"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == str(real)
+
+    def test_url_like_path_not_in_media(self):
+        # Greedy \S+ formerly matched bare URL tokens
+        content = "MEDIA:https://example.com/audio.ogg"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_instructional_example_ignored(self):
+        # Agent replies sometimes echo the tag as an example instruction
+        content = "Use MEDIA:/path/to/file.ogg to attach audio."
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_mixed_real_and_nonexistent(self, tmp_path):
+        real = tmp_path / "ok.ogg"
+        real.write_bytes(b"")
+        content = f"MEDIA:/fake/missing.ogg\nMEDIA:{real}"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == str(real)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`extract_media()` in `gateway/platforms/base.py` uses a `\S+` fallback regex to capture file paths from `MEDIA:` tags. This greedy pattern also matches:

- Bare URLs (`https://example.com/audio.ogg`)
- Hostnames and instructional text echoed by the agent (`Use MEDIA:/path/to/file.ogg to attach audio.`)

Every matched string was appended to the media list even when it didn't point to a real file, causing callers (e.g. `send_voice`, `send_document`) to log `File not found` warnings for every such match.

## Root cause

No existence check between regex match and `media.append()`. The sibling method `extract_local_files()` (line 2133) already applies `os.path.isfile()` validation — `extract_media()` was missing the same guard.

## Fix

Add `os.path.isfile(expanded)` validation before appending to the media list, mirroring `extract_local_files()`:

```python
if path:
    expanded = os.path.expanduser(path)
    if not os.path.isfile(expanded):
        continue
    media.append((expanded, has_voice_tag))
```

## Tests

- Added `TestExtractMediaNonExistentPath` (5 regression tests): non-existent paths, real files via `tmp_path`, URL-like tokens, instructional examples, mixed real+non-existent inputs.
- Existing `TestExtractMedia` tests use synthetic non-disk paths; added `autouse` fixture patching `os.path.isfile` to `True` to preserve their semantics unchanged.
- All 95 tests pass, 2 skipped (pre-existing).

## Visual

```
Before: MEDIA:https://example.com/audio.ogg → media=[("https://example.com/audio.ogg", False)]
After:  MEDIA:https://example.com/audio.ogg → media=[]  (path not on disk, silently skipped)
```

Closes #24575