### PR TITLE
fix(gateway): bridge gateway_restart_notification from config.yaml platform sections (#24644)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -850,11 +850,22 @@ def load_gateway_config() -> GatewayConfig:
                     else:
                         bridged["channel_prompts"] = channel_prompts
                 enabled_was_explicit = "enabled" in platform_cfg
-                if not bridged and not enabled_was_explicit:
+                # `gateway_restart_notification` is a top-level field on
+                # `PlatformConfig` (consumed via `platform_cfg.gateway_restart_notification`
+                # in gateway/run.py, not via `cfg.extra.get(...)`), so it
+                # must land at `plat_data["gateway_restart_notification"]`
+                # rather than be folded into `bridged` → `extra`. Mirrors
+                # the `enabled` handling below.
+                restart_notif_explicit = "gateway_restart_notification" in platform_cfg
+                if not bridged and not enabled_was_explicit and not restart_notif_explicit:
                     continue
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
+                if restart_notif_explicit:
+                    plat_data["gateway_restart_notification"] = platform_cfg[
+                        "gateway_restart_notification"
+                    ]
                 if plat == Platform.SLACK and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -599,6 +599,71 @@ class TestLoadGatewayConfig:
         import os
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
+    def test_bridges_gateway_restart_notification_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        """Setting `gateway_restart_notification: false` under a top-level
+        platform section in `config.yaml` must reach `PlatformConfig` (#24644)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "telegram:\n"
+            "  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        tg_cfg = config.platforms.get(Platform.TELEGRAM)
+        assert tg_cfg is not None
+        assert tg_cfg.gateway_restart_notification is False
+        # Belt and braces: must NOT be filed under `extra`, since gateway
+        # consumers read `platform_cfg.gateway_restart_notification` (a
+        # top-level dataclass field), not `cfg.extra.get(...)`.
+        assert "gateway_restart_notification" not in tg_cfg.extra
+
+    def test_gateway_restart_notification_defaults_true_when_absent(
+        self, tmp_path, monkeypatch
+    ):
+        """When the key is absent from config.yaml the default (True) holds."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "telegram:\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        tg_cfg = config.platforms.get(Platform.TELEGRAM)
+        assert tg_cfg is not None
+        assert tg_cfg.gateway_restart_notification is True
+
+    def test_bridges_gateway_restart_notification_when_only_setting(
+        self, tmp_path, monkeypatch
+    ):
+        """`gateway_restart_notification` alone (no other bridgeable keys, no
+        explicit `enabled`) must still create the platform entry — otherwise
+        the early `continue` on `not bridged and not enabled_was_explicit`
+        would drop the section before the field reaches `from_dict`."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        slack_cfg = config.platforms.get(Platform.SLACK)
+        assert slack_cfg is not None
+        assert slack_cfg.gateway_restart_notification is False
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already


### PR DESCRIPTION
## What does this PR do?

Wires `gateway_restart_notification: false` (under a top-level platform section like `telegram:` in `config.yaml`) into the platform's `PlatformConfig` so the lifecycle-notification suppression at `gateway/run.py:2767/:2810/:12801/:12860` actually fires. The feature was introduced in #20892 but the config bridge in `load_gateway_config()` was never updated, so setting the flag in `config.yaml` had no effect — confirmed by the issue's gateway log (notifications sent despite the setting).

`PlatformConfig.gateway_restart_notification` (`gateway/config.py:281`) is a dataclass field, serialized in `to_dict()`, parsed by `from_dict()` via `_coerce_bool`. Consumers in `gateway/run.py` read it directly as `platform_cfg.gateway_restart_notification`. But `load_gateway_config()` (`gateway/config.py:758–825`) — the bridge that copies top-level `telegram:`/`slack:`/etc. keys from `config.yaml` into the internal platforms dict — has an allow-listed bridge set with no entry for `gateway_restart_notification`.

The issue's suggested snippet would land the value inside `extra` (the bridge folds into `extra.update(bridged)`), but `gateway_restart_notification` is a **top-level** `PlatformConfig` field, not an `extra` key. Mirrors the `enabled` handling instead: track `restart_notif_explicit`, include it in the early-`continue` predicate so a section containing only this key isn't skipped, and assign `plat_data["gateway_restart_notification"]` directly alongside `plat_data["enabled"]`. `_coerce_bool` already covers `false`/`"false"`/`0`.

## Related Issue

Fixes #24644

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py` — in `load_gateway_config()`, track `restart_notif_explicit = "gateway_restart_notification" in platform_cfg`, include it in the early-`continue` predicate, and assign `plat_data["gateway_restart_notification"]` directly (not via `bridged`/`extra`).
- `tests/gateway/test_config.py` — 3 new cases in `TestLoadGatewayConfig`: bridges from config.yaml, defaults true when absent, bridges when only setting in the section. Belt-and-braces assertion that the value does NOT land in `tg_cfg.extra`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_config.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py -v`
2. Expected: 87 passed.
3. Bridge-adjacent: `tests/gateway/test_telegram_group_gating.py tests/gateway/test_slack_mention.py` — 72 passed.
4. Regression guard: with `gateway/config.py` stashed out, the two bridge tests fail with `tg_cfg is None`/`slack_cfg is None`; re-applied, they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (87/87 + 72/72 adjacent)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, key already documented from #20892
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — config-bridge logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #24644.
- #20892 introduced the field but missed the bridge — this is the follow-up.
- Same shape as previous bridge gaps: #17227 (HOME_CHANNEL bridge), #22520 (home_channel: null), #15192 (message_timestamp pipeline).

> Audited siblings: the bridge in `load_gateway_config()` follows the `enabled`/`gateway_restart_notification` pattern symmetrically across all top-level platform sections (telegram/slack/discord/wecom/feishu/dingtalk/whatsapp/signal/teams). No widening needed — the same code path handles all platforms uniformly.
