### PR TITLE
fix(gateway): bridge gateway_restart_notification from config YAML to PlatformConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -779,6 +779,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "gateway_restart_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -823,6 +825,8 @@ def load_gateway_config() -> GatewayConfig:
                 if plat == Platform.SLACK and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
+                if "gateway_restart_notification" in platform_cfg:
+                    plat_data["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
 
             # Slack settings → env vars (env vars take precedence)
             slack_cfg = yaml_cfg.get("slack", {})

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -506,6 +506,22 @@ class TestLoadGatewayConfig:
 
         assert config.get_notice_delivery(Platform.SLACK) == "private"
 
+    def test_bridges_gateway_restart_notification_false_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  gateway_restart_notification: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].gateway_restart_notification is False
+
     def test_bridges_telegram_proxy_url_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Problem

Setting `gateway_restart_notification: false` under a platform section in `config.yaml` had no effect — restart/shutdown notifications were always sent regardless of the config value.

## Root cause

`load_gateway_config()` builds a `bridged` dict from YAML keys and then calls `extra.update(bridged)`, which stores every bridged value inside the nested `extra` dict of `plat_data`. However, `PlatformConfig.from_dict` reads `gateway_restart_notification` from the **top-level** of `plat_data` (via `data.get("gateway_restart_notification")`), not from `extra`. The key was never added to the bridge, so it defaulted to `True` unconditionally.

## Fix

Two additions inside the platform bridge loop in `load_gateway_config()`:

1. Add `gateway_restart_notification` to `bridged` — ensures the guard `if not bridged` doesn't skip the block when this is the only key present.
2. After `extra.update(bridged)`, write the value directly to `plat_data` (top-level) so `PlatformConfig.from_dict` picks it up correctly.

## Test

Added `test_bridges_gateway_restart_notification_false_from_config_yaml` to `TestLoadGatewayConfig`: writes a minimal YAML with `telegram: gateway_restart_notification: false`, parses via `load_gateway_config()`, and asserts the resulting platform config has `gateway_restart_notification is False`.

Fixes #24644

🤖 Generated with [Claude Code](https://claude.com/claude-code)