### PR TITLE
feat(cron): deliver reports to Slack threads

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -79,6 +79,12 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
+def _normalize_optional_job_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value).strip() or None
+
+
 def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
@@ -496,6 +502,8 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    delivery_mode: Optional[str] = None,
+    thread_title_template: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -540,6 +548,10 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        delivery_mode: Optional delivery formatter mode. ``slack_thread`` creates
+                a new Slack thread per cron run and posts the response inside it.
+        thread_title_template: Optional Python format string used for Slack
+                thread anchors. Supports job fields plus ``job_id`` and ``name``.
 
     Returns:
         The created job dict
@@ -574,6 +586,8 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_delivery_mode = _normalize_optional_job_text(delivery_mode)
+    normalized_thread_title_template = _normalize_optional_job_text(thread_title_template)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -627,6 +641,8 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        "delivery_mode": normalized_delivery_mode,
+        "thread_title_template": normalized_thread_title_template,
     }
 
     jobs = load_jobs()
@@ -668,6 +684,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["workdir"] = None
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
+
+        for key in ("delivery_mode", "thread_title_template"):
+            if key in updates:
+                updates[key] = _normalize_optional_job_text(updates[key])
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -426,6 +426,44 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     return targets[0] if targets else None
 
 
+def _cron_delivery_mode(job: dict) -> str:
+    mode = str(job.get("delivery_mode") or "").strip().lower()
+    if mode == "threaded":
+        return "slack_thread"
+    return mode
+
+
+def _render_thread_title(job: dict) -> str:
+    job_id = str(job.get("id", ""))
+    name = str(job.get("name") or job_id)
+    template = str(job.get("thread_title_template") or "{name} (job_id: {job_id})")
+    values = dict(job)
+    values["id"] = job_id
+    values["job_id"] = job_id
+    values["name"] = name
+    try:
+        rendered = template.format(**values)
+    except Exception:
+        rendered = "{name} (job_id: {job_id})".format(name=name, job_id=job_id)
+    return rendered.strip() or "{name} (job_id: {job_id})".format(name=name, job_id=job_id)
+
+
+def _threaded_body_content(job: dict, content: str, wrap_response: bool) -> str:
+    if not wrap_response:
+        return content
+    task_name = job.get("name", job["id"])
+    return (
+        f"{content}\n\n"
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+
+
+def _message_id_from_send_result(result) -> Optional[str]:
+    if isinstance(result, dict):
+        return result.get("message_id") or result.get("ts")
+    return getattr(result, "message_id", None) or getattr(result, "ts", None)
+
+
 # Media extension sets — audio routing is centralized in gateway.platforms.base
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
 _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
@@ -524,9 +562,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
 
     try:
         config = load_gateway_config()
@@ -541,6 +577,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        threaded_mode = (
+            _cron_delivery_mode(job) == "slack_thread"
+            and platform_name.lower() == "slack"
+        )
+        target_content = (
+            _threaded_body_content(job, content, wrap_response)
+            if threaded_mode
+            else delivery_content
+        )
+        # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(target_content)
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -578,13 +625,43 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
+        threaded_anchor_id = None
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = None if threaded_mode else ({"thread_id": thread_id} if thread_id else None)
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
-                if text_to_send:
+                if threaded_mode:
+                    future = asyncio.run_coroutine_threadsafe(
+                        runtime_adapter.send(chat_id, _render_thread_title(job)),
+                        loop,
+                    )
+                    try:
+                        anchor_result = future.result(timeout=60)
+                    except TimeoutError:
+                        future.cancel()
+                        raise
+                    if anchor_result and not getattr(anchor_result, "success", True):
+                        err = getattr(anchor_result, "error", "unknown")
+                        logger.warning(
+                            "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
+                            job["id"], platform_name, chat_id, err,
+                        )
+                        adapter_ok = False
+                    else:
+                        anchor_id = _message_id_from_send_result(anchor_result)
+                        if not anchor_id:
+                            logger.warning(
+                                "Job '%s': live adapter Slack thread anchor did not return a message id, falling back to standalone",
+                                job["id"],
+                            )
+                            adapter_ok = False
+                        else:
+                            threaded_anchor_id = anchor_id
+                            send_metadata = {"thread_id": threaded_anchor_id}
+
+                if adapter_ok and text_to_send:
                     future = asyncio.run_coroutine_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                         loop,
@@ -625,18 +702,65 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            def run_standalone_send(message, send_thread_id=None, send_media_files=None):
+                coro = _send_to_platform(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    message,
+                    thread_id=send_thread_id,
+                    media_files=send_media_files or [],
+                )
+                try:
+                    return asyncio.run(coro)
+                except RuntimeError:
+                    # asyncio.run() checks for a running loop before awaiting the coroutine;
+                    # when it raises, the original coro was never started — close it to
+                    # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
+                    # fresh thread that has no running loop.
+                    coro.close()
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                message,
+                                thread_id=send_thread_id,
+                                media_files=send_media_files or [],
+                            ),
+                        )
+                        return future.result(timeout=30)
+
             try:
