### PR TITLE
fix(prompt_builder): use TERMINAL_CWD in system prompt when configured

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -772,7 +772,13 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            # Prefer the explicitly configured terminal.cwd (bridged to
+            # TERMINAL_CWD by the gateway) over the process's actual cwd,
+            # which may be the daemon's launch directory rather than the
+            # user's intended workspace.
+            terminal_cwd = os.getenv("TERMINAL_CWD", "").strip()
+            effective_cwd = terminal_cwd if terminal_cwd else os.getcwd()
+            host_lines.append(f"Current working directory: {effective_cwd}")
         except OSError:
             pass
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -939,6 +939,30 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in result
         assert "/workspace" in result
 
+    def test_build_environment_hints_prefers_terminal_cwd(self, monkeypatch):
+        """When TERMINAL_CWD is set, the system prompt should show that path."""
+        import agent.prompt_builder as _pb
+        import sys
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", "/Users/test/my-workspace")
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Current working directory: /Users/test/my-workspace" in result
+
+    def test_build_environment_hints_falls_back_to_getcwd(self, monkeypatch):
+        """When TERMINAL_CWD is empty, os.getcwd() is used."""
+        import agent.prompt_builder as _pb
+        import sys, os
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert f"Current working directory: {os.getcwd()}" in result
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb


### PR DESCRIPTION
## What does this PR do?

`build_environment_hints()` always uses `os.getcwd()` for the "Current working directory" line in the system prompt, ignoring the `terminal.cwd` config setting. When Hermes runs as a daemon (e.g. via launchd), `os.getcwd()` reflects the daemon's launch directory rather than the user's configured workspace.


### Root Cause

In `agent/prompt_builder.py`, `build_environment_hints()` calls `os.getcwd()` directly (line 775) without checking the `TERMINAL_CWD` environment variable, which the gateway sets from `terminal.cwd` in config.yaml.

## Related Issue

Fixes #24882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Blast radius**: LOW — single function (`build_environment_hints`) in `hermes_cli/prompt_builder.py`
- **Scope**: Only affects the "Current working directory" line in the system prompt
- **Risk**: None — reads from config instead of `os.getcwd()`, falls back to `os.getcwd()` if config is unset
- **Tests**: Existing tests cover `build_environment_hints()` output