### PR TITLE
fix(web): add Bearer auth header for Tavily /crawl endpoint

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -429,7 +429,9 @@ def _tavily_request(endpoint: str, payload: dict) -> dict:
     payload["api_key"] = api_key
     url = f"{_TAVILY_BASE_URL}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
-    response = httpx.post(url, json=payload, timeout=60)
+    # Tavily /crawl requires Bearer auth in header (body-only auth returns 401)
+    headers = {"Authorization": f"Bearer {api_key}"} if endpoint.strip("/") == "crawl" else {}
+    response = httpx.post(url, json=payload, headers=headers, timeout=60)
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
Salvage of #22915 by @McClean onto current main.

The Tavily /crawl endpoint requires `Authorization: Bearer <key>` per their API docs; the existing call was missing it. Endpoint-scoped 1-line fix.