### PR TITLE
Fix dashboard custom theme first-paint flash

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -3564,6 +3565,57 @@ def mount_spa(application: FastAPI):
 
     _index_path = WEB_DIST / "index.html"
 
+    def _initial_dashboard_theme() -> Optional[Dict[str, Any]]:
+        """Return the active custom dashboard theme for first paint, if any.
+
+        Custom YAML themes normally arrive from ``/api/dashboard/themes`` after
+        React mounts; embedding the active custom definition into ``index.html``
+        lets the client initialize from the right theme immediately. Built-in
+        themes remain owned by the frontend bundle.
+        """
+        try:
+            config = load_config()
+            active = cfg_get(config, "dashboard", "theme", default="default")
+            if not isinstance(active, str) or not active:
+                return None
+            for theme in _discover_user_themes():
+                if theme.get("name") == active:
+                    return {"active": active, "definition": theme}
+        except Exception:
+            return None
+        return None
+
+    def _dashboard_theme_layer_color(
+        initial_theme: Dict[str, Any],
+        layer: str,
+        fallback: str,
+    ) -> str:
+        definition = initial_theme.get("definition")
+        palette = definition.get("palette") if isinstance(definition, dict) else None
+        layer_value = palette.get(layer) if isinstance(palette, dict) else None
+        color = layer_value.get("hex") if isinstance(layer_value, dict) else None
+        if isinstance(color, str) and re.fullmatch(r"#[0-9a-fA-F]{3,8}", color.strip()):
+            return color.strip()
+        return fallback
+
+    def _dashboard_theme_head() -> str:
+        initial_theme = _initial_dashboard_theme()
+        if not initial_theme:
+            return ""
+        background = _dashboard_theme_layer_color(initial_theme, "background", "#041c1c")
+        midground = _dashboard_theme_layer_color(initial_theme, "midground", "#ffe6cb")
+        first_paint_style = (
+            '<style id="hermes-initial-custom-theme">'
+            f":root{{--background-base:{background};--midground-base:{midground};}}"
+            f"html,body,#root{{background:{background};color:{midground};}}"
+            "</style>"
+        )
+        payload = json.dumps(initial_theme, ensure_ascii=False).replace("</", "<\\/")
+        return (
+            first_paint_style
+            + f"<script>window.__HERMES_INITIAL_DASHBOARD_THEME__={payload};</script>"
+        )
+
     def _serve_index(prefix: str = ""):
         """Return index.html with the session token + base-path injected.
 
@@ -3577,6 +3629,7 @@ def mount_spa(application: FastAPI):
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
             f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
         )
+        theme_head = _dashboard_theme_head()
         if prefix:
             # Rewrite absolute asset URLs baked into the Vite build so the
             # browser fetches them through the same proxy prefix.
@@ -3586,7 +3639,7 @@ def mount_spa(application: FastAPI):
             html = html.replace('href="/fonts/', f'href="{prefix}/fonts/')
             html = html.replace('href="/ds-assets/', f'href="{prefix}/ds-assets/')
             html = html.replace('src="/ds-assets/', f'src="{prefix}/ds-assets/')
-        html = html.replace("</head>", f"{token_script}</head>", 1)
+        html = html.replace("</head>", f"{token_script}{theme_head}</head>", 1)
         return HTMLResponse(
             html,
             headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
@@ -3647,7 +3700,6 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
-
 
 def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[Dict[str, Any]]:
     """Normalise a theme layer spec from YAML into `{hex, alpha}` form.

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -22,13 +22,139 @@ import type {
 } from "./types";
 import { api } from "@/lib/api";
 
+declare global {
+  interface Window {
+    __HERMES_INITIAL_DASHBOARD_THEME__?: {
+      active?: string;
+      definition?: DashboardTheme;
+    };
+  }
+}
+
 /** LocalStorage key — pre-applied before the React tree mounts to avoid
  *  a visible flash of the default palette on theme-overridden installs. */
 const STORAGE_KEY = "hermes-dashboard-theme";
+const DEFINITION_CACHE_KEY = `${STORAGE_KEY}:definitions`;
+const FIRST_PAINT_CACHE_KEY = `${STORAGE_KEY}:first-paint`;
+
+interface FirstPaintCache {
+  background: string;
+  midground: string;
+  name: string;
+}
 
 /** Tracks fontUrls we've already injected so multiple theme switches don't
  *  pile up <link> tags. Keyed by URL. */
 const INJECTED_FONT_URLS = new Set<string>();
