### PR TITLE
feat(agent): allow pre_llm_call hooks to set turn reasoning

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -628,6 +628,7 @@ def init_agent(
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+    agent._turn_reasoning_config = None
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -818,6 +818,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
+    reasoning_config = agent._current_reasoning_config()
     tools_for_api = agent.tools
 
     if agent.api_mode == "anthropic_messages":
@@ -833,7 +834,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -909,7 +910,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
@@ -1014,7 +1015,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
@@ -1046,7 +1047,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
@@ -1795,6 +1796,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        reasoning_config = agent._current_reasoning_config()
         summary_extra_body = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP
@@ -1822,8 +1824,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if _is_lmstudio_summary else None
         )
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
-            if agent.reasoning_config is not None:
-                summary_extra_body["reasoning"] = agent.reasoning_config
+            if reasoning_config is not None:
+                summary_extra_body["reasoning"] = reasoning_config
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,
@@ -1866,7 +1868,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                         provider_preferences=provider_preferences or None,
                         model=agent.model,
                         base_url=agent.base_url,
-                        reasoning_config=agent.reasoning_config,
+                        reasoning_config=reasoning_config,
                     )
             except Exception:
                 pass
@@ -1906,7 +1908,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
                 _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                               max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                               max_tokens=agent.max_tokens, reasoning_config=reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
                                preserve_dots=agent._anthropic_preserve_dots())
                 summary_response = agent._anthropic_messages_create(_ant_kw)
@@ -1937,7 +1939,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _tretry = agent._get_transport()
                 _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
                                 is_oauth=agent._is_anthropic_oauth,
-                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                                max_tokens=agent.max_tokens, reasoning_config=reasoning_config,
                                 preserve_dots=agent._anthropic_preserve_dots())
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -574,8 +574,9 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     skipping the translation silently breaks every ``pre_tool_call``
     block directive.
 
-    For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    For ``pre_llm_call``, ``{"context": "..."}`` and
+    ``{"reasoning_config": {...}}`` are passed through unchanged to
+    match the plugin-hook contract.
 
     Anything else returns ``None``.
     """
@@ -611,6 +612,18 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
             message = data.get("message") or data.get("reason")
             if isinstance(message, str) and message.strip():
                 return {"action": "continue", "message": message.strip()}
+        return None
+
+    if event == "pre_llm_call":
+        result: Dict[str, Any] = {}
+        context = data.get("context")
+        if isinstance(context, str) and context.strip():
+            result["context"] = context
+        reasoning_config = data.get("reasoning_config")
+        if isinstance(reasoning_config, dict):
+            result["reasoning_config"] = reasoning_config
+        if result:
+            return result
         return None
 
     context = data.get("context")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -521,6 +521,10 @@ def build_turn_context(
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
+    agent._turn_reasoning_config = None
+    configured_reasoning = getattr(agent, "reasoning_config", None)
+    if isinstance(configured_reasoning, dict):
+        configured_reasoning = dict(configured_reasoning)
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -532,6 +536,7 @@ def build_turn_context(
             conversation_history=list(messages),
             is_first_turn=(not bool(conversation_history)),
             model=agent.model,
+            reasoning_config=configured_reasoning,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
         )
@@ -550,11 +555,16 @@ def build_turn_context(
             _spill_config_cached = None
         for r in _pre_results:
             _piece: str = ""
-            if isinstance(r, dict) and r.get("context"):
-                _piece = str(r["context"])
+            if isinstance(r, dict):
+                if isinstance(r.get("reasoning_config"), dict):
+                    agent._turn_reasoning_config = dict(r["reasoning_config"])
+                if r.get("context"):
+                    _piece = str(r["context"])
             elif isinstance(r, str) and r.strip():
                 _piece = r
             else:
+                continue
+            if not _piece:
                 continue
             if _spill_if_oversized is not None:
                 try:

--- a/docs/plans/2026-07-13-pre-llm-turn-reasoning-port-design.md
+++ b/docs/plans/2026-07-13-pre-llm-turn-reasoning-port-design.md
@@ -1,0 +1,19 @@
+# Pre-LLM Turn Reasoning Port
+
+## Goal
+
+Allow a `pre_llm_call` hook to return a `reasoning_config` override that applies only to the current user turn. The configured `agent.reasoning_config` remains the persistent fallback and must never be mutated by a hook.
+
+## Design
+
+The turn prologue in `agent/turn_context.py` owns the override lifecycle. It clears stale override state before invoking hooks, passes the configured reasoning value to callbacks, and copies the last valid `reasoning_config` dictionary returned by a hook. Context injection remains independent, so one hook result may contain both `context` and `reasoning_config`.
+
+`AIAgent` exposes one effective-config resolver: a dictionary-valued turn override wins; otherwise the configured value is returned. Every request path in `agent/chat_completion_helpers.py` uses that resolver, including Anthropic Messages, Codex Responses, provider-profile and legacy chat completions, and iteration-limit summary/retry requests. The outer `run_conversation` boundary clears the override after every exit so exceptions, interruptions, and early returns cannot leak turn state.
+
+Shell hooks accept the same return shape as Python callbacks. Multiple reasoning overrides follow existing plugin discovery order; the last valid dictionary wins.
+
+## Verification
+
+Unit tests cover hook parsing, turn setup/reset, configured fallback, combined context and reasoning results, and exception cleanup. Request-builder tests cover the active override on the current provider paths, while conversation-level coverage proves the first turn uses the override and a later turn falls back to the configured default. Public plugin and hook documentation describes the callback input, return shape, precedence, and per-turn scope.
+
+All work remains local on the fork branch until explicit approval to push.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1898,9 +1898,11 @@ class PluginManager:
         Returns a list of non-``None`` return values from callbacks.
 
         For ``pre_llm_call``, callbacks may return a dict describing
-        context to inject into the current turn's user message::
+        context to inject into the current turn's user message and/or
+        turn-scoped model options::
 
             {"context": "recalled text..."}
+            {"reasoning_config": {"enabled": True, "effort": "high"}}
             "recalled text..."          # plain string, equivalent
 
         Context is ALWAYS injected into the user message, never the

--- a/run_agent.py
+++ b/run_agent.py
@@ -5422,6 +5422,13 @@ class AIAgent:
         from agent.chat_completion_helpers import build_api_kwargs
         return build_api_kwargs(self, api_messages)
 
+    def _current_reasoning_config(self) -> dict | None:
+        """Return this turn's reasoning override or the configured fallback."""
+        turn_config = getattr(self, "_turn_reasoning_config", None)
+        if isinstance(turn_config, dict):
+            return turn_config
+        return self.reasoning_config
+
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.
 
