### PR TITLE
Feat/openrouter stt provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -788,8 +788,8 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
-# Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
+# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe) | xai (Grok STT) | openrouter (Whisper via OpenRouter)
+# Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, MISTRAL_API_KEY, XAI_API_KEY, or OPENROUTER_API_KEY.
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
@@ -800,6 +800,10 @@ stt:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
+  # openrouter:                       # #24415 -- reuse OPENROUTER_API_KEY for STT.
+  #   model: "openai/whisper-1"       # openai/whisper-1 | openai/gpt-4o-mini-transcribe | openai/gpt-4o-transcribe
+  #   # api_key:  ${OPENROUTER_API_KEY}        # falls back to env if omitted
+  #   # base_url: "https://openrouter.ai/api/v1"  # override only for self-hosted proxies
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/tests/tools/test_transcription_openrouter.py
+++ b/tests/tools/test_transcription_openrouter.py
@@ -1,0 +1,378 @@
+"""Unit tests for the OpenRouter STT provider (#24415).
+
+Three test classes cover the three observable surfaces of the new
+provider:
+
+- ``TestGetProviderOpenRouter`` -- ``_get_provider()`` resolution
+  for both explicit-config and auto-detect paths, with the
+  precedence rules from the issue baked in as assertions.
+- ``TestTranscribeOpenRouter`` -- the ``_transcribe_openrouter()``
+  helper: env-var key resolution, ``stt.openrouter.api_key`` /
+  ``base_url`` overrides, the OpenAI-SDK call shape, and every
+  error path ``_transcribe_groq`` already covers.
+- ``TestTranscribeAudioDispatchOpenRouter`` -- the public
+  ``transcribe_audio()`` dispatch plus the model-default chain
+  (``stt.openrouter.model`` > ``DEFAULT_OPENROUTER_STT_MODEL``).
+
+All tests mock the OpenAI SDK; no real network traffic, runs on
+every CI box.  Mirrors the conventions in
+``tests/tools/test_transcription_tools.py``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    """Drop every API key the provider chain inspects so tests stay
+    hermetic and don't pick up the developer's real credentials."""
+    for var in (
+        "OPENROUTER_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "OPENAI_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "XAI_API_KEY",
+        "STT_OPENROUTER_BASE_URL",
+        "STT_OPENROUTER_MODEL",
+        "HERMES_LOCAL_STT_COMMAND",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def sample_audio(tmp_path):
+    """A minimal byte-stream audio file the helpers can ``open()``."""
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"fake-ogg-bytes")
+    return str(audio_path)
+
+
+def _patch_load_stt_config(stt_config: dict):
+    """Patch ``_load_stt_config`` so the helper sees the test config."""
+    return patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value=stt_config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_provider -- OpenRouter resolution
+# ---------------------------------------------------------------------------
+
+
+class TestGetProviderOpenRouter:
+    def test_explicit_openrouter_with_key_returns_openrouter(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "openrouter"}) == "openrouter"
+
+    def test_explicit_openrouter_no_key_returns_none(self, monkeypatch):
+        """Explicit provider must NOT silently fall back to a different
+        cloud provider just because another key is set -- mirrors the
+        GH-1774 contract for groq / openai."""
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-real")
+        with patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "openrouter"}) == "none"
+
+    def test_explicit_openrouter_without_openai_sdk_returns_none(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with patch("tools.transcription_tools._HAS_OPENAI", False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({"provider": "openrouter"}) == "none"
+
+    def test_auto_detect_picks_openrouter_when_only_or_key_set(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._has_openai_audio_backend", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "openrouter"
+
+    def test_auto_detect_prefers_groq_over_openrouter(self, monkeypatch):
+        """Per the issue: openrouter is last in the cloud chain so a
+        dedicated STT key wins -- users who set both want the
+        dedicated provider's pricing & routing."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "groq"
+
+    def test_auto_detect_prefers_openai_over_openrouter(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "openai"
+
+    def test_auto_detect_prefers_xai_over_openrouter(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        monkeypatch.setenv("XAI_API_KEY", "xai-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._has_openai_audio_backend", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "xai"
+
+
+# ---------------------------------------------------------------------------
+# _transcribe_openrouter
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeOpenRouter:
+    def test_no_key_returns_clear_error(self, monkeypatch, sample_audio):
+        from tools.transcription_tools import _transcribe_openrouter
+        with _patch_load_stt_config({}):
+            result = _transcribe_openrouter(sample_audio, "openai/whisper-1")
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+
+    def test_openai_package_missing(self, monkeypatch, sample_audio):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with _patch_load_stt_config({}), \
+             patch("tools.transcription_tools._HAS_OPENAI", False):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_audio, "openai/whisper-1")
+        assert result["success"] is False
+        assert "openai package" in result["error"]
+
+    def test_happy_path_uses_env_key_and_default_base_url(
+        self, monkeypatch, sample_audio,
+    ):
+        """The headline contract: ``OPENROUTER_API_KEY`` from env reaches
+        the OpenAI SDK along with the OpenRouter base URL."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+
+        fake_openai_module = MagicMock()
+        fake_client = MagicMock()
+        fake_openai_module.OpenAI.return_value = fake_client
+        fake_openai_module.APIError = Exception
+        fake_openai_module.APIConnectionError = Exception
+        fake_openai_module.APITimeoutError = Exception
+        fake_client.audio.transcriptions.create.return_value = "hello world"
+
+        with _patch_load_stt_config({}), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import (
+                OPENROUTER_STT_BASE_URL,
+                _transcribe_openrouter,
+            )
+            result = _transcribe_openrouter(sample_audio, "openai/whisper-1")
+
+        assert result == {
+            "success": True,
+            "transcript": "hello world",
+            "provider": "openrouter",
+        }
+        kwargs = fake_openai_module.OpenAI.call_args.kwargs
+        assert kwargs["api_key"] == "sk-or-real"
+        assert kwargs["base_url"] == OPENROUTER_STT_BASE_URL
+        # response_format=text is the OpenAI/Groq Whisper default that
+        # also works against OpenRouter -- pin it so a refactor can't
+        # silently switch to JSON and break legacy whisper-1 routing.
+        create_kwargs = fake_client.audio.transcriptions.create.call_args.kwargs
+        assert create_kwargs["response_format"] == "text"
+        assert create_kwargs["model"] == "openai/whisper-1"
+
+    def test_config_api_key_wins_over_env(self, monkeypatch, sample_audio):
+        """``stt.openrouter.api_key`` overrides the env var so users on
+        managed deployments can pin per-deployment credentials."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "env-key")
+
+        fake_openai_module = MagicMock()
+        fake_openai_module.OpenAI.return_value.audio.transcriptions.create.return_value = "ok"
+        fake_openai_module.APIError = Exception
+        fake_openai_module.APIConnectionError = Exception
+        fake_openai_module.APITimeoutError = Exception
+
+        cfg = {"openrouter": {"api_key": "config-key"}}
+        with _patch_load_stt_config(cfg), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_audio, "openai/whisper-1")
+
+        kwargs = fake_openai_module.OpenAI.call_args.kwargs
+        assert kwargs["api_key"] == "config-key", (
+            "stt.openrouter.api_key in config must win over the env var"
+        )
+
+    def test_config_base_url_override_is_respected(
+        self, monkeypatch, sample_audio,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+
+        fake_openai_module = MagicMock()
+        fake_openai_module.OpenAI.return_value.audio.transcriptions.create.return_value = "ok"
+        fake_openai_module.APIError = Exception
+        fake_openai_module.APIConnectionError = Exception
+        fake_openai_module.APITimeoutError = Exception
+
+        cfg = {"openrouter": {"base_url": "https://proxy.example.com/v1/"}}
+        with _patch_load_stt_config(cfg), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_audio, "openai/whisper-1")
+
+        kwargs = fake_openai_module.OpenAI.call_args.kwargs
+        # Trailing slash stripped to match how the OpenAI SDK
+        # builds endpoint URLs internally.
+        assert kwargs["base_url"] == "https://proxy.example.com/v1"
+
+    def test_api_error_wrapped(self, monkeypatch, sample_audio):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+
+        # Three distinct subclasses so the except-chain in
+        # _transcribe_openrouter routes APIError to the right handler
+        # rather than matching the broader Exception base first.
+        class _APIError(Exception):
+            pass
+
+        class _APIConnectionError(Exception):
+            pass
+
+        class _APITimeoutError(Exception):
+            pass
+
+        fake_openai_module = MagicMock()
+        fake_client = MagicMock()
+        fake_openai_module.OpenAI.return_value = fake_client
+        fake_openai_module.APIError = _APIError
+        fake_openai_module.APIConnectionError = _APIConnectionError
+        fake_openai_module.APITimeoutError = _APITimeoutError
+        fake_client.audio.transcriptions.create.side_effect = _APIError("rate limited")
+
+        with _patch_load_stt_config({}), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_audio, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "API error" in result["error"]
+        assert "rate limited" in result["error"]
+
+    def test_permission_error_returns_clear_message(
+        self, monkeypatch, sample_audio,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+
+        fake_openai_module = MagicMock()
+        fake_openai_module.OpenAI.side_effect = PermissionError("no read")
+        fake_openai_module.APIError = Exception
+        fake_openai_module.APIConnectionError = Exception
+        fake_openai_module.APITimeoutError = Exception
+
+        with _patch_load_stt_config({}), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_audio, "openai/whisper-1")
+
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# transcribe_audio() -- end-to-end dispatch + model defaults
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAudioDispatchOpenRouter:
+    def test_dispatch_routes_to_openrouter_with_default_model(
+        self, monkeypatch, sample_audio,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+
+        cfg = {"enabled": True, "provider": "openrouter"}
+        with _patch_load_stt_config(cfg), \
+             patch(
+                 "tools.transcription_tools._transcribe_openrouter",
+                 return_value={"success": True, "transcript": "hi", "provider": "openrouter"},
+             ) as mock_transcribe, \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import (
+                DEFAULT_OPENROUTER_STT_MODEL,
+                transcribe_audio,
+            )
+            result = transcribe_audio(sample_audio)
+
+        assert result["success"] is True
+        assert result["provider"] == "openrouter"
+        # Default model wired through
+        called_model = mock_transcribe.call_args.args[1]
+        assert called_model == DEFAULT_OPENROUTER_STT_MODEL == "openai/whisper-1"
+
+    def test_dispatch_uses_config_model_override(
+        self, monkeypatch, sample_audio,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+        cfg = {
+            "enabled": True,
+            "provider": "openrouter",
+            "openrouter": {"model": "openai/gpt-4o-mini-transcribe"},
+        }
+        with _patch_load_stt_config(cfg), \
+             patch(
+                 "tools.transcription_tools._transcribe_openrouter",
+                 return_value={"success": True, "transcript": "", "provider": "openrouter"},
+             ) as mock_transcribe, \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_audio)
+
+        assert mock_transcribe.call_args.args[1] == "openai/gpt-4o-mini-transcribe"
+
+    def test_dispatch_explicit_model_argument_wins(
+        self, monkeypatch, sample_audio,
+    ):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or")
+        cfg = {
+            "enabled": True,
+            "provider": "openrouter",
+            "openrouter": {"model": "openai/whisper-1"},
+        }
+        with _patch_load_stt_config(cfg), \
+             patch(
+                 "tools.transcription_tools._transcribe_openrouter",
+                 return_value={"success": True, "transcript": "", "provider": "openrouter"},
+             ) as mock_transcribe, \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_audio, model="openai/gpt-4o-transcribe")
+
+        assert mock_transcribe.call_args.args[1] == "openai/gpt-4o-transcribe"
+
+    def test_no_provider_error_message_mentions_openrouter(
+        self, monkeypatch, sample_audio,
+    ):
+        """The fallback hint must list every supported provider so
+        users discover OpenRouter without spelunking the source."""
+        with _patch_load_stt_config({"enabled": True}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._has_openai_audio_backend", return_value=False):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_audio)
+
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+        assert "OpenRouter" in result["error"]

--- a/tests/tools/test_transcription_openrouter_feature_anchor.py
+++ b/tests/tools/test_transcription_openrouter_feature_anchor.py
@@ -1,0 +1,208 @@
+"""Feature-shape anchor for the OpenRouter STT provider (#24415).
+
+Drives the exact end-to-end shape from the issue's "Proposed
+Solution" section so a future refactor that drops any of the four
+contract bullet points fails with an explicit "#24415" message.
+
+The feature contract from the issue:
+
+  1. ``stt.provider: openrouter`` in config is honoured.
+  2. The OpenAI SDK gets called with
+     ``base_url=https://openrouter.ai/api/v1``.
+  3. Authorisation uses ``OPENROUTER_API_KEY`` from the env (the
+     same env var the LLM stack reads).
+  4. The default model is ``openai/whisper-1``.
+  5. The provider lives in the auto-detect chain so a user who only
+     has ``OPENROUTER_API_KEY`` set (no other STT key) gets STT for
+     free.
+
+This module ships ONE focused end-to-end test that asserts every
+bullet at once.  Why a single test instead of five: the issue's
+acceptance criterion is the user-visible round trip, not any
+individual internal helper -- if any link breaks, the whole chain
+fails.
+
+Why this proves the feature is wired: on upstream/main the test
+fails with ``AssertionError: #24415 anchor: ...`` because either
+the dispatch returns a "no provider available" error (provider name
+unknown) or the OpenAI SDK is never reached at all.  After the
+feature lands the test passes.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in (
+        "OPENROUTER_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "OPENAI_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "XAI_API_KEY",
+        "STT_OPENROUTER_BASE_URL",
+        "STT_OPENROUTER_MODEL",
+        "HERMES_LOCAL_STT_COMMAND",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def sample_audio(tmp_path):
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"fake-ogg-bytes")
+    return str(audio_path)
+
+
+def _build_fake_openai_module(transcript: str = "hello from openrouter"):
+    """Mock the openai package surface ``_transcribe_openrouter``
+    actually consumes."""
+    fake = MagicMock()
+    fake.OpenAI.return_value.audio.transcriptions.create.return_value = transcript
+
+    class _APIError(Exception):
+        pass
+
+    class _APIConnectionError(Exception):
+        pass
+
+    class _APITimeoutError(Exception):
+        pass
+
+    fake.APIError = _APIError
+    fake.APIConnectionError = _APIConnectionError
+    fake.APITimeoutError = _APITimeoutError
+    return fake
+
+
+class TestOpenRouterSttFeatureContract:
+    def test_full_user_round_trip_honours_issue_contract(
+        self, monkeypatch, sample_audio,
+    ):
+        """End-to-end #24415 anchor:
+
+        Given:
+          * ``OPENROUTER_API_KEY=sk-or-real`` in env (the same key
+            the LLM stack reads).
+          * ``stt.provider: openrouter`` in config (no other STT
+            keys set).
+
+        When transcribe_audio() is called,
+
+        Then ALL of the following must hold:
+          * The result reports ``provider == "openrouter"``.
+          * The OpenAI SDK was constructed with
+            ``base_url=https://openrouter.ai/api/v1``.
+          * The OpenAI SDK was constructed with
+            ``api_key=sk-or-real``.
+          * The transcription call used model ``openai/whisper-1``
+            (the documented default).
+
+        On upstream/main this whole chain fails -- the provider
+        name is unknown to ``_get_provider``, dispatch returns a
+        "no provider available" error, and the OpenAI SDK is never
+        constructed.  After the fix it passes.
+        """
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+
+        fake_openai_module = _build_fake_openai_module(
+            transcript="hello from openrouter",
+        )
+
+        cfg = {"enabled": True, "provider": "openrouter"}
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value=cfg,
+        ), patch(
+            "tools.transcription_tools._HAS_FASTER_WHISPER", False
+        ), patch(
+            "tools.transcription_tools._has_local_command",
+            return_value=False,
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_audio)
+
+        # ---- Bullet 1+3: provider routes to openrouter, not "none" ------
+        assert result["success"] is True, (
+            "#24415 anchor: stt.provider=openrouter with OPENROUTER_API_KEY "
+            f"set must succeed -- got error: {result.get('error')!r}.  This "
+            "means _get_provider does not recognise 'openrouter' or the "
+            "dispatch in transcribe_audio is missing -- the feature is "
+            "not wired."
+        )
+        assert result["provider"] == "openrouter", (
+            "#24415 anchor: provider field in the response must be "
+            f"'openrouter', got {result.get('provider')!r}"
+        )
+        assert result["transcript"] == "hello from openrouter"
+
+        # ---- Bullet 2: OpenAI SDK called with OpenRouter base_url -------
+        assert fake_openai_module.OpenAI.called, (
+            "#24415 anchor: the OpenAI SDK was never constructed -- the "
+            "OpenRouter dispatch path is not reaching _transcribe_openrouter"
+        )
+        sdk_kwargs = fake_openai_module.OpenAI.call_args.kwargs
+        assert sdk_kwargs["base_url"] == "https://openrouter.ai/api/v1", (
+            "#24415 anchor: OpenAI SDK base_url must be the OpenRouter "
+            f"endpoint, got {sdk_kwargs.get('base_url')!r}"
+        )
+
+        # ---- Bullet 3: env key reached the SDK --------------------------
+        assert sdk_kwargs["api_key"] == "sk-or-real", (
+            "#24415 anchor: OPENROUTER_API_KEY must reach the OpenAI SDK "
+            f"unchanged, got {sdk_kwargs.get('api_key')!r}"
+        )
+
+        # ---- Bullet 4: default model = openai/whisper-1 -----------------
+        create_kwargs = (
+            fake_openai_module.OpenAI.return_value
+            .audio.transcriptions.create.call_args.kwargs
+        )
+        assert create_kwargs["model"] == "openai/whisper-1", (
+            "#24415 anchor: default OpenRouter STT model must be "
+            f"'openai/whisper-1', got {create_kwargs.get('model')!r}"
+        )
+
+    def test_auto_detect_lights_up_with_only_openrouter_key(
+        self, monkeypatch, sample_audio,
+    ):
+        """Bullet 5 from the issue: a user who has ONLY
+        ``OPENROUTER_API_KEY`` set (no Groq / OpenAI / xAI key, no
+        explicit ``stt.provider``, no local backend) must get STT
+        via OpenRouter -- the provider has to be in the auto-detect
+        chain, not just an opt-in setting."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+
+        fake_openai_module = _build_fake_openai_module()
+        cfg = {"enabled": True}  # no provider, no per-provider config
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value=cfg,
+        ), patch(
+            "tools.transcription_tools._HAS_FASTER_WHISPER", False
+        ), patch(
+            "tools.transcription_tools._has_local_command",
+            return_value=False,
+        ), patch(
+            "tools.transcription_tools._HAS_OPENAI", True
+        ), patch(
+            "tools.transcription_tools._has_openai_audio_backend",
+            return_value=False,
+        ), patch.dict("sys.modules", {"openai": fake_openai_module}):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_audio)
+
+        assert result["success"] is True and result["provider"] == "openrouter", (
+            "#24415 anchor: with only OPENROUTER_API_KEY set and no other "
+            "STT backend available, auto-detect MUST land on the openrouter "
+            f"provider -- got result={result!r}.  Without this the user has "
+            "no STT at all, which is the headline regression the feature "
+            "request was filed to prevent."
+        )

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -11,6 +11,9 @@ Provides speech-to-text transcription with six providers:
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
+  - **openrouter** — OpenRouter aggregated transcription, requires
+    ``OPENROUTER_API_KEY``. Routes to Whisper-family models via the
+    same OpenRouter credit pool as LLM access. See #24415.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -84,6 +87,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_OPENROUTER_STT_MODEL = os.getenv("STT_OPENROUTER_MODEL", "openai/whisper-1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -91,6 +95,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+OPENROUTER_STT_BASE_URL = os.getenv("STT_OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -99,6 +104,14 @@ MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
+# OpenRouter prefixes Whisper-family models with "openai/" -- these are the
+# common ones a user is likely to land on; the list is informational only,
+# we do NOT block other model IDs (OpenRouter routinely adds new ones).
+OPENROUTER_MODELS = {
+    "openai/whisper-1",
+    "openai/gpt-4o-mini-transcribe",
+    "openai/gpt-4o-transcribe",
+}
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
@@ -273,11 +286,26 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "openrouter":
+            if _HAS_OPENAI and get_env_value("OPENROUTER_API_KEY"):
+                return "openrouter"
+            logger.warning(
+                "STT provider 'openrouter' configured but OPENROUTER_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > xai ---
-    # mistral is intentionally skipped while `mistralai` is quarantined on
-    # PyPI (malicious 2.4.6 release on 2026-05-12).
+    # --- Auto-detect (no explicit provider) ------------------------------
+    #
+    # Order: local > groq > openai > xai > openrouter.  openrouter is
+    # last in the cloud chain because it is a catch-all that many users
+    # already have configured for LLM access -- if they ALSO have a
+    # dedicated STT key (Groq / OpenAI / xAI) we should prefer the
+    # dedicated provider's pricing and routing.  See #24415.
+    #
+    # mistral is intentionally skipped while `mistralai` is quarantined
+    # on PyPI (malicious 2.4.6 release on 2026-05-12).
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -292,6 +320,9 @@ def _get_provider(stt_config: dict) -> str:
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
+    if _HAS_OPENAI and get_env_value("OPENROUTER_API_KEY"):
+        logger.info("No local STT available, using OpenRouter Whisper API")
+        return "openrouter"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -786,6 +817,74 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: openrouter (Whisper-family via OpenRouter aggregator)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_openrouter(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe via OpenRouter's OpenAI-compatible audio endpoint (#24415).
+
+    OpenRouter exposes ``POST /api/v1/audio/transcriptions`` with the
+    same wire format as OpenAI, so the OpenAI SDK with a custom
+    ``base_url`` + ``api_key`` is the cleanest route -- no new
+    dependency.  Lets users with ``OPENROUTER_API_KEY`` already
+    configured for LLM access reuse the same key & billing for STT.
+    """
+    stt_config = _load_stt_config()
+    openrouter_cfg = stt_config.get("openrouter", {}) or {}
+
+    # Per-provider overrides win, env var is the fallback.  Mirrors
+    # how the OpenAI / xAI providers do it -- never reaches outside
+    # this module's resolution rules so users get one consistent story.
+    api_key = openrouter_cfg.get("api_key") or get_env_value("OPENROUTER_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "OPENROUTER_API_KEY not set"}
+
+    if not _HAS_OPENAI:
+        return {"success": False, "transcript": "", "error": "openai package not installed"}
+
+    base_url = str(
+        openrouter_cfg.get("base_url")
+        or os.getenv("STT_OPENROUTER_BASE_URL")
+        or OPENROUTER_STT_BASE_URL
+    ).strip().rstrip("/")
+
+    try:
+        from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
+        client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
+        try:
+            with open(file_path, "rb") as audio_file:
+                transcription = client.audio.transcriptions.create(
+                    model=model_name,
+                    file=audio_file,
+                    response_format="text",
+                )
+
+            transcript_text = _extract_transcript_text(transcription)
+            logger.info(
+                "Transcribed %s via OpenRouter API (%s, %d chars)",
+                Path(file_path).name, model_name, len(transcript_text),
+            )
+            return {"success": True, "transcript": transcript_text, "provider": "openrouter"}
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except APIConnectionError as e:
+        return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
+    except APITimeoutError as e:
+        return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+    except APIError as e:
+        return {"success": False, "transcript": "", "error": f"API error: {e}"}
+    except Exception as e:
+        logger.error("OpenRouter transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -858,6 +957,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "openrouter":
+        openrouter_cfg = stt_config.get("openrouter", {}) or {}
+        model_name = model or openrouter_cfg.get("model", DEFAULT_OPENROUTER_STT_MODEL)
+        return _transcribe_openrouter(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -866,8 +970,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, set OPENROUTER_API_KEY "
+            "for OpenRouter Whisper, or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for "
+            "the OpenAI Whisper API."
         ),
     }
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -91,11 +91,19 @@ Add to `~/.hermes/.env`:
 # pip install faster-whisper          # Free, runs locally, recommended
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
+XAI_API_KEY=your-key                  # xAI Grok STT (cloud, diarization)
+OPENROUTER_API_KEY=your-key           # OpenRouter — Whisper via your existing OpenRouter credits (#24415)
 
 # Text-to-Speech (optional — Edge TTS and NeuTTS work without any key)
 ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
 # VOICE_TOOLS_OPENAI_KEY above also enables OpenAI TTS
 ```
+
+:::tip OpenRouter STT (#24415)
+If you already have `OPENROUTER_API_KEY` in your `.env` for LLM access, that same key now works for voice transcription — no separate Groq / OpenAI / xAI account needed. Hermes routes to OpenRouter's OpenAI-compatible `/api/v1/audio/transcriptions` endpoint and bills against the same credit pool. Default model is `openai/whisper-1`; override via `stt.openrouter.model` (`openai/gpt-4o-mini-transcribe`, `openai/gpt-4o-transcribe`).
+
+Auto-detect order: `local > groq > openai > xai > openrouter`. OpenRouter sits last in the cloud chain because it's a catch-all — if you also have a dedicated STT key it wins, so you keep that provider's pricing & routing.
+:::
 
 :::tip
 If `faster-whisper` is installed, voice mode works with **zero API keys** for STT. The model (~150 MB for `base`) downloads automatically on first use.
@@ -422,12 +430,16 @@ tts:
 # pip install faster-whisper        # Free local STT — no API key needed
 GROQ_API_KEY=...                    # Groq Whisper (fast, free tier)
 VOICE_TOOLS_OPENAI_KEY=...         # OpenAI Whisper (paid)
+XAI_API_KEY=...                    # xAI Grok STT (cloud, diarization)
+OPENROUTER_API_KEY=...             # OpenRouter Whisper — reuse your LLM key (#24415)
 
 # STT advanced overrides (optional)
-STT_GROQ_MODEL=whisper-large-v3-turbo    # Override default Groq STT model
-STT_OPENAI_MODEL=whisper-1               # Override default OpenAI STT model
+STT_GROQ_MODEL=whisper-large-v3-turbo            # Override default Groq STT model
+STT_OPENAI_MODEL=whisper-1                       # Override default OpenAI STT model
+STT_OPENROUTER_MODEL=openai/whisper-1            # Override default OpenRouter STT model (#24415)
 GROQ_BASE_URL=https://api.groq.com/openai/v1     # Custom Groq endpoint
 STT_OPENAI_BASE_URL=https://api.openai.com/v1    # Custom OpenAI STT endpoint
+STT_OPENROUTER_BASE_URL=https://openrouter.ai/api/v1  # Custom OpenRouter STT endpoint (#24415)
 
 # Text-to-Speech providers (Edge TTS and NeuTTS need no key)
 ELEVENLABS_API_KEY=***             # ElevenLabs (premium quality)
@@ -492,7 +504,7 @@ The bot requires an @mention by default in server channels. Make sure you:
 
 ### Bot hears me but doesn't respond
 
-- Verify STT is available: install `faster-whisper` (no key needed) or set `GROQ_API_KEY` / `VOICE_TOOLS_OPENAI_KEY`
+- Verify STT is available: install `faster-whisper` (no key needed), set `GROQ_API_KEY` / `VOICE_TOOLS_OPENAI_KEY` / `XAI_API_KEY`, or set `OPENROUTER_API_KEY` to reuse your existing OpenRouter LLM credits for transcription (#24415)
 - Check the LLM model is configured and accessible
 - Review gateway logs: `tail -f ~/.hermes/logs/gateway.log`
 


### PR DESCRIPTION
## What does this PR do?

Implements #24415 — adds **OpenRouter** as a first-class STT provider alongside the existing five (`local`, `groq`, `openai`, `mistral`, `xai`).

Hermes today supports five STT providers but has no way to reuse `OPENROUTER_API_KEY` for transcription — users with OpenRouter set up for LLM access have to spin up a separate Groq / OpenAI / xAI account just to transcribe a voice message. OpenRouter exposes an OpenAI-compatible `/api/v1/audio/transcriptions` endpoint that routes to Whisper-family models (`openai/whisper-1`, `openai/gpt-4o-mini-transcribe`, `openai/gpt-4o-transcribe`) billed through the same credit pool as LLM access. Adding `openrouter` as a native provider closes that gap with zero new dependencies — the existing `openai` SDK with a custom `base_url` handles the wire format.

The implementation lives in `tools/transcription_tools.py`:

1. **Provider detection** — explicit `stt.provider: openrouter` branch + auto-detect chain entry. Auto-detect order is `local > groq > openai > xai > openrouter`. OpenRouter sits last in the cloud chain because it's a catch-all — if the user *also* has a dedicated STT key (Groq / OpenAI / xAI), the dedicated provider wins so they keep that provider's pricing and routing.
2. **Client routing** — `_transcribe_openrouter()` mirrors the `_transcribe_groq()` shape: `OpenAI(api_key=..., base_url="https://openrouter.ai/api/v1", timeout=30, max_retries=0)` then `audio.transcriptions.create(model=..., file=..., response_format="text")`. Same error envelope, same `_extract_transcript_text` post-processing.
3. **Model selection** — default `openai/whisper-1`, overridable via `stt.openrouter.model` or the `STT_OPENROUTER_MODEL` env var. The known-models set is informational only — Hermes does **not** block other model IDs (OpenRouter routinely adds new ones).
4. **Auth** — reuses `OPENROUTER_API_KEY` from `.env` (no new env var). `stt.openrouter.api_key` in config wins over the env var so managed deployments can pin per-deployment credentials.
5. **No new dependency** — the existing `openai` SDK does the work; the issue's "no new SDK required" promise is honoured.

## Related Issue

Closes #24415 — `[Feature]: Add OpenRouter as an STT provider`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/transcription_tools.py` (+109 / −8):
  - New constants `DEFAULT_OPENROUTER_STT_MODEL = "openai/whisper-1"`, `OPENROUTER_STT_BASE_URL = "https://openrouter.ai/api/v1"`, `OPENROUTER_MODELS = {…}` (informational only).
  - `_get_provider()` — explicit `openrouter` branch (requires `OPENROUTER_API_KEY` + the `openai` SDK) + auto-detect chain entry after `xai`.
  - `_transcribe_openrouter()` — new function modeled on `_transcribe_groq()`, with config/env key resolution, base-url override, full error-envelope coverage (`PermissionError`, `APIConnectionError`, `APITimeoutError`, `APIError`, `Exception`).
  - `transcribe_audio()` — new dispatch arm + per-provider model resolution (`stt.openrouter.model` wins, default `openai/whisper-1`).
  - Module docstring updated to "seven providers"; the "no provider available" hint mentions `OPENROUTER_API_KEY` so users discover it without reading source.
- `cli-config.yaml.example` (+4 / −2) — new commented `stt.openrouter` block with `model` / `api_key` / `base_url` examples.
- `tests/tools/test_transcription_openrouter.py` (new, +378 lines) — 18 unit tests across three classes:
  - `TestGetProviderOpenRouter` (7) — explicit-config and auto-detect resolution, including the precedence rule from the issue (`groq` / `openai` / `xai` win over `openrouter` in auto-detect).
  - `TestTranscribeOpenRouter` (7) — env-key resolution, config overrides, OpenAI-SDK call shape (`response_format="text"` pinned), error-path wrappers.
  - `TestTranscribeAudioDispatchOpenRouter` (4) — end-to-end `transcribe_audio()` dispatch + the model-default chain.
- `tests/tools/test_transcription_openrouter_feature_anchor.py` (new, +208 lines) — 2 feature-shape regression anchors that drive the issue's full "Proposed Solution" contract end-to-end:
  - `test_full_user_round_trip_honours_issue_contract` — asserts bullets 1–4 (provider routes, base URL, env key, default model) in a single round trip with per-bullet `#24415 anchor` messages.
  - `test_auto_detect_lights_up_with_only_openrouter_key` — asserts bullet 5 (auto-detect with only `OPENROUTER_API_KEY` set must land on `openrouter`).
- `website/docs/user-guide/features/voice-mode.md` (+15 / −3) — added `OPENROUTER_API_KEY` to the API-Keys section with a tip explaining the "reuse your LLM key" value proposition + the auto-detect rationale; troubleshooting bullet updated; Configuration Reference section gets `STT_OPENROUTER_MODEL` and `STT_OPENROUTER_BASE_URL` overrides.

No existing files outside the additions above are touched; existing provider code paths (`_transcribe_groq`, `_transcribe_openai`, `_transcribe_xai`, `_transcribe_mistral`, `_transcribe_local`, `_transcribe_local_command`) are byte-identical.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new + adjacent test suites:
   ```
   scripts/run_tests.sh \
     tests/tools/test_transcription_openrouter.py \
     tests/tools/test_transcription_openrouter_feature_anchor.py \
     tests/tools/test_transcription_tools.py \
     tests/tools/test_transcription.py \
     tests/tools/test_transcription_dotenv_fallback.py
   ```
   Expected: **147 passed** (20 new + 127 pre-existing).
3. Verify the feature-shape regression anchor really catches the missing feature:
   ```
   git checkout upstream/main -- tools/transcription_tools.py
   pytest tests/tools/test_transcription_openrouter_feature_anchor.py -v
   ```
   Expected: **2 failed** with the anchor messages
   `#24415 anchor: stt.provider=openrouter with OPENROUTER_API_KEY set must succeed -- got error: 'No STT provider available...'`
   and
   `#24415 anchor: with only OPENROUTER_API_KEY set and no other STT backend available, auto-detect MUST land on the openrouter provider...`.
   Restore the fix (`git checkout HEAD -- tools/transcription_tools.py`) → both pass.
4. (Optional, manual) Drop your real `OPENROUTER_API_KEY` into `~/.hermes/.env`, set `stt.provider: openrouter` in `~/.hermes/config.yaml`, then send a voice message via the gateway:
   - Discord/Telegram: voice-note → Hermes transcribes via `https://openrouter.ai/api/v1/audio/transcriptions` and replies. OpenRouter dashboard should show a hit on `openai/whisper-1`.
   - CLI voice mode: `hermes` → `/voice on` → push-to-talk; transcript flows through the same code path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(stt): ...`, `test(stt): ...`, `docs(stt): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (4 commits, all scoped to OpenRouter STT + its tests + its docs)
- [x] I've run `scripts/run_tests.sh` on the affected test files and all 147 tests pass
- [x] I've added tests for my changes (18 unit tests + 2 feature-shape regression anchors)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/features/voice-mode.md` got an OpenRouter tip, troubleshooting hint, and env-var reference rows
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — added a commented `stt.openrouter` block
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — feature is platform-agnostic; relies only on the `openai` SDK + `OPENROUTER_API_KEY` env var, both of which work identically on Windows / macOS / Linux. Tests are hermetic (mocked `openai` module via `patch.dict("sys.modules", ...)`, no real network or filesystem outside `tmp_path`).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal STT pipeline; the `transcribe_audio` public surface keeps the exact same signature and return shape)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_transcription_openrouter.py tests/tools/test_transcription_openrouter_feature_anchor.py tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py
4 workers [147 items]
============================== 147 passed in 1.17s =============================

$ ruff check tools/transcription_tools.py tests/tools/test_transcription_openrouter.py tests/tools/test_transcription_openrouter_feature_anchor.py
All checks passed!
```

Feature-shape repro on `upstream/main` (anchor proves the feature is genuinely missing pre-PR):

```
$ git checkout upstream/main -- tools/transcription_tools.py
$ pytest tests/tools/test_transcription_openrouter_feature_anchor.py -v
FAILED tests/tools/test_transcription_openrouter_feature_anchor.py::TestOpenRouterSttFeatureContract::test_full_user_round_trip_honours_issue_contract
  AssertionError: #24415 anchor: stt.provider=openrouter with OPENROUTER_API_KEY set
    must succeed -- got error: 'No STT provider available. Install faster-whisper for
    free local transcription, ... or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for
    the OpenAI Whisper API.'.  This means _get_provider does not recognise
    'openrouter' or the dispatch in transcribe_audio is missing -- the feature is not
    wired.
FAILED tests/tools/test_transcription_openrouter_feature_anchor.py::TestOpenRouterSttFeatureContract::test_auto_detect_lights_up_with_only_openrouter_key
  AssertionError: #24415 anchor: with only OPENROUTER_API_KEY set and no other STT
    backend available, auto-detect MUST land on the openrouter provider...
```


feat/openrouter-stt-provider