-                result = asyncio.run(coro)
-            except RuntimeError:
-                # asyncio.run() checks for a running loop before awaiting the coroutine;
-                # when it raises, the original coro was never started — close it to
-                # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
-                # fresh thread that has no running loop.
-                coro.close()
-                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
-                    result = future.result(timeout=30)
+                if threaded_mode:
+                    if not threaded_anchor_id:
+                        anchor_result = run_standalone_send(_render_thread_title(job), send_thread_id=None)
+                        if anchor_result and anchor_result.get("error"):
+                            result = anchor_result
+                        else:
+                            threaded_anchor_id = _message_id_from_send_result(anchor_result)
+                            if not threaded_anchor_id:
+                                result = {"error": "Slack thread anchor did not return message_id"}
+                            else:
+                                result = run_standalone_send(
+                                    cleaned_delivery_content,
+                                    send_thread_id=threaded_anchor_id,
+                                    send_media_files=media_files,
+                                )
+                    else:
+                        result = run_standalone_send(
+                            cleaned_delivery_content,
+                            send_thread_id=threaded_anchor_id,
+                            send_media_files=media_files,
+                        )
+                else:
+                    result = run_standalone_send(
+                        cleaned_delivery_content,
+                        send_thread_id=thread_id,
+                        send_media_files=media_files,
+                    )
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -88,6 +88,12 @@ def cron_list(show_all: bool = False):
         print(f"    Repeat:    {repeat_str}")
         print(f"    Next run:  {next_run}")
         print(f"    Deliver:   {deliver_str}")
+        delivery_mode = job.get("delivery_mode")
+        if delivery_mode:
+            print(f"    Delivery:  {delivery_mode}")
+        thread_title_template = job.get("thread_title_template")
+        if thread_title_template:
+            print(f"    Thread title: {thread_title_template}")
         if skills:
             print(f"    Skills:    {', '.join(skills)}")
         script = job.get("script")
