### PR TITLE
[codex] Thread Slack cron reports and sync profile templates

### DIFF
--- a/cron/job_templates.py
+++ b/cron/job_templates.py
@@ -1,0 +1,133 @@
+"""Sync cron job templates from the active Hermes profile."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+from cron.jobs import create_job, list_jobs, parse_schedule, update_job
+
+
+TEMPLATES_DIR = "cron/templates"
+
+def _templates_path() -> Path:
+    return get_hermes_home() / TEMPLATES_DIR
+
+
+def _template_version(template: Dict[str, Any]) -> Optional[str]:
+    version = template.get("template_version", template.get("version"))
+    if version is None:
+        return None
+    text = str(version).strip()
+    return text or None
+
+
+def _template_key(template: Dict[str, Any], path: Path) -> str:
+    key = str(template.get("template_key") or path.stem).strip()
+    if not key:
+        raise ValueError(f"Cron template has no template_key: {path}")
+    return key
+
+
+def _read_template(path: Path) -> Optional[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as f:
+        template = json.load(f)
+    if not isinstance(template, dict):
+        raise ValueError(f"Cron template must be a JSON object: {path}")
+    if template.get("active", True) is False:
+        return None
+    return template
+
+
+def _load_templates() -> List[Dict[str, Any]]:
+    templates_dir = _templates_path()
+    if not templates_dir.exists():
+        return []
+
+    templates: List[Dict[str, Any]] = []
+    for path in sorted(templates_dir.glob("*.json")):
+        template = _read_template(path)
+        if template is None:
+            continue
+        template = dict(template)
+        template["template_key"] = _template_key(template, path)
+        template["template_version"] = _template_version(template)
+        templates.append(template)
+    return templates
+
+
+def _create_kwargs(template: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "prompt": template.get("prompt", ""),
+        "schedule": template["schedule"],
+        "name": template.get("name"),
+        "deliver": template.get("deliver"),
+        "skill": template.get("skill"),
+        "skills": template.get("skills"),
+        "model": template.get("model"),
+        "provider": template.get("provider"),
+        "base_url": template.get("base_url"),
+        "script": template.get("script"),
+        "context_from": template.get("context_from"),
+        "enabled_toolsets": template.get("enabled_toolsets"),
+        "workdir": template.get("workdir"),
+        "no_agent": bool(template.get("no_agent", False)),
+        "delivery_mode": template.get("delivery_mode"),
+        "thread_title_template": template.get("thread_title_template"),
+        "template_key": template["template_key"],
+        "template_version": template.get("template_version"),
+    }
+
+
+def _update_fields(template: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Any]:
+    updates = {
+        "prompt": template.get("prompt", ""),
+        "name": template.get("name"),
+        "deliver": template.get("deliver", "local"),
+        "skill": template.get("skill"),
+        "skills": template.get("skills"),
+        "model": template.get("model"),
+        "provider": template.get("provider"),
+        "base_url": template.get("base_url"),
+        "script": template.get("script"),
+        "context_from": template.get("context_from"),
+        "enabled_toolsets": template.get("enabled_toolsets"),
+        "workdir": template.get("workdir"),
+        "no_agent": bool(template.get("no_agent", False)),
+        "delivery_mode": template.get("delivery_mode"),
+        "thread_title_template": template.get("thread_title_template"),
+        "template_key": template["template_key"],
+        "template_version": template.get("template_version"),
+    }
+    if "schedule" in template:
+        parsed_schedule = parse_schedule(template["schedule"])
+        if parsed_schedule != existing.get("schedule"):
+            updates["schedule"] = parsed_schedule
+            updates["schedule_display"] = parsed_schedule.get("display", template["schedule"])
+    return updates
+
+
+def sync_cron_templates() -> Dict[str, Any]:
+    """Upsert active cron templates into cron/jobs.json."""
+    created: List[str] = []
+    updated: List[str] = []
+
+    jobs_by_template_key = {
+        job.get("template_key"): job
+        for job in list_jobs(include_disabled=True)
+        if job.get("template_key")
+    }
+
+    for template in _load_templates():
+        key = template["template_key"]
+        existing = jobs_by_template_key.get(key)
+        if existing is None:
+            create_job(**_create_kwargs(template))
+            created.append(key)
+            continue
+
+        update_job(existing["id"], _update_fields(template, existing))
+        updated.append(key)
+
+    return {"created": created, "updated": updated}

--- a/cron/job_templates.py
+++ b/cron/job_templates.py
@@ -6,7 +6,16 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 
-from cron.jobs import create_job, list_jobs, parse_schedule, update_job
+from cron.jobs import (
+    compute_next_run,
+    create_job,
+    load_jobs,
+    parse_duration,
+    parse_schedule,
+    save_jobs,
+    _normalize_skill_list,
+    _normalize_workdir,
+)
 
 
 TEMPLATES_DIR = "cron/templates"
@@ -40,11 +49,19 @@ def _read_template(path: Path) -> Optional[Dict[str, Any]]:
     return template
 
 
+def _validate_template(template: Dict[str, Any], path: Path) -> None:
+    if "schedule" not in template:
+        raise ValueError(f"Cron template is missing schedule: {path}")
+    if bool(template.get("no_agent", False)) and not str(template.get("script") or "").strip():
+        raise ValueError(f"no_agent=True requires a script in cron template: {path}")
+
+
 def _load_templates() -> List[Dict[str, Any]]:
     templates_dir = _templates_path()
     if not templates_dir.exists():
         return []
 
+    seen_keys: Dict[str, Path] = {}
     templates: List[Dict[str, Any]] = []
     for path in sorted(templates_dir.glob("*.json")):
         template = _read_template(path)
@@ -52,6 +69,13 @@ def _load_templates() -> List[Dict[str, Any]]:
             continue
         template = dict(template)
         template["template_key"] = _template_key(template, path)
+        if template["template_key"] in seen_keys:
+            raise ValueError(
+                "Duplicate cron template_key "
+                f"{template['template_key']!r}: {seen_keys[template['template_key']]} and {path}"
+            )
+        seen_keys[template["template_key"]] = path
+        _validate_template(template, path)
         template["template_version"] = _template_version(template)
         templates.append(template)
     return templates
@@ -80,54 +104,119 @@ def _create_kwargs(template: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _update_fields(template: Dict[str, Any], existing: Dict[str, Any]) -> Dict[str, Any]:
-    updates = {
-        "prompt": template.get("prompt", ""),
-        "name": template.get("name"),
-        "deliver": template.get("deliver", "local"),
-        "skill": template.get("skill"),
-        "skills": template.get("skills"),
-        "model": template.get("model"),
-        "provider": template.get("provider"),
-        "base_url": template.get("base_url"),
-        "script": template.get("script"),
-        "context_from": template.get("context_from"),
-        "enabled_toolsets": template.get("enabled_toolsets"),
-        "workdir": template.get("workdir"),
-        "no_agent": bool(template.get("no_agent", False)),
-        "delivery_mode": template.get("delivery_mode"),
-        "thread_title_template": template.get("thread_title_template"),
-        "template_key": template["template_key"],
-        "template_version": template.get("template_version"),
-    }
-    if "schedule" in template:
-        parsed_schedule = parse_schedule(template["schedule"])
-        if parsed_schedule != existing.get("schedule"):
-            updates["schedule"] = parsed_schedule
-            updates["schedule_display"] = parsed_schedule.get("display", template["schedule"])
-    return updates
+def _optional_text(value: Any, *, strip_trailing_slash: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if strip_trailing_slash:
+        text = text.rstrip("/")
+    return text or None
+
+
+def _normalize_context_from(value: Any) -> Optional[List[str]]:
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else None
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()] or None
+    return None
+
+
+def _is_relative_oneshot_schedule(schedule: str) -> bool:
+    try:
+        parse_duration(schedule)
+    except ValueError:
+        return False
+    return True
+
+
+def _schedule_changed(existing: Dict[str, Any], schedule: str) -> bool:
+    template_schedule = existing.get("template_schedule")
+    if template_schedule is not None:
+        return template_schedule != schedule
+    if existing.get("schedule_display") == schedule:
+        return False
+    if existing.get("schedule", {}).get("kind") == "once" and _is_relative_oneshot_schedule(schedule):
+        return False
+    return parse_schedule(schedule) != existing.get("schedule")
+
+
+def _apply_template_update(job: Dict[str, Any], template: Dict[str, Any]) -> None:
+    raw_schedule = str(template["schedule"])
+    schedule_changed = _schedule_changed(job, raw_schedule)
+
+    normalized_skills = _normalize_skill_list(template.get("skill"), template.get("skills"))
+    job.update(
+        {
+            "prompt": str(template.get("prompt") or ""),
+            "name": template.get("name") or (str(template.get("prompt") or "")[:50].strip() or "cron job"),
+            "skills": normalized_skills,
+            "skill": normalized_skills[0] if normalized_skills else None,
+            "model": _optional_text(template.get("model")),
+            "provider": _optional_text(template.get("provider")),
+            "base_url": _optional_text(template.get("base_url"), strip_trailing_slash=True),
+            "script": _optional_text(template.get("script")),
+            "no_agent": bool(template.get("no_agent", False)),
+            "context_from": _normalize_context_from(template.get("context_from")),
+            "deliver": template.get("deliver", "local"),
+            "enabled_toolsets": [
+                str(item).strip()
+                for item in template.get("enabled_toolsets", []) or []
+                if str(item).strip()
+            ]
+            or None,
+            "workdir": _normalize_workdir(template.get("workdir")),
+            "delivery_mode": _optional_text(template.get("delivery_mode")),
+            "thread_title_template": _optional_text(template.get("thread_title_template")),
+            "template_key": template["template_key"],
+            "template_version": template.get("template_version"),
+            "template_schedule": raw_schedule,
+        }
+    )
+
+    if schedule_changed:
+        parsed_schedule = parse_schedule(raw_schedule)
+        job["schedule"] = parsed_schedule
+        job["schedule_display"] = parsed_schedule.get("display", raw_schedule)
+        if job.get("state") != "paused":
+            job["next_run_at"] = compute_next_run(parsed_schedule)
+
+
+def _remember_template_schedule(job_id: str, raw_schedule: str) -> None:
+    jobs = load_jobs()
+    for job in jobs:
+        if job.get("id") == job_id:
+            job["template_schedule"] = raw_schedule
+            break
+    save_jobs(jobs)
 
 
 def sync_cron_templates() -> Dict[str, Any]:
     """Upsert active cron templates into cron/jobs.json."""
+    templates = _load_templates()
     created: List[str] = []
     updated: List[str] = []
 
     jobs_by_template_key = {
         job.get("template_key"): job
-        for job in list_jobs(include_disabled=True)
+        for job in load_jobs()
         if job.get("template_key")
     }
 
-    for template in _load_templates():
+    for template in templates:
         key = template["template_key"]
         existing = jobs_by_template_key.get(key)
         if existing is None:
-            create_job(**_create_kwargs(template))
+            created_job = create_job(**_create_kwargs(template))
+            _remember_template_schedule(created_job["id"], str(template["schedule"]))
             created.append(key)
             continue
 
-        update_job(existing["id"], _update_fields(template, existing))
+        jobs = load_jobs()
+        for job in jobs:
+            if job.get("id") == existing["id"]:
+                _apply_template_update(job, template)
+                break
+        save_jobs(jobs)
         updated.append(key)
 
     return {"created": created, "updated": updated}

--- a/cron/job_templates.py
+++ b/cron/job_templates.py
@@ -129,6 +129,14 @@ def _is_relative_oneshot_schedule(schedule: str) -> bool:
     return True
 
 
+def _legacy_relative_oneshot_schedule(existing: Dict[str, Any]) -> Optional[str]:
+    display = str(existing.get("schedule_display") or "").strip()
+    prefix = "once in "
+    if display.lower().startswith(prefix):
+        return display[len(prefix):].strip()
+    return None
+
+
 def _schedule_changed(existing: Dict[str, Any], schedule: str) -> bool:
     template_schedule = existing.get("template_schedule")
     if template_schedule is not None:
@@ -136,6 +144,9 @@ def _schedule_changed(existing: Dict[str, Any], schedule: str) -> bool:
     if existing.get("schedule_display") == schedule:
         return False
     if existing.get("schedule", {}).get("kind") == "once" and _is_relative_oneshot_schedule(schedule):
+        legacy_schedule = _legacy_relative_oneshot_schedule(existing)
+        if legacy_schedule is not None:
+            return legacy_schedule != schedule
         return False
     return parse_schedule(schedule) != existing.get("schedule")
 

--- a/cron/job_templates.py
+++ b/cron/job_templates.py
@@ -95,7 +95,7 @@ def _create_kwargs(template: Dict[str, Any]) -> Dict[str, Any]:
         "script": template.get("script"),
         "context_from": template.get("context_from"),
         "enabled_toolsets": template.get("enabled_toolsets"),
-        "workdir": template.get("workdir"),
+        "workdir": _expand_template_workdir(template.get("workdir")),
         "no_agent": bool(template.get("no_agent", False)),
         "delivery_mode": template.get("delivery_mode"),
         "thread_title_template": template.get("thread_title_template"),
@@ -111,6 +111,20 @@ def _optional_text(value: Any, *, strip_trailing_slash: bool = False) -> Optiona
     if strip_trailing_slash:
         text = text.rstrip("/")
     return text or None
+
+
+def _expand_template_workdir(value: Any) -> Any:
+    """Expand profile-local placeholders in distribution-owned cron templates."""
+    if value is None:
+        return None
+    text = str(value)
+    hermes_home = str(get_hermes_home())
+    return (
+        text.replace("${HERMES_HOME}", hermes_home)
+        .replace("$HERMES_HOME", hermes_home)
+        .replace("{HERMES_HOME}", hermes_home)
+        .replace("{hermes_home}", hermes_home)
+    )
 
 
 def _normalize_context_from(value: Any) -> Optional[List[str]]:
@@ -175,7 +189,7 @@ def _apply_template_update(job: Dict[str, Any], template: Dict[str, Any]) -> Non
                 if str(item).strip()
             ]
             or None,
-            "workdir": _normalize_workdir(template.get("workdir")),
+            "workdir": _normalize_workdir(_expand_template_workdir(template.get("workdir"))),
             "delivery_mode": _optional_text(template.get("delivery_mode")),
             "thread_title_template": _optional_text(template.get("thread_title_template")),
             "template_key": template["template_key"],

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -79,6 +79,12 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def _normalize_optional_job_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value).strip() or None
+
+
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
@@ -496,6 +502,10 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    delivery_mode: Optional[str] = None,
+    thread_title_template: Optional[str] = None,
+    template_key: Optional[str] = None,
+    template_version: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -540,6 +550,10 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        delivery_mode: Optional delivery metadata for downstream formatters.
+        thread_title_template: Optional thread title template metadata.
+        template_key: Optional response template key metadata.
+        template_version: Optional response template version metadata.
 
     Returns:
         The created job dict
@@ -574,6 +588,10 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_delivery_mode = _normalize_optional_job_text(delivery_mode)
+    normalized_thread_title_template = _normalize_optional_job_text(thread_title_template)
+    normalized_template_key = _normalize_optional_job_text(template_key)
+    normalized_template_version = _normalize_optional_job_text(template_version)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -627,6 +645,10 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "delivery_mode": normalized_delivery_mode,
+        "thread_title_template": normalized_thread_title_template,
+        "template_key": normalized_template_key,
+        "template_version": normalized_template_version,
     }
 
     jobs = load_jobs()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1867,7 +1867,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip().upper() == SILENT_MARKER:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -426,7 +426,10 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
 
 
 def _cron_delivery_mode(job: dict) -> str:
-    return str(job.get("delivery_mode") or "").strip().lower()
+    mode = str(job.get("delivery_mode") or "").strip().lower()
+    if mode == "threaded":
+        return "slack_thread"
+    return mode
 
 
 def _render_thread_title(job: dict) -> str:
@@ -576,7 +579,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         threaded_mode = (
             _cron_delivery_mode(job) == "slack_thread"
             and platform_name.lower() == "slack"
-            and not thread_id
         )
         target_content = (
             _threaded_body_content(job, content, wrap_response)
@@ -622,8 +624,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
+        threaded_anchor_id = None
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = None if threaded_mode else ({"thread_id": thread_id} if thread_id else None)
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -655,7 +658,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             )
                             adapter_ok = False
                         else:
-                            send_metadata = {"thread_id": anchor_id}
+                            threaded_anchor_id = anchor_id
+                            send_metadata = {"thread_id": threaded_anchor_id}
 
                 if adapter_ok and text_to_send:
                     future = asyncio.run_coroutine_threadsafe(
@@ -731,19 +735,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
             try:
                 if threaded_mode:
-                    anchor_result = run_standalone_send(_render_thread_title(job), send_thread_id=None)
-                    if anchor_result and anchor_result.get("error"):
-                        result = anchor_result
+                    if threaded_anchor_id:
+                        result = run_standalone_send(
+                            cleaned_delivery_content,
+                            send_thread_id=threaded_anchor_id,
+                            send_media_files=media_files,
+                        )
                     else:
-                        anchor_id = _message_id_from_send_result(anchor_result)
-                        if not anchor_id:
-                            result = {"error": "Slack thread anchor did not return message_id"}
+                        anchor_result = run_standalone_send(_render_thread_title(job), send_thread_id=None)
+                        if anchor_result and anchor_result.get("error"):
+                            result = anchor_result
                         else:
-                            result = run_standalone_send(
-                                cleaned_delivery_content,
-                                send_thread_id=anchor_id,
-                                send_media_files=media_files,
-                            )
+                            anchor_id = _message_id_from_send_result(anchor_result)
+                            if not anchor_id:
+                                result = {"error": "Slack thread anchor did not return message_id"}
+                            else:
+                                result = run_standalone_send(
+                                    cleaned_delivery_content,
+                                    send_thread_id=anchor_id,
+                                    send_media_files=media_files,
+                                )
                 else:
                     result = run_standalone_send(
                         cleaned_delivery_content,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -425,6 +425,41 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     return targets[0] if targets else None
 
 
+def _cron_delivery_mode(job: dict) -> str:
+    return str(job.get("delivery_mode") or "").strip().lower()
+
+
+def _render_thread_title(job: dict) -> str:
+    job_id = str(job.get("id", ""))
+    name = str(job.get("name") or job_id)
+    template = str(job.get("thread_title_template") or "{name} (job_id: {job_id})")
+    values = dict(job)
+    values["id"] = job_id
+    values["job_id"] = job_id
+    values["name"] = name
+    try:
+        rendered = template.format(**values)
+    except Exception:
+        rendered = "{name} (job_id: {job_id})".format(name=name, job_id=job_id)
+    return rendered.strip() or "{name} (job_id: {job_id})".format(name=name, job_id=job_id)
+
+
+def _threaded_body_content(job: dict, content: str, wrap_response: bool) -> str:
+    if not wrap_response:
+        return content
+    task_name = job.get("name", job["id"])
+    return (
+        f"{content}\n\n"
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+
+
+def _message_id_from_send_result(result) -> Optional[str]:
+    if isinstance(result, dict):
+        return result.get("message_id") or result.get("ts")
+    return getattr(result, "message_id", None) or getattr(result, "ts", None)
+
+
 # Media extension sets — audio routing is centralized in gateway.platforms.base
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
 _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
@@ -523,9 +558,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
 
     try:
         config = load_gateway_config()
@@ -540,6 +573,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        threaded_mode = (
+            _cron_delivery_mode(job) == "slack_thread"
+            and platform_name.lower() == "slack"
+            and not thread_id
+        )
+        target_content = (
+            _threaded_body_content(job, content, wrap_response)
+            if threaded_mode
+            else delivery_content
+        )
+        # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(target_content)
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -583,7 +628,36 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
-                if text_to_send:
+                if threaded_mode:
+                    title = _render_thread_title(job)
+                    future = asyncio.run_coroutine_threadsafe(
+                        runtime_adapter.send(chat_id, title),
+                        loop,
+                    )
+                    try:
+                        anchor_result = future.result(timeout=60)
+                    except TimeoutError:
+                        future.cancel()
+                        raise
+                    if anchor_result and not getattr(anchor_result, "success", True):
+                        err = getattr(anchor_result, "error", "unknown")
+                        logger.warning(
+                            "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
+                            job["id"], platform_name, chat_id, err,
+                        )
+                        adapter_ok = False  # fall through to standalone path
+                    else:
+                        anchor_id = _message_id_from_send_result(anchor_result)
+                        if not anchor_id:
+                            logger.warning(
+                                "Job '%s': live adapter Slack thread anchor did not return a message id, falling back to standalone",
+                                job["id"],
+                            )
+                            adapter_ok = False
+                        else:
+                            send_metadata = {"thread_id": anchor_id}
+
+                if adapter_ok and text_to_send:
                     future = asyncio.run_coroutine_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                         loop,
@@ -624,18 +698,58 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            def run_standalone_send(message, send_thread_id=None, send_media_files=None):
+                coro = _send_to_platform(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    message,
+                    thread_id=send_thread_id,
+                    media_files=send_media_files or [],
+                )
+                try:
+                    return asyncio.run(coro)
+                except RuntimeError:
+                    # asyncio.run() checks for a running loop before awaiting the coroutine;
+                    # when it raises, the original coro was never started — close it to
+                    # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
+                    # fresh thread that has no running loop.
+                    coro.close()
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                message,
+                                thread_id=send_thread_id,
+                                media_files=send_media_files or [],
+                            ),
+                        )
+                        return future.result(timeout=30)
+
             try:
-                result = asyncio.run(coro)
-            except RuntimeError:
-                # asyncio.run() checks for a running loop before awaiting the coroutine;
-                # when it raises, the original coro was never started — close it to
-                # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
-                # fresh thread that has no running loop.
-                coro.close()
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                    result = future.result(timeout=30)
+                if threaded_mode:
+                    anchor_result = run_standalone_send(_render_thread_title(job), send_thread_id=None)
+                    if anchor_result and anchor_result.get("error"):
+                        result = anchor_result
+                    else:
+                        anchor_id = _message_id_from_send_result(anchor_result)
+                        if not anchor_id:
+                            result = {"error": "Slack thread anchor did not return message_id"}
+                        else:
+                            result = run_standalone_send(
+                                cleaned_delivery_content,
+                                send_thread_id=anchor_id,
+                                send_media_files=media_files,
+                            )
+                else:
+                    result = run_standalone_send(
+                        cleaned_delivery_content,
+                        send_thread_id=thread_id,
+                        send_media_files=media_files,
+                    )
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -91,6 +91,9 @@ def cron_list(show_all: bool = False):
         delivery_mode = job.get("delivery_mode")
         if delivery_mode:
             print(f"    Delivery:  {delivery_mode}")
+        thread_title_template = job.get("thread_title_template")
+        if thread_title_template:
+            print(f"    Thread title: {thread_title_template}")
         template_key = job.get("template_key")
         template_version = job.get("template_version")
         if template_key:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -88,6 +88,16 @@ def cron_list(show_all: bool = False):
         print(f"    Repeat:    {repeat_str}")
         print(f"    Next run:  {next_run}")
         print(f"    Deliver:   {deliver_str}")
+        delivery_mode = job.get("delivery_mode")
+        if delivery_mode:
+            print(f"    Delivery:  {delivery_mode}")
+        template_key = job.get("template_key")
+        template_version = job.get("template_version")
+        if template_key:
+            template_label = template_key
+            if template_version:
+                template_label = f"{template_label}@{template_version}"
+            print(f"    Template:  {template_label}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
         script = job.get("script")
@@ -175,6 +185,10 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        delivery_mode=getattr(args, "delivery_mode", None),
+        thread_title_template=getattr(args, "thread_title_template", None),
+        template_key=getattr(args, "template_key", None),
+        template_version=getattr(args, "template_version", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -231,6 +245,10 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        delivery_mode=getattr(args, "delivery_mode", None),
+        thread_title_template=getattr(args, "thread_title_template", None),
+        template_key=getattr(args, "template_key", None),
+        template_version=getattr(args, "template_version", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -250,6 +268,23 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    return 0
+
+
+def cron_sync_templates():
+    """Sync cron templates from the active Hermes profile."""
+    from cron.job_templates import sync_cron_templates
+
+    result = sync_cron_templates()
+    created = result.get("created", [])
+    updated = result.get("updated", [])
+    print(color("Synced cron templates.", Colors.GREEN))
+    print(f"  Created: {len(created)}")
+    if created:
+        print(f"    {', '.join(created)}")
+    print(f"  Updated: {len(updated)}")
+    if updated:
+        print(f"    {', '.join(updated)}")
     return 0
 
 
@@ -284,6 +319,9 @@ def cron_command(args):
         cron_tick()
         return 0
 
+    if subcmd == "sync-templates":
+        return cron_sync_templates()
+
     if subcmd in {"create", "add"}:
         return cron_create(args)
 
@@ -303,5 +341,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick|sync-templates]")
     sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9844,6 +9844,16 @@ def main():
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument("--delivery-mode", help="Optional delivery mode metadata")
+    cron_create.add_argument(
+        "--thread-title-template",
+        help="Optional thread title template metadata",
+    )
+    cron_create.add_argument("--template-key", help="Optional cron template key metadata")
+    cron_create.add_argument(
+        "--template-version",
+        help="Optional cron template version metadata",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -9908,6 +9918,16 @@ def main():
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
     )
+    cron_edit.add_argument("--delivery-mode", help="New delivery mode metadata")
+    cron_edit.add_argument(
+        "--thread-title-template",
+        help="New thread title template metadata",
+    )
+    cron_edit.add_argument("--template-key", help="New cron template key metadata")
+    cron_edit.add_argument(
+        "--template-version",
+        help="New cron template version metadata",
+    )
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")
@@ -9933,6 +9953,12 @@ def main():
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     _add_accept_hooks_flag(cron_tick)
+
+    # cron sync-templates
+    cron_subparsers.add_parser(
+        "sync-templates",
+        help="Sync active profile cron templates into jobs.json",
+    )
     _add_accept_hooks_flag(cron_parser)
     cron_parser.set_defaults(func=cmd_cron)
 

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -538,22 +538,25 @@ def _copy_dist_payload(
     """
     target.mkdir(parents=True, exist_ok=True)
 
