### PR TITLE
fix(tui): use TERMINAL_CWD in _session_info for accurate status line path

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1378,7 +1378,7 @@ def _session_info(agent) -> dict:
         "fast": service_tier == "priority",
         "tools": {},
         "skills": {},
-        "cwd": os.getcwd(),
+        "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         "version": "",
         "release_date": "",
         "update_behind": None,


### PR DESCRIPTION
Salvage of #23337 by @Dangooy onto current main.

The TUI status line ignored the canonical `TERMINAL_CWD` env var (used elsewhere in the codebase to track the agent's working directory) and just used `os.getcwd()`. Switching to `os.getenv("TERMINAL_CWD", os.getcwd())` makes it consistent with the rest of the codebase.