### PR TITLE
fix(honcho): session title overrides sessionStrategy setting

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -196,12 +196,11 @@ The Honcho session name determines which conversation bucket memory lands in. Re
 | Priority | Source | Example session name |
 |----------|--------|---------------------|
 | 1 | Manual map (`sessions` config) | `"myproject-main"` |
-| 2 | `/title` command (mid-session rename) | `"refactor-auth"` |
-| 3 | Gateway session key (Telegram, Discord, etc.) | `"agent-main-telegram-dm-8439114563"` |
-| 4 | `per-session` strategy | Hermes session ID (`20260415_a3f2b1`) |
-| 5 | `per-repo` strategy | Git root directory name (`hermes-agent`) |
-| 6 | `per-directory` strategy | Current directory basename (`src`) |
-| 7 | `global` strategy | Workspace name (`hermes`) |
+| 2 | Gateway session key (Telegram, Discord, etc.) | `"agent-main-telegram-dm-8439114563"` |
+| 3 | `per-session` strategy | Hermes session ID (`20260415_a3f2b1`) |
+| 4 | `per-repo` strategy | Git root directory name (`hermes-agent`) |
+| 5 | `per-directory` strategy | Current directory basename (`src`) |
+| 6 | `global` strategy | Workspace name (`hermes`) |
 
 Gateway platforms always resolve via priority 3 (per-chat isolation) regardless of `sessionStrategy`. The strategy setting only affects CLI sessions.
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -356,11 +356,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
     def _resolve_session_key(self, cfg, session_id: str, **kwargs) -> str:
         """Resolve the Honcho session key without touching the network."""
