### PR TITLE
refactor(gateway): replace print() with logger in platform adapters

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2798,7 +2798,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not to_resolve:
             return
 
-        print(f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}")
+        logger.info("[%s] Resolving %d username(s): %s", self.name, len(to_resolve), ', '.join(to_resolve))
         resolved_count = 0
 
         for guild in self._client.guilds:
@@ -2825,19 +2825,19 @@ class DiscordAdapter(BasePlatformAdapter):
                         display_lower if display_lower in to_resolve else global_lower
                     )
                     to_resolve.discard(matched_name)
-                    print(f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})")
+                    logger.info("[%s] Resolved '%s' -> %s (%s#%s)", self.name, matched_name, uid, member.name, member.discriminator)
 
             if not to_resolve:
                 break
 
         if to_resolve:
-            print(f"[{self.name}] Could not resolve usernames: {', '.join(to_resolve)}")
+            logger.warning("[%s] Could not resolve usernames: %s", self.name, ', '.join(to_resolve))
 
         # Update internal set and env var so gateway auth checks use IDs
         self._allowed_user_ids = numeric_ids
         os.environ["DISCORD_ALLOWED_USERS"] = ",".join(sorted(numeric_ids))
         if resolved_count:
-            print(f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)")
+            logger.info("[%s] Updated DISCORD_ALLOWED_USERS with %d resolved ID(s)", self.name, resolved_count)
 
     def format_message(self, content: str) -> str:
         """
@@ -4311,9 +4311,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     cached_path = await self._cache_discord_image(att, ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
-                    print(f"[Discord] Cached user image: {cached_path}", flush=True)
+                    logger.debug("[Discord] Cached user image: %s", cached_path)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache image attachment: {e}", flush=True)
+                    logger.error("[Discord] Failed to cache image attachment: %s", e)
                     # Fall back to the CDN URL if caching fails
                     media_urls.append(att.url)
                     media_types.append(content_type)
@@ -4325,9 +4325,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     cached_path = await self._cache_discord_audio(att, ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
-                    print(f"[Discord] Cached user audio: {cached_path}", flush=True)
+                    logger.debug("[Discord] Cached user audio: %s", cached_path)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
+                    logger.error("[Discord] Failed to cache audio attachment: %s", e)
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -327,7 +327,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        logger.info("[Email] Connected as %s", self._address)
         return True
 
     async def disconnect(self) -> None:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3297,7 +3297,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send document: {e}")
+            logger.error("[%s] Failed to send document: %s", self.name, e)
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_video(
@@ -3343,7 +3343,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send video: {e}")
+            logger.error("[%s] Failed to send video: %s", self.name, e)
             return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
 
     async def send_image(

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -488,7 +488,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Auto-install npm dependencies if node_modules doesn't exist
             bridge_dir = bridge_path.parent
             if not (bridge_dir / "node_modules").exists():
-                print(f"[{self.name}] Installing WhatsApp bridge dependencies...")
+                logger.info("[%s] Installing WhatsApp bridge dependencies...", self.name)
                 # Resolve npm path so Windows can execute the .cmd shim.
                 # shutil.which honours PATHEXT; on POSIX it returns the
                 # plain executable path.
@@ -505,11 +505,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         timeout=npm_install_timeout,
                     )
                     if install_result.returncode != 0:
-                        print(f"[{self.name}] npm install failed: {install_result.stderr}")
+                        logger.error("[%s] npm install failed: %s", self.name, install_result.stderr)
                         return False
-                    print(f"[{self.name}] Dependencies installed")
+                    logger.info("[%s] Dependencies installed", self.name)
                 except Exception as e:
-                    print(f"[{self.name}] Failed to install dependencies: {e}")
+                    logger.error("[%s] Failed to install dependencies: %s", self.name, e)
                     return False
 
             # Ensure session directory exists
@@ -527,14 +527,14 @@ class WhatsAppAdapter(BasePlatformAdapter):
                             data = await resp.json()
                             bridge_status = data.get("status", "unknown")
                             if bridge_status == "connected":
-                                print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
+                                logger.info("[%s] Using existing bridge (status: %s)", self.name, bridge_status)
                                 self._mark_connected()
                                 self._bridge_process = None  # Not managed by us
                                 self._http_session = aiohttp.ClientSession()
                                 self._poll_task = asyncio.create_task(self._poll_messages())
                                 return True
                             else:
-                                print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
+                                logger.info("[%s] Bridge found but not connected (status: %s), restarting", self.name, bridge_status)
             except Exception:
                 pass  # Bridge not running, start a new one
             
@@ -582,8 +582,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
             for attempt in range(15):
                 await asyncio.sleep(1)
                 if self._bridge_process.poll() is not None:
-                    print(f"[{self.name}] Bridge process died (exit code {self._bridge_process.returncode})")
-                    print(f"[{self.name}] Check log: {self._bridge_log}")
+                    logger.error("[%s] Bridge process died (exit code %s)", self.name, self._bridge_process.returncode)
+                    logger.error("[%s] Check log: %s", self.name, self._bridge_log)
                     self._close_bridge_log()
                     return False
                 try:
@@ -596,26 +596,26 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 http_ready = True
                                 data = await resp.json()
                                 if data.get("status") == "connected":
-                                    print(f"[{self.name}] Bridge ready (status: connected)")
+                                    logger.info("[%s] Bridge ready (status: connected)", self.name)
                                     break
                 except Exception:
                     continue
 
             if not http_ready:
-                print(f"[{self.name}] Bridge HTTP server did not start in 15s")
-                print(f"[{self.name}] Check log: {self._bridge_log}")
+                logger.error("[%s] Bridge HTTP server did not start in 15s", self.name)
+                logger.error("[%s] Check log: %s", self.name, self._bridge_log)
                 self._close_bridge_log()
                 return False
             
             # Phase 2: HTTP is up but WhatsApp may still be connecting.
             # Give it more time to authenticate with saved credentials.
             if data.get("status") != "connected":
-                print(f"[{self.name}] Bridge HTTP ready, waiting for WhatsApp connection...")
+                logger.info("[%s] Bridge HTTP ready, waiting for WhatsApp connection...", self.name)
                 for attempt in range(15):
                     await asyncio.sleep(1)
                     if self._bridge_process.poll() is not None:
-                        print(f"[{self.name}] Bridge process died during connection")
-                        print(f"[{self.name}] Check log: {self._bridge_log}")
+                        logger.error("[%s] Bridge process died during connection", self.name)
+                        logger.error("[%s] Check log: %s", self.name, self._bridge_log)
                         self._close_bridge_log()
                         return False
                     try:
@@ -627,16 +627,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 if resp.status == 200:
                                     data = await resp.json()
                                     if data.get("status") == "connected":
-                                        print(f"[{self.name}] Bridge ready (status: connected)")
+                                        logger.info("[%s] Bridge ready (status: connected)", self.name)
                                         break
                     except Exception:
                         continue
                 else:
                     # Still not connected — warn but proceed (bridge may
                     # auto-reconnect later, e.g. after a code 515 restart).
-                    print(f"[{self.name}] ⚠ WhatsApp not connected after 30s")
-                    print(f"[{self.name}]   Bridge log: {self._bridge_log}")
-                    print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
+                    logger.warning("[%s] ⚠ WhatsApp not connected after 30s", self.name)
+                    logger.warning("[%s]   Bridge log: %s", self.name, self._bridge_log)
+                    logger.warning("[%s]   If session expired, re-pair: hermes whatsapp", self.name)
             
             # Create a persistent HTTP session for all bridge communication
             self._http_session = aiohttp.ClientSession()
@@ -645,7 +645,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             self._poll_task = asyncio.create_task(self._poll_messages())
             
             self._mark_connected()
-            print(f"[{self.name}] Bridge started on port {self._bridge_port}")
+            logger.info("[%s] Bridge started on port %s", self.name, self._bridge_port)
             return True
             
         except Exception as e:
@@ -717,10 +717,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     except (ProcessLookupError, PermissionError):
                         self._bridge_process.kill()
             except Exception as e:
-                print(f"[{self.name}] Error stopping bridge: {e}")
+                logger.error("[%s] Error stopping bridge: %s", self.name, e)
         else:
             # Bridge was not started by us, don't kill it
-            print(f"[{self.name}] Disconnecting (external bridge left running)")
+            logger.info("[%s] Disconnecting (external bridge left running)", self.name)
 
         # Clean up PID file
         try:
@@ -747,7 +747,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         self._bridge_process = None
         self._close_bridge_log()
-        print(f"[{self.name}] Disconnected")
+        logger.info("[%s] Disconnected", self.name)
     
     def format_message(self, content: str) -> str:
         """Convert standard markdown to WhatsApp-compatible formatting.
