### PR TITLE
fix(openrouter): prevent TOCTOU race in get_async_client()

### DIFF
--- a/tests/tools/test_openrouter_client.py
+++ b/tests/tools/test_openrouter_client.py
@@ -1,0 +1,98 @@
+"""Regression tests for tools/openrouter_client.py.
+
+Covers the TOCTOU race in get_async_client() fixed in Issue #24731:
+two threads simultaneously seeing _client=None could each call
+resolve_provider_client() and create duplicate async HTTP clients.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _reset_module():
+    """Reset the openrouter_client module singleton so each test starts fresh."""
+    import tools.openrouter_client as mod
+    mod._client = None
+
+
+class TestGetAsyncClientToctouRace:
+    """50-thread barrier tests for get_async_client() double-checked locking."""
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        """All 50 concurrent callers must receive the exact same client object."""
+        _reset_module()
+
+        fake_client = MagicMock(name="fake_async_client")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        import tools.openrouter_client as mod
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(fake_client, "some-model")):
+            barrier = threading.Barrier(50)
+            results: list = []
+            lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                client = mod.get_async_client()
+                with lock:
+                    results.append(client)
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert len(results) == 50
+        first = results[0]
+        assert all(r is first for r in results), (
+            f"Expected 1 unique client, got {len(set(id(r) for r in results))}"
+        )
+
+    def test_only_one_client_created(self, monkeypatch):
+        """resolve_provider_client must be called exactly once regardless of concurrency."""
+        _reset_module()
+
+        call_count = 0
+        call_lock = threading.Lock()
+        fake_client = MagicMock(name="fake_async_client")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+        import tools.openrouter_client as mod
+
+        def counting_resolver(provider, *, async_mode=False):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+            return fake_client, "some-model"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=counting_resolver):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                mod.get_async_client()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"resolve_provider_client called {call_count} times (expected 1)"
+
+
+class TestCheckApiKey:
+    def test_returns_true_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        import tools.openrouter_client as mod
+        assert mod.check_api_key() is True
+
+    def test_returns_false_when_key_absent(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        import tools.openrouter_client as mod
+        assert mod.check_api_key() is False

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -7,8 +7,10 @@ consistently.
 """
 
 import os
+import threading
 
 _client = None
+_client_lock = threading.Lock()
 
 
 def get_async_client():
@@ -20,11 +22,13 @@ def get_async_client():
     """
     global _client
     if _client is None:
-        from agent.auxiliary_client import resolve_provider_client
-        client, _model = resolve_provider_client("openrouter", async_mode=True)
-        if client is None:
-            raise ValueError("OPENROUTER_API_KEY environment variable not set")
-        _client = client
+        with _client_lock:
+            if _client is None:
+                from agent.auxiliary_client import resolve_provider_client
+                client, _model = resolve_provider_client("openrouter", async_mode=True)
+                if client is None:
+                    raise ValueError("OPENROUTER_API_KEY environment variable not set")
+                _client = client
     return _client
 
 


### PR DESCRIPTION
## What does this PR do?

`tools/openrouter_client.get_async_client()` used a bare `if _client is None:` guard with no lock. Under concurrent load two threads can simultaneously see `_client=None`, both call `resolve_provider_client("openrouter", async_mode=True)`, and construct two separate `AsyncOpenAI` HTTP clients. The losing thread's client is assigned to `_client` but the winning thread's client is already in use — or vice versa — leaving an orphaned connection pool that is never closed.

## Root cause

`tools/openrouter_client.get_async_client()` used a bare `if _client is None:` guard with no lock. Under concurrent load two threads can simultaneously see `_client=None`, both call `resolve_provider_client("openrouter", async_mode=True)`, and construct two separate `AsyncOpenAI` HTTP clients. The losing thread's client is assigned to `_client` but the winning thread's client is already in use — or vice versa — leaving an orphaned connection pool that is never closed.

## Fix

Double-checked locking:
- Fast lock-free early-return when `_client` is already set (common path)
- Re-check inside `_client_lock` before calling `resolve_provider_client` (init path, once per process)

```python
_client_lock = threading.Lock()

def get_async_client():
    global _client
    if _client is None:
        with _client_lock:
            if _client is None:
                from agent.auxiliary_client import resolve_provider_client
                client, _model = resolve_provider_client("openrouter", async_mode=True)
                if client is None:
                    raise ValueError("OPENROUTER_API_KEY environment variable not set")
                _client = client
    return _client
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24731

<details>
<summary>Original body</summary>

## Summary

`tools/openrouter_client.get_async_client()` used a bare `if _client is None:` guard with no lock. Under concurrent load two threads can simultaneously see `_client=None`, both call `resolve_provider_client("openrouter", async_mode=True)`, and construct two separate `AsyncOpenAI` HTTP clients. The losing thread's client is assigned to `_client` but the winning thread's client is already in use — or vice versa — leaving an orphaned connection pool that is never closed.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`tools/openrouter_client.get_async_client()` used a bare `if _client is None:` guard with no lock. Under concurrent load two threads can simultaneously see `_client=None`, both call `resolve_provider_client("openrouter", async_mode=True)`, and construct two separate `AsyncOpenAI` HTTP clients. The losing thread's client is assigned to `_client` but the winning thread's client is already in use — or vice versa — leaving an orphaned connection pool that is never closed.

## Fix

Double-checked locking:
- Fast lock-free early-return when `_client` is already set (common path)
- Re-check inside `_client_lock` before calling `resolve_provider_client` (init path, once per process)

```python
_client_lock = threading.Lock()

def get_async_client():
    global _client
    if _client is None:
        with _client_lock:
            if _client is None:
                from agent.auxiliary_client import resolve_provider_client
                client, _model = resolve_provider_client("openrouter", async_mode=True)
                if client is None:
                    raise ValueError("OPENROUTER_API_KEY environment variable not set")
                _client = client
    return _client
```

## Tests

`tests/tools/test_openrouter_client.py` — `TestGetAsyncClientToctouRace`:

- **`test_concurrent_calls_return_same_instance`** — 50-thread `Barrier` race; all 50 callers must receive the identical object (`is` check).
- **`test_only_one_client_created`** — spy on `resolve_provider_client`; asserts call count == 1 despite 50 concurrent callers.

All 4 tests pass (`uv run python -m pytest tests/tools/test_openrouter_client.py -v`).

Closes #24731

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24731

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_