### PR TITLE
docs: add duplicate PR prevention guidance for agent runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -871,6 +871,21 @@ file will silently overwrite recent fixes on main when squashed. Verify
 with `git diff HEAD~1..HEAD` after merging — unexpected deletions are a
 red flag.
 
+### Before opening a PR, check for an existing PR on the same fix topic
+Codex/Claude/Hermes runs can accidentally open duplicate PRs for the same
+issue. Before `gh pr create`, list open PRs for your branch/author/topic and
+reuse the existing PR when the changed files or issue number overlap.
+
+Minimum check:
+```bash
+gh pr list --author @me --state open --limit 100 \
+  --json number,title,headRefName,url
+```
+
+If an open PR already covers the same issue or same core files, push new
+commits to that branch/PR or close the duplicate instead of opening another
+one. Keep exactly one canonical PR per fix topic.
+
 ### Don't wire in dead code without E2E validation
 Unused code that was never shipped was dead for a reason. Before wiring an
 unused module into a live code path, E2E test the real resolution chain


### PR DESCRIPTION
## What does this PR do?

- update the narrow documentation surface that explains the behavior being changed - keep examples and wording aligned with the current implementation and CLI/API names - avoid mixing unrelated docs cleanup into the same PR

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- update the narrow documentation surface that explains the behavior being changed
- keep examples and wording aligned with the current implementation and CLI/API names
- avoid mixing unrelated docs cleanup into the same PR

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- update the narrow documentation surface that explains the behavior being changed - keep examples and wording aligned with the current implementation and CLI/API names - avoid mixing unrelated docs cleanup into the same PR

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary\n- add AGENTS.md guidance to check existing open PRs before creating a new one\n- instruct Codex/Claude/Hermes runs to keep exactly one canonical PR per fix topic\n\n## Why\n- recent agent runs opened duplicate PRs for the same fix topic\n- this adds an explicit repo-local guardrail so future runs reuse the existing PR instead of splitting review across duplicates\n\n## Test Plan\n- docs-only change\n- manually verified the new guidance in AGENTS.md\n

## Solution Sketch

- update the narrow documentation surface that explains the behavior being changed
- keep examples and wording aligned with the current implementation and CLI/API names
- avoid mixing unrelated docs cleanup into the same PR

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_