### PR TITLE
fix(vision): enable native vision for kimi-coding provider + alias mapping

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -441,6 +441,21 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
         if mid.lower() == model_lower and isinstance(mdata, dict):
             return mdata
 
+    # Alias match: some providers use friendly names in config that differ
+    # from the canonical model IDs in models.dev.
+    _MODEL_ALIASES: Dict[str, str] = {
+        "kimi-for-coding": "k2p6",
+    }
+    aliased_id = _MODEL_ALIASES.get(model_lower)
+    if aliased_id:
+        entry = models.get(aliased_id)
+        if isinstance(entry, dict):
+            return entry
+        # Also try case-insensitive alias lookup
+        for mid, mdata in models.items():
+            if mid.lower() == aliased_id.lower() and isinstance(mdata, dict):
+                return mdata
+
     return None
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -460,6 +460,10 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
         return True
 
+    # Kimi (Moonshot) — K2.5/K2.6 support vision in tool results
+    if p in {"kimi-coding", "kimi-coding-cn", "kimi", "moonshot"}:
+        return True
+
     # Gemini — gate on model name; older Gemini variants did not support
     # multimodal functionResponse. Gemini 3.x does.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:


### PR DESCRIPTION
## Problem

When using <code>kimi-coding</code> provider with model <code>kimi-for-coding</code> (Kimi K2.6), <code>vision_analyze</code> fails with:

<pre>Error analyzing image: No LLM provider configured for task=vision provider=auto. Run: hermes setup</pre>

This happens even though Kimi K2.6 fully supports multimodal/vision natively.

## Root Cause

Two issues chain together:

1. **Provider not in native vision allow-list**: <code>_supports_media_in_tool_results()</code> in <code>tools/vision_tools.py</code> does not include <code>kimi-coding</code>, so the native fast path is skipped.

2. **Config model name not resolvable in models.dev**: Config uses friendly name <code>kimi-for-coding</code>, but models.dev cache stores the canonical ID <code>k2p6</code>. <code>_find_model_entry()</code> cannot bridge this gap, so <code>get_model_capabilities()</code> returns <code>None</code>. This causes <code>decide_image_input_mode()</code> to fall back to <code>'text'</code> mode, triggering the legacy auxiliary-LLM path that fails when no vision provider is configured.

## Changes

### tools/vision_tools.py
- Add <code>kimi-coding</code>, <code>kimi-coding-cn</code>, <code>kimi</code>, <code>moonshot</code> to <code>_supports_media_in_tool_results()</code>

### agent/models_dev.py
- Add <code>_MODEL_ALIASES</code> mapping in <code>_find_model_entry()</code> to bridge friendly config names (e.g. <code>kimi-for-coding</code>) to canonical models.dev IDs (e.g. <code>k2p6</code>)

## Verification

After the fix:
- <code>_supports_media_in_tool_results('kimi-coding', 'kimi-for-coding')</code> → <code>True</code>
- <code>get_model_capabilities('kimi-coding', 'kimi-for-coding')</code> → <code>ModelCapabilities(supports_vision=True, ...)</code>
- <code>decide_image_input_mode('kimi-coding', 'kimi-for-coding', cfg)</code> → <code>'native'</code>
- <code>vision_analyze</code> returns a multimodal tool-result envelope with the base64-encoded image

## Related

Closes #24681