### PR TITLE
fix(signal_rate_limit): prevent TOCTOU race in get_scheduler() singleton init

### DIFF
--- a/gateway/platforms/signal_rate_limit.py
+++ b/gateway/platforms/signal_rate_limit.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import threading
 import time
 from typing import Any, Optional
 
@@ -346,19 +347,22 @@ class SignalAttachmentScheduler:
 # ---------------------------------------------------------------------------
 
 _scheduler: Optional[SignalAttachmentScheduler] = None
+_scheduler_lock = threading.Lock()
 
 
 def get_scheduler() -> SignalAttachmentScheduler:
     """Return the process-wide scheduler, creating it on first access."""
     global _scheduler
     if _scheduler is None:
-        _scheduler = SignalAttachmentScheduler()
-        logger.info(
-            "Signal scheduler: created (capacity=%d tokens, refill=%.4f/s ≈ %.1fs/token)",
-            int(_scheduler.capacity),
-            _scheduler.refill_rate,
-            1.0 / _scheduler.refill_rate,
-        )
+        with _scheduler_lock:
+            if _scheduler is None:
+                _scheduler = SignalAttachmentScheduler()
+                logger.info(
+                    "Signal scheduler: created (capacity=%d tokens, refill=%.4f/s ≈ %.1fs/token)",
+                    int(_scheduler.capacity),
+                    _scheduler.refill_rate,
+                    1.0 / _scheduler.refill_rate,
+                )
     return _scheduler
 
 

--- a/tests/gateway/test_signal_rate_limit.py
+++ b/tests/gateway/test_signal_rate_limit.py
@@ -1,6 +1,8 @@
 """Tests for the SignalAttachmentScheduler token-bucket simulator."""
 import asyncio
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -231,3 +233,72 @@ class TestSingleton:
         _reset_scheduler()
         s2 = get_scheduler()
         assert s1 is not s2
+
+
+# ─── TOCTOU Race Regression Tests (Issue #24745) ─────────────────────────────
+
+class TestGetSchedulerToctouRace:
+    """50-thread barrier tests for get_scheduler() double-checked locking."""
+
+    def setup_method(self):
+        _reset_scheduler()
+
+    def teardown_method(self):
+        _reset_scheduler()
+
+    def test_concurrent_calls_return_same_instance(self):
+        """All 50 concurrent callers must receive the exact same scheduler object."""
+        barrier = threading.Barrier(50)
+        results: list = []
+        results_lock = threading.Lock()
+
+        def call():
+            barrier.wait()
+            s = get_scheduler()
+            with results_lock:
+                results.append(id(s))
+
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            futures = [pool.submit(call) for _ in range(50)]
+            for f in futures:
+                f.result()
+
+        assert len(results) == 50
+        assert len(set(results)) == 1, (
+            f"Expected 1 unique scheduler, got {len(set(results))} distinct ids"
+        )
+
+    def test_only_one_scheduler_constructed(self):
+        """SignalAttachmentScheduler() must be called exactly once under concurrency."""
+        import gateway.platforms.signal_rate_limit as rl_mod
+
+        construct_count = 0
+        count_lock = threading.Lock()
+        _OriginalScheduler = SignalAttachmentScheduler
+
+        class _SpyScheduler(_OriginalScheduler):
+            def __init__(self):
+                nonlocal construct_count
+                with count_lock:
+                    construct_count += 1
+                super().__init__()
+
+        original_cls = rl_mod.SignalAttachmentScheduler
+        rl_mod.SignalAttachmentScheduler = _SpyScheduler
+        try:
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                get_scheduler()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+        finally:
+            rl_mod.SignalAttachmentScheduler = original_cls
+
+        assert construct_count == 1, (
+            f"SignalAttachmentScheduler() called {construct_count} times (expected 1)"
+        )


### PR DESCRIPTION
## What does this PR do?

`gateway/platforms/signal_rate_limit.get_scheduler()` used a bare `if _scheduler is None:` guard with no lock. Under concurrent tool dispatch two coroutines can both see `_scheduler is None`, each construct a `SignalAttachmentScheduler()`, and the loser's token-bucket instance is orphaned — effectively **doubling the allowed burst rate** since each scheduler maintains its own independent state. The file had no `threading` import.

## Root cause

`gateway/platforms/signal_rate_limit.get_scheduler()` used a bare `if _scheduler is None:` guard with no lock. Under concurrent tool dispatch two coroutines can both see `_scheduler is None`, each construct a `SignalAttachmentScheduler()`, and the loser's token-bucket instance is orphaned — effectively **doubling the allowed burst rate** since each scheduler maintains its own independent state. The file had no `threading` import.

## Fix

Added `import threading` and `_scheduler_lock = threading.Lock()`. Applied double-checked locking:

```python
_scheduler_lock = threading.Lock()

def get_scheduler() -> SignalAttachmentScheduler:
    global _scheduler
    if _scheduler is None:
        with _scheduler_lock:
            if _scheduler is None:
                _scheduler = SignalAttachmentScheduler()
                logger.info(...)
    return _scheduler
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24745

<details>
<summary>Original body</summary>

## Summary

`gateway/platforms/signal_rate_limit.get_scheduler()` used a bare `if _scheduler is None:` guard with no lock. Under concurrent tool dispatch two coroutines can both see `_scheduler is None`, each construct a `SignalAttachmentScheduler()`, and the loser's token-bucket instance is orphaned — effectively **doubling the allowed burst rate** since each scheduler maintains its own independent state. The file had no `threading` import.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`gateway/platforms/signal_rate_limit.get_scheduler()` used a bare `if _scheduler is None:` guard with no lock. Under concurrent tool dispatch two coroutines can both see `_scheduler is None`, each construct a `SignalAttachmentScheduler()`, and the loser's token-bucket instance is orphaned — effectively **doubling the allowed burst rate** since each scheduler maintains its own independent state. The file had no `threading` import.

## Fix

Added `import threading` and `_scheduler_lock = threading.Lock()`. Applied double-checked locking:

```python
_scheduler_lock = threading.Lock()

def get_scheduler() -> SignalAttachmentScheduler:
    global _scheduler
    if _scheduler is None:
        with _scheduler_lock:
            if _scheduler is None:
                _scheduler = SignalAttachmentScheduler()
                logger.info(...)
    return _scheduler
```

## Tests

`TestGetSchedulerToctouRace` in `tests/gateway/test_signal_rate_limit.py`:

- **`test_concurrent_calls_return_same_instance`** — 50-thread Barrier; asserts all 50 callers get the same object id.
- **`test_only_one_scheduler_constructed`** — spy subclass counts `__init__` calls; asserts count == 1.

Both tests pass.

Closes #24745

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24745

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_