### PR TITLE
webhook: support action_type field for n0loc compatibility

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -388,10 +388,13 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
         # Check event type filter
+        # Note: also checks action_type for n0loc and similar tools that use
+        # action_type instead of event_type in their webhook payloads
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
+            or payload.get("action_type", "")  # n0loc and similar tools
             or "unknown"
         )
         allowed_events = route_config.get("events", [])


### PR DESCRIPTION
Check payload.get('action_type') as a fallback when event_type is not present. This allows n0loc travel tap webhooks to work without needing to include event_type alongside action_type.

Fixes: n0loc travel tap integration with hermes agent