### PR TITLE
fix(send_message): recognize XMPP JIDs as explicit targets

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -355,6 +355,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit
     if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
         return target_ref, None, True
+    # XMPP JIDs (user@server or room@conference.server) are explicit
+    if platform_name == "xmpp" and "@" in target_ref:
+        return target_ref, None, True
     return None, None, False
 
 


### PR DESCRIPTION
Salvage of #21424 by @Quarkex onto current main.

`_parse_target_ref` was missing a branch for XMPP JIDs (`user@domain/resource`), mirroring the existing matrix branch. Adds the missing detection so XMPP targets pass through correctly.