-    for rel_str in manifest.owned_paths():
-        rel = Path(rel_str)
+    def _is_user_owned_path(rel: Path) -> bool:
+        return any(part in USER_OWNED_EXCLUDE for part in rel.parts)
+
+    def _copy_owned_path(rel: Path) -> None:
         if rel.is_absolute() or ".." in rel.parts or not rel.parts:
-            continue
-        if rel.parts[0] in USER_OWNED_EXCLUDE:
-            continue
-        if rel_str == ENV_TEMPLATE_FILENAME:
+            return
+        if _is_user_owned_path(rel):
+            return
+        rel_posix = rel.as_posix()
+        if rel_posix == ENV_TEMPLATE_FILENAME:
             # Handled below as .env.EXAMPLE.
-            continue
-        if rel_str == "config.yaml" and preserve_config and (target / "config.yaml").exists():
+            return
+        if rel_posix == "config.yaml" and preserve_config and (target / "config.yaml").exists():
             # Leave user's config.yaml alone on update
-            continue
+            return
 
         entry = staged / rel
         if not entry.exists():
-            continue
+            return
 
         dest = target / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -571,6 +574,13 @@ def _copy_dist_payload(
             if dest.is_dir():
                 shutil.rmtree(dest)
             shutil.copy2(entry, dest)
+
+    if manifest.distribution_owned:
+        for rel_str in manifest.owned_paths():
+            _copy_owned_path(Path(rel_str))
+    else:
+        for entry in staged.iterdir():
+            _copy_owned_path(Path(entry.name))
 
     env_template = staged / ENV_TEMPLATE_FILENAME
     if env_template.is_file():

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -538,29 +538,43 @@ def _copy_dist_payload(
     """
     target.mkdir(parents=True, exist_ok=True)
 
-    for entry in staged.iterdir():
-        name = entry.name
-
-        if name in USER_OWNED_EXCLUDE:
+    for rel_str in manifest.owned_paths():
+        rel = Path(rel_str)
+        if rel.is_absolute() or ".." in rel.parts or not rel.parts:
             continue
-        if name == ENV_TEMPLATE_FILENAME:
-            shutil.copy2(entry, target / ENV_EXAMPLE_FILENAME)
+        if rel.parts[0] in USER_OWNED_EXCLUDE:
             continue
-        if name == "config.yaml" and preserve_config and (target / "config.yaml").exists():
+        if rel_str == ENV_TEMPLATE_FILENAME:
+            # Handled below as .env.EXAMPLE.
+            continue
+        if rel_str == "config.yaml" and preserve_config and (target / "config.yaml").exists():
             # Leave user's config.yaml alone on update
             continue
 
-        dest = target / name
+        entry = staged / rel
+        if not entry.exists():
+            continue
+
+        dest = target / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
         if entry.is_dir():
-            if dest.exists():
+            if dest.is_dir():
                 shutil.rmtree(dest)
+            elif dest.exists():
+                dest.unlink()
             shutil.copytree(
                 entry,
                 dest,
                 ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE],
             )
         else:
+            if dest.is_dir():
+                shutil.rmtree(dest)
             shutil.copy2(entry, dest)
+
+    env_template = staged / ENV_TEMPLATE_FILENAME
+    if env_template.is_file():
+        shutil.copy2(env_template, target / ENV_EXAMPLE_FILENAME)
 
     # Emit .env.EXAMPLE from manifest if the staged tree didn't ship one
     if manifest.env_requires and not (target / ENV_EXAMPLE_FILENAME).exists():

--- a/tests/cron/test_job_templates.py
+++ b/tests/cron/test_job_templates.py
@@ -3,6 +3,10 @@
 import importlib
 import json
 
+import pytest
+
+from hermes_cli.cron import cron_list
+
 
 def _load_modules(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
@@ -111,3 +115,134 @@ def test_sync_cron_templates_updates_prompt_but_preserves_runtime_state(tmp_path
     assert stored["state"] == "paused"
     assert stored["paused_at"] == "2026-05-12T09:05:00+00:00"
     assert stored["paused_reason"] == "maintenance"
+
+
+def test_sync_cron_templates_preserves_missing_next_run_when_schedule_unchanged(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    existing = jobs.create_job(
+        prompt="old",
+        schedule="every 1h",
+        name="Existing template job",
+        deliver="slack",
+        template_key="repo-self-improvement",
+        template_version="1",
+    )
+    stored_jobs = jobs.load_jobs()
+    stored_jobs[0]["next_run_at"] = None
+    jobs.save_jobs(stored_jobs)
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="2",
+        name="Existing template job",
+        schedule="every 1h",
+        prompt="new",
+        deliver="slack",
+    )
+
+    job_templates.sync_cron_templates()
+
+    stored = jobs.get_job(existing["id"])
+    assert stored["next_run_at"] is None
+    assert stored["prompt"] == "new"
+
+
+def test_sync_cron_templates_relative_one_shot_does_not_shift_on_second_sync(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="1",
+        name="Repo self improvement",
+        schedule="30m",
+        prompt="Review the repository and suggest one improvement.",
+        deliver="slack",
+    )
+    job_templates.sync_cron_templates()
+    before = jobs.list_jobs(include_disabled=True)[0]
+    first_schedule = before["schedule"]
+    first_next_run_at = before["next_run_at"]
+
+    job_templates.sync_cron_templates()
+
+    after = jobs.list_jobs(include_disabled=True)[0]
+    assert after["schedule"] == first_schedule
+    assert after["next_run_at"] == first_next_run_at
+
+
+def test_sync_cron_templates_duplicate_keys_raise_before_mutating_jobs(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    _write_template(
+        hermes_home,
+        "one.json",
+        template_key="repo-self-improvement",
+        version="1",
+        name="First",
+        schedule="every 1h",
+        prompt="first",
+    )
+    _write_template(
+        hermes_home,
+        "two.json",
+        template_key="repo-self-improvement",
+        version="1",
+        name="Second",
+        schedule="every 2h",
+        prompt="second",
+    )
+
+    with pytest.raises(ValueError, match="Duplicate cron template_key"):
+        job_templates.sync_cron_templates()
+
+    assert jobs.list_jobs(include_disabled=True) == []
+
+
+def test_sync_cron_templates_rejects_no_agent_without_script_on_update(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    existing = jobs.create_job(
+        prompt="old",
+        schedule="every 1h",
+        name="Existing template job",
+        template_key="repo-self-improvement",
+        template_version="1",
+    )
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="2",
+        name="Existing template job",
+        schedule="every 1h",
+        prompt="new",
+        no_agent=True,
+    )
+
+    with pytest.raises(ValueError, match="no_agent=True requires a script"):
+        job_templates.sync_cron_templates()
+
+    stored = jobs.get_job(existing["id"])
+    assert stored["no_agent"] is False
+    assert stored["prompt"] == "old"
+
+
+def test_cron_list_shows_thread_title_template(tmp_path, monkeypatch, capsys):
+    _hermes_home, jobs, _job_templates = _load_modules(tmp_path, monkeypatch)
+    jobs.create_job(
+        prompt="report",
+        schedule="every 1h",
+        name="Threaded report",
+        deliver="slack",
+        delivery_mode="slack_thread",
+        thread_title_template="Repo improvement - {date}",
+        template_key="repo-self-improvement",
+        template_version="1",
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+
+    cron_list(show_all=True)
+
+    out = capsys.readouterr().out
+    assert "Thread title:" in out
+    assert "Repo improvement - {date}" in out

--- a/tests/cron/test_job_templates.py
+++ b/tests/cron/test_job_templates.py
@@ -1,0 +1,113 @@
+"""Tests for syncing distribution-owned cron job templates."""
+
+import importlib
+import json
+
+
+def _load_modules(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs
+
+    jobs = importlib.reload(jobs)
+    job_templates = importlib.import_module("cron.job_templates")
+    job_templates = importlib.reload(job_templates)
+    return hermes_home, jobs, job_templates
+
+
+def _write_template(hermes_home, filename, **template):
+    templates_dir = hermes_home / "cron" / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    (templates_dir / filename).write_text(
+        json.dumps(template, indent=2),
+        encoding="utf-8",
+    )
+
+
+def test_sync_cron_templates_creates_job(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="1",
+        name="Repo self improvement",
+        schedule="every 1h",
+        prompt="Review the repository and suggest one improvement.",
+        deliver="slack",
+        delivery_mode="slack_thread",
+        thread_title_template="Repo improvement - {date}",
+    )
+
+    result = job_templates.sync_cron_templates()
+
+    assert result["created"] == ["repo-self-improvement"]
+    assert result["updated"] == []
+    stored = jobs.list_jobs(include_disabled=True)
+    assert len(stored) == 1
+    assert stored[0]["template_key"] == "repo-self-improvement"
+    assert stored[0]["template_version"] == "1"
+    assert stored[0]["delivery_mode"] == "slack_thread"
+    assert stored[0]["thread_title_template"] == "Repo improvement - {date}"
+
+
+def test_sync_cron_templates_updates_prompt_but_preserves_runtime_state(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    existing = jobs.create_job(
+        prompt="old",
+        schedule="every 1h",
+        name="Existing template job",
+        deliver="slack",
+        template_key="repo-self-improvement",
+        template_version="1",
+    )
+    jobs.update_job(
+        existing["id"],
+        {
+            "last_run_at": "2026-05-12T09:00:00+00:00",
+            "last_status": "ok",
+            "last_error": "keep this",
+            "last_delivery_error": "delivery retry later",
+            "repeat": {"times": 5, "completed": 2},
+            "enabled": False,
+            "state": "paused",
+            "paused_at": "2026-05-12T09:05:00+00:00",
+            "paused_reason": "maintenance",
+            "next_run_at": "2026-05-13T09:00:00+00:00",
+        },
+    )
+    before = jobs.get_job(existing["id"])
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="2",
+        name="Existing template job",
+        schedule="every 1h",
+        prompt="new",
+        deliver="slack",
+        delivery_mode="slack_thread",
+        thread_title_template="Repo improvement - {date}",
+    )
+
+    result = job_templates.sync_cron_templates()
+
+    assert result["created"] == []
+    assert result["updated"] == ["repo-self-improvement"]
+    stored = jobs.get_job(existing["id"])
+    assert stored["id"] == existing["id"]
+    assert stored["created_at"] == before["created_at"]
+    assert stored["next_run_at"] == before["next_run_at"]
+    assert stored["prompt"] == "new"
+    assert stored["template_version"] == "2"
+    assert stored["delivery_mode"] == "slack_thread"
+    assert stored["last_run_at"] == "2026-05-12T09:00:00+00:00"
+    assert stored["last_status"] == "ok"
+    assert stored["last_error"] == "keep this"
+    assert stored["last_delivery_error"] == "delivery retry later"
+    assert stored["repeat"] == {"times": 5, "completed": 2}
+    assert stored["enabled"] is False
+    assert stored["state"] == "paused"
+    assert stored["paused_at"] == "2026-05-12T09:05:00+00:00"
+    assert stored["paused_reason"] == "maintenance"

--- a/tests/cron/test_job_templates.py
+++ b/tests/cron/test_job_templates.py
@@ -172,6 +172,38 @@ def test_sync_cron_templates_relative_one_shot_does_not_shift_on_second_sync(tmp
     assert after["next_run_at"] == first_next_run_at
 
 
+def test_sync_cron_templates_legacy_relative_one_shot_detects_changed_duration(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    existing = jobs.create_job(
+        prompt="old",
+        schedule="30m",
+        name="Legacy one-shot template job",
+        template_key="repo-self-improvement",
+        template_version="1",
+    )
+    before = jobs.get_job(existing["id"])
+    assert before["schedule_display"] == "once in 30m"
+    assert "template_schedule" not in before
+
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="2",
+        name="Legacy one-shot template job",
+        schedule="60m",
+        prompt="new",
+    )
+
+    job_templates.sync_cron_templates()
+
+    stored = jobs.get_job(existing["id"])
+    assert stored["schedule_display"] == "once in 60m"
+    assert stored["schedule"]["run_at"] != before["schedule"]["run_at"]
+    assert stored["next_run_at"] == stored["schedule"]["run_at"]
+    assert stored["template_schedule"] == "60m"
+
+
 def test_sync_cron_templates_duplicate_keys_raise_before_mutating_jobs(tmp_path, monkeypatch):
     hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
     _write_template(

--- a/tests/cron/test_job_templates.py
+++ b/tests/cron/test_job_templates.py
@@ -56,6 +56,26 @@ def test_sync_cron_templates_creates_job(tmp_path, monkeypatch):
     assert stored[0]["thread_title_template"] == "Repo improvement - {date}"
 
 
+def test_sync_cron_templates_expands_profile_workdir(tmp_path, monkeypatch):
+    hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
+    _write_template(
+        hermes_home,
+        "repo-self-improvement.json",
+        template_key="repo-self-improvement",
+        version="1",
+        name="Repo self improvement",
+        schedule="every 1h",
+        prompt="Review the repository and suggest one improvement.",
+        workdir="${HERMES_HOME}",
+    )
+
+    result = job_templates.sync_cron_templates()
+
+    assert result["created"] == ["repo-self-improvement"]
+    stored = jobs.list_jobs(include_disabled=True)
+    assert stored[0]["workdir"] == str(hermes_home.resolve())
+
+
 def test_sync_cron_templates_updates_prompt_but_preserves_runtime_state(tmp_path, monkeypatch):
     hermes_home, jobs, job_templates = _load_modules(tmp_path, monkeypatch)
     existing = jobs.create_job(

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -775,6 +775,77 @@ class TestDeliverResultWrapping:
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
 
 
+class TestSlackThreadedDelivery:
+    def _mock_slack_config(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+        return Platform, mock_cfg
+
+    def test_slack_thread_posts_anchor_then_report_reply(self, monkeypatch):
+        Platform, mock_cfg = self._mock_slack_config()
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123456789")
+
+        send_mock = AsyncMock(
+            side_effect=[
+                {"success": True, "message_id": "ts-1"},
+                {"success": True, "message_id": "ts-2"},
+            ]
+        )
+
+        job = {
+            "id": "ed752022f2c5",
+            "name": "kb-hermes-daily-self-improvement",
+            "deliver": "slack",
+            "delivery_mode": "slack_thread",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            result = _deliver_result(job, "Detailed cron report body.")
+
+        assert result is None
+        assert send_mock.await_count == 2
+
+        anchor_call, reply_call = send_mock.await_args_list
+        assert anchor_call.args[:3] == (Platform.SLACK, mock_cfg.platforms[Platform.SLACK], "C123456789")
+        assert anchor_call.args[3] == "kb-hermes-daily-self-improvement (job_id: ed752022f2c5)"
+        assert anchor_call.kwargs["thread_id"] is None
+
+        assert reply_call.args[:3] == (Platform.SLACK, mock_cfg.platforms[Platform.SLACK], "C123456789")
+        assert reply_call.kwargs["thread_id"] == "ts-1"
+        assert "Detailed cron report body." in reply_call.args[3]
+        assert "To stop or manage this job" in reply_call.args[3]
+        assert "Cronjob Response" not in reply_call.args[3]
+
+    def test_default_slack_delivery_stays_single_message_without_thread_id(self, monkeypatch):
+        Platform, mock_cfg = self._mock_slack_config()
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123456789")
+
+        send_mock = AsyncMock(return_value={"success": True, "message_id": "ts-1"})
+
+        job = {
+            "id": "daily",
+            "name": "daily-report",
+            "deliver": "slack",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "Plain Slack report.")
+
+        assert result is None
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.args[:3] == (Platform.SLACK, mock_cfg.platforms[Platform.SLACK], "C123456789")
+        assert send_mock.await_args.args[3] == "Plain Slack report."
+        assert send_mock.await_args.kwargs["thread_id"] is None
+
+
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -845,6 +845,114 @@ class TestSlackThreadedDelivery:
         assert send_mock.await_args.args[3] == "Plain Slack report."
         assert send_mock.await_args.kwargs["thread_id"] is None
 
+    def test_slack_thread_ignores_configured_home_thread_for_anchor(self, monkeypatch):
+        Platform, mock_cfg = self._mock_slack_config()
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123456789")
+        monkeypatch.setenv("SLACK_HOME_CHANNEL_THREAD_ID", "configured-thread")
+
+        send_mock = AsyncMock(
+            side_effect=[
+                {"success": True, "message_id": "ts-anchor"},
+                {"success": True, "message_id": "ts-reply"},
+            ]
+        )
+
+        job = {
+            "id": "thread-home",
+            "name": "thread-home-report",
+            "deliver": "slack",
+            "delivery_mode": "slack_thread",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "Report body.")
+
+        assert result is None
+        assert send_mock.await_count == 2
+        anchor_call, reply_call = send_mock.await_args_list
+        assert anchor_call.kwargs["thread_id"] is None
+        assert reply_call.kwargs["thread_id"] == "ts-anchor"
+
+    def test_live_adapter_body_failure_falls_back_without_duplicate_anchor(self, monkeypatch):
+        from concurrent.futures import Future
+
+        Platform, mock_cfg = self._mock_slack_config()
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123456789")
+
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        send_results = [
+            MagicMock(success=True, message_id="live-anchor-ts"),
+            MagicMock(success=False, error="body failed"),
+        ]
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(send_results.pop(0))
+            coro.close()
+            return future
+
+        standalone_send = AsyncMock(return_value={"success": True, "message_id": "fallback-reply"})
+        job = {
+            "id": "live-fallback",
+            "name": "live-fallback-report",
+            "deliver": "slack",
+            "delivery_mode": "slack_thread",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Live body.",
+                adapters={Platform.SLACK: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        assert adapter.send.call_count == 2
+        anchor_call, body_call = adapter.send.call_args_list
+        assert anchor_call.args == ("C123456789", "live-fallback-report (job_id: live-fallback)")
+        assert body_call.args == ("C123456789", "Live body.")
+        assert body_call.kwargs["metadata"] == {"thread_id": "live-anchor-ts"}
+
+        standalone_send.assert_awaited_once()
+        assert standalone_send.await_args.args[3] == "Live body."
+        assert standalone_send.await_args.kwargs["thread_id"] == "live-anchor-ts"
+
+    def test_threaded_delivery_mode_alias_uses_slack_thread_behavior(self, monkeypatch):
+        Platform, mock_cfg = self._mock_slack_config()
+        monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123456789")
+
+        send_mock = AsyncMock(
+            side_effect=[
+                {"success": True, "message_id": "ts-anchor"},
+                {"success": True, "message_id": "ts-reply"},
+            ]
+        )
+
+        job = {
+            "id": "alias-job",
+            "name": "alias-report",
+            "deliver": "slack",
+            "delivery_mode": "threaded",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=send_mock), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            result = _deliver_result(job, "Alias body.")
+
+        assert result is None
+        assert send_mock.await_count == 2
+        assert send_mock.await_args_list[0].kwargs["thread_id"] is None
+        assert send_mock.await_args_list[1].kwargs["thread_id"] == "ts-anchor"
+
 
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1897,7 +1897,7 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
-    def test_silent_with_note_suppresses_delivery(self):
+    def test_silent_with_note_delivers(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -1905,10 +1905,10 @@ class TestSilentDelivery:
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
-    def test_silent_trailing_suppresses_delivery(self):
-        """Agent appended [SILENT] after explanation text — must still suppress."""
+    def test_silent_trailing_delivers(self):
+        """Only a standalone [SILENT] marker suppresses delivery."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
@@ -1917,17 +1917,28 @@ class TestSilentDelivery:
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
     def test_silent_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
         deliver_mock.assert_not_called()
+
+    def test_silent_literal_inside_report_delivers(self):
+        response = "Report mentions the literal [SILENT] policy but has content."
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -342,6 +342,35 @@ class TestInstall:
         with pytest.raises(DistributionError, match="requires Hermes"):
             install_distribution(str(staged), name="future")
 
+    def test_install_explicit_nested_user_owned_files_are_not_copied(self, profile_env):
+        mf = DistributionManifest(
+            name="explicit_secret",
+            version="0.1.0",
+            distribution_owned=[
+                "skills/demo/SKILL.md",
+                "skills/demo/auth.json",
+                "skills/demo/.env",
+                MANIFEST_FILENAME,
+            ],
+        )
+        staged = _make_staging_dir(profile_env, "explicit_secret", manifest=mf)
+        (staged / "skills" / "demo" / "auth.json").write_text('{"leaked": true}\n')
+        (staged / "skills" / "demo" / ".env").write_text("LEAKED=1\n")
+
+        plan = install_distribution(str(staged), name="explicit_secret")
+
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").is_file()
+        assert not (plan.target_dir / "skills" / "demo" / "auth.json").exists()
+        assert not (plan.target_dir / "skills" / "demo" / ".env").exists()
+
+    def test_install_default_manifest_copies_top_level_non_default_files(self, profile_env):
+        staged = _make_staging_dir(profile_env, "default_payload")
+        (staged / "README.md").write_text("# Profile distribution\n")
+
+        plan = install_distribution(str(staged), name="default_payload")
+
+        assert (plan.target_dir / "README.md").read_text() == "# Profile distribution\n"
+
 
 # ===========================================================================
 # Update — preserves user data, preserves config by default

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -405,6 +405,56 @@ class TestUpdate:
         assert "claude" in (plan.target_dir / "config.yaml").read_text()
         assert "gpt-5" not in (plan.target_dir / "config.yaml").read_text()
 
+    def test_update_explicit_nested_owned_paths_preserves_sibling_runtime_state(self, profile_env):
+        staged = profile_env / "nested_distribution"
+        staged.mkdir()
+        (staged / "SOUL.md").write_text("I am Source.\n")
+        (staged / "skills" / "demo").mkdir(parents=True)
+        (staged / "skills" / "demo" / "SKILL.md").write_text("# Demo skill v1\n")
+        (staged / "cron" / "templates").mkdir(parents=True)
+        (staged / "cron" / "templates" / "daily.json").write_text(
+            '{"schedule": "0 9 * * *"}\n'
+        )
+        write_manifest(
+            staged,
+            DistributionManifest(
+                name="nested",
+                version="0.1.0",
+                distribution_owned=[
+                    "SOUL.md",
+                    "skills/demo",
+                    "cron/templates/daily.json",
+                    MANIFEST_FILENAME,
+                ],
+            ),
+        )
+
+        plan = install_distribution(str(staged), name="nested")
+        (plan.target_dir / "cron" / "jobs.json").write_text('{"jobs": []}\n')
+        (plan.target_dir / "cron" / "output").mkdir()
+        (plan.target_dir / "cron" / "output" / "keep.txt").write_text("runtime output\n")
+        (plan.target_dir / "skills" / "custom").mkdir()
+        (plan.target_dir / "skills" / "custom" / "SKILL.md").write_text("# Custom skill\n")
+
+        (staged / "cron" / "templates" / "daily.json").write_text(
+            '{"schedule": "0 10 * * *"}\n'
+        )
+        (staged / "skills" / "demo" / "SKILL.md").write_text("# Demo skill v2\n")
+
+        update_distribution("nested", force_config=False)
+
+        assert (
+            plan.target_dir / "cron" / "templates" / "daily.json"
+        ).read_text() == '{"schedule": "0 10 * * *"}\n'
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").read_text() == "# Demo skill v2\n"
+        assert (plan.target_dir / "cron" / "jobs.json").read_text() == '{"jobs": []}\n'
+        assert (
+            plan.target_dir / "cron" / "output" / "keep.txt"
+        ).read_text() == "runtime output\n"
+        assert (
+            plan.target_dir / "skills" / "custom" / "SKILL.md"
+        ).read_text() == "# Custom skill\n"
+
     def test_update_missing_manifest_errors(self, profile_env):
         # Make a profile without a manifest; update must refuse
         from hermes_cli.profiles import create_profile
@@ -581,4 +631,3 @@ class TestErrorSurfaces:
         staged = _make_staging_dir(profile_env, "bad", manifest=mf)
         with pytest.raises((ValueError, DistributionError)):
             plan_install(str(staged), tmp_path / "work")
-

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -123,6 +123,82 @@ class TestCronjobRequirements:
         assert check_cronjob_requirements() is False
 
 
+@pytest.fixture
+def isolated_cron_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+
+def test_create_job_preserves_delivery_metadata(isolated_cron_dir):
+    from cron.jobs import get_job
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            prompt="Summarize the daily status",
+            schedule="every 1h",
+            delivery_mode="threaded",
+            thread_title_template="Daily status - {date}",
+            template_key="kb_daily_status",
+            template_version="v1",
+        )
+    )
+
+    assert created["success"] is True
+    assert created["job"]["delivery_mode"] == "threaded"
+    assert created["job"]["thread_title_template"] == "Daily status - {date}"
+    assert created["job"]["template_key"] == "kb_daily_status"
+    assert created["job"]["template_version"] == "v1"
+
+    listing = json.loads(cronjob(action="list"))
+    assert listing["jobs"][0]["delivery_mode"] == "threaded"
+    assert listing["jobs"][0]["thread_title_template"] == "Daily status - {date}"
+    assert listing["jobs"][0]["template_key"] == "kb_daily_status"
+    assert listing["jobs"][0]["template_version"] == "v1"
+
+    stored = get_job(created["job_id"])
+    assert stored["delivery_mode"] == "threaded"
+    assert stored["thread_title_template"] == "Daily status - {date}"
+    assert stored["template_key"] == "kb_daily_status"
+    assert stored["template_version"] == "v1"
+
+
+def test_update_job_preserves_delivery_metadata(isolated_cron_dir):
+    created = json.loads(
+        cronjob(
+            action="create",
+            prompt="Summarize the daily status",
+            schedule="every 1h",
+            delivery_mode="threaded",
+            thread_title_template="Daily status - {date}",
+            template_key="kb_daily_status",
+            template_version="v1",
+        )
+    )
+
+    updated = json.loads(
+        cronjob(
+            action="update",
+            job_id=created["job_id"],
+            delivery_mode="channel",
+            template_version="",
+        )
+    )
+
+    assert updated["success"] is True
+    assert updated["job"]["delivery_mode"] == "channel"
+    assert updated["job"]["thread_title_template"] == "Daily status - {date}"
+    assert updated["job"]["template_key"] == "kb_daily_status"
+    assert "template_version" not in updated["job"]
+
+    listing = json.loads(cronjob(action="list"))
+    assert listing["jobs"][0]["delivery_mode"] == "channel"
+    assert listing["jobs"][0]["thread_title_template"] == "Daily status - {date}"
+    assert listing["jobs"][0]["template_key"] == "kb_daily_status"
+    assert "template_version" not in listing["jobs"][0]
+
+
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)
     def _setup_cron_dir(self, tmp_path, monkeypatch):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -279,6 +279,14 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    for key in (
+        "delivery_mode",
+        "thread_title_template",
+        "template_key",
+        "template_version",
+    ):
+        if job.get(key):
+            result[key] = job[key]
     return result
 
 
