### PR TITLE
fix(signal): handle group messages from linked devices in syncMessage path

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -446,7 +446,9 @@ class SignalAdapter(BasePlatformAdapter):
                 if sent_msg and isinstance(sent_msg, dict):
                     dest = sent_msg.get("destinationNumber") or sent_msg.get("destination")
                     sent_ts = sent_msg.get("timestamp")
-                    if dest == self._account_normalized:
+                    sent_msg_group_info = sent_msg.get("groupInfo") or {}
+                    sent_msg_group_id = sent_msg_group_info.get("groupId") if sent_msg_group_info else None
+                    if dest == self._account_normalized or sent_msg_group_id:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
                             self._recent_sent_timestamps.discard(sent_ts)


### PR DESCRIPTION
Salvage of #23293 by @ms-alan onto current main.

Linked-device group syncMessages were dropped because `dest != self`. Gates the syncMessage handler via `groupInfo.groupId` so legitimate group messages from linked devices reach the agent. Echoes still filtered by `_recent_sent_timestamps`.