### PR TITLE
fix(web_tools): prevent TOCTOU races in _get_parallel_client / _get_async_parallel_client / _get_exa_client

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -12,7 +12,9 @@ import importlib
 import json
 import os
 import sys
+import threading
 import types
+from concurrent.futures import ThreadPoolExecutor
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -625,3 +627,220 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+# ─── TOCTOU Race Regression Tests (Issue #24736) ─────────────────────────────
+
+class TestParallelClientToctouRace:
+    """50-thread barrier tests for _get_parallel_client() double-checked locking."""
+
+    def setup_method(self):
+        import tools.web_tools as wt
+        wt._parallel_client = None
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        """All 50 concurrent callers must receive the exact same client object."""
+        monkeypatch.setenv("PARALLEL_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        fake_parallel = MagicMock(name="fake_parallel")
+        fake_module = types.ModuleType("parallel")
+        fake_module.Parallel = lambda api_key: fake_parallel
+        fake_module.AsyncParallel = MagicMock()
+
+        with patch.dict(sys.modules, {"parallel": fake_module}):
+            barrier = threading.Barrier(50)
+            results: list = []
+            lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                c = wt._get_parallel_client()
+                with lock:
+                    results.append(c)
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert len(results) == 50
+        first = results[0]
+        assert all(r is first for r in results), (
+            f"Expected 1 unique client, got {len(set(id(r) for r in results))}"
+        )
+
+    def test_only_one_client_created(self, monkeypatch):
+        """Parallel() constructor must be called exactly once under concurrency."""
+        monkeypatch.setenv("PARALLEL_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        call_count = 0
+        call_lock = threading.Lock()
+        fake_parallel = MagicMock(name="fake_parallel")
+
+        def counting_constructor(api_key):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+            return fake_parallel
+
+        fake_module = types.ModuleType("parallel")
+        fake_module.Parallel = counting_constructor
+        fake_module.AsyncParallel = MagicMock()
+
+        with patch.dict(sys.modules, {"parallel": fake_module}):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                wt._get_parallel_client()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"Parallel() called {call_count} times (expected 1)"
+
+
+class TestAsyncParallelClientToctouRace:
+    """50-thread barrier tests for _get_async_parallel_client() double-checked locking."""
+
+    def setup_method(self):
+        import tools.web_tools as wt
+        wt._async_parallel_client = None
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        monkeypatch.setenv("PARALLEL_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        fake_client = MagicMock(name="fake_async_parallel")
+        fake_module = types.ModuleType("parallel")
+        fake_module.Parallel = MagicMock()
+        fake_module.AsyncParallel = lambda api_key: fake_client
+
+        with patch.dict(sys.modules, {"parallel": fake_module}):
+            barrier = threading.Barrier(50)
+            results: list = []
+            lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                c = wt._get_async_parallel_client()
+                with lock:
+                    results.append(c)
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert len(results) == 50
+        first = results[0]
+        assert all(r is first for r in results), (
+            f"Expected 1 unique client, got {len(set(id(r) for r in results))}"
+        )
+
+    def test_only_one_client_created(self, monkeypatch):
+        monkeypatch.setenv("PARALLEL_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        call_count = 0
+        call_lock = threading.Lock()
+
+        def counting_constructor(api_key):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+            return MagicMock()
+
+        fake_module = types.ModuleType("parallel")
+        fake_module.Parallel = MagicMock()
+        fake_module.AsyncParallel = counting_constructor
+
+        with patch.dict(sys.modules, {"parallel": fake_module}):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                wt._get_async_parallel_client()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"AsyncParallel() called {call_count} times (expected 1)"
+
+
+class TestExaClientToctouRace:
+    """50-thread barrier tests for _get_exa_client() double-checked locking."""
+
+    def setup_method(self):
+        import tools.web_tools as wt
+        wt._exa_client = None
+
+    def test_concurrent_calls_return_same_instance(self, monkeypatch):
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        fake_exa = MagicMock(name="fake_exa")
+        fake_exa.headers = {}
+
+        fake_module = types.ModuleType("exa_py")
+        fake_module.Exa = lambda api_key: fake_exa
+
+        with patch.dict(sys.modules, {"exa_py": fake_module}):
+            barrier = threading.Barrier(50)
+            results: list = []
+            lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                c = wt._get_exa_client()
+                with lock:
+                    results.append(c)
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert len(results) == 50
+        first = results[0]
+        assert all(r is first for r in results), (
+            f"Expected 1 unique client, got {len(set(id(r) for r in results))}"
+        )
+
+    def test_only_one_client_created(self, monkeypatch):
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+        import tools.web_tools as wt
+
+        call_count = 0
+        call_lock = threading.Lock()
+
+        def counting_constructor(api_key):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+            m = MagicMock()
+            m.headers = {}
+            return m
+
+        fake_module = types.ModuleType("exa_py")
+        fake_module.Exa = counting_constructor
+
+        with patch.dict(sys.modules, {"exa_py": fake_module}):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                wt._get_exa_client()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"Exa() called {call_count} times (expected 1)"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import asyncio
+import threading
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx
 # NOTE: `from firecrawl import Firecrawl` is deliberately NOT at module top —
@@ -358,7 +359,9 @@ def _get_firecrawl_client():
 # ─── Parallel Client ─────────────────────────────────────────────────────────
 
 _parallel_client = None
+_parallel_client_lock = threading.Lock()
 _async_parallel_client = None
+_async_parallel_client_lock = threading.Lock()
 
 def _get_parallel_client():
     """Get or create the Parallel sync client (lazy initialization).
@@ -375,13 +378,15 @@ def _get_parallel_client():
     from parallel import Parallel
     global _parallel_client
     if _parallel_client is None:
-        api_key = os.getenv("PARALLEL_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "PARALLEL_API_KEY environment variable not set. "
-                "Get your API key at https://parallel.ai"
-            )
-        _parallel_client = Parallel(api_key=api_key)
+        with _parallel_client_lock:
+            if _parallel_client is None:
+                api_key = os.getenv("PARALLEL_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "PARALLEL_API_KEY environment variable not set. "
+                        "Get your API key at https://parallel.ai"
+                    )
+                _parallel_client = Parallel(api_key=api_key)
     return _parallel_client
 
 
@@ -400,13 +405,15 @@ def _get_async_parallel_client():
     from parallel import AsyncParallel
     global _async_parallel_client
     if _async_parallel_client is None:
-        api_key = os.getenv("PARALLEL_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "PARALLEL_API_KEY environment variable not set. "
-                "Get your API key at https://parallel.ai"
-            )
-        _async_parallel_client = AsyncParallel(api_key=api_key)
+        with _async_parallel_client_lock:
+            if _async_parallel_client is None:
+                api_key = os.getenv("PARALLEL_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "PARALLEL_API_KEY environment variable not set. "
+                        "Get your API key at https://parallel.ai"
+                    )
+                _async_parallel_client = AsyncParallel(api_key=api_key)
     return _async_parallel_client
 
 # ─── Tavily Client ───────────────────────────────────────────────────────────
@@ -1007,6 +1014,7 @@ def clean_base64_images(text: str) -> str:
 # ─── Exa Client ──────────────────────────────────────────────────────────────
 
 _exa_client = None
+_exa_client_lock = threading.Lock()
 
 def _get_exa_client():
     """Get or create the Exa client (lazy initialization).
@@ -1023,14 +1031,16 @@ def _get_exa_client():
     from exa_py import Exa
     global _exa_client
     if _exa_client is None:
-        api_key = os.getenv("EXA_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "EXA_API_KEY environment variable not set. "
-                "Get your API key at https://exa.ai"
-            )
-        _exa_client = Exa(api_key=api_key)
-        _exa_client.headers["x-exa-integration"] = "hermes-agent"
+        with _exa_client_lock:
+            if _exa_client is None:
+                api_key = os.getenv("EXA_API_KEY")
+                if not api_key:
+                    raise ValueError(
+                        "EXA_API_KEY environment variable not set. "
+                        "Get your API key at https://exa.ai"
+                    )
+                _exa_client = Exa(api_key=api_key)
+                _exa_client.headers["x-exa-integration"] = "hermes-agent"
     return _exa_client
 
 


### PR DESCRIPTION
## What does this PR do?

Three module-level lazy-init singletons in `tools/web_tools.py` had no lock:

## Root cause

Three module-level lazy-init singletons in `tools/web_tools.py` had no lock:

| Singleton | Guard (line) | Function |
|-----------|-------------|----------|
| `_parallel_client` (360) | `if _parallel_client is None:` | `_get_parallel_client()` |
| `_async_parallel_client` (361) | `if _async_parallel_client is None:` | `_get_async_parallel_client()` |
| `_exa_client` (1009) | `if _exa_client is None:` | `_get_exa_client()` |

Under concurrent tool dispatch (MoA, parallel tool calls) two threads can simultaneously see `None`, both call the constructor, and the losing thread's client — with its underlying connection pool or API session — is orphaned and never closed.

## Fix

Added `import threading` and one `threading.Lock()` per singleton. Applied double-checked locking to each function:

```python
_parallel_client = None
_parallel_client_lock = threading.Lock()

def _get_parallel_client():
    ...
    global _parallel_client
    if _parallel_client is None:
        with _parallel_client_lock:
            if _parallel_client is None:
                ...
                _parallel_client = Parallel(api_key=api_key)
    return _parallel_client
```

Same pattern applied to `_get_async_parallel_client()` and `_get_exa_client()`.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24736

<details>
<summary>Original body</summary>

## Summary

Three module-level lazy-init singletons in `tools/web_tools.py` had no lock:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

Three module-level lazy-init singletons in `tools/web_tools.py` had no lock:

| Singleton | Guard (line) | Function |
|-----------|-------------|----------|
| `_parallel_client` (360) | `if _parallel_client is None:` | `_get_parallel_client()` |
| `_async_parallel_client` (361) | `if _async_parallel_client is None:` | `_get_async_parallel_client()` |
| `_exa_client` (1009) | `if _exa_client is None:` | `_get_exa_client()` |

Under concurrent tool dispatch (MoA, parallel tool calls) two threads can simultaneously see `None`, both call the constructor, and the losing thread's client — with its underlying connection pool or API session — is orphaned and never closed.

## Fix

Added `import threading` and one `threading.Lock()` per singleton. Applied double-checked locking to each function:

```python
_parallel_client = None
_parallel_client_lock = threading.Lock()

def _get_parallel_client():
    ...
    global _parallel_client
    if _parallel_client is None:
        with _parallel_client_lock:
            if _parallel_client is None:
                ...
                _parallel_client = Parallel(api_key=api_key)
    return _parallel_client
```

Same pattern applied to `_get_async_parallel_client()` and `_get_exa_client()`.

## Tests

Added to `tests/tools/test_web_tools_config.py`:

- `TestParallelClientToctouRace` — 50-thread Barrier; asserts all callers get the same object and `Parallel()` is called exactly once.
- `TestAsyncParallelClientToctouRace` — same for `AsyncParallel`.
- `TestExaClientToctouRace` — same for `Exa`.

All 6 new tests pass (`uv run python -m pytest tests/tools/test_web_tools_config.py::TestParallelClientToctouRace tests/tools/test_web_tools_config.py::TestAsyncParallelClientToctouRace tests/tools/test_web_tools_config.py::TestExaClientToctouRace -v`).

Closes #24736

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24736

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_