### PR TITLE
fix(agent): add MiMo to reasoning_content echo-back providers in _needs_thinking_reasoning_pad

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10092,6 +10092,19 @@ class AIAgent:
 
         return msg
 
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the active provider is Xiaomi MiMo thinking mode.
+
+        MiMo requires reasoning_content to be echoed back on every assistant
+        turn (same contract as DeepSeek/Kimi).
+        Ref: https://platform.xiaomimimo.com/docs/usage-guide/passing-back-reasoning_content
+        """
+        model = (self.model or "").lower()
+        return (
+            base_url_host_matches(self.base_url, "xiaomimimo.com")
+            or "mimo" in model
+        )
+
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
@@ -10102,6 +10115,7 @@ class AIAgent:
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:

--- a/tests/run_agent/test_mimo_reasoning_content.py
+++ b/tests/run_agent/test_mimo_reasoning_content.py
@@ -1,0 +1,29 @@
+"""Tests for MiMo reasoning_content echo-back detection (#24443)."""
+
+from run_agent import AIAgent
+
+
+def _make_agent(base_url="", model="", provider="openai"):
+    agent = object.__new__(AIAgent)
+    agent.base_url = base_url
+    agent.model = model
+    agent.provider = provider
+    return agent
+
+
+def test_mimo_url_triggers_pad():
+    agent = _make_agent(base_url="https://api.xiaomimimo.com/v1")
+    assert agent._needs_mimo_tool_reasoning() is True
+    assert agent._needs_thinking_reasoning_pad() is True
+
+
+def test_mimo_model_name_triggers_pad():
+    agent = _make_agent(model="mimo-v2.5-pro")
+    assert agent._needs_mimo_tool_reasoning() is True
+    assert agent._needs_thinking_reasoning_pad() is True
+
+
+def test_non_mimo_unaffected():
+    agent = _make_agent(base_url="https://api.openai.com", model="gpt-4o")
+    assert agent._needs_mimo_tool_reasoning() is False
+    assert agent._needs_thinking_reasoning_pad() is False


### PR DESCRIPTION
## Problem

Multi-turn conversations with Xiaomi MiMo thinking models fail with HTTP 400:

```
"The reasoning_content in the thinking mode must be passed back to the API"
```

Hermes does not echo `reasoning_content` back on subsequent assistant turns for MiMo, even though the same requirement is already handled for DeepSeek and Kimi.

## Root cause

`_needs_thinking_reasoning_pad()` at `run_agent.py:10095` only covered two providers:

```python
def _needs_thinking_reasoning_pad(self) -> bool:
    return (
        self._needs_deepseek_tool_reasoning()
        or self._needs_kimi_tool_reasoning()
    )
```

MiMo (`xiaomimimo.com`, model names containing `mimo`) has the identical contract but was absent from this check, so `_copy_reasoning_content_for_api` never injected the required `reasoning_content` placeholder on assistant turns during history replay.

## Fix

Add `_needs_mimo_tool_reasoning()` detecting `xiaomimimo.com` base URLs or model names containing `"mimo"`, and include it in `_needs_thinking_reasoning_pad()`:

```python
def _needs_mimo_tool_reasoning(self) -> bool:
    model = (self.model or "").lower()
    return (
        base_url_host_matches(self.base_url, "xiaomimimo.com")
        or "mimo" in model
    )

def _needs_thinking_reasoning_pad(self) -> bool:
    return (
        self._needs_deepseek_tool_reasoning()
        or self._needs_kimi_tool_reasoning()
        or self._needs_mimo_tool_reasoning()   # ← new
    )
```

## Tests

`tests/run_agent/test_mimo_reasoning_content.py` (new file):

| Test | Assertion |
|------|-----------|
| `test_mimo_url_triggers_pad` | `xiaomimimo.com` base URL → both methods return `True` |
| `test_mimo_model_name_triggers_pad` | model `"mimo-v2.5-pro"` → `_needs_mimo_tool_reasoning()` returns `True` |
| `test_non_mimo_unaffected` | `openai.com` + `gpt-4o` → both methods return `False` |

Stash-verify: `FAILED` (`AttributeError: 'AIAgent' object has no attribute '_needs_mimo_tool_reasoning'`) before fix, `3 passed` after.

## Visual

```mermaid
graph TD
    A[_needs_thinking_reasoning_pad] --> B[_needs_deepseek_tool_reasoning]
    A --> C[_needs_kimi_tool_reasoning]
    A --> D[_needs_mimo_tool_reasoning]
    D --> E{xiaomimimo.com in base_url?}
    D --> F{mimo in model name?}
```

Closes #24443