### PR TITLE
fix(api-server): honor display.show_reasoning on chat completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -271,6 +271,77 @@ def _content_has_visible_payload(content: Any) -> bool:
     return False
 
 
+def _strip_inline_reasoning_blocks(text: str) -> str:
+    """Remove display-only reasoning tags from replayed assistant content."""
+    if not text:
+        return ""
+    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<thinking>.*?</thinking>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r'<reasoning>.*?</reasoning>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(
+        r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>',
+        '',
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    text = re.sub(r'<thought>.*?</thought>', '', text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(
+        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
+        '',
+        text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    return re.sub(
+        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+        '',
+        text,
+        flags=re.IGNORECASE,
+    )
+
+
+def _strip_assistant_display_reasoning(content: Any) -> Any:
+    """Strip inline reasoning blocks from assistant history sent by clients."""
+    if isinstance(content, str):
+        return _strip_inline_reasoning_blocks(content)
+    if isinstance(content, list):
+        cleaned: List[Any] = []
+        for part in content:
+            if isinstance(part, dict) and str(part.get("type") or "").strip().lower() in _TEXT_PART_TYPES:
+                next_part = dict(part)
+                next_part["text"] = _strip_inline_reasoning_blocks(str(next_part.get("text") or ""))
+                cleaned.append(next_part)
+            else:
+                cleaned.append(part)
+        return cleaned
+    return content
+
+
+def _api_server_show_reasoning_enabled() -> bool:
+    """Resolve display.show_reasoning for the API server platform."""
+    try:
+        from gateway.display_config import resolve_display_setting
+        from gateway.run import _load_gateway_config
+
+        return bool(
+            resolve_display_setting(
+                _load_gateway_config(),
+                "api_server",
+                "show_reasoning",
+                False,
+            )
+        )
+    except Exception:
+        return False
+
+
+def _prepend_reasoning_think_block(content: str, reasoning: Any) -> str:
+    """Expose reasoning to OpenAI-compatible UIs using inline think tags."""
+    reasoning_text = str(reasoning or "").strip()
+    if not content or not reasoning_text:
+        return content
+    return f"<think>\n{reasoning_text}\n</think>\n\n{content}"
+
+
 def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Response":
     """Translate a ``_normalize_multimodal_content`` ValueError into a 400 response."""
     raw = str(exc)
@@ -1008,6 +1079,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     content = _normalize_multimodal_content(raw_content)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
+                if role == "assistant":
+                    content = _strip_assistant_display_reasoning(content)
                 conversation_messages.append({"role": role, "content": content})
 
         # Extract the last user message as the primary input
@@ -1084,6 +1157,7 @@ class APIServerAdapter(BasePlatformAdapter):
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", self._model_name)
         created = int(time.time())
+        show_reasoning = _api_server_show_reasoning_enabled()
 
         if stream:
             import queue as _q
@@ -1176,6 +1250,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                show_reasoning=show_reasoning,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -1210,6 +1285,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = result.get("final_response") or ""
+        if show_reasoning:
+            final_response = _prepend_reasoning_think_block(
+                final_response,
+                result.get("last_reasoning"),
+            )
         is_partial = bool(result.get("partial"))
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
@@ -1292,6 +1372,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
         gateway_session_key: str = None,
+        show_reasoning: bool = False,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -1321,6 +1402,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             last_activity = time.monotonic()
+            buffered_content_parts: List[str] = []
 
             # Role chunk
             role_chunk = {
@@ -1332,6 +1414,14 @@ class APIServerAdapter(BasePlatformAdapter):
             last_activity = time.monotonic()
 
             # Helper — route a queue item to the correct SSE event.
+            async def _write_content_delta(text: str):
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
@@ -1348,12 +1438,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    if show_reasoning:
+                        buffered_content_parts.append(str(item))
+                    else:
+                        await _write_content_delta(str(item))
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
@@ -1385,11 +1473,22 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result: Dict[str, Any] = {}
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
             except Exception as exc:
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
+
+            if show_reasoning:
+                buffered_content = "".join(buffered_content_parts)
+                content = buffered_content or str(result.get("final_response") or "")
+                content = _prepend_reasoning_think_block(
+                    content,
+                    result.get("last_reasoning"),
+                )
+                if content:
+                    await _write_content_delta(content)
 
             # Finish chunk
             finish_chunk = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -682,6 +682,46 @@ class TestChatCompletionsEndpoint:
                 assert "Hello!" in body
 
     @pytest.mark.asyncio
+    async def test_stream_show_reasoning_emits_think_block_before_answer(self, adapter):
+        """display.show_reasoning exposes final reasoning as inline <think> tags."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Visible ")
+                    cb("answer.")
+                return (
+                    {
+                        "final_response": "Visible answer.",
+                        "last_reasoning": "I should answer directly.",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with (
+                patch("gateway.platforms.api_server._api_server_show_reasoning_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert "<think>" in body
+        assert "I should answer directly." in body
+        assert "Visible answer." in body
+        assert body.index("<think>") < body.index("Visible answer.")
+
+    @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
         """Regression guard for #24451: completion callback must signal SSE EOS."""
         app = _create_app(adapter)
@@ -1149,6 +1189,65 @@ class TestChatCompletionsEndpoint:
             assert len(call_kwargs["conversation_history"]) == 2
             assert call_kwargs["conversation_history"][0] == {"role": "user", "content": "1+1=?"}
             assert call_kwargs["conversation_history"][1] == {"role": "assistant", "content": "2"}
+
+    @pytest.mark.asyncio
+    async def test_assistant_history_think_blocks_are_stripped_before_agent(self, adapter):
+        """Inline display reasoning from stateless clients must not be replayed."""
+        mock_result = {"final_response": "4", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {"role": "user", "content": "1+1=?"},
+                            {
+                                "role": "assistant",
+                                "content": "<think>private scratchpad</think>2",
+                            },
+                            {"role": "user", "content": "Now add 2 more"},
+                        ],
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        assert history[1] == {"role": "assistant", "content": "2"}
+
+    @pytest.mark.asyncio
+    async def test_show_reasoning_prepends_think_block_to_non_streaming_content(self, adapter):
+        """display.show_reasoning is honored on /v1/chat/completions."""
+        mock_result = {
+            "final_response": "17 * 23 = 391.",
+            "last_reasoning": "Compute 17 * 20 + 17 * 3.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server._api_server_show_reasoning_enabled", return_value=True),
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "What is 17 * 23?"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        content = data["choices"][0]["message"]["content"]
+        assert content.startswith("<think>\nCompute 17 * 20 + 17 * 3.\n</think>\n\n")
+        assert content.endswith("17 * 23 = 391.")
 
     @pytest.mark.asyncio
     async def test_agent_error_returns_500(self, adapter):


### PR DESCRIPTION
## Summary

- Prepends an inline think block to `/v1/chat/completions` responses when `display.show_reasoning` is enabled
- Strips replayed assistant think blocks from incoming chat history so stateless clients do not pollute future turns
- Applies the same reasoning display behavior to streamed chat completions by buffering visible text until the final reasoning block is available

Closes #7556

## Tests

- `uv run --frozen pytest tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_show_reasoning_prepends_think_block_to_non_streaming_content tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_assistant_history_think_blocks_are_stripped_before_agent tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_show_reasoning_emits_think_block_before_answer -q -o addopts=`
- `uv run --frozen pytest tests/gateway/test_api_server.py -q -o addopts=`
- `uv run --frozen pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_normalize.py tests/gateway/test_display_config.py -q -o addopts=`
- `uv run --frozen ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- `git diff --check`

## Notes

This stays focused on `/v1/chat/completions`. Structured reasoning for `/v1/responses` is being handled separately in #17064.

I also ran the repository-preferred `scripts/run_tests.sh` locally after opening the PR. It is not green in this local environment: 22317 passed, 157 skipped, 41 failed, 1 error. The failures are outside this PR area and include missing optional dependencies such as `numpy`/`botocore` plus unrelated platform tests.