### PR TITLE
feat(agent): support user-provided extra CA bundles for OpenAI/httpx clients

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -185,7 +185,7 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
-from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
+from utils import atomic_json_write, base_url_host_matches, base_url_hostname, configure_extra_ca_bundle, env_var_enabled, normalize_proxy_url
 from hermes_cli.config import cfg_get
 
 
@@ -6492,10 +6492,15 @@ class AIAgent:
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
             _proxy = _get_proxy_for_base_url(base_url)
-            return _httpx.Client(
-                transport=_httpx.HTTPTransport(socket_options=_sock_opts),
-                proxy=_proxy,
-            )
+            _kwargs: "dict[str, Any]" = {
+                "transport": _httpx.HTTPTransport(socket_options=_sock_opts),
+                "proxy": _proxy,
+            }
+            _verify = configure_extra_ca_bundle()
+            if _verify:
+                import ssl as _ssl
+                _kwargs["verify"] = _ssl.create_default_context(cafile=_verify)
+            return _httpx.Client(**_kwargs)
         except Exception:
             return None
 

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -18,11 +18,28 @@ This test pins that the constructed ``httpx.Client`` mounts an ``HTTPProxy``
 pool when a proxy env var is set, AND that the socket-level keepalive
 transport is still installed on the no-proxy default path.
 """
+import os
 from unittest.mock import patch
 
 import httpx
 
 from run_agent import AIAgent, _get_proxy_from_env, _get_proxy_for_base_url
+from utils import configure_extra_ca_bundle
+
+
+def _clear_ca_env(monkeypatch):
+    for key in (
+        "HERMES_EXTRA_CA_CERTS",
+        "NODE_EXTRA_CA_CERTS",
+        "HERMES_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "_HERMES_CA_BASE_BUNDLE",
+    ):
+        if key in os.environ:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, "")
 
 
 def _make_agent():
@@ -83,6 +100,7 @@ def test_create_openai_client_routes_via_proxy_when_env_set(mock_openai, monkeyp
     transport suppressed httpx's env-proxy auto-detection, so requests bypassed
     the proxy entirely.
     """
+    _clear_ca_env(monkeypatch)
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy"):
         monkeypatch.delenv(key, raising=False)
@@ -119,6 +137,7 @@ def test_create_openai_client_routes_via_proxy_when_env_set(mock_openai, monkeyp
 def test_create_openai_client_no_proxy_when_env_unset(mock_openai, monkeypatch):
     """Without proxy env vars, the keepalive transport must still be installed
     and no HTTPProxy mount should exist."""
+    _clear_ca_env(monkeypatch)
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy"):
         monkeypatch.delenv(key, raising=False)
@@ -192,6 +211,7 @@ def test_get_proxy_for_base_url_returns_none_when_proxy_unset(monkeypatch):
 def test_create_openai_client_bypasses_proxy_for_no_proxy_host(mock_openai, monkeypatch):
     """E2E: with HTTPS_PROXY + NO_PROXY=localhost, a local base_url gets a
     keepalive client with NO HTTPProxy mount."""
+    _clear_ca_env(monkeypatch)
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy",
                 "NO_PROXY", "no_proxy"):
@@ -218,3 +238,59 @@ def test_create_openai_client_bypasses_proxy_for_no_proxy_host(mock_openai, monk
         "NO_PROXY host must not route through HTTPProxy; pools were %r" % (pool_types,)
     )
     http_client.close()
