### PR TITLE
fix(anthropic): strip native base url v1 suffix

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,6 +17,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
@@ -361,6 +362,26 @@ def _normalize_base_url_text(base_url) -> str:
     return str(base_url).strip()
 
 
+def _normalize_anthropic_sdk_base_url(base_url) -> str:
+    """Return a base URL safe to pass to the Anthropic SDK.
+
+    Anthropic's Python SDK appends ``/v1`` internally. If users configure the
+    native endpoint as ``https://api.anthropic.com/v1``, passing that through
+    produces requests to ``/v1/v1/messages``. Third-party Anthropic-compatible
+    endpoints may legitimately include ``/v1`` in their base URL, so only
+    normalize the official native API host.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized or not base_url_host_matches(normalized, "api.anthropic.com"):
+        return normalized
+
+    parts = urlsplit(normalized)
+    if parts.path.rstrip("/").lower() != "/v1":
+        return normalized
+
+    return urlunsplit((parts.scheme, parts.netloc, "", parts.query, parts.fragment)).rstrip("/")
+
+
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for non-Anthropic endpoints using the Anthropic Messages API.
 
@@ -553,7 +574,7 @@ def build_anthropic_client(
 
     from httpx import Timeout
 
-    normalized_base_url = _normalize_base_url_text(base_url)
+    normalized_base_url = _normalize_anthropic_sdk_base_url(base_url)
     _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
@@ -2075,5 +2096,4 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -155,6 +155,31 @@ class TestMinimaxBetaHeaders:
         )
         assert self._TOOL_BETA in betas
 
+
+class TestAnthropicBaseUrlNormalization:
+    """Native Anthropic SDK appends /v1 internally; do not pass it twice."""
+
+    def _build_and_get_base_url(self, base_url):
+        from agent.anthropic_adapter import build_anthropic_client
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("sk-ant-api03-real-key-here", base_url=base_url)
+            return mock_sdk.Anthropic.call_args[1].get("base_url")
+
+    def test_native_anthropic_strips_trailing_v1(self):
+        assert self._build_and_get_base_url(
+            "https://api.anthropic.com/v1"
+        ) == "https://api.anthropic.com"
+
+    def test_native_anthropic_strips_trailing_v1_slash(self):
+        assert self._build_and_get_base_url(
+            "https://api.anthropic.com/v1/"
+        ) == "https://api.anthropic.com"
+
+    def test_third_party_v1_base_url_is_preserved(self):
+        assert self._build_and_get_base_url(
+            "https://my-proxy.example.com/v1"
+        ) == "https://my-proxy.example.com/v1"
+
     # -- _common_betas_for_base_url unit tests ---------------------------
 
     def test_common_betas_none_url(self):


### PR DESCRIPTION
## Summary

- normalize native Anthropic base URLs before constructing the Anthropic SDK client
- strip a trailing `/v1` only for `api.anthropic.com`, since the SDK appends `/v1` itself
- preserve third-party Anthropic-compatible `/v1` base URLs unchanged

Fixes #24833

## Tests

- scripts/run_tests.sh tests/agent/test_minimax_provider.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_bedrock_1m_context.py tests/test_ctx_halving_fix.py
- .venv/bin/ruff check agent/anthropic_adapter.py tests/agent/test_minimax_provider.py