### PR TITLE
fix: classify landed file mutations with diagnostics

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -14,6 +14,7 @@ from difflib import unified_diff
 from pathlib import Path
 
 from utils import safe_json_loads
+from agent.tool_result_classification import file_mutation_result_landed
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -809,6 +810,8 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     failures.  On success, returns ``(False, "")``.
     """
     if result is None:
+        return False, ""
+    if file_mutation_result_landed(tool_name, result):
         return False, ""
 
     if tool_name == "terminal":

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
+from agent.tool_result_classification import file_mutation_result_landed
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -195,6 +196,8 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     (tests, tooling) still get consistent behavior.
     """
     if result is None:
+        return False, ""
+    if file_mutation_result_landed(tool_name, result):
         return False, ""
 
     if tool_name == "terminal":

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -1,0 +1,26 @@
+"""Shared helpers for classifying tool result payloads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
+
+
+def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
+    """Return True when a file mutation result proves the write landed."""
+    if tool_name not in FILE_MUTATING_TOOL_NAMES or not isinstance(result, str):
+        return False
+    try:
+        data = json.loads(result.strip())
+    except Exception:
+        return False
+    if not isinstance(data, dict) or data.get("error"):
+        return False
+    if tool_name == "write_file":
+        return "bytes_written" in data
+    if tool_name == "patch":
+        return data.get("success") is True
+    return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -181,6 +181,7 @@ from agent.tool_guardrails import (
     append_toolguard_guidance,
     toolguard_synthetic_result,
 )
+from agent.tool_result_classification import file_mutation_result_landed
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -5347,7 +5348,8 @@ class AIAgent:
         targets = _extract_file_mutation_targets(tool_name, args)
         if not targets:
             return
-        if is_error:
+        landed = file_mutation_result_landed(tool_name, result)
+        if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -1,6 +1,7 @@
 """Tests for agent/display.py — build_tool_preview() and inline diff previews."""
 
 import os
+import json
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -148,6 +149,27 @@ class TestCuteToolMessagePreviewLength:
 
         assert path in line
         assert "..." not in line
+
+    def test_write_file_lint_error_result_is_not_marked_failed(self):
+        result = json.dumps({
+            "bytes_written": 12,
+            "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+        })
+
+        line = get_cute_tool_message("write_file", {"path": "/tmp/a.py"}, 0.1, result=result)
+
+        assert "[error]" not in line
+
+    def test_patch_lsp_diagnostics_result_is_not_marked_failed(self):
+        result = json.dumps({
+            "success": True,
+            "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+            "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+        })
+
+        line = get_cute_tool_message("patch", {"path": "/tmp/a.py"}, 0.1, result=result)
+
+        assert "[error]" not in line
 
 
 class TestEditDiffPreview:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -7,6 +7,7 @@ from agent.tool_guardrails import (
     ToolCallGuardrailController,
     ToolCallSignature,
     canonical_tool_args,
+    classify_tool_failure,
 )
 
 
@@ -129,6 +130,21 @@ def test_success_resets_exact_signature_failure_streak():
     assert controller.before_call("web_search", args).action == "allow"
     controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
     assert controller.before_call("web_search", args).action == "allow"
+
+
+def test_file_mutation_lint_error_result_is_not_a_tool_failure():
+    write_result = json.dumps({
+        "bytes_written": 12,
+        "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+    })
+    patch_result = json.dumps({
+        "success": True,
+        "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+        "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+    })
+
+    assert classify_tool_failure("write_file", write_result) == (False, "")
+    assert classify_tool_failure("patch", patch_result) == (False, "")
 
 
 def test_same_tool_varying_args_warns_by_default_without_halting():

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -1,0 +1,30 @@
+"""Tests for shared tool result classification helpers."""
+
+import json
+
+from agent.tool_result_classification import file_mutation_result_landed
+
+
+def test_write_file_with_nested_lint_error_counts_as_landed():
+    result = json.dumps({
+        "bytes_written": 12,
+        "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+    })
+
+    assert file_mutation_result_landed("write_file", result) is True
+
+
+def test_patch_with_nested_lsp_diagnostics_counts_as_landed():
+    result = json.dumps({
+        "success": True,
+        "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+        "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+    })
+
+    assert file_mutation_result_landed("patch", result) is True
+
+
+def test_top_level_file_mutation_error_does_not_count_as_landed():
+    result = json.dumps({"success": True, "error": "post-write verification failed"})
+
+    assert file_mutation_result_landed("patch", result) is False

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -166,6 +166,56 @@ class TestRecordFileMutationResult:
         )
         assert agent._turn_failed_file_mutations == {}
 
+    def test_write_file_with_lint_error_counts_as_landed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.py", "content": "bad"},
+            json.dumps({"error": "write failed"}),
+            is_error=True,
+        )
+        assert "/tmp/a.py" in agent._turn_failed_file_mutations
+
+        result = json.dumps({
+            "bytes_written": 24,
+            "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+        })
+
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.py", "content": "def nope(:\n"},
+            result,
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
+    def test_patch_with_lsp_diagnostics_counts_as_landed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.py", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+        assert "/tmp/a.py" in agent._turn_failed_file_mutations
+
+        result = json.dumps({
+            "success": True,
+            "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+            "files_modified": ["/tmp/a.py"],
+            "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+        })
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.py", "old_string": "x", "new_string": "y"},
+            result,
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
     def test_repeated_failure_keeps_first_error(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(


### PR DESCRIPTION
## What does this PR do?

Fixes a false positive in file mutation result handling where successful `write_file` and `patch` calls could be treated as failed when their JSON result contained nested diagnostic text such as lint errors or LSP diagnostics. The change centralizes landed mutation classification so verifier footers, CLI tool status, and tool guardrails agree on the same success contract.

## Related Issue

Fixes #24927

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added shared file mutation result classification in `agent/tool_result_classification.py`.
- Updated the turn-end file mutation verifier to clear stale failures when a diagnostic-bearing mutation result proves the write landed.
- Updated CLI display and tool guardrail failure classification to avoid marking landed file mutations as failed because of nested diagnostics.
- Added regression coverage for verifier recovery, display status, guardrail classification, and the shared classifier helper.

## How to Test

1. `uv run --extra dev python -m pytest -q tests/run_agent/test_file_mutation_verifier.py tests/agent/test_display.py::TestCuteToolMessagePreviewLength tests/agent/test_tool_guardrails.py tests/agent/test_tool_result_classification.py`
2. `uv run --extra dev python -m ruff check agent/tool_result_classification.py agent/display.py agent/tool_guardrails.py run_agent.py tests/agent/test_tool_result_classification.py tests/agent/test_display.py tests/agent/test_tool_guardrails.py tests/run_agent/test_file_mutation_verifier.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted verifier, display, guardrail, and classifier tests passed: 55 passed.
Ruff passed on changed Python files.
Whitespace check passed with `git diff --check`.
