### PR TITLE
fix(tools): improve cua window targeting

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -289,6 +289,159 @@ class TestCaptureResponse:
 
 
 # ---------------------------------------------------------------------------
+# cua-driver window targeting regressions
+# ---------------------------------------------------------------------------
+
+class TestCuaWindowTargeting:
+    class FakeCuaSession:
+        def __init__(self, on_screen_windows, all_windows=None, apps=None):
+            self.on_screen_windows = on_screen_windows
+            self.all_windows = all_windows if all_windows is not None else on_screen_windows
+            self.apps = apps or []
+
+        def call_tool(self, name, args, timeout=30.0):
+            if name == "list_windows":
+                windows = self.on_screen_windows if args.get("on_screen_only") else self.all_windows
+                return {
+                    "data": None,
+                    "images": [],
+                    "structuredContent": {"windows": windows},
+                    "isError": False,
+                }
+            if name == "list_apps":
+                return {"data": self.apps, "images": [], "structuredContent": None, "isError": False}
+            if name == "get_window_state":
+                return {
+                    "data": '✅ FakeApp — 0 elements\n- [1] AXWindow "Fake Window"',
+                    "images": [],
+                    "structuredContent": None,
+                    "isError": False,
+                }
+            raise AssertionError(f"unexpected tool call: {name}")
+
+    def _backend(self, *, on_screen_windows, all_windows=None, apps=None):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = self.FakeCuaSession(on_screen_windows, all_windows, apps)
+        return backend
+
+    def test_explicit_app_target_does_not_fall_back_to_unrelated_window(self):
+        backend = self._backend(on_screen_windows=[
+            {"app_name": "Notes", "pid": 1, "window_id": 10, "is_on_screen": True, "z_index": 0},
+            {"app_name": "Mail", "pid": 2, "window_id": 20, "is_on_screen": True, "z_index": 1},
+        ])
+
+        assert backend._select_window("Browser") is None
+        cap = backend.capture(mode="ax", app="Browser")
+        assert cap.app == ""
+        assert cap.window_title == "No window found for app 'Browser'."
+
+    def test_focus_app_target_does_not_fall_back_to_unrelated_window(self):
+        backend = self._backend(on_screen_windows=[
+            {"app_name": "Notes", "pid": 1, "window_id": 10, "is_on_screen": True, "z_index": 0},
+        ])
+
+        result = backend.focus_app("Browser")
+        assert not result.ok
+        assert backend._active_pid is None
+        assert "No window found" in result.message
+
+    def test_app_query_matches_list_apps_name_by_pid_for_decorated_app_name(self):
+        backend = self._backend(
+            on_screen_windows=[
+                {"app_name": "Unknown", "pid": 37031, "window_id": 7, "is_on_screen": True, "z_index": 0},
+            ],
+            apps=[{"name": "- Browser", "pid": 37031, "bundle_id": "com.example.browser"}],
+        )
+
+        target = backend._select_window("Browser")
+        assert target is not None
+        assert target["pid"] == 37031
+
+    def test_bundle_id_query_matches_window_via_list_apps_metadata(self):
+        backend = self._backend(
+            on_screen_windows=[
+                {"app_name": "Unknown", "pid": 37031, "window_id": 7, "is_on_screen": True, "z_index": 0},
+            ],
+            apps=[{"name": "- Browser", "pid": 37031, "bundle_id": "com.example.browser"}],
+        )
+
+        target = backend._select_window("com.example.browser")
+        assert target is not None
+        assert target["window_id"] == 7
+
+    def test_explicit_app_target_can_fall_back_to_offscreen_window(self):
+        backend = self._backend(
+            on_screen_windows=[
+                {"app_name": "Notes", "pid": 1, "window_id": 10, "is_on_screen": True, "z_index": 0},
+            ],
+            all_windows=[
+                {"app_name": "Notes", "pid": 1, "window_id": 10, "is_on_screen": True, "z_index": 0},
+                {"app_name": "- Browser", "pid": 37031, "window_id": 7, "is_on_screen": False, "z_index": 9},
+            ],
+        )
+
+        target = backend._select_window("Browser")
+        assert target is not None
+        assert target["pid"] == 37031
+
+    def test_app_query_prefers_titled_content_window_over_titleless_utility_window(self):
+        backend = self._backend(on_screen_windows=[
+            {"app_name": "Browser", "pid": 37031, "window_id": 1, "title": "", "is_on_screen": True, "z_index": 0},
+            {"app_name": "Browser", "pid": 37031, "window_id": 2, "title": "Documentation", "is_on_screen": True, "z_index": 1},
+        ])
+
+        target = backend._select_window("Browser")
+        assert target is not None
+        assert target["window_id"] == 2
+
+    def test_app_identity_match_beats_unrelated_matching_window_title(self):
+        backend = self._backend(on_screen_windows=[
+            {"app_name": "Notes", "pid": 1, "window_id": 10, "title": "Browser", "is_on_screen": True, "z_index": 0},
+            {"app_name": "Browser", "pid": 2, "window_id": 20, "title": "", "is_on_screen": True, "z_index": 1},
+        ])
+
+        target = backend._select_window("Browser")
+        assert target is not None
+        assert target["pid"] == 2
+
+    def test_offscreen_app_identity_match_beats_onscreen_title_match(self):
+        backend = self._backend(
+            on_screen_windows=[
+                {"app_name": "Notes", "pid": 1, "window_id": 10, "title": "Browser", "is_on_screen": True, "z_index": 0},
+            ],
+            all_windows=[
+                {"app_name": "Notes", "pid": 1, "window_id": 10, "title": "Browser", "is_on_screen": True, "z_index": 0},
+                {"app_name": "Browser", "pid": 2, "window_id": 20, "title": "", "is_on_screen": False, "z_index": 99},
+            ],
+        )
+
+        target = backend._select_window("Browser")
+        assert target is not None
+        assert target["pid"] == 2
+
+    def test_capture_after_prefers_backend_capture_active(self):
+        from tools.computer_use import tool as cu_tool
+        from tools.computer_use.backend import ActionResult, CaptureResult
+
+        class FakeBackend:
+            def key(self, keys):
+                return ActionResult(ok=True, action="key", message=f"pressed {keys}")
+
+            def capture(self, mode="som", app=None):
+                return CaptureResult(mode=mode, width=1, height=1, app="WrongApp")
+
+            def capture_active(self, mode="som"):
+                return CaptureResult(mode=mode, width=1, height=1, app="Ghostty")
+
+        out = cu_tool._dispatch(FakeBackend(), "key", {"keys": "escape", "capture_after": True})
+        parsed = json.loads(out)
+        assert parsed["app"] == "Ghostty"
+        assert parsed["action"] == "key"
+
+
+# ---------------------------------------------------------------------------
 # Anthropic adapter: multimodal tool-result conversion
 # ---------------------------------------------------------------------------
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -102,8 +102,34 @@ def _parse_windows_from_text(text: str) -> List[Dict[str, Any]]:
             "pid": int(m.group(2)),
             "window_id": int(m.group(3)),
             "off_screen": "[off-screen]" in m.group(0),
