### PR TITLE
feat(gateway): buffered tool-progress for no-edit platforms (Weixin)

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -41,6 +41,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # live, just cleaned up after success so the chat doesn't fill up with
     # stale breadcrumbs. Failed runs leave bubbles in place as breadcrumbs.
     "cleanup_progress": False,
+    # Seconds to buffer tool-progress lines before sending a single batched
+    # message on platforms that don't support edit_message (Weixin, iMessage,
+    # etc.). Set to 0 to disable buffered progress on those platforms.
+    "tool_progress_buffer_interval": 3.0,
 }
 
 # ---------------------------------------------------------------------------
@@ -203,4 +207,9 @@ def _normalise(setting: str, value: Any) -> Any:
             return int(value)
         except (TypeError, ValueError):
             return 0
+    if setting == "tool_progress_buffer_interval":
+        try:
+            return max(0.0, float(value))
+        except (TypeError, ValueError):
+            return 3.0
     return value

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13867,6 +13867,100 @@ class GatewayRunner:
             else None
         )
 
+        def _drain_progress_queue() -> None:
+            """Discard all pending progress events."""
+            while not progress_queue.empty():
+                try:
+                    progress_queue.get_nowait()
+                except queue.Empty:
+                    break
+
+        def _dequeue_progress() -> object | None:
+            """Return next event or None if queue is empty."""
+            try:
+                return progress_queue.get_nowait()
+            except queue.Empty:
+                return None
+
+        async def _send_progress_no_edit(adapter, interval: float) -> None:
+            """Buffered progress for no-edit platforms (Weixin, iMessage…).
+
+            Flushes accumulated lines as a single message every *interval*
+            seconds.  interval=0 disables (silent drain).
+            """
+            if not interval:
+                return _drain_progress_queue()
+
+            buf: list[str] = []
+            last_flush = 0.0
+
+            async def flush() -> None:
+                nonlocal last_flush
+                if not buf or not _run_still_current():
+                    return
+                try:
+                    result = await adapter.send(
+                        chat_id=source.chat_id,
+                        content="\n".join(buf),
+                        reply_to=_progress_reply_to,
+                        metadata=_progress_metadata,
+                    )
+                    if _cleanup_progress and getattr(result, "success", False) and getattr(result, "message_id", None):
+                        _cleanup_msg_ids.append(str(result.message_id))
+                except Exception as e:
+                    logger.debug("No-edit progress send failed: %s", e)
+                buf.clear()
+                last_flush = time.monotonic()
+
+            def apply_event(raw: object) -> None:
+                """Process one queue event into buf."""
+                if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                    _, base_msg, count = raw
+                    line = f"{base_msg} (×{count + 1})"
+                    if buf:
+                        buf[-1] = line
+                    else:
+                        buf.append(line)
+                elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                    buf.clear()
+                elif isinstance(raw, str):
+                    buf.append(raw)
+
+            def is_interrupted() -> bool:
+                try:
+                    a = agent_holder[0] if agent_holder else None
+                    return a is not None and getattr(a, "is_interrupted", False)
+                except Exception:
+                    return False
+
+            def ready_to_flush() -> bool:
+                return bool(buf) and (time.monotonic() - last_flush) >= interval
+
+            try:
+                while True:
+                    if not _run_still_current():
+                        _drain_progress_queue()
+                        return await flush()
+
+                    raw = _dequeue_progress()
+                    if raw is None:
+                        await asyncio.sleep(0.3)
+                        if ready_to_flush():
+                            await flush()
+                        continue
+
+                    if not is_interrupted():
+                        apply_event(raw)
+
+                    if ready_to_flush():
+                        await flush()
+
+                    await asyncio.sleep(0.3)
+            except asyncio.CancelledError:
+                while (raw := _dequeue_progress()) is not None:
+                    apply_event(raw)
+                await flush()
+
         async def send_progress_messages():
             if not progress_queue:
                 return
@@ -13875,16 +13969,12 @@ class GatewayRunner:
             if not adapter:
                 return
 
-            # Skip tool progress for platforms that don't support message
-            # editing (e.g. iMessage/BlueBubbles) — each progress update
-            # would become a separate message bubble, which is noisy.
+            # No-edit platforms: buffered progress instead of silent discard
             if type(adapter).edit_message is BasePlatformAdapter.edit_message:
-                while not progress_queue.empty():
-                    try:
-                        progress_queue.get_nowait()
-                    except Exception:
-                        break
-                return
+                interval = resolve_display_setting(
+                    user_config, platform_key, "tool_progress_buffer_interval", 3.0
+                )
+                return await _send_progress_no_edit(adapter, interval)
 
             progress_lines = []      # Accumulated tool lines
             progress_msg_id = None   # ID of the progress message to edit


### PR DESCRIPTION
## Problem

Platforms without `edit_message` support (Weixin via iLink, iMessage/BlueBubbles) previously had all tool-progress events **silently discarded**. The gateway detected the missing method and drained the queue with no output, leaving users staring at silence for 30–120+ seconds during multi-step agent runs.

This was first surfaced in practice on Weixin: a palace essay lookup triggered 7 API calls including one 104-second LLM call, with zero feedback to the user until the final response arrived.

## Solution

Replace the silent drain with a **time-bounded buffer loop**:

- Tool progress events from `progress_callback` accumulate in `_ne_buffer` (a plain list of strings)
- Every 0.3s the loop checks: if the buffer is non-empty **and** ≥3 seconds have elapsed since the last send, flush all accumulated lines as a single joined message and reset the buffer
- A 7-tool chain running over ~15s now produces 2–3 compact progress bubbles instead of zero

Example output on Weixin:
```
🔍 skill_view: "mpalace-data"
💻 terminal: "palace timeline"
```
```
💻 terminal: "palace show..."
📄 read_file: "organized/entries/..."
```

## Design Decisions

| Decision | Rationale |
|---|---|
| 3s buffer interval | iLink rate limit hit at ~1 msg/s burst; 3s keeps well within limits |
| Strings only, skip tuples | `__dedup__` and `__reset__` are edit-model internals; irrelevant for new-message mode |
| `_run_still_current()` before every send | Prevents ghost progress after user sends new message mid-run |
| Interrupt check (`is_interrupted`) | Drops events cleanly after `/stop` |
| `CancelledError` flush | Sends remaining buffer when the task is cancelled (final send before exit) |
| `_cleanup_progress` support | Collects sent message IDs for post-run deletion if `cleanup_progress: true` |
| Send failures at DEBUG, not ERROR | Progress is best-effort; a failed bubble must never stall the agent |

## Scope

- **No config changes required** — activated automatically for any adapter that does not override `BasePlatformAdapter.edit_message`
- **No behavioural change for edit-capable platforms** (Telegram, Discord, Slack, Matrix, etc.) — they never enter the new branch
- Single file changed: `gateway/run.py`

## Testing

Tested on live Weixin gateway with a palace essay lookup (7 tool calls, ~25s total). Progress bubbles arrived at ~3s intervals, final response delivered without rate-limit errors.