### PR TITLE
fix(browser_tool): eliminate four TOCTOU races in lazy-init singletons

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -179,6 +179,7 @@ _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
 
 _cached_command_timeout: Optional[int] = None
 _command_timeout_resolved = False
+_command_timeout_lock = threading.Lock()
 
 
 def _get_command_timeout() -> int:
@@ -187,23 +188,27 @@ def _get_command_timeout() -> int:
     Reads ``config["browser"]["command_timeout"]`` and falls back to
     ``DEFAULT_COMMAND_TIMEOUT`` (30s) if unset or unreadable.  Result is
     cached after the first call and cleared by ``cleanup_all_browsers()``.
+    Thread-safe via double-checked locking (issue #24669).
     """
     global _cached_command_timeout, _command_timeout_resolved
     if _command_timeout_resolved:
         return _cached_command_timeout  # type: ignore[return-value]
 
-    _command_timeout_resolved = True
-    result = DEFAULT_COMMAND_TIMEOUT
-    try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
-        val = cfg_get(cfg, "browser", "command_timeout")
-        if val is not None:
-            result = max(int(val), 5)  # Floor at 5s to avoid instant kills
-    except Exception as e:
-        logger.debug("Could not read command_timeout from config: %s", e)
-    _cached_command_timeout = result
-    return result
+    with _command_timeout_lock:
+        if _command_timeout_resolved:
+            return _cached_command_timeout  # type: ignore[return-value]
+        result = DEFAULT_COMMAND_TIMEOUT
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            val = cfg_get(cfg, "browser", "command_timeout")
+            if val is not None:
+                result = max(int(val), 5)  # Floor at 5s to avoid instant kills
+        except Exception as e:
+            logger.debug("Could not read command_timeout from config: %s", e)
+        _cached_command_timeout = result
+        _command_timeout_resolved = True
+    return _cached_command_timeout  # type: ignore[return-value]
 
 
 def _get_vision_model() -> Optional[str]:
@@ -401,6 +406,7 @@ _cached_cloud_provider: Optional[CloudBrowserProvider] = None
 _cloud_provider_resolved = False
 _allow_private_urls_resolved = False
 _cached_allow_private_urls: Optional[bool] = None
+_allow_private_urls_lock = threading.Lock()
 _cached_agent_browser: Optional[str] = None
 _agent_browser_resolved = False
 
@@ -408,6 +414,7 @@ _agent_browser_resolved = False
 # agent-browser v0.25.3+ supports ``--engine lightpanda`` natively.
 _cached_browser_engine: Optional[str] = None
 _browser_engine_resolved = False
+_browser_engine_lock = threading.Lock()
 
 
 def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
@@ -517,6 +524,7 @@ def _is_local_backend() -> bool:
 
 _auto_local_for_private_urls_resolved = False
 _cached_auto_local_for_private_urls: bool = True
+_auto_local_for_private_urls_lock = threading.Lock()
 
 
 def _get_browser_engine() -> str:
@@ -534,37 +542,42 @@ def _get_browser_engine() -> str:
     """
     global _cached_browser_engine, _browser_engine_resolved
     if _browser_engine_resolved:
-        return _cached_browser_engine
+        return _cached_browser_engine  # type: ignore[return-value]
 
-    _browser_engine_resolved = True
-    _cached_browser_engine = "auto"  # safe default
+    with _browser_engine_lock:
+        if _browser_engine_resolved:
+            return _cached_browser_engine  # type: ignore[return-value]
 
-    # Config file takes priority
-    try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
-        val = cfg.get("browser", {}).get("engine")
-        if val and str(val).strip():
-            _cached_browser_engine = str(val).strip().lower()
-    except Exception as e:
-        logger.debug("Could not read browser.engine from config: %s", e)
+        result = "auto"  # safe default
 
-    # Fall back to env var (only if config didn't set a value)
-    if _cached_browser_engine == "auto":
-        env_val = os.environ.get("AGENT_BROWSER_ENGINE", "").strip().lower()
-        if env_val:
-            _cached_browser_engine = env_val
+        # Config file takes priority
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            val = cfg.get("browser", {}).get("engine")
+            if val and str(val).strip():
+                result = str(val).strip().lower()
+        except Exception as e:
+            logger.debug("Could not read browser.engine from config: %s", e)
 
-    # Validate: agent-browser only accepts "chrome" and "lightpanda".
-    _VALID_ENGINES = {"auto", "lightpanda", "chrome"}
-    if _cached_browser_engine not in _VALID_ENGINES:
-        logger.warning(
-            "Unknown browser engine %r (valid: %s), falling back to 'auto'",
-            _cached_browser_engine, ", ".join(sorted(_VALID_ENGINES)),
-        )
-        _cached_browser_engine = "auto"
+        # Fall back to env var (only if config didn't set a value)
+        if result == "auto":
+            env_val = os.environ.get("AGENT_BROWSER_ENGINE", "").strip().lower()
+            if env_val:
+                result = env_val
 
-    return _cached_browser_engine
+        # Validate: agent-browser only accepts "chrome" and "lightpanda".
+        _VALID_ENGINES = {"auto", "lightpanda", "chrome"}
+        if result not in _VALID_ENGINES:
+            logger.warning(
+                "Unknown browser engine %r (valid: %s), falling back to 'auto'",
+                result, ", ".join(sorted(_VALID_ENGINES)),
+            )
+            result = "auto"
+
+        _cached_browser_engine = result
+        _browser_engine_resolved = True
+    return _cached_browser_engine  # type: ignore[return-value]
 
 
 def _should_inject_engine(engine: str) -> bool:
@@ -867,17 +880,20 @@ def _auto_local_for_private_urls() -> bool:
     if _auto_local_for_private_urls_resolved:
         return _cached_auto_local_for_private_urls
 
-    _auto_local_for_private_urls_resolved = True
-    try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
-        browser_cfg = cfg.get("browser", {})
-        if isinstance(browser_cfg, dict) and "auto_local_for_private_urls" in browser_cfg:
-            _cached_auto_local_for_private_urls = bool(
-                browser_cfg.get("auto_local_for_private_urls")
-            )
-    except Exception as e:
-        logger.debug("Could not read auto_local_for_private_urls from config: %s", e)
+    with _auto_local_for_private_urls_lock:
+        if _auto_local_for_private_urls_resolved:
+            return _cached_auto_local_for_private_urls
+        result = True  # safe default (match _cached_auto_local_for_private_urls init)
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            browser_cfg = cfg.get("browser", {})
+            if isinstance(browser_cfg, dict) and "auto_local_for_private_urls" in browser_cfg:
+                result = bool(browser_cfg.get("auto_local_for_private_urls"))
+        except Exception as e:
+            logger.debug("Could not read auto_local_for_private_urls from config: %s", e)
+        _cached_auto_local_for_private_urls = result
+        _auto_local_for_private_urls_resolved = True
     return _cached_auto_local_for_private_urls
 
 
@@ -997,24 +1013,29 @@ def _allow_private_urls() -> bool:
 
     Reads ``config["browser"]["allow_private_urls"]`` once and caches the result
     for the process lifetime.  Defaults to ``False`` (SSRF protection active).
+    Thread-safe via double-checked locking (issue #24669).
     """
     global _cached_allow_private_urls, _allow_private_urls_resolved
     if _allow_private_urls_resolved:
-        return _cached_allow_private_urls
+        return _cached_allow_private_urls  # type: ignore[return-value]
 
-    _allow_private_urls_resolved = True
-    _cached_allow_private_urls = False  # safe default
-    try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config()
-        browser_cfg = cfg.get("browser", {})
-        if isinstance(browser_cfg, dict):
-            _cached_allow_private_urls = is_truthy_value(
-                browser_cfg.get("allow_private_urls"), default=False
-            )
-    except Exception as e:
-        logger.debug("Could not read allow_private_urls from config: %s", e)
-    return _cached_allow_private_urls
+    with _allow_private_urls_lock:
+        if _allow_private_urls_resolved:
+            return _cached_allow_private_urls  # type: ignore[return-value]
+        result = False  # safe default
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config()
+            browser_cfg = cfg.get("browser", {})
+            if isinstance(browser_cfg, dict):
+                result = is_truthy_value(
+                    browser_cfg.get("allow_private_urls"), default=False
+                )
+        except Exception as e:
+            logger.debug("Could not read allow_private_urls from config: %s", e)
+        _cached_allow_private_urls = result
+        _allow_private_urls_resolved = True
+    return _cached_allow_private_urls  # type: ignore[return-value]
 
 
 def _socket_safe_tmpdir() -> str:


### PR DESCRIPTION
## What does this PR do?

Four resolver functions in \`tools/browser_tool.py\` share the same TOCTOU pattern: the \`_resolved\` flag is set to \`True\` **before** the cached value is computed, creating a window where a concurrent thread hitting the early-return fast path reads a stale default.

## Root cause

Four resolver functions in \`tools/browser_tool.py\` share the same TOCTOU pattern: the \`_resolved\` flag is set to \`True\` **before** the cached value is computed, creating a window where a concurrent thread hitting the early-return fast path reads a stale default.

| Function | Stale value | Impact |
|---|---|---|
| \`_get_command_timeout()\` | \`None\` (typed \`int\`) | \`TypeError\` downstream on first concurrent access |
| \`_get_browser_engine()\` | \`"auto"\` | configured engine (e.g. \`lightpanda\`) silently ignored |
| \`_allow_private_urls()\` | \`False\` | SSRF protection not disabled when configured |
| \`_auto_local_for_private_urls()\` | \`True\` | private-URL routing…

## Fix

Double-checked locking applied to all four functions:

1. Fast path (\`if _resolved: return _cached\`) stays lock-free after first init — no added overhead on the hot path.
2. Slow path acquires a per-function \`threading.Lock\`, re-checks inside the lock.
3. Computes result into a local variable.
4. Writes \`_cached_* = result\` **before** \`_resolved = True\`.

Four new module-level locks added: \`_command_timeout_lock\`, \`_browser_engine_lock\`, \`_allow_private_urls_lock\`, \`_auto_local_for_private_urls_lock\`.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24669

<details>
<summary>Original body</summary>

## Summary

Four resolver functions in \`tools/browser_tool.py\` share the same TOCTOU pattern: the \`_resolved\` flag is set to \`True\` **before** the cached value is computed, creating a window where a concurrent thread hitting the early-return fast path reads a stale default.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

Four resolver functions in \`tools/browser_tool.py\` share the same TOCTOU pattern: the \`_resolved\` flag is set to \`True\` **before** the cached value is computed, creating a window where a concurrent thread hitting the early-return fast path reads a stale default.

| Function | Stale value | Impact |
|---|---|---|
| \`_get_command_timeout()\` | \`None\` (typed \`int\`) | \`TypeError\` downstream on first concurrent access |
| \`_get_browser_engine()\` | \`"auto"\` | configured engine (e.g. \`lightpanda\`) silently ignored |
| \`_allow_private_urls()\` | \`False\` | SSRF protection not disabled when configured |
| \`_auto_local_for_private_urls()\` | \`True\` | private-URL routing decision wrong for concurrent callers |

Example from \`_get_command_timeout()\`:

\`\`\`python
_command_timeout_resolved = True   # ← flag set first
result = DEFAULT_COMMAND_TIMEOUT
# … config file read …
_cached_command_timeout = result   # ← value written last
\`\`\`

## Root cause

Non-atomic read-modify-write. Under concurrent gateway load, every incoming request triggers browser tool calls on potentially cold singletons. Two threads can both see \`_resolved == False\`, one sets the flag and both proceed to compute — but the one that wins the flag write doesn't hold a lock, so a third concurrent reader can see \`_resolved=True\` with the stale default still in \`_cached_*\`.

On non-GIL runtimes (CPython 3.13+ free-threaded, PyPy) this is an unconditional data race.

## Fix

Double-checked locking applied to all four functions:

1. Fast path (\`if _resolved: return _cached\`) stays lock-free after first init — no added overhead on the hot path.
2. Slow path acquires a per-function \`threading.Lock\`, re-checks inside the lock.
3. Computes result into a local variable.
4. Writes \`_cached_* = result\` **before** \`_resolved = True\`.

Four new module-level locks added: \`_command_timeout_lock\`, \`_browser_engine_lock\`, \`_allow_private_urls_lock\`, \`_auto_local_for_private_urls_lock\`.

## Tests

161 passed, 6 skipped (all pre-existing skips). The 2 failures in \`test_browser_sandbox_env_var.py\` are a pre-existing subset of 3 that fail on \`main\` before this change — this PR does not introduce them.

Closes #24669

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24669

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_