@@ -302,6 +310,10 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    delivery_mode: Optional[str] = None,
+    thread_title_template: Optional[str] = None,
+    template_key: Optional[str] = None,
+    template_version: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -368,6 +380,10 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                delivery_mode=_normalize_optional_job_value(delivery_mode),
+                thread_title_template=_normalize_optional_job_value(thread_title_template),
+                template_key=_normalize_optional_job_value(template_key),
+                template_version=_normalize_optional_job_value(template_version),
             )
             return json.dumps(
                 {
@@ -495,6 +511,14 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if delivery_mode is not None:
+                updates["delivery_mode"] = _normalize_optional_job_value(delivery_mode)
+            if thread_title_template is not None:
+                updates["thread_title_template"] = _normalize_optional_job_value(thread_title_template)
+            if template_key is not None:
+                updates["template_key"] = _normalize_optional_job_value(template_key)
+            if template_version is not None:
+                updates["template_version"] = _normalize_optional_job_value(template_version)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -634,6 +658,22 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "delivery_mode": {
+                "type": "string",
+                "description": "Optional delivery metadata for downstream formatters. Blank string clears the field on update."
+            },
+            "thread_title_template": {
+                "type": "string",
+                "description": "Optional thread title template metadata. Blank string clears the field on update."
+            },
+            "template_key": {
+                "type": "string",
+                "description": "Optional response template key metadata. Blank string clears the field on update."
+            },
+            "template_version": {
+                "type": "string",
+                "description": "Optional response template version metadata. Blank string clears the field on update."
+            },
         },
         "required": ["action"]
     }
