### PR TITLE
Harden Google Chat OAuth credential persistence

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -61,6 +61,8 @@ import json
 import logging
 import os
 import re
+import secrets
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -88,6 +90,8 @@ except (ModuleNotFoundError, ImportError):
             return "~/" + str(home.relative_to(Path.home()))
         except ValueError:
             return str(home)
+
+from utils import atomic_replace
 
 
 def _hermes_home() -> Path:
@@ -296,14 +300,11 @@ def list_authorized_emails() -> List[str]:
 
 
 def _persist_credentials(creds: Any, token_path: Path) -> None:
-    """Atomic-ish JSON write of refreshed credentials."""
+    """Persist refreshed credentials atomically with private permissions."""
     try:
-        token_path.parent.mkdir(parents=True, exist_ok=True)
-        token_path.write_text(
-            json.dumps(
-                _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                indent=2,
-            )
+        _write_private_json(
+            token_path,
+            _normalize_authorized_user_payload(json.loads(creds.to_json())),
         )
     except Exception:
         logger.debug(
@@ -323,6 +324,38 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
     if not normalized.get("type"):
         normalized["type"] = "authorized_user"
     return normalized
+
+
+def _write_private_json(path: Path, data: Any) -> None:
+    """Atomically write JSON with 0o600 permissions where supported."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
+
+    tmp_path = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+    try:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        atomic_replace(tmp_path, path)
+        try:
+            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
 
 
 def _ensure_deps() -> None:
@@ -402,25 +435,21 @@ def store_client_secret(path: str) -> None:
         sys.exit(1)
 
     target = _client_secret_path()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(json.dumps(data, indent=2))
+    _write_private_json(target, data)
     print(f"OK: Client secret saved to {target}")
 
 
 def _save_pending_auth(*, state: str, code_verifier: str,
                       email: Optional[str] = None) -> None:
     pending = _pending_auth_path(email)
-    pending.parent.mkdir(parents=True, exist_ok=True)
-    pending.write_text(
-        json.dumps(
-            {
-                "state": state,
-                "code_verifier": code_verifier,
-                "redirect_uri": _REDIRECT_URI,
-                "email": email or "",
-            },
-            indent=2,
-        )
+    _write_private_json(
+        pending,
+        {
+            "state": state,
+            "code_verifier": code_verifier,
+            "redirect_uri": _REDIRECT_URI,
+            "email": email or "",
+        },
     )
 
 
@@ -548,8 +577,7 @@ def exchange_auth_code(code: str, email: Optional[str] = None) -> None:
         token_payload["scopes"] = granted_scopes
 
     token_path = _token_path(email)
-    token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(json.dumps(token_payload, indent=2))
+    _write_private_json(token_path, token_payload)
     _pending_auth_path(email).unlink(missing_ok=True)
 
     print(f"OK: Authenticated. Token saved to {token_path}")

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1511,6 +1511,13 @@ class TestSetupFilesSlashCommand:
 
 
 class TestUserOAuthHelper:
+    @staticmethod
+    def _assert_private_json_file(path, expected):
+        assert json.loads(path.read_text(encoding="utf-8")) == expected
+        assert list(path.parent.glob(f"{path.stem}.tmp.*")) == []
+        if os.name != "nt":
+            assert (path.stat().st_mode & 0o777) == 0o600
+
     def test_load_user_credentials_returns_none_when_no_token(self, tmp_path, monkeypatch):
         """Missing token file is the expected no-op case (user hasn't
         run /setup-files yet). Must NOT raise."""
@@ -1604,6 +1611,78 @@ class TestUserOAuthHelper:
         assert a != b
         assert a != legacy
         assert "google_chat_user_oauth_pending" in str(a.parent)
+
+    def test_persist_credentials_writes_private_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from plugins.platforms.google_chat.oauth import _persist_credentials, _token_path
+
+        creds = type(
+            "Creds",
+            (),
+            {
+                "to_json": lambda self: json.dumps(
+                    {
+                        "client_id": "cid",
+                        "client_secret": "secret",
+                        "refresh_token": "rtok",
+                        "token": "atok",
+                    }
+                )
+            },
+        )()
+
+        path = _token_path("alice@example.com")
+        _persist_credentials(creds, path)
+
+        self._assert_private_json_file(
+            path,
+            {
+                "client_id": "cid",
+                "client_secret": "secret",
+                "refresh_token": "rtok",
+                "token": "atok",
+                "type": "authorized_user",
+            },
+        )
+
+    def test_store_client_secret_writes_private_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        src = tmp_path / "client_secret.json"
+        payload = {"installed": {"client_id": "cid", "client_secret": "secret"}}
+        src.write_text(json.dumps(payload), encoding="utf-8")
+
+        from plugins.platforms.google_chat.oauth import (
+            _client_secret_path,
+            store_client_secret,
+        )
+
+        store_client_secret(str(src))
+
+        self._assert_private_json_file(_client_secret_path(), payload)
+
+    def test_save_pending_auth_writes_private_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from plugins.platforms.google_chat.oauth import (
+            _REDIRECT_URI,
+            _pending_auth_path,
+            _save_pending_auth,
+        )
+
+        _save_pending_auth(
+            state="state-123",
+            code_verifier="verifier-abc",
+            email="alice@example.com",
+        )
+
+        self._assert_private_json_file(
+            _pending_auth_path("alice@example.com"),
+            {
+                "state": "state-123",
+                "code_verifier": "verifier-abc",
+                "redirect_uri": _REDIRECT_URI,
+                "email": "alice@example.com",
+            },
+        )
 
 
 class TestPerUserAttachmentRouting:


### PR DESCRIPTION
## Summary

Google Chat user OAuth helper was still persisting sensitive JSON files with direct `write_text()` calls. That left two problems:

1. credential and PKCE state files could be left partially written if the process died mid-write
2. refreshed tokens and client secrets were not being created with restricted permissions like the rest of Hermes' OAuth storage paths

This patch introduces a single private JSON write helper for the Google Chat OAuth plugin and routes all sensitive persistence through it.

## What changed

- Added `_write_private_json()` to `plugins/platforms/google_chat/oauth.py`
- Switched these write paths to use atomic temp-file + fsync + replace semantics:
  - refreshed user token persistence in `_persist_credentials()`
  - client secret storage in `store_client_secret()`
  - pending PKCE state storage in `_save_pending_auth()`
  - final token write in `exchange_auth_code()`
- Tighten parent directory permissions where supported and create files with `0600` semantics on POSIX platforms
- Added focused regression coverage in `tests/gateway/test_google_chat.py` for:
  - refreshed credential persistence
  - client secret persistence
  - pending OAuth state persistence
  - no leftover temp files after write
  - restricted file mode checks on non-Windows platforms

## Why this matters

The rest of Hermes already hardens OAuth/token persistence in core auth flows. The Google Chat user OAuth helper had drifted from that standard even though it stores the same class of sensitive material:

- refresh tokens
- client secrets
- pending PKCE verifier/state blobs

This change brings the plugin in line with existing Hermes auth persistence guarantees without changing the user-facing setup flow.

## Scope

Intentionally narrow:
- no auth flow redesign
- no scope changes
- no routing changes
- no API behavior changes outside persistence semantics

## Testing

Passed:

- `pytest tests/gateway/test_google_chat.py -k UserOAuthHelper`

Result 

- `12 passed in 4.18s`

Also verified locally with targeted smoke checks and syntax compilation.
