### PR TITLE
fix(tui): move system collapse limit to config

### DIFF
--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -1,7 +1,7 @@
 import { Ansi, Box, NoSelect, Text } from '@hermes/ink'
 import { memo, useState } from 'react'
 
-import { LONG_MSG } from '../config/limits.js'
+import { LONG_MSG, SYSTEM_COLLAPSE_CHARS } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
@@ -21,9 +21,6 @@ import { Md } from './markdown.js'
 import { StreamingMd } from './streamingMarkdown.js'
 import { ToolTrail } from './thinking.js'
 import { TodoPanel } from './todoPanel.js'
-
-// Collapse threshold for long system messages (system prompt etc.)
-const SYSTEM_COLLAPSE_CHARS = 400
 
 export const MessageLine = memo(function MessageLine({
   cols,

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -14,6 +14,7 @@ export const FULL_RENDER_TAIL_ITEMS = 8
 
 export const LONG_MSG = 300
 export const MAX_HISTORY = 800
+export const SYSTEM_COLLAPSE_CHARS = 400
 export const THINKING_COT_MAX = 160
 
 // Rows per wheel event (pre-accel). 1 keeps Ink's DECSTBM fast path live


### PR DESCRIPTION
## Summary
- export SYSTEM_COLLAPSE_CHARS from ui-tui/src/config/limits.ts
- import the shared limit in messageLine.tsx for long system message collapse handling

Closes #20667

## Checks
- npm run type-check
- npx eslint src/components/messageLine.tsx src/config/limits.ts
- git diff --check

Note: npm run lint still reports pre-existing unrelated lint errors outside this patch.