### PR TITLE
fix(providers): prevent TOCTOU race in _discover_providers()

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -34,6 +34,7 @@ import importlib
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 
 from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _discovered = False
+_discover_lock = threading.Lock()
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -151,41 +153,45 @@ def _discover_providers() -> None:
     global _discovered
     if _discovered:
         return
-    _discovered = True
+    with _discover_lock:
+        if _discovered:
+            return
 
-    # 1. Bundled plugins — shipped with hermes-agent.
-    if _BUNDLED_PLUGINS_DIR.is_dir():
-        for child in sorted(_BUNDLED_PLUGINS_DIR.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
-                continue
-            _import_plugin_dir(child, "bundled")
+        # 1. Bundled plugins — shipped with hermes-agent.
+        if _BUNDLED_PLUGINS_DIR.is_dir():
+            for child in sorted(_BUNDLED_PLUGINS_DIR.iterdir()):
+                if not child.is_dir() or child.name.startswith(("_", ".")):
+                    continue
+                _import_plugin_dir(child, "bundled")
 
-    # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
-    #    These can override any bundled profile of the same name (last-writer-wins
-    #    in register_provider()).
-    user_dir = _user_plugins_dir()
-    if user_dir is not None:
-        for child in sorted(user_dir.iterdir()):
-            if not child.is_dir() or child.name.startswith(("_", ".")):
-                continue
-            _import_plugin_dir(child, "user")
+        # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
+        #    These can override any bundled profile of the same name (last-writer-wins
+        #    in register_provider()).
+        user_dir = _user_plugins_dir()
+        if user_dir is not None:
+            for child in sorted(user_dir.iterdir()):
+                if not child.is_dir() or child.name.startswith(("_", ".")):
+                    continue
+                _import_plugin_dir(child, "user")
 
-    # 3. Legacy single-file profiles at providers/<name>.py. Kept for
-    #    back-compat — if someone drops a ``providers/foo.py`` into an
-    #    editable install, it still works without the plugin layout.
-    try:
-        import pkgutil
+        # 3. Legacy single-file profiles at providers/<name>.py. Kept for
+        #    back-compat — if someone drops a ``providers/foo.py`` into an
+        #    editable install, it still works without the plugin layout.
+        try:
+            import pkgutil
 
-        import providers as _pkg
+            import providers as _pkg
 
-        for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
-            if modname.startswith("_") or modname == "base":
-                continue
-            try:
-                importlib.import_module(f"providers.{modname}")
-            except ImportError as exc:
-                logger.warning(
-                    "Failed to import legacy provider module %s: %s", modname, exc
-                )
-    except Exception:
-        pass
+            for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
+                if modname.startswith("_") or modname == "base":
+                    continue
+                try:
+                    importlib.import_module(f"providers.{modname}")
+                except ImportError as exc:
+                    logger.warning(
+                        "Failed to import legacy provider module %s: %s", modname, exc
+                    )
+        except Exception:
+            pass
+
+        _discovered = True

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import importlib
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -143,3 +145,71 @@ def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch)
     # No import means the module must NOT be in the plugins list as a loaded one.
     # We check that the general loader didn't crash and didn't raise from the
     # broken __init__.py.
