### PR TITLE
fix: preserve Xiaomi MiMo reasoning_content on anthropic adapter replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -459,6 +459,25 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+def _is_xiaomi_mimo_endpoint(base_url: str | None, model: str | None = None) -> bool:
+    """Return True for Xiaomi MiMo Anthropic-compatible endpoints/models.
+
+    MiMo's ``/anthropic`` route has the same strict thinking-history contract
+    as Kimi and DeepSeek: when thinking is enabled, unsigned thinking blocks
+    synthesised from ``reasoning_content`` must be replayed on later turns.
+    """
+    if isinstance(model, str) and "mimo" in model.strip().lower():
+        return True
+    for _domain in (
+        "api.xiaomimimo.com",
+        "xiaomimimo.com",
+        "token-plan-cn.xiaomimimo.com",
+    ):
+        if base_url_host_matches(base_url or "", _domain):
+            return True
+    return False
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1476,7 +1495,8 @@ def convert_messages_to_anthropic(
     *base_url* is a Kimi / Moonshot host), unsigned thinking blocks
     synthesised from ``reasoning_content`` are preserved on replayed
     assistant tool-call messages — Kimi requires the field to exist, even
-    if empty.
+    if empty. Xiaomi MiMo's Anthropic-compatible endpoint follows the same
+    strict reasoning replay contract.
     """
     system = None
     result = []
@@ -1747,6 +1767,7 @@ def convert_messages_to_anthropic(
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_mimo_endpoint(base_url, model)
     )
 
     last_assistant_idx = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -9911,13 +9911,14 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that omit
+        ``reasoning_content`` (refs #15250, #17400).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_xiaomi_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -9947,6 +9948,23 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_xiaomi_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        Xiaomi MiMo uses the same replay contract as DeepSeek/Kimi thinking:
+        assistant tool-call turns must carry ``reasoning_content`` back to the
+        API or the next request fails with HTTP 400.
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or "mimo" in model
+            or base_url_host_matches(self.base_url, "api.xiaomimimo.com")
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
+            or base_url_host_matches(self.base_url, "token-plan-cn.xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -210,3 +210,53 @@ class TestKimiCodingSkipsAnthropicThinking:
         ]
         assert len(thinking_blocks) == 1
         assert thinking_blocks[0]["thinking"] == "planning the tool call"
+
+    def test_xiaomi_mimo_anthropic_endpoint_preserves_unsigned_thinking(self) -> None:
+        """Xiaomi MiMo's Anthropic endpoint also requires reasoning replay.
+
+        The endpoint returns the same 400 as Kimi when an assistant tool-use
+        history turn loses the unsigned thinking block synthesised from
+        reasoning_content.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "planning the tool call",
+                "content": [
+                    {"type": "text", "text": "I'll inspect that."},
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "search_files",
+                        "input": {"pattern": "reasoning_content"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_1",
+                        "content": "ok",
+                    }
+                ],
+            },
+        ]
+        _, converted = convert_messages_to_anthropic(
+            messages,
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+            model="mimo-v2.5-pro",
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b
+            for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1
+        assert thinking_blocks[0]["thinking"] == "planning the tool call"


### PR DESCRIPTION
MiMo's /anthropic endpoint enforces the same strict thinking-history contract as Kimi and DeepSeek: assistant tool-call turns must carry reasoning_content back or the API returns HTTP 400.

- Add _is_xiaomi_mimo_endpoint() to anthropic_adapter.py
- Include MiMo in _preserve_unsigned_thinking condition
- Add _needs_xiaomi_tool_reasoning() to run_agent.py
- Add regression test for MiMo thinking replay

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

