### PR TITLE
fix(extract_media): restrict \S+ fallback to absolute paths only

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2113,7 +2113,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|(?:~/|/)\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -748,6 +748,16 @@ class TestSignalMediaExtraction:
         assert media[0][0] == "/tmp/price_graph.png"
         assert "MEDIA:" not in cleaned
 
+    def test_extract_media_ignores_relative_word_fallback(self):
+        """extract_media() must not capture plain words or relative tokens after MEDIA:."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:description")
+        assert media == [], "plain word after MEDIA: must not be extracted"
+        media2, _ = BasePlatformAdapter.extract_media("MEDIA:relative/path.png")
+        assert media2 == [], "relative path without leading slash must not be extracted"
+        media3, _ = BasePlatformAdapter.extract_media("MEDIA:/tmp/file.ogg")
+        assert len(media3) == 1 and media3[0][0] == "/tmp/file.ogg"
+
     def test_extract_media_finds_audio_tag(self):
         """BasePlatformAdapter.extract_media should find MEDIA: audio paths."""
         from gateway.platforms.base import BasePlatformAdapter


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter.extract_media()` logs spurious *File not found* warnings whenever the agent **explains** the `MEDIA:` syntax in a response. The regex's last fallback alternative — a bare `\S+` — matches any non-whitespace token, so plain words, relative tokens, and template placeholders like `<filename>` are all captured as media paths. `send_document()` then fails with `os.path.exists() == False` and the gateway emits:

## Root cause

`BasePlatformAdapter.extract_media()` logs spurious *File not found* warnings
whenever the agent **explains** the `MEDIA:` syntax in a response. The regex's
last fallback alternative — a bare `\S+` — matches any non-whitespace token,
so plain words, relative tokens, and template placeholders like `<filename>`
are all captured as media paths. `send_document()` then fails with
`os.path.exists() == False` and the gateway emits:

```
WARNING: File file not found: /home/hermes/outbox/<filename>
WARNING: File file not found: /home/hermes/outbox/file
WARNING: File file not found: /outbox/
```

## Fix

Change the fallback from `\S+` to `(?:~/|/)\S+` so only strings beginning
with an absolute-path prefix are captured. Relative tokens and plain words no
longer trigger false-positive media sends.

```python
# After (restricted to absolute paths)
r'''[`"']?MEDIA:\s*(?P<path>...|(?:~/|/)\S+...extension-list...|(?:~/|/)\S+)[`"']?'''
#                                                                  ^^^^^^^^^^
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24575

<details>
<summary>Original body</summary>

## Summary

`BasePlatformAdapter.extract_media()` logs spurious *File not found* warnings whenever the agent **explains** the `MEDIA:` syntax in a response. The regex's last fallback alternative — a bare `\S+` — matches any non-whitespace token, so plain words, relative tokens, and template placeholders like `<filename>` are all captured as media paths. `send_document()` then fails with `os.path.exists() == False` and the gateway emits:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`BasePlatformAdapter.extract_media()` logs spurious *File not found* warnings
whenever the agent **explains** the `MEDIA:` syntax in a response. The regex's
last fallback alternative — a bare `\S+` — matches any non-whitespace token,
so plain words, relative tokens, and template placeholders like `<filename>`
are all captured as media paths. `send_document()` then fails with
`os.path.exists() == False` and the gateway emits:

```
WARNING: File file not found: /home/hermes/outbox/<filename>
WARNING: File file not found: /home/hermes/outbox/file
WARNING: File file not found: /outbox/
```

## Root cause

`gateway/platforms/base.py` — the named path group in the `extract_media`
regex ends with `|\S+)`. This makes the fallback match anything:

```python
# Before (too broad)
r'''[`"']?MEDIA:\s*(?P<path>...|(?:~/|/)\S+...extension-list...|\S+)[`"']?'''
#                                                                   ^^^^
```

## Fix

Change the fallback from `\S+` to `(?:~/|/)\S+` so only strings beginning
with an absolute-path prefix are captured. Relative tokens and plain words no
longer trigger false-positive media sends.

```python
# After (restricted to absolute paths)
r'''[`"']?MEDIA:\s*(?P<path>...|(?:~/|/)\S+...extension-list...|(?:~/|/)\S+)[`"']?'''
#                                                                  ^^^^^^^^^^
```

## Tests

Added `test_extract_media_ignores_relative_word_fallback` in
`tests/gateway/test_signal.py`:

- `MEDIA:description` → empty (plain word, no leading `/`)
- `MEDIA:relative/path.png` → empty (relative path, no leading `/`)
- `MEDIA:/tmp/file.ogg` → extracted correctly (absolute path still works)

All 3 new assertions pass. Existing `test_extract_media_finds_image_tag` and
`test_extract_media_finds_audio_tag` continue to pass.

## Visual

```mermaid
flowchart LR
    BUG["❌ Bug: MEDIA:description → captured as media path"] --> WARN["WARNING: File not found"]
    FIX["✅ Fix: MEDIA:description → ignored (no leading /)"] --> OK["No spurious warning"]
```

Closes #24575

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_