### PR TITLE
fix(telegram): use thread fallback helper in slash-confirm result send

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2772,7 +2772,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     {"thread_id": str(thread_id)},
                                 )
                             )
-                        await self._bot.send_message(**send_kwargs)
+                        await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return


### PR DESCRIPTION
Salvage of #23669 by @AhmetArif0 onto current main.

Switches the slash-confirm result send to use the existing `_send_message_with_thread_fallback` helper, consistent with other call sites in the same file.