-        session_title = kwargs.get("session_title")
         gateway_session_key = kwargs.get("gateway_session_key")
         return (
             cfg.resolve_session_name(
-                session_title=session_title,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
             )

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -670,7 +670,6 @@ class HonchoClientConfig:
     def resolve_session_name(
         self,
         cwd: str | None = None,
-        session_title: str | None = None,
         session_id: str | None = None,
         gateway_session_key: str | None = None,
     ) -> str | None:
@@ -678,12 +677,11 @@ class HonchoClientConfig:
 
         Resolution order:
           1. Manual directory override from sessions map
-          2. Hermes session title (from /title command)
-          3. Gateway session key (stable per-chat identifier from gateway platforms)
-          4. per-session strategy — Hermes session_id ({timestamp}_{hex})
-          5. per-repo strategy — git repo root directory name
-          6. per-directory strategy — directory basename
-          7. global strategy — workspace name
+          2. Gateway session key (stable per-chat identifier from gateway platforms)
+          3. per-session strategy — Hermes session_id ({timestamp}_{hex})
+          4. per-repo strategy — git repo root directory name
+          5. per-directory strategy — directory basename
+          6. global strategy — workspace name
         """
         import re
 
@@ -694,14 +692,6 @@ class HonchoClientConfig:
         manual = self.sessions.get(cwd)
         if manual:
             return manual
-
-        # /title mid-session remap
-        if session_title:
-            sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', session_title).strip('-')
-            if sanitized:
-                if self.session_peer_prefix and self.peer_name:
-                    return f"{self.peer_name}-{sanitized}"
-                return sanitized
 
         # Gateway session key: stable per-chat identifier passed by the gateway
         # (e.g. "agent:main:telegram:dm:8439114563"). Sanitize colons to hyphens

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -99,46 +99,32 @@ class TestWriteFrequencyParsing:
 
 
 # ---------------------------------------------------------------------------
-# resolve_session_name with session_title
+# resolve_session_name
 # ---------------------------------------------------------------------------
 
-class TestResolveSessionNameTitle:
-    def test_manual_override_beats_title(self):
+class TestResolveSessionName:
+    def test_manual_override_wins(self):
         cfg = HonchoClientConfig(sessions={"/my/project": "manual-name"})
-        result = cfg.resolve_session_name("/my/project", session_title="the-title")
+        result = cfg.resolve_session_name("/my/project", session_id="20260309_175514_9797dd")
         assert result == "manual-name"
 
-    def test_title_beats_dirname(self):
+    def test_dirname_used_by_default(self):
         cfg = HonchoClientConfig()
-        result = cfg.resolve_session_name("/some/dir", session_title="my-project")
-        assert result == "my-project"
+        result = cfg.resolve_session_name("/some/dir")
+        assert result == "dir"
 
-    def test_title_with_peer_prefix(self):
+    def test_dirname_with_peer_prefix(self):
         cfg = HonchoClientConfig(peer_name="eri", session_peer_prefix=True)
-        result = cfg.resolve_session_name("/some/dir", session_title="aeris")
-        assert result == "eri-aeris"
+        result = cfg.resolve_session_name("/some/dir")
+        assert result == "eri-dir"
 
-    def test_title_sanitized(self):
+    def test_gateway_key_used_when_present(self):
         cfg = HonchoClientConfig()
-        result = cfg.resolve_session_name("/some/dir", session_title="my project/name!")
-        # trailing dashes stripped by .strip('-')
-        assert result == "my-project-name"
-
-    def test_title_all_invalid_chars_falls_back_to_dirname(self):
-        cfg = HonchoClientConfig()
-        result = cfg.resolve_session_name("/some/dir", session_title="!!! ###")
-        # sanitized to empty → falls back to dirname
-        assert result == "dir"
-
-    def test_none_title_falls_back_to_dirname(self):
-        cfg = HonchoClientConfig()
-        result = cfg.resolve_session_name("/some/dir", session_title=None)
-        assert result == "dir"
-
-    def test_empty_title_falls_back_to_dirname(self):
-        cfg = HonchoClientConfig()
-        result = cfg.resolve_session_name("/some/dir", session_title="")
-        assert result == "dir"
+        result = cfg.resolve_session_name(
+            "/some/dir",
+            gateway_session_key="agent:main:discord:group:123:456",
+        )
+        assert result == "agent-main-discord-group-123-456"
 
     def test_per_session_uses_session_id(self):
         cfg = HonchoClientConfig(session_strategy="per-session")
@@ -155,10 +141,11 @@ class TestResolveSessionNameTitle:
         result = cfg.resolve_session_name("/some/dir", session_id=None)
         assert result == "dir"
 
-    def test_title_beats_session_id(self):
-        cfg = HonchoClientConfig(session_strategy="per-session")
-        result = cfg.resolve_session_name("/some/dir", session_title="my-title", session_id="20260309_175514_9797dd")
-        assert result == "my-title"
+    def test_per_repo_uses_repo_name(self):
+        cfg = HonchoClientConfig(session_strategy="per-repo")
+        with patch.object(HonchoClientConfig, "_git_repo_name", return_value="repo-name"):
+            result = cfg.resolve_session_name("/some/dir")
+        assert result == "repo-name"
 
     def test_manual_beats_session_id(self):
         cfg = HonchoClientConfig(session_strategy="per-session", sessions={"/some/dir": "pinned"})

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -711,15 +711,14 @@ class TestResolveSessionNameGatewayKey:
         )
         assert result == "agent-main-telegram-dm-8439114563"
 
-    def test_session_title_still_wins_over_gateway_key(self):
-        """Explicit /title remap takes priority over gateway_session_key."""
+    def test_gateway_key_defines_identity(self):
+        """gateway_session_key still defines identity when provided."""
         config = HonchoClientConfig(session_strategy="per-session")
         result = config.resolve_session_name(
-            session_title="my-custom-title",
             session_id="20260412_171002_69bb38",
             gateway_session_key="agent:main:telegram:dm:8439114563",
         )
-        assert result == "my-custom-title"
+        assert result == "agent-main-telegram-dm-8439114563"
 
     def test_per_session_fallback_without_gateway_key(self):
         """Without gateway_session_key, per-session returns session_id (CLI path)."""


### PR DESCRIPTION
## What does this PR do?

Removes `session_title` as a possible Honcho session ID.

Causes sessionStrategy to be honored correctly.

## Related Issue

Fixes #24740

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- remove `session_title` from honcho plugin session creation flow

## How to Test

1. Enable Honcho
2. Set sessionStrategy to per-repo
3. Open two cli chats in the same directory
4. In each chat, talk about a different topics, so each session has a title generated
5. Check latest sessions in Honcho workspace
6. Confirm only one session was created in Honcho (not two)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
