### PR TITLE
fix(email): attach audio files sent as voice

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -684,6 +684,30 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
         return msg_id
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as an email attachment.
+
+        The shared media router sends recognized audio extensions through
+        ``send_voice`` on non-Telegram platforms. Email has no native voice
+        primitive, so preserve the file by attaching it as a regular MIME
+        document instead of falling back to the base text-only implementation.
+        """
+        return await self.send_document(
+            chat_id=chat_id,
+            file_path=audio_path,
+            caption=caption,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
     async def send_document(
         self,
         chat_id: str,

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -706,6 +706,44 @@ class TestSendMethods(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_send_voice_attaches_audio_file(self):
+        """send_voice should attach audio files instead of leaking paths as text."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+            f.write(b"fake mp3 bytes")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                result = asyncio.run(
+                    adapter.send_voice("user@test.com", tmp_path, "Here is the audio")
+                )
+
+                self.assertTrue(result.success)
+                mock_server.send_message.assert_called_once()
+                sent_msg = mock_server.send_message.call_args[0][0]
+                parts = list(sent_msg.walk())
+                attachments = [
+                    p for p in parts
+                    if "attachment" in str(p.get("Content-Disposition", ""))
+                ]
+                self.assertEqual(len(attachments), 1)
+                self.assertIn(".mp3", attachments[0].get_filename())
+                text_parts = [
+                    p.get_payload(decode=True).decode(p.get_content_charset() or "utf-8")
+                    for p in parts
+                    if p.get_content_type() == "text/plain"
+                ]
+                self.assertIn("Here is the audio", "\n".join(text_parts))
+        finally:
+            os.unlink(tmp_path)
+
     def test_send_typing_is_noop(self):
         """send_typing should do nothing for email."""
         import asyncio


### PR DESCRIPTION
## Summary
- implement `EmailAdapter.send_voice()` by delegating audio files to MIME document attachment delivery
- add a regression test proving `.mp3` voice/audio sends are attached instead of falling back to text-only path leakage

## Why
The shared media router sends recognized audio extensions through `send_voice()` for non-Telegram platforms. Email has no native voice primitive, so it should preserve the generated audio as a normal email attachment.

Fixes #24922.

## Tests
- `uv run pytest tests/gateway/test_email.py -q`
- `uv run pytest tests/gateway/test_email.py::TestSendMethods::test_send_voice_attaches_audio_file tests/gateway/test_email.py::TestSendMethods::test_send_document_with_attachment tests/gateway/test_platform_base.py::TestShouldSendMediaAsAudio -q`