+            "title": "",
+            "bundle_id": "",
+            "z_index": 0,
         })
     return windows
+
+
+def _normalize_match_text(value: Any) -> str:
+    """Normalize app/window identifiers for conservative matching."""
+    text = str(value or "").strip().lower()
+    # Some apps surface names with leading UI decoration, e.g. "- Browser".
+    # Treat leading decoration as noise without changing meaningful bundle IDs
+    # or names.
+    text = re.sub(r"^[\s\-–—_:•]+", "", text).strip()
+    return re.sub(r"\s+", " ", text)
+
+
+def _prefix_word_match(query: str, candidate: str) -> bool:
+    """Return True for prefix matches that stop on a word boundary.
+
+    This keeps "Code" from matching "Codex", while still allowing app/window
+    names like "Code - project" or "Browser Settings".
+    """
+    if not candidate.startswith(query):
+        return False
+    if len(candidate) == len(query):
+        return True
+    return not candidate[len(query)].isalnum()
 
 
 def _parse_elements_from_tree(markdown: str) -> List[UIElement]:
@@ -336,18 +362,10 @@ class CuaDriverBackend(ComputerUseBackend):
             return False
         return cua_driver_binary_available()
 
-    # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        """Capture the frontmost on-screen window (optionally filtered by app name).
+    def _list_windows(self, on_screen_only: bool) -> List[Dict[str, Any]]:
+        """Return normalized cua-driver window records sorted frontmost first."""
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": on_screen_only})
 
