### PR TITLE
fix(branch): preserve tool and reasoning metadata during branching

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5970,7 +5970,12 @@ class HermesCLI:
                     tool_name=msg.get("tool_name") or msg.get("name"),
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning"),
+                    reasoning_content=msg.get("reasoning_content"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                    codex_message_items=msg.get("codex_message_items"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -87,6 +87,54 @@ class TestBranchCommandCLI:
         messages = session_db.get_messages_as_conversation(cli_instance.session_id)
         assert len(messages) == 4  # All 4 messages copied
 
+    def test_branch_preserves_assistant_replay_metadata(self, cli_instance, session_db):
+        """Branching should preserve provider replay metadata in the DB copy."""
+        from cli import HermesCLI
+
+        cli_instance.conversation_history = [
+            {"role": "user", "content": "use the shell tool"},
+            {
+                "role": "assistant",
+                "content": "I'll inspect the repo.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"command\":\"pwd\"}"},
+                    }
+                ],
+                "finish_reason": "tool_calls",
+                "reasoning": "Need to inspect the working directory first.",
+                "reasoning_content": "Inspect cwd before editing.",
+                "reasoning_details": [{"type": "summary", "text": "inspect cwd"}],
+                "codex_reasoning_items": [{"id": "r1", "type": "reasoning"}],
+                "codex_message_items": [{"id": "m1", "type": "message"}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "tool_name": "terminal",
+                "content": "{\"cwd\":\"/repo\"}",
+            },
+        ]
+
+        HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        messages = session_db.get_messages_as_conversation(cli_instance.session_id)
+        assert len(messages) == 3
+        assistant = messages[1]
+        tool = messages[2]
+        assert assistant["tool_calls"][0]["id"] == "call_1"
+        assert assistant["finish_reason"] == "tool_calls"
+        assert assistant["reasoning"] == "Need to inspect the working directory first."
+        assert assistant["reasoning_content"] == "Inspect cwd before editing."
+        assert assistant["reasoning_details"] == [{"type": "summary", "text": "inspect cwd"}]
+        assert assistant["codex_reasoning_items"] == [{"id": "r1", "type": "reasoning"}]
+        assert assistant["codex_message_items"] == [{"id": "m1", "type": "message"}]
+        assert tool["role"] == "tool"
+        assert tool["tool_call_id"] == "call_1"
+        assert tool["tool_name"] == "terminal"
+
     def test_branch_preserves_parent_link(self, cli_instance, session_db):
         """The new session should reference the original as parent."""
         from cli import HermesCLI

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2291,6 +2291,94 @@ def test_snapshot_restore_is_blocked_from_tui_worker():
     )
 
 
+def test_session_branch_preserves_replay_metadata(monkeypatch):
+    append_calls = []
+    init_calls = {}
+
+    class _FakeDB:
+        def get_session_title(self, _key):
+            return "Current Session"
+
+        def get_next_title_in_lineage(self, current):
+            return f"{current} #2"
+
+        def create_session(self, *args, **kwargs):
+            init_calls["create"] = (args, kwargs)
+
+        def append_message(self, **kwargs):
+            append_calls.append(kwargs)
+
+        def set_session_title(self, session_id, title):
+            init_calls["title"] = (session_id, title)
+
+    history = [
+        {"role": "user", "content": "use the shell tool"},
+        {
+            "role": "assistant",
+            "content": "I'll inspect the repo.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{\"command\":\"pwd\"}"},
+                }
+            ],
+            "finish_reason": "tool_calls",
+            "reasoning": "Need cwd before editing.",
+            "reasoning_content": "Inspect cwd before editing.",
+            "reasoning_details": [{"type": "summary", "text": "inspect cwd"}],
+            "codex_reasoning_items": [{"id": "r1", "type": "reasoning"}],
+            "codex_message_items": [{"id": "m1", "type": "message"}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "tool_name": "terminal",
+            "content": "{\"cwd\":\"/repo\"}",
+        },
+    ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_new_session_key", lambda: "branch-key")
+    monkeypatch.setattr(server, "_set_session_context", lambda _key: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None: types.SimpleNamespace())
+    monkeypatch.setattr(
+        server,
+        "_init_session",
+        lambda sid, key, agent, session_history, cols=80: init_calls.setdefault(
+            "init", (sid, key, list(session_history), cols)
+        ),
+    )
+
+    server._sessions["sid"] = _session(history=history)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.branch",
+                "params": {"session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"]["parent"] == "session-key"
+    assert len(append_calls) == 3
+    assistant = append_calls[1]
+    tool = append_calls[2]
+    assert assistant["tool_calls"][0]["id"] == "call_1"
+    assert assistant["finish_reason"] == "tool_calls"
+    assert assistant["reasoning"] == "Need cwd before editing."
+    assert assistant["reasoning_content"] == "Inspect cwd before editing."
+    assert assistant["reasoning_details"] == [{"type": "summary", "text": "inspect cwd"}]
+    assert assistant["codex_reasoning_items"] == [{"id": "r1", "type": "reasoning"}]
+    assert assistant["codex_message_items"] == [{"id": "m1", "type": "message"}]
+    assert tool["role"] == "tool"
+    assert tool["tool_call_id"] == "call_1"
+    assert tool["tool_name"] == "terminal"
+
+
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2690,6 +2690,15 @@ def _(rid, params: dict) -> dict:
                 session_id=new_key,
                 role=msg.get("role", "user"),
                 content=msg.get("content"),
+                tool_name=msg.get("tool_name") or msg.get("name"),
+                tool_calls=msg.get("tool_calls"),
+                tool_call_id=msg.get("tool_call_id"),
+                finish_reason=msg.get("finish_reason"),
+                reasoning=msg.get("reasoning"),
+                reasoning_content=msg.get("reasoning_content"),
+                reasoning_details=msg.get("reasoning_details"),
+                codex_reasoning_items=msg.get("codex_reasoning_items"),
+                codex_message_items=msg.get("codex_message_items"),
             )
         db.set_session_title(new_key, title)
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes `/branch` transcript copying in the CLI and TUI so branched sessions preserve replay metadata, not just `role` and `content`.

This keeps branch copies faithful for:
- `tool_calls`
- `tool_call_id`
- `tool_name`
- `finish_reason`
- `reasoning`
- `reasoning_content`
- `reasoning_details`
- `codex_reasoning_items`
- `codex_message_items`

The gateway branch path already preserved these fields; CLI and TUI did not.

## Tests

Passed locally:

- `pytest tests/cli/test_branch_command.py tests/test_tui_gateway_server.py -k branch`
- `pytest tests/cli/test_branch_command.py -k replay_metadata`
- `pytest tests/test_tui_gateway_server.py -k session_branch_preserves_replay_metadata`
