### PR TITLE
fix(plugins): lock lazy plugin manager singleton init

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1284,13 +1284,16 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
     """Return (and lazily create) the global PluginManager singleton."""
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,6 +3,8 @@
 import logging
 import os
 import sys
+import threading
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -88,6 +90,44 @@ def _make_plugin_dir(base: Path, name: str, *, register_body: str = "pass",
 
 class TestPluginDiscovery:
     """Tests for plugin discovery from directories and entry points."""
+
+    def test_get_plugin_manager_singleton_init_is_thread_safe(self):
+        """Concurrent lazy init must not create orphaned PluginManager instances."""
+        import hermes_cli.plugins as plugins_mod
+
+        first_started = threading.Event()
+        allow_finish = threading.Event()
+        created: list[object] = []
+
+        class FakeManager:
+            def __init__(self):
+                created.append(self)
+                if len(created) == 1:
+                    first_started.set()
+                    assert allow_finish.wait(timeout=1), "timed out waiting to release first constructor"
+
+        results: list[object] = []
+
+        def _worker():
+            results.append(plugins_mod.get_plugin_manager())
+
+        with patch.object(plugins_mod, "_plugin_manager", None), patch.object(
+            plugins_mod, "PluginManager", FakeManager
+        ):
+            t1 = threading.Thread(target=_worker)
+            t2 = threading.Thread(target=_worker)
+            t1.start()
+            assert first_started.wait(timeout=1), "first constructor never started"
+            t2.start()
+            time.sleep(0.05)
+            assert len(created) == 1
+            allow_finish.set()
+            t1.join(timeout=1)
+            t2.join(timeout=1)
+
+        assert len(created) == 1
+        assert len(results) == 2
+        assert results[0] is results[1]
 
     def test_discover_user_plugins(self, tmp_path, monkeypatch):
         """Plugins in ~/.hermes/plugins/ are discovered."""


### PR DESCRIPTION
## Summary
- lock `get_plugin_manager()` with double-checked locking so concurrent lazy init cannot orphan a discovered `PluginManager`
- add a regression test that holds the first constructor open and proves a second thread does not create a replacement manager

## Testing
- `uv run --frozen --extra dev pytest tests/hermes_cli/test_plugins.py -q -o addopts=''`
- `git diff --check HEAD^ HEAD`
- `uv run --frozen ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugins.py`

## Notes
- Closes #24714.
- Known shared GitHub CI noise may still exist outside this diff; local proof for `c1905e8c1be1657ed892c1b774cee4b6b573a313` is green.
