### PR TITLE
fix(cli): add 'lsp' to _BUILTIN_SUBCOMMANDS so plugin discovery is skipped

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9188,10 +9188,10 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
-        "kanban", "login", "logout", "logs", "mcp", "memory", "model",
-        "pairing", "plugins", "profile", "sessions", "setup", "skills",
-        "slack", "status", "tools", "uninstall", "update", "version",
-        "webhook", "whatsapp", "chat",
+        "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
+        "model", "pairing", "plugins", "profile", "sessions", "setup",
+        "skills", "slack", "status", "tools", "uninstall", "update",
+        "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an
         # expensive eager import of every bundled plugin module.


### PR DESCRIPTION
## Summary

`lsp` is registered as a top-level subparser in `main()` ([hermes_cli/main.py:9539-9545](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/main.py#L9539-L9545)) via `agent.lsp.cli.register_subparser`, so it shows up in `hermes --help` alongside the other built-ins. The `_BUILTIN_SUBCOMMANDS` set used by `_plugin_cli_discovery_needed` to short-circuit the ~500-650ms plugin-import pass did not list it, so every `hermes lsp …` invocation paid the full plugin-discovery cost despite being a fully-built-in command.

## The bug

The parity guard added in [#22120](https://github.com/NousResearch/hermes-agent/pull/22120) has been failing on clean `origin/main` since `lsp` shipped in [#24168](https://github.com/NousResearch/hermes-agent/pull/24168):

```
$ pytest tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand
FAILED  tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand
        AssertionError: _BUILTIN_SUBCOMMANDS is missing these live
        subcommands: ['lsp']. Add them to
        hermes_cli/main.py::_BUILTIN_SUBCOMMANDS so plugin discovery
        can be skipped when the user targets them.
```

The discovery skip is correctness-safe either way (missing only costs a one-time slow path), but matches what #22120 declared the intended invariant.

## The fix

Add `\"lsp\"` to the frozenset, alphabetical position between `logs` and `mcp`. One-line addition; no other code paths touched.

`test_builtin_set_has_no_phantom_entries` keeps passing because `lsp` is genuinely registered as a subparser via the `try/except` guard at [hermes_cli/main.py:9539-9545](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/main.py#L9539-L9545).

## Test plan

- [x] Focused regression — failing test now passes:
  ```
  uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \\
    tests/hermes_cli/test_startup_plugin_gating.py -v
  # before: 1 failed, 36 passed
  # after:  37 passed
  ```
- [x] Adjacent suite — `_BUILTIN_SUBCOMMANDS` is the stop-word source used by `_coalesce_session_name_args` in the in-flight [#24637](https://github.com/NousResearch/hermes-agent/pull/24637); confirmed no regression there:
  ```
  uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \\
    tests/hermes_cli/test_startup_plugin_gating.py \\
    tests/hermes_cli/test_coalesce_session_args.py -v
  # 54 passed
  ```
- [x] Regression guard — before/after:
  - before: `pytest --help` and `_first_positional_argv() == 'lsp'` → `_plugin_cli_discovery_needed()` returns `True` → eager plugin import pass runs (~500-650ms).
  - after: same invocation → `True` because `'lsp' in _BUILTIN_SUBCOMMANDS` short-circuits to `False` per the docstring at line 9263-9268.

## Related

- Compounds positively with [#24637](https://github.com/NousResearch/hermes-agent/pull/24637) (uses `_BUILTIN_SUBCOMMANDS` as session-name stop words): after both land, `hermes -c \"my session\" lsp` correctly treats `lsp` as a command boundary.