### PR TITLE
docs: + Branching Strategy 段到 CONTRIBUTING.md (5-13)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -813,3 +813,13 @@ test(tools): add unit tests for file_operations
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+
+## Branching Strategy
+
+- `main` = 主分支 (= 部署源 if 该仓有部署 · 否则 sync ~/.claude submodule)
+- 临时分支: `feat/<name>` · `fix/<name>` · base 永远 `origin/main`
+- PR target = `main` · CI pass + mergeable + 无 conflict 才合
+- lead merge 不 auto · subagent 不自合
+- subagent 创 worktree 干活前必读 README + 本 CONTRIBUTING.md
+
+详见 `~/.claude/memories/feedback_lead_main_branch_only.md`


### PR DESCRIPTION
## Summary

akong 团队 fork (yarnovo/hermes-agent · REQ-010 AgentRun backend) · 跟齐内部 35 仓统一规约。

业界 13/13 头部仓共识: CONTRIBUTING.md (root) 含 `## Branching Strategy` 段 (老板 5-13 v2 拍)。

## Changes

仅 CONTRIBUTING.md 尾部追加内部分支策略段 (模板 B 单分支):
- `main` = 主分支 · 临时分支 `feat/<name>` / `fix/<name>` base `origin/main`
- PR target = `main` · CI pass + mergeable 才合
- subagent 创 worktree 干活前必读 README + CONTRIBUTING.md

README 不动 (上游 NousResearch/hermes-agent README 无内部分支策略段需迁出)。

## Test plan
- [x] CONTRIBUTING.md 尾部干净追加 (上游内容不动)
- [ ] CI pass (如有)
- [ ] mergeable + 无 conflict