### PR TITLE
fix: auth/DingTalk/streaming/MCP schema improvements

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1489,6 +1489,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
 
 def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources: Set[str]) -> bool:
+    stale_seed_sources = {"gh_cli", "claude_code", "hermes_pkce"}
     retained = [
         entry
         for entry in entries
@@ -1496,7 +1497,7 @@ def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources:
         or entry.source in active_sources
         or not (
             entry.source.startswith("env:")
-            or entry.source in {"claude_code", "hermes_pkce"}
+            or entry.source in stale_seed_sources
         )
     ]
     if len(retained) == len(entries):

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -107,7 +107,91 @@ _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 DINGTALK_TYPE_MAPPING = {
     "picture": "image",
     "voice": "audio",
+    "audio": "audio",
+    "video": "video",
+    "file": "file",
+    "document": "file",
 }
+
+
+def _guess_dingtalk_media_mime(payload: Any, default: str = "application/octet-stream") -> str:
+    """Best-effort MIME detection for DingTalk media payloads.
+
+    DingTalk file/document callbacks are inconsistent across SDK versions: the
+    parsed ChatbotMessage may keep the raw content only in ``extensions``. We
+    infer a stable MIME hint from file name / media type fields so downstream
+    document handling can distinguish text-ish files like ``.md``.
+    """
+    if isinstance(payload, dict):
+        file_name = str(
+            payload.get("fileName")
+            or payload.get("filename")
+            or payload.get("name")
+            or ""
+        ).strip()
+        explicit = str(
+            payload.get("mimeType")
+            or payload.get("mime_type")
+            or payload.get("contentType")
+            or payload.get("content_type")
+            or payload.get("fileType")
+            or payload.get("file_type")
+            or ""
+        ).strip()
+    else:
+        file_name = str(
+            getattr(payload, "file_name", None)
+            or getattr(payload, "fileName", None)
+            or getattr(payload, "filename", None)
+            or getattr(payload, "name", None)
+            or ""
+        ).strip()
+        explicit = str(
+            getattr(payload, "mime_type", None)
+            or getattr(payload, "mimeType", None)
+            or getattr(payload, "content_type", None)
+            or getattr(payload, "contentType", None)
+            or getattr(payload, "file_type", None)
+            or getattr(payload, "fileType", None)
+            or ""
+        ).strip()
+
+    explicit_lower = explicit.lower()
+    if "/" in explicit_lower:
+        return explicit_lower
+    if explicit_lower in DINGTALK_TYPE_MAPPING:
+        mapped = DINGTALK_TYPE_MAPPING[explicit_lower]
+        if mapped == "image":
+            return "image/*"
+        if mapped == "audio":
+            return "audio/*"
+        if mapped == "video":
+            return "video/*"
+
+    import mimetypes
+    from pathlib import Path
+
+    guessed, _ = mimetypes.guess_type(file_name)
+    if guessed:
+        return guessed
+
+    ext = Path(file_name).suffix.lower()
+    text_like_overrides = {
+        ".md": "text/markdown",
+        ".txt": "text/plain",
+        ".csv": "text/csv",
+        ".log": "text/plain",
+        ".json": "text/plain",
+        ".xml": "text/plain",
+        ".yaml": "text/plain",
+        ".yml": "text/plain",
+        ".toml": "text/plain",
+        ".ini": "text/plain",
+        ".cfg": "text/plain",
+    }
+    if ext in text_like_overrides:
+        return text_like_overrides[ext]
+    return default
 
 
 def check_dingtalk_requirements() -> bool:
@@ -718,14 +802,35 @@ class DingTalkAdapter(BasePlatformAdapter):
         media_urls = []
         media_types = []
 
