### PR TITLE
fix(mcp): read connect_timeout from server config in _probe_single_server; default to 300s for OAuth

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -164,13 +164,18 @@ def _apply_mcp_preset(
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
 
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30
+    name: str, config: dict, connect_timeout: float | None = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
     Returns list of ``(tool_name, description)`` tuples.
     Raises on connection failure.
     """
+    if connect_timeout is None:
+        # OAuth flows need time for a full browser round-trip; default to 300 s.
+        # Honour per-server connect_timeout from config when present.
+        connect_timeout = float(config.get("connect_timeout", 300))
+
     from tools.mcp_tool import (
         _ensure_mcp_loop,
         _run_on_mcp_loop,

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -600,3 +600,43 @@ class TestMcpLogin:
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
 
+
+class TestProbeConnectTimeout:
+    def _patch_mcp_tool(self, monkeypatch, captured):
+        import tools.mcp_tool as mcp_tool_mod
+
+        monkeypatch.setattr(
+            mcp_tool_mod,
+            "_run_on_mcp_loop",
+            lambda coro, timeout: captured.update({"timeout": timeout}),
+        )
+        monkeypatch.setattr(mcp_tool_mod, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool_mod, "_stop_mcp_loop", lambda: None)
+
+        async def _fake_connect(name, config):
+            class _FakeServer:
+                _tools = []
+
+                async def shutdown(self):
+                    pass
+
+            return _FakeServer()
+
+        monkeypatch.setattr(mcp_tool_mod, "_connect_server", _fake_connect)
+
+    def test_probe_reads_connect_timeout_from_config(self, monkeypatch):
+        captured = {}
+        self._patch_mcp_tool(monkeypatch, captured)
+        from hermes_cli.mcp_config import _probe_single_server
+
+        _probe_single_server("srv", {"connect_timeout": 120, "url": "https://x.example.com"})
+        assert captured["timeout"] == 130  # 120 + 10
+
+    def test_probe_default_timeout_is_300(self, monkeypatch):
+        captured = {}
+        self._patch_mcp_tool(monkeypatch, captured)
+        from hermes_cli.mcp_config import _probe_single_server
+
+        _probe_single_server("srv", {"url": "https://x.example.com"})
+        assert captured["timeout"] == 310  # 300 + 10
+


### PR DESCRIPTION
## Problem

`hermes mcp login` and `hermes mcp add` both internally call
`_probe_single_server()`, which hardcoded `connect_timeout=30`. Any
`connect_timeout` value stored in the server's config dict was silently
ignored. OAuth flows that involve a browser round-trip routinely exceed
30 s, causing the probe to time out and return an unhelpful error before
the user can even finish authenticating.

## Root cause

```python
# before
def _probe_single_server(
    name: str, config: dict, connect_timeout: float = 30
) -> List[Tuple[str, str]]:
```

The function accepted `connect_timeout` as an explicit argument but callers
never passed it, so the hardcoded default always won regardless of what was
stored in `config`.

## Fix

Change the default to `None` and derive the actual timeout from the server
config dict when no explicit override is supplied:

```python
def _probe_single_server(
    name: str, config: dict, connect_timeout: float | None = None
) -> List[Tuple[str, str]]:
    if connect_timeout is None:
        connect_timeout = float(config.get("connect_timeout", 300))
```

The fallback is 300 s (5 min) — enough for a complete browser OAuth round-trip.
The existing `+10` margin passed to `_run_on_mcp_loop` is unchanged.

## Tests

`tests/hermes_cli/test_mcp_config.py` — `TestProbeConnectTimeout`:

| Test | Assertion |
|------|-----------|
| `test_probe_reads_connect_timeout_from_config` | `config.connect_timeout=120` → `_run_on_mcp_loop(timeout=130)` |
| `test_probe_default_timeout_is_300` | no config timeout → `_run_on_mcp_loop(timeout=310)` |

Both pass; existing 32-test suite passes with no regressions.

## Visual

```mermaid
sequenceDiagram
    participant Caller
    participant _probe_single_server
    participant _run_on_mcp_loop

    Caller->>_probe_single_server: (name, config)
    Note over _probe_single_server: connect_timeout = config.get("connect_timeout", 300)
    _probe_single_server->>_run_on_mcp_loop: timeout = connect_timeout + 10
    _run_on_mcp_loop-->>_probe_single_server: tools list
    _probe_single_server-->>Caller: [(tool_name, desc), ...]
```

Closes #24097