### PR TITLE
fix(cron): isolate workdir tool sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1261,8 +1261,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         )
         _job_workdir = None
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
+    _registered_task_env_override = False
     if _job_workdir:
         os.environ["TERMINAL_CWD"] = _job_workdir
+        try:
+            from tools.terminal_tool import register_task_env_overrides
+            register_task_env_overrides(_cron_session_id, {"cwd": _job_workdir})
+            _registered_task_env_override = True
+        except Exception as _env_override_exc:
+            logger.warning(
+                "Job '%s': failed to register workdir override for cron task %s: %s",
+                job_id,
+                _cron_session_id,
+                _env_override_exc,
+            )
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
     try:
@@ -1483,7 +1495,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            task_id=_cron_session_id,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -1622,6 +1639,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        if _registered_task_env_override:
+            try:
+                from tools.terminal_tool import clear_task_env_overrides
+                clear_task_env_overrides(_cron_session_id)
+            except Exception as _env_override_exc:
+                logger.debug(
+                    "Job '%s': failed to clear workdir override for cron task %s: %s",
+                    job_id,
+                    _cron_session_id,
+                    _env_override_exc,
+                )
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -264,15 +264,29 @@ class TestRunJobTerminalCwd:
 
         class FakeAgent:
             def __init__(self, **kwargs):
+                observed["session_id"] = kwargs.get("session_id")
                 observed["skip_context_files"] = kwargs.get("skip_context_files")
                 observed["load_soul_identity"] = kwargs.get("load_soul_identity")
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
 
-            def run_conversation(self, *_a, **_kw):
+            def run_conversation(self, *_a, **kwargs):
+                observed["run_task_id"] = kwargs.get("task_id")
                 observed["terminal_cwd_during_run"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
+                )
+                from tools.terminal_tool import (
+                    _resolve_container_task_id,
+                    _task_env_overrides,
+                )
+
+                session_id = observed["session_id"]
+                observed["container_task_id_during_run"] = _resolve_container_task_id(
+                    session_id
+                )
+                observed["task_env_override_during_run"] = _task_env_overrides.get(
+                    session_id
                 )
                 return {"final_response": "done", "messages": []}
 
@@ -343,6 +357,37 @@ class TestRunJobTerminalCwd:
 
         # And it was restored to the original value in finally.
         assert os.environ["TERMINAL_CWD"] == "/original/cwd"
+
+    def test_workdir_registers_cron_task_env_override(
+        self, tmp_path, monkeypatch
+    ):
+        import cron.scheduler as sched
+        from tools.terminal_tool import (
+            _resolve_container_task_id,
+            _task_env_overrides,
+        )
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "abc",
+            "name": "wd-job",
+            "workdir": str(tmp_path),
+            "schedule_display": "manual",
+        }
+
+        success, _output, response, error = sched.run_job(job)
+        assert success is True, f"run_job failed: error={error!r} response={response!r}"
+
+        session_id = observed["session_id"]
+        assert observed["run_task_id"] == session_id
+        assert observed["container_task_id_during_run"] == session_id
+        assert observed["task_env_override_during_run"]["cwd"] == str(
+            tmp_path.resolve()
+        )
+        assert _resolve_container_task_id(session_id) == "default"
+        assert session_id not in _task_env_overrides
 
     def test_no_workdir_leaves_terminal_cwd_untouched(self, monkeypatch):
         """When workdir is absent, run_job must not touch TERMINAL_CWD at all —


### PR DESCRIPTION
## What does this PR do?

Fixes cron jobs with `workdir` so terminal tool sessions use the same per-job working directory that cron already exposes through `TERMINAL_CWD` and context-file loading.

The scheduler now registers a per-cron-session terminal environment override, passes that cron session id into `agent.run_conversation(task_id=...)`, and clears the override in `finally`.

## Related Issue

No exact existing issue found. I searched existing issues/PRs for cron workdir, `TERMINAL_CWD`, and task/session isolation before opening this focused fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: register a per-cron-session terminal env override for workdir jobs and clear it after the run.
- `cron/scheduler.py`: pass the cron session id as `task_id` to `agent.run_conversation` so terminal tools resolve the isolated cron environment.
- `tests/cron/test_cron_workdir.py`: assert the cron session id is used as the tool task id and the override is cleaned up.

## How to Test

1. Create a cron job with an absolute `workdir`.
2. Trigger the job and have it use terminal/file tools.
3. Verify those tools run from the job workdir, not the scheduler/default environment.

Validated locally with:

```bash
scripts/run_tests.sh tests/cron/test_cron_workdir.py -q
```

Result: `22 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, targeted pytest suite above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses existing terminal env override helpers, no new OS-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
22 passed in 1.23s
```