+        def _append_media(download_ref: str, item_type: str = "file", payload: Any = None) -> None:
+            nonlocal msg_type
+            if not download_ref:
+                return
+            mapped = DINGTALK_TYPE_MAPPING.get((item_type or "").lower(), "file")
+            media_urls.append(download_ref)
+            if mapped == "image":
+                media_types.append(_guess_dingtalk_media_mime(payload, "image/*"))
+                if msg_type == MessageType.TEXT:
+                    msg_type = MessageType.PHOTO
+            elif mapped == "audio":
+                media_types.append(_guess_dingtalk_media_mime(payload, "audio/*"))
+                if msg_type == MessageType.TEXT:
+                    msg_type = MessageType.AUDIO
+            elif mapped == "video":
+                media_types.append(_guess_dingtalk_media_mime(payload, "video/*"))
+                if msg_type == MessageType.TEXT:
+                    msg_type = MessageType.VIDEO
+            else:
+                media_types.append(_guess_dingtalk_media_mime(payload, "application/octet-stream"))
+                if msg_type == MessageType.TEXT:
+                    msg_type = MessageType.DOCUMENT
+
         # Check for image/picture
         image_content = getattr(message, "image_content", None)
         if image_content:
             download_code = getattr(image_content, "download_code", None)
             if download_code:
