### PR TITLE
fix(auxiliary): fallback to OPENROUTER_API_KEY env var when credential pool is exhausted

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1385,12 +1385,13 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), _OPENROUTER_MODEL
+        # Fall through to env var fallback when pool entries are exhausted
+        logger.info("OpenRouter pool exhausted, falling back to OPENROUTER_API_KEY env var")
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:


### PR DESCRIPTION
## Problem
When the OpenRouter credential pool has entries but all of them are exhausted/rate-limited (e.g. HTTP 429), `_try_openrouter()` returns `(None, None)` **without falling back to the `OPENROUTER_API_KEY` environment variable**, even when that env var is valid and usable.

This causes auxiliary tasks (title_generation, compression, session_search, vision, etc.) to fail with:
```
No LLM provider configured for task=<task> provider=auto
```

Meanwhile the main agent continues to work fine because it uses a different code path.

## Root Cause
In `agent/auxiliary_client.py`, `_try_openrouter()`:
- `_select_pool_entry("openrouter")` returns `(True, None)` when the pool exists but all entries are in cooldown
- Since `pool_present=True`, the function bailed out immediately with `return None, None` without ever checking `os.getenv("OPENROUTER_API_KEY")`

## Fix
When `pool_present=True` but no usable entry is found, fall through to the env var check instead of returning early. Added an info log line to make this fallback visible in logs.

## Testing
- Verified the code path change matches the expected behavior described in the issue
- The change is minimal and only affects the exhausted pool case; normal pool usage behavior remains unchanged

Fixes #23452