### PR TITLE
Fix: use ensure_ascii=False when writing cron jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -433,7 +433,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)


### PR DESCRIPTION
## Summary

The `json.dump()` call in `cron/jobs.py` that persists `~/.hermes/cron/jobs.json` was missing `ensure_ascii=False`. This caused Chinese (and other non-ASCII) characters in job prompts and names to be encoded as Unicode escape sequences (e.g. `\\u6bcf\\u65e5` instead of `每日`), making the config file unreadable for human inspection.

## Change

- `cron/jobs.py`: Added `ensure_ascii=False` to `json.dump()`

## Before / After

- Before: `"prompt": "\\u6bcf\\u65e5\\u65b0\\u95fb\\u901f\\u9012"`
- After: `"prompt": "每日新闻速递"`