### PR TITLE
fix(run_agent): replace non-atomic Event prewarm guard with Lock gate

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -358,7 +358,13 @@ _MAX_TOOL_WORKERS = 8
 # process, not once per AIAgent instantiation.  Without this, long-running
 # gateway processes leak one OS thread per incoming message and eventually
 # exhaust the system thread limit (RuntimeError: can't start new thread).
-_openrouter_prewarm_done = threading.Event()
+#
+# Implemented as a Lock used as a one-shot gate (acquire(blocking=False)):
+# the winner holds the lock permanently so subsequent callers cannot acquire
+# it.  This is atomic — unlike the former Event.is_set()+Event.set() pair
+# which had a TOCTOU window where two concurrent AIAgent.__init__ calls could
+# both see is_set()==False and each spawn a prewarm thread (issue #24651).
+_openrouter_prewarm_lock = threading.Lock()
 
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
@@ -1359,8 +1365,7 @@ class AIAgent:
         # each message leaks one OS thread and the process eventually exhausts
         # the system thread limit (RuntimeError: can't start new thread).
         if (self.provider == "openrouter" or self._is_openrouter_url()) and \
-                not _openrouter_prewarm_done.is_set():
-            _openrouter_prewarm_done.set()
+                _openrouter_prewarm_lock.acquire(blocking=False):
             threading.Thread(
                 target=fetch_model_metadata,
                 daemon=True,

--- a/tests/run_agent/test_prewarm_atomic_gate.py
+++ b/tests/run_agent/test_prewarm_atomic_gate.py
@@ -1,0 +1,52 @@
+"""Regression tests for the atomic prewarm gate in AIAgent.__init__.
+
+Issue #24651: the former Event.is_set() + Event.set() pattern was not atomic.
+Two concurrent AIAgent instantiations could both see is_set()==False and each
+spawn a fetch_model_metadata thread, defeating the "spawn exactly once" guard.
+
+The fix replaces the Event with a Lock used via acquire(blocking=False).
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import run_agent
+
+
+class TestPrewarmAtomicGate:
+    """Verify _openrouter_prewarm_lock spawns the prewarm thread exactly once."""
+
+    def setup_method(self):
+        """Reset the module-level lock before each test."""
+        self._orig_lock = run_agent._openrouter_prewarm_lock
+        run_agent._openrouter_prewarm_lock = threading.Lock()
+
+    def teardown_method(self):
+        run_agent._openrouter_prewarm_lock = self._orig_lock
+
+    def test_prewarm_thread_spawned_exactly_once_under_concurrency(self):
+        """50 concurrent callers racing the gate must win the lock exactly once."""
+        spawn_count = []
+        spawn_lock = threading.Lock()
+        barrier = threading.Barrier(50)
+
+        def simulate_init():
+            barrier.wait()  # maximise contention at the gate
+            if run_agent._openrouter_prewarm_lock.acquire(blocking=False):
+                with spawn_lock:
+                    spawn_count.append(1)
+
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            futures = [pool.submit(simulate_init) for _ in range(50)]
+            for f in futures:
+                f.result()
+
+        assert len(spawn_count) == 1, (
+            f"Expected exactly 1 prewarm thread spawn, got {len(spawn_count)}"
+        )
+
+    def test_lock_stays_held_after_first_acquisition(self):
+        """Lock must remain held after the winning acquire so late callers fail."""
+        assert run_agent._openrouter_prewarm_lock.acquire(blocking=False) is True
+        # Lock is never released — a second acquire must fail immediately
+        assert run_agent._openrouter_prewarm_lock.acquire(blocking=False) is False


### PR DESCRIPTION
## What does this PR do?

## Problem

The prewarm guard in \`AIAgent.__init__\` used \`threading.Event\` with a non-atomic check-then-act:

\`\`\`python
if ... and not _openrouter_prewarm_done.is_set():
    _openrouter_prewarm_done.set()
    threading.Thread(target=fetch_model_metadata, ...).start()
\`\`\`

## Root cause

\`Event.is_set()\` and \`Event.set()\` are two separate operations — not a single atomic compare-and-swap. Under concurrent load (every gateway request creates a new \`AIAgent\`), two threads can both observe \`is_set()==False\`, both call \`.set()\`, and both spawn a \`fetch_model_metadata\` thread.

The comment above the guard explicitly states the intent: prevent per-message thread leaks that exhaust the system thread limit. The \`Event\` approach reduces the problem from \`N threads per N messages\` to \`2 threads per burst\`, but it still violates the documented invariant.

## Fix

Replace the \`Event\` with a \`threading.Lock\` used as a permanent one-shot gate:

\`\`\`python
_openrouter_prewarm_lock = threading.Lock()

# In AIAgent.__init__:
if ... and _openrouter_prewarm_lock.acquire(blocking=False):
    threading.Thread(target=fetch_model_metadata, ...).start()
\`\`\`

\`Lock.acquire(blocking=False)\` is a single atomic operation — exactly one caller wins, and the lock is never released, so all subsequent callers fail the acquire and skip the spawn. No TOCTOU window.

## Tests

New file \`tests/run_agent/test_prewarm_atomic_gate.py\`:

- \`test_prewarm_thread_spawned_exactly_once_under_concurrency\` — 50 threads race through the gate simultaneously; exactly 1 must win.
- \`test_lock_stays_held_after_first_acquisition\` — verifies the lock is permanent: a second \`acquire(blocking=False)\` returns \`False\` immediately.

```
2 passed in 16.79s
```

## Visual

```
Before (TOCTOU)                     After (atomic)
──────────────────────────────────  ─────────────────────────────────
if not event.is_set():   ← check    if lock.acquire(blocking=False):
    event.set()          ← act          threading.Thread(...).start()
    threading.Thread(...).start()
    # Two threads can slip through
    # the window between check+act
```

Closes #24651

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24651

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.