### PR TITLE
fix(install): use stash@{0} instead of git rev-parse refs/stash for autostash recovery

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -890,7 +890,7 @@ clone_repo() {
                 stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Local changes detected, stashing before update..."
                 git stash push --include-untracked -m "$stash_name"
-                autostash_ref="$(git rev-parse --verify refs/stash)"
+                autostash_ref="stash@{0}"
             fi
 
             git fetch origin


### PR DESCRIPTION
Salvage of #23611 by @Jwd-gity onto current main.

`git stash drop <SHA>` errors with "not a stash reference"; `stash@{0}` is the correct symbolic form and reliably matches the just-pushed stash entry.