### PR TITLE
feat(browser): add persistent_sessions config to keep browser alive across turns

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -565,6 +565,11 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        # When true, the browser session is kept alive across agent turns instead
+        # of being torn down at the end of every turn.  The session still closes
+        # when the agent instance is destroyed (e.g. /new or gateway restart) or
+        # when the inactivity timeout fires.
+        "persistent_sessions": False,
         # Browser engine for local mode.  Passed as ``--engine <value>`` to
         # agent-browser v0.25.3+.
         # "auto"       — use Chrome (default, don't pass --engine at all)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1881,6 +1881,14 @@ class AIAgent:
         # broad pseudo-public config object on the agent instance.
         self._aux_compression_context_length_config = None
 
+        # Browser persistence across turns (mirrors persistent_filesystem for VMs)
+        try:
+            self._browser_persistent_sessions = bool(
+                _agent_cfg.get("browser", {}).get("persistent_sessions", False)
+            )
+        except Exception:
+            self._browser_persistent_sessions = False
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -3845,6 +3853,10 @@ class AIAgent:
         ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
         torn down per-turn as before to prevent resource leakage (the original
         intent of this hook for the Morph backend, see commit fbd3a2fd).
+
+        Skips ``cleanup_browser`` when ``browser.persistent_sessions`` is true
+        so the browser stays open across turns. The background inactivity reaper
+        (``BROWSER_SESSION_INACTIVITY_TIMEOUT``) still tears it down once idle.
         """
         try:
             if is_persistent_env(task_id):
@@ -3859,7 +3871,14 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup VM for task {task_id}: {e}")
         try:
-            cleanup_browser(task_id)
+            if self._browser_persistent_sessions:
+                if self.verbose_logging:
+                    logging.debug(
+                        f"Skipping per-turn cleanup_browser for persistent session {task_id}; "
+                        f"inactivity reaper will handle it."
+                    )
+            else:
+                cleanup_browser(task_id)
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5223,3 +5223,37 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestCleanupTaskResources:
+    """_cleanup_task_resources must respect browser.persistent_sessions."""
+
+    def test_cleanup_browser_called_when_not_persistent(self, agent):
+        """Default behaviour: cleanup_browser is invoked per-turn."""
+        agent._browser_persistent_sessions = False
+        with patch("run_agent.cleanup_browser") as mock_cleanup_browser, \
+             patch("run_agent.cleanup_vm") as mock_cleanup_vm, \
+             patch("run_agent.is_persistent_env", return_value=False):
+            agent._cleanup_task_resources("task-123")
+            mock_cleanup_browser.assert_called_once_with("task-123")
+            mock_cleanup_vm.assert_called_once_with("task-123")
+
+    def test_cleanup_browser_skipped_when_persistent(self, agent):
+        """With persistent_sessions=True, per-turn browser cleanup is skipped."""
+        agent._browser_persistent_sessions = True
+        with patch("run_agent.cleanup_browser") as mock_cleanup_browser, \
+             patch("run_agent.cleanup_vm") as mock_cleanup_vm, \
+             patch("run_agent.is_persistent_env", return_value=False):
+            agent._cleanup_task_resources("task-123")
+            mock_cleanup_browser.assert_not_called()
+            mock_cleanup_vm.assert_called_once_with("task-123")
+
+    def test_vm_cleanup_still_honours_persistent_env(self, agent):
+        """VM persistence logic is unchanged by the browser flag."""
+        agent._browser_persistent_sessions = True
+        with patch("run_agent.cleanup_browser") as mock_cleanup_browser, \
+             patch("run_agent.cleanup_vm") as mock_cleanup_vm, \
+             patch("run_agent.is_persistent_env", return_value=True):
+            agent._cleanup_task_resources("task-123")
+            mock_cleanup_browser.assert_not_called()
+            mock_cleanup_vm.assert_not_called()

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -534,6 +534,26 @@ browser:
 
 When enabled, recording starts automatically on the first `browser_navigate` and saves to `~/.hermes/browser_recordings/` when the session closes. Works in both local and cloud (Browserbase) modes. Recordings older than 72 hours are automatically cleaned up.
 
+## Persistent Sessions Across Turns
+
+By default, Hermes closes the browser at the end of every agent turn. This is normally fine, but when a task spans multiple turns (e.g. the agent asks for clarification, the user replies, and the agent continues), the browser state is lost and the agent must start over.
+
+To keep the browser session alive across turns, add this to `~/.hermes/config.yaml`:
+
+```yaml
+browser:
+  persistent_sessions: true  # default: false
+```
+
+When enabled:
+- The browser session is **not** torn down at the end of each turn.
+- The agent can continue interacting with the same page after a `clarify` or other multi-turn exchange.
+- The session is still closed when:
+  - The agent instance is fully destroyed (e.g. `/new`, gateway restart, or process exit).
+  - The browser inactivity timeout fires (default: 2 minutes of idle time).
+
+This is independent of `browser.camofox.managed_persistence` (which preserves the Firefox profile on the Camofox server) and works with all browser backends.
+
 ## Stealth Features
 
 Browserbase provides automatic stealth capabilities:


### PR DESCRIPTION
## What

Adds an opt-in `browser.persistent_sessions` config flag that keeps the browser session alive across agent turns instead of tearing it down after every turn.

## Why

Currently, Hermes closes the browser at the end of each turn. When a task spans multiple turns (e.g. the agent hits a blocker like a missing form field, asks the user a clarifying question, and then continues), the browser state is lost and the agent must start over. This is especially painful for long interactive workflows.

With `persistent_sessions: true`, the browser stays open so the agent can resume exactly where it left off after a `clarify` or any other multi-turn exchange.

## Changes

- **hermes_cli/config.py** — adds `browser.persistent_sessions: false` default
- **run_agent.py** — reads the flag in `__init__`; `_cleanup_task_resources` skips `cleanup_browser` when persistent
- **tests/run_agent/test_run_agent.py** — 3 unit tests covering default behaviour, persistent skip, and VM persistence unaffected
- **website/docs/user-guide/features/browser.md** — user-facing documentation

## How to test

1. Set `browser.persistent_sessions: true` in `~/.hermes/config.yaml`
2. Start a task that requires browser interaction (e.g. "fill out a form on example.com")
3. Trigger a clarifying question mid-task (e.g. ask the agent to pause and ask you for missing info)
4. Reply to the clarifying question
5. Verify the agent resumes on the same page without reloading

Default behaviour (`false`) is unchanged — browser still closes per-turn.

## Platforms tested

- Telegram (gateway)

---

Fixes the per-turn browser refresh issue described above.