### PR TITLE
fix(docs): update DeepSeek provider description to reflect V4 models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -917,7 +917,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
-    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
+    ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (V4 Pro/Flash, R1 — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
     ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),


### PR DESCRIPTION
Fixes #24471

## Problem

The provider selection menu shows DeepSeek as:
```
DeepSeek (DeepSeek-V3, R1, coder — direct API)
```

This is stale — the direct DeepSeek provider now exposes V4 models (`deepseek-v4-pro`, `deepseek-v4-flash`) as primary models. The model list already includes those IDs, but the provider-level description makes it look outdated.

## Fix

Updated `hermes_cli/models.py` line 920:
```
- "DeepSeek (DeepSeek-V3, R1, coder — direct API)"
+ "DeepSeek (V4 Pro/Flash, R1 — direct API)"
```

## Testing

- 33 provider-related tests pass
- No tests reference the old description string
- 1 file changed, 1 line modified