### PR TITLE
fix(plugins): lock get_plugin_manager() singleton init against concurrent calls

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1284,13 +1284,16 @@ class PluginManager:
 # ---------------------------------------------------------------------------
 
 _plugin_manager: Optional[PluginManager] = None
+_plugin_manager_lock = threading.Lock()
 
 
 def get_plugin_manager() -> PluginManager:
     """Return (and lazily create) the global PluginManager singleton."""
     global _plugin_manager
     if _plugin_manager is None:
-        _plugin_manager = PluginManager()
+        with _plugin_manager_lock:
+            if _plugin_manager is None:
+                _plugin_manager = PluginManager()
     return _plugin_manager
 
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1306,3 +1306,31 @@ class TestPluginDebugLogging:
             plugins_mod._PLUGINS_DEBUG = original_debug
             plugins_mod.logger.setLevel(original_level)
             plugins_mod.logger.handlers = original_handlers
+
+
+class TestGetPluginManagerConcurrency:
+    def test_concurrent_calls_return_same_instance(self):
+        """Concurrent get_plugin_manager() calls must return the same singleton."""
+        import threading
+        from hermes_cli import plugins as plugins_mod
+
+        original = plugins_mod._plugin_manager
+        plugins_mod._plugin_manager = None
+        try:
+            results = []
+            barrier = threading.Barrier(8)
+
+            def _call():
+                barrier.wait()
+                results.append(get_plugin_manager())
+
+            threads = [threading.Thread(target=_call) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert len(results) == 8
+            assert len(set(id(r) for r in results)) == 1
+        finally:
+            plugins_mod._plugin_manager = original


### PR DESCRIPTION
## Problem

`get_plugin_manager()` in `hermes_cli/plugins.py` uses an unguarded check-then-init pattern:

```python
if _plugin_manager is None:
    _plugin_manager = PluginManager()
```

Two threads racing before the singleton is set both pass the `is None` guard, each construct a `PluginManager`, and the second write silently discards any hooks or state registered on the first instance.

## Fix

Add `_plugin_manager_lock = threading.Lock()` at module level (`threading` is already imported at line 44) and apply double-checked locking in `get_plugin_manager()`:

- Outer unlocked check keeps the fast-path free once the singleton is set.
- Inner locked check prevents duplicate construction on first init.

## Test

Added `TestGetPluginManagerConcurrency.test_concurrent_calls_return_same_instance`: 8 threads synchronised on a `Barrier` all call `get_plugin_manager()` simultaneously and assert every call returns the same object (`id` equality).

Fixes #24754

🤖 Generated with [Claude Code](https://claude.com/claude-code)