### PR TITLE
fix: read auxiliary.vision.model from config.yaml in vision/browser tools

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -207,8 +207,27 @@ def _get_command_timeout() -> int:
 
 
 def _get_vision_model() -> Optional[str]:
-    """Model for browser_vision (screenshot analysis — multimodal)."""
-    return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    """Model for browser_vision (screenshot analysis — multimodal).
+
+    Resolution order:
+      1. ``AUXILIARY_VISION_MODEL`` env var (explicit override)
+      2. ``auxiliary.vision.model`` in config.yaml
+      3. ``None`` (caller lets the auxiliary router auto-detect)
+    """
+    env_model = os.getenv("AUXILIARY_VISION_MODEL", "").strip()
+    if env_model:
+        return env_model
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        cfg = load_config()
+        cfg_model = cfg_get(cfg, "auxiliary", "vision", "model")
+        if cfg_model is not None:
+            cfg_model = str(cfg_model).strip()
+            if cfg_model:
+                return cfg_model
+    except Exception:
+        pass
+    return None
 
 
 def _get_extraction_model() -> Optional[str]:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1039,11 +1039,24 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         logger.debug("Native vision fast-path check failed; using aux LLM: %s", exc)
 
     # Legacy path: aux LLM describes the image and we return its text.
+    # Resolve model: env var takes precedence, then config.yaml, then None
+    # (lets the auxiliary router auto-detect).
     full_prompt = (
         "Fully describe and explain everything about this image, then answer the "
         f"following question:\n\n{question}"
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    if not model:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            _cfg = load_config()
+            _cfg_model = cfg_get(_cfg, "auxiliary", "vision", "model")
+            if _cfg_model is not None:
+                _cfg_model = str(_cfg_model).strip()
+                if _cfg_model:
+                    model = _cfg_model
+        except Exception:
+            pass
     return vision_analyze_tool(image_url, full_prompt, model)
 
 
@@ -1407,6 +1420,20 @@ def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         f"transitions. Then answer the following question:\n\n{question}"
     )
     model = os.getenv("AUXILIARY_VIDEO_MODEL", "").strip() or os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
+    if not model:
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            _cfg = load_config()
+            # Try auxiliary.video.model first, then auxiliary.vision.model
+            _cfg_model = cfg_get(_cfg, "auxiliary", "video", "model")
+            if not _cfg_model:
+                _cfg_model = cfg_get(_cfg, "auxiliary", "vision", "model")
+            if _cfg_model is not None:
+                _cfg_model = str(_cfg_model).strip()
+                if _cfg_model:
+                    model = _cfg_model
+        except Exception:
+            pass
     return video_analyze_tool(video_url, full_prompt, model)
 
 


### PR DESCRIPTION
## Problem

`vision_analyze`, `browser_vision`, and `video_analyze` tools only read the vision model from the `AUXILIARY_VISION_MODEL` **environment variable**, ignoring the `auxiliary.vision.model` setting in `config.yaml`.

When users configure a custom vision model via config.yaml:
```yaml
auxiliary:
  vision:
    model: nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
    api_key: sk-...
```

The tools still use the auto-detected default (often `google/gemma-4-31b-it:free` from Nous Portal free tier), making it impossible to work around rate limits by switching to a different vision model.

## Fix

Each tool now reads from `config.yaml` as fallback when the env var is not set.

**Resolution order:** env var (`AUXILIARY_VISION_MODEL`) > `auxiliary.vision.model` in config.yaml > `None` (lets auxiliary router auto-detect)

### Files changed:
- `tools/browser_tool.py`: `_get_vision_model()` now reads `auxiliary.vision.model` from config
- `tools/vision_tools.py`: `_handle_vision_analyze` and `_handle_video_analyze` now read `auxiliary.vision.model` / `auxiliary.video.model` from config

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `auxiliary.vision.model` set in config, no env var | Ignored (auto-detect picks Gemma) | Respected ✓ |
| `AUXILIARY_VISION_MODEL` env var set | Used ✓ | Used ✓ (still takes precedence) |
| Neither set | Auto-detect | Auto-detect (unchanged) |

## Tests

- `py_compile` passes on both modified files
- 189 vision-related tests pass (0 regressions)
- Pre-existing test failures (missing optional deps) unchanged

Fixes #24842