### PR TITLE
fix: route background review via curator auxiliary config

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4363,15 +4363,46 @@ class AIAgent:
                     # reconstruct auth from scratch -- producing the spurious
                     # "No LLM provider configured" warning at end of turn.
                     _parent_runtime = self._current_main_runtime()
+
+                    # Background reviews are auxiliary work.  By default they
+                    # inherit the parent runtime to preserve OAuth/session-scoped
+                    # credentials, but allow operators to route them to a cheaper
+                    # configured auxiliary curator model so skill/memory review
+                    # does not burn the primary provider's budget.
+                    _review_model = self.model
+                    _review_provider = self.provider
+                    _review_api_mode = _parent_runtime.get("api_mode") or None
+                    _review_base_url = _parent_runtime.get("base_url") or None
+                    _review_api_key = _parent_runtime.get("api_key") or None
+                    try:
+                        from hermes_cli.config import load_config as _load_config
+
+                        _cfg = _load_config() or {}
+                        _curator_cfg = (
+                            (_cfg.get("auxiliary") or {}).get("curator") or {}
+                        )
+                        _aux_provider = (_curator_cfg.get("provider") or "").strip()
+                        if _aux_provider and _aux_provider != "auto":
+                            _review_provider = _aux_provider
+                            _review_model = (_curator_cfg.get("model") or _review_model).strip()
+                            _review_base_url = (_curator_cfg.get("base_url") or "").strip() or None
+                            _review_api_key = (_curator_cfg.get("api_key") or "").strip() or None
+                            # Let the provider resolver select the correct API
+                            # mode for the auxiliary backend rather than reusing
+                            # the parent's Codex/Responses mode.
+                            _review_api_mode = None
+                    except Exception:
+                        pass
+
                     review_agent = AIAgent(
-                        model=self.model,
+                        model=_review_model,
                         max_iterations=16,
                         quiet_mode=True,
                         platform=self.platform,
-                        provider=self.provider,
-                        api_mode=_parent_runtime.get("api_mode") or None,
-                        base_url=_parent_runtime.get("base_url") or None,
-                        api_key=_parent_runtime.get("api_key") or None,
+                        provider=_review_provider,
+                        api_mode=_review_api_mode,
+                        base_url=_review_base_url,
+                        api_key=_review_api_key,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                         enabled_toolsets=["memory", "skills"],

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -129,6 +129,66 @@ def test_background_review_installs_auto_deny_approval_callback(monkeypatch):
     )
 
 
+def test_background_review_uses_configured_auxiliary_curator_runtime(monkeypatch):
+    """Background reviews may be routed to a cheaper curator model.
+
+    The parent runtime remains the fallback for OAuth/session-scoped setups, but
+    when ``auxiliary.curator.provider`` is explicitly configured the review fork
+    should use that provider/model and let provider resolution pick a fresh API
+    mode instead of reusing the parent's Codex/Responses mode.
+    """
+    captured_kwargs: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_load_config():
+        return {
+            "auxiliary": {
+                "curator": {
+                    "provider": "openrouter",
+                    "model": "google/gemini-flash-preview",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key": "curator-key",
+                }
+            }
+        }
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+
+    agent = _bare_agent()
+    agent.model = "gpt-5.5"
+    agent.provider = "openai-codex"
+    agent.api_mode = "codex_responses"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    agent.api_key = "parent-key"
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hi"}],
+        review_memory=True,
+    )
+
+    assert captured_kwargs["provider"] == "openrouter"
+    assert captured_kwargs["model"] == "google/gemini-flash-preview"
+    assert captured_kwargs["base_url"] == "https://openrouter.ai/api/v1"
+    assert captured_kwargs["api_key"] == "curator-key"
+    assert captured_kwargs["api_mode"] is None
+
+
 def test_background_review_summary_is_attributed_to_self_improvement_loop(monkeypatch):
     """The CLI/gateway emission must identify the self-improvement loop.
 


### PR DESCRIPTION
## Summary
- Route background self-improvement reviews through `auxiliary.curator` when explicitly configured
- Preserve parent runtime fallback for OAuth/session-scoped providers
- Add regression coverage for curator auxiliary runtime selection

## Test Plan
- `python3 -m py_compile run_agent.py`
- `pytest tests/run_agent/test_background_review.py -q`