@@ -5544,7 +5551,7 @@ class AIAgent:
         """
         from agent.lmstudio_reasoning import resolve_lmstudio_effort
         return resolve_lmstudio_effort(
-            self.reasoning_config,
+            self._current_reasoning_config(),
             self._lmstudio_reasoning_options_cached(),
         )
 
@@ -5559,11 +5566,12 @@ class AIAgent:
         if not supported_efforts:
             return None
 
-        if self.reasoning_config and isinstance(self.reasoning_config, dict):
-            if self.reasoning_config.get("enabled") is False:
+        reasoning_config = self._current_reasoning_config()
+        if reasoning_config and isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
                 return None
             requested_effort = str(
-                self.reasoning_config.get("effort", "medium")
+                reasoning_config.get("effort", "medium")
             ).strip().lower()
         else:
             requested_effort = "medium"
@@ -6000,6 +6008,7 @@ class AIAgent:
         finally:
             reset_accounting_context(acct_token)
             reset_conversation_context(token)
+            self._turn_reasoning_config = None
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -84,6 +84,24 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_llm_call_reasoning_config_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call",
+            '{"reasoning_config": {"enabled": true, "effort": "high"}}',
+        )
+        assert r == {"reasoning_config": {"enabled": True, "effort": "high"}}
+
+    def test_pre_llm_call_context_and_reasoning_config_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_llm_call",
+            '{"context": "remember this", '
+            '"reasoning_config": {"enabled": true, "effort": "high"}}',
+        )
+        assert r == {
+            "context": "remember this",
+            "reasoning_config": {"enabled": True, "effort": "high"},
+        }
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',
@@ -415,6 +433,35 @@ class TestCallbackSubprocess:
             model="gpt-4", platform="cli",
         )
         assert result == {"context": "env-note"}
+
+    def test_pre_llm_call_reasoning_override_flows_through_subprocess(
+        self, tmp_path
+    ):
+        script = _write_script(
+            tmp_path,
+            "reasoning.sh",
+            "#!/usr/bin/env bash\n"
+            'printf \'{"reasoning_config": '
+            '{"enabled": true, "effort": "high"}}\\n\'\n',
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_llm_call", command=str(script)
+        )
+        callback = shell_hooks._make_callback(spec)
+
+        result = callback(
+            session_id="s1",
+            user_message="use high reasoning",
+            conversation_history=[],
+            is_first_turn=True,
+            model="gpt-5.6",
+            reasoning_config={"enabled": True, "effort": "low"},
+            platform="cli",
+        )
+
+        assert result == {
+            "reasoning_config": {"enabled": True, "effort": "high"}
+        }
 
     def test_shlex_handles_paths_with_spaces(self, tmp_path):
         dir_with_space = tmp_path / "path with space"

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -45,6 +45,8 @@ class _FakeAgent:
         self.base_url = "https://openrouter.ai/api/v1"
         self.api_key = "sk-x"
         self.api_mode = "chat_completions"
+        self.reasoning_config = {"enabled": True, "effort": "low"}
+        self._turn_reasoning_config = None
         self.platform = "cli"
         self.quiet_mode = True
         self.max_iterations = 90
@@ -199,6 +201,53 @@ def test_task_id_passthrough():
     ctx = _build(agent, task_id="fixed-task")
     assert ctx.effective_task_id == "fixed-task"
     assert agent._current_task_id == "fixed-task"
+
+
+def test_pre_llm_call_sets_turn_reasoning_and_context():
+    agent = _FakeAgent()
+    hook_result = {
+        "context": "plugin context",
+        "reasoning_config": {"enabled": True, "effort": "high"},
+    }
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]) as invoke:
+        ctx = _build(agent)
+
+    assert ctx.plugin_user_context == "plugin context"
+    assert agent._turn_reasoning_config == {"enabled": True, "effort": "high"}
+    assert invoke.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "low",
+    }
+    assert invoke.call_args.kwargs["reasoning_config"] is not agent.reasoning_config
+    assert hook_result["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+def test_pre_llm_call_resets_stale_turn_reasoning():
+    agent = _FakeAgent()
+    agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        _build(agent)
+
+    assert agent._turn_reasoning_config is None
+
+
+def test_last_pre_llm_call_reasoning_override_wins():
+    agent = _FakeAgent()
+    hook_results = [
+        {"reasoning_config": {"enabled": True, "effort": "medium"}},
+        {"reasoning_config": {"enabled": True, "effort": "high"}},
+    ]
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=hook_results):
+        ctx = _build(agent)
+
+    assert ctx.plugin_user_context == ""
+    assert agent._turn_reasoning_config == {"enabled": True, "effort": "high"}
 
 
 def test_persist_user_message_becomes_original():
@@ -416,4 +465,3 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
-

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -729,6 +729,42 @@ class TestPluginHooks:
         assert len(results) == 1
         assert results[0] == {"context": "memory from plugin"}
 
+    def test_discovered_pre_llm_hook_returns_reasoning_override(
+        self, tmp_path, monkeypatch
+    ):
+        """An enabled user plugin can supply the documented turn override."""
+        hermes_home = tmp_path / "hermes_test"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _make_plugin_dir(
+            hermes_home / "plugins",
+            "reasoning_plugin",
+            register_body=(
+                'ctx.register_hook("pre_llm_call", '
+                'lambda **kw: {"reasoning_config": '
+                '{"enabled": True, "effort": "high"}})'
+            ),
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        plugin = next(
+            item for item in mgr.list_plugins() if item["key"] == "reasoning_plugin"
+        )
+        assert plugin["enabled"] is True
+        assert plugin["hooks"] == 1
+        assert mgr.invoke_hook(
+            "pre_llm_call",
+            session_id="s1",
+            user_message="use high reasoning",
+            conversation_history=[],
+            is_first_turn=True,
+            model="test",
+            reasoning_config={"enabled": True, "effort": "low"},
+        ) == [
+            {"reasoning_config": {"enabled": True, "effort": "high"}}
+        ]
+
     def test_hook_none_returns_excluded(self, tmp_path, monkeypatch):
         """invoke_hook() excludes None returns from the result list."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1955,6 +1955,21 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
 
