### PR TITLE
fix(profile): add --toolsets flag to hermes profile create

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8594,6 +8594,7 @@ def cmd_profile(args):
         try:
             clone_from = getattr(args, "clone_from", None)
 
+            toolsets = getattr(args, "toolsets", None)
             profile_dir = create_profile(
                 name=name,
                 clone_from=clone_from,
@@ -8601,6 +8602,7 @@ def cmd_profile(args):
                 clone_config=clone,
                 no_alias=no_alias,
                 no_skills=no_skills,
+                toolsets=toolsets,
             )
             print(f"\nProfile '{name}' created at {profile_dir}")
 
@@ -11476,6 +11478,16 @@ Examples:
         "--no-skills",
         action="store_true",
         help="Create an empty profile with no bundled skills (opts out of `hermes update` skill sync)",
+    )
+    profile_create.add_argument(
+        "--toolsets",
+        metavar="TOOLSET",
+        nargs="+",
+        help=(
+            "Toolsets to enable in the new profile's config.yaml "
+            "(e.g. --toolsets hermes-cli web browser terminal file). "
+            "Ignored when --clone / --clone-all is used."
+        ),
     )
 
     profile_delete = profile_subparsers.add_parser("delete", help="Delete a profile")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -544,6 +544,7 @@ def create_profile(
     clone_config: bool = False,
     no_alias: bool = False,
     no_skills: bool = False,
+    toolsets: Optional[List[str]] = None,
 ) -> Path:
     """Create a new profile directory.
 
@@ -566,6 +567,10 @@ def create_profile(
         a marker file so ``hermes update`` skips re-seeding this profile's
         skills. Mutually exclusive with ``clone_config``/``clone_all`` (those
         explicitly copy skills from the source).
+    toolsets:
+        Optional list of toolset names to enable in the new profile's
+        config.yaml. Ignored when ``--clone`` / ``--clone-all`` is used
+        (the source config is copied verbatim in that case).
 
     Returns
     -------
@@ -653,6 +658,17 @@ def create_profile(
             soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
         except Exception:
             pass  # best-effort — don't fail profile creation over this
+
+    # Write a minimal config.yaml with explicit toolsets when requested and
+    # we're not cloning (clone already carries the source config verbatim).
+    if toolsets and not (clone_config or clone_all):
+        config_path = profile_dir / "config.yaml"
+        if not config_path.exists():
+            import yaml
+            config_path.write_text(
+                yaml.safe_dump({"toolsets": list(toolsets)}, default_flow_style=False),
+                encoding="utf-8",
+            )
 
     # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
     # all-profile sync loop both skip this profile for bundled-skill seeding.

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -423,6 +423,53 @@ class TestNoSkillsOptOut:
 
 
 # ===================================================================
+# TestToolsetsFlag
+# ===================================================================
+
+class TestToolsetsFlag:
+    """Tests for `hermes profile create --toolsets`."""
+
+    def test_toolsets_written_to_config(self, profile_env):
+        """--toolsets creates config.yaml with those toolsets."""
+        import yaml
+
+        profile_dir = create_profile(
+            "kanban-worker",
+            no_alias=True,
+            toolsets=["hermes-cli", "web", "browser", "terminal", "file"],
+        )
+        config_path = profile_dir / "config.yaml"
+        assert config_path.exists(), "config.yaml must be written when --toolsets is given"
+        cfg = yaml.safe_load(config_path.read_text())
+        assert cfg["toolsets"] == ["hermes-cli", "web", "browser", "terminal", "file"]
+
+    def test_no_config_written_without_toolsets(self, profile_env):
+        """Without --toolsets, no config.yaml is written (DEFAULT_CONFIG used on first load)."""
+        profile_dir = create_profile("bare-worker", no_alias=True)
+        assert not (profile_dir / "config.yaml").exists()
+
+    def test_toolsets_ignored_when_clone(self, profile_env):
+        """--toolsets must not overwrite the config.yaml copied by --clone."""
+        import yaml
+
+        from hermes_constants import get_hermes_home
+        source_cfg = get_hermes_home() / "config.yaml"
+        source_cfg.write_text(yaml.safe_dump({"toolsets": ["hermes-cli"]}))
+
+        profile_dir = create_profile(
+            "cloned",
+            no_alias=True,
+            clone_config=True,
+            toolsets=["hermes-cli", "web", "terminal"],
+        )
+
+        config_path = profile_dir / "config.yaml"
+        if config_path.exists():
+            cfg = yaml.safe_load(config_path.read_text())
+            assert cfg.get("toolsets") == ["hermes-cli"]
+
+
+# ===================================================================
 # TestDeleteProfile
 # ===================================================================
 


### PR DESCRIPTION
## What does this PR do?

`hermes profile create <name>` bootstraps a new profile with only `toolsets: [hermes-cli]` (the hard-coded `DEFAULT_CONFIG` value). When this profile is assigned as a kanban worker it has no `web`, `browser`, `terminal`, or `file` access, so tasks silently degrade — the worker either produces trivial output or crashes calling tools that aren't available.

## Root cause

`hermes profile create <name>` bootstraps a new profile with only
`toolsets: [hermes-cli]` (the hard-coded `DEFAULT_CONFIG` value).
When this profile is assigned as a kanban worker it has no `web`,
`browser`, `terminal`, or `file` access, so tasks silently degrade —
the worker either produces trivial output or crashes calling tools that
aren't available.

## Fix

* Added optional `toolsets: Optional[List[str]] = None` parameter to
  `create_profile()` in `hermes_cli/profiles.py`.
* When `toolsets` is provided and the profile is **not** a clone (clone
  paths copy the source `config.yaml` verbatim), a minimal `config.yaml`
  containing only the `toolsets` key is written to the new profile
  directory before first use.
* Added `--toolsets TOOLSET [TOOLSET ...]` argument to `hermes profile
  create` in `hermes_cli/main.py` and wired it through `cmd_profile`.

Usage:
```bash
hermes profile create kanban-worker \
  --toolsets hermes-cli web browser terminal file
```

Cloning still takes the source config verbatim (`--toolsets` is ignored):
```bash
hermes profile create kanban-worker --clone  # ignores --toolsets
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #22924

<details>
<summary>Original body</summary>

## Summary

`hermes profile create <name>` bootstraps a new profile with only `toolsets: [hermes-cli]` (the hard-coded `DEFAULT_CONFIG` value). When this profile is assigned as a kanban worker it has no `web`, `browser`, `terminal`, or `file` access, so tasks silently degrade — the worker either produces trivial output or crashes calling tools that aren't available.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`hermes profile create <name>` bootstraps a new profile with only
`toolsets: [hermes-cli]` (the hard-coded `DEFAULT_CONFIG` value).
When this profile is assigned as a kanban worker it has no `web`,
`browser`, `terminal`, or `file` access, so tasks silently degrade —
the worker either produces trivial output or crashes calling tools that
aren't available.

## Root cause

`create_profile()` in `hermes_cli/profiles.py` accepts no `toolsets`
parameter and never writes a `config.yaml` for fresh (non-clone)
profiles. The DEFAULT_CONFIG kicks in on first load with only
`hermes-cli` in the toolsets list.

## Fix

* Added optional `toolsets: Optional[List[str]] = None` parameter to
  `create_profile()` in `hermes_cli/profiles.py`.
* When `toolsets` is provided and the profile is **not** a clone (clone
  paths copy the source `config.yaml` verbatim), a minimal `config.yaml`
  containing only the `toolsets` key is written to the new profile
  directory before first use.
* Added `--toolsets TOOLSET [TOOLSET ...]` argument to `hermes profile
  create` in `hermes_cli/main.py` and wired it through `cmd_profile`.

Usage:
```bash
hermes profile create kanban-worker \
  --toolsets hermes-cli web browser terminal file
```

Cloning still takes the source config verbatim (`--toolsets` is ignored):
```bash
hermes profile create kanban-worker --clone  # ignores --toolsets
```

## Tests

Added `TestToolsetsFlag` class to `tests/hermes_cli/test_profiles.py`
with 3 tests:
- `test_toolsets_written_to_config` — verifies `config.yaml` is created
  with the specified toolsets
- `test_no_config_written_without_toolsets` — no `config.yaml` written
  when flag is absent (existing behavior preserved)
- `test_toolsets_ignored_when_clone` — toolsets flag does not overwrite
  the source config when `--clone` is used

All 3 pass; full `tests/hermes_cli/` suite shows only pre-existing
failures unrelated to this change.

## Visual

```mermaid
sequenceDiagram
    participant U as User
    participant CLI as hermes CLI
    participant C as create_profile()
    participant FS as ~/.hermes/profiles/

    U->>CLI: hermes profile create kanban-worker --toolsets hermes-cli web terminal
    CLI->>C: create_profile("kanban-worker", toolsets=["hermes-cli","web","terminal"])
    C->>FS: mkdir kanban-worker/{memories,sessions,skills,...}
    C->>FS: write config.yaml → {toolsets: [hermes-cli, web, terminal]}
    C-->>CLI: profile_dir
    CLI-->>U: Profile 'kanban-worker' created
```

Closes #22924

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #22924

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_