### PR TITLE
fix(gateway/feishu): in-process WS reconnect + fallback send strips thread_id

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2471,13 +2471,22 @@ class BasePlatformAdapter(ABC):
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
 
-        # Non-network / post-retry formatting failure: try plain text as fallback
+        # Non-network / post-retry formatting failure: try plain text as fallback.
+        # Strip thread_id and reply_to_message_id from metadata so the fallback
+        # goes out as a top-level chat message rather than a thread reply — a
+        # stale or invalid thread_id causes Feishu to return 99992402 field
+        # validation failure, making the fallback fail too.
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
+        fallback_metadata = (
+            {k: v for k, v in metadata.items() if k not in ("thread_id", "reply_to_message_id")} or None
+            if metadata
+            else None
+        )
         fallback_result = await self.send(
             chat_id=chat_id,
             content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
             reply_to=reply_to,
-            metadata=metadata,
+            metadata=fallback_metadata,
         )
         if not fallback_result.success:
             logger.error("[%s] Fallback send also failed: %s", self.name, fallback_result.error)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4388,6 +4388,19 @@ class FeishuAdapter(BasePlatformAdapter):
             self,
         )
 
+        def _on_ws_thread_done(fut: "asyncio.Future[None]") -> None:
+            # Guard against normal shutdown or an error already being set.
+            if not self._running or self.has_fatal_error:
+                return
+            exc = fut.exception() if not fut.cancelled() else None
+            detail = repr(exc) if exc else "thread exited without exception"
+            msg = f"Feishu websocket thread exited unexpectedly: {detail}"
+            logger.error("[Feishu] %s — triggering in-process reconnect", msg)
+            self._set_fatal_error("feishu_ws_exited", msg, retryable=True)
+            loop.create_task(self._notify_fatal_error())
+
+        self._ws_future.add_done_callback(_on_ws_thread_done)
+
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:
             raise RuntimeError("aiohttp not installed; webhook mode unavailable")


### PR DESCRIPTION
Closes #24807, closes #24808

## Problems

**1. WS thread exit is silently swallowed (no in-process reconnect)**

When the Feishu WebSocket thread exits unexpectedly (keepalive ping timeout escaping `lark_oapi`'s internal reconnect loop), the exception was caught by a bare `except Exception: pass` in `_run_official_feishu_ws_client`. No fatal error was raised, so the adapter stayed registered but went deaf. Recovery required a full gateway process restart via systemd (exit 75 / TEMPFAIL), which killed any in-flight agent tasks and triggered the 60s drain timeout.

**2. Fallback send fails with `[99992402] field validation failed`**

`_send_with_retry`'s plain-text fallback passed the original `metadata` unchanged. If `metadata` contained a stale `thread_id`, Feishu returned `[99992402] field validation failed`, making the fallback fail too.

## Fixes

**1.** Add a done-callback on `_ws_future` in `_connect_websocket`. When the WS thread exits while the adapter is still running, the callback calls `_set_fatal_error(retryable=True)` and schedules `_notify_fatal_error()`. This wires into the existing `_failed_platforms` reconnect infrastructure in `run.py` (exponential backoff, up to `_MAX_ATTEMPTS`) — reconnect happens in-process without restarting the gateway.

**2.** Before the fallback `send()` call, build a copy of `metadata` with `thread_id` and `reply_to_message_id` stripped, so the fallback degrades to a plain top-level chat message.

## Changes

- `gateway/platforms/feishu.py`: add `_on_ws_thread_done` done-callback on `_ws_future`
- `gateway/platforms/base.py`: strip `thread_id`/`reply_to_message_id` from metadata before fallback send