@@ -1068,7 +1068,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 break
             bridge_exit = await self._check_managed_bridge_exit()
             if bridge_exit:
-                print(f"[{self.name}] {bridge_exit}")
+                logger.error("[%s] %s", self.name, bridge_exit)
                 break
             try:
                 async with self._http_session.get(
@@ -1086,9 +1086,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
             except Exception as e:
                 bridge_exit = await self._check_managed_bridge_exit()
                 if bridge_exit:
-                    print(f"[{self.name}] {bridge_exit}")
+                    logger.error("[%s] %s", self.name, bridge_exit)
                     break
-                print(f"[{self.name}] Poll error: {e}")
+                logger.error("[%s] Poll error: %s", self.name, e)
                 await asyncio.sleep(5)
             
             await asyncio.sleep(1)  # Poll interval
@@ -1136,42 +1136,42 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         cached_path = await cache_image_from_url(url, ext=".jpg")
                         cached_urls.append(cached_path)
                         media_types.append("image/jpeg")
-                        print(f"[{self.name}] Cached user image: {cached_path}", flush=True)
+                        logger.debug("[%s] Cached user image: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache image: {e}", flush=True)
+                        logger.error("[%s] Failed to cache image: %s", self.name, e)
                         cached_urls.append(url)
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
                     cached_urls.append(url)
                     media_types.append("image/jpeg")
-                    print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached image: %s", self.name, url)
                 elif msg_type == MessageType.VOICE and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
                         cached_urls.append(cached_path)
                         media_types.append("audio/ogg")
-                        print(f"[{self.name}] Cached user voice: {cached_path}", flush=True)
+                        logger.debug("[%s] Cached user voice: %s", self.name, cached_path)
                     except Exception as e:
-                        print(f"[{self.name}] Failed to cache voice: {e}", flush=True)
+                        logger.error("[%s] Failed to cache voice: %s", self.name, e)
                         cached_urls.append(url)
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
                     # Local file path — bridge already downloaded the audio
                     cached_urls.append(url)
                     media_types.append("audio/ogg")
-                    print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached audio: %s", self.name, url)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
                     mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
                     media_types.append(mime)
-                    print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached document: %s", self.name, url)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):
                     cached_urls.append(url)
                     media_types.append("video/mp4")
-                    print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    logger.debug("[%s] Using bridge-cached video: %s", self.name, url)
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")
@@ -1190,7 +1190,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         try:
                             file_size = Path(doc_path).stat().st_size
                             if file_size > MAX_TEXT_INJECT_BYTES:
-                                print(f"[{self.name}] Skipping text injection for {doc_path} ({file_size} bytes > {MAX_TEXT_INJECT_BYTES})", flush=True)
+                                logger.debug("[%s] Skipping text injection for %s (%s bytes > %s)", self.name, doc_path, file_size, MAX_TEXT_INJECT_BYTES)
                                 continue
                             content = Path(doc_path).read_text(encoding="utf-8", errors="replace")
                             fname = Path(doc_path).name
@@ -1205,9 +1205,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 body = f"{injection}\n\n{body}"
                             else:
                                 body = injection
-                            print(f"[{self.name}] Injected text content from: {doc_path}", flush=True)
+                            logger.debug("[%s] Injected text content from: %s", self.name, doc_path)
                         except Exception as e:
-                            print(f"[{self.name}] Failed to read document text: {e}", flush=True)
+                            logger.error("[%s] Failed to read document text: %s", self.name, e)
 
             return MessageEvent(
                 text=body,
@@ -1219,5 +1219,5 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 media_types=media_types,
             )
         except Exception as e:
-            print(f"[{self.name}] Error building event: {e}")
+            logger.error("[%s] Error building event: %s", self.name, e)
             return None


### PR DESCRIPTION
Addresses #24690

## Summary

Replace **48 runtime `print()` calls** with proper `logger` calls across 4 gateway platform adapters. All calls use `%s` lazy formatting for performance.

## Files changed

| File | print() converted | print() kept | Reason |
|------|------------------|-------------|--------|
| `whatsapp.py` | **37** → 0 | 0 | Bridge status, cache messages, errors |
| `discord.py` | **8** → 2 | 0 (2 are `fingerprint` false positives) | Username resolution, media cache |
| `telegram.py` | **2** → 0 | 0 | Send failures |
| `email.py` | **1** → 0 | 0 | Connection status |

## Files intentionally NOT changed

| File | print() count | Reason kept |
|------|--------------|-------------|
| `feishu_comment_rules.py` | 39 | Standalone CLI tool (`__main__`) — all output is user-facing |
| `wecom.py` | 15 | QR code setup flow — QR display, progress dots, user instructions |
| `feishu.py` | 12 | Onboard polling — progress dots (`end="", flush=True`), newlines |
| `weixin.py` | 10 | QR scan setup — QR display, scan prompts, progress dots |

## Log levels used

| Level | When |
|-------|------|
| `logger.error` | Failures: npm install, bridge process died, cache failures, send failures |
| `logger.warning` | Degraded state: WhatsApp not connected after 30s, unresolved usernames |
| `logger.info` | Status changes: bridge started/ready/disconnected, dependencies installed |
| `logger.debug` | Verbose details: cached media paths, text injection, bridge-cached files |

## Testing

```
882 passed, 3 warnings in 18.01s
```

All gateway platform tests pass. No `print()` calls remain in the modified files (verified: whatsapp=0, discord=0, telegram=0, email=0).

## Design decisions

- **`%s` lazy formatting** everywhere (no f-strings in logger calls) — avoids string interpolation when the log level is disabled
- **`flush=True` removed** — logger handlers manage their own buffering
- **User-facing setup output preserved** — QR codes, progress dots, and setup wizard prompts remain as `print()` since they serve a different purpose (interactive terminal UI, not operational logging)
- **No message content changed** — only the delivery mechanism (`print` → `logger.XXX`)