@@ -175,6 +181,8 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        delivery_mode=getattr(args, "delivery_mode", None),
+        thread_title_template=getattr(args, "thread_title_template", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -231,6 +239,8 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        delivery_mode=getattr(args, "delivery_mode", None),
+        thread_title_template=getattr(args, "thread_title_template", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9864,6 +9864,14 @@ def main():
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--delivery-mode",
+        help="Optional delivery formatter mode, e.g. slack_thread.",
+    )
+    cron_create.add_argument(
+        "--thread-title-template",
+        help="Optional Slack thread anchor template, e.g. '{name} (job_id: {job_id})'.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -9927,6 +9935,14 @@ def main():
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--delivery-mode",
+        help="New delivery formatter mode. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--thread-title-template",
+        help="New Slack thread anchor template. Pass empty string to clear.",
     )
 
     # lifecycle actions

--- a/tests/cron/test_cron_delivery_metadata.py
+++ b/tests/cron/test_cron_delivery_metadata.py
@@ -1,0 +1,50 @@
+"""Tests for cron delivery metadata stored on scheduled jobs."""
+
+from __future__ import annotations
+
+import json
+
+
+def test_create_job_stores_delivery_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="Summarize repo changes",
+        schedule="every 1h",
+        delivery_mode="slack_thread",
+        thread_title_template="{name} (job_id: {job_id})",
+    )
+
+    stored = get_job(job["id"])
+    assert stored["delivery_mode"] == "slack_thread"
+    assert stored["thread_title_template"] == "{name} (job_id: {job_id})"
+
+
+def test_cronjob_tool_roundtrips_delivery_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    from tools.cronjob_tools import cronjob
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            prompt="Summarize repo changes",
+            schedule="every 1h",
+            delivery_mode="slack_thread",
+            thread_title_template="{name} (job_id: {job_id})",
+        )
+    )
+
+    assert created["success"] is True
+    assert created["job"]["delivery_mode"] == "slack_thread"
+    assert created["job"]["thread_title_template"] == "{name} (job_id: {job_id})"
+
+    listed = json.loads(cronjob(action="list"))
+    assert listed["jobs"][0]["delivery_mode"] == "slack_thread"
+    assert listed["jobs"][0]["thread_title_template"] == "{name} (job_id: {job_id})"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -775,6 +775,102 @@ class TestDeliverResultWrapping:
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
 
 
+class TestSlackThreadedDelivery:
+    """Verify cron deliveries can create a Slack thread per run."""
+
+    def test_standalone_slack_threaded_delivery_sends_anchor_then_body(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        async def fake_send(_platform, _pconfig, chat_id, content, **kwargs):
+            if kwargs.get("thread_id") is None:
+                return {"success": True, "message_id": "1700000000.000001"}
+            return {"success": True}
+
+        job = {
+            "id": "abc123",
+            "name": "repo-self-improvement",
+            "deliver": "origin",
+            "delivery_mode": "slack_thread",
+            "thread_title_template": "{name} (job_id: {job_id})",
+            "origin": {"platform": "slack", "chat_id": "C123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(side_effect=fake_send)) as send_mock:
+            result = _deliver_result(job, "Daily report body")
+
+        assert result is None
+        assert send_mock.await_count == 2
+        anchor_call, body_call = send_mock.await_args_list
+        assert anchor_call.args[2] == "C123"
+        assert anchor_call.args[3] == "repo-self-improvement (job_id: abc123)"
+        assert anchor_call.kwargs["thread_id"] is None
+        assert body_call.args[2] == "C123"
+        assert body_call.args[3] == "Daily report body"
+        assert body_call.kwargs["thread_id"] == "1700000000.000001"
+
+    def test_live_adapter_slack_threaded_delivery_uses_anchor_ts(self):
+        from concurrent.futures import Future
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            SendResult(success=True, message_id="1700000000.000002"),
+            SendResult(success=True, message_id="1700000000.000003"),
+        ]
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            try:
+                coro.send(None)
+            except StopIteration as exc:
+                future.set_result(exc.value)
+            else:
+                raise AssertionError("expected adapter.send coroutine to complete immediately")
+            return future
+
+        job = {
+            "id": "abc123",
+            "name": "repo-self-improvement",
+            "deliver": "origin",
+            "delivery_mode": "slack_thread",
+            "origin": {"platform": "slack", "chat_id": "C123"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Daily report body",
+                adapters={Platform.SLACK: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        assert adapter.send.await_count == 2
+        anchor_call, body_call = adapter.send.await_args_list
+        assert anchor_call.args == ("C123", "repo-self-improvement (job_id: abc123)")
+        assert anchor_call.kwargs == {}
+        assert body_call.args == ("C123", "Daily report body")
+        assert body_call.kwargs["metadata"] == {"thread_id": "1700000000.000002"}
+
+
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -279,6 +279,10 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("delivery_mode"):
+        result["delivery_mode"] = job["delivery_mode"]
+    if job.get("thread_title_template"):
+        result["thread_title_template"] = job["thread_title_template"]
     return result
 
 
@@ -302,6 +306,8 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    delivery_mode: Optional[str] = None,
+    thread_title_template: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -368,6 +374,8 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                delivery_mode=_normalize_optional_job_value(delivery_mode),
+                thread_title_template=_normalize_optional_job_value(thread_title_template),
             )
             return json.dumps(
                 {
@@ -481,6 +489,10 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if delivery_mode is not None:
+                updates["delivery_mode"] = _normalize_optional_job_value(delivery_mode)
+            if thread_title_template is not None:
+                updates["thread_title_template"] = _normalize_optional_job_value(thread_title_template)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -634,6 +646,14 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
+            "delivery_mode": {
+                "type": "string",
+                "description": "Optional delivery formatter mode. Use 'slack_thread' to create a new Slack thread per cron run and deliver the response as replies. Blank string clears the field on update."
+            },
+            "thread_title_template": {
+                "type": "string",
+                "description": "Optional Python format string for Slack thread anchor messages, e.g. '{name} (job_id: {job_id})'. Blank string clears the field on update."
+            },
         },
         "required": ["action"]
     }
@@ -682,6 +702,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        delivery_mode=args.get("delivery_mode"),
+        thread_title_template=args.get("thread_title_template"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Slack delivery mode for cron jobs: `delivery_mode=slack_thread`. When enabled for a Slack delivery target, the scheduler posts a short anchor message first and then sends the cron response, plus any extracted media, as replies in that Slack thread.

This keeps long scheduled reports grouped under one Slack thread per run while preserving the existing delivery behavior by default.

## Related Issue

No exact existing issue found. I searched existing issues/PRs for Slack threaded cron delivery; the closest results were about gateway thread handling, not per-run cron delivery threads.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: add Slack-threaded delivery mode, thread title rendering, and anchor/reply delivery for both live adapter and standalone send paths.
- `cron/jobs.py`: persist optional `delivery_mode` and `thread_title_template` fields on cron jobs.
- `tools/cronjob_tools.py`: expose the new delivery metadata through the cronjob tool schema and formatted job output.
- `hermes_cli/main.py`, `hermes_cli/cron.py`: add CLI flags and display the delivery metadata in `hermes cron list`.
- `tests/cron/test_scheduler.py`, `tests/cron/test_cron_delivery_metadata.py`: cover Slack threaded delivery and metadata round trips.

## How to Test

1. Create or update a Slack-delivered cron job with `delivery_mode=slack_thread` and an optional `thread_title_template`.
2. Trigger the cron job.
3. Verify Slack receives one anchor message and the cron response as replies in that thread.

Validated locally with:

```bash
scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_cron_delivery_metadata.py tests/tools/test_cronjob_tools.py -q
```

Result: `157 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, targeted pytest suite above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific APIs added; Slack behavior is adapter-level
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `tools/cronjob_tools.py` schema updated

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
157 passed in 2.94s
```
