### PR TITLE
fix(config): bridge gateway_restart_notification into PlatformConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -779,6 +779,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -816,6 +818,10 @@ def load_gateway_config() -> GatewayConfig:
                     platforms_data[plat.value] = plat_data
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
+                if "gateway_restart_notification" in bridged:
+                    plat_data["gateway_restart_notification"] = bridged.pop(
+                        "gateway_restart_notification"
+                    )
                 extra = plat_data.setdefault("extra", {})
                 if not isinstance(extra, dict):
                     extra = {}

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -490,6 +490,24 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["disable_link_previews"] is True
 
+    def test_bridges_telegram_gateway_restart_notification_from_config_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].gateway_restart_notification is False
+
     def test_bridges_notice_delivery_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Problem

Setting `gateway_restart_notification: false` under a platform section (e.g. `telegram:`) in `config.yaml` had no effect — restart/shutdown notifications were always sent regardless of the configured value.

## Root Cause

`load_gateway_config()` in `gateway/config.py` bridges individual YAML keys into the internal `PlatformConfig` dataclass via an explicit allowlist. `gateway_restart_notification` was missing from that list, so it was never forwarded and always fell back to its default value of `True`.

## Fix

1. Add `gateway_restart_notification` to the bridge list (copy from `platform_cfg` → `bridged`).
2. Pop it from `bridged` directly into `plat_data` before `extra.update(bridged)` — required because it is a first-class `PlatformConfig` field, not an extra.

## Tests

Added regression test `test_bridges_telegram_gateway_restart_notification_from_config_yaml` to `tests/gateway/test_config.py`:
- Parses a minimal YAML with `telegram: gateway_restart_notification: false`
- Asserts `config.platforms[Platform.TELEGRAM].gateway_restart_notification is False`

Closes #24644