### PR TITLE
fix(anthropic): strip native SDK /v1 base URL suffix

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,6 +17,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
@@ -361,6 +362,38 @@ def _normalize_base_url_text(base_url) -> str:
     return str(base_url).strip()
 
 
+def _normalize_anthropic_sdk_base_url(base_url) -> str:
+    """Return a base URL safe to pass to Anthropic's native SDK.
+
+    The SDK appends ``/v1/messages`` itself. Users sometimes configure the
+    OpenAI-style Anthropic models endpoint root (``https://api.anthropic.com/v1``),
+    which would make the SDK request ``/v1/v1/messages``. Only strip the suffix
+    on Anthropic's own host; third-party Anthropic-compatible URLs may require
+    their explicit path.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return ""
+
+    try:
+        stripped = normalized.rstrip("/")
+        parsed = urlsplit(stripped)
+    except Exception:
+        return normalized
+
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    if (
+        parsed.scheme in {"http", "https"}
+        and hostname == "api.anthropic.com"
+        and parsed.path == "/v1"
+        and not parsed.query
+        and not parsed.fragment
+    ):
+        return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+    return normalized
+
+
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for non-Anthropic endpoints using the Anthropic Messages API.
 
@@ -553,7 +586,7 @@ def build_anthropic_client(
 
     from httpx import Timeout
 
-    normalized_base_url = _normalize_base_url_text(base_url)
+    normalized_base_url = _normalize_anthropic_sdk_base_url(base_url)
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
@@ -2075,5 +2108,4 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -111,6 +111,25 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
 
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.anthropic.com/v1",
+            "https://api.anthropic.com/v1/",
+        ],
+    )
+    def test_native_anthropic_base_url_strips_v1_for_sdk(self, base_url):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-x", base_url=base_url)
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.anthropic.com"
+
+    def test_custom_v1_base_url_is_preserved(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-x", base_url="https://custom.api.com/v1")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://custom.api.com/v1"
+
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(


### PR DESCRIPTION
## Summary
- normalize native Anthropic SDK base URLs so https://api.anthropic.com/v1 becomes https://api.anthropic.com before the SDK appends /v1/messages
- preserve /v1 paths for custom and third-party Anthropic-compatible endpoints
- add regression coverage for native /v1, trailing slash, and custom /v1 base URLs

Fixes #24833

## Tests
- uv run --frozen python -m pytest tests/agent/test_anthropic_adapter.py::TestBuildAnthropicClient -q -o 'addopts='
- uv run --frozen python -m pytest tests/agent/test_anthropic_adapter.py -q -o 'addopts='
- uv run --frozen python -m pytest tests/agent/test_auxiliary_transport_autodetect.py -q -o 'addopts='
- uv run --frozen python -m py_compile agent/anthropic_adapter.py
- uv run --with ruff ruff check agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py
- git diff --check