### PR TITLE
fix(slack): route replies from mentioned thread parents

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1950,7 +1950,34 @@ class SlackAdapter(BasePlatformAdapter):
                         user_id=user_id,
                     )
                 )
-                if not reply_to_bot_thread and not in_mentioned_thread and not has_session:
+                parent_mentions_bot = False
+                if (
+                    is_thread_reply
+                    and event_thread_ts
+                    and not reply_to_bot_thread
+                    and not in_mentioned_thread
+                    and not has_session
+                ):
+                    parent_text = await self._fetch_thread_parent_text(
+                        channel_id=channel_id,
+                        thread_ts=event_thread_ts,
+                        team_id=team_id,
+                        strip_bot_mention=False,
+                    )
+                    parent_mentions_bot = bool(bot_uid and f"<@{bot_uid}>" in parent_text)
+                    if parent_mentions_bot:
+                        self._mentioned_threads.add(event_thread_ts)
+                        if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
+                            to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
+                            for t in to_remove:
+                                self._mentioned_threads.discard(t)
+
+                if (
+                    not reply_to_bot_thread
+                    and not in_mentioned_thread
+                    and not has_session
+                    and not parent_mentions_bot
+                ):
                     return
 
         if is_mentioned:
@@ -1960,8 +1987,8 @@ class SlackAdapter(BasePlatformAdapter):
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
             # defeat the feature (and re-enable agent-to-agent ack loops).
-            if event_thread_ts and not self._slack_strict_mention():
-                self._mentioned_threads.add(event_thread_ts)
+            if thread_ts and not self._slack_strict_mention():
+                self._mentioned_threads.add(thread_ts)
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
                     for t in to_remove:
@@ -2673,9 +2700,13 @@ class SlackAdapter(BasePlatformAdapter):
             return ""
 
     async def _fetch_thread_parent_text(
-        self, channel_id: str, thread_ts: str, team_id: str = "",
+        self,
+        channel_id: str,
+        thread_ts: str,
+        team_id: str = "",
+        strip_bot_mention: bool = True,
     ) -> str:
-        """Return the raw text of the thread parent message (for reply_to_text).
+        """Return the text of the thread parent message.
 
         Uses the same per-thread cache as :meth:`_fetch_thread_context` to avoid
         hitting ``conversations.replies`` twice. Falls back to a cheap single-
@@ -2706,7 +2737,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return ""
             bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
             text = (parent.get("text") or "").strip()
-            if bot_uid:
+            if strip_bot_mention and bot_uid:
                 text = text.replace(f"<@{bot_uid}>", "").strip()
             return text
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1922,6 +1922,9 @@ class TestThreadReplyHandling:
     ):
         """Thread replies without mention should be ignored if no active session."""
         mock_session_store._entries = {}  # No active sessions
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={"messages": [{"ts": "123.000", "text": "Parent without mention"}]}
+        )
 
         event = {
             "text": "Just replying in the thread",
@@ -1934,6 +1937,58 @@ class TestThreadReplyHandling:
         }
         await adapter_with_session_store._handle_slack_message(event)
         adapter_with_session_store.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_routes_when_parent_mentioned_bot(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """A plain thread reply should route when the thread parent mentioned the bot."""
+        mock_session_store._entries = {}
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(side_effect=[
+            {
+                "messages": [
+                    {
+                        "ts": "123.000",
+                        "user": "U_USER",
+                        "text": "<@U_BOT> check this and ask me for run",
+                    },
+                ],
+            },
+            {
+                "messages": [
+                    {
+                        "ts": "123.000",
+                        "user": "U_USER",
+                        "text": "<@U_BOT> check this and ask me for run",
+                    },
+                    {
+                        "ts": "123.456",
+                        "user": "U_USER",
+                        "text": "run",
+                    },
+                ],
+            },
+        ])
+
+        event = {
+            "text": "run",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+        with patch.object(
+            adapter_with_session_store, "_resolve_user_name", new=AsyncMock(return_value="Kai Yi")
+        ):
+            await adapter_with_session_store._handle_slack_message(event)
+
+        adapter_with_session_store.handle_message.assert_called_once()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert msg_event.text.endswith("run")
+        assert "check this and ask me for run" in msg_event.text
+        assert "123.000" in adapter_with_session_store._mentioned_threads
 
     @pytest.mark.asyncio
     async def test_thread_reply_without_mention_with_session_processed(
@@ -2012,6 +2067,9 @@ class TestThreadReplyHandling:
     ):
         """If no session store is attached, thread replies without mention should be ignored."""
         # adapter fixture has no session store attached
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={"messages": [{"ts": "123.000", "text": "Parent without mention"}]}
+        )
         event = {
             "text": "Thread reply without mention",
             "user": "U_USER",


### PR DESCRIPTION
## Summary
- route plain thread replies when the thread parent mentioned the Slack bot, even after restart/cache loss
- preserve existing strict mention/session routing behavior
- add regression coverage for parent-mentioned thread replies and no-mention ignored cases

## Verification
- /Users/leekaiyi/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/slack.py
- /Users/leekaiyi/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_slack.py -k 'parent_mentioned_bot or thread_reply_without_mention_no_session_ignored or no_session_store_ignores_thread_replies or thread_reply_without_mention_with_session_processed' -q
- live NurtureAny smoke after gateway restart: plain run routed and bot replied 'routing ok source backed.'
