### PR TITLE
fix(lazy_deps): use sys.prefix for venv_root in Docker overlay environments

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,6 +12,8 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -226,3 +228,55 @@ class TestIsAvailable:
         monkeypatch.setitem(ld.LAZY_DEPS, "test.miss", ("zzzfake>=1",))
         monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
         assert ld.is_available("test.miss") is False
+
+
+# --------------------------------------------------------------------------
+# Docker overlay path fix — sys.prefix vs executable.parent.parent
+# --------------------------------------------------------------------------
+
+
+class TestVenvRootResolution:
+    """Regression test for Docker overlay path issue.
+
+    In a Docker image with a volume mounted at /opt/data and packages
+    installed at /opt/hermes, ``sys.executable`` resolves to something inside
+    the overlay (e.g. /opt/data/.venv/bin/python) while ``sys.prefix`` is
+    /opt/hermes (the actual venv root).  Using executable.parent.parent
+    caused lazy_deps to install into the overlay volume, where the package
+    was lost on container restart.  Using sys.prefix targets the real
+    site-packages regardless of overlay mounts.
+    """
+
+    def test_sys_prefix_is_used_as_venv_root(self, monkeypatch, tmp_path):
+        """Verify _venv_pip_install targets sys.prefix, not executable.parent.parent.
+
+        In Docker with /opt/data volume overlay and /opt/hermes as the real venv,
+        sys.executable may point inside the overlay while sys.prefix = /opt/hermes.
+        We verify the VIRTUAL_ENV passed to the install command matches sys.prefix.
+        """
+        # Simulate: real venv is /opt/hermes, but executable is accessed via overlay
+        real_venv = str(tmp_path / "hermes")
+        (Path(real_venv) / "bin").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(sys, "prefix", real_venv)
+        # executable resolves to overlay path (simulates /opt/data/.local/bin/python)
+        overlay_exec = str(tmp_path / "data" / ".local" / "bin" / "python")
+        (tmp_path / "data" / ".local" / "bin").mkdir(parents=True)
+        Path(overlay_exec).touch()
+        monkeypatch.setattr(sys, "executable", overlay_exec)
+
+        captured_venv = {}
+        def fake_run(cmd, *args, **kwargs):
+            env = kwargs.get("env", {})
+            captured_venv["virtual_env"] = env.get("VIRTUAL_ENV", "MISSING")
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+        ld._venv_pip_install(("fake-pkg>=1",))
+
+        assert captured_venv.get("virtual_env") == real_venv, (
+            f"Expected VIRTUAL_ENV={real_venv!r}, "
+            f"got {captured_venv.get('virtual_env')!r}. "
+            "Using executable.parent.parent would give the overlay path. "
+            "sys.prefix must be used instead."
+        )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -277,7 +277,11 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     if not specs:
         return _InstallResult(True, "", "")
 
-    venv_root = Path(sys.executable).parent.parent
+    # Use sys.prefix instead of executable.parent.parent so that Docker
+    # environments with overlaid /opt/data volumes resolve to /opt/hermes
+    # (where packages are installed) rather than the data volume mount point.
+    # Fixes: python-telegram-bot lazy-install silently fails in Docker.
+    venv_root = Path(sys.prefix)
     uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
 
     # Tier 1: uv (preferred — fast, doesn't need pip in the venv)


### PR DESCRIPTION
## Summary
In the official Docker image, HERMES_HOME=/opt/data is a volume mount while packages are installed at /opt/hermes. Path(sys.executable).parent.parent resolves through the overlay to /opt/data, causing lazy installs (python-telegram-bot, etc.) to write to the ephemeral overlay layer instead of site-packages. After container restart the packages are gone.

sys.prefix is /opt/hermes in the Docker image and always points to the real venv regardless of how the Python interpreter was invoked.

fixes #24698

## Files changed
- tools/lazy_deps.py — 1 line: use sys.prefix instead of executable.parent.parent
- tests/tools/test_lazy_deps.py — regression test + missing imports (sys, Path)

## Tests
44 passed (full lazy_deps suite)