### PR TITLE
fix(install): rm symlink before writing hermes launcher to prevent venv corruption

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1280,6 +1280,9 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
+    # Remove any existing file/symlink first so the redirect cannot follow
+    # a symlink back into the venv and overwrite the real entry-point.
+    rm -f "$command_link_dir/hermes"
     cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH


### PR DESCRIPTION
## Summary

When `~/.local/bin/hermes` is a symlink pointing into the venv (state left by an earlier install), `cat > $command_link_dir/hermes` follows the symlink and **overwrites the real Python entry-point** with the bash launcher template. The launcher then `exec`s itself in an infinite loop and `hermes` hangs forever.

## Changes

- Add `rm -f "$command_link_dir/hermes"` before the `cat >` redirect in `scripts/install.sh` so any existing file or symlink is removed first, ensuring the redirect always creates a fresh regular file.

## How to test

1. Create the problematic state: `ln -sf ~/.hermes/hermes-agent/venv/bin/hermes ~/.local/bin/hermes`
2. Run `scripts/install.sh`
3. Verify `hermes --help` works (no hang)
4. Verify `~/.local/bin/hermes` is a regular file, not a symlink
5. Verify `~/.hermes/hermes-agent/venv/bin/hermes` is still the Python console-script

## Related

Fixes #24834