-        Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
-        `get_window_state` (ax/som) or `screenshot` (vision).
-        """
-        # Step 1: enumerate on-screen windows to find target pid/window_id.
-        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
-
-        # Prefer structuredContent.windows (MCP 2024-11-05+); fall back to
-        # text-line parsing for older cua-driver builds.
         sc = lw_out.get("structuredContent") or {}
         raw_windows = sc.get("windows") if sc else None
         if raw_windows:
@@ -358,38 +376,229 @@ class CuaDriverBackend(ComputerUseBackend):
                     "window_id": int(w["window_id"]),
                     "off_screen": not w.get("is_on_screen", True),
                     "title": w.get("title", ""),
+                    "bundle_id": (
+                        w.get("bundle_id")
+                        or w.get("bundle_identifier")
+                        or w.get("bundleIdentifier")
+                        or ""
+                    ),
                     "z_index": w.get("z_index", 0),
                 }
                 for w in raw_windows
             ]
-            # Sort by z_index descending (lowest z_index = frontmost on macOS).
-            windows.sort(key=lambda w: w["z_index"])
+            # cua-driver reports lower z_index as closer to the front on macOS.
+            windows.sort(key=lambda w: w.get("z_index", 0))
         else:
             raw_text = lw_out["data"] if isinstance(lw_out["data"], str) else ""
             windows = _parse_windows_from_text(raw_text)
 
-        if not windows:
-            return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
-                                 elements=[], app="", window_title="", png_bytes_len=0)
+        if windows:
+            self._augment_windows_from_apps(windows)
+        return windows
 
-        # Filter by app name (case-insensitive substring) if requested.
+    def _augment_windows_from_apps(self, windows: List[Dict[str, Any]]) -> None:
+        """Merge list_apps metadata into windows by PID.
+
+        Some cua-driver window records expose surprising app names, while
+        list_apps can still have the canonical app name and bundle ID. Merge
+        that metadata by PID so matching can use whichever identifier the
+        platform exposes most reliably.
+        """
+        try:
+            apps = self.list_apps()
+        except Exception:
+            return
+        by_pid: Dict[int, Dict[str, Any]] = {}
+        for app in apps:
+            try:
+                pid = int(app.get("pid"))
+            except (TypeError, ValueError):
+                continue
+            by_pid[pid] = app
+
+        for window in windows:
+            app = by_pid.get(window.get("pid"))
+            if not app:
+                continue
+            window.setdefault("bundle_id", "")
+            window["bundle_id"] = (
+                window.get("bundle_id")
+                or app.get("bundle_id")
+                or app.get("bundle_identifier")
+                or app.get("bundleIdentifier")
+                or ""
+            )
+            window["list_app_name"] = app.get("name", "")
+
+    def _window_match_score(self, query: str, window: Dict[str, Any]) -> int:
+        q_raw = str(query or "").strip().lower()
+        q = _normalize_match_text(query)
+        if not q:
+            return 0
+
+        pid = str(window.get("pid", ""))
+        if q_raw and q_raw == pid:
+            return 400
+
+        identity_fields = [
+            window.get("bundle_id", ""),
+            window.get("app_name", ""),
+            window.get("list_app_name", ""),
+        ]
+        title_fields = [window.get("title", "")]
+        identity = [_normalize_match_text(f) for f in identity_fields if f]
+        titles = [_normalize_match_text(f) for f in title_fields if f]
+
+        # App identity beats window title. A query for an app should not select
+        # an unrelated app just because that unrelated window has a matching
+        # document title.
+        if q in identity:
+            return 320
+        for candidate in identity:
+            if _prefix_word_match(q, candidate):
+                return 300
+        if len(q) >= 4:
+            for candidate in identity:
+                if q in candidate:
+                    return 240
+
+        # Title is useful as a fallback for users who pass a visible window
+        # title, but it stays lower confidence than any app/bundle/PID match.
+        if q in titles:
+            return 160
+        for candidate in titles:
+            if _prefix_word_match(q, candidate):
+                return 140
+        if len(q) >= 4:
+            for candidate in titles:
+                if q in candidate:
+                    return 80
+        return 0
+
+    def _window_preference_score(self, window: Dict[str, Any]) -> int:
+        """Prefer normal content windows over transient titleless utility windows.
+
+        Some apps expose several same-process windows with the same app name.
+        The frontmost entry can be a hover card, About box, or titleless
+        auxiliary surface. When the app query matches several windows equally,
+        prefer windows that look like real browsing/document content.
+        """
+        score = 0
+        title = str(window.get("title") or "").strip()
+        if title:
+            score += 20
+        if not window.get("off_screen"):
+            score += 5
+        return score
+
+    def _select_window(self, app: str) -> Optional[Dict[str, Any]]:
+        """Select the best window for an explicit app query, or None.
+
+        Explicit app targeting must never silently fall back to the first
+        unrelated window. Rank on-screen and off-screen candidates together so
+        a strong app-identity match is not beaten by a weak on-screen title
+        match from another app.
+        """
+        windows_by_key: Dict[Tuple[int, int], Dict[str, Any]] = {}
+        order_by_key: Dict[Tuple[int, int], int] = {}
+        order = 0
+        for on_screen_only in (True, False):
+            for window in self._list_windows(on_screen_only=on_screen_only):
+                key = (int(window.get("pid", 0)), int(window.get("window_id", 0)))
+                if key not in windows_by_key:
+                    windows_by_key[key] = window
+                    order_by_key[key] = order
+                    order += 1
+                else:
+                    # Keep useful metadata from the all-windows pass, but do
+                    # not let it downgrade an already observed on-screen window.
+                    existing = windows_by_key[key]
+                    for field, value in window.items():
+                        if field != "off_screen" and value not in (None, ""):
+                            existing[field] = value
+                    if not window.get("off_screen"):
+                        existing["off_screen"] = False
+
+        scored = []
+        for key, window in windows_by_key.items():
+            match = self._window_match_score(app, window)
+            if match > 0:
+                scored.append((match, self._window_preference_score(window), order_by_key[key], window))
+        if not scored:
+            return None
+
+        # Highest match score wins; for ties prefer likely content windows,
+        # then preserve frontmost order.
+        scored.sort(key=lambda item: (-item[0], -item[1], item[2]))
+        return scored[0][3]
+
+    def _default_window(self) -> Optional[Dict[str, Any]]:
+        """Return the frontmost window for captures without an explicit app."""
+        for on_screen_only in (True, False):
+            windows = self._list_windows(on_screen_only=on_screen_only)
+            if windows:
+                return next((w for w in windows if not w.get("off_screen")), windows[0])
+        return None
+
+    def _empty_capture(self, mode: str, message: str = "") -> CaptureResult:
+        return CaptureResult(mode=mode, width=0, height=0, png_b64=None,
+                             elements=[], app="", window_title=message,
+                             png_bytes_len=0)
+
+    # ── Capture ────────────────────────────────────────────────────
+    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+        """Capture the frontmost on-screen window (optionally filtered by app name).
+
+        Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
+        `get_window_state` (ax/som) or `screenshot` (vision).
+        """
         if app:
-            app_lower = app.lower()
-            filtered = [w for w in windows if app_lower in w["app_name"].lower()]
-            if filtered:
-                windows = filtered
+            target = self._select_window(app)
+            if target is None:
+                return self._empty_capture(mode, f"No window found for app '{app}'.")
+        else:
+            target = self._default_window()
+            if target is None:
+                return self._empty_capture(mode)
 
-        # Pick first on-screen window (sorted by z_index / z-order above).
-        target = next((w for w in windows if not w["off_screen"]), windows[0])
-        self._active_pid = target["pid"]
-        self._active_window_id = target["window_id"]
-        app_name = target["app_name"]
+        return self._capture_window(mode, target)
 
-        # Step 2: capture.
+    def capture_active(self, mode: str = "som") -> CaptureResult:
+        """Capture the sticky active window after an action.
+
+        `capture_after` should not re-run generic frontmost-window selection,
+        because that can lose the target selected by capture/focus_app and land
+        on an unrelated app. Preserve the stored pid/window_id whenever we can.
+        """
+        if self._active_pid is None or self._active_window_id is None:
+            return self.capture(mode=mode)
+        target = None
+        try:
+            for window in self._list_windows(on_screen_only=False):
+                if (window.get("pid") == self._active_pid
+                        and window.get("window_id") == self._active_window_id):
+                    target = window
+                    break
+        except Exception:
+            target = None
+        if target is None:
+            target = {
+                "pid": self._active_pid,
+                "window_id": self._active_window_id,
+                "app_name": "",
+                "title": "",
+            }
+        return self._capture_window(mode, target)
+
+    def _capture_window(self, mode: str, target: Dict[str, Any]) -> CaptureResult:
+        self._active_pid = int(target["pid"])
+        self._active_window_id = int(target["window_id"])
+        app_name = target.get("app_name") or target.get("list_app_name", "")
+
         png_b64: Optional[str] = None
         elements: List[UIElement] = []
         width = height = 0
-        window_title = ""
+        window_title = str(target.get("title", "") or "")
 
         if mode == "vision":
             # screenshot tool: just the PNG, no AX walk.
@@ -593,45 +802,26 @@ class CuaDriverBackend(ComputerUseBackend):
 
         cua-driver background-automation never needs to bring a window to the
         front: capture(app=...) already selects the right window via
-        list_windows. We implement focus_app as a pure window-selector —
-        enumerate on-screen windows, find the best match for *app*, and store
-        its pid/window_id so that subsequent click/type calls hit the right
-        process.
+        list_windows. We implement focus_app as a pure window-selector. An
+        explicit app target must not silently fall back to a random first
+        window, because that routes later keys/clicks to the wrong app.
 
         raise_window=True is intentionally ignored: stealing the user's focus
         is exactly what this backend is designed to avoid.
         """
