### PR TITLE
fix(honcho): prevent TOCTOU race in get_honcho_client()

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -17,6 +17,7 @@ import json
 import os
 import logging
 import hashlib
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -663,6 +664,7 @@ class HonchoClientConfig:
 
 
 _honcho_client: Honcho | None = None
+_honcho_client_lock = threading.Lock()
 
 
 def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
@@ -676,102 +678,106 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     if _honcho_client is not None:
         return _honcho_client
 
-    if config is None:
-        config = HonchoClientConfig.from_global_config()
+    with _honcho_client_lock:
+        if _honcho_client is not None:
+            return _honcho_client
 
-    if not config.api_key and not config.base_url:
-        raise ValueError(
-            "Honcho API key not found. "
-            "Get your API key at https://app.honcho.dev, "
-            "then run 'hermes honcho setup' or set HONCHO_API_KEY. "
-            "For local instances, set HONCHO_BASE_URL instead."
-        )
+        if config is None:
+            config = HonchoClientConfig.from_global_config()
 
-    # Lazy-install the honcho SDK on demand. ensure() honors
-    # security.allow_lazy_installs (default true). On failure we surface
-    # the original ImportError-shape message so existing callers still get
-    # the "go run hermes honcho setup" hint they used to.
-    try:
-        from tools.lazy_deps import FeatureUnavailable, ensure as _lazy_ensure
-        _lazy_ensure("memory.honcho", prompt=False)
-    except ImportError:
-        # lazy_deps module missing — fall through to the raw import below.
-        pass
-    except Exception:
-        # FeatureUnavailable or unexpected error. Don't crash here; let the
-        # actual import attempt produce the canonical error message.
-        pass
+        if not config.api_key and not config.base_url:
+            raise ValueError(
+                "Honcho API key not found. "
+                "Get your API key at https://app.honcho.dev, "
+                "then run 'hermes honcho setup' or set HONCHO_API_KEY. "
+                "For local instances, set HONCHO_BASE_URL instead."
+            )
 
-    try:
-        from honcho import Honcho
-    except ImportError:
-        raise ImportError(
-            "honcho-ai is required for Honcho integration. "
-            "Install it with: pip install honcho-ai  "
-            "(or run `hermes honcho setup` to configure)."
-        )
-
-    # Allow config.yaml honcho.base_url to override the SDK's environment
-    # mapping, enabling remote self-hosted Honcho deployments without
-    # requiring the server to live on localhost.
-    resolved_base_url = config.base_url
-    resolved_timeout = config.timeout
-    if not resolved_base_url or resolved_timeout is None:
+        # Lazy-install the honcho SDK on demand. ensure() honors
+        # security.allow_lazy_installs (default true). On failure we surface
+        # the original ImportError-shape message so existing callers still get
+        # the "go run hermes honcho setup" hint they used to.
         try:
-            from hermes_cli.config import load_config
-            hermes_cfg = load_config()
-            honcho_cfg = hermes_cfg.get("honcho", {})
-            if isinstance(honcho_cfg, dict):
-                if not resolved_base_url:
-                    resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
-                if resolved_timeout is None:
-                    resolved_timeout = _resolve_optional_float(
-                        honcho_cfg.get("timeout"),
-                        honcho_cfg.get("request_timeout"),
-                    )
+            from tools.lazy_deps import FeatureUnavailable, ensure as _lazy_ensure
+            _lazy_ensure("memory.honcho", prompt=False)
+        except ImportError:
+            # lazy_deps module missing — fall through to the raw import below.
+            pass
         except Exception:
+            # FeatureUnavailable or unexpected error. Don't crash here; let the
+            # actual import attempt produce the canonical error message.
             pass
 
-    # Fall back to the default so an unconfigured install cannot hang
-    # indefinitely on a stalled Honcho request.
-    if resolved_timeout is None:
-        resolved_timeout = _DEFAULT_HTTP_TIMEOUT
+        try:
+            from honcho import Honcho
+        except ImportError:
+            raise ImportError(
+                "honcho-ai is required for Honcho integration. "
+                "Install it with: pip install honcho-ai  "
+                "(or run `hermes honcho setup` to configure)."
+            )
 
