### PR TITLE
fix(browser): use correct env var for --no-sandbox bypass

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1871,8 +1871,8 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
 
         # Use temp files for stdout/stderr instead of pipes.


### PR DESCRIPTION
## Bug

On Ubuntu 23.10+ (and other distros with AppArmor unprivileged user namespace restrictions), `browser_navigate` crashes with:

```
FATAL: No usable sandbox! ... No usable sandbox!
```

The detection logic in `tools/browser_tool.py` correctly identifies the AppArmor restriction and attempts to inject `--no-sandbox`, but passes it via the **wrong environment variable**.

## Root Cause

Lines 1873-1876 set `AGENT_BROWSER_CHROME_FLAGS`, but `agent-browser` CLI reads `AGENT_BROWSER_ARGS` (see `agent-browser --help`: `--args <args>  Browser launch args (or AGENT_BROWSER_ARGS)`).

Additionally, the value uses space-separation (`"--no-sandbox --disable-dev-shm-usage"`) but `agent-browser` expects comma-separated values.

## Fix

Two-line change in `tools/browser_tool.py`:

```diff
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
```

## Testing

```bash
# Before fix (AGENT_BROWSER_CHROME_FLAGS):
$ AGENT_BROWSER_CHROME_FLAGS="--no-sandbox --disable-dev-shm-usage" npx agent-browser navigate "https://example.com" --json
# → FATAL: No usable sandbox!

# After fix (AGENT_BROWSER_ARGS):
$ AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage" npx agent-browser navigate "https://example.com" --json
# → {"success":true,"data":{"title":"Example Domain","url":"https://example.com/"}}
```

Tested on Ubuntu with `apparmor_restrict_unprivileged_userns = 1`, Playwright Chromium 147.0.7727.15, agent-browser 0.27.0.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Verified the fix resolves the issue on the affected platform