### PR TITLE
fix: include context_length in run_conversation result

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -15459,6 +15459,7 @@ class AIAgent:
             "completion_tokens": self.session_completion_tokens,
             "total_tokens": self.session_total_tokens,
             "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
+            "context_length": getattr(self.context_compressor, "context_length", 0) or 0,
             "estimated_cost_usd": self.session_estimated_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,


### PR DESCRIPTION
## Problem

The runtime footer (gateway/run.py) reads context_length from agent_result to compute context_pct. Previously run_conversation() did not include this field in its return dict, so the footer always fell back to None and the percentage was either hidden or computed against a wrong default.

This was especially visible with Kimi K2.6 (262K context) where users would see 29% after just a few messages because the footer was using a fallback value instead of the actual configured context length.

## Fix

Add context_length from self.context_compressor to the result dict returned by run_conversation().

## Testing

- [x] Verified that context_length is now present in the returned dict
- [x] Footer correctly computes percentage against the configured value (262144 for Kimi K2.6)

Fixes context length display for all providers, not just Kimi.