### PR TITLE
fix(docs): add baseUrl prefix to SVG image paths

### DIFF
--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -49,7 +49,7 @@ hermes -w -q "Fix issue #123"     # Single query in worktree
 
 ## Interface Layout
 
-<img className="docs-terminal-figure" src="/img/docs/cli-layout.svg" alt="Stylized preview of the Hermes CLI layout showing the banner, conversation area, and fixed input prompt." />
+<img className="docs-terminal-figure" src="/docs/img/docs/cli-layout.svg" alt="Stylized preview of the Hermes CLI layout showing the banner, conversation area, and fixed input prompt." />
 <p className="docs-figure-caption">The Hermes CLI banner, conversation stream, and fixed input prompt rendered as a stable docs figure instead of fragile text art.</p>
 
 The welcome banner shows your model, terminal backend, working directory, available tools, and installed skills at a glance.

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -105,7 +105,7 @@ Session IDs are shown when you exit a CLI session, and can be found with `hermes
 
 When you resume a session, Hermes displays a compact recap of the previous conversation in a styled panel before the input prompt:
 
-<img className="docs-terminal-figure" src="/img/docs/session-recap.svg" alt="Stylized preview of the Previous Conversation recap panel shown when resuming a Hermes session." />
+<img className="docs-terminal-figure" src="/docs/img/docs/session-recap.svg" alt="Stylized preview of the Previous Conversation recap panel shown when resuming a Hermes session." />
 <p className="docs-figure-caption">Resume mode shows a compact recap panel with recent user and assistant turns before returning you to the live prompt.</p>
 
 The recap:


### PR DESCRIPTION
Fixes #24809

## Problem

The docs site uses `baseUrl: "/docs/"` in docusaurus.config.ts, but the `<img>` tags in `sessions.md` and `cli.md` referenced images at `/img/docs/...` which resolves to a 404:

```
GET /img/docs/session-recap.svg     → 404
GET /docs/img/docs/session-recap.svg → 200 ✓
```

## Fix

Added the `/docs` prefix to both `<img src>` paths:

| File | Before | After |
|------|--------|-------|
| `sessions.md` | `/img/docs/session-recap.svg` | `/docs/img/docs/session-recap.svg` |
| `cli.md` | `/docs/img/docs/cli-layout.svg` | `/docs/img/docs/cli-layout.svg` |

## Verification

```bash
$ curl -sI https://hermes-agent.nousresearch.com/docs/img/docs/session-recap.svg | head -1
HTTP/2 200

$ curl -sI https://hermes-agent.nousresearch.com/docs/img/docs/cli-layout.svg | head -1
HTTP/2 200
```

## Note

Markdown `![](/img/...)` syntax in other docs (e.g. kanban-tutorial.md) also has this issue but those are a separate scope — Docusaurus markdown image resolution may handle absolute paths differently from raw HTML `<img>` tags.