+
+function readCachedThemeDefinitions(): Record<string, DashboardTheme> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(DEFINITION_CACHE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const defs: Record<string, DashboardTheme> = {};
+    for (const value of Object.values(parsed)) {
+      const theme = value as Partial<DashboardTheme> | null;
+      if (
+        theme &&
+        typeof theme.name === "string" &&
+        theme.palette &&
+        theme.typography &&
+        theme.layout
+      ) {
+        defs[theme.name] = theme as DashboardTheme;
+      }
+    }
+    return defs;
+  } catch {
+    return {};
+  }
+}
+
+function writeCachedThemeDefinitions(defs: Record<string, DashboardTheme>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DEFINITION_CACHE_KEY, JSON.stringify(defs));
+  } catch {}
+}
+
+function mergeThemeDefinitions(
+  existing: Record<string, DashboardTheme>,
+  incoming: Record<string, DashboardTheme>,
+): Record<string, DashboardTheme> {
+  return Object.keys(incoming).length ? { ...existing, ...incoming } : existing;
+}
+
+function definitionsFromEntries(
+  entries: Array<{ definition?: DashboardTheme }>,
+): Record<string, DashboardTheme> {
+  const defs: Record<string, DashboardTheme> = {};
+  for (const entry of entries) {
+    const definition = entry.definition;
+    if (definition?.name) defs[definition.name] = definition;
+  }
+  return defs;
+}
+
+function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && /^#[0-9a-fA-F]{3,8}$/.test(value.trim());
+}
+
+function readCachedFirstPaint(): FirstPaintCache | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.localStorage.getItem(FIRST_PAINT_CACHE_KEY);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<FirstPaintCache> | null;
+    if (
+      parsed &&
+      typeof parsed.name === "string" &&
+      isHexColor(parsed.background) &&
+      isHexColor(parsed.midground)
+    ) {
+      return {
+        name: parsed.name,
+        background: parsed.background.trim(),
+        midground: parsed.midground.trim(),
+      };
+    }
+  } catch {}
+  return undefined;
+}
+
+function writeCachedFirstPaint(theme: DashboardTheme) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      FIRST_PAINT_CACHE_KEY,
+      JSON.stringify({
+        name: theme.name,
+        background: theme.palette.background.hex,
+        midground: theme.palette.midground.hex,
+      }),
+    );
+  } catch {}
+}
+
+function applyCachedFirstPaint() {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+  const activeName = window.localStorage.getItem(STORAGE_KEY);
+  const cached = readCachedFirstPaint();
+  if (!activeName || !cached || cached.name !== activeName) return;
+
+  const root = document.documentElement;
+  root.style.setProperty("--background-base", cached.background);
+  root.style.setProperty("--midground-base", cached.midground);
+  root.style.background = cached.background;
+  root.style.color = cached.midground;
+  document.body.style.background = cached.background;
+  document.body.style.color = cached.midground;
+  document.getElementById("root")?.style.setProperty("background", cached.background);
+}
+
+applyCachedFirstPaint();
 
 // ---------------------------------------------------------------------------
 // CSS variable builders
@@ -296,6 +422,7 @@ function applyTheme(theme: DashboardTheme) {
   injectFontStylesheet(theme.typography.fontUrl);
   applyCustomCSS(theme.customCSS);
   applyLayoutVariant(theme.layoutVariant);
+  writeCachedFirstPaint(theme);
 }
 
 // ---------------------------------------------------------------------------
@@ -303,9 +430,18 @@ function applyTheme(theme: DashboardTheme) {
 // ---------------------------------------------------------------------------
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
+  const initialTheme =
+    typeof window === "undefined" ? undefined : window.__HERMES_INITIAL_DASHBOARD_THEME__;
+  const cachedThemeDefs = useMemo(() => readCachedThemeDefinitions(), []);
+
   /** Name of the currently active theme (built-in id or user YAML name). */
   const [themeName, setThemeName] = useState<string>(() => {
     if (typeof window === "undefined") return "default";
+    const initialName = initialTheme?.active ?? initialTheme?.definition?.name;
+    if (initialName) {
+      window.localStorage.setItem(STORAGE_KEY, initialName);
+      return initialName;
+    }
     return window.localStorage.getItem(STORAGE_KEY) ?? "default";
   });
 
@@ -323,7 +459,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
    *  these so custom YAMLs apply without a client-side stub. */
   const [userThemeDefs, setUserThemeDefs] = useState<
     Record<string, DashboardTheme>
-  >({});
+  >(() => {
+    const definition = initialTheme?.definition;
+    return definition?.name
+      ? { ...cachedThemeDefs, [definition.name]: definition }
+      : cachedThemeDefs;
+  });
 
   // Resolve a theme name to a full DashboardTheme, falling back to default
   // only when neither a built-in nor a user theme is found.
@@ -362,13 +503,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
             })),
           );
           // Index any definitions the server shipped (user themes).
-          const defs: Record<string, DashboardTheme> = {};
-          for (const entry of resp.themes) {
-            if (entry.definition) {
-              defs[entry.name] = entry.definition;
-            }
+          const defs = definitionsFromEntries(resp.themes);
+          if (Object.keys(defs).length > 0) {
+            setUserThemeDefs((prev) => {
+              const next = mergeThemeDefinitions(prev, defs);
+              writeCachedThemeDefinitions(next);
+              return next;
+            });
           }
-          if (Object.keys(defs).length > 0) setUserThemeDefs(defs);
         }
         if (resp.active && resp.active !== themeName) {
           setThemeName(resp.active);
@@ -394,6 +536,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setThemeName(next);
       if (typeof window !== "undefined") {
         window.localStorage.setItem(STORAGE_KEY, next);
+        const definition =
+          availableThemes.find((t) => t.name === next)?.definition ??
+          userThemeDefs[next];
+        if (definition) {
+          writeCachedThemeDefinitions({
+            ...readCachedThemeDefinitions(),
+            [definition.name]: definition,
+          });
+        }
       }
       api.setTheme(next).catch(() => {});
     },


### PR DESCRIPTION
## Summary
Fixes a visible dashboard theme flash when using custom YAML themes.

Custom dashboard themes are discovered by the Python dashboard server, but the React app only receives those definitions after mount. This can cause the dashboard to briefly render with the default palette before the active custom theme applies.

This change embeds the active custom theme definition into the initial HTML and applies a minimal first-paint background/text color before React mounts. Full theme application remains owned by ThemeProvider.

## Details
- Embeds only the active custom dashboard theme, if one is configured.
- Adds a tiny first-paint style using the custom theme palette.
- Caches last-applied first-paint colors client-side for subsequent loads.
- Keeps built-in theme definitions owned by frontend presets; no Python mirror map.

## Testing
- python -m py_compile hermes_cli/web_server.py
- cd web && tsc -b
- cd web && vite build
- Verified local dashboard loads at http://127.0.0.1:9119/sessions