### PR TITLE
fix(google_chat): double-checked locking for _load_google_modules() TOCTOU

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -43,6 +43,7 @@ import logging
 import os
 import random
 import re
+import threading
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -71,6 +72,7 @@ HttpError: Any = Exception  # type: ignore
 MediaFileUpload: Any = None  # type: ignore
 
 _google_modules_loaded: bool = False
+_google_modules_lock = threading.Lock()
 
 
 def _load_google_modules() -> bool:
@@ -92,29 +94,32 @@ def _load_google_modules() -> bool:
     global AuthorizedHttp, build_service, HttpError, MediaFileUpload
     if _google_modules_loaded:
         return GOOGLE_CHAT_AVAILABLE
-    _google_modules_loaded = True
-    try:
-        import httplib2 as _httplib2
-        from google.cloud import pubsub_v1 as _pubsub_v1
-        from google.api_core import exceptions as _gax_exceptions
-        from google.oauth2 import service_account as _service_account
-        from google_auth_httplib2 import AuthorizedHttp as _AuthorizedHttp
-        from googleapiclient.discovery import build as _build_service
-        from googleapiclient.errors import HttpError as _HttpError
-        from googleapiclient.http import MediaFileUpload as _MediaFileUpload
-    except ImportError:
-        GOOGLE_CHAT_AVAILABLE = False
-        return False
-    httplib2 = _httplib2
-    pubsub_v1 = _pubsub_v1
-    gax_exceptions = _gax_exceptions
-    service_account = _service_account
-    AuthorizedHttp = _AuthorizedHttp
-    build_service = _build_service
-    HttpError = _HttpError
-    MediaFileUpload = _MediaFileUpload
-    GOOGLE_CHAT_AVAILABLE = True
-    return True
+    with _google_modules_lock:
+        if _google_modules_loaded:
+            return GOOGLE_CHAT_AVAILABLE
+        try:
+            import httplib2 as _httplib2
+            from google.cloud import pubsub_v1 as _pubsub_v1
+            from google.api_core import exceptions as _gax_exceptions
+            from google.oauth2 import service_account as _service_account
+            from google_auth_httplib2 import AuthorizedHttp as _AuthorizedHttp
+            from googleapiclient.discovery import build as _build_service
+            from googleapiclient.errors import HttpError as _HttpError
+            from googleapiclient.http import MediaFileUpload as _MediaFileUpload
+        except ImportError:
+            _google_modules_loaded = True
+            return False
+        httplib2 = _httplib2
+        pubsub_v1 = _pubsub_v1
+        gax_exceptions = _gax_exceptions
+        service_account = _service_account
+        AuthorizedHttp = _AuthorizedHttp
+        build_service = _build_service
+        HttpError = _HttpError
+        MediaFileUpload = _MediaFileUpload
+        GOOGLE_CHAT_AVAILABLE = True
+        _google_modules_loaded = True
+    return GOOGLE_CHAT_AVAILABLE
 
 from gateway.config import Platform, PlatformConfig
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -15,7 +15,9 @@ import asyncio
 import json
 import os
 import sys
+import threading
 import types
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2866,3 +2868,59 @@ class TestGoogleChatStandaloneSend:
         assert "error" in result
         # The error names the expected resource shape so plugin authors can self-correct
         assert "spaces/" in result["error"] or "users/" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TOCTOU race regression — _load_google_modules() double-checked locking
+# ---------------------------------------------------------------------------
+
+class TestLoadGoogleModulesToctouRace:
+    """Verify _load_google_modules() is safe under concurrent first-call contention."""
+
+    def setup_method(self):
+        import plugins.platforms.google_chat.adapter as gc
+        self._orig_loaded = gc._google_modules_loaded
+        self._orig_lock = gc._google_modules_lock
+        self._orig_available = gc.GOOGLE_CHAT_AVAILABLE
+        # Reset to uninitialized state for each test
+        gc._google_modules_loaded = False
+        gc._google_modules_lock = threading.Lock()
+        gc.GOOGLE_CHAT_AVAILABLE = False
+
+    def teardown_method(self):
+        import plugins.platforms.google_chat.adapter as gc
+        gc._google_modules_loaded = self._orig_loaded
+        gc._google_modules_lock = self._orig_lock
+        gc.GOOGLE_CHAT_AVAILABLE = self._orig_available
+
+    def test_concurrent_calls_return_consistent_result(self):
+        """50 threads racing on first call must all see the same return value."""
+        import plugins.platforms.google_chat.adapter as gc
+        barrier = threading.Barrier(50)
+
+        def call_load():
+            barrier.wait()
+            return gc._load_google_modules()
+
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            futures = [pool.submit(call_load) for _ in range(50)]
+            results = [f.result() for f in futures]
+
+        # All threads must agree on the result (True or False, deps installed or not)
+        assert len(set(results)) == 1, (
+            f"_load_google_modules() returned inconsistent values under concurrency: {set(results)}"
+        )
+
+    def test_flag_set_after_globals_assigned(self):
+        """_google_modules_loaded must be True only after all module globals are set."""
+        import plugins.platforms.google_chat.adapter as gc
+
+        # Simulate the ImportError path — flag must still be set (no infinite retry)
+        with patch.dict("sys.modules", {"httplib2": None}):
+            # Reset again
+            gc._google_modules_loaded = False
+            gc._google_modules_lock = threading.Lock()
+            gc.GOOGLE_CHAT_AVAILABLE = False
+            # Call should not raise and must mark as loaded
+            gc._load_google_modules()
+            assert gc._google_modules_loaded is True


### PR DESCRIPTION
## What does this PR do?

Fixes a TOCTOU race condition in `plugins/platforms/google_chat/adapter.py::_load_google_modules()`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24673

<details>
<summary>Original body</summary>

## Summary

Fixes a TOCTOU race condition in `plugins/platforms/google_chat/adapter.py::_load_google_modules()`.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Fixes a TOCTOU race condition in `plugins/platforms/google_chat/adapter.py::_load_google_modules()`.

**Bug:** `_google_modules_loaded = True` was set on line 95 **before** any imports ran and **before** any module globals (`httplib2`, `pubsub_v1`, `service_account`, etc.) were assigned. A concurrent thread entering on the fast path (`if _google_modules_loaded: return GOOGLE_CHAT_AVAILABLE`) would see the flag as `True` but read stale `None` globals and `GOOGLE_CHAT_AVAILABLE=False`, causing downstream `NoneType` errors or silently degraded behaviour.

**Fix:** Added `_google_modules_lock = threading.Lock()` and applied the standard double-checked locking pattern:
- Fast lock-free path for the already-initialized case (no contention after first call)
- Slow path acquires lock and re-checks before doing work
- All module globals are assigned before `GOOGLE_CHAT_AVAILABLE = True`
- `_google_modules_loaded = True` is set **last**, after all writes are visible
- `ImportError` path also sets `_google_modules_loaded = True` so missing-deps environments don't retry the import on every call

## Test plan

- [ ] `tests/gateway/test_google_chat.py::TestLoadGoogleModulesToctouRace::test_concurrent_calls_return_consistent_result` — 50 threads race on first call, all must see same return value
- [ ] `tests/gateway/test_google_chat.py::TestLoadGoogleModulesToctouRace::test_flag_set_after_globals_assigned` — ImportError path still sets flag (no infinite retry)
- [ ] Full `tests/gateway/test_google_chat.py` suite: 159 passed, 0 failed

Closes #24673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24673

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_