### PR TITLE
Fix/lmstudio detect server type

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -451,10 +451,46 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+# Process-level cache for detect_local_server_type results (#24510).
+#
+# Without caching, every gateway message handler invocation re-probes
+# the local server: up to 4 sync HTTP requests x 1s timeout each.  On
+# Discord the gateway runs inside the asyncio event loop; sync IO
+# inside the loop blocks the heartbeat and Discord disconnects after
+# ~20s of stall (see the traceback in #24510).  Caching by
+# ``(normalized_base_url, api_key)`` collapses the per-message cost
+# from "up to 4 HTTP probes" to "one dict lookup" after the first
+# detection succeeds.
+#
+# We cache positive results for ``_DETECT_CACHE_TTL_S`` seconds so a
+# user who restarts their local server with a different backend
+# (Ollama -> LM Studio etc.) eventually re-probes.  Negative results
+# get the same TTL: surfacing the "no server detected" answer
+# instantly when the user just hasn't started their server yet is
+# worth the slight delay before re-probing.
+_DETECT_CACHE: Dict[tuple, tuple] = {}
+_DETECT_CACHE_TTL_S = 300.0  # 5 minutes
+
+
+def clear_local_server_type_cache() -> None:
+    """Drop every cached :func:`detect_local_server_type` entry.
+
+    Public helper so tests, /reload paths, and "I just restarted my
+    local server" workflows don't have to wait for the TTL to expire.
+    """
+    _DETECT_CACHE.clear()
+
+
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 
     Returns one of: "ollama", "lm-studio", "vllm", "llamacpp", or None.
