### PR TITLE
fix(terminal): strip PYTHONHOME/PYTHONPATH from subprocess env

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -285,6 +285,12 @@ def _make_run_env(env: dict) -> dict:
     except Exception:
         pass
 
+    # Sanitize PYTHONHOME/PYTHONPATH — they can cause the subprocess to load
+    # the wrong Python interpreter (e.g. uv's Python instead of conda's), which
+    # breaks tools like conda that rely on finding their own stdlib packages.
+    run_env.pop("PYTHONHOME", None)
+    run_env.pop("PYTHONPATH", None)
+
     return run_env
 
 


### PR DESCRIPTION
## Summary

On Windows, Hermes Agent bootstraps its own Python via `uv` and sets `PYTHONHOME` in the process environment. When the terminal tool spawns subprocesses, this `PYTHONHOME` is inherited, causing `conda` (and potentially other Python-based tools) to load `uv`'s Python instead of the system/conda Python — resulting in `No module named conda`.

## Fix

Strip `PYTHONHOME` and `PYTHONPATH` from the subprocess environment in `_make_run_env()`. This mirrors the `unset PYTHONHOME` / `unset PYTHONPATH` logic already present in `install.sh` at launch time.

```python
run_env.pop("PYTHONHOME", None)
run_env.pop("PYTHONPATH", None)
```

## Testing

After patching, `conda --version` returns `conda 25.5.1` correctly in the Hermes Agent terminal session on Windows.

## Checklist

- [x] Tests pass (if applicable)
- [x] Documentation updated (if applicable)
- [x] `scripts/install.sh` Python-path sanitization is already in place