+
+
+def test_extra_ca_bundle_merges_even_when_ssl_cert_file_preconfigured(monkeypatch, tmp_path):
+    """Gateway startup order: SSL_CERT_FILE pre-set, HERMES_EXTRA_CA_CERTS loaded later.
+
+    Hermes must merge the extra CA instead of treating an existing SSL_CERT_FILE
+    as final. The generated bundle must contain both base and extra certs.
+    """
+    _clear_ca_env(monkeypatch)
+    base_ca = tmp_path / "base-ca.pem"
+    base_ca.write_text("BASE-CA-CONTENT")
+    extra_ca = tmp_path / "extra-ca.pem"
+    extra_ca.write_text("EXTRA-CA-CONTENT")
+    bundle_path = tmp_path / "merged-bundle.pem"
+
+    monkeypatch.setenv("SSL_CERT_FILE", str(base_ca))
+    monkeypatch.setenv("HERMES_EXTRA_CA_CERTS", str(extra_ca))
+    monkeypatch.setenv("HERMES_CA_BUNDLE", str(bundle_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    result = configure_extra_ca_bundle()
+
+    assert result == str(bundle_path)
+    merged = bundle_path.read_text()
+    assert "BASE-CA-CONTENT" in merged
+    assert "EXTRA-CA-CONTENT" in merged
+    assert os.environ["SSL_CERT_FILE"] == str(bundle_path)
+    assert os.environ["REQUESTS_CA_BUNDLE"] == str(bundle_path)
+
+
+def test_extra_ca_bundle_is_idempotent_when_ssl_cert_file_is_generated_bundle(monkeypatch, tmp_path):
+    """Repeated calls must not duplicate extra CA contents."""
+    _clear_ca_env(monkeypatch)
+    base_ca = tmp_path / "base-ca.pem"
+    base_ca.write_text("BASE-CA-CONTENT")
+    extra_ca = tmp_path / "extra-ca.pem"
+    extra_ca.write_text("EXTRA-CA-CONTENT")
+    bundle_path = tmp_path / "merged-bundle.pem"
+
+    monkeypatch.setenv("SSL_CERT_FILE", str(base_ca))
+    monkeypatch.setenv("HERMES_EXTRA_CA_CERTS", str(extra_ca))
+    monkeypatch.setenv("HERMES_CA_BUNDLE", str(bundle_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    first_result = configure_extra_ca_bundle()
+    first_content = bundle_path.read_text()
+
+    second_result = configure_extra_ca_bundle()
+    second_content = bundle_path.read_text()
+
+    assert first_result == str(bundle_path)
+    assert second_result == str(bundle_path)
+    assert first_content == second_content
+    assert first_content.count("EXTRA-CA-CONTENT") == 1, (
+        "Extra CA content must not be duplicated on repeated calls"
+    )

--- a/utils.py
+++ b/utils.py
@@ -295,6 +295,8 @@ _PROXY_ENV_KEYS = (
     "https_proxy", "http_proxy", "all_proxy",
 )
 
+_TLS_CA_ENV_KEYS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE")
+
 
 def normalize_proxy_url(proxy_url: str | None) -> str | None:
     """Normalize proxy URLs for httpx/aiohttp compatibility.
@@ -318,6 +320,129 @@ def normalize_proxy_env_vars() -> None:
         normalized = normalize_proxy_url(value)
         if normalized and normalized != value:
             os.environ[key] = normalized
+    configure_extra_ca_bundle()
+
+
+# ─── Extra CA Bundle ──────────────────────────────────────────────────────────
+
+
+def configure_extra_ca_bundle() -> "str | None":
+    """Build a merged CA bundle that includes user-provided extra CA certs.
+
+    Reads extra CA paths from ``HERMES_EXTRA_CA_CERTS`` and
+    ``NODE_EXTRA_CA_CERTS`` (both ``os.pathsep``-separated path lists).
+
+    When extra CA files are configured this helper:
+
+    * determines the base CA bundle from ``SSL_CERT_FILE``,
+      ``REQUESTS_CA_BUNDLE``, ``certifi.where()`` or Python's default
+      ``ssl.get_default_verify_paths().cafile``
+    * writes a merged bundle to ``HERMES_CA_BUNDLE`` (or
+      ``$HERMES_HOME/hermes-ca-bundle.pem``)
+    * sets ``SSL_CERT_FILE`` and ``REQUESTS_CA_BUNDLE`` to point at the
+      merged bundle
+    * records the original base bundle in ``_HERMES_CA_BASE_BUNDLE`` so
+      repeated calls are idempotent
+
+    Returns the merged bundle path, or ``None`` when no extra CA files
+    are configured (or when ``HERMES_DISABLE_EXTRA_CA_AUTO`` is truthy).
+    """
+    if env_var_enabled("HERMES_DISABLE_EXTRA_CA_AUTO"):
+        return None
+
+    # Collect extra CA paths
+    extra_ca_raw = os.getenv("HERMES_EXTRA_CA_CERTS", "")
+    node_extra_ca_raw = os.getenv("NODE_EXTRA_CA_CERTS", "")
+
+    extra_paths: "list[Path]" = []
+    for raw in (extra_ca_raw, node_extra_ca_raw):
+        if not raw or not raw.strip():
+            continue
+        for part in raw.split(os.pathsep):
+            part = part.strip()
+            if not part:
+                continue
+            p = Path(part)
+            if p not in extra_paths:
+                extra_paths.append(p)
+
+    if not extra_paths:
+        # No extra CA certs — return existing bundle if set, else None
+        for key in _TLS_CA_ENV_KEYS:
+            val = os.getenv(key, "")
+            if val and Path(val).exists():
+                return val
+        return None
+
+    # Determine base CA bundle
+    base_bundle = os.getenv("_HERMES_CA_BASE_BUNDLE", "")
+    if not base_bundle or not Path(base_bundle).exists():
+        for key in _TLS_CA_ENV_KEYS:
+            val = os.getenv(key, "")
+            if val and Path(val).exists():
+                base_bundle = val
+                break
+        if not base_bundle or not Path(base_bundle).exists():
+            try:
+                import certifi
+                base_bundle = certifi.where()
+            except Exception:
+                base_bundle = ""
+        if not base_bundle or not Path(base_bundle).exists():
+            import ssl
+            base_bundle = ssl.get_default_verify_paths().cafile or ""
+        if not base_bundle or not Path(base_bundle).exists():
+            return None
+
+    # Determine output path
+    output_env = os.getenv("HERMES_CA_BUNDLE", "")
+    if output_env:
+        bundle_path = Path(output_env)
+    else:
+        try:
+            from hermes_constants import get_hermes_home
+            hermes_home = get_hermes_home()
+        except Exception:
+            hermes_home = Path.home() / ".hermes"
+        bundle_path = Path(hermes_home) / "hermes-ca-bundle.pem"
+
+    # Read extra cert contents
+    extra_certs: "list[str]" = []
+    for p in extra_paths:
+        if not p.exists():
+            continue
+        try:
+            extra_certs.append(p.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+
+    if not extra_certs:
+        # All extra paths were missing/unreadable
+        for key in _TLS_CA_ENV_KEYS:
+            val = os.getenv(key, "")
+            if val and Path(val).exists():
+                return val
+        return None
+
+    # Build merged bundle
+    try:
+        base_content = Path(base_bundle).read_text(encoding="utf-8")
+    except Exception:
+        base_content = ""
+
+    merged = base_content
+    for cert in extra_certs:
+        if cert not in merged:
+            merged = merged.rstrip("\n") + "\n" + cert
+
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle_path.write_text(merged, encoding="utf-8")
+
+    os.environ["_HERMES_CA_BASE_BUNDLE"] = str(Path(base_bundle).resolve())
+    os.environ["SSL_CERT_FILE"] = str(bundle_path.resolve())
+    os.environ["REQUESTS_CA_BUNDLE"] = str(bundle_path.resolve())
+
+    return str(bundle_path.resolve())
 
 
 # ─── URL Parsing Helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This adds generic extra CA bundle support for Hermes' Python/httpx-based OpenAI client path.

When users configure extra CA cert files via `HERMES_EXTRA_CA_CERTS` or `NODE_EXTRA_CA_CERTS`, Hermes now builds a merged CA bundle and uses it for the keepalive-enabled httpx client used by the main agent.

This helps in environments where an HTTPS proxy presents certificates signed by a local/private root CA. The change keeps TLS verification enabled and does not hardcode any organization, vendor, or company-specific CA paths.

Closes #24917.

## Details

### New helper: `configure_extra_ca_bundle()`

Added in `utils.py`.

The helper:

- reads extra CA paths from:
  - `HERMES_EXTRA_CA_CERTS`
  - `NODE_EXTRA_CA_CERTS`
- supports path-list values using `os.pathsep`
- filters missing files
- deduplicates cert paths
- builds a merged CA bundle from:
  - existing `SSL_CERT_FILE` or `REQUESTS_CA_BUNDLE`, when configured
  - otherwise `certifi.where()`
  - otherwise Python's default SSL cafile
- writes the merged bundle to:
  - `HERMES_CA_BUNDLE`, if set
  - otherwise `$HERMES_HOME/hermes-ca-bundle.pem`
- sets:
  - `SSL_CERT_FILE`
  - `REQUESTS_CA_BUNDLE`
- stores the original base bundle in `_HERMES_CA_BASE_BUNDLE` so repeated calls are idempotent
- supports opt-out via `HERMES_DISABLE_EXTRA_CA_AUTO`

### Proxy normalization path

`normalize_proxy_env_vars()` now calls `configure_extra_ca_bundle()` after normalizing proxy env vars.

This keeps proxy and TLS trust configuration on the same runtime initialization path.

### Main OpenAI/httpx client

`AIAgent._build_keepalive_http_client()` now calls `configure_extra_ca_bundle()`.

If a merged bundle is available, the httpx client receives:

```python
ssl.create_default_context(cafile=bundle_path)
```

This preserves the existing keepalive transport and explicit proxy handling while also allowing Python/httpx to trust user-provided extra CA roots.

The implementation uses an `SSLContext` instead of `verify=<str>` to avoid httpx's deprecation warning for string verify paths.

## Why this is needed

Hermes can already route requests through proxies, but proxy routing alone is not sufficient when the proxy presents certificates signed by a CA that Python/httpx does not trust.

Some users already have extra CA configuration for Node-based tools via `NODE_EXTRA_CA_CERTS`, but Hermes' Python/httpx clients do not automatically consume that setting.

Gateway mode also has a specific ordering issue: `SSL_CERT_FILE` may be set before `.env` is loaded. The new helper handles this by merging extra CA files even when `SSL_CERT_FILE` is already present.

## Tests

Added regression coverage in `tests/run_agent/test_create_openai_client_proxy_env.py`:

- existing proxy tests now clear CA-related env vars to avoid cross-test contamination
- extra CA bundle is merged when `SSL_CERT_FILE` is preconfigured
- repeated calls are idempotent and do not duplicate extra CA contents

## How to test

```bash
env HERMES_HOME=/private/tmp/hermes-pytest \
  venv/bin/python -m pytest \
  tests/run_agent/test_create_openai_client_proxy_env.py \
  tests/agent/test_proxy_and_url_validation.py
```

All 27 tests pass.

## Platforms tested

- macOS 15.x (darwin, arm64)

## Validation

- `git diff --check`: passed
- Targeted tests: 27 passed
- Full suite (`scripts/run_tests.sh`): 22,000+ passed, failures are pre-existing (optional deps: discord, faster_whisper, bedrock)