### PR TITLE
fix(agent): preserve reasoning_content on Xiaomi MiMo thinking endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,33 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+def _is_xiaomi_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Xiaomi MiMo's Anthropic-compatible endpoint.
+
+    Xiaomi's ``/anthropic`` route (e.g. ``token-plan-cn.xiaomimimo.com/anthropic``)
+    speaks the Anthropic Messages protocol but, when thinking mode is enabled
+    server-side, requires ``reasoning_content`` (synthesised as an unsigned
+    thinking block) to round-trip on subsequent requests.  The generic
+    third-party path strips them and triggers HTTP 400::
+
+        The reasoning_content in the thinking mode must be passed back
+        to the API.
+
+    Xiaomi MiMo (mimo-v2.5-pro, mimo-v2.5, …) is a DeepSeek-derived
+    thinking-capable model family, so the same strip-signed / keep-unsigned
+    policy used for DeepSeek's ``/anthropic`` and Kimi's ``/coding``
+    endpoints applies here.  The match is pinned to the ``/anthropic``
+    path so the OpenAI-compatible ``api.xiaomimimo.com/v1`` base URL
+    (which never reaches this adapter) is not misclassified.
+    """
+    if not base_url_host_matches(base_url or "", "xiaomimimo.com"):
+        return False
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return "/anthropic" in normalized.rstrip("/").lower()
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1746,15 +1773,19 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
-    # Anthropic Messages protocol upstream but require that thinking blocks
-    # synthesised from reasoning_content round-trip on subsequent turns when
-    # thinking is enabled.  Signed Anthropic blocks still have to be stripped
-    # (neither endpoint can validate Anthropic's signatures); unsigned blocks
-    # are preserved.  See hermes-agent#13848 (Kimi) and #16748 (DeepSeek).
+    # Kimi /coding, DeepSeek /anthropic, and Xiaomi MiMo /anthropic share
+    # a contract: all three speak the Anthropic Messages protocol upstream
+    # but require that thinking blocks synthesised from reasoning_content
+    # round-trip on subsequent turns when thinking is enabled.  Signed
+    # Anthropic blocks still have to be stripped (none of these endpoints
+    # can validate Anthropic's signatures); unsigned blocks are preserved.
+    # See hermes-agent#13848 (Kimi) and #16748 (DeepSeek); Xiaomi MiMo
+    # reports ``The reasoning_content in the thinking mode must be passed
+    # back to the API.`` from the same code path.
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_anthropic_endpoint(base_url)
     )
 
     last_assistant_idx = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -10112,13 +10112,16 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that
+        omit ``reasoning_content`` (refs #15250, #17400; Xiaomi reports
+        ``The reasoning_content in the thinking mode must be passed back
+        to the API.``).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_xiaomi_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10148,6 +10151,27 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_xiaomi_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        Xiaomi MiMo (mimo-v2.5-pro, mimo-v2.5, …) is a DeepSeek-derived
+        thinking-capable model family.  Both its OpenAI-compatible
+        ``api.xiaomimimo.com/v1`` endpoint and its Anthropic-compatible
+        ``token-plan-*.xiaomimimo.com/anthropic`` endpoints enforce the
+        same reasoning_content echo-back contract as DeepSeek; omitting
+        it causes HTTP 400 on replay::
+
+            The reasoning_content in the thinking mode must be passed
+            back to the API.
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or model.startswith("mimo-")
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:

--- a/tests/agent/test_xiaomi_anthropic_thinking.py
+++ b/tests/agent/test_xiaomi_anthropic_thinking.py
@@ -1,0 +1,184 @@
+"""Regression guard: preserve thinking blocks on Xiaomi MiMo's /anthropic endpoint.
+
+Xiaomi's ``token-plan-*.xiaomimimo.com/anthropic`` route speaks the Anthropic
+Messages protocol but, when thinking mode is enabled, requires reasoning
+content from prior assistant turns to round-trip on subsequent requests. The
+generic third-party path strips them and the next tool-call turn fails with
+HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the
+    API.
+
+Xiaomi MiMo (mimo-v2.5-pro, mimo-v2.5, …) is a DeepSeek-derived
+thinking-capable model family, so handling is the same as DeepSeek's
+``/anthropic`` endpoint: strip Anthropic-signed blocks (Xiaomi can't validate
+them) but preserve unsigned blocks that Hermes synthesises from
+``reasoning_content``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestXiaomiAnthropicPreservesThinking:
+    """convert_messages_to_anthropic must replay Xiaomi MiMo thinking blocks."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://token-plan-cn.xiaomimimo.com/anthropic",
+            "https://token-plan-sgp.xiaomimimo.com/anthropic",
+            "https://token-plan-ams.xiaomimimo.com/anthropic",
+            "https://api.xiaomimimo.com/anthropic",
+            "https://api.xiaomimimo.com/anthropic/",
+            "https://API.XiaomiMiMo.com/anthropic",
+        ],
+    )
+    def test_unsigned_thinking_block_survives_replay(self, base_url: str) -> None:
+        """Unsigned thinking (synthesised from reasoning_content) must be preserved."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "planning the tool call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "skill_view", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url=base_url
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1, (
+            f"Xiaomi /anthropic ({base_url}) must preserve unsigned thinking "
+            "blocks synthesised from reasoning_content — upstream rejects "
+            "replayed tool-call messages without them."
+        )
+        assert thinking_blocks[0]["thinking"] == "planning the tool call"
+        # Synthesised block — never has a signature
+        assert "signature" not in thinking_blocks[0]
+
+    def test_unsigned_thinking_preserved_on_non_latest_assistant_turn(self) -> None:
+        """Xiaomi validates history across every prior assistant turn, not just last."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "q1"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r1",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+            {"role": "user", "content": "q2"},
+            {
+                "role": "assistant",
+                "reasoning_content": "r2",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url="https://token-plan-cn.xiaomimimo.com/anthropic"
+        )
+
+        assistants = [m for m in converted if m["role"] == "assistant"]
+        assert len(assistants) == 2
+        for assistant, expected in zip(assistants, ("r1", "r2")):
+            thinking = [
+                b for b in assistant["content"]
+                if isinstance(b, dict) and b.get("type") == "thinking"
+            ]
+            assert len(thinking) == 1
+            assert thinking[0]["thinking"] == expected
+
+    def test_signed_anthropic_thinking_block_is_stripped(self) -> None:
+        """Anthropic-signed blocks (that leaked through) must still be stripped.
+
+        Xiaomi issues its own signatures and cannot validate Anthropic's —
+        the strip-signed / keep-unsigned split matches the DeepSeek policy.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "anthropic-signed payload",
+                        "signature": "anthropic-sig-xyz",
+                    },
+                    {"type": "text", "text": "hello"},
+                ],
+            },
+            {"role": "user", "content": "again"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url="https://token-plan-cn.xiaomimimo.com/anthropic"
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking_blocks == [], (
+            "Signed Anthropic thinking blocks must be stripped on Xiaomi — "
+            "Xiaomi cannot validate Anthropic-proprietary signatures."
+        )
+
+    def test_openai_compat_xiaomi_base_is_not_matched(self) -> None:
+        """The OpenAI-compatible ``api.xiaomimimo.com/v1`` base must NOT trigger
+        the Xiaomi /anthropic branch — it never reaches this adapter, but the
+        detector should still fail closed so an accidental misuse doesn't
+        quietly send signed Anthropic blocks to an OpenAI endpoint.
+        """
+        from agent.anthropic_adapter import _is_xiaomi_anthropic_endpoint
+
+        assert _is_xiaomi_anthropic_endpoint("https://api.xiaomimimo.com") is False
+        assert _is_xiaomi_anthropic_endpoint("https://api.xiaomimimo.com/v1") is False
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com/v1") is False
+        assert _is_xiaomi_anthropic_endpoint("https://api.xiaomimimo.com/anthropic") is True
+        assert _is_xiaomi_anthropic_endpoint("https://api.xiaomimimo.com/anthropic/v1") is True
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com/anthropic") is True
+
+    def test_xiaomi_path_substring_false_positive_guarded(self) -> None:
+        """``xiaomimimo.com`` must match host, not substring — a domain that
+        merely embeds the string in its path must not be misclassified.
+        """
+        from agent.anthropic_adapter import _is_xiaomi_anthropic_endpoint
+
+        assert _is_xiaomi_anthropic_endpoint(
+            "https://evil.example.com/xiaomimimo.com/anthropic"
+        ) is False
+        assert _is_xiaomi_anthropic_endpoint(
+            "https://xiaomimimo.com.evil/anthropic"
+        ) is False

--- a/tests/run_agent/test_xiaomi_reasoning_content_echo.py
+++ b/tests/run_agent/test_xiaomi_reasoning_content_echo.py
@@ -1,0 +1,318 @@
+"""Regression test: Xiaomi MiMo thinking mode reasoning_content echo.
+
+Xiaomi MiMo (mimo-v2.5-pro, mimo-v2.5, …) is a DeepSeek-derived
+thinking-capable model family. Both its OpenAI-compatible
+``api.xiaomimimo.com/v1`` endpoint and its Anthropic-compatible
+``token-plan-*.xiaomimimo.com/anthropic`` endpoints enforce the same
+reasoning_content echo-back contract as DeepSeek. When a persisted session
+replays an assistant tool-call turn that was recorded without
+``reasoning_content``, Xiaomi rejects the next request with HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the API.
+
+Coverage mirrors the DeepSeek regression test (see
+``test_deepseek_reasoning_content_echo.py``):
+
+1. ``_needs_xiaomi_tool_reasoning`` recognises three signals — provider name,
+   model prefix, and base URL host.
+2. ``_copy_reasoning_content_for_api`` pads / preserves reasoning_content for
+   Xiaomi assistant turns the same way it does for DeepSeek.
+3. ``_build_assistant_message`` pins reasoning_content on tool-call turns so
+   nothing gets persisted poisoned.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+_ATTR_ABSENT = object()
+_EXPECT_NOT_PRESENT = object()
+
+
+def _sdk_tool_call(call_id: str = "c1", name: str = "terminal", arguments: str = "{}"):
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+        extra_content=None,
+    )
+
+
+def _build_sdk_message(reasoning_content=_ATTR_ABSENT, **extra):
+    kwargs = {"content": "", **extra}
+    if reasoning_content is not _ATTR_ABSENT:
+        kwargs["reasoning_content"] = reasoning_content
+    return SimpleNamespace(**kwargs)
+
+
+class TestNeedsXiaomiToolReasoning:
+    """_needs_xiaomi_tool_reasoning() recognises all three detection signals."""
+
+    def test_provider_xiaomi(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_model_prefix(self) -> None:
+        # Custom provider pointing at Xiaomi with provider='custom'
+        agent = _make_agent(provider="custom", model="mimo-v2.5-pro")
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_model_prefix_lowercase(self) -> None:
+        # Model names get lowercased before matching — mixed case input still matches.
+        agent = _make_agent(provider="custom", model="MiMo-V2.5-Pro")
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_base_url_host_v1(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="some-aliased-name",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_base_url_host_anthropic(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="some-aliased-name",
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+        )
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_provider_case_insensitive(self) -> None:
+        agent = _make_agent(provider="Xiaomi", model="")
+        assert agent._needs_xiaomi_tool_reasoning() is True
+
+    def test_non_xiaomi_provider(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._needs_xiaomi_tool_reasoning() is False
+
+    def test_empty_everything(self) -> None:
+        agent = _make_agent()
+        assert agent._needs_xiaomi_tool_reasoning() is False
+
+
+class TestCopyReasoningContentForApiXiaomi:
+    """_copy_reasoning_content_for_api pads reasoning_content for Xiaomi tool-calls."""
+
+    def test_xiaomi_tool_call_poisoned_history_gets_space_placeholder(self) -> None:
+        """Already-poisoned history (no reasoning_content, no reasoning) gets ' '."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_xiaomi_assistant_no_tool_call_gets_padded(self) -> None:
+        """Xiaomi thinking mode pads ALL assistant turns, even without tool_calls."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {"role": "assistant", "content": "hello"}
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_xiaomi_explicit_reasoning_content_preserved(self) -> None:
+        """When reasoning_content is already set, it's copied verbatim."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "reasoning_content": "<think>real chain of thought</think>",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "<think>real chain of thought</think>"
+
+    def test_xiaomi_stale_empty_placeholder_upgraded_to_space(self) -> None:
+        """Sessions persisted with ``reasoning_content=""`` get upgraded to " "
+        on replay because Xiaomi rejects empty-string reasoning_content the
+        same way DeepSeek V4 Pro does.
+        """
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_xiaomi_reasoning_field_promoted(self) -> None:
+        """When only 'reasoning' is set, it gets promoted to reasoning_content."""
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "thought trace",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "thought trace"
+
+    def test_xiaomi_poisoned_cross_provider_history_padded(self) -> None:
+        """Cross-provider tool-call turn: if the source has tool_calls AND a
+        'reasoning' field but NO 'reasoning_content' key, it's from a prior
+        provider. Inject ' ' instead of forwarding the prior chain of thought.
+        """
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "MiniMax chain of thought from a prior turn",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == " "
+
+    def test_xiaomi_anthropic_base_url(self) -> None:
+        """Custom provider pointing at Xiaomi /anthropic is detected via host."""
+        agent = _make_agent(
+            provider="custom",
+            model="whatever",
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+    def test_xiaomi_v1_base_url(self) -> None:
+        """Custom provider pointing at Xiaomi /v1 is detected via host too."""
+        agent = _make_agent(
+            provider="custom",
+            model="whatever",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "
+
+
+class TestBuildAssistantMessageXiaomiReasoningContent:
+    """_build_assistant_message pins replay-safe Xiaomi tool-call state."""
+
+    def test_xiaomi_tool_call_reasoning_is_backfilled_into_reasoning_content(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assistant_message = SimpleNamespace(
+            content=None,
+            reasoning="Xiaomi tool-call reasoning",
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+
+        assert msg["reasoning_content"] == "Xiaomi tool-call reasoning"
+        assert msg["tool_calls"][0]["id"] == "call_1"
+
+    def test_xiaomi_tool_call_without_raw_reasoning_content_gets_space_placeholder(self) -> None:
+        agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
+        assistant_message = SimpleNamespace(
+            content=None,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+
+        assert msg["reasoning_content"] == " "
+        assert msg["tool_calls"][0]["id"] == "call_1"
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url,sdk_reasoning_content,expected",
+        [
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                None, " ",
+                id="xiaomi-attr-none",
+            ),
+            pytest.param(
+                "xiaomi", "mimo-v2.5-pro", "",
+                _ATTR_ABSENT, " ",
+                id="xiaomi-attr-absent",
+            ),
+            pytest.param(
+                "custom", "mimo-v2.5", "https://token-plan-cn.xiaomimimo.com/anthropic",
+                _ATTR_ABSENT, " ",
+                id="xiaomi-anthropic-base-url",
+            ),
+            pytest.param(
+                "openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1",
+                _ATTR_ABSENT, _EXPECT_NOT_PRESENT,
+                id="openrouter-no-pad",
+            ),
+        ],
+    )
+    def test_tool_call_reasoning_content_pad(
+        self, provider, model, base_url, sdk_reasoning_content, expected,
+    ) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        msg_in = _build_sdk_message(
+            reasoning_content=sdk_reasoning_content,
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        if expected is _EXPECT_NOT_PRESENT:
+            assert "reasoning_content" not in msg
+        else:
+            assert msg["reasoning_content"] == expected


### PR DESCRIPTION
## What does this PR do?

Xiaomi MiMo (mimo-v2.5-pro, mimo-v2.5, …) is a DeepSeek-derived thinking-capable model family. Both its OpenAI-compatible `api.xiaomimimo.com/v1` endpoint and its Anthropic-compatible `token-plan-*.xiaomimimo.com/anthropic` endpoint enforce the same reasoning_content echo-back contract as DeepSeek and Kimi: when a persisted session replays an assistant tool-call turn that was recorded without `reasoning_content`, Xiaomi rejects the next request with HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

But the existing guards only matched DeepSeek and Kimi:

- `_preserve_unsigned_thinking` (`agent/anthropic_adapter.py`) drops reasoning_content-derived thinking blocks for any non-whitelisted third-party `/anthropic` endpoint, so Xiaomi history loses its thinking blocks on replay.
- `_needs_thinking_reasoning_pad` (`run_agent.py`) doesn't pad/preserve reasoning_content on tool-call turns for Xiaomi, so even new turns are persisted without the field.

This PR adds Xiaomi to both whitelists, mirroring the DeepSeek policy verbatim. Same strip-signed / keep-unsigned policy, same three detection signals, same regression test layout — Xiaomi-shaped scenarios were just missing from the whitelist.

## Related Issue

Fixes an unfiled bug; reproduction is straightforward (see *How to Test*). Happy to file a tracking issue if maintainers prefer one.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`
  - Add `_is_xiaomi_anthropic_endpoint(base_url)` — pinned to the `/anthropic` path (host match `xiaomimimo.com` covers `token-plan-{cn,sgp,ams,…}` regional subdomains). The OpenAI-compatible `/v1` base URL never reaches this adapter, so detection fails closed there.
  - Add `_is_xiaomi_anthropic_endpoint(base_url)` to the `_preserve_unsigned_thinking` whitelist in `convert_messages_to_anthropic`, alongside `_is_kimi_family_endpoint` and `_is_deepseek_anthropic_endpoint`.
- `run_agent.py`
  - Add `_needs_xiaomi_tool_reasoning()` — three detection signals matching the DeepSeek shape: `provider == "xiaomi"`, model starts with `mimo-`, or host matches `xiaomimimo.com` (covers both `/v1` and `/anthropic` transports).
  - Wire it into `_needs_thinking_reasoning_pad()`.
- `tests/agent/test_xiaomi_anthropic_thinking.py` — new: unsigned thinking block survival on `/anthropic`, signed-block stripping, OpenAI-base fail-closed, substring false-positive guard. (10 tests)
- `tests/run_agent/test_xiaomi_reasoning_content_echo.py` — new: detection signals, replay padding, build-time pinning, cross-provider history guard, parametrized pad scenarios. (22 tests)

## How to Test

### Reproduce the bug (before this fix)

```yaml
# cli-config.yaml
model:
  default: mimo-v2.5-pro
  provider: xiaomi
  base_url: https://token-plan-cn.xiaomimimo.com/anthropic
  api_mode: anthropic_messages
```

Run any multi-turn session that uses `terminal` or another tool (a cron job that fetches a URL is a good reproducer). On the second tool-call turn, the upstream call fails with:

```
RuntimeError: Error code: 400 - {'error': {'code': '400', 'message': 'Param Incorrect',
  'param': 'The reasoning_content in the thinking mode must be passed back to the API.',
  'type': ''}}
```

### Verify the fix

1. `pytest tests/agent/test_xiaomi_anthropic_thinking.py tests/run_agent/test_xiaomi_reasoning_content_echo.py -q` — 32 new tests pass.
2. `pytest tests/run_agent/test_deepseek_reasoning_content_echo.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py tests/hermes_cli/test_xiaomi_provider.py -q` — 114 existing tests still pass (no regression on DeepSeek / Kimi / xiaomi provider).
3. Rerun the cron job / multi-turn session against `token-plan-cn.xiaomimimo.com/anthropic` — the next tool-call turn now carries the synthesised thinking block on replay and the 400 disappears.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites locally — see *How to Test* above (1462 tests pass; two pre-existing failures on `main` — `test_switch_model_preserves_config_context_length` and `test_interrupt_child_during_api_call` — are unrelated to this change and reproduce on a clean checkout)
- [x] I've added tests for my changes — 32 new tests covering both the detection helpers and the conversion path
- [x] I've tested on my platform: macOS 15 (Darwin 25.2.0), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings on the new helpers explain the contract; no user-facing docs needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architectural change)
- [x] I've considered cross-platform impact — change is pure Python string/dict handling; no I/O, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool surface unchanged)