### PR TITLE
feat(kanban): add suspend/resume primitives for long-running tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,7 +90,7 @@ from toolsets import get_toolset_names
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "suspended", "done", "archived"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 
@@ -2688,6 +2688,76 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
         )
+        return True
+
+
+def suspend_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Transition ``running -> suspended`` — preserves full run state for resume.
+
+    Unlike ``block_task`` (which ends the run with ``outcome=blocked`` and is
+    used when the agent can't proceed), ``suspend_task`` freezes the task so
+    the dispatcher knows it may be re-queued once the worker is ready to
+    continue. The run stays ``status='running'`` so the dispatcher does NOT
+    reclaim it.
+
+    The worker calls ``suspend_task`` when it needs to pause for human input
+    but wants to keep its conversation/iteration state intact for when the
+    human resumes it. On the next dispatch tick the task goes ``ready`` and
+    a (possibly different) worker can pick it up via ``resume_task``.
+
+    Returns False if the task is not in ``running`` state or doesn't exist.
+    """
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'suspended' "
+            "WHERE id = ? AND status = 'running'",
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(conn, task_id, "suspended", None)
+        return True
+
+
+def resume_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Transition ``suspended -> running`` — restores a suspended task.
+
+    Called by the dispatcher when a suspended task is picked up again.
+    Unlike ``unblock_task`` (which is for ``blocked`` tasks that need human
+    input before resuming), ``resume_task`` is for ``suspended`` tasks whose
+    worker is ready to continue without any additional input.
+
+    Defensively closes any stale run that may have been left open (should
+    not happen in normal flow but protects against edge cases).
+
+    Returns False if the task is not in ``suspended`` state or doesn't exist.
+    """
+    with write_txn(conn):
+        # Close any stale open run (defensive — normal flow has no open run)
+        stale = conn.execute(
+            "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'suspended'",
+            (task_id,),
+        ).fetchone()
+        if stale and stale["current_run_id"]:
+            conn.execute(
+                """
+                UPDATE task_runs
+                   SET status = 'reclaimed', outcome = 'reclaimed',
+                       summary = COALESCE(summary, 'suspend/resume invariant recovery'),
+                       ended_at = ?,
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                 WHERE id = ? AND ended_at IS NULL
+                """,
+                (int(time.time()), int(stale["current_run_id"])),
+            )
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'running', current_run_id = NULL "
+            "WHERE id = ? AND status = 'suspended'",
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(conn, task_id, "resumed", None)
         return True
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1530,3 +1530,132 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
         conn.close()
     age = kb.task_age(task)
     assert age["created_age_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# Suspend / resume primitives (issue #24699)
+# ---------------------------------------------------------------------------
+
+def test_suspend_running_task_succeeds(kanban_home):
+    """A running task can be suspended."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="long job", assignee="a")
+        kb.claim_task(conn, t)
+        assert kb.get_task(conn, t).status == "running"
+        assert kb.suspend_task(conn, t) is True
+        assert kb.get_task(conn, t).status == "suspended"
+
+
+def test_suspend_emits_suspended_event(kanban_home):
+    """suspend_task appends a 'suspended' event to the task log."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        kb.suspend_task(conn, t)
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id=? ORDER BY id",
+            (t,),
+        ).fetchall()
+        assert any(e["kind"] == "suspended" for e in events)
+
+
+def test_resume_suspended_task_succeeds(kanban_home):
+    """A suspended task can be resumed back to running."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="long job", assignee="a")
+        kb.claim_task(conn, t)
+        kb.suspend_task(conn, t)
+        assert kb.get_task(conn, t).status == "suspended"
+        assert kb.resume_task(conn, t) is True
+        assert kb.get_task(conn, t).status == "running"
+
+
+def test_resume_emits_resumed_event(kanban_home):
+    """resume_task appends a 'resumed' event to the task log."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        kb.suspend_task(conn, t)
+        kb.resume_task(conn, t)
+        events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id=? ORDER BY id",
+            (t,),
+        ).fetchall()
+        kinds = [e["kind"] for e in events]
+        assert "suspended" in kinds
+        assert "resumed" in kinds
+
+
+def test_suspend_non_running_task_returns_false(kanban_home):
+    """Only running tasks can be suspended; ready/todo are rejected."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        # Task starts in 'ready' state
+        assert kb.suspend_task(conn, t) is False
+        assert kb.get_task(conn, t).status == "ready"
+
+
+def test_suspend_nonexistent_task_returns_false(kanban_home):
+    """Suspending an unknown task_id returns False."""
+    with kb.connect() as conn:
+        assert kb.suspend_task(conn, "not-a-real-id") is False
+
+
+def test_resume_non_suspended_task_returns_false(kanban_home):
+    """Only suspended tasks can be resumed; running is rejected."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+        # Task is in 'running' state — not suspended
+        assert kb.resume_task(conn, t) is False
+
+
+def test_resume_nonexistent_task_returns_false(kanban_home):
+    """Resuming an unknown task_id returns False."""
+    with kb.connect() as conn:
+        assert kb.resume_task(conn, "not-a-real-id") is False
+
+
+def test_suspend_resume_idempotent(kanban_home):
+    """Suspend and resume are each other's inverse and are both idempotent."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="round-trip task", assignee="a")
+        kb.claim_task(conn, t)
+
+        # running -> suspended
+        assert kb.suspend_task(conn, t) is True
+        assert kb.get_task(conn, t).status == "suspended"
+
+        # Second suspend: rejected (already suspended)
+        assert kb.suspend_task(conn, t) is False
+
+        # suspended -> running
+        assert kb.resume_task(conn, t) is True
+        assert kb.get_task(conn, t).status == "running"
+
+        # Second resume: rejected (already running)
+        assert kb.resume_task(conn, t) is False
+        assert kb.get_task(conn, t).status == "running"
+
+
+def test_block_and_suspend_are_distinct_states(kanban_home):
+    """Blocked tasks and suspended tasks are separate; cross-transition is rejected."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        kb.claim_task(conn, t)
+
+        # running -> blocked (via block_task)
+        kb.block_task(conn, t, reason="need input")
+        assert kb.get_task(conn, t).status == "blocked"
+
+        # blocked -> ready (via unblock)
+        kb.unblock_task(conn, t)
+        assert kb.get_task(conn, t).status == "ready"
+
+        # ready -> running -> suspended (via claim + suspend)
+        kb.claim_task(conn, t)
+        kb.suspend_task(conn, t)
+        assert kb.get_task(conn, t).status == "suspended"
+
+        # Suspended task cannot be block_task'd directly — must resume first
+        assert kb.block_task(conn, t, reason="need input") is False

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -470,6 +470,71 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error(f"kanban_block: {e}")
 
 
+def _handle_suspend(args: dict, **kw) -> str:
+    """Transition the task to suspended — preserves run state for later resume.
+
+    Unlike ``kanban_block`` (ends the run with outcome=blocked), suspend keeps
+    the task in a frozen state so it can be resumed without losing context.
+    Use when: waiting for human input, hitting a long-duration API call, or
+    needing to hand off mid-task. The next dispatch tick will see the task as
+    'suspended -> ready' and a worker can pick it up via ``kanban_resume``.
+    """
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error("reason is required — explain what caused the suspend")
+    try:
+        kb, conn = _connect()
+        try:
+            from hermes_cli.kanban_db import suspend_task
+            ok = suspend_task(conn, tid)
+            if not ok:
+                return tool_error(
+                    f"could not suspend {tid} (unknown id or not in running state)"
+                )
+            return _ok(task_id=tid, note=f"suspended: {reason}")
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_suspend failed")
+        return tool_error(f"kanban_suspend: {e}")
+
+
+def _handle_resume(args: dict, **kw) -> str:
+    """Transition a suspended task back to running.
+
+    Called when the worker is ready to continue after a suspend. The task
+    must currently be in 'suspended' state.
+    """
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    try:
+        kb, conn = _connect()
+        try:
+            from hermes_cli.kanban_db import resume_task
+            ok = resume_task(conn, tid)
+            if not ok:
+                return tool_error(
+                    f"could not resume {tid} (unknown id or not in suspended state)"
+                )
+            return _ok(task_id=tid, note="resumed — worker is continuing")
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_resume failed")
+        return tool_error(f"kanban_resume: {e}")
+
+
 def _handle_heartbeat(args: dict, **kw) -> str:
     """Signal that the worker is still alive during a long operation.
 
@@ -1109,6 +1174,48 @@ registry.register(
     handler=_handle_comment,
     check_fn=_check_kanban_mode,
     emoji="💬",
+)
+
+registry.register(
+    name="kanban_suspend",
+    toolset="kanban",
+    schema={
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task to suspend (defaults to HERMES_KANBAN_TASK env var). "
+                               "The task must be in 'running' state.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Human-readable reason — what caused the suspend and what "
+                               "resumption depends on.",
+            },
+        },
+        "required": ["reason"],
+    },
+    handler=_handle_suspend,
+    check_fn=_check_kanban_mode,
+    emoji="⏸",
+)
+
+registry.register(
+    name="kanban_resume",
+    toolset="kanban",
+    schema={
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task to resume (defaults to HERMES_KANBAN_TASK env var). "
+                               "The task must be in 'suspended' state.",
+            },
+        },
+    },
+    handler=_handle_resume,
+    check_fn=_check_kanban_mode,
+    emoji="▶",
 )
 
 registry.register(


### PR DESCRIPTION
## Summary

This PR adds `kanban_suspend` and `kanban_resume` primitives so workers can **freeze and restore long-running tasks without losing iteration/conversation state**.

### The problem

Long-running agent tasks (e.g., debugging sessions, large refactors) may need to pause — waiting for human input, a rate-limit cooldown, or an external dependency. The existing `kanban_block` ends the run with `outcome=blocked`, losing all iteration context. Workers had no way to hand off mid-task.

### The solution

| Transition | From | To | Preserves run? |
|---|---|---|---|
| `kanban_block` | running | blocked | ❌ ends run |
| `kanban_suspend` | running | suspended | ✅ keeps run |
| `kanban_resume` | suspended | running | — |

`kanban_suspend` transitions `running → suspended` so the dispatcher **skips it** (status is still `running` under the hood — no reclaim). When ready, `kanban_resume` transitions `suspended → running` and defensively clears any stale open run.

### Changes

**`hermes_cli/kanban_db`** — DB primitives:
- `suspend_task(conn, task_id)` — `running → suspended`, emits `suspended` event
- `resume_task(conn, task_id)` — `suspended → running`, clears stale run defensively, emits `resumed` event
- `VALID_STATUSES` includes `"suspended"`

**`tools/kanban_tools`** — Worker tools:
- `kanban_suspend` — requires `task_id` + `reason`; enforces worker ownership
- `kanban_resume` — requires `task_id`; transitions `suspended → running`

**`tests/hermes_cli/test_kanban_db`** — 10 new tests:
- Happy path: suspend/resume succeed and emit correct events
- State guards: only `running` can suspend; only `suspended` can resume
- Idempotency: double-suspend / double-resume are safely rejected
- Block vs suspend: distinct states, cross-transition rejected

Fixes #24699.