+    def test_reasoning_config_turn_override_wins(self, agent):
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["extra_body"]["reasoning"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
     def test_reasoning_not_sent_for_unsupported_openrouter_model(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"
         agent.model = "minimax/minimax-m2.5"
@@ -3859,6 +3874,54 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_uses_turn_reasoning_override(self, agent):
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}], 60
+        )
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["extra_body"]["reasoning"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+    def test_summary_retry_uses_turn_reasoning_override(self, agent):
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=""),
+            _mock_response(content="Retry summary"),
+        ]
+        agent._cached_system_prompt = "You are helpful."
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}], 60
+        )
+
+        assert result == "Retry summary"
+        request_kwargs = [
+            call.kwargs for call in agent.client.chat.completions.create.call_args_list
+        ]
+        assert len(request_kwargs) == 2
+        assert [call["extra_body"]["reasoning"] for call in request_kwargs] == [
+            {"enabled": True, "effort": "high"},
+            {"enabled": True, "effort": "high"},
+        ]
+
     def test_summary_request_removes_orphan_tool_result(self, agent):
         """Regression: max-iterations summary request must NOT contain
         orphan tool results (tool_call_id with no matching assistant tool_call)."""
@@ -4403,6 +4466,180 @@ class TestRunConversation:
         assert result["final_response"] == "No listeners"
         assert hook_checks == {"pre_api_request": 1, "post_api_request": 1}
         assert payload_counts == {"request": 0, "response": 0}
