### PR TITLE
Harden GitHub Actions supply-chain boundaries

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -13,8 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pages: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: pages
@@ -24,6 +23,7 @@ jobs:
   deploy-vercel:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Trigger Vercel Deploy
         run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
@@ -31,6 +31,10 @@ jobs:
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/nix-setup
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # Do not expose cache-push credentials to pull_request jobs. Fork PRs
+          # do not receive secrets anyway, but this also keeps same-repo PR
+          # execution on the read-only Cachix path.
+          cachix-auth-token: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.CACHIX_AUTH_TOKEN || '' }}
 
       - name: Resolve head SHA
         if: github.event_name == 'pull_request'

--- a/.github/workflows/workflow-security-drift.yml
+++ b/.github/workflows/workflow-security-drift.yml
@@ -1,0 +1,24 @@
+name: Workflow Security Drift
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check_workflow_security.py'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/check_workflow_security.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-workflow-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Check workflow security drift
+        run: python3 scripts/check_workflow_security.py

--- a/scripts/check_workflow_security.py
+++ b/scripts/check_workflow_security.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""High-signal GitHub Actions security drift check.
+
+Fails on patterns that materially widen CI supply-chain blast radius:
+- pull_request_target
+- permissions: write-all
+- unpinned external actions
+- newly introduced id-token: write outside the explicit allowlist
+- explicit install-script enabling
+
+This is intentionally regex/text based to avoid runtime dependencies in CI.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+SHA_RE = re.compile(r"^[a-f0-9]{40}$")
+USES_RE = re.compile(r"^\s*uses\s*:\s*([^\s#]+)", re.IGNORECASE)
+
+# id-token is intentionally allowed only where GitHub Pages deployment needs OIDC.
+ID_TOKEN_ALLOWLIST = {
+    ".github/workflows/deploy-site.yml": 1,
+    ".github/workflows/skills-index.yml": 1,
+}
+
+INSTALL_SCRIPT_ENABLE_PATTERNS = [
+    re.compile(r"ignore-scripts\s*[=:]\s*false", re.IGNORECASE),
+    re.compile(r"npm\s+config\s+set\s+ignore-scripts\s+false", re.IGNORECASE),
+    re.compile(r"--ignore-scripts=false", re.IGNORECASE),
+]
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def is_unpinned_action(ref: str) -> bool:
+    # Local actions and docker images are outside this check.
+    if ref.startswith("./") or ref.startswith("docker://"):
+        return False
+    if "@" not in ref:
+        return True
+    action, version = ref.rsplit("@", 1)
+    if "/" not in action:
+        return False
+    return SHA_RE.fullmatch(version.strip('"\'')) is None
+
+
+def main() -> int:
+    findings: list[str] = []
+    workflow_files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+
+    for path in workflow_files:
+        text = path.read_text(errors="ignore")
+        r = rel(path)
+        lines = text.splitlines()
+
+        for idx, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if re.search(r"\bpull_request_target\b", line):
+                findings.append(f"{r}:{idx}: pull_request_target is not allowed without explicit security review")
+            if re.search(r"permissions\s*:\s*write-all\b", line):
+                findings.append(f"{r}:{idx}: permissions: write-all is not allowed")
+            for pat in INSTALL_SCRIPT_ENABLE_PATTERNS:
+                if pat.search(line):
+                    findings.append(f"{r}:{idx}: install-script enabling detected: {stripped}")
+
+            m = USES_RE.match(line)
+            if m and is_unpinned_action(m.group(1).strip('"\'')):
+                findings.append(f"{r}:{idx}: external action is not pinned to a full SHA: {m.group(1)}")
+
+        id_token_count = len(re.findall(r"id-token\s*:\s*write", text, flags=re.IGNORECASE))
+        allowed = ID_TOKEN_ALLOWLIST.get(r, 0)
+        if id_token_count > allowed:
+            findings.append(f"{r}: id-token: write count {id_token_count} exceeds allowlist {allowed}")
+        if id_token_count and r not in ID_TOKEN_ALLOWLIST:
+            findings.append(f"{r}: id-token: write is not allowlisted")
+
+    if findings:
+        print("Workflow security drift check failed:")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+
+    print(f"Workflow security drift check passed ({len(workflow_files)} workflow files checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Hardens GitHub Actions supply-chain boundaries after the TanStack/npm incident review.

Changes:
- narrows `deploy-site.yml` workflow permissions so only the GitHub Pages deploy job gets `pages: write` + `id-token: write`
- makes the Vercel deploy-hook job explicitly `permissions: {}`
- prevents `CACHIX_AUTH_TOKEN` from being passed to `nix.yml` pull request jobs; it is now only passed on `push` to `main`
- adds a workflow security drift detector for high-risk Actions patterns

## Drift detector flags

`scripts/check_workflow_security.py` fails on:
- `pull_request_target`
- `permissions: write-all`
- unpinned external actions
- `id-token: write` outside the explicit allowlist/counts
- explicit install-script enabling such as `ignore-scripts=false`

## Validation

Ran locally:
- `python3 -m py_compile scripts/check_workflow_security.py`
- `python3 scripts/check_workflow_security.py`
- PyYAML parse over all workflow files
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`

All passed.

## Notes

No package installs, dependency updates, secret inspection, or service changes were performed.
