### PR TITLE
fix(gateway): preserve Telegram topic routing

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -75,7 +75,11 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
             return await self._primary.handle_async_request(request)
 
         sticky_ip = self._sticky_ip
-        attempt_order: list[Optional[str]] = [sticky_ip] if sticky_ip else [None]
+        # If a previously-good fallback IP becomes stale, re-probe the normal
+        # api.telegram.org path before trying the remaining fallbacks.  Without
+        # this, a transient outage on the sticky IP can make sends fail even
+        # after the primary Telegram route has recovered.
+        attempt_order: list[Optional[str]] = [sticky_ip, None] if sticky_ip else [None]
         for ip in self._fallback_ips:
             if ip != sticky_ip:
                 attempt_order.append(ip)

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -246,15 +246,47 @@ class TestFallbackTransport:
         await transport.handle_async_request(_telegram_request())
         assert transport._sticky_ip == "149.154.167.220"
 
-        # Now .220 goes bad too
+        # Now .220 goes bad too and primary is still unreachable.
         calls.clear()
         behavior["149.154.167.220"] = "timeout"
 
         resp = await transport.handle_async_request(_telegram_request())
         assert resp.status_code == 200
-        # Tried sticky (.220) first, then fell through to .221
-        assert [c["url_host"] for c in calls] == ["149.154.167.220", "149.154.167.221"]
+        # Tried sticky (.220), re-probed primary, then fell through to .221.
+        assert [c["url_host"] for c in calls] == [
+            "149.154.167.220",
+            "api.telegram.org",
+            "149.154.167.221",
+        ]
         assert transport._sticky_ip == "149.154.167.221"
+
+    @pytest.mark.asyncio
+    async def test_stale_sticky_ip_reprobes_recovered_primary(self, monkeypatch):
+        """Regression: sticky fallback failure should not hide recovered primary route."""
+        calls = []
+        behavior = {
+            "api.telegram.org": "timeout",
+            "149.154.167.220": "ok",
+        }
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", _fake_transport_factory(calls, behavior))
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        # First request: primary fails → fallback works → becomes sticky.
+        await transport.handle_async_request(_telegram_request())
+        assert transport._sticky_ip == "149.154.167.220"
+
+        # Later, the fallback path fails but the primary path has recovered.
+        calls.clear()
+        behavior["149.154.167.220"] = "timeout"
+        behavior["api.telegram.org"] = "ok"
+
+        resp = await transport.handle_async_request(_telegram_request())
+        assert resp.status_code == 200
+        assert [c["url_host"] for c in calls] == ["149.154.167.220", "api.telegram.org"]
+        # Primary success leaves the existing sticky value intact; the next
+        # request still tries it first, then re-probes primary if needed.
+        assert transport._sticky_ip == "149.154.167.220"
 
 
 class TestFallbackTransportPassthrough:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -113,6 +113,45 @@ class TestSendMessageTool:
         send_mock.assert_not_awaited()
         mirror_mock.assert_not_called()
 
+    def test_bare_platform_home_channel_preserves_thread_id(self):
+        home = SimpleNamespace(chat_id="-1001", thread_id="17585")
+        config, telegram_cfg = _make_config()
+        config.get_home_channel = lambda _platform: home
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_cfg,
+            "-1001",
+            "hello",
+            thread_id="17585",
+            media_files=[],
+            force_document=False,
+        )
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "-1001",
+            "hello",
+            source_label="cli",
+            thread_id="17585",
+            user_id=None,
+        )
+
     def test_resolved_telegram_topic_name_preserves_thread_id(self):
         config, telegram_cfg = _make_config()
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -261,6 +261,8 @@ def _handle_send(args):
                 home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
         if home:
             chat_id = home.chat_id
+            if not thread_id:
+                thread_id = getattr(home, "thread_id", None)
             used_home_channel = True
         else:
             return json.dumps({


### PR DESCRIPTION
## Summary
- Re-probe the primary Telegram API when a sticky fallback IP fails, so recovered normal routing is not masked by a stale fallback.
- Preserve home-channel thread_id values when send_message targets a bare platform such as telegram.

## Test Plan
- python -m pytest tests/gateway/test_telegram_network.py tests/tools/test_send_message_tool.py
- git diff --check