### PR TITLE
fix(clarify): treat timeout as refusal instead of implicit consent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9825,10 +9825,12 @@ class HermesCLI:
         self._clarify_freetext = False
         self._clarify_deadline = 0
         self._invalidate()
-        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
+        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — treating as refusal){_RST}")
         return (
             "The user did not provide a response within the time limit. "
-            "Use your best judgement to make the choice and proceed."
+            "Treat this as a refusal — do NOT proceed with any pending "
+            "destructive or irreversible action. Ask again or wait for "
+            "explicit confirmation."
         )
 
     def _sudo_password_callback(self) -> str:

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -56,10 +56,12 @@ def clarify_callback(cli, question, choices):
     cli._clarify_deadline = 0
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
-    cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
+    cprint(f"\n{_DIM}(clarify timed out after {timeout}s — treating as refusal){_RST}")
     return (
         "The user did not provide a response within the time limit. "
-        "Use your best judgement to make the choice and proceed."
+        "Treat this as a refusal — do NOT proceed with any pending "
+        "destructive or irreversible action. Ask again or wait for "
+        "explicit confirmation."
     )
 
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -156,6 +156,26 @@ class TestClarifyToolCallbackHandling:
         result = json.loads(clarify_tool("Q?", callback=mock_callback))
         assert result["user_response"] == "response with spaces"
 
+    def test_timeout_refusal_response_passed_through(self):
+        """When callback returns a timeout refusal, it should be passed through unchanged.
+
+        Regression test for #24912: clarify timeout must not instruct
+        the agent to proceed with destructive actions.
+        """
+        def timeout_callback(question, choices):
+            return (
+                "The user did not provide a response within the time limit. "
+                "Treat this as a refusal — do NOT proceed with any pending "
+                "destructive or irreversible action. Ask again or wait for "
+                "explicit confirmation."
+            )
+
+        result = json.loads(clarify_tool("Delete .git folder?", callback=timeout_callback))
+        response = result["user_response"]
+        assert "refusal" in response.lower() or "do not proceed" in response.lower()
+        assert "best judgement" not in response.lower()
+        assert "best judgment" not in response.lower()
+
 
 class TestCheckClarifyRequirements:
     """Tests for the requirements check function."""

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -98,6 +98,8 @@ CLARIFY_SCHEMA = {
         "- You want post-task feedback ('How did that work out?')\n"
         "- You want to offer to save a skill or update memory\n"
         "- A decision has meaningful trade-offs the user should weigh in on\n\n"
+        "If the user does not respond (timeout), treat the result as a "
+        "refusal — do NOT proceed with destructive or irreversible actions. "
         "Do NOT use this tool for simple yes/no confirmation of dangerous "
         "commands (the terminal tool handles that). Prefer making a reasonable "
         "default choice yourself when the decision is low-stakes."


### PR DESCRIPTION
## What does this PR do?

When the `clarify` tool times out (user does not respond within the configured window), the CLI callback currently returns:

> "Use your best judgement to make the choice and proceed."

The LLM interprets this as permission to execute whatever action it was asking about — including destructive operations like `rm -rf .git`. This is a security/safety failure: **silence is not consent**.


### Root Cause

In `hermes_cli/callbacks.py`, the `clarify_callback` function handles timeout by returning a message that explicitly tells the agent to proceed:

```python
return (
    "The user did not provide a response within the time limit. "
    "Use your best judgement to make the choice and proceed."
)
```

This message is then passed to the LLM as the user's "response" to the clarify question. For permission-seeking questions ("May I delete .git?"), the LLM reads this as approval.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A