### PR TITLE
fix(gateway): add chat_id to hook_ctx for message source tracking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7543,6 +7543,7 @@ class GatewayRunner:
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }


### PR DESCRIPTION
Salvage of #23463 by @diablozzc onto current main.

Adds `source.chat_id` to the agent:start `hook_ctx` payload so plugin hooks can identify the message source. Harmless additive field. (Only one of two hook_ctx sites is updated; the other is a separate non-breaking concern.)