### PR TITLE
fix(vision): respect auxiliary vision routing

### DIFF
--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -1,7 +1,7 @@
 """Tests for auxiliary model config bridging — verifies that config.yaml values
 are properly mapped to environment variables by both CLI and gateway loaders.
 
-Also tests the vision_tools and browser_tool model override env vars.
+Also tests that vision tools leave model selection to the auxiliary router.
 """
 
 import json
@@ -229,27 +229,24 @@ class TestGatewayBridgeCodeParity:
 
 
 class TestVisionModelOverride:
-    """Test that AUXILIARY_VISION_MODEL env var overrides the default model in the handler."""
+    """Vision handlers should let call_llm(task="vision") resolve config."""
 
-    def test_env_var_overrides_default(self, monkeypatch):
+    def test_env_var_does_not_override_router(self, monkeypatch):
         monkeypatch.setenv("AUXILIARY_VISION_MODEL", "openai/gpt-4o")
         from tools.vision_tools import _handle_vision_analyze
         with patch("tools.vision_tools.vision_analyze_tool", new_callable=MagicMock) as mock_tool:
             mock_tool.return_value = '{"success": true}'
             _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
             call_args = mock_tool.call_args
-            # 3rd positional arg = model
-            assert call_args[0][2] == "openai/gpt-4o"
+            assert call_args[0][2] is None
 
-    def test_default_model_when_no_override(self, monkeypatch):
+    def test_no_explicit_model_when_no_env(self, monkeypatch):
         monkeypatch.delenv("AUXILIARY_VISION_MODEL", raising=False)
         from tools.vision_tools import _handle_vision_analyze
         with patch("tools.vision_tools.vision_analyze_tool", new_callable=MagicMock) as mock_tool:
             mock_tool.return_value = '{"success": true}'
             _handle_vision_analyze({"image_url": "http://test.jpg", "question": "test"})
             call_args = mock_tool.call_args
-            # With no AUXILIARY_VISION_MODEL env var, model should be None
-            # (the centralized call_llm router picks the provider default)
             assert call_args[0][2] is None
 
 

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -160,7 +160,6 @@ class TestBrowserVisionAnnotate:
         with (
             patch("tools.browser_tool._run_browser_command") as mock_cmd,
             patch("tools.browser_tool.call_llm") as mock_call_llm,
-            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
         ):
             mock_cmd.return_value = {"success": True, "data": {}}
             # Will fail at screenshot file read, but we can check the command
@@ -181,7 +180,6 @@ class TestBrowserVisionAnnotate:
         with (
             patch("tools.browser_tool._run_browser_command") as mock_cmd,
             patch("tools.browser_tool.call_llm") as mock_call_llm,
-            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
         ):
             mock_cmd.return_value = {"success": True, "data": {}}
             try:
@@ -216,7 +214,6 @@ class TestBrowserVisionConfig:
             patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
             patch("tools.browser_tool._cleanup_old_screenshots"),
             patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
-            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {"temperature": 1, "timeout": 45}}}),
             patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
         ):
@@ -240,7 +237,6 @@ class TestBrowserVisionConfig:
             patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
             patch("tools.browser_tool._cleanup_old_screenshots"),
             patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
-            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
             patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
             patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
         ):
@@ -250,6 +246,29 @@ class TestBrowserVisionConfig:
         assert result["analysis"] == "Default screenshot analysis"
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
+    def test_browser_vision_does_not_pass_stale_env_model(self, tmp_path, monkeypatch):
+        from tools.browser_tool import browser_vision
+
+        monkeypatch.setenv("AUXILIARY_VISION_MODEL", "stale/gemma")
+        shots_dir, screenshot = self._setup_screenshot(tmp_path)
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Configured screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {"model": "configured/model"}}}),
+            patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is True
+        assert mock_llm.call_args.kwargs["task"] == "vision"
+        assert "model" not in mock_llm.call_args.kwargs
 
 
 # ── auto-recording config ────────────────────────────────────────────

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -209,13 +209,13 @@ class TestHandleVisionAnalyze:
             assert "Describe the cat" in full_prompt
             assert "Fully describe and explain" in full_prompt
 
