### PR TITLE
fix: add Xiaomi MiMo thinking mode reasoning_content echo-back

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,32 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+def _is_xiaomi_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Xiaomi MiMo's Anthropic-compatible endpoint.
+
+    Xiaomi MiMo's ``/anthropic`` route speaks the Anthropic Messages protocol
+    but, when thinking mode is enabled, requires the ``thinking`` blocks
+    (synthesised from ``reasoning_content``) from prior assistant turns to
+    round-trip on subsequent requests — the generic third-party path strips
+    them and triggers HTTP 400::
+
+        The reasoning_content in the thinking mode must be passed back
+        to the API.
+
+    The blocks are unsigned (no Anthropic-proprietary signature), so this
+    endpoint is handled with the same strip-signed / keep-unsigned policy
+    used for Kimi's ``/coding`` and DeepSeek's ``/anthropic`` endpoints.
+    The match is pinned to the ``xiaomimimo.com`` domain so other providers
+    are not misclassified.
+    """
+    if not base_url_host_matches(base_url or "", "xiaomimimo.com"):
+        return False
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return "/anthropic" in normalized.rstrip("/").lower()
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1755,6 +1781,7 @@ def convert_messages_to_anthropic(
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_anthropic_endpoint(base_url)
     )
 
     last_assistant_idx = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -10095,13 +10095,14 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that
+        omit ``reasoning_content`` (refs #15250, #17400).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_xiaomi_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10131,6 +10132,21 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_xiaomi_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        Xiaomi MiMo thinking mode requires ``reasoning_content`` on every
+        assistant tool-call turn; omitting it causes HTTP 400 when the
+        message is replayed in a subsequent API request.
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or "mimo" in model
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:


### PR DESCRIPTION
 Summary

    Xiaomi MiMo thinking mode requires reasoning_content on every assistant tool-call turn. Without it, replaying the persisted message causes HTTP 400 (The reasoning_content in the thinking mode must be passed back to the API).

    This is the same pattern already fixed for DeepSeek (#15250, #17341) and Kimi/Moonshot (#17400), but Xiaomi was missed.

    Changes

    - Add _needs_xiaomi_tool_reasoning() method to detect Xiaomi MiMo provider/model/base_url
    - Update _needs_thinking_reasoning_pad() to include Xiaomi check

    Test Plan

    - [x] Patch applied successfully (lint passed)
    - [x] Gateway restarted with fix
    - [ ] Verify no more HTTP 400 errors in ~/.hermes/logs/errors.log

    Refs

    Refs: #15250, #17400, #17341