### PR TITLE
fix(prompt_builder): inject tool-use enforcement for GLM models

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -268,7 +268,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm")
 
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,


### PR DESCRIPTION
Salvage of #23702 by @ALIYILD onto current main.

Adds "glm" to the `TOOL_USE_ENFORCEMENT_MODELS` tuple so GLM models get the same tool-use guidance injected into their system prompt as other models that need it. Trivial 1-line addition.