### PR TITLE
fix(line): use build_source instead of nonexistent create_source

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -959,7 +959,7 @@ class LineAdapter(BasePlatformAdapter):
         if chat_type == "dm" and self._client:
             asyncio.create_task(self._client.loading(chat_id))
 
-        source_obj = self.create_source(
+        source_obj = self.build_source(
             chat_id=chat_id,
             chat_type=chat_type,
             user_id=user_id,


### PR DESCRIPTION
Salvage of #23730 by @mizgyo onto current main. Supersedes #23782 (byte-identical fix from @wali-reheman).

`create_source` doesn't exist in the codebase; `build_source` is the actual function defined in `base.py`. The LINE adapter call site was crashing with AttributeError. Real bug fix.