### PR TITLE
fix(browser): inject --no-sandbox via cmd_parts instead of AGENT_BROWSER_CHROME_FLAGS

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1892,9 +1892,11 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
-                )
+                # AGENT_BROWSER_CHROME_FLAGS is NOT honoured by agent-browser 0.26+.
+                # Inject --args via cmd_parts instead. Each --args takes the flag as a single string value.
+                _chrome_args = ["--args", "--no-sandbox"]
+                _json_idx = cmd_parts.index("--json")
+                cmd_parts = cmd_parts[:_json_idx] + _chrome_args + cmd_parts[_json_idx:]
 
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
agent-browser 0.26+ no longer honours the `AGENT_BROWSER_CHROME_FLAGS` environment variable. The old approach of setting `browser_env["AGENT_BROWSER_CHROME_FLAGS"] = "--no-sandbox --disable-dev-shm-usage"` was silently ignored, causing the sandbox bypass to fail on systems that need `--no-sandbox` (root, AppArmor userns-restricted systems).

Fix: inject `--args` directly into `cmd_parts` before the `--json` flag, bypassing the env-var mechanism entirely. Each flag gets its own element in the list, matching agent-browser's CLI argument parser.

Also removes `--disable-dev-shm-usage` which is no longer needed and was causing issues with agent-browser's argument parsing.