### PR TITLE
fix(cron): include whatsapp in _HOME_TARGET_ENV_VARS

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "whatsapp": "WHATSAPP_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current


### PR DESCRIPTION
Salvage of #22998 by @dhruv-saxena onto current main. Supersedes #23531 (byte-identical fix from @Kailigithub).

"whatsapp" was listed in delivery toolsets but absent from `_HOME_TARGET_ENV_VARS` so cron-scheduled deliveries to whatsapp couldn't pick up the right env vars. One-line addition matches the existing pattern.