### PR TITLE
fix(dashboard): bundle backdrop filler image via Vite import (#24355)

### DIFF
--- a/tests/tools/test_backdrop_filler_bundling.py
+++ b/tests/tools/test_backdrop_filler_bundling.py
@@ -1,0 +1,63 @@
+"""contract test: Backdrop's filler image is bundled by Vite, not served from /ds-assets/.
+
+Regression guard for #24355.  The default dashboard backdrop renders a
+faint filler image at the top-left of the viewport.  It used to load
+from `/ds-assets/filler-bg0.<ext>`, which Vite only emits when
+`npm run sync-assets` has populated `web/public/ds-assets/` first.
+That prebuild hook can be silently bypassed — `vite build` invoked
+directly, `prebuild` failing partway through, or `_build_web_ui`'s
+stale-dist fallback (#23817) serving a `web_dist` that never had
+`ds-assets/` written.  In any of those cases the URL 404s and the
+default backdrop disappears.
+
+Importing the asset through the package's `./assets/*` export forces
+Vite to bundle it into the JS chunk graph, so the file always lands in
+`web_dist/assets/` with a content-hashed name regardless of whether
+`sync-assets` ran.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKDROP = REPO_ROOT / "web" / "src" / "components" / "Backdrop.tsx"
+
+
+def test_backdrop_does_not_reference_public_ds_assets_path() -> None:
+    """`/ds-assets/filler-bg0.<ext>` requires the prebuild hook to have run.
+
+    Any source reference to that literal path re-introduces the #24355
+    regression — the backdrop silently disappears whenever `sync-assets`
+    is bypassed.
+    """
+    source = BACKDROP.read_text(encoding="utf-8")
+    assert "/ds-assets/filler-bg0" not in source, (
+        "Backdrop.tsx must not reference `/ds-assets/filler-bg0.<ext>` directly. "
+        "Use an ES import (`@nous-research/ui/assets/filler-bg0.webp`) so Vite "
+        "bundles the asset and the default backdrop survives flows that skip "
+        "the `sync-assets` prebuild hook (see #24355)."
+    )
+
+
+def test_backdrop_imports_filler_via_design_system_package() -> None:
+    """The filler image must travel with the JS bundle.
+
+    Vite resolves `@nous-research/ui/assets/filler-bg0.<ext>` through the
+    package's `./assets/*` export and emits a content-hashed copy into
+    `web_dist/assets/`, removing the dependency on
+    `web/public/ds-assets/` being populated before build.
+
+    The asserted pattern tolerates either quote style and either
+    extension (`.webp` or `.jpg`) so a reformat or an asset-extension
+    bump in `@nous-research/ui` doesn't false-positive this contract.
+    """
+    source = BACKDROP.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"""from\s+['"]@nous-research/ui/assets/filler-bg0\.(?:webp|jpg)['"]"""
+    )
+    assert pattern.search(source), (
+        "Backdrop.tsx must import the filler image from "
+        "`@nous-research/ui/assets/filler-bg0.webp` (or `.jpg`) so Vite "
+        "bundles it. See #24355."
+    )


### PR DESCRIPTION
## What does this PR do?

When this PR was first opened, `web/src/components/Backdrop.tsx` still imported the filler image via the fragile `/ds-assets/filler-bg0.*` public path that depended on the `sync-assets` prebuild hook firing. Direct `vite build`, partial prebuild failures, or `_build_web_ui`'s stale-dist fallback (#23817) would silently 404 the asset and the default backdrop would disappear. The PR switched the import to `@nous-research/ui/assets/filler-bg0.webp` so Vite bundles a content-hashed copy into `web_dist/assets/`.

That `Backdrop.tsx` change has since landed on `main` independently (along with removal of the redundant `sync-assets` / `predev` / `prebuild` scripts), so the original code change is no longer needed.

This PR now carries the two remaining pieces around that landed change:

1. **Regression contract test** (`tests/tools/test_backdrop_filler_bundling.py`) — asserts `Backdrop.tsx` does NOT reference the fragile public path and DOES import via the design-system package's `./assets/*` export. The import-pattern assertion uses a regex that tolerates either quote style and either `.webp` / `.jpg` extension so future ds-asset bumps or reformats don't false-positive the contract.

2. **`@nous-research/ui` bump 0.14.0 → 0.15.0** per @austinpickett's request — the breaking changes that surfaced the original regression originate in the 0.15.0 release. Verified that 0.15.0 still ships `dist/assets/filler-bg0.webp` + `dist/hooks/use-gpu-tier` + every `dist/ui/components/{button,list-item,selection-switcher,spinner,badge,select,tabs,command-block}` import used in `web/src/`. `npm run build` passes clean.

## Related Issue

Addresses #24355 (original code change already on main; this PR adds the regression test + the upstream-requested ui bump)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/tools/test_backdrop_filler_bundling.py` (new, 63 LOC, 2 tests) — contract guard against re-introducing the `/ds-assets/` public-path dependency in `Backdrop.tsx`.
- `web/package.json` — bump `@nous-research/ui` from `0.14.0` to `0.15.0`.
- `web/package-lock.json` — regenerated against `0.15.0`.

## How to Test

1. `pytest tests/tools/test_backdrop_filler_bundling.py -q` → 2 passed.
2. `cd web && npm install && npm run build` → vite build passes clean; `web_dist/assets/filler-bg0-<hash>.webp` emitted.
3. Reverting either Backdrop.tsx import on a local branch should fail one of the two contract assertions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_backdrop_filler_bundling.py -q
..                                                                       [100%]
2 passed in 8.68s

$ cd web && npm run build
vite v7.3.2 building client environment for production...
✓ 2067 modules transformed.
../hermes_cli/web_dist/assets/filler-bg0-RwOqXSl_.webp    931.56 kB
../hermes_cli/web_dist/assets/index-DK2Uerqs.js         1,581.97 kB │ gzip: 460.21 kB
✓ built in 6.08s
```
