### PR TITLE
fix(deepseek): update provider picker description to list V4 models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -917,7 +917,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
+    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V4 Pro, V4 Flash — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),


### PR DESCRIPTION
## Summary

Updates the DeepSeek provider picker description in  from:

**Before:** 
**After:** 

The provider-level description was stale — the direct DeepSeek provider now exposes first-class V4 models (, ), but the picker description still listed V3/R1/coder.

## Files

-  — 1 line change

Closes #24471