+
+    def test_pre_llm_reasoning_override_spans_tool_loop_and_resets_next_turn(
+        self, agent
+    ):
+        self._setup_agent(agent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        tool_call = _mock_tool_call(
+            name="web_search", arguments="{}", call_id="reasoning-contract-tool"
+        )
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[tool_call],
+            ),
+            _mock_response(content="First answer", finish_reason="stop"),
+            _mock_response(content="Second answer", finish_reason="stop"),
+        ]
+
+        hook_calls = []
+        pre_llm_count = 0
+
+        def _hook(name, **kwargs):
+            nonlocal pre_llm_count
+            hook_calls.append((name, kwargs))
+            if name == "pre_llm_call":
+                pre_llm_count += 1
+                if pre_llm_count == 1:
+                    return [
+                        {
+                            "reasoning_config": {
+                                "enabled": True,
+                                "effort": "high",
+                            }
+                        }
+                    ]
+            return []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch(
+                "hermes_cli.plugins.has_hook",
+                side_effect=lambda name: name == "pre_api_request",
+            ),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            first_result = agent.run_conversation("use a tool")
+            assert agent._turn_reasoning_config is None
+            second_result = agent.run_conversation(
+                "answer without a tool",
+                conversation_history=first_result["messages"],
+            )
+
+        assert first_result["final_response"] == "First answer"
+        assert second_result["final_response"] == "Second answer"
+
+        request_kwargs = [
+            call.kwargs for call in agent.client.chat.completions.create.call_args_list
+        ]
+        assert len(request_kwargs) == 3
+        assert [
+            call["extra_body"]["reasoning"] for call in request_kwargs[:2]
+        ] == [
+            {"enabled": True, "effort": "high"},
+            {"enabled": True, "effort": "high"},
+        ]
+        assert request_kwargs[2]["extra_body"]["reasoning"] == {
+            "enabled": True,
+            "effort": "low",
+        }
+
+        pre_llm_calls = [
+            kwargs for name, kwargs in hook_calls if name == "pre_llm_call"
+        ]
+        pre_request_calls = [
+            kwargs for name, kwargs in hook_calls if name == "pre_api_request"
+        ]
+        assert len(pre_llm_calls) == 2
+        assert len(pre_request_calls) == 3
+        assert all(
+            call["reasoning_config"] == {"enabled": True, "effort": "low"}
+            and call["reasoning_config"] is not agent.reasoning_config
+            for call in pre_llm_calls
+        )
+        first_turn_id = pre_llm_calls[0]["turn_id"]
+        second_turn_id = pre_llm_calls[1]["turn_id"]
+        assert first_turn_id != second_turn_id
+        assert [call["turn_id"] for call in pre_request_calls] == [
+            first_turn_id,
+            first_turn_id,
+            second_turn_id,
+        ]
+        assert agent._turn_reasoning_config is None
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_non_dictionary_pre_llm_reasoning_override_uses_baseline(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Baseline answer", finish_reason="stop"
+        )
+
+        def _hook(name, **_kwargs):
+            if name == "pre_llm_call":
+                return [{"reasoning_config": "high"}]
+            return []
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("ignore an invalid override")
+
+        assert result["final_response"] == "Baseline answer"
+        assert agent.client.chat.completions.create.call_args.kwargs["extra_body"][
+            "reasoning"
+        ] == {"enabled": True, "effort": "low"}
+        assert agent._turn_reasoning_config is None
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_pre_llm_hook_exception_fails_open_to_reasoning_baseline(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "anthropic/claude-sonnet-4-20250514"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Baseline answer", finish_reason="stop"
+        )
+
+        def _hook(name, **_kwargs):
+            if name == "pre_llm_call":
+                raise RuntimeError("plugin failed")
+            return []
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue despite hook failure")
+
+        assert result["final_response"] == "Baseline answer"
+        assert agent.client.chat.completions.create.call_args.kwargs["extra_body"][
+            "reasoning"
+        ] == {"enabled": True, "effort": "low"}
+        assert agent._turn_reasoning_config is None
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_turn_reasoning_override_clears_when_conversation_raises(self, agent):
+        agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+
+        with (
+            patch(
+                "agent.conversation_loop.run_conversation",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            agent.run_conversation("hello")
+
+        assert agent._turn_reasoning_config is None
 
     def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
         self._setup_agent(agent)
@@ -6843,6 +7080,20 @@ class TestBuildApiKwargsAnthropicMaxTokens:
                 assert call_args[1].get("max_tokens") is None
             else:
                 assert call_args[0][3] is None
+
+    def test_turn_reasoning_override_passed_to_anthropic(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.reasoning_config = {"enabled": True, "effort": "low"}
+        agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+
+        with patch("agent.anthropic_adapter.build_anthropic_kwargs") as mock_build:
+            mock_build.return_value = {"model": agent.model, "messages": []}
+            agent._build_api_kwargs([{"role": "user", "content": "test"}])
+
+        assert mock_build.call_args.kwargs["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+        }
 
 
 class TestAnthropicImageFallback:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -400,6 +400,22 @@ def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     assert kwargs["reasoning"]["effort"] == "low"
 
 
+def test_build_api_kwargs_codex_uses_turn_reasoning_override(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.reasoning_config = {"enabled": True, "effort": "low"}
+    agent._turn_reasoning_config = {"enabled": True, "effort": "high"}
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert kwargs["reasoning"]["effort"] == "high"
+    assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+
 def test_build_api_kwargs_codex_preserves_supported_efforts(monkeypatch):
     """Effort levels natively supported by the Responses API pass through unchanged."""
     _patch_agent_bootstrap(monkeypatch)

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -599,7 +599,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
 | [`post_tool_call`](/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str, duration_ms: int` | ignored |
-| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
+| [`pre_llm_call`](/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, reasoning_config: dict \| None, platform: str` | [context and reasoning overrides](#pre_llm_call-context-and-reasoning-overrides) |
 | [`post_llm_call`](/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
@@ -609,21 +609,30 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
 
-Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
+Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation and override reasoning options for the current turn.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
 
-### `pre_llm_call` context injection
+### `pre_llm_call` context and reasoning overrides
 
-This is the only hook whose return value matters. When a `pre_llm_call` callback returns a dict with a `"context"` key (or a plain string), Hermes injects that text into the **current turn's user message**. This is the mechanism for memory plugins, RAG integrations, guardrails, and any plugin that needs to provide the model with additional context.
+When a `pre_llm_call` callback returns a dict, it can inject text into the **current turn's user message** with `"context"`, override the turn's model reasoning options with `"reasoning_config"`, or do both. A plain string remains equivalent to `{"context": "..."}`. The callback receives the configured `reasoning_config` as a keyword argument so it can make its decision without mutating agent state.
 
 #### Return format
 
 ```python
 # Dict with context key
 return {"context": "Recalled memories:\n- User prefers dark mode\n- Last project: hermes-agent"}
+
+# Reasoning override for this turn only
+return {"reasoning_config": {"enabled": True, "effort": "high"}}
+
+# Context and reasoning can be returned together
+return {
+    "context": "This request requires careful analysis.",
+    "reasoning_config": {"enabled": True, "effort": "high"},
+}
 
 # Plain string (equivalent to the dict form above)
 return "Recalled memories:\n- User prefers dark mode"
@@ -632,7 +641,7 @@ return "Recalled memories:\n- User prefers dark mode"
 return None
 ```
 
-Any non-None, non-empty return with a `"context"` key (or a plain non-empty string) is collected and appended to the user message for the current turn.
+Any non-empty `"context"` value (or plain non-empty string) is collected and appended to the user message for the current turn. A dictionary-valued `"reasoning_config"` replaces the configured reasoning options for every model request in that turn, including tool-loop follow-ups and an iteration-limit summary or retry. The configured value is not mutated and becomes active again after the turn. If multiple plugins return reasoning overrides, the last valid dictionary in plugin discovery order wins.
 
 #### Oversized-context spill
 
@@ -655,6 +664,8 @@ Injected context is appended to the **user message**, not the system prompt. Thi
 - **Prompt cache preservation** — the system prompt stays identical across turns. Anthropic and OpenRouter cache the system prompt prefix, so keeping it stable saves 75%+ on input tokens in multi-turn conversations. If plugins modified the system prompt, every turn would be a cache miss.
 - **Ephemeral** — the injection happens at API call time only. The original user message in the conversation history is never mutated, and nothing is persisted to the session database.
 - **The system prompt is Hermes's territory** — it contains model-specific guidance, tool enforcement rules, personality instructions, and cached skill content. Plugins contribute context alongside the user's input, not by altering the agent's core instructions.
+
+Reasoning overrides are also ephemeral. They affect request construction only while the current `run_conversation()` call is active and are cleared on every exit path.
 
 #### Example: Memory recall plugin
 
@@ -724,7 +735,7 @@ def register(ctx):
 
 #### Multiple plugins returning context
 
-When multiple plugins return context from `pre_llm_call`, their outputs are joined with double newlines and appended to the user message together. The order follows plugin discovery order (alphabetical by plugin directory name).
+When multiple plugins return context from `pre_llm_call`, their outputs are joined with double newlines and appended to the user message together. The order follows plugin discovery order (alphabetical by plugin directory name). For reasoning overrides, the last valid dictionary in that same order wins.
 
 ### Register CLI commands
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -371,7 +371,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context or override reasoning options for the current turn**. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -380,7 +380,7 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
-| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
+| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str, "reasoning_config": dict}`; either key may be omitted |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`pre_verify`](#pre_verify) | Once per turn when the agent edited code, before it verifies/finishes | `{"action": "continue", "message": str}` to keep going |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -510,13 +510,14 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. It can inject context into the current turn's user message, override reasoning options for that turn, or do both.
 
 **Callback signature:**
 
 ```python
 def my_callback(session_id: str, user_message: str, conversation_history: list,
-                is_first_turn: bool, model: str, platform: str, **kwargs):
+                is_first_turn: bool, model: str, reasoning_config: dict | None,
+                platform: str, **kwargs):
 ```
 
 | Parameter | Type | Description |
@@ -526,15 +527,25 @@ def my_callback(session_id: str, user_message: str, conversation_history: list,
 | `conversation_history` | `list` | Copy of the full message list (OpenAI format: `[{"role": "user", "content": "..."}]`) |
 | `is_first_turn` | `bool` | `True` if this is the first turn of a new session, `False` on subsequent turns |
 | `model` | `str` | The model identifier (e.g. `"anthropic/claude-sonnet-4.6"`) |
+| `reasoning_config` | `dict \| None` | The agent's configured reasoning options before any turn override |
 | `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
 
-**Fires:** In `run_agent.py`, inside `run_conversation()`, after context compression but before the main `while` loop. Fires once per `run_conversation()` call (i.e. once per user turn), not once per API call within the tool loop.
+**Fires:** In `agent/turn_context.py`, after context compression but before the main tool-calling loop. Fires once per `run_conversation()` call (i.e. once per user turn), not once per API call within the tool loop.
 
-**Return value:** If the callback returns a dict with a `"context"` key, or a plain non-empty string, the text is appended to the current turn's user message. Return `None` for no injection.
+**Return value:** A callback may return a dict containing `"context"`, `"reasoning_config"`, or both. A plain non-empty string is equivalent to `{"context": "..."}`. Return `None` to make no change.
 
 ```python
 # Inject context
 return {"context": "Recalled memories:\n- User likes Python\n- Working on hermes-agent"}
+
+# Increase reasoning effort for this turn
+return {"reasoning_config": {"enabled": True, "effort": "high"}}
+
+# Combine both behaviors
+return {
+    "context": "Treat this as a high-risk migration.",
+    "reasoning_config": {"enabled": True, "effort": "high"},
+}
 
 # Plain string (equivalent)
 return "Recalled memories:\n- User likes Python"
@@ -547,9 +558,11 @@ return None
 
 All injected context is **ephemeral** — added at API call time only. The original user message in the conversation history is never mutated, and nothing is persisted to the session database.
 
-When **multiple plugins** return context, their outputs are joined with double newlines in plugin discovery order (alphabetical by directory name).
+Reasoning overrides are also **ephemeral**. They apply to every model request in the current turn, including tool-loop follow-ups and iteration-limit summary or retry requests. The configured `reasoning_config` is never mutated and becomes active again after the turn.
 
-**Use cases:** Memory recall, RAG context injection, guardrails, per-turn analytics.
+When **multiple plugins** return context, their outputs are joined with double newlines in plugin discovery order (alphabetical by directory name). When multiple plugins return reasoning overrides, the last valid dictionary in that order wins.
+
+**Use cases:** Memory recall, RAG context injection, guardrails, per-turn analytics, and selectively increasing or disabling model reasoning.
 
 **Example — memory recall:**
 
@@ -1339,7 +1352,7 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 }
 ```
 
-`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
+`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `reasoning_config`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
 
 **stdout — optional response:**
 
@@ -1350,6 +1363,9 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 
 // Inject context for pre_llm_call:
 {"context": "Today is Friday, 2026-04-17"}
+
+// Inject context and increase reasoning for the current turn:
+{"context": "This needs careful analysis", "reasoning_config": {"enabled": true, "effort": "high"}}
 
 // Keep the agent going at the verify gate (pre_verify); both shapes accepted:
 {"action": "continue", "message": "Run the formatter, then finish."}


### PR DESCRIPTION
## What changed and why

Adds support for `pre_llm_call` hooks to return a per-turn `reasoning_config`, for example:

```json
{"reasoning_config": {"enabled": true, "effort": "high"}}
```

This lets plugins adjust reasoning effort for the current LLM turn without mutating the agent's configured default. The override applies to every request in that turn, including tool follow-ups and iteration-limit summary retries, and is cleared before the next turn.

## Implementation

- Processes the turn-scoped override in `agent/turn_context.py`.
- Applies it through the current request-building paths in `agent/chat_completion_helpers.py`.
- Preserves configured `agent.reasoning_config` as the fallback.
- Clears the override in the conversation `finally` path.
- Documents the Python-plugin and shell-hook return contract.
- Composes with per-model reasoning resolution: the per-turn override has request-time priority while the resolved per-model configuration remains the persistent baseline.

## Validation

- Focused reasoning, fallback, model-switch, plugin, shell-hook, and background-review matrix: **818 passed**
- Core `tests/run_agent/test_run_agent.py`: **440 passed**
- Ruff, lock verification, Windows-footgun checks, diagram lint, and Docusaurus build passed.
- The full suite completed with 27 failures across 14 untouched, environment-sensitive files; no affected-path failures.

### Live validation

Live testing used isolated Ubuntu 24.04 canaries with baseline effort `low`:

| Adapter | Model | High-effort request representation | Result |
|---|---|---|---|
| Codex Responses | `gpt-5.6-sol` | `reasoning.effort=high` | Pass |
| Chat Completions | `openrouter/qwen/qwen3.6-plus` | `reasoning_effort=high` | Pass |
| Anthropic Messages | `claude-sonnet-5` | `thinking.type=adaptive`, `output_config.effort=high` | Pass |

For every adapter:

- `pre_llm_call` ran exactly once per user turn and received the unchanged configured `low` baseline.
- The high turn's initial request and tool follow-up shared one `turn_id` and both used `high`.
- The next turn received a new `turn_id` and returned to `low`.
- Persistent reasoning configuration remained unchanged.
- Tool execution and the requested functional responses completed successfully.
- No reasoning parameter was rejected.

## Platforms tested

- macOS / Darwin
- Ubuntu 24.04 containers

## Related issues

None.
