### PR TITLE
fix(plugins): prevent TOCTOU race in get_plugin_manager()

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1284,13 +1284,16 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
     """Return (and lazily create) the global PluginManager singleton."""
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,7 +3,9 @@
 import logging
 import os
 import sys
+import threading
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1285,6 +1287,81 @@ class TestPluginDebugLogging:
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
 
+
+class TestGetPluginManagerToctouRace:
+    """Regression tests for the TOCTOU race in get_plugin_manager().
+
+    Before the fix, two threads could both observe _plugin_manager is None,
+    each create a PluginManager(), and race to write the global. The second
+    write wins; the first manager — including any hooks or plugins discovered
+    on it — is orphaned, and the global singleton ends up undiscovered.
+    """
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        """50 threads calling get_plugin_manager() concurrently must all
+        receive the exact same PluginManager object (identity, not equality)."""
+        from hermes_cli import plugins as pm_mod
+
+        monkeypatch.setattr(pm_mod, "_plugin_manager", None)
+
+        n = 50
+        barrier = threading.Barrier(n)
+        results: list = []
+        result_lock = threading.Lock()
+
+        def worker():
+            barrier.wait()
+            mgr = pm_mod.get_plugin_manager()
+            with result_lock:
+                results.append(id(mgr))
+
+        with ThreadPoolExecutor(max_workers=n) as ex:
+            futures = [ex.submit(worker) for _ in range(n)]
+            for f in futures:
+                f.result()
+
+        assert len(results) == n
+        assert len(set(results)) == 1, (
+            f"Expected 1 unique PluginManager instance, got {len(set(results))} — "
+            "TOCTOU race allowed multiple instances to be created"
+        )
+
+    def test_only_one_instance_created(self, monkeypatch):
+        """get_plugin_manager() must construct exactly one PluginManager even
+        under concurrent load. Counts constructor calls via a spy."""
+        from hermes_cli import plugins as pm_mod
+
+        monkeypatch.setattr(pm_mod, "_plugin_manager", None)
+
+        construction_count = 0
+        count_lock = threading.Lock()
+        original_cls = pm_mod.PluginManager
+
+        class SpyPluginManager(original_cls):
+            def __init__(self):
+                nonlocal construction_count
+                with count_lock:
+                    construction_count += 1
+                super().__init__()
+
+        monkeypatch.setattr(pm_mod, "PluginManager", SpyPluginManager)
+
+        n = 50
+        barrier = threading.Barrier(n)
+
+        def worker():
+            barrier.wait()
+            pm_mod.get_plugin_manager()
+
+        with ThreadPoolExecutor(max_workers=n) as ex:
+            futures = [ex.submit(worker) for _ in range(n)]
+            for f in futures:
+                f.result()
+
+        assert construction_count == 1, (
+            f"PluginManager constructed {construction_count} times — "
+            "lock did not prevent duplicate construction"
+        )
     def test_debug_handler_idempotent(self, monkeypatch):
         """Calling install twice (without force) does not double-attach."""
         monkeypatch.setenv("HERMES_PLUGINS_DEBUG", "1")


### PR DESCRIPTION
## Summary

Fixes a time-of-check/time-of-use (TOCTOU) race in `hermes_cli/plugins.py:get_plugin_manager()`.

**Root cause:** `_plugin_manager` had no lock, so two threads could both observe `None`, each construct a `PluginManager()`, and race to write the global. The second write wins; the first manager — including hooks and plugins already registered on it — is orphaned. Any caller that gets the global after the overwrite sees an undiscovered (empty) singleton.

**Impact:** In gateway deployments where multiple agent threads start concurrently (e.g. `model_tools.py`, `tools/skills_tool.py`, or any platform adapter calling `discover_plugins()`), the race causes `invoke_hook()` to fire no hooks and plugin-registered tools to be silently absent for the lifetime of the process.

**Fix:** Double-checked locking — `threading` is already imported by `plugins.py`:

```python
_plugin_manager_lock = threading.Lock()

def get_plugin_manager() -> PluginManager:
    global _plugin_manager
    if _plugin_manager is None:
        with _plugin_manager_lock:
            if _plugin_manager is None:
                _plugin_manager = PluginManager()
    return _plugin_manager
```

Matches the pattern already applied to `providers/__init__.py` (#24696), `agent/transports/__init__.py` (#24692), and `plugins/platforms/google_chat/adapter.py` (#24679).

## Changes

- `hermes_cli/plugins.py`: add `_plugin_manager_lock`; apply double-checked locking to `get_plugin_manager()`
- `tests/hermes_cli/test_plugins.py`: add `TestGetPluginManagerToctouRace` — 50-thread Barrier identity test + spy constructor-count test

## Test plan

- [x] `uv run pytest tests/hermes_cli/test_plugins.py` — 67 passed
- [x] New `TestGetPluginManagerToctouRace`: 2 tests confirm singleton identity and exactly-one-construction invariant under concurrent load

Closes #24714