### PR TITLE
fix(voice_mode): detect audio in WSL when sd.query_devices() returns empty list

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -130,7 +130,9 @@ def detect_audio_environment() -> dict:
         try:
             devices = sd.query_devices()
             if not devices:
-                if termux_capture:
+                if os.environ.get('PULSE_SERVER'):
+                    notices.append("No PortAudio devices detected but PULSE_SERVER is set -- continuing")
+                elif termux_capture:
                     notices.append("No PortAudio devices detected, but Termux:API microphone capture is available")
                 else:
                     warnings.append("No audio input/output devices detected")


### PR DESCRIPTION
Salvage of #23310 by @RhombusMaximus onto current main.

WSL with PulseAudio bridging returns an empty device list from `sd.query_devices()` even when audio works. The PR mirrors the existing exception-branch `PULSE_SERVER` bypass to the empty-devices branch. Minimal and correct.