### PR TITLE
fix(agent): make OpenRouter prewarm guard atomic (#24651)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -358,7 +358,11 @@ _MAX_TOOL_WORKERS = 8
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
 # exhaust the system thread limit (RuntimeError: can't start new thread).
-_openrouter_prewarm_done = threading.Event()
+# Used as a one-shot gate via acquire(blocking=False): the first caller wins
+# and the lock is intentionally never released.  An Event with is_set()+set()
+# would be a TOCTOU race — two concurrent AIAgent.__init__ calls could both
+# observe is_set() == False and both spawn the thread (see #24651).
+_openrouter_prewarm_lock = threading.Lock()
 
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
@@ -1354,13 +1358,15 @@ class AIAgent:
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.
-        # Use a process-level Event so this thread is only spawned once — a new
-        # AIAgent is created for every gateway request, so without the guard
-        # each message leaks one OS thread and the process eventually exhausts
-        # the system thread limit (RuntimeError: can't start new thread).
+        # Use a process-level lock as a one-shot gate so this thread is only
+        # spawned once — a new AIAgent is created for every gateway request,
+        # so without the guard each message leaks one OS thread and the
+        # process eventually exhausts the system thread limit (RuntimeError:
+        # can't start new thread).  acquire(blocking=False) is atomic, unlike
+        # the previous Event.is_set()+set() pair which raced under concurrent
+        # __init__ calls (see #24651).
         if (self.provider == "openrouter" or self._is_openrouter_url()) and \
-                not _openrouter_prewarm_done.is_set():
-            _openrouter_prewarm_done.set()
+                _openrouter_prewarm_lock.acquire(blocking=False):
             threading.Thread(
                 target=fetch_model_metadata,
                 daemon=True,

--- a/tests/run_agent/test_openrouter_prewarm_guard.py
+++ b/tests/run_agent/test_openrouter_prewarm_guard.py
@@ -1,0 +1,127 @@
+"""Regression test for issue #24651.
+
+The OpenRouter metadata prewarm guard in run_agent.py used to be a
+``threading.Event`` with a non-atomic ``is_set() + set()`` pair, which
+could lose the race under concurrent ``AIAgent.__init__`` calls and
+spawn duplicate ``fetch_model_metadata`` threads.  The guard is now a
+``threading.Lock`` used as a one-shot gate via
+``acquire(blocking=False)`` — atomic, so exactly one caller wins.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import run_agent
+
+
+@pytest.fixture
+def fresh_prewarm_lock(monkeypatch):
+    """Reset the module-level one-shot gate so each test sees an unclaimed lock."""
+    monkeypatch.setattr(run_agent, "_openrouter_prewarm_lock", threading.Lock())
+
+
+def test_prewarm_guard_is_a_lock_not_an_event():
+    """Regression: the gate must be a Lock (atomic), not an Event (TOCTOU race)."""
+    expected_type = type(threading.Lock())
+    assert isinstance(run_agent._openrouter_prewarm_lock, expected_type)
+
+
+def test_concurrent_acquire_only_one_caller_wins(fresh_prewarm_lock):
+    """With N threads racing on acquire(blocking=False), exactly one returns True."""
+    lock = run_agent._openrouter_prewarm_lock
+    n = 64
+    barrier = threading.Barrier(n)
+    wins = []
+    wins_lock = threading.Lock()
+
+    def attempt():
+        barrier.wait()  # maximise the race window
+        if lock.acquire(blocking=False):
+            with wins_lock:
+                wins.append(threading.get_ident())
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        list(pool.map(lambda _: attempt(), range(n)))
+
+    assert len(wins) == 1, f"expected exactly one winner, got {len(wins)}"
+
+
+def test_aiagent_init_spawns_prewarm_only_once_under_concurrency(
+    fresh_prewarm_lock, monkeypatch
+):
+    """End-to-end: N concurrent AIAgent(provider='openrouter') spawn 1 prewarm thread."""
+    monkeypatch.setattr(run_agent, "fetch_model_metadata", lambda *a, **k: None)
+
+    started = []
+    started_lock = threading.Lock()
+    real_thread = threading.Thread
+
+    def recording_thread(*args, **kwargs):
+        if kwargs.get("name") == "openrouter-prewarm":
+            with started_lock:
+                started.append(kwargs)
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(run_agent.threading, "Thread", recording_thread)
+
+    n = 32
+    barrier = threading.Barrier(n)
+    errors = []
+
+    def make_agent():
+        try:
+            barrier.wait()
+            run_agent.AIAgent(
+                model="openai/gpt-4o-mini",
+                provider="openrouter",
+                api_key="sk-dummy",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform="cli",
+            )
+        except Exception as exc:  # pragma: no cover - surface init failures
+            errors.append(exc)
+
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        list(pool.map(lambda _: make_agent(), range(n)))
+
+    assert not errors, f"AIAgent.__init__ raised under concurrency: {errors[:3]}"
+    assert len(started) == 1, (
+        f"expected exactly one openrouter-prewarm thread spawn, got {len(started)}"
+    )
+
+
+def test_prewarm_skipped_for_non_openrouter_provider(fresh_prewarm_lock, monkeypatch):
+    """Non-openrouter providers must not spawn the prewarm thread or burn the gate."""
+    monkeypatch.setattr(run_agent, "fetch_model_metadata", lambda *a, **k: None)
+
+    started = []
+    real_thread = threading.Thread
+
+    def recording_thread(*args, **kwargs):
+        if kwargs.get("name") == "openrouter-prewarm":
+            started.append(kwargs)
+        return real_thread(*args, **kwargs)
+
+    monkeypatch.setattr(run_agent.threading, "Thread", recording_thread)
+
+    run_agent.AIAgent(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        api_key="sk-dummy",
+        base_url="https://api.anthropic.com",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+
+    assert started == [], "non-openrouter provider must not spawn prewarm thread"
+    # Gate must still be free — another openrouter caller can still claim it.
+    assert run_agent._openrouter_prewarm_lock.acquire(blocking=False)


### PR DESCRIPTION
## Summary

Closes #24651.

The OpenRouter metadata prewarm guard in `run_agent.py` used `Event.is_set() + Event.set()` as a check-then-act pair — non-atomic. Two concurrent `AIAgent.__init__` calls (the gateway creates one per request) could both observe `is_set() == False`, both call `set()`, and both spawn a `fetch_model_metadata` thread, violating the documented *"spawned once per process"* invariant.

## Fix

Replaced the `Event` with a `threading.Lock` used as a one-shot gate via `acquire(blocking=False)`. The first caller wins atomically; the lock is intentionally never released — that **is** the gate. Comment at the definition site documents this so a future contributor doesn't "fix" the missing `release()`.

```diff
-_openrouter_prewarm_done = threading.Event()
+_openrouter_prewarm_lock = threading.Lock()
...
-if (... or self._is_openrouter_url()) and \
-        not _openrouter_prewarm_done.is_set():
-    _openrouter_prewarm_done.set()
+if (... or self._is_openrouter_url()) and \
+        _openrouter_prewarm_lock.acquire(blocking=False):
     threading.Thread(target=fetch_model_metadata, ...).start()
```

## Tests

New file `tests/run_agent/test_openrouter_prewarm_guard.py` with 4 regression tests:

1. **Type guard** — asserts the gate is a `Lock`, not an `Event` (catches accidental reverts).
2. **Bare-primitive race** — 64 threads on a `Barrier` race for `acquire(blocking=False)`; exactly one wins.
3. **End-to-end** — 32 concurrent `AIAgent(provider="openrouter", ...)` instantiations gated by a `Barrier`, with `threading.Thread` patched to record `name="openrouter-prewarm"` spawns; exactly 1 spawn observed.
4. **Negative** — non-openrouter provider does **not** spawn the thread and does **not** claim the gate.

All 4 pass; `ruff check` clean.

## Test plan
- [x] `pytest tests/run_agent/test_openrouter_prewarm_guard.py -o addopts="" -v` — 4 passed
- [x] `ruff check run_agent.py tests/run_agent/test_openrouter_prewarm_guard.py` — clean
- [ ] Maintainer: confirm no other consumers of the (private) `_openrouter_prewarm_done` symbol (verified locally: only reference was in `run_agent.py` itself)