### PR TITLE
fix(tui_gateway): prevent TOCTOU race in _get_db() singleton init

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4649,3 +4649,81 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
     )
 
     assert ["Max Turns", "120"] in agent_rows
+
+
+# ─── TOCTOU Race Regression Tests (Issue #24744) ─────────────────────────────
+
+from concurrent.futures import ThreadPoolExecutor
+
+
+class TestGetDbToctouRace:
+    """50-thread barrier tests for _get_db() double-checked locking."""
+
+    def setup_method(self):
+        server._db = None
+        server._db_error = None
+
+    def teardown_method(self):
+        server._db = None
+        server._db_error = None
+
+    def test_concurrent_calls_return_same_instance(self):
+        """All 50 concurrent callers must receive the exact same SessionDB object."""
+        call_count = 0
+        call_lock = threading.Lock()
+
+        class _SpySessionDB:
+            def __init__(self):
+                nonlocal call_count
+                with call_lock:
+                    call_count += 1
+
+        fake_mod = types.ModuleType("hermes_state")
+        fake_mod.SessionDB = _SpySessionDB
+
+        with patch.dict(sys.modules, {"hermes_state": fake_mod}):
+            barrier = threading.Barrier(50)
+            results: list = []
+            results_lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                db = server._get_db()
+                with results_lock:
+                    results.append(id(db))
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"SessionDB() called {call_count} times (expected 1)"
+        assert len(set(results)) == 1, f"Expected 1 unique db id, got {len(set(results))}"
+
+    def test_only_one_sessiondb_created(self):
+        """SessionDB constructor must be called exactly once regardless of concurrency."""
+        call_count = 0
+        call_lock = threading.Lock()
+
+        class _SpySessionDB:
+            def __init__(self):
+                nonlocal call_count
+                with call_lock:
+                    call_count += 1
+
+        fake_mod = types.ModuleType("hermes_state")
+        fake_mod.SessionDB = _SpySessionDB
+
+        with patch.dict(sys.modules, {"hermes_state": fake_mod}):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                server._get_db()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert call_count == 1, f"SessionDB() called {call_count} times (expected 1)"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -121,6 +121,7 @@ _pending: dict[str, tuple[str, threading.Event]] = {}
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
+_db_lock = threading.Lock()
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
@@ -338,18 +339,20 @@ atexit.register(_shutdown_sessions)
 def _get_db():
     global _db, _db_error
     if _db is None:
-        from hermes_state import SessionDB
+        with _db_lock:
+            if _db is None:
+                from hermes_state import SessionDB
 
-        try:
-            _db = SessionDB()
-            _db_error = None
-        except Exception as exc:
-            _db_error = str(exc)
-            logger.warning(
-                "TUI session store unavailable — continuing without state.db features: %s",
-                exc,
-            )
-            return None
+                try:
+                    _db = SessionDB()
+                    _db_error = None
+                except Exception as exc:
+                    _db_error = str(exc)
+                    logger.warning(
+                        "TUI session store unavailable — continuing without state.db features: %s",
+                        exc,
+                    )
+                    return None
     return _db
 
 


### PR DESCRIPTION
## What does this PR do?

`tui_gateway/server.py:_get_db()` used a bare `if _db is None:` guard with no lock. The TUI gateway handles concurrent HTTP requests, so two simultaneous requests can both see `_db is None`, both call `SessionDB()`, and create duplicate SQLite database connections — risking `database is locked` errors under WAL mode. The file already imported `threading` and used locks elsewhere (`_stdout_lock`, `_cfg_lock`) — `_get_db` was missed.

## Root cause

`tui_gateway/server.py:_get_db()` used a bare `if _db is None:` guard with no lock. The TUI gateway handles concurrent HTTP requests, so two simultaneous requests can both see `_db is None`, both call `SessionDB()`, and create duplicate SQLite database connections — risking `database is locked` errors under WAL mode. The file already imported `threading` and used locks elsewhere (`_stdout_lock`, `_cfg_lock`) — `_get_db` was missed.

## Fix

Added `_db_lock = threading.Lock()` alongside `_db = None`. Applied double-checked locking:

```python
def _get_db():
    global _db, _db_error
    if _db is None:
        with _db_lock:
            if _db is None:
                from hermes_state import SessionDB
                try:
                    _db = SessionDB()
                    _db_error = None
                except Exception as exc:
                    _db_error = str(exc)
                    ...
                    return None
    return _db
```

The retry-on-error behavior is preserved: after a failed init `_db` stays `None`, so the next call re-enters the lock and tries again.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24744

<details>
<summary>Original body</summary>

## Summary

`tui_gateway/server.py:_get_db()` used a bare `if _db is None:` guard with no lock. The TUI gateway handles concurrent HTTP requests, so two simultaneous requests can both see `_db is None`, both call `SessionDB()`, and create duplicate SQLite database connections — risking `database is locked` errors under WAL mode. The file already imported `threading` and used locks elsewhere (`_stdout_lock`, `_cfg_lock`) — `_get_db` was missed.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`tui_gateway/server.py:_get_db()` used a bare `if _db is None:` guard with no lock. The TUI gateway handles concurrent HTTP requests, so two simultaneous requests can both see `_db is None`, both call `SessionDB()`, and create duplicate SQLite database connections — risking `database is locked` errors under WAL mode. The file already imported `threading` and used locks elsewhere (`_stdout_lock`, `_cfg_lock`) — `_get_db` was missed.

## Fix

Added `_db_lock = threading.Lock()` alongside `_db = None`. Applied double-checked locking:

```python
def _get_db():
    global _db, _db_error
    if _db is None:
        with _db_lock:
            if _db is None:
                from hermes_state import SessionDB
                try:
                    _db = SessionDB()
                    _db_error = None
                except Exception as exc:
                    _db_error = str(exc)
                    ...
                    return None
    return _db
```

The retry-on-error behavior is preserved: after a failed init `_db` stays `None`, so the next call re-enters the lock and tries again.

## Tests

`TestGetDbToctouRace` in `tests/test_tui_gateway_server.py`:

- **`test_concurrent_calls_return_same_instance`** — 50-thread Barrier; spy `SessionDB`; asserts all callers get the same object id and constructor called exactly once.
- **`test_only_one_sessiondb_created`** — same spy, asserts `call_count == 1`.

Both tests pass.

Closes #24744

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_