### PR TITLE
fix(dingtalk): trip reconnect loop after 5 consecutive startup failures (#24851)

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import re
+import time
 import traceback
 import uuid
 from datetime import datetime, timezone
@@ -100,6 +101,14 @@ logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+# Trip the reconnect loop after this many consecutive *startup* failures so a
+# permanent SDK/credential breakage doesn't produce a multi-hundred-MB error
+# log (#24851).  A stream that ran for at least RECONNECT_HEALTHY_THRESHOLD_S
+# before failing is treated as a transient mid-session disconnect and resets
+# the counter — the breaker only catches the case where start() fails fast
+# every iteration.
+MAX_CONSECUTIVE_RECONNECT_FAILURES = 5
+RECONNECT_HEALTHY_THRESHOLD_S = 30.0
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 
@@ -301,7 +310,9 @@ class DingTalkAdapter(BasePlatformAdapter):
     async def _run_stream(self) -> None:
         """Run the async stream client with auto-reconnection."""
         backoff_idx = 0
+        consecutive_failures = 0
         while self._running:
+            started_at = time.monotonic()
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
                 await self._stream_client.start()
@@ -311,6 +322,28 @@ class DingTalkAdapter(BasePlatformAdapter):
                 if not self._running:
                     return
                 logger.warning("[%s] Stream client error: %s", self.name, e)
+                if time.monotonic() - started_at >= RECONNECT_HEALTHY_THRESHOLD_S:
+                    # The stream connected and ran for a while before failing —
+                    # treat as a transient mid-session disconnect, not a
+                    # startup loop.  Reset both the backoff index and the
+                    # failure counter so the next attempt starts fresh.
+                    consecutive_failures = 0
+                    backoff_idx = 0
+                else:
+                    consecutive_failures += 1
+                    if consecutive_failures >= MAX_CONSECUTIVE_RECONNECT_FAILURES:
+                        logger.critical(
+                            "[%s] Stream client failed %d consecutive times "
+                            "without a healthy connection; giving up to avoid "
+                            "a reconnection storm. Restart the gateway after "
+                            "fixing the underlying issue (last error: %s)",
+                            self.name,
+                            consecutive_failures,
+                            e,
+                        )
+                        self._running = False
+                        self._mark_disconnected()
+                        return
 
             if not self._running:
                 return

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1169,3 +1169,135 @@ class TestDingTalkAdapterAICards:
         mock_card_sdk.deliver_card_with_options_async.assert_called_once()
         mock_card_sdk.streaming_update_with_options_async.assert_called_once()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Reconnect circuit breaker (#24851)
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectCircuitBreaker:
+    """Regression tests for the reconnection storm guard.
+
+    The SDK-side ``DingTalkStreamClient.start()`` can raise an immediate
+    coroutine-as-context-manager TypeError every iteration when the installed
+    dingtalk-stream SDK version is incompatible. Without a circuit breaker the
+    reconnect loop spins forever and produces hundreds of MB of error log
+    (#24851). The breaker trips after N consecutive *startup* failures; a
+    stream that ran for a while before failing resets the counter so genuine
+    mid-session disconnects keep retrying.
+    """
+
+    @pytest.mark.asyncio
+    async def test_trips_after_max_consecutive_startup_failures(self):
+        from gateway.platforms import dingtalk as dt_mod
+        from gateway.platforms.dingtalk import (
+            DingTalkAdapter,
+            MAX_CONSECUTIVE_RECONNECT_FAILURES,
+        )
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+
+        # Every start() raises immediately — no time elapses on the clock.
+        start_calls = 0
+
+        async def failing_start():
+            nonlocal start_calls
+            start_calls += 1
+            raise TypeError(
+                "'coroutine' object does not support the asynchronous context manager protocol"
+            )
+
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.start = failing_start
+
+        async def no_sleep(_delay):
+            return None
+
+        with patch.object(dt_mod.asyncio, "sleep", no_sleep), \
+             patch.object(dt_mod.time, "monotonic", return_value=1000.0):
+            await adapter._run_stream()
+
+        assert start_calls == MAX_CONSECUTIVE_RECONNECT_FAILURES
+        # Breaker should leave the adapter in a stopped state so the gateway
+        # doesn't keep the dead task around indefinitely.
+        assert adapter._running is False
+
+    @pytest.mark.asyncio
+    async def test_long_lived_failure_resets_counter(self):
+        from gateway.platforms import dingtalk as dt_mod
+        from gateway.platforms.dingtalk import (
+            DingTalkAdapter,
+            MAX_CONSECUTIVE_RECONNECT_FAILURES,
+            RECONNECT_HEALTHY_THRESHOLD_S,
+        )
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+
+        async def failing_start():
+            raise RuntimeError("websocket dropped")
+
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.start = failing_start
+
+        async def no_sleep(_delay):
+            return None
+
+        # Simulate a clock that advances well past the healthy threshold
+        # between every start() entry and exit, so each failure looks like a
+        # transient mid-session disconnect.  After more than the trip count
+        # has accumulated we manually stop the loop and assert the breaker
+        # never fired.
+        attempts = {"n": 0}
+        monotonic_values: list[float] = []
+        max_attempts = MAX_CONSECUTIVE_RECONNECT_FAILURES + 3
+
+        def fake_monotonic():
+            # Per iteration the loop reads the clock twice: once before
+            # start() and once after the exception.  Step the second read
+            # forward by 2× the healthy threshold so the reset branch fires.
+            monotonic_values.append(0.0)
+            attempts["n"] += 1
+            if attempts["n"] >= max_attempts * 2:
+                # Stop the loop after enough iterations to confirm it would
+                # have tripped if the reset wasn't working.
+                adapter._running = False
+            base = (attempts["n"] // 2) * 100.0
+            if attempts["n"] % 2 == 1:
+                return base
+            return base + 2 * RECONNECT_HEALTHY_THRESHOLD_S
+
+        with patch.object(dt_mod.asyncio, "sleep", no_sleep), \
+             patch.object(dt_mod.time, "monotonic", side_effect=fake_monotonic):
+            await adapter._run_stream()
+
+        # The loop exited because we flipped _running, not because the
+        # breaker tripped.  We should have seen at least one more attempt
+        # than the trip threshold.
+        assert attempts["n"] // 2 >= MAX_CONSECUTIVE_RECONNECT_FAILURES + 1
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_exits_without_tripping_breaker(self):
+        from gateway.platforms import dingtalk as dt_mod
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+
+        async def cancelling_start():
+            raise asyncio.CancelledError()
+
+        adapter._stream_client = MagicMock()
+        adapter._stream_client.start = cancelling_start
+
+        async def no_sleep(_delay):
+            return None
+
+        with patch.object(dt_mod.asyncio, "sleep", no_sleep):
+            await adapter._run_stream()
+
+        # CancelledError is a normal shutdown signal; the breaker must not
+        # treat it as a startup failure.  _running stays as the caller set it.
+        assert adapter._running is True


### PR DESCRIPTION
## Summary

- Adds a consecutive-failure circuit breaker to `DingTalkAdapter._run_stream` so a permanently-broken SDK/credential/auth doesn't produce a multi-hundred-MB error log via an infinite reconnect storm (#24851).
- Healthy stream sessions reset the counter, so the breaker only catches the case where `start()` fails *immediately* every iteration — transient mid-session disconnects keep reconnecting indefinitely as before.

## The bug

#24851 (DingTalk Stream Mode: reconnection storm causes gateway to hang) reports that when `dingtalk_stream.DingTalkStreamClient.start()` throws synchronously every retry, the existing reconnect loop spins forever:

```
WARNING gateway.platforms.dingtalk: [Dingtalk] Stream client error: 'coroutine' object does not support the asynchronous context manager protocol
--- (repeats ~6000 times, 315MB total)
```

The user's gateway accumulated **315 MB of repeated stack traces** before they manually restarted. The reporter explicitly asked for a circuit breaker after N consecutive failures.

The existing `_run_stream` at `gateway/platforms/dingtalk.py:277` only sleeps between retries; there's no ceiling on the number of consecutive failures, so any persistent breakage (SDK incompatibility, revoked credentials, network firewall) loops forever.

## The fix

1. New constants `MAX_CONSECUTIVE_RECONNECT_FAILURES = 5` and `RECONNECT_HEALTHY_THRESHOLD_S = 30.0`.
2. Track `time.monotonic()` before each `start()` call. After an exception, compare elapsed time:
   - **Elapsed ≥ 30 s** → the stream actually ran for a while (genuine mid-session disconnect). Reset both `consecutive_failures` and `backoff_idx` so subsequent reconnects start fresh.
   - **Elapsed < 30 s** → counts toward the failure budget. Once the counter hits `MAX_CONSECUTIVE_RECONNECT_FAILURES`, log `CRITICAL` with the last error, set `_running = False`, call `_mark_disconnected()`, and exit the loop.
3. `asyncio.CancelledError` still exits cleanly without engaging the breaker (existing shutdown semantics preserved).

This matches the existing convention in the codebase — see `hermes_cli/goals.py` (`DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES`) and `gateway/stream_consumer.py` (`_MAX_FLOOD_STRIKES`) for consecutive-failure breakers with permanent-disable semantics.

## Test plan

- [x] **Focused regression test** (`tests/gateway/test_dingtalk.py::TestReconnectCircuitBreaker`, 3 cases):
  - `test_trips_after_max_consecutive_startup_failures` — every `start()` raises immediately, breaker trips after exactly `MAX_CONSECUTIVE_RECONNECT_FAILURES` attempts and `_running` flips to False.
  - `test_long_lived_failure_resets_counter` — every `start()` runs for `2× RECONNECT_HEALTHY_THRESHOLD_S` before failing. Loops past the trip threshold without the breaker firing.
  - `test_cancelled_error_exits_without_tripping_breaker` — `CancelledError` exits cleanly; `_running` left untouched.
- [x] **Adjacent suite**: full `tests/gateway/test_dingtalk.py` — **68 passed** locally with `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with 'alibabacloud-dingtalk>=2.0.0' --with 'dingtalk-stream>=0.20,<1' python3 -m pytest tests/gateway/test_dingtalk.py -v`.
- [x] **Regression guard**: removing the `consecutive_failures >= MAX_CONSECUTIVE_RECONNECT_FAILURES` branch would cause `test_trips_after_max_consecutive_startup_failures` to hang indefinitely — `asyncio.sleep` is patched to a no-op so the loop has nothing to bound it without the breaker.

## Related

- Fixes #24851