### PR TITLE
feat: add Xiaomi MiMo Anthropic-compatible endpoint support for thinking mode

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,28 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+def _is_xiaomi_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Xiaomi MiMo's Anthropic-compatible endpoint.
+
+    Xiaomi's ``/anthropic`` route speaks the Anthropic Messages protocol
+    but, when thinking mode is enabled, requires the ``thinking`` blocks
+    from prior assistant turns to round-trip on subsequent requests — the
+    generic third-party path strips them and triggers HTTP 400::
+
+        The reasoning_content in the thinking mode must be passed back
+        to the API.
+
+    Similar to Kimi and DeepSeek, Xiaomi uses unsigned thinking blocks
+    (no Anthropic-proprietary signature). This endpoint is handled with
+    the same strip-signed / keep-unsigned policy used for Kimi and DeepSeek.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    normalized = normalized.rstrip("/").lower()
+    return "xiaomimimo.com" in normalized and "/anthropic" in normalized
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1745,15 +1767,17 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
-    # Anthropic Messages protocol upstream but require that thinking blocks
-    # synthesised from reasoning_content round-trip on subsequent turns when
-    # thinking is enabled.  Signed Anthropic blocks still have to be stripped
-    # (neither endpoint can validate Anthropic's signatures); unsigned blocks
-    # are preserved.  See hermes-agent#13848 (Kimi) and #16748 (DeepSeek).
+    # Kimi /coding, DeepSeek /anthropic, and Xiaomi /anthropic share a
+    # contract: all speak the Anthropic Messages protocol upstream but
+    # require that thinking blocks synthesised from reasoning_content
+    # round-trip on subsequent turns when thinking is enabled.  Signed
+    # Anthropic blocks still have to be stripped (none of these endpoints
+    # can validate Anthropic's signatures); unsigned blocks are preserved.
+    # See hermes-agent#13848 (Kimi), #16748 (DeepSeek), and Xiaomi MiMo.
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_anthropic_endpoint(base_url)
     )
 
     last_assistant_idx = None


### PR DESCRIPTION
## Summary

Add support for Xiaomi MiMo's Anthropic-compatible endpoint (`/anthropic`) for thinking mode. This fix resolves HTTP 400 errors when using Xiaomi MiMo models with thinking/reasoning enabled.

### Problem

When using Xiaomi MiMo model (`mimo-v2.5-pro`) via Anthropic-compatible endpoint (`https://token-plan-cn.xiaomimimo.com/anthropic`), enabling thinking mode causes HTTP 400 error:

```
HTTP 400: Param Incorrect
The reasoning_content in the thinking mode must be passed back to the API.
```

### Root Cause

Xiaomi's `/anthropic` endpoint, like Kimi and DeepSeek, uses the Anthropic Messages protocol but requires unsigned thinking blocks to be preserved when thinking mode is enabled. The current code strips all thinking blocks for third-party endpoints, causing Xiaomi's API to not receive the required `reasoning_content`.

### Solution

Following the approach used for Kimi and DeepSeek endpoints:

1. Added `_is_xiaomi_anthropic_endpoint()` detection function
2. Added Xiaomi endpoint to `_preserve_unsigned_thinking` condition in `convert_messages_to_anthropic()`

This preserves unsigned thinking blocks synthesized from `reasoning_content` while stripping Anthropic's signed blocks, matching the behavior for Kimi and DeepSeek endpoints.

## Test plan

- [x] Test Xiaomi MiMo model with thinking mode enabled (`reasoning_effort: medium/high`)
- [x] Verify no HTTP 400 errors when using thinking mode
- [x] Verify thinking blocks are properly preserved in multi-turn conversations
- [x] Verify existing Kimi and DeepSeek endpoints still work correctly

## Related issues

Closes #24884

---

**Note:** This PR was created by ClaudeCode powered by MiMo-2.5-Pro.