### PR TITLE
fix(tools): forward thread_id via metadata in _send_via_adapter live path

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -461,7 +461,8 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                result = await adapter.send(chat_id=chat_id, content=chunk)
+                metadata = {"thread_id": thread_id} if thread_id else None
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
             except Exception as e:


### PR DESCRIPTION
Salvage of #23875 by @AhmetArif0 onto current main.

Forwards `thread_id` through the `metadata` kwarg in `_send_via_adapter` so threaded sends from the live path reach the right thread. All adapter `send()` signatures already accept `metadata`.