### PR TITLE
feat(session_search): cross-platform visibility isolation

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -468,6 +468,20 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Per-platform whitelist of session sources that session_search may read
+    # when the current conversation lives on that platform.  Maps platform
+    # name (e.g. "qqbot") -> list of allowed source values (e.g. ["qqbot",
+    # "weixin"]).  Platforms not listed here are treated as "self only" --
+    # session_search will only surface past sessions from the same platform.
+    # Non-gateway sources (cli, cron, acp, local, ...) are never restricted.
+    #
+    # Example config.yaml:
+    #   gateway:
+    #     session_search_visibility:
+    #       qqbot: [qqbot, weixin]   # QQ can read QQ + weixin history
+    #       # weixin omitted -> defaults to weixin-only (one-way isolation)
+    session_search_visibility: Dict[str, List[str]] = field(default_factory=dict)
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -561,6 +575,9 @@ class GatewayConfig:
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
+            "session_search_visibility": {
+                k: list(v) for k, v in self.session_search_visibility.items()
+            },
         }
     
     @classmethod
@@ -615,6 +632,25 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        # Parse session_search_visibility: {platform_name: [allowed_sources]}.
+        # Coerce defensively -- users may write scalars instead of lists, or
+        # supply None values; normalize to Dict[str, List[str]] and silently
+        # drop malformed entries rather than crash gateway startup.
+        raw_visibility = data.get("session_search_visibility") or {}
+        session_search_visibility: Dict[str, List[str]] = {}
+        if isinstance(raw_visibility, dict):
+            for k, v in raw_visibility.items():
+                if not isinstance(k, str) or not k.strip():
+                    continue
+                if isinstance(v, str):
+                    allowed = [v.strip()] if v.strip() else []
+                elif isinstance(v, (list, tuple)):
+                    allowed = [str(x).strip() for x in v if str(x).strip()]
+                else:
+                    continue
+                if allowed:
+                    session_search_visibility[k.strip()] = allowed
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -630,6 +666,7 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            session_search_visibility=session_search_visibility,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -642,6 +679,41 @@ class GatewayConfig:
                     self.unauthorized_dm_behavior,
                 )
         return self.unauthorized_dm_behavior
