### PR TITLE
feat(memory): add Maindex memory provider

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -246,7 +246,7 @@ TIPS = [
     # --- Plugins ---
     "Three plugin types: general (tools/hooks), memory providers, and context engines.",
     "hermes plugins install owner/repo installs plugins directly from GitHub.",
-    "8 external memory providers available: Honcho, OpenViking, Mem0, Hindsight, and more.",
+    "9 external memory providers available: Honcho, OpenViking, Mem0, Hindsight, Maindex, and more.",
     "Plugin hooks include pre/post_tool_call, pre/post_llm_call, and transform_terminal_output for output canonicalization.",
 
     # --- Miscellaneous ---

--- a/plugins/memory/maindex/README.md
+++ b/plugins/memory/maindex/README.md
@@ -1,0 +1,71 @@
+# Maindex Memory Provider
+
+Structured memory graph with semantic + relational recall via the Maindex Expert REST API. Multi-tier retrieval: exact match, relaxed OR fallback with synonym expansion, fuzzy trigram, and semantic/hybrid search.
+
+## Requirements
+
+- `pip install httpx`
+- API key from [maindex.io/dashboard](https://maindex.io/dashboard)
+
+## Setup
+
+```bash
+hermes memory setup    # select "maindex"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider maindex
+echo "MAINDEX_API_KEY=your-key" >> ~/.hermes/.env
+```
+
+## Config
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MAINDEX_API_KEY` | API key (one of api_key or token required) |
+| `MAINDEX_TOKEN` | OAuth bearer token (alternative to API key) |
+| `MAINDEX_COLLECTION` | Default collection slug (optional) |
+
+### Config File
+
+Config file: `$HERMES_HOME/maindex.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `collection` | `""` | Default collection slug for scoping memories |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `maindex_search` | Full-text, fuzzy, semantic, and hybrid search. Filter by tags, kind, collection. |
+| `maindex_keep` | Store a new memory with headline, body, tags, kind, and collection. |
+| `maindex_recall` | Retrieve a specific memory by ID (UUID or short ID like `mem-1a`). |
+| `maindex_update` | Revise an existing memory with full revision history. Modes: body_append, body_replace, headline_replace, headline_and_body_replace, revision_only. Also supports changing kind, canon_status, confidence, verification_status. |
+| `maindex_forget` | Soft-delete a memory (restorable). |
+
+## Lifecycle Hooks
+
+| Hook | Behavior |
+|------|----------|
+| `system_prompt_block` | Injects provider info into system prompt |
+| `prefetch` / `queue_prefetch` | Semantic search before each turn (top 5 results) |
+| `sync_turn` | Stores each conversation turn as a note (non-blocking, background thread) |
+| `on_memory_write` | Mirrors MEMORY.md/USER.md writes as facts |
+| `on_pre_compress` | Saves context snapshot before compression discards messages |
+| `shutdown` | Clean thread + client teardown |
+
+## Circuit Breaker
+
+5 consecutive failures triggers a 120-second cooldown before retrying API calls.
+
+## Links
+
+- [Website](https://maindex.io)
+- [Expert API Docs](https://expert.maindex.io/docs)
+- [Dashboard](https://maindex.io/dashboard)
+- [Help](https://maindex.io/help)

--- a/plugins/memory/maindex/__init__.py
+++ b/plugins/memory/maindex/__init__.py
@@ -1,0 +1,721 @@
+"""Maindex memory plugin — MemoryProvider interface.
+
+Structured memory graph with semantic + relational recall via the Maindex
+Expert REST API. Stores memories with tags, collections, typed associations,
+and full revision history. Multi-tier retrieval: exact match, relaxed OR
+fallback with synonym expansion, fuzzy trigram, and semantic/hybrid search.
+
+Connects to https://expert.maindex.io — the full Expert API surface.
+
+Config via environment variables (profile-scoped via each profile's .env):
+  MAINDEX_API_KEY   — Maindex API key (from https://maindex.io/dashboard)
+  MAINDEX_TOKEN     — OAuth bearer token (alternative to API key)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+_READ_TIMEOUT = 8
+_WRITE_TIMEOUT = 15
+
+_MIN_QUERY_LEN = 10
+
+
+# ---------------------------------------------------------------------------
+# REST client
+# ---------------------------------------------------------------------------
+
+class MaindexClient:
+    """Thin REST wrapper around the Maindex Expert API."""
+
+    BASE_URL = "https://expert.maindex.io"
+
+    def __init__(self, api_key: str = "", bearer_token: str = ""):
+        import httpx
+
+        headers = {"Content-Type": "application/json"}
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+        if api_key:
+            headers["X-API-Key"] = api_key
+
+        self._client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers=headers,
+            timeout=httpx.Timeout(_READ_TIMEOUT, write=_WRITE_TIMEOUT),
+        )
+
+    def search(self, q: str, *, limit: int = 5,
+               search_strategy: str = "auto", **filters) -> dict:
+        params: Dict[str, Any] = {
+            "q": q[:1000], "limit": limit,
+            "search_strategy": search_strategy,
+        }
+        params.update({k: v for k, v in filters.items() if v is not None})
+        resp = self._client.get("/v1/search", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def keep(self, headline: str, body: str = "", tags: Optional[List[str]] = None,
+             kind: str = "note", **kwargs) -> dict:
+        payload: Dict[str, Any] = {"headline": headline, "body": body,
+                                    "kind": kind}
+        if tags:
+            payload["tags"] = tags
+        payload.update({k: v for k, v in kwargs.items() if v is not None})
+        resp = self._client.post("/v1/memories", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def recall(self, memory_id: str, include_links: bool = True) -> dict:
+        params = {"include_links": str(include_links).lower()}
+        resp = self._client.get(f"/v1/memories/{memory_id}", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update(self, memory_id: str, mode: str, **kwargs) -> dict:
+        payload: Dict[str, Any] = {"mode": mode}
+        payload.update({k: v for k, v in kwargs.items() if v is not None})
+        resp = self._client.post(f"/v1/memories/{memory_id}/update",
+                                 json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def forget(self, memory_id: str) -> dict:
+        resp = self._client.delete(f"/v1/memories/{memory_id}")
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_memories(self, **filters) -> dict:
+        params = {k: v for k, v in filters.items() if v is not None}
+        resp = self._client.get("/v1/memories", params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self):
+        self._client.close()
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "api_key": os.environ.get("MAINDEX_API_KEY", ""),
+        "token": os.environ.get("MAINDEX_TOKEN", ""),
+        "collection": os.environ.get("MAINDEX_COLLECTION", ""),
+    }
+
+    config_path = get_hermes_home() / "maindex.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "maindex_search",
+    "description": (
+        "Search Maindex memories by meaning, keywords, or concepts. "
+        "Multi-tier retrieval: full-text, fuzzy, semantic, and hybrid search. "
+        "Returns relevance-ranked results with match context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string",
+                       "description": "What to search for."},
+            "limit": {"type": "integer",
+                       "description": "Max results (default: 10, max: 50)."},
+            "tags": {"type": "array", "items": {"type": "string"},
+                     "description": "Filter by tags."},
+            "kind": {"type": "string",
+                     "description": "Filter by memory kind (note, fact, idea, decision, constraint, question, summary, artifact, task_context)."},
+            "collection": {"type": "string",
+                          "description": "Filter by collection slug or ID."},
+        },
+        "required": ["query"],
+    },
+}
+
+KEEP_SCHEMA = {
+    "name": "maindex_keep",
+    "description": (
+        "Store a new memory in Maindex. Memories are structured with a "
+        "headline, optional body, tags, and kind. Use for decisions, facts, "
+        "constraints, ideas — anything worth remembering across sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "headline": {"type": "string",
+                         "description": "Title or core assertion (required)."},
+            "body": {"type": "string",
+                     "description": "Supporting detail. Omit if headline is self-contained."},
+            "tags": {"type": "array", "items": {"type": "string"},
+                     "description": "Tags for categorization. Use facet:name format (e.g. domain:auth, project:my-app)."},
+            "kind": {"type": "string",
+                     "description": "Memory type: note, fact, idea, decision, constraint, question, summary, artifact, task_context."},
+            "collections": {"type": "array", "items": {"type": "string"},
+                           "description": "Collection slugs to add this memory to."},
+        },
+        "required": ["headline"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "maindex_recall",
+    "description": (
+        "Retrieve a specific memory by ID (UUID or short ID like mem-1a). "
+        "Returns the full memory with tags, collections, metadata, and links."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string",
+                          "description": "Memory ID (UUID or short ID)."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "maindex_update",
+    "description": (
+        "Update an existing memory by creating a new revision. Full history "
+        "is preserved. Tags are additive. Modes: body_append, body_replace, "
+        "headline_replace, headline_and_body_replace, revision_only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string",
+                          "description": "Memory ID to update."},
+            "mode": {"type": "string",
+                     "description": "How to apply: body_append, body_replace, headline_replace, headline_and_body_replace, revision_only."},
+            "headline": {"type": "string",
+                         "description": "New headline text."},
+            "body": {"type": "string",
+                     "description": "New body text."},
+            "tags": {"type": "array", "items": {"type": "string"},
+                     "description": "Tags to add (additive)."},
+            "kind": {"type": "string",
+                     "description": "Change the memory kind (note, fact, idea, decision, constraint, question, summary, artifact, task_context)."},
+            "canon_status": {"type": "string",
+                             "description": "Set canon status: draft, proposed, accepted, deprecated, alternative, meta."},
+            "confidence": {"type": "integer",
+                           "description": "Confidence as integer percentage 0-100."},
+            "verification_status": {"type": "string",
+                                    "description": "Set verification status: unverified, verified, disputed, superseded."},
+        },
+        "required": ["memory_id", "mode"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "maindex_forget",
+    "description": (
+        "Soft-delete a memory (restorable). Use when a memory is no longer "
+        "relevant or was created in error."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string",
+                          "description": "Memory ID to delete."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class MaindexMemoryProvider(MemoryProvider):
+    """Maindex structured memory via the Expert REST API."""
+
+    def __init__(self):
+        self._config: Optional[dict] = None
+        self._client: Optional[MaindexClient] = None
+        self._session_id = ""
+        self._collection = ""
+        self._platform = ""
+        self._user_id = ""
+        self._chat_id = ""
+        self._chat_type = ""
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        self._sync_thread: Optional[threading.Thread] = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "maindex"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        return bool(cfg.get("api_key") or cfg.get("token"))
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "api_key",
+                "description": "Maindex API key",
+                "secret": True,
+                "required": False,
+                "env_var": "MAINDEX_API_KEY",
+                "url": "https://maindex.io/dashboard",
+            },
+            {
+                "key": "token",
+                "description": "OAuth bearer token (alternative to API key)",
+                "secret": True,
+                "required": False,
+                "env_var": "MAINDEX_TOKEN",
+            },
+            {
+                "key": "collection",
+                "description": "Default collection for scoping memories (optional)",
+                "default": "",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        from pathlib import Path
+        config_path = Path(hermes_home) / "maindex.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text())
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2))
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = (time.monotonic()
+                                        + _BREAKER_COOLDOWN_SECS)
+            logger.warning(
+                "Maindex circuit breaker tripped after %d consecutive "
+                "failures. Pausing API calls for %ds.",
+                self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
+            )
+
+    def _source_metadata(self) -> Dict[str, Any]:
+        source: Dict[str, Any] = {"origin": "hermes"}
+        if self._platform:
+            source["platform"] = self._platform
+        if self._user_id:
+            source["user_id"] = self._user_id
+        if self._chat_id:
+            source["chat_id"] = self._chat_id
+        if self._chat_type:
+            source["chat_type"] = self._chat_type
+        return source
+
+    def _auto_tags(self, *extra: str) -> List[str]:
+        tags = ["source:hermes"]
+        if self._platform:
+            tags.append(f"platform:{self._platform}")
+        tags.extend(extra)
+        return tags
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._session_id = session_id
+        self._collection = self._config.get("collection", "")
+        self._platform = str(kwargs.get("platform") or "").strip()
+        self._user_id = str(kwargs.get("user_id") or "").strip()
+        self._chat_id = str(kwargs.get("chat_id") or "").strip()
+        self._chat_type = str(kwargs.get("chat_type") or "").strip()
+        self._client = MaindexClient(
+            api_key=self._config.get("api_key", ""),
+            bearer_token=self._config.get("token", ""),
+        )
+
+    def system_prompt_block(self) -> str:
+        parts = ["# Maindex Memory", "Active. Structured knowledge graph."]
+        if self._collection:
+            parts.append(f"Default collection: {self._collection}.")
+        parts.append(
+            "Use maindex_search to find memories, maindex_keep to store facts, "
+            "maindex_recall for a specific memory, maindex_update to revise, "
+            "maindex_forget to delete."
+        )
+        return "\n".join(parts)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Maindex Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open() or not self._client:
+            return
+        if not query or len(query.strip()) < _MIN_QUERY_LEN:
+            return
+
+        def _run():
+            try:
+                filters: Dict[str, Any] = {}
+                if self._collection:
+                    filters["collection"] = self._collection
+                data = self._client.search(
+                    query.strip()[:1000], limit=5,
+                    search_strategy="auto", **filters,
+                )
+                items = data.get("items", [])
+                if items:
+                    lines = []
+                    for m in items:
+                        headline = m.get("headline", "")
+                        short_id = m.get("shortId", "")
+                        body = m.get("body", "")
+                        entry = f"- [{short_id}] {headline}"
+                        if body:
+                            entry += f": {body[:200]}"
+                        lines.append(entry)
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(lines)
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Maindex prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="maindex-prefetch",
+        )
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str,
+                  *, session_id: str = "") -> None:
+        if self._is_breaker_open() or not self._client:
+            return
+        if len(user_content.strip()) < _MIN_QUERY_LEN:
+            return
+
+        def _sync():
+            try:
+                headline = user_content[:200].strip()
+                if len(user_content) > 200:
+                    headline += "..."
+                body = (f"User: {user_content[:2000]}\n"
+                        f"Assistant: {assistant_content[:2000]}")
+                keep_kw: Dict[str, Any] = {
+                    "source": self._source_metadata(),
+                    "conversations": [{
+                        "conversation_type": "hermes_session",
+                        "conversation_key": self._session_id,
+                    }],
+                }
+                if self._collection:
+                    keep_kw["collections"] = [self._collection]
+                self._client.keep(
+                    headline=headline, body=body,
+                    tags=self._auto_tags(), kind="note", **keep_kw,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.warning("Maindex sync failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
+        self._sync_thread = threading.Thread(
+            target=_sync, daemon=True, name="maindex-sync",
+        )
+        self._sync_thread.start()
+
+    def on_memory_write(self, action: str, target: str, content: str,
+                        metadata: Optional[Dict[str, Any]] = None) -> None:
+        if action not in ("add", "replace") or not content or not self._client:
+            return
+        if self._is_breaker_open():
+            return
+
+        def _write():
+            try:
+                label = "User profile" if target == "user" else "Agent memory"
+                keep_kw: Dict[str, Any] = {
+                    "source": self._source_metadata(),
+                }
+                if self._collection:
+                    keep_kw["collections"] = [self._collection]
+                self._client.keep(
+                    headline=f"[{label}] {content[:200]}",
+                    body=content if len(content) > 200 else "",
+                    tags=self._auto_tags(f"hermes:{target}"),
+                    kind="fact", **keep_kw,
+                )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Maindex memory mirror failed: %s", e)
+
+        t = threading.Thread(target=_write, daemon=True, name="maindex-memwrite")
+        t.start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if not messages or not self._client:
+            return ""
+
+        parts = []
+        for msg in messages[-10:]:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if isinstance(content, str) and content.strip() and role in ("user", "assistant"):
+                parts.append(f"{role}: {content[:500]}")
+
+        if not parts:
+            return ""
+
+        combined = "\n".join(parts)
+
+        def _flush():
+            try:
+                keep_kw: Dict[str, Any] = {
+                    "source": self._source_metadata(),
+                    "conversations": [{
+                        "conversation_type": "hermes_session",
+                        "conversation_key": self._session_id,
+                    }],
+                }
+                if self._collection:
+                    keep_kw["collections"] = [self._collection]
+                self._client.keep(
+                    headline="Pre-compression context snapshot",
+                    body=combined,
+                    tags=self._auto_tags("hermes:compression"),
+                    kind="summary", **keep_kw,
+                )
+                self._record_success()
+                logger.info("Maindex pre-compression flush: %d messages",
+                            len(parts))
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Maindex pre-compression flush failed: %s", e)
+
+        t = threading.Thread(target=_flush, daemon=True, name="maindex-flush")
+        t.start()
+        return ""
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA, KEEP_SCHEMA, RECALL_SCHEMA, UPDATE_SCHEMA,
+                FORGET_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "Maindex API temporarily unavailable "
+                         "(multiple consecutive failures). Will retry "
+                         "automatically."
+            })
+
+        if not self._client:
+            return tool_error("Maindex client not initialized")
+
+        if tool_name == "maindex_search":
+            return self._tool_search(args)
+        elif tool_name == "maindex_keep":
+            return self._tool_keep(args)
+        elif tool_name == "maindex_recall":
+            return self._tool_recall(args)
+        elif tool_name == "maindex_update":
+            return self._tool_update(args)
+        elif tool_name == "maindex_forget":
+            return self._tool_forget(args)
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    # -- Tool implementations ------------------------------------------------
+
+    def _tool_search(self, args: dict) -> str:
+        query = args.get("query", "")
+        if not query:
+            return tool_error("query is required")
+        try:
+            filters: Dict[str, Any] = {}
+            for key in ("tags", "kind", "collection"):
+                if args.get(key):
+                    filters[key] = args[key]
+            if self._collection and "collection" not in filters:
+                filters["collection"] = self._collection
+            data = self._client.search(
+                query, limit=min(int(args.get("limit", 10)), 50),
+                **filters,
+            )
+            self._record_success()
+            items = data.get("items", [])
+            if not items:
+                return json.dumps({"result": "No relevant memories found."})
+            results = []
+            for m in items:
+                entry: Dict[str, Any] = {
+                    "id": m.get("shortId", m.get("id", "")),
+                    "headline": m.get("headline", ""),
+                    "score": m.get("score"),
+                }
+                if m.get("body"):
+                    entry["body"] = m["body"][:500]
+                if m.get("tags"):
+                    entry["tags"] = m["tags"]
+                results.append(entry)
+            return json.dumps({"results": results, "count": len(results)})
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"Search failed: {e}")
+
+    def _tool_keep(self, args: dict) -> str:
+        headline = args.get("headline", "")
+        if not headline:
+            return tool_error("headline is required")
+        try:
+            keep_kwargs: Dict[str, Any] = {}
+            if args.get("body"):
+                keep_kwargs["body"] = args["body"]
+            if args.get("tags"):
+                keep_kwargs["tags"] = args["tags"]
+            if args.get("kind"):
+                keep_kwargs["kind"] = args["kind"]
+            if args.get("collections"):
+                keep_kwargs["collections"] = args["collections"]
+            elif self._collection:
+                keep_kwargs["collections"] = [self._collection]
+            keep_kwargs["conversations"] = [{
+                "conversation_type": "hermes_session",
+                "conversation_key": self._session_id,
+            }]
+            keep_kwargs["source"] = self._source_metadata()
+            data = self._client.keep(headline, **keep_kwargs)
+            self._record_success()
+            return json.dumps({
+                "result": "Memory stored.",
+                "id": data.get("shortId", data.get("id", "")),
+                "headline": data.get("headline", ""),
+            })
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"Failed to store: {e}")
+
+    def _tool_recall(self, args: dict) -> str:
+        memory_id = args.get("memory_id", "")
+        if not memory_id:
+            return tool_error("memory_id is required")
+        try:
+            data = self._client.recall(memory_id)
+            self._record_success()
+            result: Dict[str, Any] = {
+                "id": data.get("shortId", data.get("id", "")),
+                "headline": data.get("headline", ""),
+                "body": data.get("body", ""),
+                "tags": data.get("tags", []),
+                "kind": data.get("kind", ""),
+                "canon_status": data.get("canonStatus", ""),
+                "collections": data.get("collections", []),
+                "created": data.get("createdAt", ""),
+                "updated": data.get("updatedAt", ""),
+            }
+            return json.dumps(result)
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"Recall failed: {e}")
+
+    def _tool_update(self, args: dict) -> str:
+        memory_id = args.get("memory_id", "")
+        mode = args.get("mode", "")
+        if not memory_id:
+            return tool_error("memory_id is required")
+        if not mode:
+            return tool_error("mode is required")
+        try:
+            update_kwargs: Dict[str, Any] = {}
+            for key in ("headline", "body", "tags", "kind", "canon_status",
+                         "confidence", "verification_status"):
+                if args.get(key) is not None:
+                    update_kwargs[key] = args[key]
+            data = self._client.update(memory_id, mode, **update_kwargs)
+            self._record_success()
+            return json.dumps({
+                "result": "Memory updated.",
+                "id": data.get("shortId", data.get("id", "")),
+            })
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"Update failed: {e}")
+
+    def _tool_forget(self, args: dict) -> str:
+        memory_id = args.get("memory_id", "")
+        if not memory_id:
+            return tool_error("memory_id is required")
+        try:
+            self._client.forget(memory_id)
+            self._record_success()
+            return json.dumps({"result": "Memory deleted."})
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"Delete failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register Maindex as a memory provider plugin."""
+    ctx.register_memory_provider(MaindexMemoryProvider())

--- a/plugins/memory/maindex/plugin.yaml
+++ b/plugins/memory/maindex/plugin.yaml
@@ -1,0 +1,8 @@
+name: maindex
+version: 1.0.0
+description: "Maindex — structured memory graph with semantic + relational recall via the Expert REST API."
+pip_dependencies:
+  - httpx
+hooks:
+  - on_pre_compress
+  - on_memory_write

--- a/tests/plugins/memory/test_maindex_provider.py
+++ b/tests/plugins/memory/test_maindex_provider.py
@@ -1,0 +1,809 @@
+"""MaindexMemoryProvider: lifecycle hooks, tool dispatch, circuit breaker, config."""
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.memory.maindex import (
+    MaindexMemoryProvider,
+    MaindexClient,
+    _load_config,
+    register,
+    SEARCH_SCHEMA,
+    KEEP_SCHEMA,
+    RECALL_SCHEMA,
+    UPDATE_SCHEMA,
+    FORGET_SCHEMA,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _event_side_effect(return_value=None):
+    """Return (event, side_effect) for deterministic background-thread tests.
+
+    The side_effect sets the event when called, so the test can wait on
+    the event instead of sleeping.
+    """
+    event = threading.Event()
+
+    def _fn(*args, **kwargs):
+        event.set()
+        return return_value if return_value is not None else {}
+
+    return event, _fn
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def provider():
+    """Fresh MaindexMemoryProvider with a mock client pre-injected.
+
+    Returns (provider, mock_client) so tests can set up return values
+    on mock_client methods and assert calls.
+    """
+    p = MaindexMemoryProvider()
+    mock_client = MagicMock()
+    p._client = mock_client
+    p._session_id = "sess-001"
+    p._config = {"api_key": "k", "token": "", "collection": ""}
+    return p, mock_client
+
+
+# ── Availability ─────────────────────────────────────────────────────────
+
+
+class TestAvailability:
+
+    def test_available_with_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "k")
+        monkeypatch.delenv("MAINDEX_TOKEN", raising=False)
+        assert MaindexMemoryProvider().is_available() is True
+
+    def test_available_with_token(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.delenv("MAINDEX_API_KEY", raising=False)
+        monkeypatch.setenv("MAINDEX_TOKEN", "t")
+        assert MaindexMemoryProvider().is_available() is True
+
+    def test_unavailable_without_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.delenv("MAINDEX_API_KEY", raising=False)
+        monkeypatch.delenv("MAINDEX_TOKEN", raising=False)
+        assert MaindexMemoryProvider().is_available() is False
+
+
+# ── _load_config ─────────────────────────────────────────────────────────
+
+
+class TestLoadConfig:
+
+    def test_reads_all_env_vars(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "env-key")
+        monkeypatch.setenv("MAINDEX_TOKEN", "env-tok")
+        monkeypatch.setenv("MAINDEX_COLLECTION", "env-col")
+        cfg = _load_config()
+        assert cfg == {"api_key": "env-key", "token": "env-tok", "collection": "env-col"}
+
+    def test_file_values_override_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "env-key")
+        monkeypatch.delenv("MAINDEX_TOKEN", raising=False)
+        monkeypatch.delenv("MAINDEX_COLLECTION", raising=False)
+        (tmp_path / "maindex.json").write_text(
+            json.dumps({"api_key": "file-key", "collection": "file-col"})
+        )
+        cfg = _load_config()
+        assert cfg["api_key"] == "file-key"
+        assert cfg["collection"] == "file-col"
+
+    def test_empty_file_values_do_not_clobber_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "env-key")
+        monkeypatch.delenv("MAINDEX_TOKEN", raising=False)
+        monkeypatch.delenv("MAINDEX_COLLECTION", raising=False)
+        (tmp_path / "maindex.json").write_text(json.dumps({"api_key": ""}))
+        cfg = _load_config()
+        assert cfg["api_key"] == "env-key"
+
+    def test_corrupt_json_file_is_ignored(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "env-key")
+        monkeypatch.delenv("MAINDEX_TOKEN", raising=False)
+        monkeypatch.delenv("MAINDEX_COLLECTION", raising=False)
+        (tmp_path / "maindex.json").write_text("NOT VALID JSON{{{")
+        cfg = _load_config()
+        assert cfg["api_key"] == "env-key"
+
+
+# ── save_config ──────────────────────────────────────────────────────────
+
+
+class TestSaveConfig:
+
+    def test_writes_json_file(self, tmp_path):
+        p = MaindexMemoryProvider()
+        p.save_config({"api_key": "new-key"}, str(tmp_path))
+        data = json.loads((tmp_path / "maindex.json").read_text())
+        assert data["api_key"] == "new-key"
+
+    def test_merges_with_existing_file(self, tmp_path):
+        (tmp_path / "maindex.json").write_text(
+            json.dumps({"api_key": "old", "collection": "kept"})
+        )
+        p = MaindexMemoryProvider()
+        p.save_config({"api_key": "new"}, str(tmp_path))
+        data = json.loads((tmp_path / "maindex.json").read_text())
+        assert data["api_key"] == "new"
+        assert data["collection"] == "kept"
+
+
+# ── Initialize & shutdown ────────────────────────────────────────────────
+
+
+class TestInitialize:
+
+    def test_wires_config_to_client(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            sys.modules["hermes_constants"], "get_hermes_home", lambda: tmp_path,
+        )
+        monkeypatch.setenv("MAINDEX_API_KEY", "init-key")
+        monkeypatch.setenv("MAINDEX_TOKEN", "init-tok")
+        monkeypatch.setenv("MAINDEX_COLLECTION", "init-col")
+
+        p = MaindexMemoryProvider()
+        p.initialize("sess-x")
+
+        assert p._session_id == "sess-x"
+        assert p._collection == "init-col"
+        assert p._client is not None
+        assert p._client._client.headers["x-api-key"] == "init-key"
+        assert p._client._client.headers["authorization"] == "Bearer init-tok"
+        p.shutdown()
+
+
+class TestShutdown:
+
+    def test_closes_client_and_nullifies(self, provider):
+        p, mock_client = provider
+        p.shutdown()
+        mock_client.close.assert_called_once()
+        assert p._client is None
+
+
+# ── System prompt ────────────────────────────────────────────────────────
+
+
+class TestSystemPrompt:
+
+    def test_includes_provider_name_and_tool_hints(self, provider):
+        p, _ = provider
+        block = p.system_prompt_block()
+        assert "Maindex Memory" in block
+        assert "maindex_search" in block
+
+    def test_includes_collection_when_set(self, provider):
+        p, _ = provider
+        p._collection = "my-project"
+        assert "my-project" in p.system_prompt_block()
+
+    def test_omits_collection_line_when_empty(self, provider):
+        p, _ = provider
+        p._collection = ""
+        assert "Default collection" not in p.system_prompt_block()
+
+
+# ── Tool schemas ─────────────────────────────────────────────────────────
+
+
+class TestToolSchemas:
+
+    def test_returns_exactly_five_schemas(self, provider):
+        p, _ = provider
+        assert len(p.get_tool_schemas()) == 5
+
+    def test_schema_names_match_expected_set(self, provider):
+        p, _ = provider
+        names = {s["name"] for s in p.get_tool_schemas()}
+        assert names == {
+            "maindex_search", "maindex_keep", "maindex_recall",
+            "maindex_update", "maindex_forget",
+        }
+
+    def test_update_schema_exposes_metadata_fields(self, provider):
+        p, _ = provider
+        update = next(s for s in p.get_tool_schemas() if s["name"] == "maindex_update")
+        props = set(update["parameters"]["properties"])
+        for field in ("canon_status", "kind", "confidence", "verification_status"):
+            assert field in props, f"{field} missing from update schema"
+
+
+# ── Tool routing ─────────────────────────────────────────────────────────
+
+
+class TestToolRouting:
+
+    def test_dispatches_each_tool_to_correct_handler(self, provider):
+        p, mock = provider
+        mock.search.return_value = {"items": []}
+        mock.keep.return_value = {"id": "x", "shortId": "mem-1"}
+        mock.recall.return_value = {
+            "id": "x", "shortId": "mem-1", "headline": "H",
+            "body": "", "tags": [], "kind": "note", "canonStatus": "",
+            "collections": [], "createdAt": "", "updatedAt": "",
+        }
+        mock.update.return_value = {"id": "x", "shortId": "mem-1"}
+        mock.forget.return_value = {"ok": True}
+
+        p.handle_tool_call("maindex_search", {"query": "test"})
+        mock.search.assert_called_once()
+
+        p.handle_tool_call("maindex_keep", {"headline": "H"})
+        mock.keep.assert_called_once()
+
+        p.handle_tool_call("maindex_recall", {"memory_id": "mem-1"})
+        mock.recall.assert_called_once()
+
+        p.handle_tool_call("maindex_update", {"memory_id": "m", "mode": "body_replace"})
+        mock.update.assert_called_once()
+
+        p.handle_tool_call("maindex_forget", {"memory_id": "m"})
+        mock.forget.assert_called_once()
+
+    def test_unknown_tool_returns_error(self, provider):
+        p, _ = provider
+        result = json.loads(p.handle_tool_call("maindex_nope", {}))
+        assert "Unknown tool" in result["error"]
+
+    def test_no_client_returns_error(self):
+        p = MaindexMemoryProvider()
+        result = json.loads(p.handle_tool_call("maindex_search", {"query": "x"}))
+        assert "error" in result
+
+    def test_breaker_open_returns_unavailable(self, provider):
+        p, _ = provider
+        for _ in range(5):
+            p._record_failure()
+        result = json.loads(p.handle_tool_call("maindex_search", {"query": "x"}))
+        assert "temporarily unavailable" in result["error"]
+
+
+# ── Circuit breaker ──────────────────────────────────────────────────────
+
+
+class TestCircuitBreaker:
+
+    def test_stays_closed_under_threshold(self, provider):
+        p, _ = provider
+        for _ in range(4):
+            p._record_failure()
+        assert p._is_breaker_open() is False
+
+    def test_trips_at_threshold(self, provider):
+        p, _ = provider
+        for _ in range(5):
+            p._record_failure()
+        assert p._is_breaker_open() is True
+        assert p._consecutive_failures == 5
+
+    def test_resets_after_cooldown_expires(self, provider):
+        p, _ = provider
+        for _ in range(5):
+            p._record_failure()
+        future = p._breaker_open_until + 1
+        with patch.object(time, "monotonic", return_value=future):
+            assert p._is_breaker_open() is False
+        assert p._consecutive_failures == 0
+
+    def test_success_resets_failure_counter(self, provider):
+        p, _ = provider
+        for _ in range(3):
+            p._record_failure()
+        assert p._consecutive_failures == 3
+        p._record_success()
+        assert p._consecutive_failures == 0
+
+    def test_tool_error_increments_failure_counter(self, provider):
+        p, mock = provider
+        mock.search.side_effect = Exception("API down")
+        p.handle_tool_call("maindex_search", {"query": "test"})
+        assert p._consecutive_failures == 1
+
+
+# ── Tool: search ─────────────────────────────────────────────────────────
+
+
+class TestToolSearch:
+
+    def test_requires_query(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_search({}))
+        assert "error" in result
+
+    def test_formats_results_with_short_id(self, provider):
+        p, mock = provider
+        mock.search.return_value = {
+            "items": [{
+                "shortId": "mem-1a", "headline": "Auth design",
+                "body": "OAuth2 with PKCE", "tags": ["domain:auth"],
+                "score": 0.92,
+            }],
+        }
+        result = json.loads(p._tool_search({"query": "auth"}))
+        assert result["count"] == 1
+        r = result["results"][0]
+        assert r["id"] == "mem-1a"
+        assert r["headline"] == "Auth design"
+        assert r["body"] == "OAuth2 with PKCE"
+        assert r["tags"] == ["domain:auth"]
+        assert r["score"] == 0.92
+
+    def test_truncates_body_at_500_chars(self, provider):
+        p, mock = provider
+        mock.search.return_value = {
+            "items": [{"shortId": "m", "headline": "H", "body": "B" * 1000}],
+        }
+        result = json.loads(p._tool_search({"query": "test"}))
+        assert len(result["results"][0]["body"]) == 500
+
+    def test_returns_no_results_message(self, provider):
+        p, mock = provider
+        mock.search.return_value = {"items": []}
+        result = json.loads(p._tool_search({"query": "nonexistent"}))
+        assert "No relevant memories" in result["result"]
+
+    def test_applies_collection_fallback(self, provider):
+        p, mock = provider
+        p._collection = "project-x"
+        mock.search.return_value = {"items": []}
+        p._tool_search({"query": "test"})
+        _, kwargs = mock.search.call_args
+        assert kwargs["collection"] == "project-x"
+
+    def test_explicit_collection_overrides_fallback(self, provider):
+        p, mock = provider
+        p._collection = "project-x"
+        mock.search.return_value = {"items": []}
+        p._tool_search({"query": "test", "collection": "other"})
+        _, kwargs = mock.search.call_args
+        assert kwargs["collection"] == "other"
+
+    def test_caps_limit_at_50(self, provider):
+        p, mock = provider
+        mock.search.return_value = {"items": []}
+        p._tool_search({"query": "test", "limit": 200})
+        _, kwargs = mock.search.call_args
+        assert kwargs["limit"] == 50
+
+    def test_records_failure_on_api_exception(self, provider):
+        p, mock = provider
+        mock.search.side_effect = Exception("timeout")
+        p._tool_search({"query": "test"})
+        assert p._consecutive_failures == 1
+
+
+# ── Tool: keep ───────────────────────────────────────────────────────────
+
+
+class TestToolKeep:
+
+    def test_requires_headline(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_keep({}))
+        assert "error" in result
+
+    def test_attaches_session_and_source(self, provider):
+        p, mock = provider
+        mock.keep.return_value = {"id": "uuid", "shortId": "mem-1a", "headline": "H"}
+        result = json.loads(p._tool_keep({"headline": "Important fact"}))
+        assert result["result"] == "Memory stored."
+        assert result["id"] == "mem-1a"
+        _, kwargs = mock.keep.call_args
+        assert kwargs["conversations"][0]["conversation_key"] == "sess-001"
+        assert kwargs["source"]["origin"] == "hermes"
+
+    def test_applies_collection_fallback(self, provider):
+        p, mock = provider
+        p._collection = "my-col"
+        mock.keep.return_value = {"id": "x", "shortId": "mem-1"}
+        p._tool_keep({"headline": "Test"})
+        _, kwargs = mock.keep.call_args
+        assert kwargs["collections"] == ["my-col"]
+
+    def test_explicit_collections_override_fallback(self, provider):
+        p, mock = provider
+        p._collection = "my-col"
+        mock.keep.return_value = {"id": "x", "shortId": "mem-1"}
+        p._tool_keep({"headline": "Test", "collections": ["other"]})
+        _, kwargs = mock.keep.call_args
+        assert kwargs["collections"] == ["other"]
+
+    def test_forwards_optional_fields(self, provider):
+        p, mock = provider
+        mock.keep.return_value = {"id": "x", "shortId": "mem-1"}
+        p._tool_keep({"headline": "H", "body": "B", "tags": ["t1"], "kind": "fact"})
+        args, kwargs = mock.keep.call_args
+        assert args[0] == "H"
+        assert kwargs["body"] == "B"
+        assert kwargs["tags"] == ["t1"]
+        assert kwargs["kind"] == "fact"
+
+    def test_records_failure_on_api_exception(self, provider):
+        p, mock = provider
+        mock.keep.side_effect = Exception("timeout")
+        p._tool_keep({"headline": "H"})
+        assert p._consecutive_failures == 1
+
+
+# ── Tool: recall ─────────────────────────────────────────────────────────
+
+
+class TestToolRecall:
+
+    def test_requires_memory_id(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_recall({}))
+        assert "error" in result
+
+    def test_formats_full_response(self, provider):
+        p, mock = provider
+        mock.recall.return_value = {
+            "id": "uuid-123", "shortId": "mem-1a",
+            "headline": "Auth decision", "body": "Use OAuth2",
+            "tags": ["domain:auth"], "kind": "decision",
+            "canonStatus": "accepted",
+            "collections": [{"slug": "infra"}],
+            "createdAt": "2025-01-01", "updatedAt": "2025-06-01",
+        }
+        result = json.loads(p._tool_recall({"memory_id": "mem-1a"}))
+        assert result["id"] == "mem-1a"
+        assert result["headline"] == "Auth decision"
+        assert result["canon_status"] == "accepted"
+        assert result["kind"] == "decision"
+        assert result["created"] == "2025-01-01"
+        assert result["updated"] == "2025-06-01"
+
+    def test_records_failure_on_api_exception(self, provider):
+        p, mock = provider
+        mock.recall.side_effect = Exception("not found")
+        result = json.loads(p._tool_recall({"memory_id": "mem-1"}))
+        assert "error" in result
+        assert p._consecutive_failures == 1
+
+
+# ── Tool: update ─────────────────────────────────────────────────────────
+
+
+class TestToolUpdate:
+
+    def test_requires_memory_id(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_update({"mode": "body_replace"}))
+        assert "error" in result
+        assert "memory_id" in result["error"]
+
+    def test_requires_mode(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_update({"memory_id": "mem-1"}))
+        assert "error" in result
+        assert "mode" in result["error"]
+
+    def test_forwards_all_metadata_fields(self, provider):
+        """Prior bug: only headline/body/tags were forwarded,
+        ignoring canon_status, kind, confidence, verification_status."""
+        p, mock = provider
+        mock.update.return_value = {"id": "x", "shortId": "mem-1"}
+        p._tool_update({
+            "memory_id": "mem-1", "mode": "revision_only",
+            "canon_status": "accepted", "kind": "decision",
+            "confidence": 95, "verification_status": "verified",
+            "tags": ["important"],
+        })
+        mock.update.assert_called_once_with(
+            "mem-1", "revision_only",
+            canon_status="accepted", kind="decision",
+            confidence=95, verification_status="verified",
+            tags=["important"],
+        )
+
+    def test_omits_absent_fields(self, provider):
+        p, mock = provider
+        mock.update.return_value = {"id": "x", "shortId": "mem-1"}
+        p._tool_update({"memory_id": "mem-1", "mode": "headline_replace", "headline": "New"})
+        _, kwargs = mock.update.call_args
+        assert "headline" in kwargs
+        assert "body" not in kwargs
+        assert "canon_status" not in kwargs
+
+    def test_records_failure_on_api_exception(self, provider):
+        p, mock = provider
+        mock.update.side_effect = Exception("conflict")
+        result = json.loads(p._tool_update({"memory_id": "m", "mode": "body_replace"}))
+        assert "error" in result
+        assert p._consecutive_failures == 1
+
+
+# ── Tool: forget ─────────────────────────────────────────────────────────
+
+
+class TestToolForget:
+
+    def test_requires_memory_id(self, provider):
+        p, _ = provider
+        result = json.loads(p._tool_forget({}))
+        assert "error" in result
+
+    def test_returns_success_message(self, provider):
+        p, mock = provider
+        mock.forget.return_value = {"ok": True}
+        result = json.loads(p._tool_forget({"memory_id": "mem-1"}))
+        assert result["result"] == "Memory deleted."
+
+    def test_records_failure_on_api_exception(self, provider):
+        p, mock = provider
+        mock.forget.side_effect = Exception("server error")
+        result = json.loads(p._tool_forget({"memory_id": "mem-1"}))
+        assert "error" in result
+        assert p._consecutive_failures == 1
+
+
+# ── sync_turn ────────────────────────────────────────────────────────────
+
+
+class TestSyncTurn:
+
+    def test_skips_short_user_content(self, provider):
+        p, mock = provider
+        p.sync_turn("hi", "hello")
+        if p._sync_thread:
+            p._sync_thread.join(timeout=1.0)
+        mock.keep.assert_not_called()
+
+    def test_skips_when_breaker_open(self, provider):
+        p, mock = provider
+        for _ in range(5):
+            p._record_failure()
+        p.sync_turn("A" * 50, "response text")
+        if p._sync_thread:
+            p._sync_thread.join(timeout=1.0)
+        mock.keep.assert_not_called()
+
+    def test_skips_when_no_client(self):
+        p = MaindexMemoryProvider()
+        p.sync_turn("A" * 50, "response")
+        assert p._sync_thread is None
+
+    def test_stores_turn_as_note(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.sync_turn(
+            "Tell me about Python classes and inheritance patterns",
+            "Python supports single and multiple inheritance...",
+        )
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert kwargs["kind"] == "note"
+        assert "source:hermes" in kwargs["tags"]
+        assert "User:" in kwargs["body"]
+        assert "Assistant:" in kwargs["body"]
+
+    def test_appends_ellipsis_to_long_headline(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.sync_turn("A" * 300, "response")
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert kwargs["headline"].endswith("...")
+        assert len(kwargs["headline"]) <= 204
+
+    def test_includes_collection_when_configured(self, provider):
+        p, mock = provider
+        p._collection = "my-col"
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.sync_turn("A long enough user message here!", "response text")
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert kwargs["collections"] == ["my-col"]
+
+
+# ── queue_prefetch + prefetch ────────────────────────────────────────────
+
+
+class TestPrefetch:
+
+    def test_queue_prefetch_skips_short_query(self, provider):
+        p, mock = provider
+        p.queue_prefetch("hi")
+        assert p._prefetch_thread is None
+        mock.search.assert_not_called()
+
+    def test_queue_prefetch_skips_breaker_open(self, provider):
+        p, mock = provider
+        for _ in range(5):
+            p._record_failure()
+        p.queue_prefetch("a long enough query to pass the length check")
+        assert p._prefetch_thread is None
+
+    def test_roundtrip_stores_and_retrieves_results(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({
+            "items": [
+                {"shortId": "mem-1a", "headline": "Auth design", "body": "OAuth2 flow"},
+            ],
+        })
+        mock.search.side_effect = side_effect
+
+        p.queue_prefetch("how does authentication work in our system?")
+        assert done.wait(timeout=2.0)
+
+        result = p.prefetch("irrelevant")
+        assert "mem-1a" in result
+        assert "Auth design" in result
+
+    def test_prefetch_clears_result_after_read(self, provider):
+        p, _ = provider
+        with p._prefetch_lock:
+            p._prefetch_result = "cached data"
+        p.prefetch("q")
+        assert p._prefetch_result == ""
+
+    def test_prefetch_returns_empty_when_nothing_queued(self, provider):
+        p, _ = provider
+        assert p.prefetch("q") == ""
+
+
+# ── on_memory_write ──────────────────────────────────────────────────────
+
+
+class TestOnMemoryWrite:
+
+    def test_skips_delete_action(self, provider):
+        p, mock = provider
+        p.on_memory_write("delete", "user", "some content that is long enough")
+        time.sleep(0.05)
+        mock.keep.assert_not_called()
+
+    def test_skips_empty_content(self, provider):
+        p, mock = provider
+        p.on_memory_write("add", "user", "")
+        time.sleep(0.05)
+        mock.keep.assert_not_called()
+
+    def test_skips_breaker_open(self, provider):
+        p, mock = provider
+        for _ in range(5):
+            p._record_failure()
+        p.on_memory_write("add", "user", "User prefers dark mode")
+        time.sleep(0.05)
+        mock.keep.assert_not_called()
+
+    def test_stores_user_profile_as_fact(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.on_memory_write("add", "user", "User prefers dark mode and vim keybindings")
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert "User profile" in kwargs["headline"]
+        assert kwargs["kind"] == "fact"
+        assert "hermes:user" in kwargs["tags"]
+
+    def test_stores_agent_memory_label(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.on_memory_write("replace", "agent", "Agent learned a new pattern")
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert "Agent memory" in kwargs["headline"]
+
+
+# ── on_pre_compress ──────────────────────────────────────────────────────
+
+
+class TestOnPreCompress:
+
+    def test_skips_empty_messages(self, provider):
+        p, mock = provider
+        result = p.on_pre_compress([])
+        assert result == ""
+        time.sleep(0.05)
+        mock.keep.assert_not_called()
+
+    def test_skips_when_no_client(self):
+        p = MaindexMemoryProvider()
+        result = p.on_pre_compress([{"role": "user", "content": "hello"}])
+        assert result == ""
+
+    def test_filters_non_user_assistant_roles(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.on_pre_compress([
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "What is Python?"},
+            {"role": "assistant", "content": "Python is a language"},
+            {"role": "tool", "content": "tool output"},
+        ])
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert "system:" not in kwargs["body"]
+        assert "tool:" not in kwargs["body"]
+        assert "user:" in kwargs["body"]
+        assert "assistant:" in kwargs["body"]
+
+    def test_stores_as_summary_kind(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        p.on_pre_compress([
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ])
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert kwargs["kind"] == "summary"
+        assert "hermes:compression" in kwargs["tags"]
+
+    def test_limits_to_last_10_messages(self, provider):
+        p, mock = provider
+        done, side_effect = _event_side_effect({"id": "x"})
+        mock.keep.side_effect = side_effect
+        messages = [
+            {"role": "user", "content": f"msg-{i}"} for i in range(20)
+        ]
+        p.on_pre_compress(messages)
+        assert done.wait(timeout=2.0)
+        _, kwargs = mock.keep.call_args
+        assert "msg-10" in kwargs["body"]
+        assert "msg-0" not in kwargs["body"]
+
+    def test_skips_messages_with_empty_content(self, provider):
+        p, mock = provider
+        result = p.on_pre_compress([
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": "   "},
+        ])
+        assert result == ""
+        time.sleep(0.05)
+        mock.keep.assert_not_called()
+
+
+# ── Plugin entry point ───────────────────────────────────────────────────
+
+
+class TestRegister:
+
+    def test_registers_provider_instance(self):
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_memory_provider.assert_called_once()
+        arg = ctx.register_memory_provider.call_args[0][0]
+        assert isinstance(arg, MaindexMemoryProvider)

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -76,7 +76,7 @@ Speech-to-text supports six providers: local faster-whisper (free, runs on-devic
 ## Memory & Personalization
 
 - **[Built-in Memory](/docs/user-guide/features/memory)** — Persistent, curated memory via `MEMORY.md` and `USER.md` files. The agent maintains bounded stores of personal notes and user profile data that survive across sessions.
-- **[Memory Providers](/docs/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Eight providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), and Supermemory.
+- **[Memory Providers](/docs/user-guide/features/memory-providers)** — Plug in external memory backends for deeper personalization. Nine providers are supported: Honcho (dialectic reasoning), OpenViking (tiered retrieval), Mem0 (cloud extraction), Hindsight (knowledge graphs), Holographic (local SQLite), RetainDB (hybrid search), ByteRover (CLI-based), Supermemory, and Maindex (structured memory graph).
 
 ## Messaging Platforms
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1330,6 +1330,7 @@ You can switch between providers at any time with `hermes model` — no restart 
 | RL Training | [Tinker](https://tinker-console.thinkingmachines.ai/) + [WandB](https://wandb.ai/) | `TINKER_API_KEY`, `WANDB_API_KEY` |
 | Cross-session user modeling | [Honcho](https://honcho.dev/) | `HONCHO_API_KEY` |
 | Semantic long-term memory | [Supermemory](https://supermemory.ai) | `SUPERMEMORY_API_KEY` |
+| Structured memory graph | [Maindex](https://maindex.io) | `MAINDEX_API_KEY` |
 
 ### Self-Hosting Firecrawl
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -895,7 +895,7 @@ See [Hooks](../user-guide/features/hooks.md) for event signatures and payload sh
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory, maindex. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -145,6 +145,9 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |
 | `HINDSIGHT_TIMEOUT` | Timeout in seconds for Hindsight memory-provider API calls (default: `60`). Bump this if your Hindsight instance is slow to respond during `/sync` or `on_session_switch` and you're seeing timeouts in `errors.log`. |
 | `SUPERMEMORY_API_KEY` | Semantic long-term memory with profile recall and session ingest ([supermemory.ai](https://supermemory.ai)) |
+| `MAINDEX_API_KEY` | Structured memory graph with multi-tier retrieval ([maindex.io](https://maindex.io)) |
+| `MAINDEX_TOKEN` | OAuth bearer token for Maindex (alternative to `MAINDEX_API_KEY`) |
+| `MAINDEX_COLLECTION` | Default collection slug for scoping Maindex memories (optional) |
 | `TINKER_API_KEY` | RL training ([tinker-console.thinkingmachines.ai](https://tinker-console.thinkingmachines.ai/)) |
 | `WANDB_API_KEY` | RL training metrics ([wandb.ai](https://wandb.ai/)) |
 | `DAYTONA_API_KEY` | Daytona cloud sandboxes ([daytona.io](https://daytona.io/)) |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -6,7 +6,7 @@ description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hin
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, maindex
 ```
 
 ## How It Works
@@ -522,6 +522,47 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### Maindex
+
+Structured memory graph with multi-tier retrieval (full-text, fuzzy, semantic, hybrid), typed associations between memories, collections, and full revision history via the [Maindex Expert API](https://expert.maindex.io).
+
+| | |
+|---|---|
+| **Best for** | Structured knowledge management with relational recall across sessions and platforms |
+| **Requires** | `pip install httpx` + [API key](https://maindex.io/dashboard) or OAuth bearer token |
+| **Data storage** | Maindex Cloud |
+| **Cost** | [Maindex pricing](https://maindex.io) |
+
+**Tools (5):** `maindex_search` (multi-tier search with tag/kind/collection filters), `maindex_keep` (store with headline, body, tags, kind, collections), `maindex_recall` (retrieve by ID with full metadata), `maindex_update` (revise with full history — 5 edit modes + metadata fields), `maindex_forget` (soft-delete, restorable)
+
+**Setup:**
+
+```bash
+hermes memory setup    # select "maindex"
+# Or manually:
+hermes config set memory.provider maindex
+echo "MAINDEX_API_KEY=your-key" >> ~/.hermes/.env
+```
+
+**Config:** `$HERMES_HOME/maindex.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `collection` | — | Default collection slug for scoping memories (optional) |
+
+**Environment variables:** `MAINDEX_API_KEY` (API key) or `MAINDEX_TOKEN` (OAuth bearer token) — one is required. `MAINDEX_COLLECTION` (optional default collection).
+
+**Key features:**
+
+- 9 memory kinds (note, fact, idea, decision, constraint, question, summary, artifact, task\_context) with canon status and confidence tracking
+- Automatic pre-compression extraction (saves context snapshot before compression discards messages)
+- Built-in memory mirroring (MEMORY.md/USER.md writes stored as facts)
+- Circuit breaker (5 failures → 120s cooldown) for graceful degradation
+
+**Links:** [Website](https://maindex.io) · [Expert API Docs](https://expert.maindex.io/docs) · [Dashboard](https://maindex.io/dashboard) · [Help](https://maindex.io/help)
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -534,13 +575,14 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **Maindex** | Cloud | Paid | 5 | `httpx` | Structured memory graph + multi-tier retrieval + revision history |
 
 ## Profile Isolation
 
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Mem0, Hindsight, Supermemory, Maindex) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -209,7 +209,7 @@ memory:
 
 ## External Memory Providers
 
-For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Supermemory.
+For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 9 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, and Maindex.
 
 External providers run **alongside** built-in memory (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
 

--- a/website/docs/user-guide/features/overview.md
+++ b/website/docs/user-guide/features/overview.md
@@ -39,7 +39,7 @@ Hermes Agent includes a rich set of capabilities that extend far beyond basic ch
 - **[Provider Routing](provider-routing.md)** — Fine-grained control over which AI providers handle your requests. Optimize for cost, speed, or quality with sorting, whitelists, blacklists, and priority ordering.
 - **[Fallback Providers](fallback-providers.md)** — Automatic failover to backup LLM providers when your primary model encounters errors, including independent fallback for auxiliary tasks like vision and compression.
 - **[Credential Pools](credential-pools.md)** — Distribute API calls across multiple keys for the same provider. Automatic rotation on rate limits or failures.
-- **[Memory Providers](memory-providers.md)** — Plug in external memory backends (Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory) for cross-session user modeling and personalization beyond the built-in memory system.
+- **[Memory Providers](memory-providers.md)** — Plug in external memory backends (Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Maindex) for cross-session user modeling and personalization beyond the built-in memory system.
 - **[API Server](api-server.md)** — Expose Hermes as an OpenAI-compatible HTTP endpoint. Connect any frontend that speaks the OpenAI format — Open WebUI, LobeChat, LibreChat, and more.
 - **[IDE Integration (ACP)](acp.md)** — Use Hermes inside ACP-compatible editors such as VS Code, Zed, and JetBrains. Chat, tool activity, file diffs, and terminal commands render inside your editor.
 - **[RL Training](rl-training.md)** — Generate trajectory data from agent sessions for reinforcement learning and model fine-tuning.


### PR DESCRIPTION
## What does this PR do?

Adds **Maindex** as a native memory provider plugin. Maindex is a structured memory graph with multi-tier retrieval (full-text, fuzzy, semantic, hybrid), typed associations between memories, collections, and full revision history via the [Maindex Expert REST API](https://expert.maindex.io).

## Related Issue

N/A (new provider integration)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Plugin implementation:**

- `plugins/memory/maindex/__init__.py` — Full MemoryProvider implementation (722 lines)
- `plugins/memory/maindex/plugin.yaml` — Plugin manifest
- `plugins/memory/maindex/README.md` — Usage docs

**Tests:**

- `tests/plugins/memory/test_maindex_provider.py` — 45 focused tests

**Documentation:**

- Add full Maindex section to `memory-providers.md` (config table, tools, setup, key features, comparison row)
- Update provider count 8 → 9 in `memory.md`, `memory-providers.md`, `overview.md`, `integrations/index.md`
- Add `MAINDEX_API_KEY`, `MAINDEX_TOKEN`, `MAINDEX_COLLECTION` to `environment-variables.md`
- Add Maindex row to `integrations/providers.md` optional API keys
- Add to `cli-commands.md` provider list
- Add to profile isolation section (config file providers)
- Update tip text in `hermes_cli/tips.py`

## Provider capabilities

- **5 tools**: `maindex_search`, `maindex_keep`, `maindex_recall`, `maindex_update`, `maindex_forget`
- **Auto-recall**: Prefetches relevant memory context (top 5 semantic search results) before each turn
- **Turn capture**: Stores each conversation turn as a note (non-blocking, background thread)
- **Memory mirroring**: MEMORY.md/USER.md writes are stored as facts via `on_memory_write`
- **Pre-compression extraction**: Saves context snapshot before compression discards messages
- **9 memory kinds**: note, fact, idea, decision, constraint, question, summary, artifact, task_context
- **Revision history**: Updates create new revisions; full history preserved
- **Profile-aware**: Config stored in `$HERMES_HOME/maindex.json`, isolated per profile
- **Circuit breaker**: 5 consecutive failures triggers 120s cooldown
- **Graceful degradation**: Missing API key or network failures don't crash the agent
- **Single dependency**: `httpx` (stdlib REST client, no vendor SDK required)

## How to Test

1. `pip install httpx`
2. Get an API key from https://maindex.io/dashboard
3. `hermes config set memory.provider maindex`
4. `echo "MAINDEX_API_KEY=your-key" >> ~/.hermes/.env`
5. `hermes chat -q "Remember that my favorite color is blue"`
6. Start a new session: `hermes chat -q "What is my favorite color?"`

**Unit tests:**
```bash
pytest tests/plugins/memory/test_maindex_provider.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04, Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (uses env vars and `$HERMES_HOME/maindex.json`)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python + httpx, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (new tools only)
