### PR TITLE
fix(kimi): enable vision_analyze native fast path for kimi-coding provider

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -428,12 +428,33 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
     return models
 
 
+# Aliases from friendly model names (as they appear in config / user settings)
+# to canonical models.dev IDs.  Used by _find_model_entry when exact and
+# case-insensitive lookups miss.
+_MODEL_ALIASES: Dict[str, str] = {
+    # Kimi / Moonshot
+    "kimi-for-coding": "k2.6",
+    "kimi-for-coding:cloud": "k2.6:cloud",
+}
+
+
 def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry by exact match, then case-insensitive fallback."""
+    """Find a model entry by exact match, then case-insensitive fallback.
+
+    Also consults _MODEL_ALIASES to bridge friendly config names to their
+    canonical models.dev IDs when exact and case-insensitive lookups miss.
+    """
     # Exact match
     entry = models.get(model)
     if isinstance(entry, dict):
         return entry
+
+    # Friendly-name aliases (e.g. "kimi-for-coding" → "k2.6")
+    canonical = _MODEL_ALIASES.get(model) or _MODEL_ALIASES.get(model.lower())
+    if canonical:
+        entry = models.get(canonical)
+        if isinstance(entry, dict):
+            return entry
 
     # Case-insensitive match
     model_lower = model.lower()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -473,6 +473,8 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result
     # multimodal support empirically.
+    if p in {"kimi", "kimi-coding", "kimi-coding-cn", "moonshot"}:
+        return True
     return False
 
 


### PR DESCRIPTION
## Summary

Fixes two chained bugs causing `vision_analyze` to fail with Kimi K2.6 (kimi-coding provider, model kimi-for-coding).

**Bug 1 — Provider allow-list missing:** `_supports_media_in_tool_results()` did not list kimi-coding, so the native fast path was always skipped.

**Bug 2 — Friendly name not resolvable:** `_find_model_entry()` couldn't bridge friendly config name `kimi-for-coding` to canonical models.dev ID `k2.6`, so `get_model_capabilities()` returned `None` and `decide_image_input_mode` fell back to `text` mode.

**Fix 1** (): Add kimi, kimi-coding, kimi-coding-cn, moonshot to the provider allow-list in `_supports_media_in_tool_results()`.

**Fix 2** (): Add `_MODEL_ALIASES` dict mapping friendly names to canonical IDs, consulted in `_find_model_entry()` before the case-insensitive sweep.

Tests: 30/30 pass in test_models_dev.py (pre-existing failures in test_vision_tools.py are unrelated to this change).

**Closes** #24681