### PR TITLE
fix(gateway,xiaomi): reasoning_content echo-back for MiMo + prevent infinite retry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7758,10 +7758,28 @@ class GatewayRunner:
                 ))
                 or ("400" in _err_str_for_classify and len(history) > 50)
             )
+            # Reasoning echo-back failures (DeepSeek, Kimi, Xiaomi MiMo):
+            # The provider requires reasoning_content on every assistant
+            # message in thinking mode. When replaying stale history that
+            # lacks it, the API returns 400 deterministically — retrying
+            # the same session will always fail. Treat as non-recoverable.
+            is_reasoning_echo_failure = agent_failed_early and any(
+                p in _err_str_for_classify for p in (
+                    "reasoning_content", "thinking mode",
+                    "must be passed back",
+                )
+            )
+
             if is_context_overflow_failure:
                 logger.info(
                     "Skipping transcript persistence for context-overflow "
                     "failure in session %s to prevent session growth loop.",
+                    session_entry.session_id,
+                )
+            elif is_reasoning_echo_failure:
+                logger.warning(
+                    "Non-recoverable reasoning echo-back failure in session %s "
+                    "— resetting session to prevent infinite retry loop.",
                     session_entry.session_id,
                 )
             elif agent_failed_early:
@@ -7775,10 +7793,11 @@ class GatewayRunner:
             # large to process.  Auto-reset it so the next message starts
             # fresh instead of replaying the same oversized context in an
             # infinite fail loop.  (#9893)
-            if agent_result.get("compression_exhausted") and session_entry and session_key:
+            if (agent_result.get("compression_exhausted") or is_reasoning_echo_failure) and session_entry and session_key:
                 logger.info(
-                    "Auto-resetting session %s after compression exhaustion.",
+                    "Auto-resetting session %s after %s.",
                     session_entry.session_id,
+                    "reasoning echo-back failure" if is_reasoning_echo_failure else "compression exhaustion",
                 )
                 self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
@@ -7797,7 +7816,7 @@ class GatewayRunner:
             # If this is a fresh session (no history), write the full tool
             # definitions as the first entry so the transcript is self-describing
             # -- the same list of dicts sent as tools=[...] in the API request.
-            if is_context_overflow_failure:
+            if is_context_overflow_failure or is_reasoning_echo_failure:
                 pass  # Skip all transcript writes — don't grow a broken session
             elif not history:
                 tool_defs = agent_result.get("tools", [])
@@ -7816,7 +7835,7 @@ class GatewayRunner:
             # Use the filtered history length (history_offset) that was actually
             # passed to the agent, not len(history) which includes session_meta
             # entries that were stripped before the agent saw them.
-            if is_context_overflow_failure:
+            if is_context_overflow_failure or is_reasoning_echo_failure:
                 pass  # handled above — skip all transcript writes
             elif agent_failed_early:
                 # Transient failure (429/timeout/5xx): persist only the user


### PR DESCRIPTION
## Summary

Xiaomi MiMo's Anthropic-compatible `/anthropic` endpoint requires `reasoning_content` on every assistant message when thinking mode is enabled. Omitting it causes HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

This PR adds three fixes:

### 1. `run_agent.py` — Xiaomi reasoning pad detection

Added `_needs_xiaomi_tool_reasoning()` matching provider `xiaomi`/`mimo`/`xiaomi-mimo` or `base_url` containing `xiaomimimo.com`. Included in `_needs_thinking_reasoning_pad()` so the padding logic applies to MiMo tool-call replays (same pattern as DeepSeek #15250 and Kimi #17400).

### 2. `agent/anthropic_adapter.py` — Anthropic adapter compatibility

- Added `_is_xiaomi_anthropic_endpoint()` function
- Added it to `_preserve_unsigned_thinking` whitelist so unsigned thinking blocks survive signature stripping on third-party endpoints
- Fixed `reasoning_content` → thinking block insertion to always insert even when `_already_has_thinking` is True, because signed blocks from `reasoning_details` will be stripped by the third-party endpoint code below

### 3. `gateway/run.py` — Prevent infinite retry loop

Added `is_reasoning_echo_failure` detection matching `"reasoning_content"`, `"thinking mode"`, `"must be passed back"` in error messages. When triggered:
- Auto-resets the session (like `compression_exhausted`)
- Skips transcript persistence (don't grow a broken session)
- Logs a warning instead of "Transient agent failure"

Without this, the gateway enters an infinite retry loop on the same stale session history that always produces the same 400 error. Observed: a session retried for 2+ hours hitting the same error every time.

## Testing

```bash
# Verify Xiaomi detection
hermes chat -q "echo hello" -m mimo-v2.5-pro --provider xiaomi --yolo

# Verify gateway doesn't infinite retry on stale sessions
# (requires a session that previously hit the reasoning_content 400)
```

## Related

- Refs #15250 (DeepSeek reasoning_content)
- Refs #17400 (Kimi reasoning_content)
- Refs #mimo-pass-back (Xiaomi MiMo)