-                media_urls.append(download_code)
-                media_types.append("image")
-                msg_type = MessageType.PHOTO
+                _append_media(download_code, "picture", image_content)
 
         # Check for rich text with mixed content
         rich_text = getattr(message, "rich_text_content", None) or getattr(
@@ -737,28 +842,50 @@ class DingTalkAdapter(BasePlatformAdapter):
                 for item in rich_list:
                     if isinstance(item, dict):
                         dl_code = (
-                            item.get("downloadCode") or item.get("download_code") or ""
+                            item.get("downloadCode")
+                            or item.get("download_code")
+                            or item.get("pictureDownloadCode")
+                            or ""
                         )
                         item_type = item.get("type", "")
                         if dl_code:
-                            mapped = DINGTALK_TYPE_MAPPING.get(item_type, "file")
-                            media_urls.append(dl_code)
-                            if mapped == "image":
-                                media_types.append("image")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.PHOTO
-                            elif mapped == "audio":
-                                media_types.append("audio")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.AUDIO
-                            elif mapped == "video":
-                                media_types.append("video")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.VIDEO
-                            else:
-                                media_types.append("application/octet-stream")
-                                if msg_type == MessageType.TEXT:
-                                    msg_type = MessageType.DOCUMENT
+                            _append_media(dl_code, item_type, item)
+
+        # SDK fallback: unsupported msgtype payloads are often kept in extensions.
+        if not media_urls:
+            ext = getattr(message, "extensions", None) or {}
+            candidates = []
+            if isinstance(ext, dict):
+                for key in ("content", "file", "image", "audio", "video"):
+                    value = ext.get(key)
+                    if value:
+                        candidates.append(value)
+                candidates.append(ext)
+
+            msg_type_str = (getattr(message, "message_type", "") or "").lower()
+            for payload in candidates:
+                if isinstance(payload, dict):
+                    dl_code = (
+                        payload.get("downloadCode")
+                        or payload.get("download_code")
+                        or payload.get("pictureDownloadCode")
+                        or payload.get("mediaId")
+                        or payload.get("media_id")
+                        or ""
+                    )
+                    if not dl_code:
+                        continue
+                    payload_type = str(
+                        payload.get("type")
+                        or payload.get("msgtype")
+                        or payload.get("msgType")
+                        or payload.get("fileType")
+                        or payload.get("file_type")
+                        or msg_type_str
+                        or "file"
+                    ).lower()
+                    _append_media(dl_code, payload_type, payload)
+                    break
 
         msg_type_str = getattr(message, "message_type", "") or ""
         if msg_type_str == "picture" and not media_urls:
@@ -1211,14 +1338,39 @@ class DingTalkAdapter(BasePlatformAdapter):
                         if item.get(key):
                             codes_to_resolve.append((item, key))
 
+        # 3. Raw extension payloads for SDK-unsupported msgtypes (e.g. file)
+        ext = getattr(message, "extensions", None) or {}
+        if isinstance(ext, dict):
+            candidate_payloads = []
+            for key in ("content", "file", "image", "audio", "video"):
+                value = ext.get(key)
+                if isinstance(value, dict):
+                    candidate_payloads.append(value)
+            candidate_payloads.append(ext)
+
+            for payload in candidate_payloads:
+                if isinstance(payload, dict):
+                    for key in (
+                        "downloadCode",
+                        "pictureDownloadCode",
+                        "download_code",
+                        "mediaId",
+                        "media_id",
+                    ):
+                        if payload.get(key):
+                            codes_to_resolve.append((payload, key))
+                            break
+
         if not codes_to_resolve:
             return
 
         # Resolve all codes in parallel
         tasks = []
+        seen = set()
         for obj, key in codes_to_resolve:
             code = getattr(obj, key, None) if hasattr(obj, key) else obj.get(key)
-            if code:
+            if code and code not in seen:
+                seen.add(code)
                 tasks.append(
                     self._fetch_download_url(code, robot_code, token, obj, key)
                 )

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -14,6 +14,10 @@ Credential search order (matching Copilot CLI behaviour):
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
   4. gh auth token  CLI fallback
+
+Optional GitHub CLI selectors:
+  COPILOT_GH_HOST  Host passed to ``gh auth token --hostname``
+  COPILOT_GH_USER  User passed to ``gh auth token --user``
 """
 
 from __future__ import annotations
@@ -41,6 +45,16 @@ COPILOT_ENV_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 # Polling constants
 _DEVICE_CODE_POLL_INTERVAL = 5  # seconds
 _DEVICE_CODE_POLL_SAFETY_MARGIN = 3  # seconds
+
+
+def _copilot_env_value(name: str) -> str:
+    """Read a Copilot-related env var from ~/.hermes/.env or process env."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        return (get_env_value(name) or os.getenv(name, "")).strip()
+    except Exception:
+        return os.getenv(name, "").strip()
 
 
 def validate_copilot_token(token: str) -> tuple[bool, str]:
@@ -72,7 +86,7 @@ def resolve_copilot_token() -> tuple[str, str]:
     """
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
-        val = os.getenv(env_var, "").strip()
+        val = _copilot_env_value(env_var)
         if val:
             valid, msg = validate_copilot_token(val)
             if not valid:
@@ -120,11 +134,14 @@ def _try_gh_cli_token() -> Optional[str]:
     """Return a token from ``gh auth token`` when the GitHub CLI is available.
 
     When COPILOT_GH_HOST is set, passes ``--hostname`` so gh returns the
-    correct host's token.  Also strips GITHUB_TOKEN / GH_TOKEN from the
-    subprocess environment so ``gh`` reads from its own credential store
-    (hosts.yml) instead of just echoing the env var back.
+    correct host's token. When COPILOT_GH_USER is set, passes ``--user`` so
+    gh returns that account's token instead of the active account. Also strips
+    GITHUB_TOKEN / GH_TOKEN from the subprocess environment so ``gh`` reads
+    from its own credential store (hosts.yml) instead of just echoing the env
+    var back.
     """
-    hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+    hostname = _copilot_env_value("COPILOT_GH_HOST")
+    username = _copilot_env_value("COPILOT_GH_USER")
 
     # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
     clean_env = {k: v for k, v in os.environ.items()
@@ -134,6 +151,8 @@ def _try_gh_cli_token() -> Optional[str]:
         cmd = [gh_path, "auth", "token"]
         if hostname:
             cmd += ["--hostname", hostname]
+        if username:
+            cmd += ["--user", username]
         try:
             result = subprocess.run(
                 cmd,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2201,6 +2201,12 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
     if item.get("model_picker_enabled") is False:
         return False
 
+    policy = item.get("policy")
+    if isinstance(policy, dict):
+        policy_state = str(policy.get("state") or "").strip().lower()
+        if policy_state == "disabled":
+            return False
+
     capabilities = item.get("capabilities")
     if isinstance(capabilities, dict):
         model_type = str(capabilities.get("type") or "").strip().lower()

--- a/run_agent.py
+++ b/run_agent.py
@@ -7189,7 +7189,14 @@ class AIAgent:
                     if not tool_calls_acc:
                         _fire_first_delta()
                         self._fire_stream_delta(delta.content)
-                        deltas_were_sent["yes"] = True
+                        # Track whether text was actually visible to an external
+                        # stream consumer. Quiet callers such as cron still use
+                        # streaming for health checks, but no user has seen any
+                        # partial text there; if the provider dies mid tool-call,
+                        # we should let the normal retry/fallback path recover
+                        # instead of returning a partial warning stub.
+                        if self._has_stream_consumers():
+                            deltas_were_sent["yes"] = True
                     else:
                         # Tool calls suppress regular content streaming (avoids
                         # displaying chatty "I'll use the tool..." text alongside
@@ -7390,7 +7397,11 @@ class AIAgent:
                                 if text and not has_tool_use:
                                     _fire_first_delta()
                                     self._fire_stream_delta(text)
-                                    deltas_were_sent["yes"] = True
+                                    # Only treat partial text as delivered if a
+                                    # real stream consumer exists. Quiet callers
+                                    # can safely retry on stream failures.
+                                    if self._has_stream_consumers():
+                                        deltas_were_sent["yes"] = True
                             elif delta_type == "thinking_delta":
                                 thinking_text = getattr(delta, "thinking", "")
                                 if thinking_text:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1187,6 +1187,44 @@ def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):
     assert pool.entries() == []
 
 
+def test_load_pool_removes_stale_copilot_gh_cli_entry_when_token_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "copilot": [
+                    {
+                        "id": "seeded-gh",
+                        "label": "gh auth token",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "gh_cli",
+                        "access_token": "stale-gho-token",
+                        "base_url": "https://api.githubcopilot.com",
+                    }
+                ]
+            },
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("", ""),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("copilot")
+
+    assert not pool.has_credentials()
+    assert pool.entries() == []
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert auth_payload["credential_pool"]["copilot"] == []
+
+
 def test_load_pool_seeds_qwen_oauth_via_cli_tokens(tmp_path, monkeypatch):
     """Qwen OAuth credentials from ~/.qwen/oauth_creds.json should be seeded into the pool."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -422,6 +422,64 @@ class TestExtractText:
         assert DingTalkAdapter._extract_text(msg) == ""
 
 
+class TestExtractMedia:
+    def test_extracts_file_message_from_sdk_extensions(self):
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        msg = SimpleNamespace(
+            image_content=None,
+            rich_text_content=None,
+            rich_text=None,
+            message_type="file",
+            extensions={
+                "content": {
+                    "downloadCode": "dl-file-123",
+                    "fileName": "note.md",
+                }
+            },
+        )
+
+        msg_type, media_urls, media_types = adapter._extract_media(msg)
+
+        assert msg_type == MessageType.DOCUMENT
+        assert media_urls == ["dl-file-123"]
+        assert media_types and media_types[0].startswith("text/")
+
+
+class TestResolveMediaCodes:
+    @pytest.mark.asyncio
+    async def test_resolves_download_codes_from_sdk_extension_content(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._client_id = "robot-code-1"
+        adapter._get_access_token = AsyncMock(return_value="token-123")
+        adapter._fetch_download_url = AsyncMock()
+
+        content = {
+            "downloadCode": "dl-file-123",
+            "fileName": "brief.md",
+        }
+        msg = SimpleNamespace(
+            robot_code=None,
+            image_content=None,
+            rich_text_content=None,
+            extensions={"content": content},
+        )
+
+        await adapter._resolve_media_codes(msg)
+
+        adapter._fetch_download_url.assert_awaited_once_with(
+            "dl-file-123",
+            "robot-code-1",
+            "token-123",
+            content,
+            "downloadCode",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Group gating — require_mention + allowed_users (parity with other platforms)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -478,6 +478,34 @@ class TestResolveApiKeyProviderCredentials:
         assert _try_gh_cli_token() == "gh-cli-secret"
         assert calls == [["/opt/homebrew/bin/gh", "auth", "token"]]
 
+    def test_try_gh_cli_token_passes_host_and_user_when_configured(self, monkeypatch):
+        monkeypatch.setenv("COPILOT_GH_HOST", "github.com")
+        monkeypatch.setenv("COPILOT_GH_USER", "pearjelly")
+        monkeypatch.setattr("hermes_cli.copilot_auth.shutil.which", lambda command: "/usr/local/bin/gh")
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = "gh-cli-secret\n"
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Result()
+
+        monkeypatch.setattr("hermes_cli.copilot_auth.subprocess.run", _fake_run)
+
+        assert _try_gh_cli_token() == "gh-cli-secret"
+        assert calls == [[
+            "/usr/local/bin/gh",
+            "auth",
+            "token",
+            "--hostname",
+            "github.com",
+            "--user",
+            "pearjelly",
+        ]]
+
     def test_resolve_copilot_acp_with_local_cli(self, monkeypatch):
         monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio")
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -88,6 +88,35 @@ class TestResolveToken:
         assert token == "gho_from_cli"
         assert source == "gh auth token"
 
+    def test_gh_cli_fallback_can_target_specific_user(self, monkeypatch):
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("COPILOT_GH_USER", "pearjelly")
+        monkeypatch.setattr("hermes_cli.copilot_auth._gh_cli_candidates", lambda: ["/usr/local/bin/gh"])
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = "gho_from_cli\n"
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Result()
+
+        monkeypatch.setattr("hermes_cli.copilot_auth.subprocess.run", _fake_run)
+
+        assert _try_gh_cli_token() == "gho_from_cli"
+        assert calls == [[
+            "/usr/local/bin/gh",
+            "auth",
+            "token",
+            "--user",
+            "pearjelly",
+        ]]
+
     def test_gh_cli_classic_pat_raises(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -321,6 +321,33 @@ class TestFetchApiModels:
         assert catalog is not None
         assert [item["id"] for item in catalog] == ["gpt-5.4"]
 
+    def test_fetch_github_model_catalog_filters_policy_disabled_models(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data": ['
+                    b'{"id": "gpt-5.4", "model_picker_enabled": true, '
+                    b'"policy": {"state": "disabled"}, '
+                    b'"supported_endpoints": ["/responses"], '
+                    b'"capabilities": {"type": "chat"}}, '
+                    b'{"id": "gpt-5-mini", "model_picker_enabled": true, '
+                    b'"policy": {"state": "enabled"}, '
+                    b'"supported_endpoints": ["/chat/completions"], '
+                    b'"capabilities": {"type": "chat"}}]}'
+                )
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            catalog = fetch_github_model_catalog("gh-token")
+
+        assert catalog is not None
+        assert [item["id"] for item in catalog] == ["gpt-5-mini"]
+
 
 class TestGithubReasoningEfforts:
     def test_gpt5_supports_minimal_to_high(self):

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1053,7 +1053,7 @@ class TestPartialToolCallWarning:
         agent._interrupt_requested = False
 
         fired_deltas: list = []
-        agent._fire_stream_delta = lambda text: fired_deltas.append(text)
+        agent.stream_delta_callback = lambda text: fired_deltas.append(text)
         agent._current_streamed_assistant_text = "Let me write the audit: "
 
         import os as _os
@@ -1112,7 +1112,8 @@ class TestPartialToolCallWarning:
         )
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
-        agent._current_streamed_assistant_text = "Here's my answer so far"
+        fired_deltas: list = []
+        agent.stream_delta_callback = lambda text: fired_deltas.append(text)
 
         import os as _os
         _prev = _os.environ.get("HERMES_STREAM_RETRIES")
@@ -1200,7 +1201,7 @@ class TestSilentRetryMidToolCall:
         agent._interrupt_requested = False
 
         fired_deltas: list = []
-        agent._fire_stream_delta = lambda text: fired_deltas.append(text)
+        agent.stream_delta_callback = lambda text: fired_deltas.append(text)
 
         import os as _os
         _prev = _os.environ.get("HERMES_STREAM_RETRIES")
@@ -1242,6 +1243,80 @@ class TestSilentRetryMidToolCall:
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_quiet_mid_tool_stream_error_uses_general_retry_not_stub(
+        self, mock_close, mock_create, mock_replace,
+    ):
+        """Quiet callers (cron/subagents) use streaming for health checks even
+        with no display consumer. If that stream dies after text + partial tool
+        JSON, no user-visible text was actually delivered, so the safe recovery
+        is the normal retry path — not a partial warning stub that marks the
+        turn as a textual assistant reply and drops the tool call."""
+        from run_agent import AIAgent
+        import httpx as _httpx
+
+        attempts = {"n": 0}
+
+        def _first_stream():
+            yield _make_stream_chunk(content="Let me write the audit: ")
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "/tmp/x", '),
+            ])
+            raise _httpx.RemoteProtocolError("peer closed connection")
+
+        def _second_stream():
+            yield _make_stream_chunk(content="Let me write the audit: ")
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0, arguments='{"path": "/tmp/x", "content": "hi"}',
+                ),
+            ])
+            yield _make_stream_chunk(finish_reason="tool_calls")
+
+        def _pick_stream(*a, **kw):
+            attempts["n"] += 1
+            return _first_stream() if attempts["n"] == 1 else _second_stream()
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = _pick_stream
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        assert not agent._has_stream_consumers()
+
+        import os as _os
+        _prev = _os.environ.get("HERMES_STREAM_RETRIES")
+        _os.environ["HERMES_STREAM_RETRIES"] = "1"
+        try:
+            response = agent._interruptible_streaming_api_call({})
+        finally:
+            if _prev is None:
+                _os.environ.pop("HERMES_STREAM_RETRIES", None)
+            else:
+                _os.environ["HERMES_STREAM_RETRIES"] = _prev
+
+        assert attempts["n"] == 2
+        msg = response.choices[0].message
+        assert "Stream stalled" not in (getattr(msg, "content", None) or "")
+        assert getattr(msg, "tool_calls", None)
+
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_silent_retry_exhausted_falls_back_to_stub(
         self, mock_close, mock_create, mock_replace,
     ):