-    def test_uses_auxiliary_vision_model_env(self):
-        """AUXILIARY_VISION_MODEL env var should override DEFAULT_VISION_MODEL."""
+    def test_stale_auxiliary_vision_model_env_does_not_override_router(self):
+        """Stale env bridges must not override config-driven vision routing."""
         with (
             patch(
                 "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
             ) as mock_tool,
-            patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "custom/model-v1"}),
+            patch.dict(os.environ, {"AUXILIARY_VISION_MODEL": "stale/gemma"}),
         ):
             mock_tool.return_value = json.dumps({"result": "ok"})
             coro = _handle_vision_analyze(
@@ -224,17 +224,16 @@ class TestHandleVisionAnalyze:
             coro.close()
             call_args = mock_tool.call_args
             model = call_args[0][2]  # third positional arg
-            assert model == "custom/model-v1"
+            assert model is None
 
-    def test_falls_back_to_default_model(self):
-        """Without AUXILIARY_VISION_MODEL, model should be None (let call_llm resolve default)."""
+    def test_does_not_pass_explicit_model_when_env_absent(self):
+        """Without a direct override, call_llm(task="vision") resolves the model."""
         with (
             patch(
                 "tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock
             ) as mock_tool,
             patch.dict(os.environ, {}, clear=False),
         ):
-            # Ensure AUXILIARY_VISION_MODEL is not set
             os.environ.pop("AUXILIARY_VISION_MODEL", None)
             mock_tool.return_value = json.dumps({"result": "ok"})
             coro = _handle_vision_analyze(
@@ -243,8 +242,6 @@ class TestHandleVisionAnalyze:
             coro.close()
             call_args = mock_tool.call_args
             model = call_args[0][2]
-            # With no AUXILIARY_VISION_MODEL set, model should be None
-            # (the centralized call_llm router picks the default)
             assert model is None
 
     def test_empty_args_graceful(self):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -222,11 +222,6 @@ def _get_command_timeout() -> int:
     return result
 
 
-def _get_vision_model() -> Optional[str]:
-    """Model for browser_vision (screenshot analysis — multimodal)."""
-    return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
-
-
 def _get_extraction_model() -> Optional[str]:
     """Model for page snapshot text summarization — same as web_extract."""
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
@@ -3048,9 +3043,9 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     Take a screenshot of the current page and analyze it with vision AI.
 
     This tool captures what's visually displayed in the browser and sends it
-    to Gemini for analysis. Useful for understanding visual content that the
-    text-based snapshot may not capture (CAPTCHAs, verification challenges,
-    images, complex layouts, etc.).
+    to the configured auxiliary vision router for analysis. Useful for
+    understanding visual content that the text-based snapshot may not capture
+    (CAPTCHAs, verification challenges, images, complex layouts, etc.).
 
     The screenshot is saved persistently and its file path is returned alongside
     the analysis, so it can be shared with users via MEDIA:<path> in the response.
@@ -3195,8 +3190,8 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             f"Focus on answering the user's specific question."
         )
 
-        # Use the centralized LLM router
-        vision_model = _get_vision_model()
+        # Use the centralized LLM router. Do not pass a model here: task="vision"
+        # lets auxiliary.vision provider/model/base_url/api_key resolve together.
         logger.debug("browser_vision: analysing screenshot (%d bytes)",
                      len(_screenshot_bytes))
 
@@ -3233,8 +3228,6 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             "temperature": vision_temperature,
             "timeout": vision_timeout,
         }
-        if vision_model:
-            call_kwargs["model"] = vision_model
         # Try full-size screenshot; on size-related rejection, downscale and retry.
         try:
             response = call_llm(**call_kwargs)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -640,7 +640,7 @@ async def vision_analyze_tool(
     
     This tool accepts either an HTTP/HTTPS URL or a local file path. For URLs,
     it downloads the image first. In both cases, the image is converted to base64
-    and processed using Gemini 3 Flash Preview via OpenRouter API.
+    and processed via the centralized auxiliary vision router.
     
     The user_prompt parameter is expected to be pre-formatted by the calling
     function (typically model_tools.py) to include both full description
@@ -650,7 +650,8 @@ async def vision_analyze_tool(
         image_url (str): The URL or local file path of the image to analyze.
                          Accepts http://, https:// URLs or absolute/relative file paths.
         user_prompt (str): The pre-formatted prompt for the vision model
-        model (str): The vision model to use (default: google/gemini-3-flash-preview)
+        model (str): Optional explicit vision model. Usually omitted so
+                     auxiliary.vision config can resolve the model/provider.
     
     Returns:
         str: JSON string containing the analysis results with the following structure:
@@ -1043,8 +1044,7 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         "Fully describe and explain everything about this image, then answer the "
         f"following question:\n\n{question}"
     )
-    model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
-    return vision_analyze_tool(image_url, full_prompt, model)
+    return vision_analyze_tool(image_url, full_prompt, None)
 
 
 registry.register(


### PR DESCRIPTION
## Summary

- stop vision_analyze from passing stale AUXILIARY_VISION_MODEL values as explicit model overrides
- let browser_vision rely on call_llm(task="vision") so auxiliary.vision provider/model/base_url/api_key resolve together
- update regression tests around stale env bridges and browser screenshot vision routing

Fixes #24842

## Tests

- scripts/run_tests.sh tests/tools/test_vision_tools.py tests/tools/test_browser_console.py tests/tools/test_vision_native_fast_path.py tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_config_bridge.py
- .venv/bin/ruff check tools/vision_tools.py tools/browser_tool.py tests/tools/test_vision_tools.py tests/tools/test_browser_console.py tests/agent/test_auxiliary_config_bridge.py