### PR TITLE
fix(tools): inject SOUL.md system prompt into vision_analyze API calls

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -759,7 +759,16 @@ async def vision_analyze_tool(
         comprehensive_prompt = user_prompt
         
         # Prepare the message with base64-encoded image
-        messages = [
+        messages = []
+        # Inject SOUL.md as system message if available so persona carries over
+        try:
+            from agent.prompt_builder import load_soul_md
+            soul = load_soul_md()
+            if soul:
+                messages.append({"role": "system", "content": soul})
+        except Exception:
+            pass
+        messages.append(
             {
                 "role": "user",
                 "content": [
@@ -775,7 +784,7 @@ async def vision_analyze_tool(
                     }
                 ]
             }
-        ]
+        )
         
         logger.info("Processing image with vision model...")
         


### PR DESCRIPTION
## Description

When using a non-vision LLM (e.g., DeepSeek V4 Flash) as the main model, image analysis via the auxiliary vision fallback never includes the current session's SOUL.md system prompt. The vision model receives only a generic user message, losing persona context.

## Root Cause

`tools/vision_tools.py:vision_analyze_tool()` builds messages with only `role: "user"` — no `role: "system"` message is ever added. The Codex adapter (`agent/auxiliary_client.py:280`) defaults to `instructions = "You are a helpful assistant."` — it would use a system message if present, but never receives one.

## Fix

Inject SOUL.md content as `role: "system"` before the user message using the existing `load_soul_md()` from `agent.prompt_builder`. All callers go through `vision_analyze_tool()`, so no caller changes needed.