### PR TITLE
fix(acp): preserve leading/trailing whitespace in message content rendering (#24592)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -189,12 +189,12 @@ def _render_message_content(content: Any) -> str:
     if content is None:
         return ""
     if isinstance(content, str):
-        return content.strip()
+        return content
     if isinstance(content, dict):
         if "text" in content:
-            return str(content.get("text") or "").strip()
+            return str(content.get("text") or "")
         if "content" in content and isinstance(content.get("content"), str):
-            return str(content.get("content") or "").strip()
+            return str(content.get("content") or "")
         return json.dumps(content, ensure_ascii=True)
     if isinstance(content, list):
         parts: list[str] = []
@@ -204,9 +204,9 @@ def _render_message_content(content: Any) -> str:
             elif isinstance(item, dict):
                 text = item.get("text")
                 if isinstance(text, str) and text.strip():
-                    parts.append(text.strip())
-        return "\n".join(parts).strip()
-    return str(content).strip()
+                    parts.append(text)
+        return "\n".join(parts)
+    return str(content)
 
 
 def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:


### PR DESCRIPTION
## Problem

Issue #24592 reports that LLM responses via the `api_server` path arrive with inter-word whitespace stripped (e.g. "Hey there!" becomes "Heythere!"). The root cause is the same `.strip()` anti-pattern that commit 1173adbe8 fixed for the ACP client chunk processing path, present in `_render_message_content`.

## Root Cause

`_render_message_content` in `agent/copilot_acp_client.py` applies `.strip()` to content values throughout:

- `return content.strip()` — strips leading/trailing whitespace from string content (line 192)
- `str(content.get("text") or "").strip()` — strips text from dict entries (line 195)
- `str(content.get("content") or "").strip()` — strips content from dict entries (line 197)
- `parts.append(text.strip())` — strips individual text parts before joining (line 207)
- `"\n".join(parts).strip()` — strips the final rendered result (line 208)
- `str(content).strip()` — strips the fallback result (line 209)

When conversation history messages are rendered into the prompt with stripped whitespace, subsequent LLM responses may mimic the compressed format, producing output without spaces. The bug persists for the remainder of the session because each turn feeds stripped history back to the model.

## Fix

Mirror the pattern from [1173adbe8](https://github.com/NousResearch/hermes-agent/commit/1173adbe86caeac1cfb5811d0a5bbf5ea6b9d9d0): preserve the original text content without stripping. The validation check (`text.strip()` for non-empty items) is retained to skip empty/whitespace-only items, but the actual content is no longer modified.

## Verification

- ✅ All existing tests pass (`tests/agent/test_copilot_acp_client.py`, `tests/gateway/test_api_server_normalize.py`)
- ✅ Code compiles cleanly
- ✅ Follows the same pattern as the established fix from #2049 / 1173adbe8

Closes #24592