### PR TITLE
fix(cli): surface webhook in `hermes gateway setup` picker (#24911)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3683,6 +3683,21 @@ _PLATFORMS = [
              "help": "The App Secret (used for HMAC signing) from your Yuanbao IM Bot."},
         ],
     },
+    {
+        # Bespoke setup flow lives in ``hermes_cli.setup._setup_webhooks`` —
+        # ``_builtin_setup_fn`` dispatches on this key, so no ``vars`` schema
+        # is needed here.
+        "key": "webhook",
+        "label": "Webhook",
+        "emoji": "🔗",
+        "token_var": "WEBHOOK_ENABLED",
+        "setup_instructions": [
+            "1. Define webhook routes (per service) in config.yaml under platforms.webhook.routes",
+            "2. Point your service (GitHub, GitLab, Stripe, etc.) at",
+            "   http://<your-server>:<WEBHOOK_PORT>/webhooks/<route-name>",
+            "3. Full guide: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/",
+        ],
+    },
 ]
 def _all_platforms() -> list[dict]:
     """Return the full list of platforms for setup menus.
@@ -4736,6 +4751,12 @@ def _builtin_setup_fn(key: str):
         # plugins/platforms/mattermost/adapter.py::register() and dispatched
         # via the plugin path in _configure_platform().
         "bluebubbles": _s._setup_bluebubbles,
+        # ``webhook`` is the canonical key (matches ``Platform.WEBHOOK`` and the
+        # entry in ``_PLATFORMS``). ``webhooks`` is kept as a defensive alias —
+        # the platform key has historically been singular everywhere else, but
+        # leaving the plural in place costs nothing and avoids surprising any
+        # external caller that happens to use it.
+        "webhook": _s._setup_webhooks,
         "webhooks": _s._setup_webhooks,
         "signal": _setup_signal,
         "whatsapp": _setup_whatsapp,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3692,7 +3692,7 @@ _PLATFORMS = [
         "emoji": "🔗",
         "token_var": "WEBHOOK_ENABLED",
         "setup_instructions": [
-            "1. Define webhook routes (per service) in config.yaml under platforms.webhook.routes",
+            "1. Define webhook routes (per service) in config.yaml under platforms.webhook.extra.routes",
             "2. Point your service (GitHub, GitLab, Stripe, etc.) at",
             "   http://<your-server>:<WEBHOOK_PORT>/webhooks/<route-name>",
             "3. Full guide: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/",
@@ -3796,6 +3796,14 @@ def _platform_status(platform: dict) -> str:
             if session_file.exists():
                 return "configured + paired"
             return "enabled, not paired"
+        return "not configured"
+    if token_var == "WEBHOOK_ENABLED":
+        # Match gateway/config.py:1429 — the runtime only honors the platform
+        # when WEBHOOK_ENABLED parses truthy. Without this branch the picker
+        # would mark WEBHOOK_ENABLED=false as "configured" because the
+        # fallthrough below treats any non-empty value as truthy.
+        if val and val.strip().lower() in {"true", "1", "yes"}:
+            return "configured"
         return "not configured"
     if platform.get("key") == "signal":
         account = get_env_value("SIGNAL_ACCOUNT")

--- a/tests/hermes_cli/test_gateway_setup_webhook.py
+++ b/tests/hermes_cli/test_gateway_setup_webhook.py
@@ -1,0 +1,54 @@
+"""Webhook must surface in ``hermes gateway setup`` (Issue #24911).
+
+Two regressions to lock in:
+
+1. ``_all_platforms()`` must include a ``"webhook"`` entry so the
+   interactive picker lists it alongside the other messaging
+   platforms. Before the fix, the runtime supported the webhook
+   platform (``Platform.WEBHOOK`` + env-driven config bridge in
+   ``gateway/config.py``) but ``_PLATFORMS`` had no entry, so the
+   menu silently omitted it.
+
+2. ``_builtin_setup_fn("webhook")`` must resolve to
+   ``hermes_cli.setup._setup_webhooks``. Before the fix the
+   dispatch table only had a ``"webhooks"`` (plural) key, which
+   never matched any platform key, so even if a caller added a
+   ``"webhook"`` entry to the menu the setup flow would not run.
+"""
+
+from __future__ import annotations
+
+
+class TestWebhookSetupSurfaces:
+    def test_webhook_present_in_gateway_setup_menu(self):
+        from hermes_cli.gateway import _all_platforms
+
+        keys = {p["key"] for p in _all_platforms()}
+        assert "webhook" in keys, (
+            "webhook missing from gateway setup picker — runtime "
+            "supports Platform.WEBHOOK but the menu won't surface it"
+        )
+
+    def test_webhook_has_builtin_setup_fn(self):
+        from hermes_cli.gateway import _builtin_setup_fn
+        from hermes_cli.setup import _setup_webhooks
+
+        fn = _builtin_setup_fn("webhook")
+        assert fn is _setup_webhooks, (
+            "_builtin_setup_fn('webhook') must dispatch to "
+            "hermes_cli.setup._setup_webhooks"
+        )
+
+    def test_webhook_entry_has_token_var(self):
+        """``_platform_status`` keys off ``token_var`` to report
+        'configured' vs 'not configured' — without it the picker
+        would show webhook as permanently unconfigured even after
+        ``WEBHOOK_ENABLED=true``.
+        """
+        from hermes_cli.gateway import _all_platforms
+
+        webhook = next(p for p in _all_platforms() if p["key"] == "webhook")
+        assert webhook.get("token_var") == "WEBHOOK_ENABLED", (
+            "webhook entry must use WEBHOOK_ENABLED as its sentinel "
+            "env var to match the gateway/config.py bridge"
+        )

--- a/tests/hermes_cli/test_gateway_setup_webhook.py
+++ b/tests/hermes_cli/test_gateway_setup_webhook.py
@@ -52,3 +52,37 @@ class TestWebhookSetupSurfaces:
             "webhook entry must use WEBHOOK_ENABLED as its sentinel "
             "env var to match the gateway/config.py bridge"
         )
+
+
+class TestWebhookPlatformStatus:
+    """``WEBHOOK_ENABLED`` is a boolean env var (see ``gateway/config.py``
+    where the value is parsed against ``{"true", "1", "yes"}``). The picker's
+    ``_platform_status`` must mirror that truthy check so users don't see
+    ``WEBHOOK_ENABLED=false`` reported as ``configured``.
+    """
+
+    def _webhook_entry(self):
+        from hermes_cli.gateway import _all_platforms
+
+        return next(p for p in _all_platforms() if p["key"] == "webhook")
+
+    def test_status_false_value_is_not_configured(self, monkeypatch):
+        from hermes_cli import gateway as g
+
+        monkeypatch.setattr(g, "get_env_value", lambda _k: "false")
+        assert g._platform_status(self._webhook_entry()) == "not configured"
+
+    def test_status_empty_value_is_not_configured(self, monkeypatch):
+        from hermes_cli import gateway as g
+
+        monkeypatch.setattr(g, "get_env_value", lambda _k: "")
+        assert g._platform_status(self._webhook_entry()) == "not configured"
+
+    def test_status_truthy_value_is_configured(self, monkeypatch):
+        from hermes_cli import gateway as g
+
+        for truthy in ("true", "1", "yes", "TRUE", " true "):
+            monkeypatch.setattr(g, "get_env_value", lambda _k, v=truthy: v)
+            assert g._platform_status(self._webhook_entry()) == "configured", (
+                f"WEBHOOK_ENABLED={truthy!r} should be reported as configured"
+            )

--- a/tests/hermes_cli/test_setup_openclaw_migration.py
+++ b/tests/hermes_cli/test_setup_openclaw_migration.py
@@ -558,7 +558,10 @@ class TestGetSectionConfigSummary:
             def env_side(key, _target=env_var):
                 if key != _target:
                     return ""
-                if _target == "WHATSAPP_ENABLED":
+                # Some platforms parse a boolean-style sentinel and only treat
+                # truthy values as "configured" (WhatsApp, Webhook). Use the
+                # literal "true" so _platform_status doesn't drop them.
+                if _target in {"WHATSAPP_ENABLED", "WEBHOOK_ENABLED"}:
                     return "true"
                 return "x"
             import hermes_cli.gateway as gateway_mod


### PR DESCRIPTION
## Summary

- Add a `webhook` entry to `_PLATFORMS` so `hermes gateway setup` lists it alongside the other messaging platforms.
- Add a singular `webhook` key to `_builtin_setup_fn` so the existing `_setup_webhooks()` flow is reachable from the picker.

## The bug

`gateway/config.py` already supports the webhook platform (`Platform.WEBHOOK = "webhook"`, env-driven config bridge around `gateway/config.py:1428-1442`), and `hermes_cli/setup.py:_setup_webhooks` ships a bespoke interactive flow. But the platform picker built by `hermes gateway setup` enumerates `_PLATFORMS` in `hermes_cli/gateway.py`, and that list had no webhook entry — so the option silently never appeared.

Even if a caller had a way to feed `key="webhook"` into the picker, the dispatch table in `_builtin_setup_fn` only had a `"webhooks"` (plural) key, which never matched any platform key. Every other platform key in the runtime is singular (matches `Platform.<NAME>` values).

## The fix

`hermes_cli/gateway.py`:

1. New `_PLATFORMS` entry for webhook with `token_var: "WEBHOOK_ENABLED"` so `_platform_status` mirrors the env-driven bridge — picker correctly reports "configured" / "not configured". No `vars` schema; webhook setup is bespoke and dispatches through `_setup_webhooks`, not `_setup_standard_platform`.
2. `_builtin_setup_fn` gains a `"webhook": _s._setup_webhooks` entry. The existing `"webhooks"` plural alias is kept defensively in case any external caller relies on it.

## Test plan

- [x] Focused regression test: `tests/hermes_cli/test_gateway_setup_webhook.py` (3 tests):
  - `test_webhook_present_in_gateway_setup_menu` — `_all_platforms()` includes `webhook`.
  - `test_webhook_has_builtin_setup_fn` — `_builtin_setup_fn("webhook") is _setup_webhooks`.
  - `test_webhook_entry_has_token_var` — entry uses `WEBHOOK_ENABLED` so `_platform_status` works.
- [x] Adjacent suite: `tests/hermes_cli/test_gateway.py`, `test_gateway_platform_gating.py`, `test_setup_openclaw_migration.py` — 67 passed.
- [x] Regression guard: stashed the `hermes_cli/gateway.py` change, reran focused tests — all 3 fail (one with `assert "webhook" not in {...}`, one with `assert None is _setup_webhooks`, one with `StopIteration`). Restored, all 3 pass.

## Related

- Fixes #24911