### PR TITLE
fix(telegram): route image documents (.png/.jpg/.webp/.gif) through vision pipeline

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -786,6 +786,26 @@ SUPPORTED_DOCUMENT_TYPES = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Image document types
+#
+# Image extensions that platforms may deliver as "documents" rather than
+# native photo attachments (Telegram users uploading via the file picker,
+# clients that wrap stickers/screenshots as files, etc.). When we see one
+# of these, we route the bytes through the image cache and the normal
+# vision/photo handling path instead of rejecting them as unsupported
+# documents.
+# ---------------------------------------------------------------------------
+
+SUPPORTED_IMAGE_DOCUMENT_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
+
+
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
     DOCUMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -76,6 +76,7 @@ from gateway.platforms.base import (
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
+    SUPPORTED_IMAGE_DOCUMENT_TYPES,
     utf16_len,
     _prefix_within_utf16_limit,
 )
@@ -3250,6 +3251,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
                     ext = video_mime_to_ext.get(doc.mime_type, "")
 
+                if not ext and doc.mime_type:
+                    # SUPPORTED_IMAGE_DOCUMENT_TYPES has duplicate values (.jpg + .jpeg
+                    # both map to image/jpeg); keep the first ext we encounter.
+                    image_mime_to_ext: dict[str, str] = {}
+                    for _ext, _mime in SUPPORTED_IMAGE_DOCUMENT_TYPES.items():
+                        image_mime_to_ext.setdefault(_mime, _ext)
+                    ext = image_mime_to_ext.get(doc.mime_type, "")
+
                 if ext in SUPPORTED_VIDEO_TYPES:
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()
@@ -3259,6 +3268,21 @@ class TelegramAdapter(BasePlatformAdapter):
                     event.message_type = MessageType.VIDEO
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
                     await self.handle_message(event)
+                    return
+
+                if ext in SUPPORTED_IMAGE_DOCUMENT_TYPES:
+                    file_obj = await doc.get_file()
+                    image_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [SUPPORTED_IMAGE_DOCUMENT_TYPES[ext]]
+                    event.message_type = MessageType.PHOTO
+                    logger.info("[Telegram] Cached user image document at %s", cached_path)
+                    media_group_id = getattr(msg, "media_group_id", None)
+                    if media_group_id:
+                        await self._queue_media_group_event(str(media_group_id), event)
+                    else:
+                        await self.handle_message(event)
                     return
 
                 # Check if supported


### PR DESCRIPTION

## Summary

When users send images as **documents** (via Telegram file picker instead of photo button), they were rejected with `"Unsupported document type"` because `SUPPORTED_DOCUMENT_TYPES` only includes text/office formats.

This PR adds `SUPPORTED_IMAGE_DOCUMENT_TYPES` to handle `.png`, `.jpg`, `.jpeg`, `.webp`, and `.gif` files sent as documents, routing them through the image cache and vision pipeline.

## Changes

- **`gateway/platforms/base.py`**: Add `SUPPORTED_IMAGE_DOCUMENT_TYPES` constant (mirrors existing `SUPPORTED_VIDEO_TYPES` pattern)
- **`gateway/platforms/telegram.py`**: 
  - Import the new constant
  - Add MIME reverse-lookup for image types (handles `.jpg`/`.jpeg` → `image/jpeg` dedup)
  - Route image documents through `cache_image_from_bytes` + vision pipeline
  - Handle media groups for image documents

## Why this approach

- **Shared constant** in `base.py` — consistent with `SUPPORTED_VIDEO_TYPES`, reusable by other platforms
- **MIME fallback** — works even when filename has no extension but MIME type is `image/*`
- **Media group support** — respects Telegram album/group photo behavior
- **No semantic pollution** — image types are NOT added to `SUPPORTED_DOCUMENT_TYPES` (images are not documents)

## Related Issues

Closes #20128
Closes #18620

## Supersedes

This PR consolidates the fixes from several open PRs:
- #20147 (duplicate constant, no MIME lookup)
- #18819 (inline constant, no media group support)
- #16710 (mixed with unrelated Docker changes)
- #19446 (local constant only)
- #18142 (wrong approach — adding images to SUPPORTED_DOCUMENT_TYPES)
