### PR TITLE
fix(tui_gateway): serialize SessionDB singleton init

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3232,6 +3232,50 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
     assert server._db_error == "locking protocol"
 
 
+def test_get_db_serializes_concurrent_sessiondb_init(monkeypatch):
+    fake_mod = types.ModuleType("hermes_state")
+    started = threading.Event()
+    release = threading.Event()
+    instances = []
+
+    class _FakeSessionDB:
+        def __init__(self):
+            instances.append(self)
+            started.set()
+            release.wait(timeout=2.0)
+
+    fake_mod.SessionDB = _FakeSessionDB
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    results = []
+
+    def _load_db():
+        results.append(server._get_db())
+
+    first = threading.Thread(target=_load_db)
+    second = threading.Thread(target=_load_db)
+
+    first.start()
+    assert started.wait(timeout=2.0)
+
+    second.start()
+    time.sleep(0.05)
+
+    assert len(instances) == 1
+
+    release.set()
+    first.join(timeout=2.0)
+    second.join(timeout=2.0)
+
+    assert len(results) == 2
+    assert results[0] is instances[0]
+    assert results[1] is instances[0]
+    assert server._db is instances[0]
+    assert server._db_error is None
+
+
 def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     class _FakeWorker:
         def __init__(self, key, model):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -121,6 +121,7 @@ _pending: dict[str, tuple[str, threading.Event]] = {}
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
+_db_lock = threading.Lock()
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
@@ -338,18 +339,20 @@ atexit.register(_shutdown_sessions)
 def _get_db():
     global _db, _db_error
     if _db is None:
-        from hermes_state import SessionDB
+        with _db_lock:
+            if _db is None:
+                from hermes_state import SessionDB
 
-        try:
-            _db = SessionDB()
-            _db_error = None
-        except Exception as exc:
-            _db_error = str(exc)
-            logger.warning(
-                "TUI session store unavailable — continuing without state.db features: %s",
-                exc,
-            )
-            return None
+                try:
+                    _db = SessionDB()
+                    _db_error = None
+                except Exception as exc:
+                    _db_error = str(exc)
+                    logger.warning(
+                        "TUI session store unavailable — continuing without state.db features: %s",
+                        exc,
+                    )
+                    return None
     return _db
 
 


### PR DESCRIPTION
## Summary
- guard `tui_gateway.server._get_db()` with a module-level lock so concurrent requests cannot construct multiple `SessionDB` instances
- keep the existing degraded `None` return path intact when `SessionDB()` initialization fails
- add a regression test that proves concurrent callers share the same singleton instance

## Verification
- `uv run --frozen --extra dev pytest -o addopts= tests/test_tui_gateway_server.py -k 'get_db_degrades_cleanly_when_sessiondb_init_fails or get_db_serializes_concurrent_sessiondb_init' -q`
- `uv run --frozen --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`
- `uv run --frozen --extra dev python -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py`