### PR TITLE
fix(wecom): update connection status after WebSocket reconnection

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -345,6 +345,7 @@ class WeComAdapter(BasePlatformAdapter):
                 try:
                     await self._open_connection()
                     backoff_idx = 0
+                    self._mark_connected()
                     logger.info("[%s] Reconnected", self.name)
                 except Exception as reconnect_exc:
                     logger.warning("[%s] Reconnect failed: %s", self.name, reconnect_exc)


### PR DESCRIPTION
Salvage of #23856 by @02356abc onto current main.

Calls `_mark_connected()` after a successful WebSocket reconnect so connection state reflects reality after a transient disconnect.