@@ -682,6 +722,10 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        delivery_mode=args.get("delivery_mode"),
+        thread_title_template=args.get("thread_title_template"),
+        template_key=args.get("template_key"),
+        template_version=args.get("template_version"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -699,7 +699,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1120,7 +1120,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -1134,6 +1134,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## What does this PR do?

Adds reusable cron-template syncing and Slack-threaded cron delivery so distribution-owned profiles can install a shared job while preserving runtime job state.

This is intended for profile distributions such as repo self-improvement reports: the scheduler can post a small Slack anchor message first, then deliver the detailed report as a thread reply. Runtime profiles can also sync `cron/templates/*.json` into `cron/jobs.json` without overwriting local execution state.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/jobs.py`, `tools/cronjob_tools.py`: preserve cron delivery metadata such as `delivery_mode`, `thread_title_template`, and template identifiers.
- `cron/scheduler.py`: support `delivery_mode=slack_thread`, sending a short Slack anchor followed by the report body as a thread reply; only suppress delivery when the final response is exactly `[SILENT]`.
- `tools/send_message_tool.py`: allow Slack standalone sends to target a `thread_id` / Slack `thread_ts` and return the posted message id.
- `cron/job_templates.py`, `hermes_cli/cron.py`, `hermes_cli/main.py`: add `cron sync-templates` for distribution-owned `cron/templates/*.json` files while preserving runtime state and expanding profile-local `workdir` placeholders.
- `hermes_cli/profile_distribution.py`: keep explicit nested distribution-owned paths intact while preserving sibling runtime state such as `cron/jobs.json`.
- Tests added/updated for scheduler delivery, template syncing, cron tools, and profile distribution copying.

## How to Test

1. `scripts/run_tests.sh tests/cron/test_scheduler.py::TestSilentDelivery tests/cron/test_scheduler.py::TestSlackThreadedDelivery tests/cron/test_job_templates.py tests/tools/test_cronjob_tools.py tests/hermes_cli/test_profile_distribution.py -q`
2. `/Users/eric/.hermes/hermes-agent/venv/bin/python -m py_compile cron/scheduler.py cron/job_templates.py`
3. `git merge-tree --write-tree HEAD origin/main`
4. `git diff --check`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.14

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no new platform-specific APIs beyond existing Slack delivery paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — cron tool schema updated

## For New Skills

N/A

## Screenshots / Logs

Focused wrapper run:

```text
121 passed in 1.61s
```

Additional focused run before the final fix:

```text
21 passed in 0.84s
```