-        lw_out = self._session.call_tool("list_windows", {"on_screen_only": True})
-        sc = lw_out.get("structuredContent") or {}
-        raw_windows = sc.get("windows") if sc else None
-        if raw_windows:
-            windows = [
-                {
-                    "app_name": w.get("app_name", ""),
-                    "pid": int(w["pid"]),
-                    "window_id": int(w["window_id"]),
-                    "z_index": w.get("z_index", 0),
-                }
-                for w in raw_windows
-            ]
-            windows.sort(key=lambda w: w["z_index"])
-        else:
-            raw_text = lw_out["data"] if isinstance(lw_out["data"], str) else ""
-            windows = _parse_windows_from_text(raw_text)
+        target = self._select_window(app)
+        if not target:
+            return ActionResult(ok=False, action="focus_app",
+                                message=f"No window found for app '{app}'.")
 
-        app_lower = app.lower()
-        matched = [w for w in windows if app_lower in w["app_name"].lower()]
-        target = matched[0] if matched else (windows[0] if windows else None)
-        if target:
-            self._active_pid = target["pid"]
-            self._active_window_id = target["window_id"]
-            return ActionResult(
-                ok=True, action="focus_app",
-                message=f"Targeted {target['app_name']} (pid {self._active_pid}, "
-                        f"window {self._active_window_id}) without raising window.",
-            )
-        return ActionResult(ok=False, action="focus_app",
-                            message=f"No on-screen window found for app '{app}'.")
+        self._active_pid = int(target["pid"])
+        self._active_window_id = int(target["window_id"])
+        app_name = target.get("app_name") or target.get("list_app_name", "")
+        return ActionResult(
+            ok=True, action="focus_app",
+            message=f"Targeted {app_name} (pid {self._active_pid}, "
+                    f"window {self._active_window_id}) without raising window.",
+        )
 
     # ── Internal ───────────────────────────────────────────────────
     def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -457,7 +457,11 @@ def _maybe_follow_capture(
     if not do_capture:
         return _text_response(res)
     try:
-        cap = backend.capture(mode="som")
+        capture_active = getattr(backend, "capture_active", None)
+        if callable(capture_active):
+            cap = capture_active(mode="som")
+        else:
+            cap = backend.capture(mode="som")
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)


