### PR TITLE
fix(transcription): add threading lock to prevent TOCTOU race in _transcribe_local()

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -32,6 +32,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
@@ -103,6 +104,7 @@ GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-lar
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
 _local_model_name: Optional[str] = None
+_local_model_lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -406,11 +408,16 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
-        # Lazy-load the model (downloads on first use, ~150 MB for 'base')
+        # Double-checked locking: avoid holding the lock for every call once
+        # the model is loaded, but prevent duplicate downloads/loads when
+        # multiple threads race on first use (or on model switch).
         if _local_model is None or _local_model_name != model_name:
-            logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
-            _local_model = _load_local_whisper_model(model_name)
-            _local_model_name = model_name
+            with _local_model_lock:
+                # Re-check after acquiring — another thread may have loaded it.
+                if _local_model is None or _local_model_name != model_name:
+                    logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
+                    _local_model = _load_local_whisper_model(model_name)
+                    _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
         _forced_lang = (
@@ -438,11 +445,12 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
                 "evicting cached model and retrying on CPU (int8).",
                 exc,
             )
-            _local_model = None
-            _local_model_name = None
-            from faster_whisper import WhisperModel
-            _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
-            _local_model_name = model_name
+            with _local_model_lock:
+                _local_model = None
+                _local_model_name = None
+                from faster_whisper import WhisperModel
+                _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
+                _local_model_name = model_name
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
             transcript = " ".join(segment.text.strip() for segment in segments)
 


### PR DESCRIPTION
## Summary

Fixes #24767 — TOCTOU race in `_transcribe_local()` allows duplicate faster-whisper model downloads when concurrent threads pass the unguarded `_local_model is None` check simultaneously.

## Changes

- **`tools/transcription_tools.py`**: Add `import threading` and a module-level `_local_model_lock = threading.Lock()`. Apply double-checked locking around the lazy model initialization so only one thread downloads/loads the model while others wait, then all share the cached instance. The same lock protects the CUDA-fallback-to-CPU eviction path.

## Root Cause

The module-global `_local_model` / `_local_model_name` singleton had no synchronization. Two threads calling `_transcribe_local()` before the first load completes would both pass the `is None` guard and both call `_load_local_whisper_model()`, triggering duplicate ~150 MB downloads and wasting memory.

## Testing

- All 118 existing transcription tests pass (`tests/tools/test_transcription_tools.py`, `tests/tools/test_transcription.py`).
- The double-checked locking pattern avoids lock contention on the hot path (no lock acquired when model is already loaded and name matches).