### PR TITLE
fix(model-picker): add saved-model pre-menu and preserve list order

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7225,7 +7225,7 @@ def _prompt_model_selection(
     confirm_base_url: str = "",
     confirm_api_key: str = "",
 ) -> Optional[str]:
-    """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
+    """Interactive model selection. Lists models in the given order, marking current_model in place. Returns chosen model ID or None.
 
     If *pricing* is provided (``{model_id: {prompt, completion}}``), a compact
     price indicator is shown next to each model in aligned columns.
@@ -7255,12 +7255,16 @@ def _prompt_model_selection(
             return None
         return mid
 
-    # Reorder: current model first, then the rest (deduplicated)
+    # Keep the caller's order (probe order / catalog order) and only
+    # deduplicate. Hoisting current_model to the top hid the real list order
+    # and parked the cursor on it, so ENTER silently re-picked the model the
+    # user was trying to change away from (#5248). It still gets its
+    # "← currently in use" marker wherever it naturally lands.
+    seen = set()
     ordered = []
-    if current_model and current_model in model_ids:
-        ordered.append(current_model)
     for mid in model_ids:
-        if mid not in ordered:
+        if mid not in seen:
+            seen.add(mid)
             ordered.append(mid)
 
     # All models for column-width computation (selectable + unavailable)
@@ -7363,7 +7367,9 @@ def _prompt_model_selection(
     def _label(mid):
         return "".join(text for text, _style in _label_segments(mid))
 
-    # Default cursor on the current model (index 0 if it was reordered to top)
+    # Cursor starts at the top of the list, never on current_model (#5248) —
+    # the user opened this picker to change models, so ENTER should not be a
+    # no-op re-selection of what is already active.
     default_idx = 0
 
     # Build a pricing header hint for the menu title

--- a/tests/hermes_cli/test_model_picker_order.py
+++ b/tests/hermes_cli/test_model_picker_order.py
@@ -1,0 +1,88 @@
+"""Regression tests for #5248: the model picker must show models in the order
+the caller supplied (probe order / catalog order) with the cursor at the top.
+
+The old behavior hoisted ``current_model`` to index 0 and left the cursor on
+it, so opening the picker to *change* models and pressing ENTER re-selected
+the model the user was trying to move away from.
+"""
+
+from hermes_cli.curses_ui import radio_item_plain
+
+MARKER = "← currently in use"
+
+
+def _run_picker(monkeypatch, model_ids, current_model="", choose=None):
+    """Drive ``_prompt_model_selection`` against a stubbed curses radiolist.
+
+    Returns ``(plain_labels, cursor_index, result)``. When *choose* is None the
+    stub picks "Skip (keep current)" (the last row) so the call is order-only.
+    """
+    from hermes_cli.auth import _prompt_model_selection
+
+    captured = {}
+
+    def fake_radiolist(_title, items, selected=0, **_kwargs):
+        captured["labels"] = [radio_item_plain(item) for item in items]
+        captured["cursor"] = selected
+        return len(items) - 1 if choose is None else choose
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", fake_radiolist)
+
+    result = _prompt_model_selection(model_ids, current_model=current_model)
+    return captured["labels"], captured["cursor"], result
+
+
+def _model_rows(labels):
+    """Strip the trailing "Enter custom model name" / "Skip" action rows."""
+    return labels[:-2]
+
+
+def test_current_model_is_not_hoisted_to_top(monkeypatch):
+    labels, cursor, _ = _run_picker(
+        monkeypatch, ["alpha", "beta", "gamma"], current_model="gamma"
+    )
+    rows = _model_rows(labels)
+
+    # Probe order preserved — gamma stays third, not moved to the front.
+    assert [r.split("  ")[0] for r in rows] == ["alpha", "beta", "gamma"]
+    # ...and it keeps its marker in place.
+    assert MARKER in rows[2]
+    assert MARKER not in rows[0]
+    # Cursor sits at the top of the list, not on the active model.
+    assert cursor == 0
+
+
+def test_duplicates_collapse_to_first_occurrence(monkeypatch):
+    labels, _, _ = _run_picker(
+        monkeypatch, ["alpha", "beta", "alpha", "gamma", "beta"]
+    )
+
+    assert _model_rows(labels) == ["alpha", "beta", "gamma"]
+
+
+def test_enter_at_top_selects_first_model_not_current(monkeypatch):
+    # Cursor row (index 0) must map to the first supplied model. Under the old
+    # reordering this returned "gamma" — a silent no-op re-selection.
+    _, _, result = _run_picker(
+        monkeypatch, ["alpha", "beta", "gamma"], current_model="gamma", choose=0
+    )
+
+    assert result == "alpha"
+
+
+def test_selected_index_maps_to_displayed_row(monkeypatch):
+    labels, _, result = _run_picker(
+        monkeypatch, ["alpha", "beta", "gamma"], current_model="alpha", choose=1
+    )
+
+    assert _model_rows(labels)[1] == "beta"
+    assert result == "beta"
+
+
+def test_order_preserved_when_current_model_absent(monkeypatch):
+    labels, cursor, _ = _run_picker(
+        monkeypatch, ["alpha", "beta"], current_model="not-in-list"
+    )
+
+    assert _model_rows(labels) == ["alpha", "beta"]
+    assert cursor == 0


### PR DESCRIPTION
## What does this PR do?

Fixes two behavioral issues in `hermes model` that prevented users from seeing the full model probe list and making an informed model selection for custom providers.

## Related Issue

Fixes #5248

## Type of Change

- 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### `hermes_cli/main.py` — `_model_flow_named_custom()`

**Before:** If `saved_model` existed, immediately called `_save_model_choice()` and returned — no probing, no picker.

**After:** When a saved model exists, the user sees a choice menu:

```
-> Use saved model (llama-3.1-70b)
   Browse available models
   Cancel
```

- **"Use saved model"** — quick re-activation (preserves the convenience)
- **"Browse available models"** — probes the endpoint and shows the full model picker via `_prompt_model_selection`, with the saved model marked `← currently in use`
- When no model is saved, goes straight to probing (unchanged behavior)

This delegates model selection to the shared `_prompt_model_selection` helper instead of using an inline `simple_term_menu`, ensuring consistent UX across all providers.

### `hermes_cli/auth.py` — `_prompt_model_selection()`

**Before:** Reordered model list to put `current_model` at index 0, cursor on it:

```python
ordered = []
if current_model and current_model in model_ids:
    ordered.append(current_model)  # moved to front
for mid in model_ids:
    if mid not in ordered:
        ordered.append(mid)
default_idx = 0  # cursor on the moved model
```

**After:** Preserves original list order, only deduplicates:

```python
seen = set()
ordered = []
for mid in model_ids:
    if mid not in seen:
        seen.add(mid)
        ordered.append(mid)
default_idx = 0  # cursor at top of original list
```

The current model still gets the `← currently in use` marker wherever it naturally appears — it's just no longer moved to the front.

## How to Test

1. Add a custom provider with a saved model to `~/.hermes/config.yaml`:
```yaml
custom_providers:
  - name: "My Local LLM"
    base_url: "http://localhost:8080/v1"
    model: "llama-3.1-70b"
```
2. Run `hermes model` and select "My Local LLM"
3. **Expected:** See a menu with "Use saved model (llama-3.1-70b)" and "Browse available models" options instead of immediate auto-selection
4. Select "Browse available models" → verify models appear in probe order, not reordered
5. Run `hermes model` and select any provider with models (e.g. OpenRouter) → verify model list is in its natural order with cursor at position 0, current model marked in-place

## Checklist

### Code

- [ ] I've read the [Contributing Guide](CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [ ] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A