### PR TITLE
fix(approval): DOTALL+IGNORECASE lookahead allows bypass on multi-line strings

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -314,7 +314,9 @@ DANGEROUS_PATTERNS = [
     (r'\bdd\s+.*if=', "disk copy"),
     (r'>\s*/dev/sd', "write to block device"),
     (r'\bDROP\s+(TABLE|DATABASE)\b', "SQL DROP"),
-    (r'\bDELETE\s+FROM\b(?!.*\bWHERE\b)', "SQL DELETE without WHERE"),
+    # Use [^\n]* instead of .* so DOTALL mode does not cause a WHERE clause on the
+    # *next* line to satisfy the negative lookahead, silently allowing DELETE without WHERE.
+    (r'\bDELETE\s+FROM\b(?![^\n]*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
     (r'>\s*/etc/', "overwrite system config"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),


### PR DESCRIPTION
Salvage of #22159 by @amathxbt onto current main.

The approval-DELETE pattern at `tools/approval.py` is compiled with `re.IGNORECASE | re.DOTALL` (line 217). The `(?!.*WHERE)` lookahead with DOTALL lets a WHERE on a later line silence the match — i.e. a multi-line SQL string with WHERE on line 3 would bypass the approval check. Replacing `.*` with `[^\n]*` constrains the lookahead to the same line. Real bug fix.

Note: this is the only PR from a 20-PR burst by @amathxbt that holds up under review. The other 6 of the cluster have substantive issues (broken Python, empty diffs, weakened guardrails, hallucinated bugs); we're declining those separately with feedback.