### PR TITLE
fix(docker): chown .venv to hermes so lazy_deps can install platform packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,9 +94,13 @@ RUN cd web && npm run build && \
 # hermes_cli/main.py succeeds (see #18800). /opt/hermes/web is build-time
 # only (HERMES_WEB_DIST points at hermes_cli/web_dist) and is intentionally
 # not chowned here.
+# The .venv MUST be hermes-writable so lazy_deps.py can install platform
+# packages (discord.py, telegram, slack, etc.) at first gateway boot.
+# Without this, `uv pip install` fails with EACCES and all messaging
+# adapters silently fail to load.  See tools/lazy_deps.py.
 USER root
 RUN chmod -R a+rX /opt/hermes && \
-    chown -R hermes:hermes /opt/hermes/ui-tui /opt/hermes/node_modules
+    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/node_modules
 # Start as root so the entrypoint can usermod/groupmod + gosu.
 # If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,6 +39,10 @@ if [ "$(id -u)" = "0" ]; then
         # by the mapped user on the host side.
         chown -R hermes:hermes "$HERMES_HOME" 2>/dev/null || \
             echo "Warning: chown failed (rootless container?) — continuing anyway"
+        # The .venv must also be re-chowned when UID is remapped, otherwise
+        # lazy_deps.py cannot install platform packages (discord.py, etc.).
+        chown -R hermes:hermes "$INSTALL_DIR/.venv" 2>/dev/null || \
+            echo "Warning: chown .venv failed (rootless container?) — continuing anyway"
     fi
 
     # Ensure config.yaml is readable by the hermes runtime user even if it was


### PR DESCRIPTION
## Problem

Since the 2026-05-12 policy change moved messaging packages (discord.py, telegram, slack, etc.) out of `[all]` and into `lazy_deps.py`, the Docker image no longer ships with them pre-installed. At first gateway boot, `lazy_deps.ensure()` tries to `uv pip install` them into the venv — but fails silently because `/opt/hermes/.venv/lib/python3.13/site-packages/` is root-owned while the process runs as the `hermes` user.

Every messaging platform adapter fails to load with just a cryptic warning:
```
WARNING gateway.run: Discord: discord.py not installed
WARNING gateway.run: No adapter available for discord
```

## Fix

Two-part fix:

1. **Dockerfile**: add `/opt/hermes/.venv` to the existing `chown -R hermes:hermes` line so the default (UID 10000) case works out of the box.

2. **docker/entrypoint.sh**: extend the `needs_chown` block to also re-chown `$INSTALL_DIR/.venv` when HERMES_UID is remapped. Without this, the build-time chown becomes stale when someone uses the documented `HERMES_UID=$(id -u) docker compose up` pattern.

## Related

Fixes #21536. Duplicate of #17674 — same fix (chown .venv to hermes user). See also #21543, #21755 which were previously triaged as duplicates of the same root issue.

## Follow-up (separate PR)

The error-swallowing pattern in `check_discord_requirements()` / `check_telegram_requirements()` — bare `except Exception: return False` — should propagate the actual `FeatureUnavailable` error (which contains the pip stderr) instead of silently returning False and leaving the user with a useless generic warning.
