### PR TITLE
fix(plugins): prevent TOCTOU race in get_plugin_manager()

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1284,13 +1284,16 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
     """Return (and lazily create) the global PluginManager singleton."""
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1306,3 +1306,60 @@ class TestPluginDebugLogging:
             plugins_mod._PLUGINS_DEBUG = original_debug
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
+
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+import hermes_cli.plugins as _plugins_mod
+
+
+class TestGetPluginManagerToctouRace:
+    """Regression: get_plugin_manager() must construct exactly one instance
+    even under concurrent load (double-checked locking guard)."""
+
+    def setup_method(self):
+        _plugins_mod._plugin_manager = None
+
+    def teardown_method(self):
+        _plugins_mod._plugin_manager = None
+
+    def test_concurrent_calls_return_same_instance(self):
+        n = 50
+        barrier = threading.Barrier(n)
+        results: list = []
+
+        def worker():
+            barrier.wait()
+            results.append(_plugins_mod.get_plugin_manager())
+
+        with ThreadPoolExecutor(max_workers=n) as pool:
+            list(pool.map(lambda _: worker(), range(n)))
+
+        assert len(results) == n
+        first = results[0]
+        assert all(r is first for r in results), "multiple PluginManager instances returned"
+
+    def test_only_one_plugin_manager_constructed(self):
+        n = 50
+        barrier = threading.Barrier(n)
+        construct_count = 0
+        original_cls = _plugins_mod.PluginManager
+
+        class SpyPluginManager(original_cls):
+            def __init__(self):
+                nonlocal construct_count
+                construct_count += 1
+                super().__init__()
+
+        _plugins_mod.PluginManager = SpyPluginManager
+        try:
+            def worker():
+                barrier.wait()
+                _plugins_mod.get_plugin_manager()
+
+            with ThreadPoolExecutor(max_workers=n) as pool:
+                list(pool.map(lambda _: worker(), range(n)))
+        finally:
+            _plugins_mod.PluginManager = original_cls
+
+        assert construct_count == 1, f"PluginManager constructed {construct_count} times, expected 1"


### PR DESCRIPTION
## Summary

- `get_plugin_manager()` in `hermes_cli/plugins.py` used an unguarded check-then-initialize pattern for the `_plugin_manager` singleton. Two concurrent callers could both pass the `is None` guard and construct separate `PluginManager` instances; the second would overwrite the first, silently dropping any hooks already registered on it.
- Added `_plugin_manager_lock = threading.Lock()` (one line — `threading` was already imported at line 44) and applied double-checked locking: fast lock-free early return when already set, re-checks under the lock before constructing.
- Added `TestGetPluginManagerToctouRace` (2 tests): 50-thread barrier verifying all concurrent callers receive the same instance, and a spy subclass confirming the constructor fires exactly once.

Closes #24754

## Test plan

- [ ] `uv run python -m pytest tests/hermes_cli/test_plugins.py::TestGetPluginManagerToctouRace -v` — 2 passed
- [ ] Existing `test_plugins.py` suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)