### PR TITLE
fix(retry): use float() for Retry-After header to handle sub-second values

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14449,7 +14449,7 @@ class AIAgent:
                             _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
                             if _ra_raw:
                                 try:
-                                    _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
+                                    _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
                     wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)


### PR DESCRIPTION
Salvage of #23178 by @ryptotalent onto current main.

`int(_ra_raw)` crashes on sub-second `Retry-After` values like `0.5`. The sibling code path already uses `float()`. One-line alignment.

Original commit had a placeholder `Ubuntu <ubuntu@localhost.localdomain>` author — re-authored to canonical noreply form during salvage.