### PR TITLE
fix(email): implement send_voice() to fix audio attachment delivery

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -709,6 +709,27 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] Send document failed: %s", e)
             return SendResult(success=False, error=str(e))
 
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as an email attachment (delegate to send_document)."""
+        import os
+        return await self.send_document(
+            chat_id=chat_id,
+            file_path=audio_path,
+            caption=caption,
+            file_name=os.path.basename(audio_path) if audio_path else None,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
     def _send_email_with_attachment(
         self,
         to_addr: str,


### PR DESCRIPTION
## Summary

Implements `send_voice()` in `EmailAdapter` to fix audio file attachments (.mp3, .wav, .m4a, .flac, .ogg, .opus) failing silently when sent via the Email platform.

## Problem

When an audio file is sent through the Email gateway, `should_send_media_as_audio()` in `base.py` routes it to `send_voice()`. However, `EmailAdapter` does not implement `send_voice()`, so it falls back to the base class which just sends a text link (`🔊 Audio: <path>`) instead of attaching the file.

## Fix

Added `send_voice()` to `EmailAdapter` that delegates to the existing `send_document()` method, ensuring audio files are delivered as proper email attachments with the correct filename.

## Testing

- All 81 email-related tests pass
- Syntax validated via `ast.parse()`

## Checklist

- [x] Changes are limited to `gateway/platforms/email.py`
- [x] No new dependencies
- [x] Follows existing adapter patterns (see other platform adapters like Discord, Slack)
- [x] Commit is signed

Fixes #24922