+
+
+class TestDiscoverProvidersToctouRace:
+    """Regression tests for the TOCTOU race in _discover_providers().
+
+    Before the fix, _discovered was set to True before the discovery work
+    ran, so a second thread could enter _discover_providers(), see
+    _discovered=False, then race the first thread and observe a partially
+    populated registry (or observe _discovered=True with an empty registry
+    because the flag was published before the work finished).
+    """
+
+    def test_concurrent_calls_consistent(self, monkeypatch):
+        """50 threads calling _discover_providers() concurrently must all
+        observe the same final _discovered state with no torn reads."""
+        import providers as prov_mod
+
+        monkeypatch.setattr(prov_mod, "_discovered", False)
+        monkeypatch.setattr(prov_mod, "_REGISTRY", {})
+        monkeypatch.setattr(prov_mod, "_ALIASES", {})
+
+        n = 50
+        barrier = threading.Barrier(n)
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def worker():
+            barrier.wait()
+            prov_mod._discover_providers()
+            with lock:
+                results.append(prov_mod._discovered)
+
+        with ThreadPoolExecutor(max_workers=n) as ex:
+            futures = [ex.submit(worker) for _ in range(n)]
+            for f in futures:
+                f.result()
+
+        assert all(results), "Every thread must see _discovered=True after discovery"
+        assert len(results) == n
+
+    def test_flag_set_after_registry_populated(self, monkeypatch):
+        """_discovered must not become True before the registry work completes.
+
+        We interpose on _import_plugin_dir to record whether _discovered was
+        already True when the first plugin was being imported — if so the
+        flag was published too early.
+        """
+        import providers as prov_mod
+
+        monkeypatch.setattr(prov_mod, "_discovered", False)
+        monkeypatch.setattr(prov_mod, "_REGISTRY", {})
+        monkeypatch.setattr(prov_mod, "_ALIASES", {})
+
+        flag_during_import: list[bool] = []
+        original_import = prov_mod._import_plugin_dir
+
+        def spying_import(plugin_dir, source):
+            flag_during_import.append(prov_mod._discovered)
+            return original_import(plugin_dir, source)
+
+        monkeypatch.setattr(prov_mod, "_import_plugin_dir", spying_import)
+        prov_mod._discover_providers()
+
+        # If any plugin directory was found, the flag must have been False
+        # during its import (flag set last, after all work).
+        assert all(
+            not v for v in flag_during_import
+        ), "_discovered was True during plugin import — flag published too early"


### PR DESCRIPTION
## What does this PR do?

Fixes a time-of-check/time-of-use (TOCTOU) race condition in `providers/_discover_providers()`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- `providers/__init__.py`: add `_discover_lock = threading.Lock()`; indent all three discovery sections inside `with _discover_lock:`; move `_discovered = True` to after all work completes
- `tests/providers/test_plugin_discovery.py`: add `TestDiscoverProvidersToctouRace` with a 50-thread `threading.Barrier` contention test and a spy test asserting the flag stays `False` while plugins are being imported

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24694

<details>
<summary>Original body</summary>

## Summary

Fixes a time-of-check/time-of-use (TOCTOU) race condition in `providers/_discover_providers()`.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Fixes a time-of-check/time-of-use (TOCTOU) race condition in `providers/_discover_providers()`.

**Root cause:** `_discovered` was set to `True` at the top of the function, *before* any plugin directory was scanned or any module was imported. A second thread entering concurrently could observe `_discovered=False`, pass the early-return guard, then race the first thread through the three discovery phases — resulting in a partially populated registry visible to callers.

**Fix:** Double-checked locking pattern:
- Fast lock-free early-return path (`if _discovered: return`) remains for the already-initialised steady state
- Slow path acquires `_discover_lock`, re-checks the flag inside the lock, runs all three discovery phases (bundled plugins → user plugins → legacy per-file modules), then sets `_discovered = True` as the **last** statement inside the lock

This matches the pattern already applied to `agent/transports/__init__.py` (#24692) and `plugins/platforms/google_chat/adapter.py` (#24679).

## Impact

`get_provider_profile()` has no retry-on-miss logic — it returns `None` directly if the name is absent from the registry. Under the old code, a race could cause valid provider names to return `None`, silently falling back to generic behaviour for the lifetime of the process.

## Changes

- `providers/__init__.py`: add `_discover_lock = threading.Lock()`; indent all three discovery sections inside `with _discover_lock:`; move `_discovered = True` to after all work completes
- `tests/providers/test_plugin_discovery.py`: add `TestDiscoverProvidersToctouRace` with a 50-thread `threading.Barrier` contention test and a spy test asserting the flag stays `False` while plugins are being imported

## Test plan

- [x] `uv run pytest tests/providers/` — 94 passed
- [x] New `TestDiscoverProvidersToctouRace` class: 2 new tests (concurrent consistency + flag-ordering invariant)

Closes #24694

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24694

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_