@@ -1274,7 +1349,7 @@ class TestSilentRetryMidToolCall:
         agent._interrupt_requested = False
 
         fired_deltas: list = []
-        agent._fire_stream_delta = lambda text: fired_deltas.append(text)
+        agent.stream_delta_callback = lambda text: fired_deltas.append(text)
 
         import os as _os
         _prev = _os.environ.get("HERMES_STREAM_RETRIES")
@@ -1330,7 +1405,8 @@ class TestSilentRetryMidToolCall:
         )
         agent.api_mode = "chat_completions"
         agent._interrupt_requested = False
-        agent._current_streamed_assistant_text = "Here's my answer so far"
+        fired_deltas: list = []
+        agent.stream_delta_callback = lambda text: fired_deltas.append(text)
 
         import os as _os
         _prev = _os.environ.get("HERMES_STREAM_RETRIES")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2638,7 +2638,14 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         ):
             repaired["type"] = "object"
 
-        if repaired.get("type") == "object":
+        if repaired.get("type") == "array":
+            # OpenAI Codex and other providers require items definition for arrays
+            if "items" not in repaired:
+                repaired["items"] = {"type": "object", "properties": {}}
+            elif not isinstance(repaired.get("items"), dict):
+                # items is present but not a schema object (e.g., a bool or invalid)
+                repaired["items"] = {"type": "object", "properties": {}}
+        elif repaired.get("type") == "object":
             # Ensure properties exists so required can reference it safely
             if "properties" not in repaired or not isinstance(
                 repaired.get("properties"), dict


### PR DESCRIPTION
## Summary

Six targeted fixes and one feature addition across auth, gateway, streaming, and MCP tool schema handling.

---

### 1. `fix(credential_pool)`: Include `gh_cli` source in stale seed pruning

`_prune_stale_seeded_entries` previously only treated `claude_code` and `hermes_pkce` as auto-seeded sources. The `gh_cli` source (created when GitHub CLI auth seeds the Copilot pool) was missing from the set, causing stale GHO tokens to survive across sessions where the CLI token is no longer available.

Added `gh_cli` to `stale_seed_sources`.

---

### 2. `fix(gateway)`: Extend DingTalk media handling for file/video/audio types

Several gaps in DingTalk media message processing:

- **Expanded type mapping**: `DINGTALK_TYPE_MAPPING` now covers `audio`, `video`, `file`, and `document` in addition to `picture`/`voice`.
- **MIME detection helper**: New `_guess_dingtalk_media_mime()` infers a stable MIME type from payload fields (`mimeType`/`contentType`/`fileType`/`fileName`). Handles text-like extensions (`.md`, `.csv`, `.yaml`, etc.) explicitly.
- **Refactored `_extract_media()`**: Extracted an `_append_media()` inner helper to eliminate duplicated type-mapping + `MessageType` upgrade logic.
- **SDK fallback**: When no media URLs are found via the standard `image_content`/`rich_text` paths, `_extract_media()` scans `message.extensions` for download codes. This covers `file`/`document` msgtypes not yet modelled as typed SDK attributes.
- **Extension scanning in `_resolve_media_codes()`**: Mirror the same logic so download codes found only in `extensions` are resolved to permanent URLs.
- **Deduplication**: Added a `seen` set to prevent the same download code from being fetched multiple times.
- **`pictureDownloadCode` key**: Accepted as an alternative to `downloadCode` in rich-text item parsing.

---

### 3. `feat(auth)`: Add `COPILOT_GH_USER` selector and `.env` fallback

Two improvements to GitHub Copilot CLI authentication:

- **`COPILOT_GH_USER`**: When set, passes `--user <username>` to `gh auth token` so the correct account's token is returned for users with multiple accounts. Mirrors the existing `COPILOT_GH_HOST` / `--hostname` behaviour.
- **`.env` file fallback**: New `_copilot_env_value()` reads from `~/.hermes/.env` via `hermes_cli.config.get_env_value()` before falling back to `os.getenv()`. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, `COPILOT_GH_HOST`, and `COPILOT_GH_USER` can now be set in the Hermes `.env` file.

---

### 4. `fix(models)`: Filter policy-disabled models from Copilot catalog

The GitHub Copilot model catalog can include entries where `policy.state == "disabled"`. These models are not usable even if `model_picker_enabled` is `true`. Added a policy state check to `_copilot_catalog_item_is_text_model()` to exclude them.

---

### 5. `fix(run_agent)`: Guard `deltas_were_sent` behind stream consumer check

Quiet callers (cron jobs, sub-agents) use streaming API calls even though they have no display consumer. Previously, `deltas_were_sent` was set as soon as any text chunk was forwarded to `_fire_stream_delta()`, causing a mid-tool-call stream failure to emit a partial warning stub (`Stream stalled...`) instead of retrying cleanly.

Wrapped the assignment inside `_has_stream_consumers()` so quiet callers fall through to the normal retry/fallback path on stream errors.

---

### 6. `fix(tools)`: Normalize MCP array schema to include required `items` field

OpenAI Codex and other strict providers reject MCP tool schemas where a parameter has `type=array` without a corresponding `items` definition. `_normalize_mcp_input_schema()` only handled the `type=object` case. Added `type=array` handling: injects a permissive `{"type": "object", "properties": {}}` default when `items` is absent or non-dict.

---

## Testing

Each change is covered by new tests:

| Area | New tests |
|---|---|
| `credential_pool` | `test_load_pool_removes_stale_copilot_gh_cli_entry_when_token_missing` |
| `dingtalk` | `TestExtractMedia::test_extracts_file_message_from_sdk_extensions`, `TestResolveMediaCodes::test_resolves_download_codes_from_sdk_extension_content` |
| `copilot_auth` | `test_gh_cli_fallback_can_target_specific_user`, `test_try_gh_cli_token_passes_host_and_user_when_configured` |
| `models` | `test_fetch_github_model_catalog_filters_policy_disabled_models` |
| `run_agent` | `test_quiet_mid_tool_stream_error_uses_general_retry_not_stub` |