+
+    The result is cached per ``(base_url, api_key)`` pair with a
+    :data:`_DETECT_CACHE_TTL_S` TTL so the gateway message-handling
+    hot path doesn't re-probe (and re-block the asyncio loop) on
+    every message.  Use :func:`clear_local_server_type_cache` to
+    invalidate.  See #24510.
     """
     import httpx
 
@@ -463,53 +499,74 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
     if server_url.endswith("/v1"):
         server_url = server_url[:-3]
 
+    cache_key = (normalized, api_key or "")
+    now = time.monotonic()
+    cached = _DETECT_CACHE.get(cache_key)
+    if cached is not None:
+        cached_at, cached_value = cached
+        if now - cached_at < _DETECT_CACHE_TTL_S:
+            return cached_value
+
     headers = _auth_headers(api_key)
+    detected: Optional[str] = None
 
     try:
-        with httpx.Client(timeout=2.0, headers=headers) as client:
-            # LM Studio exposes /api/v1/models — check first (most specific)
-            try:
-                r = client.get(f"{server_url}/api/v1/models")
-                if r.status_code == 200:
-                    return "lm-studio"
-            except Exception:
-                pass
-            # Ollama exposes /api/tags and responds with {"models": [...]}
-            # LM Studio returns {"error": "Unexpected endpoint"} with status 200
-            # on this path, so we must verify the response contains "models".
-            try:
-                r = client.get(f"{server_url}/api/tags")
-                if r.status_code == 200:
-                    try:
+        # 1.0s per probe (was 2.0s) -- localhost RTT is sub-millisecond,
+        # so a 1s budget still gives a 1000x safety margin while halving
+        # the worst-case stall when the server is wedged.  #24510.
+        with httpx.Client(timeout=1.0, headers=headers) as client:
+            # LM Studio exposes /api/v1/models (>= 0.4.0) and the older
+            # /api/v0/models on >= 0.3.6.  Probe both so detection
+            # works on every supported LM Studio build the user might
+            # have installed.  #24510.
+            for lm_studio_path in ("/api/v1/models", "/api/v0/models"):
+                try:
+                    r = client.get(f"{server_url}{lm_studio_path}")
+                    if r.status_code == 200:
+                        detected = "lm-studio"
+                        break
+                except Exception:
+                    pass
+            if detected is None:
+                # Ollama exposes /api/tags and responds with {"models": [...]}
+                # LM Studio returns {"error": "Unexpected endpoint"} with status 200
+                # on this path, so we must verify the response contains "models".
+                try:
+                    r = client.get(f"{server_url}/api/tags")
+                    if r.status_code == 200:
+                        try:
+                            data = r.json()
+                            if "models" in data:
+                                detected = "ollama"
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
+            if detected is None:
+                # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
+                try:
+                    r = client.get(f"{server_url}/v1/props")
+                    if r.status_code != 200:
+                        r = client.get(f"{server_url}/props")  # fallback for older builds
+                    if r.status_code == 200 and "default_generation_settings" in r.text:
+                        detected = "llamacpp"
+                except Exception:
+                    pass
+            if detected is None:
+                # vLLM: /version
+                try:
+                    r = client.get(f"{server_url}/version")
+                    if r.status_code == 200:
                         data = r.json()
-                        if "models" in data:
-                            return "ollama"
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-            # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
-            try:
-                r = client.get(f"{server_url}/v1/props")
-                if r.status_code != 200:
-                    r = client.get(f"{server_url}/props")  # fallback for older builds
-                if r.status_code == 200 and "default_generation_settings" in r.text:
-                    return "llamacpp"
-            except Exception:
-                pass
-            # vLLM: /version
-            try:
-                r = client.get(f"{server_url}/version")
-                if r.status_code == 200:
-                    data = r.json()
-                    if "version" in data:
-                        return "vllm"
-            except Exception:
-                pass
+                        if "version" in data:
+                            detected = "vllm"
+                except Exception:
+                    pass
     except Exception:
         pass
 
-    return None
+    _DETECT_CACHE[cache_key] = (now, detected)
+    return detected
 
 
 def _iter_nested_dicts(value: Any):

--- a/tests/agent/test_detect_local_server_cache.py
+++ b/tests/agent/test_detect_local_server_cache.py
@@ -1,0 +1,246 @@
+"""Unit tests for detect_local_server_type cache + LM Studio v0 fallback (#24510).
+
+The cache and the multi-version LM Studio probe are the two
+mechanically-observable parts of the fix.  These tests pin both so a
+future refactor that drops them surfaces the regression with an
+explicit "#24510" message.
+
+Every test mocks ``httpx.Client`` -- no real network traffic, runs on
+every CI box.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_detect_cache():
+    """Drop the module-level cache before and after each test so cases
+    don't poison each other."""
+    from agent.model_metadata import clear_local_server_type_cache
+    clear_local_server_type_cache()
+    yield
+    clear_local_server_type_cache()
+
+
+def _mock_client(get_side_effect):
+    """Build an ``httpx.Client`` mock whose .get() drives the test."""
+    client = MagicMock()
+    client.__enter__ = lambda s: client
+    client.__exit__ = MagicMock(return_value=False)
+    client.get.side_effect = get_side_effect
+    return client
+
+
+def _resp(status_code: int, body=None, text: str = ""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = text
+    if body is not None:
+        r.json.return_value = body
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLocalServerTypeCache:
+    """The cache is the heart of the #24510 fix -- pin it explicitly."""
+
+    def test_second_call_hits_cache_does_not_reprobe(self):
+        """First call probes; second call must return cached value
+        without issuing any HTTP requests."""
+        from agent.model_metadata import detect_local_server_type
+
+        client = _mock_client([_resp(200)])  # LM Studio v1 path -- one probe
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            first = detect_local_server_type("http://localhost:1234/v1")
+            second = detect_local_server_type("http://localhost:1234/v1")
+
+        assert first == "lm-studio"
+        assert second == "lm-studio"
+        # Crucial: only ONE httpx.Client constructed across both calls.
+        assert mock_factory.call_count == 1, (
+            "#24510 regression: detect_local_server_type re-probed on "
+            "the second call -- the cache is not wired"
+        )
+
+    def test_negative_result_is_cached_too(self):
+        """A "no server detected" answer must also be cached so a
+        misconfigured base_url doesn't drag every subsequent message
+        through 4 useless probes."""
+        from agent.model_metadata import detect_local_server_type
+
+        # All probes raise -- everything goes through the except branches
+        # and the function returns None.
+        client = _mock_client(Exception("unreachable"))
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            first = detect_local_server_type("http://localhost:9999/v1")
+            second = detect_local_server_type("http://localhost:9999/v1")
+
+        assert first is None
+        assert second is None
+        assert mock_factory.call_count == 1, (
+            "#24510 regression: negative results must be cached too"
+        )
+
+    def test_cache_keyed_by_url_plus_api_key(self):
+        """Two different (url, api_key) pairs MUST not share a cache
+        entry -- otherwise switching between local servers leaks state."""
+        from agent.model_metadata import detect_local_server_type
+
+        client = _mock_client([_resp(200)])
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            detect_local_server_type("http://localhost:1234/v1", api_key="k1")
+            detect_local_server_type("http://localhost:1234/v1", api_key="k2")
+            detect_local_server_type("http://localhost:11434/v1", api_key="k1")
+
+        assert mock_factory.call_count == 3, (
+            "Each unique (url, api_key) must trigger its own probe"
+        )
+
+    def test_clear_cache_forces_reprobe(self):
+        """``clear_local_server_type_cache`` must invalidate so the
+        next call re-probes -- the public escape hatch for users who
+        restart their local server mid-session."""
+        from agent.model_metadata import (
+            clear_local_server_type_cache,
+            detect_local_server_type,
+        )
+
+        client = _mock_client([_resp(200)])
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            detect_local_server_type("http://localhost:1234/v1")
+            clear_local_server_type_cache()
+            detect_local_server_type("http://localhost:1234/v1")
+
+        assert mock_factory.call_count == 2
+
+    def test_cache_expires_after_ttl(self, monkeypatch):
+        """A stale cache entry self-heals after the TTL -- so a user
+        who restarts their server with a different backend doesn't
+        get the wrong answer forever."""
+        from agent import model_metadata
+        from agent.model_metadata import detect_local_server_type
+
+        client = _mock_client([_resp(200)])
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            detect_local_server_type("http://localhost:1234/v1")
+            # Wind time past the TTL.
+            future = model_metadata.time.monotonic() + model_metadata._DETECT_CACHE_TTL_S + 1.0
+            monkeypatch.setattr(
+                model_metadata.time, "monotonic", lambda: future,
+            )
+            detect_local_server_type("http://localhost:1234/v1")
+
+        assert mock_factory.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# LM Studio multi-version probe (#24510)
+# ---------------------------------------------------------------------------
+
+
+class TestLmStudioVersionFallback:
+    """LM Studio >= 0.4.0 ships /api/v1/models; 0.3.6 - 0.3.x only
+    ships /api/v0/models.  Both must detect."""
+
+    def test_detects_modern_lm_studio_via_api_v1(self):
+        from agent.model_metadata import detect_local_server_type
+
+        seen_paths: list[str] = []
+
+        def fake_get(url, *a, **kw):
+            seen_paths.append(url)
+            return _resp(200) if "/api/v1/models" in url else _resp(404)
+
+        client = _mock_client(fake_get)
+        with patch("httpx.Client", return_value=client):
+            result = detect_local_server_type("http://localhost:1234/v1")
+
+        assert result == "lm-studio"
+        assert any("/api/v1/models" in p for p in seen_paths)
+
+    def test_detects_legacy_lm_studio_via_api_v0(self):
+        """The actual #24510 win: older LM Studio used to detect as
+        None, then the gateway fell through to non-LM-Studio code
+        paths.  Now /api/v0/models also wins."""
+        from agent.model_metadata import detect_local_server_type
+
+        seen_paths: list[str] = []
+
+        def fake_get(url, *a, **kw):
+            seen_paths.append(url)
+            # /api/v1/models 404s on legacy LM Studio.
+            if "/api/v1/models" in url:
+                return _resp(404)
+            # /api/v0/models works on >= 0.3.6.
+            if "/api/v0/models" in url:
+                return _resp(200)
+            return _resp(404)
+
+        client = _mock_client(fake_get)
+        with patch("httpx.Client", return_value=client):
+            result = detect_local_server_type("http://localhost:1234/v1")
+
+        assert result == "lm-studio", (
+            "#24510 regression: legacy LM Studio (< 0.4.0) detection "
+            "must succeed via /api/v0/models fallback"
+        )
+        # We must have actually probed v1 first (more specific) before
+        # falling back to v0.
+        v1_idx = next(i for i, p in enumerate(seen_paths) if "/api/v1/models" in p)
+        v0_idx = next(i for i, p in enumerate(seen_paths) if "/api/v0/models" in p)
+        assert v1_idx < v0_idx, "v1 must be probed before v0"
+
+    def test_no_lm_studio_then_continues_to_other_probes(self):
+        """When neither LM Studio path responds, detection must keep
+        going (Ollama, llama.cpp, vLLM) instead of short-circuiting."""
+        from agent.model_metadata import detect_local_server_type
+
+        seen_paths: list[str] = []
+
+        def fake_get(url, *a, **kw):
+            seen_paths.append(url)
+            if "/api/tags" in url:
+                return _resp(200, body={"models": []})
+            return _resp(404)
+
+        client = _mock_client(fake_get)
+        with patch("httpx.Client", return_value=client):
+            result = detect_local_server_type("http://localhost:11434/v1")
+
+        assert result == "ollama"
+        assert any("/api/v1/models" in p for p in seen_paths)
+        assert any("/api/v0/models" in p for p in seen_paths)
+        assert any("/api/tags" in p for p in seen_paths)
+
+
+# ---------------------------------------------------------------------------
+# Probe timeout (#24510)
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTimeout:
+    """The 1.0s per-probe timeout caps the worst-case stall when a
+    local server is wedged.  Pin the value -- tightening it further
+    is fine, loosening it back to 2.0s reintroduces the heartbeat
+    blocking."""
+
+    def test_httpx_client_uses_one_second_timeout(self):
+        from agent.model_metadata import detect_local_server_type
+
+        client = _mock_client([_resp(200)])
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            detect_local_server_type("http://localhost:1234/v1")
+
+        timeout = mock_factory.call_args.kwargs.get("timeout")
+        assert timeout == 1.0, (
+            "#24510 regression: per-probe timeout regressed from 1.0s "
+            f"-- got {timeout}.  Loosening this reintroduces the "
+            "Discord heartbeat blocking the issue was filed about."
+        )

--- a/tests/agent/test_lmstudio_heartbeat_regression.py
+++ b/tests/agent/test_lmstudio_heartbeat_regression.py
@@ -1,0 +1,149 @@
+"""End-to-end regression anchor for #24510 -- "Cannot connect to LM Studio".
+
+The bug shape (per the discord traceback in the issue):
+
+    WARNING discord.gateway: Shard ID None heartbeat blocked for
+        more than 20 seconds.
+    Loop thread traceback (most recent call last):
+      File ".../gateway/run.py", line 6849, in
+        _handle_message_with_agent
+          _hyg_context_length = get_model_context_length(...)
+      File ".../agent/model_metadata.py", line 1359, in
+        get_model_context_length
+          local_ctx = _query_local_context_length(...)
+      File ".../agent/model_metadata.py", line 987, in
+        _query_local_context_length
+          server_type = detect_local_server_type(...)
+      File ".../agent/model_metadata.py", line 455, in
+        detect_local_server_type
+          r = client.get(f"{server_url}/v1/props")
+
+The function:
+  - Issues up to 4 sync httpx.Client.get() probes per call
+  - Has no caching, so EVERY message redoes them
+  - Runs inside the asyncio event loop on the gateway hot path
+  - Therefore eats the Discord heartbeat every message
+
+This module ships ONE focused test that drives the gateway hot path
+shape (10 messages in a row, all hitting the same local base_url) and
+asserts that no more than ONE round of probes is issued -- the cache
+must absorb the rest.
+
+Why this proves the bug is fixed: on upstream/main this test fails
+with ``mock_factory.call_count >= 10`` (one fresh httpx.Client per
+"message" -> the asyncio loop blocks N times, exactly the #24510
+symptom).  After the fix it's exactly 1.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_detect_cache():
+    """Drop the module-level cache before/after each test.
+
+    Defensive about the helper missing so that on upstream/main
+    (pre-fix) the test still RUNS and fails with the actual
+    bug-shape AssertionError rather than an ImportError -- the
+    point of a regression anchor is to surface the bug, not to
+    crash before the assertion fires."""
+    from agent import model_metadata
+    clear = getattr(model_metadata, "clear_local_server_type_cache", None)
+    if clear is not None:
+        clear()
+    yield
+    if clear is not None:
+        clear()
+
+
+def _make_lm_studio_200_client():
+    """An ``httpx.Client`` mock that always returns 200 -- LM Studio
+    happy path."""
+    resp = MagicMock()
+    resp.status_code = 200
+    client = MagicMock()
+    client.__enter__ = lambda s: client
+    client.__exit__ = MagicMock(return_value=False)
+    client.get.return_value = resp
+    return client
+
+
+class TestLmStudioHeartbeatRegression:
+    """#24510 anchor: the gateway must not re-probe the local server
+    on every message."""
+
+    def test_repeated_calls_on_hot_path_collapse_to_single_probe_round(self):
+        """Simulate a Discord shard taking 10 messages in quick
+        succession against a local LM Studio base_url.  Without the
+        cache, this triggers 10 rounds of probes -- each round
+        construct a new httpx.Client, do up to 4 sync GETs, and block
+        the asyncio loop.  With the cache, exactly ONE httpx.Client
+        is constructed and the rest hit the dict.
+
+        Asserting on ``httpx.Client`` construction count is the
+        cleanest signal because every probe path sets up a fresh
+        client; one client = one probe round.
+        """
+        from agent.model_metadata import detect_local_server_type
+
+        client = _make_lm_studio_200_client()
+        with patch("httpx.Client", return_value=client) as mock_factory:
+            # Drive 10 "messages" through the same hot path.
+            results = [
+                detect_local_server_type(
+                    "http://localhost:1234/v1", api_key="lm-token"
+                )
+                for _ in range(10)
+            ]
+
+        assert results == ["lm-studio"] * 10
+        assert mock_factory.call_count == 1, (
+            "#24510 regression: detect_local_server_type re-probed "
+            f"{mock_factory.call_count} times across 10 sequential calls "
+            "to the same base_url -- the gateway hot path is back to "
+            "blocking the asyncio loop on every message and Discord "
+            "will drop the heartbeat exactly as the bug report shows."
+        )
+
+    def test_legacy_lm_studio_install_does_not_silently_misdetect(self):
+        """The other half of #24510: a user on LM Studio < 0.4.0 who
+        only has /api/v0/models.  Pre-fix, detection returned None
+        and the gateway then ran context-length code paths that
+        don't speak LM Studio -- producing the user-visible HTTP
+        400.  Post-fix, /api/v0/models is also probed and detection
+        succeeds."""
+        from agent.model_metadata import detect_local_server_type
+
+        seen_paths: list[str] = []
+
+        def fake_get(url, *a, **kw):
+            seen_paths.append(url)
+            # Legacy LM Studio: only /api/v0/models responds.
+            if "/api/v0/models" in url:
+                resp = MagicMock()
+                resp.status_code = 200
+                return resp
+            resp = MagicMock()
+            resp.status_code = 404
+            return resp
+
+        client = MagicMock()
+        client.__enter__ = lambda s: client
+        client.__exit__ = MagicMock(return_value=False)
+        client.get.side_effect = fake_get
+
+        with patch("httpx.Client", return_value=client):
+            result = detect_local_server_type("http://localhost:1234/v1")
+
+        assert result == "lm-studio", (
+            "#24510 regression: a legacy LM Studio install only exposes "
+            "/api/v0/models -- the probe sequence must include it or "
+            "the gateway falls through to non-LM-Studio code paths and "
+            "users see HTTP 400 errors as in the bug report."
+        )
+        # Sanity: we tried v1 first AND we did try v0.
+        assert any("/api/v1/models" in p for p in seen_paths)
+        assert any("/api/v0/models" in p for p in seen_paths)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -841,6 +841,8 @@ To set persistent per-model defaults: My Models tab → gear icon on the model �
 
 **Tool calling:** Supported since LM Studio 0.3.6. Models with native tool-calling training (Qwen 2.5, Llama 3.x, Mistral, Hermes) are auto-detected and shown with a tool badge. Other models use a generic fallback that may be less reliable.
 
+**Server-version detection.** Hermes probes both `/api/v1/models` (LM Studio ≥ 0.4.0) and `/api/v0/models` (LM Studio 0.3.6–0.3.x) when introspecting your local server. Older installs that only ship `v0` still detect correctly. The probe result is cached per `(base_url, api_key)` for 5 minutes so the gateway message-handling hot path doesn't re-issue the probes on every Discord/Slack/Telegram message — that previously caused `WARNING discord.gateway: Shard ID None heartbeat blocked for more than 20 seconds` warnings (#24510). If you restart your local server with a different backend (Ollama → LM Studio etc.), wait for the TTL or restart the gateway to force a re-probe.
+
 ---
 
 ### WSL2 Networking (Windows Users)


### PR DESCRIPTION
## What does this PR do?

Fixes #24510 — "Cannot connect to LM Studio".

The discord traceback in the bug report tells us exactly where the asyncio loop dies:

```
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 20 seconds.
Loop thread traceback (most recent call last):
  ...
  File "...\gateway\run.py", line 6849, in _handle_message_with_agent
    _hyg_context_length = get_model_context_length(...)
  File "...\agent\model_metadata.py", line 1359, in get_model_context_length
    local_ctx = _query_local_context_length(...)
  File "...\agent\model_metadata.py", line 987, in _query_local_context_length
    server_type = detect_local_server_type(...)
  File "...\agent\model_metadata.py", line 455, in detect_local_server_type
    r = client.get(f"{server_url}/v1/props")
```

`detect_local_server_type` issues up to **4 sync `httpx.Client.get()` probes** per call (LM Studio → Ollama → llama.cpp → vLLM), each with a 2 s timeout, has **no caching**, and runs **inside the asyncio event loop** on the gateway hot path. Every Discord/Slack/Telegram message redoes the probes — so any wedged probe blocks the heartbeat and Discord disconnects after ~20 s, exactly as the bug report shows.

A second, related issue: the LM Studio probe only tried `/api/v1/models` (LM Studio ≥ 0.4.0). Users on **0.3.6 – 0.3.x** only have `/api/v0/models`, so detection silently returned `None` and the gateway then ran code paths that don't speak LM Studio — surfacing the user-visible `HTTP 400` from `/v1/chat/completions`.

The fix lives entirely in `agent/model_metadata.py → detect_local_server_type()`:

1. Process-level cache keyed by `(normalized_base_url, api_key)` with a 5-minute TTL → hot path goes from "4 sync HTTP probes" to "1 dict lookup" after the first detection.
2. LM Studio `/api/v0/models` fallback added in front of the existing `/api/v1/models` probe (v1 first — more specific — then v0). Legacy LM Studio installs detect correctly.
3. Per-probe timeout 2.0 s → 1.0 s. Localhost RTT is sub-millisecond, so 1 s is still a 1000× safety margin and halves the worst-case stall when one probe is wedged.
4. Public `clear_local_server_type_cache()` for tests, `/reload` paths, and the "I just restarted my local server" workflow.

## Related Issue

Closes #24510 — `[Bug]: Cannot connect to LM Studio`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py` — `detect_local_server_type()` (+97 / −40):
  - Module-level `_DETECT_CACHE` dict + `_DETECT_CACHE_TTL_S = 300.0` constant.
  - Public `clear_local_server_type_cache()` to invalidate without waiting for the TTL.
  - Cache lookup at the top of `detect_local_server_type()`; result memoised at the bottom.
  - LM Studio probe now iterates `("/api/v1/models", "/api/v0/models")`; first 200 wins.
  - `httpx.Client(timeout=...)` lowered from `2.0` to `1.0`.
  - Probe order, response parsing, and return-value contract (`"ollama" | "lm-studio" | "vllm" | "llamacpp" | None`) are otherwise byte-identical.
- `tests/agent/test_detect_local_server_cache.py` (new, +246 lines) — 9 unit tests:
  - `TestDetectLocalServerTypeCache` (5 cases): cache hit, negative-result caching, key isolation across `(url, api_key)`, public clear helper, TTL expiry via monkeypatched `time.monotonic`.
  - `TestLmStudioVersionFallback` (3 cases): modern v1 detection, legacy v0 detection (asserts v1 is probed *before* v0), no-LM-Studio fall-through to Ollama / llama.cpp / vLLM.
  - `TestProbeTimeout` (1 case): pins `timeout=1.0` so a future "make it more lenient" tweak can't silently bring the heartbeat blocking back.
- `tests/agent/test_lmstudio_heartbeat_regression.py` (new, +149 lines) — 2 bug-shape regression anchors:
  - `test_repeated_calls_on_hot_path_collapse_to_single_probe_round` — drives 10 sequential calls to the same `base_url`, asserts exactly 1 `httpx.Client` construction.
  - `test_legacy_lm_studio_install_does_not_silently_misdetect` — mocks an LM Studio < 0.4.0 server (only `/api/v0/models` responds), asserts detection returns `"lm-studio"`.
  - The autouse cache-clear fixture is defensive about the helper not existing, so the anchors RUN against `upstream/main` and surface the bug-shape `AssertionError` instead of crashing in setup.
- `website/docs/integrations/providers.md` (+2 lines) — added a "Server-version detection" note under the LM Studio section explaining both probed paths, the 5-minute TTL, and how to force a re-probe.

No production code changed outside `detect_local_server_type()`; downstream callers see the exact same function signature, return shape, and side-effect surface.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new + adjacent test suites:
   ```
   scripts/run_tests.sh \
     tests/agent/test_detect_local_server_cache.py \
     tests/agent/test_lmstudio_heartbeat_regression.py \
     tests/agent/test_model_metadata_local_ctx.py \
     tests/cli/test_cli_context_warning.py
   ```
   Expected: **43 passed** (11 new + 32 pre-existing).
3. Verify the bug-shape regression anchor really catches the bug:
   ```
   git checkout upstream/main -- agent/model_metadata.py
   pytest tests/agent/test_lmstudio_heartbeat_regression.py -v
   ```
   Expected: **2 failed** with the anchor messages
   `#24510 regression: detect_local_server_type re-probed 10 times across 10 sequential calls...`
   and
   `#24510 regression: a legacy LM Studio install only exposes /api/v0/models...`
   Then restore the fix (`git checkout HEAD -- agent/model_metadata.py`) → both pass again.
4. (Optional, manual) Configure LM Studio at `http://localhost:1234/v1`, run `hermes gateway --discord`, send 10 DMs in quick succession.
   - Pre-fix: `WARNING discord.gateway: Shard ID None heartbeat blocked for more than 20 seconds` warnings + HTTP 400s.
   - Post-fix: no heartbeat warnings; if a 400 still appears it's a separate model-config issue (e.g. unloaded model / unsupported request field), no longer the gateway re-probing.
5. (Optional, manual) On a legacy LM Studio install (≤ 0.3.x): same as step 4 — detection now succeeds via `/api/v0/models`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(model_metadata): ...`, `test(model_metadata): ...`, `docs(providers): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (4 commits, all scoped to `detect_local_server_type` + its tests + its docs)
- [x] I've run `scripts/run_tests.sh tests/agent/test_detect_local_server_cache.py tests/agent/test_lmstudio_heartbeat_regression.py tests/agent/test_model_metadata_local_ctx.py tests/cli/test_cli_context_warning.py` and all 43 tests pass
- [x] I've added tests for my changes (9 unit tests + 2 bug-shape regression anchors)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/integrations/providers.md` got a "Server-version detection" note under the LM Studio section
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is platform-agnostic; the original report is on Windows 11 and the cache/timeout/v0-probe paths all run identically there. Tests are hermetic (mocked `httpx.Client`, no real network or filesystem).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal helper, no tool surface change)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_detect_local_server_cache.py tests/agent/test_lmstudio_heartbeat_regression.py tests/agent/test_model_metadata_local_ctx.py tests/cli/test_cli_context_warning.py
4 workers [43 items]
============================== 43 passed in 1.33s ==============================

$ ruff check agent/model_metadata.py tests/agent/test_detect_local_server_cache.py tests/agent/test_lmstudio_heartbeat_regression.py
All checks passed!
```

Bug-shape repro on `upstream/main` (anchor proves the fix is necessary):

```
$ git checkout upstream/main -- agent/model_metadata.py
$ pytest tests/agent/test_lmstudio_heartbeat_regression.py -v
FAILED tests/agent/test_lmstudio_heartbeat_regression.py::TestLmStudioHeartbeatRegression::test_repeated_calls_on_hot_path_collapse_to_single_probe_round
  AssertionError: #24510 regression: detect_local_server_type re-probed 10 times
    across 10 sequential calls to the same base_url -- the gateway hot path is
    back to blocking the asyncio loop on every message and Discord will drop the
    heartbeat exactly as the bug report shows.
  assert 10 == 1
FAILED tests/agent/test_lmstudio_heartbeat_regression.py::TestLmStudioHeartbeatRegression::test_legacy_lm_studio_install_does_not_silently_misdetect
  AssertionError: #24510 regression: a legacy LM Studio install only exposes
    /api/v0/models -- the probe sequence must include it or the gateway falls
    through to non-LM-Studio code paths and users see HTTP 400 errors as in the
    bug report.
  assert None == 'lm-studio'
```


fix/lmstudio-detect-server-type