### PR DESCRIPTION
## What does this PR do?

Fixes generic cua-driver window targeting issues in the `computer_use` backend:

- explicit `capture(app=...)` and `focus_app(app=...)` requests no longer silently fall back to an unrelated frontmost window
- app/window matching now ranks candidates by confidence across PID, bundle ID, app name, `list_apps` metadata, and window title
- app identity matches outrank title-only matches, so a document title from another app does not steal an app-targeted request
- on-screen and off-screen candidates are ranked together, so a strong off-screen app identity match beats a weak on-screen title match
- `capture_after=true` prefers `capture_active()` when the backend supports it, preserving the active target after actions
- same-process tied windows prefer titled content windows over titleless utility surfaces

The change is deliberately generic. It does not special-case any app or bundle ID.

## Related Issue

Related to #24170.

Also searched related open PRs before opening this draft:

- #24181 covers `type`/`drag` cua-driver behavior
- #24242 covers capture-after app context and label parsing
- #24324 covers no-match fallback behavior for `capture(app=...)`

This draft is narrower than a full issue rollup but broader than a single-app workaround: it focuses on generic app/window selection and active capture semantics.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/computer_use/cua_backend.py`
  - normalizes app/window identifiers conservatively
  - merges `list_apps` metadata into window records by PID
  - selects explicit app targets by ranked match confidence instead of falling back to the first window
  - supports bundle ID, PID, app name, list-app name, and title matching without app-specific branches
  - adds `capture_active()` to preserve the selected pid/window after actions
  - prefers titled content windows over titleless utility windows for equal-confidence same-app matches
- `tools/computer_use/tool.py`
  - updates `capture_after` handling to call backend `capture_active()` when available
- `tests/tools/test_computer_use.py`
  - adds regression coverage for no unrelated fallback, decorated app names, bundle ID matching, off-screen app matching, app identity vs title ranking, titled-window preference, `focus_app`, and `capture_after`

## How to Test

1. Run targeted backend tests:

   ```bash
   python -m compileall -q tools/computer_use/cua_backend.py tests/tools/test_computer_use.py
   python -m pytest tests/tools/test_computer_use.py -q -o 'addopts='
   git diff --check -- tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py
   ```

2. Run lint/static guardrails:

   ```bash
   ruff check .
   python scripts/check-windows-footguns.py --all
   ```

3. Manual macOS verification with cua-driver-backed `computer_use`:

   - `capture(app="<target app>")` returns the requested app/window instead of a random frontmost app
   - `focus_app(app="<target app>")` targets the requested app or returns a no-window-found error
   - actions with `capture_after=true` capture the active target instead of reselecting an unrelated window

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Current CI Note

The PR `test` job is failing with unrelated suite-wide failures that also reproduce on current `main`'s latest push CI (`25782318256`), including missing optional dependencies (`botocore`, `faster_whisper`, `numpy`) and unrelated DingTalk/Feishu/CLI failures. The touched `computer_use` tests pass locally, and the other PR checks are green.

## Screenshots / Logs

Validation run:

```text
python -m compileall -q tools/computer_use/cua_backend.py tests/tools/test_computer_use.py
python -m pytest tests/tools/test_computer_use.py -q -o 'addopts='
.....................................................                    [100%]
53 passed in 1.41s

git diff --check -- tools/computer_use/cua_backend.py tools/computer_use/tool.py tests/tools/test_computer_use.py
# passed

ruff check .
All checks passed!

python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (421 file(s) scanned).
```

Note: I attempted a local full-suite run with `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`, then with `-n 4`. Those local runs did not complete cleanly on this macOS checkout due unrelated large-suite failures/hangs, including an initial `Too many open files` failure under `-n auto`. This draft keeps the full-suite checkbox unchecked pending CI or a cleaner local full-suite run.