### PR TITLE
fix(hermes_time): eliminate TOCTOU race in get_timezone()

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -15,6 +15,7 @@ crashes due to a bad timezone string.
 
 import logging
 import os
+import threading
 from datetime import datetime
 from hermes_constants import get_config_path
 from typing import Optional
@@ -32,6 +33,7 @@ except ImportError:
 _cached_tz: Optional[ZoneInfo] = None
 _cached_tz_name: Optional[str] = None
 _cache_resolved: bool = False
+_tz_lock = threading.Lock()
 
 
 def _resolve_timezone_name() -> str:
@@ -79,9 +81,19 @@ def get_timezone() -> Optional[ZoneInfo]:
     """Return the user's configured ZoneInfo, or None (meaning server-local).
 
     Resolved once and cached. Call ``reset_cache()`` after config changes.
+    Thread-safe via double-checked locking: value is written before the
+    resolved flag is set so concurrent readers never observe a stale None
+    (issue #24650).
     """
     global _cached_tz, _cached_tz_name, _cache_resolved
-    if not _cache_resolved:
+    # Fast path: lock-free after first initialisation
+    if _cache_resolved:
+        return _cached_tz
+
+    with _tz_lock:
+        # Re-check: another thread may have completed init while we waited
+        if _cache_resolved:
+            return _cached_tz
         _cached_tz_name = _resolve_timezone_name()
         _cached_tz = _get_zoneinfo(_cached_tz_name)
         _cache_resolved = True

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -12,6 +12,8 @@ Covers:
 import os
 import logging
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
@@ -383,3 +385,55 @@ class TestCronTimezone:
 
         next_run = datetime.fromisoformat(job["next_run_at"])
         assert next_run.tzinfo is not None
+
+
+class TestGetTimezoneToctouRace:
+    """Regression tests for the TOCTOU race in get_timezone() (issue #24650).
+
+    Before the fix, _cache_resolved was set AFTER _cached_tz was written, so
+    a concurrent thread could see _cache_resolved=True while _cached_tz was
+    still the stale None default.
+    """
+
+    def setup_method(self):
+        _reset_hermes_time_cache()
+
+    def teardown_method(self):
+        _reset_hermes_time_cache()
+
+    def test_concurrent_readers_all_see_configured_timezone(self, monkeypatch):
+        """50 threads racing through cold-start must all return the configured TZ."""
+        monkeypatch.setenv("HERMES_TIMEZONE", "America/New_York")
+        expected = ZoneInfo("America/New_York")
+
+        barrier = threading.Barrier(50)
+
+        def read_tz():
+            barrier.wait()  # all threads start simultaneously
+            return hermes_time.get_timezone()
+
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            futures = [pool.submit(read_tz) for _ in range(50)]
+            results = [f.result() for f in futures]
+
+        assert all(r == expected for r in results), (
+            f"Some threads got wrong timezone: {set(str(r) for r in results)}"
+        )
+
+    def test_concurrent_readers_all_see_none_when_unconfigured(self, monkeypatch):
+        """50 threads must all return None when no timezone is configured."""
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        with patch("hermes_time._resolve_timezone_name", return_value=""):
+            barrier = threading.Barrier(50)
+
+            def read_tz():
+                barrier.wait()
+                return hermes_time.get_timezone()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(read_tz) for _ in range(50)]
+                results = [f.result() for f in futures]
+
+        assert all(r is None for r in results), (
+            f"Some threads got non-None: {[r for r in results if r is not None]}"
+        )


### PR DESCRIPTION
## What does this PR do?

\`get_timezone()\` uses a lazy-init singleton to cache the resolved \`ZoneInfo\`. The original code checked \`_cache_resolved\`, computed both \`_cached_tz_name\` and \`_cached_tz\`, then set the flag last:

## Root cause

\`get_timezone()\` uses a lazy-init singleton to cache the resolved \`ZoneInfo\`. The original code checked \`_cache_resolved\`, computed both \`_cached_tz_name\` and \`_cached_tz\`, then set the flag last:

\`\`\`python
if not _cache_resolved:
    _cached_tz_name = _resolve_timezone_name()   # file I/O
    _cached_tz = _get_zoneinfo(_cached_tz_name)
    _cache_resolved = True                        # flag set LAST
return _cached_tz
\`\`\`

## Fix

Double-checked locking with a new module-level \`_tz_lock = threading.Lock()\`:

1. Fast path (\`if _cache_resolved\`) remains lock-free after first init.
2. Slow path acquires \`_tz_lock\`, re-checks inside the lock.
3. Populates \`_cached_tz_name\` and \`_cached_tz\`, then sets \`_cache_resolved = True\` — flag flipped only after both values are published.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24650

<details>
<summary>Original body</summary>

## Summary

\`get_timezone()\` uses a lazy-init singleton to cache the resolved \`ZoneInfo\`. The original code checked \`_cache_resolved\`, computed both \`_cached_tz_name\` and \`_cached_tz\`, then set the flag last:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

\`get_timezone()\` uses a lazy-init singleton to cache the resolved \`ZoneInfo\`. The original code checked \`_cache_resolved\`, computed both \`_cached_tz_name\` and \`_cached_tz\`, then set the flag last:

\`\`\`python
if not _cache_resolved:
    _cached_tz_name = _resolve_timezone_name()   # file I/O
    _cached_tz = _get_zoneinfo(_cached_tz_name)
    _cache_resolved = True                        # flag set LAST
return _cached_tz
\`\`\`

## Root cause

TOCTOU window between the check and the flag flip. Two concurrent threads (e.g. concurrent gateway requests both calling \`now()\` on cold start) can both see \`not _cache_resolved\`, both invoke \`_resolve_timezone_name()\` (env read + file I/O), and race on the global assignments.

On non-GIL runtimes (CPython 3.13+ free-threaded, PyPy) the store to \`_cache_resolved = True\` and \`_cached_tz = …\` can be reordered or incompletely published, so a third concurrent thread may observe \`_cache_resolved=True\` while \`_cached_tz\` is still the stale \`None\` default — causing \`now()\` to return server-local time instead of the user's configured timezone.

## Fix

Double-checked locking with a new module-level \`_tz_lock = threading.Lock()\`:

1. Fast path (\`if _cache_resolved\`) remains lock-free after first init.
2. Slow path acquires \`_tz_lock\`, re-checks inside the lock.
3. Populates \`_cached_tz_name\` and \`_cached_tz\`, then sets \`_cache_resolved = True\` — flag flipped only after both values are published.

## Tests

Two new regression tests in \`TestGetTimezoneToctouRace\`:

- \`test_concurrent_readers_all_see_configured_timezone\` — 50 threads race through cold-start with \`HERMES_TIMEZONE=America/New_York\`; all must return \`ZoneInfo("America/New_York")\`, never \`None\`.
- \`test_concurrent_readers_all_see_none_when_unconfigured\` — same, no timezone configured; all must return \`None\`.

Both use \`threading.Barrier\` to maximise contention at the exact init window.

```
22 passed in 27.85s
```

## Visual

```
Before                              After
──────────────────────────────────  ─────────────────────────────────
if not _cache_resolved:             if _cache_resolved:   # fast path
    _cached_tz_name = resolve()         return _cached_tz
    _cached_tz = get_zoneinfo()
    _cache_resolved = True    ←     with _tz_lock:
                                        if _cache_resolved:
                                            return _cached_tz
                                        _cached_tz_name = resolve()
                                        _cached_tz = get_zoneinfo()
                                        _cache_resolved = True    ←
```

Closes #24650

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24650

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_