-    if resolved_base_url:
-        logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
-    else:
-        logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
+        # Allow config.yaml honcho.base_url to override the SDK's environment
+        # mapping, enabling remote self-hosted Honcho deployments without
+        # requiring the server to live on localhost.
+        resolved_base_url = config.base_url
+        resolved_timeout = config.timeout
+        if not resolved_base_url or resolved_timeout is None:
+            try:
+                from hermes_cli.config import load_config
+                hermes_cfg = load_config()
+                honcho_cfg = hermes_cfg.get("honcho", {})
+                if isinstance(honcho_cfg, dict):
+                    if not resolved_base_url:
+                        resolved_base_url = honcho_cfg.get("base_url", "").strip() or None
+                    if resolved_timeout is None:
+                        resolved_timeout = _resolve_optional_float(
+                            honcho_cfg.get("timeout"),
+                            honcho_cfg.get("request_timeout"),
+                        )
+            except Exception:
+                pass
 
-    # Local Honcho instances don't require an API key, but the SDK
-    # expects a non-empty string.  Use a placeholder for local URLs.
-    # For local: only use config.api_key if the host block explicitly
-    # sets apiKey (meaning the user wants local auth). Otherwise skip
-    # the stored key -- it's likely a cloud key that would break local.
-    _is_local = resolved_base_url and (
-        "localhost" in resolved_base_url
-        or "127.0.0.1" in resolved_base_url
-        or "::1" in resolved_base_url
-    )
-    if _is_local:
-        # Check if the host block has its own apiKey (explicit local auth)
-        _raw = config.raw or {}
-        _host_block = (_raw.get("hosts") or {}).get(config.host, {})
-        _host_has_key = bool(_host_block.get("apiKey"))
-        effective_api_key = config.api_key if _host_has_key else "local"
-    else:
-        effective_api_key = config.api_key
+        # Fall back to the default so an unconfigured install cannot hang
+        # indefinitely on a stalled Honcho request.
+        if resolved_timeout is None:
+            resolved_timeout = _DEFAULT_HTTP_TIMEOUT
 
-    kwargs: dict = {
-        "workspace_id": config.workspace_id,
-        "api_key": effective_api_key,
-        "environment": config.environment,
-    }
-    if resolved_base_url:
-        kwargs["base_url"] = resolved_base_url
-    if resolved_timeout is not None:
-        kwargs["timeout"] = resolved_timeout
+        if resolved_base_url:
+            logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
+        else:
+            logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
 
