### PR TITLE
fix(anthropic_adapter): prevent TOCTOU race in _get_claude_code_version()

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -16,6 +16,7 @@ import logging
 import os
 import platform
 import subprocess
+import threading
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -283,6 +284,7 @@ _OAUTH_ONLY_BETAS = [
 # when the spoofed user-agent version is too far behind the actual release.
 _CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
 _claude_code_version_cache: Optional[str] = None
+_claude_code_version_lock = threading.Lock()
 
 
 def _detect_claude_code_version() -> str:
@@ -318,7 +320,9 @@ def _get_claude_code_version() -> str:
     """Lazily detect the installed Claude Code version when OAuth headers need it."""
     global _claude_code_version_cache
     if _claude_code_version_cache is None:
-        _claude_code_version_cache = _detect_claude_code_version()
+        with _claude_code_version_lock:
+            if _claude_code_version_cache is None:
+                _claude_code_version_cache = _detect_claude_code_version()
     return _claude_code_version_cache
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1944,3 +1944,76 @@ class TestConvertToolsToAnthropicDedup:
 
     def test_none_tools_returns_empty(self):
         assert convert_tools_to_anthropic(None) == []
+
+
+# ─── TOCTOU Race Regression Tests (Issue #24751) ─────────────────────────────
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import agent.anthropic_adapter as _adapter_mod
+
+
+class TestGetClaudeCodeVersionToctouRace:
+    """50-thread barrier tests for _get_claude_code_version() double-checked locking."""
+
+    def setup_method(self):
+        _adapter_mod._claude_code_version_cache = None
+
+    def teardown_method(self):
+        _adapter_mod._claude_code_version_cache = None
+
+    def test_concurrent_calls_return_same_version(self):
+        """All 50 concurrent callers must receive the identical version string."""
+        detect_count = 0
+        count_lock = threading.Lock()
+
+        def _fake_detect():
+            nonlocal detect_count
+            with count_lock:
+                detect_count += 1
+            return "9.9.9"
+
+        with patch.object(_adapter_mod, "_detect_claude_code_version", side_effect=_fake_detect):
+            barrier = threading.Barrier(50)
+            results: list = []
+            results_lock = threading.Lock()
+
+            def call():
+                barrier.wait()
+                v = _adapter_mod._get_claude_code_version()
+                with results_lock:
+                    results.append(v)
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert len(results) == 50
+        assert all(v == "9.9.9" for v in results)
+        assert detect_count == 1, f"_detect_claude_code_version called {detect_count} times (expected 1)"
+
+    def test_only_one_subprocess_spawned(self):
+        """_detect_claude_code_version must be called exactly once regardless of concurrency."""
+        detect_count = 0
+        count_lock = threading.Lock()
+
+        def _fake_detect():
+            nonlocal detect_count
+            with count_lock:
+                detect_count += 1
+            return "1.2.3"
+
+        with patch.object(_adapter_mod, "_detect_claude_code_version", side_effect=_fake_detect):
+            barrier = threading.Barrier(50)
+
+            def call():
+                barrier.wait()
+                _adapter_mod._get_claude_code_version()
+
+            with ThreadPoolExecutor(max_workers=50) as pool:
+                futures = [pool.submit(call) for _ in range(50)]
+                for f in futures:
+                    f.result()
+
+        assert detect_count == 1, f"_detect_claude_code_version called {detect_count} times (expected 1)"


### PR DESCRIPTION
## What does this PR do?

- `_claude_code_version_cache` is a module-level singleton populated lazily by `_get_claude_code_version()`. Under concurrent load, multiple threads could simultaneously pass the `is None` guard and each spawn a subprocess to detect the Claude Code version — wasting resources and producing non-deterministic results. - Added `_claude_code_version_lock = threading.Lock()` and applied double-checked locking: fast lock-free early return when already populated, then re-checks under the lock before running the expensive detection. - Added a 50-thread barrier regression test (`TestGetClaudeCodeVersionToctouRace`) that verifies (a) all concurrent calls return the same value and (b) the underlying…

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24751

<details>
<summary>Original body</summary>

## Summary

- `_claude_code_version_cache` is a module-level singleton populated lazily by `_get_claude_code_version()`. Under concurrent load, multiple threads could simultaneously pass the `is None` guard and each spawn a subprocess to detect the Claude Code version — wasting resources and producing non-deterministic results. - Added `_claude_code_version_lock = threading.Lock()` and applied double-checked locking: fast lock-free early return when already populated, then re-checks under the lock before running the expensive detection. - Added a 50-thread barrier regression test (`TestGetClaudeCodeVersionToctouRace`) that verifies (a) all concurrent calls return the same value and (b) the underlying detector is invoked exactly once.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

- `_claude_code_version_cache` is a module-level singleton populated lazily by `_get_claude_code_version()`. Under concurrent load, multiple threads could simultaneously pass the `is None` guard and each spawn a subprocess to detect the Claude Code version — wasting resources and producing non-deterministic results.
- Added `_claude_code_version_lock = threading.Lock()` and applied double-checked locking: fast lock-free early return when already populated, then re-checks under the lock before running the expensive detection.
- Added a 50-thread barrier regression test (`TestGetClaudeCodeVersionToctouRace`) that verifies (a) all concurrent calls return the same value and (b) the underlying detector is invoked exactly once.

Closes #24751

## Test plan

- [ ] `uv run python -m pytest tests/agent/test_anthropic_adapter.py::TestGetClaudeCodeVersionToctouRace -v` — 2 passed
- [ ] Existing `test_anthropic_adapter.py` suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24751

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_