### PR TITLE
fix(telegram): keep audio attachments as files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -832,6 +832,12 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    ".opus": "audio/opus",
+    ".wav": "audio/wav",
+    ".flac": "audio/flac",
 }
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4212,7 +4212,7 @@ class TelegramAdapter(BasePlatformAdapter):
         elif msg.video:
             msg_type = MessageType.VIDEO
         elif msg.audio:
-            msg_type = MessageType.AUDIO
+            msg_type = MessageType.DOCUMENT
         elif msg.voice:
             msg_type = MessageType.VOICE
         elif msg.document:
@@ -4264,7 +4264,9 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
 
-        # Download voice/audio messages to cache for STT transcription
+        # Download voice messages to cache for STT transcription.
+        # Telegram message.audio represents an attached audio/music file, not
+        # a voice note, so keep it as a document for the agent/transcribe skill.
         if msg.voice:
             try:
                 file_obj = await msg.voice.get_file()
@@ -4279,10 +4281,22 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 file_obj = await msg.audio.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
+                original_filename = getattr(msg.audio, "file_name", None) or "audio"
+                _, ext = os.path.splitext(original_filename)
+                ext = ext.lower()
+                audio_mime = (getattr(msg.audio, "mime_type", None) or "").lower()
+                if not ext and audio_mime:
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    ext = mime_to_ext.get(audio_mime, "")
+                if not ext:
+                    ext = ".mp3"
+                if not original_filename.lower().endswith(ext):
+                    original_filename = f"{original_filename}{ext}"
+                cached_path = cache_document_from_bytes(bytes(audio_bytes), original_filename)
                 event.media_urls = [cached_path]
-                event.media_types = ["audio/mp3"]
-                logger.info("[Telegram] Cached user audio at %s", cached_path)
+                event.media_types = [audio_mime or SUPPORTED_DOCUMENT_TYPES.get(ext, "audio/mpeg")]
+                event.message_type = MessageType.DOCUMENT
+                logger.info("[Telegram] Cached user audio attachment at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7141,7 +7141,10 @@ class GatewayRunner:
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
-                if mtype.startswith("audio/") or event.message_type in {MessageType.VOICE, MessageType.AUDIO}:
+                if event.message_type != MessageType.DOCUMENT and (
+                    mtype.startswith("audio/")
+                    or event.message_type in {MessageType.VOICE, MessageType.AUDIO}
+                ):
                     audio_paths.append(path)
 
             if image_paths:
@@ -7218,7 +7221,7 @@ class GatewayRunner:
                         guessed, _ = _mimetypes.guess_type(path)
                         if guessed:
                             mtype = guessed
-                if not mtype.startswith(("application/", "text/")):
+                if not mtype.startswith(("application/", "text/", "audio/")):
                     continue
 
                 basename = os.path.basename(path)
@@ -7236,6 +7239,13 @@ class GatewayRunner:
                         f"[The user sent a text document: '{display_name}'. "
                         f"Its content has been included below. "
                         f"The file is also saved at: {agent_path}]"
+                    )
+                elif mtype.startswith("audio/"):
+                    context_note = (
+                        f"[The user sent an audio file: '{display_name}'. "
+                        f"The file is saved at: {agent_path}. "
+                        f"Use the file path if the user asks for transcription "
+                        f"or audio analysis.]"
                     )
                 else:
                     context_note = (

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -114,3 +114,45 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_keeps_audio_document_as_file(tmp_path):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+
+    audio_path = tmp_path / "lecture.mp3"
+    audio_path.write_bytes(b"ID3 fake audio")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="please save this",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=[str(audio_path)],
+        media_types=["audio/mpeg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("audio document should not be auto-transcribed"),
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "audio file" in result.lower()
+    assert "lecture.mp3" in result
+    assert "please save this" in result

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -124,6 +124,14 @@ def _make_video(file_obj=None):
     return video
 
 
+def _make_audio(file_name="song.mp3", mime_type="audio/mpeg", file_obj=None):
+    audio = MagicMock()
+    audio.file_name = file_name
+    audio.mime_type = mime_type
+    audio.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"audio-bytes"))
+    return audio
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -146,6 +154,9 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
     )
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +172,21 @@ class TestDocumentTypeDetection:
         await adapter._handle_media_message(update, MagicMock())
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
+
+    @pytest.mark.asyncio
+    async def test_audio_attachment_is_document_not_voice(self, adapter):
+        """Telegram message.audio is a file attachment, not a voice message."""
+        audio = _make_audio(file_name="song.mp3", mime_type="audio/mpeg")
+        msg = _make_message(document=None)
+        msg.audio = audio
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["audio/mpeg"]
+        assert len(event.media_urls) == 1
 
     @pytest.mark.asyncio
     async def test_fallback_is_document(self, adapter):
@@ -197,6 +223,28 @@ class TestDocumentDownloadBlock:
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
         assert event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_audio_document_is_cached_as_file(self, adapter):
+        audio_bytes = b"ID3 fake audio"
+        file_obj = _make_file_obj(audio_bytes)
+        doc = _make_document(
+            file_name="lecture.mp3",
+            mime_type="audio/mpeg",
+            file_size=len(audio_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["audio/mpeg"]
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].endswith("lecture.mp3")
+        assert os.path.exists(event.media_urls[0])
 
     @pytest.mark.asyncio
     async def test_supported_txt_injects_content(self, adapter):


### PR DESCRIPTION
## Summary

- treat Telegram `message.audio` as an attached file/document instead of a voice message
- allow audio documents such as mp3/m4a/ogg/wav/flac to be cached and passed to the agent as files
- skip automatic STT for document audio while preserving STT for Telegram voice notes

Fixes #24870

## Tests

- scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_stt_config.py tests/gateway/test_tts_media_routing.py
- .venv/bin/ruff check gateway/platforms/base.py gateway/platforms/telegram.py gateway/run.py tests/gateway/test_telegram_documents.py tests/gateway/test_stt_config.py