### PR TITLE
fix(cli): hide deprecated `hermes login` from --help (#24756)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12095,10 +12095,19 @@ def main():
     # =========================================================================
     # login command
     # =========================================================================
+    # `hermes login` was removed in favor of `hermes auth` (see PR #5670 and
+    # the runtime in `hermes_cli/auth.py::login_command`).  The subparser
+    # itself is kept so old scripts that invoke `hermes login [--flags]` get
+    # the actionable deprecation message instead of an argparse error, but
+    # ``help=argparse.SUPPRESS`` hides the entry from ``hermes --help`` so
+    # users don't discover and try a command that no longer works (#24756).
     login_parser = subparsers.add_parser(
         "login",
-        help="Authenticate with an inference provider",
-        description="Run OAuth device authorization flow for Hermes CLI",
+        help=argparse.SUPPRESS,
+        description=(
+            "Deprecated. Use `hermes auth` to manage credentials, "
+            "`hermes model` to select a provider, or `hermes setup` for full setup."
+        ),
     )
     login_parser.add_argument(
         "--provider",

--- a/tests/hermes_cli/test_startup_plugin_gating.py
+++ b/tests/hermes_cli/test_startup_plugin_gating.py
@@ -178,3 +178,78 @@ def test_builtin_set_has_no_phantom_entries():
         f"_BUILTIN_SUBCOMMANDS has entries that are not registered as "
         f"top-level subparsers: {sorted(phantom)}"
     )
+
+
+# ── deprecated `hermes login` subparser is hidden from --help (#24756) ─────
+
+
+def _hermes_help_text() -> str:
+    """Capture ``hermes --help`` output via in-process invocation."""
+    from hermes_cli import main as _main
+
+    argv_backup = sys.argv[:]
+    sys.argv = ["hermes", "--help"]
+    buf = io.StringIO()
+    try:
+        with patch.object(_main, "_plugin_cli_discovery_needed", return_value=False):
+            with redirect_stdout(buf):
+                with pytest.raises(SystemExit):
+                    _main.main()
+    finally:
+        sys.argv = argv_backup
+    return buf.getvalue()
+
+
+def test_login_subparser_hidden_from_help_description():
+    """The deprecated `hermes login` subcommand must not advertise itself.
+
+    `hermes login` is a removed command whose runtime (`login_command` in
+    `hermes_cli/auth.py`) prints a deprecation message and exits.  Until #5670
+    only the documentation/error-message references were migrated to `hermes
+    auth` — the subparser itself was still registered with a help string
+    ("Authenticate with an inference provider") that made it look like a
+    working command in `hermes --help`.  Issue #24756 flagged the
+    inconsistency: users discover the command from `--help`, run it, and are
+    told it has been removed.
+
+    Hiding the description row via `help=argparse.SUPPRESS` is the minimum
+    surgical fix.  Old scripts that invoke `hermes login [--flags]` still get
+    the actionable deprecation message rather than an argparse error.
+    """
+    text = _hermes_help_text()
+    # The misleading description row that pointed users at a removed command:
+    assert "Authenticate with an inference provider" not in text, (
+        "Deprecated `hermes login` description still shown in --help: \n" + text
+    )
+    # Sanity check: actually-functional auth subcommand is still listed.
+    assert "auth" in text
+
+
+def test_login_command_still_responds_with_deprecation_message():
+    """Hidden-from-help must NOT mean removed-from-argv.
+
+    Old scripts/aliases invoking `hermes login [--flags]` should keep
+    receiving the existing "command has been removed → use `hermes auth`"
+    message rather than an argparse "invalid choice: 'login'" error.
+    """
+    from hermes_cli.auth import login_command
+
+    class _Args:
+        provider = None
+        portal_url = None
+        inference_url = None
+        client_id = None
+        scope = None
+        no_browser = False
+        timeout = 15.0
+        ca_bundle = None
+        insecure = False
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        with pytest.raises(SystemExit) as exc_info:
+            login_command(_Args())
+    assert exc_info.value.code == 0
+    out = buf.getvalue()
+    assert "has been removed" in out
+    assert "hermes auth" in out


### PR DESCRIPTION
## Summary

- Hide the deprecated `hermes login` subparser from `hermes --help` via `help=argparse.SUPPRESS` so users don't discover a command that no longer works.
- Keep the subparser registered so existing scripts/aliases that invoke `hermes login [--flags]` still receive the actionable deprecation message rather than an argparse `invalid choice: 'login'` error.
- Rewrite the parser description to match the runtime's deprecation message (visible if a user runs `hermes login --help`).

## The bug

#24756 reports a confusing UX during fresh macOS setup:

> `hermes login --provider openai-codex` is shown in help, but running it says the command was removed and to use `hermes auth` instead.

`hermes login` was deprecated in favor of `hermes auth` by #5670, but that PR only updated documentation and error-message references — it left the actual subparser registration in [`hermes_cli/main.py`](hermes_cli/main.py) intact, with a help string `"Authenticate with an inference provider"` that still surfaces in `hermes --help`. When a user follows that lead, the runtime in [`hermes_cli/auth.py::login_command`](hermes_cli/auth.py) just prints "The 'hermes login' command has been removed" and exits.

## The fix

1. `subparsers.add_parser("login", help=argparse.SUPPRESS, description=…)` — the misleading row in `hermes --help` is gone, but the parser keeps accepting the old flags so scripted callers don't break.
2. Description rewrites to mirror the runtime deprecation hint (`hermes auth` / `hermes model` / `hermes setup`), visible on `hermes login --help`.
3. Symmetric `logout` is intentionally left alone — `logout_command` is still fully functional (clears auth state, resets active provider config).

Same hiding pattern is already used in `hermes_cli/kanban.py` for an undocumented escape hatch flag, so this is consistent with project precedent.

## Test plan

- [x] **Focused regression tests** (`tests/hermes_cli/test_startup_plugin_gating.py`):
  - `test_login_subparser_hidden_from_help_description` — runs `hermes --help` in-process, asserts the misleading description row is gone, asserts the `auth` subcommand is still listed.
  - `test_login_command_still_responds_with_deprecation_message` — invokes `login_command` directly with a stub `args`, asserts SystemExit(0) and the "command has been removed" + "hermes auth" message contract is preserved for scripted callers.
- [x] **Adjacent suite**: full `tests/hermes_cli/test_startup_plugin_gating.py` — **38 passed**, 1 failed (`test_builtin_set_covers_every_registered_subcommand` is the unrelated pre-existing `lsp` baseline failure on `origin/main`; addressed by my open PR #24738).
- [x] **Regression guard**: with the SUPPRESS change reverted, `test_login_subparser_hidden_from_help_description` fails with `"Authenticate with an inference provider" still in --help`. With the deprecation message gutted, `test_login_command_still_responds_with_deprecation_message` fails.

## Scope note

#24756 bundles six independent setup issues (DMG install error -36, desktop installer stuck, default provider/model states, Codex device-authorization blocker, this `login` discoverability issue, and `~/.codex/auth.json` not auto-imported). This PR fixes only the discoverability issue (item 5). The remaining items are out of scope and need separate triage — happy to follow up on `~/.codex/auth.json` auto-import in a separate PR if useful.

> Sibling code paths that may need the same fix: none — `logout`, `auth`, `model`, `setup` are all live functional commands. Only `login` is the deprecation shim.

## Related

- Refs #24756 (one of six issues bundled in that report)
- Builds on #5670 (replaced stale docs/error references but left the visible subparser)