### PR TITLE
fix(agent): reasoning event source + streaming JSONDecodeError with tools

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8501,7 +8501,20 @@ class AIAgent:
                                 "stream" in _err_lower
                                 and "not supported" in _err_lower
                             )
-                            if _is_stream_unsupported:
+                            # Detect custom providers (e.g. LLM Gateway) that
+                            # fail streaming when tools are present, returning
+                            # empty/invalid responses (JSONDecodeError with
+                            # "Expecting value" on empty body).  Disable
+                            # streaming so the next attempt uses the
+                            # non-streaming path which succeeds.
+                            _has_tools = bool(api_kwargs.get("tools"))
+                            _is_json_decode = (
+                                "jsondecodeerror" in _err_lower
+                                or "expecting value" in _err_lower
+                                or "expecting ':' delimiter" in _err_lower
+                            )
+                            _is_stream_tool_failure = _has_tools and _is_json_decode
+                            if _is_stream_unsupported or _is_stream_tool_failure:
                                 self._disable_streaming = True
                                 self._safe_print(
                                     "\n⚠  Streaming is not supported for this "

--- a/run_agent.py
+++ b/run_agent.py
@@ -14581,6 +14581,8 @@ class AIAgent:
 
                 # Notify progress callback of model's thinking (used by subagent
                 # delegation to relay the child's reasoning to the parent display).
+                raw_reasoning = getattr(assistant_message, 'reasoning_content', None) or getattr(assistant_message, 'reasoning', None)
+                _think_text = ""
                 if (assistant_message.content and self.tool_progress_callback):
                     _think_text = assistant_message.content.strip()
                     # Strip reasoning XML tags that shouldn't leak to parent display
@@ -14588,18 +14590,28 @@ class AIAgent:
                         r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
                     ).strip()
                     # For subagents: relay first line to parent display (existing behaviour).
-                    # For all agents with a structured callback: emit reasoning.available event.
                     first_line = _think_text.split('\n')[0][:80] if _think_text else ""
                     if first_line and getattr(self, '_delegate_depth', 0) > 0:
                         try:
                             self.tool_progress_callback("_thinking", first_line)
                         except Exception:
                             pass
-                    elif _think_text:
-                        try:
-                            self.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
-                        except Exception:
-                            pass
+                # Emit reasoning.available with actual reasoning content when the
+                # model provides it (reasoning_content or reasoning field). Falls
+                # back to stripped content for models without a dedicated reasoning
+                # field. Previously this always read from .content, which caused
+                # reasoning.available to carry the final response text instead of
+                # the model's reasoning.
+                if raw_reasoning:
+                    try:
+                        self.tool_progress_callback("reasoning.available", "_thinking", raw_reasoning[:500], None)
+                    except Exception:
+                        pass
+                elif _think_text:
+                    try:
+                        self.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
+                    except Exception:
+                        pass
                 
                 # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
                 # This means the model ran out of output tokens mid-reasoning — retry up to 2 times


### PR DESCRIPTION
Two bug fixes in `run_agent.py`:

**1. Fix `reasoning.available` event source ([#24518](#))**

The event was reading from `assistant_message.content` instead of the dedicated
`reasoning_content` or `reasoning` fields. Now reads from reasoning fields first,
falling back to stripped content only when no dedicated reasoning field exists.
Also initializes `_think_text = ""` to avoid unbound variable errors.

**2. Fix streaming `JSONDecodeError` when tools are present ([#24523](#))**

Custom providers like LLM Gateway can fail streaming requests that include tools,
returning empty/invalid responses. Now detects `JSONDecodeError` patterns and
disables streaming for the session, falling back to the non-streaming path.

---

## Related Issues

- Fixes #24518
- Fixes #24523

---

## Type of Change

- [x] 🐛 Bug fix

---

## Changes Made

| File | Line | Change |
|---|---|---|
| `run_agent.py` | ~L14581 | Read from `reasoning_content`/`reasoning` fields first; init `_think_text = ""` |
| `run_agent.py` | ~L8501 | Detect `JSONDecodeError` + tools, disable streaming for session |

---

## How to Test

1. **#24518** — Use a reasoning model → verify the event carries reasoning content, not the response text
2. **#24523** — Use `custom:llmgateway` with tools → verify graceful fallback to non-streaming
3. **Tests** — `streaming` (34 passed), `reasoning` (100 passed) on WSL

---

## Checklist

- [x] Conventional Commits
- [x] Tests pass
- [x] Tested on WSL (Linux)