### PR TITLE
fix: recover local terminal cwd when stored cwd is invalid

### DIFF
--- a/tests/tools/test_local_environment_cwd_recovery.py
+++ b/tests/tools/test_local_environment_cwd_recovery.py
@@ -1,0 +1,33 @@
+"""Regression tests for local terminal cwd recovery."""
+
+from pathlib import Path
+
+from tools.environments.local import LocalEnvironment
+
+
+def test_local_environment_recovers_from_corrupt_popen_cwd(tmp_path):
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        env.cwd = "%s"
+        result = env.execute("pwd", cwd=str(tmp_path), timeout=10)
+
+        assert result["returncode"] == 0
+        assert result["output"].strip() == str(tmp_path)
+        assert Path(env.cwd).is_dir()
+    finally:
+        env.cleanup()
+
+
+def test_local_environment_ignores_literal_percent_s_cwd_marker(tmp_path):
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        env.cwd = str(tmp_path)
+        marker = env._cwd_marker
+        result = {"output": f"{marker}%s{marker}\n"}
+
+        env._update_cwd(result)
+
+        assert env.cwd == str(tmp_path)
+        assert result["output"] == ""
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -740,7 +740,10 @@ class BaseEnvironment(ABC):
             return
 
         cwd_path = output[first + len(marker) : last].strip()
-        if cwd_path:
+        # A malformed wrapper/format string can leak the literal printf placeholder
+        # into stdout (``__HERMES_CWD__%s__HERMES_CWD__``).  Strip the marker,
+        # but never adopt that placeholder as the next working directory.
+        if cwd_path and cwd_path != "%s":
             self.cwd = cwd_path
 
         # Strip the marker line AND the \n we injected before it.

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -433,6 +433,24 @@ class LocalEnvironment(BaseEnvironment):
 
         return "/tmp"
 
+    def _safe_popen_cwd(self) -> str:
+        """Return a valid local cwd for subprocess.Popen.
+
+        The local backend also cd's to the effective command cwd inside the
+        wrapped shell script.  ``Popen(cwd=...)`` is only the shell launch
+        directory, but if the persisted session cwd is corrupted or deleted,
+        the shell never starts and the terminal tool gets stuck returning
+        FileNotFoundError before it can recover.
+        """
+        if self.cwd and os.path.isdir(self.cwd):
+            return self.cwd
+
+        fallback = os.getcwd()
+        if not os.path.isdir(fallback):
+            fallback = "/"
+        self.cwd = fallback
+        return fallback
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:


### PR DESCRIPTION
## Summary
- Recover local terminal working directories when the stored cwd is missing or invalid
- Add regression coverage for invalid/corrupt cwd state

## Test plan
- `python -m pytest tests/tools/test_local_environment_cwd_recovery.py -q -o 'addopts='`