+
+    def resolve_session_search_visibility(
+        self,
+        current_source: Optional[str],
+    ) -> Optional[List[str]]:
+        """Decide which session sources session_search may read.
+
+        Given the source value of the *current* session, returns:
+          - None: no restriction (search all sources). Used for non-gateway
+            sources (cli, cron, acp, local, ...) and unknown/empty input.
+          - List[str]: whitelist of source values the agent may search.
+            Always includes ``current_source`` itself.
+
+        Default policy when ``current_source`` is a known gateway platform
+        but no entry exists in ``session_search_visibility``: restrict to
+        that platform alone (one-way isolation by default).
+        """
+        if not current_source or not isinstance(current_source, str):
+            return None
+        # Only restrict third-party messaging platforms. Anything else
+        # (cli, cron, acp, local, webhook, ...) keeps full visibility --
+        # those are the operator's own surfaces, not external chats.
+        try:
+            platform = Platform(current_source)
+        except ValueError:
+            return None
+        if platform in (Platform.LOCAL, Platform.WEBHOOK):
+            return None
+        allowed = self.session_search_visibility.get(current_source)
+        if allowed:
+            # Always include self even if user forgot to list it explicitly.
+            if current_source not in allowed:
+                allowed = [current_source, *allowed]
+            return list(dict.fromkeys(allowed))  # de-dup, preserve order
+        return [current_source]
 
     def get_notice_delivery(self, platform: Optional[Platform] = None) -> str:
         """Return the effective notice-delivery mode for a platform."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -576,3 +576,204 @@ class TestSessionSearch:
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+
+# =========================================================================
+# Cross-platform session_search visibility (gateway.session_search_visibility)
+# =========================================================================
+
+class TestVisibilityResolver:
+    """Unit tests for GatewayConfig.resolve_session_search_visibility."""
+
+    def _make_config(self, visibility=None):
+        from gateway.config import GatewayConfig
+        return GatewayConfig(session_search_visibility=visibility or {})
+
+    def test_unknown_source_returns_none(self):
+        cfg = self._make_config()
+        assert cfg.resolve_session_search_visibility("made_up_thing") is None
+
+    def test_cli_source_returns_none(self):
+        # 'cli' / 'cron' / 'acp' are not Platform enum members -> unrestricted.
+        cfg = self._make_config()
+        assert cfg.resolve_session_search_visibility("cli") is None
+        assert cfg.resolve_session_search_visibility("cron") is None
+        assert cfg.resolve_session_search_visibility("acp") is None
+
+    def test_local_and_webhook_unrestricted(self):
+        cfg = self._make_config()
+        assert cfg.resolve_session_search_visibility("local") is None
+        assert cfg.resolve_session_search_visibility("webhook") is None
+
+    def test_empty_or_none_input(self):
+        cfg = self._make_config()
+        assert cfg.resolve_session_search_visibility(None) is None
+        assert cfg.resolve_session_search_visibility("") is None
+
+    def test_default_isolation_for_messaging_platform(self):
+        # Gateway platform with no explicit entry -> self only.
+        cfg = self._make_config()
+        assert cfg.resolve_session_search_visibility("weixin") == ["weixin"]
+        assert cfg.resolve_session_search_visibility("qqbot") == ["qqbot"]
+
+    def test_explicit_whitelist_one_way(self):
+        # QQ can read QQ + weixin; weixin only reads itself (the asymmetric
+        # case the user originally asked for).
+        cfg = self._make_config({"qqbot": ["qqbot", "weixin"]})
+        assert cfg.resolve_session_search_visibility("qqbot") == ["qqbot", "weixin"]
+        assert cfg.resolve_session_search_visibility("weixin") == ["weixin"]
+
+    def test_self_auto_added_if_missing(self):
+        # User forgot to list 'qqbot' itself -> still included.
+        cfg = self._make_config({"qqbot": ["weixin"]})
+        result = cfg.resolve_session_search_visibility("qqbot")
+        assert result is not None
+        assert "qqbot" in result
+        assert "weixin" in result
+
+    def test_dedup_preserves_order(self):
+        cfg = self._make_config({"qqbot": ["qqbot", "weixin", "qqbot", "feishu"]})
+        assert cfg.resolve_session_search_visibility("qqbot") == [
+            "qqbot",
+            "weixin",
+            "feishu",
+        ]
+
+
+class TestVisibilityFromDict:
+    """GatewayConfig.from_dict normalizes session_search_visibility input."""
+
+    def test_parses_clean_dict(self):
+        from gateway.config import GatewayConfig
+        cfg = GatewayConfig.from_dict({
+            "session_search_visibility": {
+                "qqbot": ["qqbot", "weixin"],
+                "weixin": ["weixin"],
+            }
+        })
+        assert cfg.session_search_visibility == {
+            "qqbot": ["qqbot", "weixin"],
+            "weixin": ["weixin"],
+        }
+
+    def test_coerces_scalar_value(self):
+        from gateway.config import GatewayConfig
+        cfg = GatewayConfig.from_dict({
+            "session_search_visibility": {"qqbot": "weixin"},
+        })
+        assert cfg.session_search_visibility == {"qqbot": ["weixin"]}
+
+    def test_drops_malformed_entries(self):
+        from gateway.config import GatewayConfig
+        cfg = GatewayConfig.from_dict({
+            "session_search_visibility": {
+                "qqbot": ["weixin"],   # ok
+                "": ["weixin"],        # empty key -> drop
+                "feishu": None,        # None value -> drop
+                "slack": 42,           # wrong type -> drop
+                "discord": [],         # empty list -> drop
+            }
+        })
+        assert cfg.session_search_visibility == {"qqbot": ["weixin"]}
+
+    def test_missing_key_yields_empty_dict(self):
+        from gateway.config import GatewayConfig
+        cfg = GatewayConfig.from_dict({})
+        assert cfg.session_search_visibility == {}
+
+    def test_roundtrip_via_to_dict(self):
+        from gateway.config import GatewayConfig
+        original = GatewayConfig(
+            session_search_visibility={"qqbot": ["qqbot", "weixin"]}
+        )
+        roundtripped = GatewayConfig.from_dict(original.to_dict())
+        assert roundtripped.session_search_visibility == {
+            "qqbot": ["qqbot", "weixin"]
+        }
+
+
+class TestSessionSearchAppliesVisibilityFilter:
+    """End-to-end: session_search must pass source_filter to db.search_messages."""
+
+    def _setup_db(self, current_source):
+        from unittest.mock import MagicMock
+        db = MagicMock()
+        db.get_session.return_value = {
+            "id": "current_sid",
+            "source": current_source,
+            "parent_session_id": None,
+        }
+        db.search_messages.return_value = []  # no matches -> short-circuit
+        return db
+
+    def _patch_gateway_config(self, monkeypatch, visibility):
+        from gateway.config import GatewayConfig
+        cfg = GatewayConfig(session_search_visibility=visibility or {})
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config",
+            lambda: cfg,
+        )
+
+    def test_weixin_session_restricted_to_weixin_by_default(self, monkeypatch):
+        from tools.session_search_tool import session_search
+        db = self._setup_db("weixin")
+        self._patch_gateway_config(monkeypatch, {})
+
+        session_search(query="hello", db=db, current_session_id="current_sid")
+
+        kwargs = db.search_messages.call_args.kwargs
+        assert kwargs["source_filter"] == ["weixin"], (
+            "Default isolation: weixin must only see its own sessions"
+        )
+
+    def test_qqbot_session_with_explicit_whitelist(self, monkeypatch):
+        from tools.session_search_tool import session_search
+        db = self._setup_db("qqbot")
+        self._patch_gateway_config(
+            monkeypatch, {"qqbot": ["qqbot", "weixin"]}
+        )
+
+        session_search(query="hello", db=db, current_session_id="current_sid")
+
+        kwargs = db.search_messages.call_args.kwargs
+        assert kwargs["source_filter"] == ["qqbot", "weixin"]
+
+    def test_weixin_session_cannot_see_qqbot_under_one_way_config(self, monkeypatch):
+        # The asymmetric scenario the user requested: QQ reads weixin, but
+        # weixin must NOT read qqbot.
+        from tools.session_search_tool import session_search
+        db = self._setup_db("weixin")
+        self._patch_gateway_config(
+            monkeypatch, {"qqbot": ["qqbot", "weixin"]}
+        )
+
+        session_search(query="hello", db=db, current_session_id="current_sid")
+
+        kwargs = db.search_messages.call_args.kwargs
+        assert kwargs["source_filter"] == ["weixin"]
+        assert "qqbot" not in kwargs["source_filter"]
+
+    def test_cli_session_unrestricted(self, monkeypatch):
+        from tools.session_search_tool import session_search
+        db = self._setup_db("cli")
+        self._patch_gateway_config(monkeypatch, {"qqbot": ["qqbot", "weixin"]})
+
+        session_search(query="hello", db=db, current_session_id="current_sid")
+
+        kwargs = db.search_messages.call_args.kwargs
+        assert kwargs["source_filter"] is None, (
+            "CLI sessions must keep full visibility (operator's own surface)"
+        )
+
+    def test_no_current_session_means_no_restriction(self, monkeypatch):
+        from tools.session_search_tool import session_search
+        from unittest.mock import MagicMock
+        db = MagicMock()
+        db.search_messages.return_value = []
+        # Don't even need to patch gateway config -- whitelist resolver
+        # short-circuits when current_session_id is missing.
+
+        session_search(query="hello", db=db, current_session_id=None)
+
+        kwargs = db.search_messages.call_args.kwargs
+        assert kwargs["source_filter"] is None

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -265,11 +265,64 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
-    """Return metadata for the most recent sessions (no LLM calls)."""
+def _get_visibility_whitelist(db, current_session_id: Optional[str]) -> Optional[List[str]]:
+    """Resolve the source whitelist for the *current* session.
+
+    Returns:
+        - None if no restriction applies (current session is CLI/cron/local/
+          webhook/unknown, or gateway config unavailable).
+        - List of allowed source values the agent may search.
+
+    Default policy for a gateway platform with no explicit visibility
+    entry is "self only" (one-way isolation by default). Configure
+    ``gateway.session_search_visibility`` to allow cross-platform reads.
+    """
+    if not current_session_id or db is None:
+        return None
     try:
+        session = db.get_session(current_session_id)
+    except Exception:
+        logging.debug(
+            "Failed to load current session for visibility check",
+            exc_info=True,
+        )
+        return None
+    if not session:
+        return None
+    current_source = session.get("source")
+    if not current_source:
+        return None
+    try:
+        from gateway.config import load_gateway_config
+        gw_config = load_gateway_config()
+    except Exception:
+        logging.debug(
+            "Gateway config unavailable for session_search visibility check",
+            exc_info=True,
+        )
+        return None
+    return gw_config.resolve_session_search_visibility(current_source)
+
+
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    allowed_sources: Optional[List[str]] = None,
+) -> str:
+    """Return metadata for the most recent sessions (no LLM calls).
+
+    When ``allowed_sources`` is set, sessions whose ``source`` is not in
+    that whitelist are filtered out (cross-platform isolation). When None,
+    no source restriction is applied.
+    """
+    try:
+        # Fetch a wider window when whitelisting -- after Python-side filter
+        # we still need at least ``limit`` rows. The cap keeps DB load bounded
+        # even if the visibility whitelist excludes most recent sessions.
+        fetch_limit = (limit + 5) if allowed_sources is None else max(limit + 5, 50)
         sessions = db.list_sessions_rich(
-            limit=limit + 5,
+            limit=fetch_limit,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             order_by_last_active=True,
         )  # fetch extra to skip current
@@ -290,6 +343,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             except Exception:
                 current_root = current_session_id
 
+        allowed_set = set(allowed_sources) if allowed_sources else None
         results = []
         for s in sessions:
             sid = s.get("id", "")
@@ -297,6 +351,9 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
                 continue
             # Skip child/delegation sessions (they have parent_session_id)
             if s.get("parent_session_id"):
+                continue
+            # Cross-platform visibility filter
+            if allowed_set is not None and s.get("source", "") not in allowed_set:
                 continue
             results.append({
                 "session_id": sid,
@@ -356,10 +413,16 @@ def session_search(
             limit = 3
     limit = max(1, min(limit, 5))  # Clamp to [1, 5]
 
+    # Resolve cross-platform visibility whitelist for the current session.
+    # None = no restriction (CLI/cron/local/webhook). List = allowed sources.
+    allowed_sources = _get_visibility_whitelist(db, current_session_id)
+
     # Recent sessions mode: when query is empty, return metadata for recent sessions.
     # No LLM calls — just DB queries for titles, previews, timestamps.
     if not query or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(
+            db, limit, current_session_id, allowed_sources=allowed_sources
+        )
 
     query = query.strip()
 
@@ -369,9 +432,13 @@ def session_search(
         if role_filter and role_filter.strip():
             role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
-        # FTS5 search -- get matches ranked by relevance
+        # FTS5 search -- get matches ranked by relevance.
+        # ``source_filter`` enforces cross-platform isolation: e.g. when this
+        # session lives on weixin and the user has not opted into reading
+        # other platforms, FTS will only return weixin matches.
         raw_results = db.search_messages(
             query=query,
+            source_filter=allowed_sources,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             limit=50,  # Get more matches to find unique sessions


### PR DESCRIPTION
Default policy: gateway sessions only see their own platform history.
Configure gateway.session_search_visibility to opt into reading other
platforms (e.g. qqbot: [qqbot, weixin]).

CLI/cron/local/webhook are unrestricted.