-    _honcho_client = Honcho(**kwargs)
+        # Local Honcho instances don't require an API key, but the SDK
+        # expects a non-empty string.  Use a placeholder for local URLs.
+        # For local: only use config.api_key if the host block explicitly
+        # sets apiKey (meaning the user wants local auth). Otherwise skip
+        # the stored key -- it's likely a cloud key that would break local.
+        _is_local = resolved_base_url and (
+            "localhost" in resolved_base_url
+            or "127.0.0.1" in resolved_base_url
+            or "::1" in resolved_base_url
+        )
+        if _is_local:
+            # Check if the host block has its own apiKey (explicit local auth)
+            _raw = config.raw or {}
+            _host_block = (_raw.get("hosts") or {}).get(config.host, {})
+            _host_has_key = bool(_host_block.get("apiKey"))
+            effective_api_key = config.api_key if _host_has_key else "local"
+        else:
+            effective_api_key = config.api_key
+
+        kwargs: dict = {
+            "workspace_id": config.workspace_id,
+            "api_key": effective_api_key,
+            "environment": config.environment,
+        }
+        if resolved_base_url:
+            kwargs["base_url"] = resolved_base_url
+        if resolved_timeout is not None:
+            kwargs["timeout"] = resolved_timeout
+
+        _honcho_client = Honcho(**kwargs)
 
     return _honcho_client
 

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -103,3 +103,76 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+import sys
+import plugins.memory.honcho.client as _honcho_mod
+
+
+class TestGetHonchoClientToctouRace:
+    """Regression: get_honcho_client() must construct exactly one Honcho instance
+    even under concurrent load (double-checked locking guard)."""
+
+    def setup_method(self):
+        _honcho_mod._honcho_client = None
+
+    def teardown_method(self):
+        _honcho_mod._honcho_client = None
+
+    def _fake_cfg(self):
+        cfg = MagicMock()
+        cfg.api_key = "test-key"
+        cfg.base_url = None
+        cfg.workspace_id = "ws-test"
+        cfg.environment = "test"
+        cfg.timeout = 30.0
+        cfg.host = "app.honcho.dev"
+        cfg.raw = {}
+        return cfg
+
+    def _fake_honcho_module(self, counter: list):
+        class SpyHoncho:
+            def __init__(self, **kwargs):
+                counter.append(1)
+        fake_mod = type(sys)("honcho")
+        fake_mod.Honcho = SpyHoncho
+        return fake_mod
+
+    def test_concurrent_calls_return_same_instance(self):
+        n = 50
+        barrier = threading.Barrier(n)
+        results: list = []
+        counter: list = []
+        cfg = self._fake_cfg()
+        fake_mod = self._fake_honcho_module(counter)
+
+        with patch.dict(sys.modules, {"honcho": fake_mod}):
+            def worker():
+                barrier.wait()
+                results.append(_honcho_mod.get_honcho_client(cfg))
+
+            with ThreadPoolExecutor(max_workers=n) as pool:
+                list(pool.map(lambda _: worker(), range(n)))
+
+        assert len(results) == n
+        assert all(r is results[0] for r in results), "multiple Honcho instances returned"
+
+    def test_only_one_honcho_constructed(self):
+        n = 50
+        barrier = threading.Barrier(n)
+        counter: list = []
+        cfg = self._fake_cfg()
+        fake_mod = self._fake_honcho_module(counter)
+
+        with patch.dict(sys.modules, {"honcho": fake_mod}):
+            def worker():
+                barrier.wait()
+                _honcho_mod.get_honcho_client(cfg)
+
+            with ThreadPoolExecutor(max_workers=n) as pool:
+                list(pool.map(lambda _: worker(), range(n)))
+
+        assert len(counter) == 1, f"Honcho constructed {len(counter)} times, expected 1"


### PR DESCRIPTION
## What does this PR do?

- `get_honcho_client()` in `plugins/memory/honcho/client.py` used an unguarded check-then-initialize pattern: two concurrent callers could both pass the `is not None` guard, both run config resolution + lazy SDK install + `Honcho(**kwargs)` construction, and the second would overwrite the first — leaking an open connection. - Added `import threading` and `_honcho_client_lock = threading.Lock()`. Applied double-checked locking: fast lock-free early return when already set, then full initialization (including the expensive config/import path) runs under the lock with a re-check at the top. - Added `TestGetHonchoClientToctouRace` (2 tests): 50-thread barrier verifying all concurrent callers…

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #24759

<details>
<summary>Original body</summary>

## Summary

- `get_honcho_client()` in `plugins/memory/honcho/client.py` used an unguarded check-then-initialize pattern: two concurrent callers could both pass the `is not None` guard, both run config resolution + lazy SDK install + `Honcho(**kwargs)` construction, and the second would overwrite the first — leaking an open connection. - Added `import threading` and `_honcho_client_lock = threading.Lock()`. Applied double-checked locking: fast lock-free early return when already set, then full initialization (including the expensive config/import path) runs under the lock with a re-check at the top. - Added `TestGetHonchoClientToctouRace` (2 tests): 50-thread barrier verifying all concurrent callers receive the same instance, and a spy `Honcho` class confirming the constructor fires exactly once.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

- `get_honcho_client()` in `plugins/memory/honcho/client.py` used an unguarded check-then-initialize pattern: two concurrent callers could both pass the `is not None` guard, both run config resolution + lazy SDK install + `Honcho(**kwargs)` construction, and the second would overwrite the first — leaking an open connection.
- Added `import threading` and `_honcho_client_lock = threading.Lock()`. Applied double-checked locking: fast lock-free early return when already set, then full initialization (including the expensive config/import path) runs under the lock with a re-check at the top.
- Added `TestGetHonchoClientToctouRace` (2 tests): 50-thread barrier verifying all concurrent callers receive the same instance, and a spy `Honcho` class confirming the constructor fires exactly once.

Closes #24759

## Test plan

- [ ] `uv run python -m pytest tests/test_honcho_client_config.py::TestGetHonchoClientToctouRace -v` — 2 passed
- [ ] Existing `test_honcho_client_config.py` suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #24759

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_