### PR TITLE
feat(dingtalk): support incoming audio messages via SDK extensions

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -704,6 +704,29 @@ class DingTalkAdapter(BasePlatformAdapter):
                             parts.append(item.text)
                     content = " ".join(parts).strip()
 
+        # Handle audio message recognition (DingTalk provides ASR result)
+        if not content:
+            msg_type_str = getattr(message, "message_type", "") or ""
+            if msg_type_str == "audio":
+                extensions = getattr(message, "extensions", {}) or {}
+                # SDK puts unrecognized fields (including 'content' for audio) in extensions dict
+                audio_content = extensions.get("content", {})
+                if isinstance(audio_content, dict):
+                    content = (audio_content.get("recognition") or "").strip()
+                # Fallback: 'recognition' might be at top level of extensions on some SDK versions
+                if not content:
+                    content = (extensions.get("recognition") or "").strip()
+                # If DingTalk's server-side ASR is not available, still let the message
+                # through so the user gets a reply (empty text + AUDIO msgtype would be
+                # dropped by the skips-empty-message gate in _on_message).
+                if not content:
+                    content = "[Voice message — transcription unavailable]"
+                logger.info(
+                    "Audio message extensions keys=%s recognition=%r",
+                    list(extensions.keys()) if extensions else "empty",
+                    content if content else "(empty)",
+                )
+
         # Do NOT strip "@bot" from the text.  The mention is a routing
         # signal (delivered structurally via callback `isInAtList`), and
         # regex-stripping @handles would collateral-damage e-mails
@@ -769,6 +792,11 @@ class DingTalkAdapter(BasePlatformAdapter):
                 if any("image" in t for t in media_types)
                 else MessageType.TEXT
             )
+        elif msg_type_str == "audio":
+            # DingTalk provides ASR via recognition field — extract in _extract_text.
+            # Do NOT add raw downloadCode to media_urls (it's not a local file path,
+            # and the STT pipeline in run.py would try to open it as a file).
+            msg_type = MessageType.AUDIO
 
         return msg_type, media_urls, media_types
 
@@ -1387,6 +1415,9 @@ class _IncomingHandler(
             data = message.data
             if isinstance(data, str):
                 data = json.loads(data)
+
+            # DEBUG: log raw msgtype to diagnose audio message delivery
+            logger.info("[%s] Stream raw msgtype=%s", self._adapter.name, data.get("msgtype", "?") if isinstance(data, dict) else "non-dict")
 
             # Parse dict into ChatbotMessage using SDK's from_dict
             chatbot_msg = ChatbotMessage.from_dict(data)


### PR DESCRIPTION
## Summary

DingTalk official API sends voice messages via Stream Mode as `msgtype: audio` with a `recognition` field containing server-side ASR text. The `dingtalk-stream` SDK only parses `text`/`picture`/`richText` into typed attributes; audio content lands in `message.extensions` as raw dict.

This PR adds handling for `msgtype: audio` in the DingTalk adapter.

## Changes

- **`_extract_text`**: read `recognition` from `extensions['content']` for audio messages, with two fallback paths and a placeholder when ASR unavailable
- **`_extract_media`**: set `MessageType.AUDIO` without adding raw `downloadCode` to `media_urls` (STT pipeline expects local paths)
- **`_IncomingHandler`**: INFO log for raw msgtype of every Stream callback

## Testing

Verified with real DingTalk single-chat bot traffic against dingtalk-stream SDK v0.24.3. Voice messages with recognition are correctly extracted as text; messages without use a placeholder to avoid silent drops.