### PR TITLE
test(run_agent): align switch_model test with new clear-on-switch semantics

### DIFF
--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -1,4 +1,4 @@
-"""Tests that switch_model preserves config_context_length."""
+"""Tests that switch_model clears the stale config_context_length override."""
 
 from unittest.mock import MagicMock, patch
 
@@ -41,8 +41,11 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)
-def test_switch_model_preserves_config_context_length(mock_ctx_len):
-    """When switching models, config_context_length should be passed to get_model_context_length."""
+def test_switch_model_clears_stale_config_context_length(mock_ctx_len):
+    """When switching models, the previous model's config_context_length override
+    must be cleared so the new model's actual context window is resolved via the
+    full chain (custom_providers, endpoint probe, models.dev, etc.) instead of
+    inheriting the stale value. See #21509."""
     agent = _make_agent_with_compressor(config_context_length=32_768)
 
     assert agent.context_compressor.model == "primary-model"
@@ -51,10 +54,14 @@ def test_switch_model_preserves_config_context_length(mock_ctx_len):
     # Switch model
     agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 
-    # Verify get_model_context_length was called with config_context_length
+    # Verify get_model_context_length was called with config_context_length=None
+    # (the stale override was cleared before the runtime field swap).
     mock_ctx_len.assert_called_once()
     call_kwargs = mock_ctx_len.call_args.kwargs
-    assert call_kwargs.get("config_context_length") == 32_768
+    assert call_kwargs.get("config_context_length") is None
+
+    # The agent attribute is also cleared so subsequent resolutions stay clean.
+    assert agent._config_context_length is None
 
     # Verify compressor was updated
     assert agent.context_compressor.model == "new-model"


### PR DESCRIPTION
## Summary
- `8ac351407` ([#24724](https://github.com/NousResearch/hermes-agent/pull/24724), closing #21509) flipped `switch_model`'s semantics from "preserve `_config_context_length` across switches" to "clear it so the new model is auto-resolved"
- The test `tests/run_agent/test_switch_model_context.py::test_switch_model_preserves_config_context_length` (added by `fd3e855d5` under the old interpretation) still asserts the stale value is passed through and is now a baseline CI failure on `main`
- Update that test (and the module docstring) to verify the new invariant

## The bug
On clean `origin/main`:
```
FAILED tests/run_agent/test_switch_model_context.py::test_switch_model_preserves_config_context_length
    AssertionError: assert None == 32768
```
The test asserts `get_model_context_length` is called with the old `config_context_length=32_768`, but after `8ac351407` the override is cleared to `None` before the runtime field swap. The test name "preserves" no longer describes the intended behavior — it was a direct casualty of the policy flip.

## The fix
Rename the test to `test_switch_model_clears_stale_config_context_length` and assert the *new* invariant:
1. `get_model_context_length` is called with `config_context_length=None`
2. `agent._config_context_length` itself is cleared on the instance so any subsequent resolution stays clean
3. The compressor is still re-pointed at the new model (unchanged behavior)

The sibling `test_switch_model_without_config_context_length` keeps passing because the unconditional-`None` case is identical under both policies — left it untouched.

## Test plan
- [x] Focused regression test: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/run_agent/test_switch_model_context.py -v` → 2 passed
- [x] Adjacent suite: `uv run ... python3 -m pytest tests/run_agent/` → 1354 passed, 9 skipped, 0 failed
- [x] Regression guard: on clean `origin/main` the renamed test passes; before the rename (i.e. on current `main`) `test_switch_model_preserves_config_context_length` fails with `assert None == 32768`

## Related
- Follow-up to #24724 / fix for #21509 — adjusts the stale assertion left behind by the policy flip
- Pure test-only change. No production-code edits.