### PR TITLE
Fix Windows-native gateway detection and cross-platform test paths

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -126,8 +126,10 @@ def get_process_start_time(pid: int) -> Optional[int]:
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string.
 
-    On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
-    platforms without /proc, falls back to ``ps -p <pid> -o command=``.
+    On Linux, reads /proc/<pid>/cmdline directly. On Windows, asks WMI for
+    the Win32 command line because MSYS ``ps`` reports only the image path for
+    native Win32 processes. On macOS and other platforms without /proc, falls
+    back to ``ps -p <pid> -o command=``.
     """
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
@@ -137,6 +139,33 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     else:
         if raw:
             return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+
+    if _IS_WINDOWS:
+        try:
+            result = subprocess.run(
+                [
+                    "wmic",
+                    "process",
+                    "where",
+                    f"ProcessId={int(pid)}",
+                    "get",
+                    "CommandLine",
+                    "/FORMAT:LIST",
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if line.startswith("CommandLine="):
+                        value = line.split("=", 1)[1].strip()
+                        if value:
+                            return value
+        except (OSError, subprocess.TimeoutExpired, ValueError):
+            pass
 
     try:
         result = subprocess.run(

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -503,32 +503,29 @@ class TestSendToPlatformChunking:
         assert all(call == [] for call in sent_calls[:-1])
         assert sent_calls[-1] == media
 
-    def test_matrix_media_uses_native_adapter_helper(self):
+    def test_matrix_media_uses_native_adapter_helper(self, tmp_path):
 
-        doc_path = Path("/tmp/test-send-message-matrix.pdf")
+        doc_path = tmp_path / "test-send-message-matrix.pdf"
         doc_path.write_bytes(b"%PDF-1.4 test")
 
-        try:
-            helper = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:example.com", "message_id": "$evt"})
-            with patch("tools.send_message_tool._send_matrix_via_adapter", helper):
-                result = asyncio.run(
-                    _send_to_platform(
-                        Platform.MATRIX,
-                        SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com"}),
-                        "!room:example.com",
-                        "here you go",
-                        media_files=[(str(doc_path), False)],
-                    )
+        helper = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:example.com", "message_id": "$evt"})
+        with patch("tools.send_message_tool._send_matrix_via_adapter", helper):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.MATRIX,
+                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com"}),
+                    "!room:example.com",
+                    "here you go",
+                    media_files=[(str(doc_path), False)],
                 )
+            )
 
-            assert result["success"] is True
-            helper.assert_awaited_once()
-            call = helper.await_args
-            assert call.args[1] == "!room:example.com"
-            assert call.args[2] == "here you go"
-            assert call.kwargs["media_files"] == [(str(doc_path), False)]
-        finally:
-            doc_path.unlink(missing_ok=True)
+        assert result["success"] is True
+        helper.assert_awaited_once()
+        call = helper.await_args
+        assert call.args[1] == "!room:example.com"
+        assert call.args[2] == "here you go"
+        assert call.kwargs["media_files"] == [(str(doc_path), False)]
 
     def test_matrix_text_only_uses_lightweight_path(self):
         """Text-only Matrix sends should NOT go through the heavy adapter path."""


### PR DESCRIPTION
## Summary

This PR addresses two issues that prevent Hermes Agent from working correctly on native Windows (outside WSL).

## Changes

### 1. `gateway/status.py`: Add WMIC fallback for process cmdline detection

On Windows, when running under Git Bash/MSYS2, `ps -p <pid> -o command=` only reports the image name for native Win32 processes (e.g., `python.exe`) instead of the full command line. This causes `is_gateway_running()` to fail to detect the gateway process, which in turn breaks `hermes status` and the `hermes doctor` gateway check.

This patch adds a WMIC fallback that queries `Win32_Process.CommandLine` for the full command line. This is a built-in Windows utility and requires no additional dependencies.

### 2. `tests/tools/test_send_message_tool.py`: Use `tmp_path` fixture

The `test_matrix_media_uses_native_adapter_helper` test used a hardcoded `/tmp/` path which doesn't exist on Windows. This change uses the pytest `tmp_path` fixture instead, ensuring tests run correctly on all platforms.