### PR TITLE
fix(plugins): add double-checked locking to get_plugin_manager() singleton

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1284,13 +1284,16 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
     """Return (and lazily create) the global PluginManager singleton."""
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1306,3 +1307,28 @@ class TestPluginDebugLogging:
             plugins_mod._PLUGINS_DEBUG = original_debug
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
+
+
+class TestGetPluginManagerThreadSafety:
+    """get_plugin_manager() must return the same singleton from concurrent threads."""
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        import hermes_cli.plugins as plugins_mod
+
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+        results: list = []
+        barrier = threading.Barrier(8)
+
+        def _call():
+            barrier.wait()
+            results.append(get_plugin_manager())
+
+        threads = [threading.Thread(target=_call) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 8
+        assert len(set(id(r) for r in results)) == 1, "all threads must get the same instance"


### PR DESCRIPTION
## Problem

`get_plugin_manager()` uses a module-level singleton initialised lazily on first call. Under concurrent access (e.g. multiple async tasks / threads calling it simultaneously at startup) the single `if _plugin_manager is None` guard is not atomic, so two or more threads can observe `None` at the same time and each construct a separate `PluginManager` instance. Subsequent callers receive whichever instance happens to win the last assignment, discarding all plugins that were discovered only by the losing constructors.

## Root cause

Classic TOCTOU (time-of-check / time-of-use) race in a lazy singleton:

```python
# before
if _plugin_manager is None:          # ← N threads all see None here
    _plugin_manager = PluginManager() # ← N instances created, N-1 discarded
```

## Fix

Double-checked locking (DCL) with a module-level `threading.Lock`:

```python
_plugin_manager_lock = threading.Lock()

def get_plugin_manager() -> PluginManager:
    global _plugin_manager
    if _plugin_manager is None:             # fast path (no lock)
        with _plugin_manager_lock:
            if _plugin_manager is None:     # slow path (under lock)
                _plugin_manager = PluginManager()
    return _plugin_manager
```

`threading` was already imported at line 44 of `plugins.py` — no new dependency.

## Tests

`TestGetPluginManagerThreadSafety.test_concurrent_calls_return_same_instance` in `tests/hermes_cli/test_plugins.py`:

* Resets `_plugin_manager` to `None` via `monkeypatch`
* Fires 8 threads through a `threading.Barrier` so they all call `get_plugin_manager()` simultaneously
* Asserts every thread received the **same object** (`id` check)

## Visual

```mermaid
sequenceDiagram
    participant T1
    participant T2
    participant Lock
    participant Singleton

    T1->>Singleton: _plugin_manager is None? → True
    T2->>Singleton: _plugin_manager is None? → True
    T1->>Lock: acquire
    T1->>Singleton: _plugin_manager is None? → True (DCL)
    T1->>Singleton: _plugin_manager = PluginManager()
    T1->>Lock: release
    T2->>Lock: acquire
    T2->>Singleton: _plugin_manager is None? → False (DCL)
    T2->>Lock: release
    T2->>Singleton: return existing instance
```

Closes #24714