### PR TITLE
feat(cli): add 'hermes gateway send-message' command

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1,10 +1,11 @@
 """
 Gateway subcommand for hermes CLI.
 
-Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
+Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup|send-message]
 """
 
 import asyncio
+import json
 import os
 import shutil
 import signal
@@ -4976,6 +4977,147 @@ def gateway_setup():
     print()
 
 
+def _send_to_single_target(target: str, message: str) -> dict:
+    """Send a message to one target and return the parsed response dict."""
+    from tools.send_message_tool import send_message_tool
+    result = send_message_tool({"action": "send", "target": target, "message": message})
+    return json.loads(result)
+
+
+def _gateway_send_message(args):
+    """Handle 'hermes gateway send-message' subcommand."""
+    list_targets = getattr(args, "list_targets", False)
+
+    if list_targets:
+        try:
+            from tools.send_message_tool import send_message_tool
+            result = send_message_tool({"action": "list"})
+            data = json.loads(result)
+        except Exception as exc:
+            print(f"Failed to list targets: {exc}")
+            sys.exit(1)
+
+        targets = data.get("targets", "")
+        if not targets:
+            print("No messaging targets available.")
+            print("Configure platforms with: hermes gateway setup")
+            return
+
+        if isinstance(targets, str):
+            print(targets)
+        else:
+            for line in targets:
+                print(f"  {line}")
+        return
+
+    message = getattr(args, "message", "") or ""
+    target = getattr(args, "target", "") or ""
+
+    # Allow piping a message via stdin when no positional argument is given
+    if not message and not sys.stdin.isatty():
+        try:
+            message = sys.stdin.read().strip()
+        except Exception:
+            message = ""
+
+    if not message:
+        print("Error: message is required.")
+        print("Example: hermes gateway send-message 'Hi there' --target telegram")
+        print("Or pipe a message: echo 'Hi there' | hermes gateway send-message --target telegram")
+        sys.exit(1)
+
+    # --target all: broadcast to every connected platform's home channel
+    if target.lower() == "all":
+        try:
+            from gateway.config import load_gateway_config
+            config = load_gateway_config()
+            connected = config.get_connected_platforms()
+        except Exception as exc:
+            print(f"Error: could not load gateway config: {exc}")
+            sys.exit(1)
+
+        if not connected:
+            print("Error: no platforms are connected.")
+            print("Configure platforms with: hermes gateway setup")
+            sys.exit(1)
+
+        successes: list[str] = []
+        failures: list[str] = []
+
+        for plat in connected:
+            plat_target = plat.value
+            try:
+                data = _send_to_single_target(plat_target, message)
+            except Exception as exc:
+                failures.append(f"{plat_target}: {exc}")
+                continue
+
+            if data.get("success"):
+                note = data.get("note", "")
+                label = f"{plat_target} ({note})" if note else plat_target
+                successes.append(label)
+            elif data.get("skipped"):
+                successes.append(f"{plat_target} (skipped)")
+            else:
+                error = data.get("error", "Unknown error")
+                failures.append(f"{plat_target}: {error}")
+
+        if successes:
+            print(f"Sent to {len(successes)} platform(s):")
+            for label in successes:
+                print(f"  ✓ {label}")
+        if failures:
+            print(f"Failed on {len(failures)} platform(s):")
+            for label in failures:
+                print(f"  ✗ {label}")
+        if failures and not successes:
+            sys.exit(1)
+        return
+
+    # Auto-default target when only one platform is connected
+    if not target:
+        try:
+            from gateway.config import load_gateway_config
+            config = load_gateway_config()
+            connected = config.get_connected_platforms()
+            if len(connected) == 1:
+                target = connected[0].value
+            elif len(connected) == 0:
+                print("Error: no platforms are connected.")
+                print("Configure platforms with: hermes gateway setup")
+                sys.exit(1)
+            else:
+                print("Error: multiple platforms are connected; --target is required.")
+                print("Available platforms:")
+                for plat in connected:
+                    print(f"  {plat.value}")
+                sys.exit(1)
+        except Exception as exc:
+            print(f"Error: could not determine default target: {exc}")
+            sys.exit(1)
+
+    try:
+        data = _send_to_single_target(target, message)
+    except Exception as exc:
+        print(f"Send failed: {exc}")
+        sys.exit(1)
+
+    if data.get("success"):
+        note = data.get("note", "")
+        if note:
+            print(f"Sent ({note}).")
+        else:
+            print("Sent.")
+        if data.get("mirrored"):
+            print("  (mirrored into gateway session)")
+    elif data.get("skipped"):
+        print(data.get("note", "Skipped."))
+    else:
+        error = data.get("error", "Unknown error")
+        print(f"Error: {error}")
+        sys.exit(1)
+
+
 # =============================================================================
 # Main Command Handler
 # =============================================================================
@@ -5386,6 +5528,9 @@ def _gateway_command_inner(args):
 
     elif subcmd == "list":
         _gateway_list()
+
+    elif subcmd == "send-message":
+        _gateway_send_message(args)
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9503,6 +9503,37 @@ def main():
     # gateway list
     gateway_subparsers.add_parser("list", help="List all profiles and their gateway status")
 
+    # gateway send-message
+    gateway_send = gateway_subparsers.add_parser(
+        "send-message",
+        help="Send a text message to a connected messaging platform",
+        description=(
+            "Send a text message through the gateway to any configured platform. "
+            "If only one platform is connected, the target defaults to it automatically."
+        ),
+    )
+    gateway_send.add_argument(
+        "message",
+        nargs="?",
+        help="Message text to send",
+    )
+    gateway_send.add_argument(
+        "-t",
+        "--target",
+        default="",
+        help=(
+            "Target channel. Examples: 'telegram', 'discord:#general', "
+            "'slack:#engineering', 'telegram:-1001234567890:17585'"
+        ),
+    )
+    gateway_send.add_argument(
+        "-l",
+        "--list",
+        action="store_true",
+        dest="list_targets",
+        help="List available messaging targets instead of sending",
+    )
+
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.gateway."""
 
+import json
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch, call
@@ -559,3 +560,321 @@ class TestStopProfileGateway:
         assert calls["kill"] == 1          # one SIGTERM
         assert calls["alive_probes"] == 20 # 20 liveness polls over the 2s window
         assert calls["remove"] == 0
+
+
+class TestGatewaySendMessage:
+    def test_list_targets_prints_targets(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: json.dumps(
+                {"targets": "Available messaging targets:\n\nTelegram:\n  telegram:#general\n\nDiscord:\n  discord:#bot-home\n\nUse these as the \"target\" parameter when sending.\nBare platform name (e.g. \"telegram\") sends to home channel."}
+            ),
+        )
+
+        args = SimpleNamespace(gateway_command="send-message", list_targets=True)
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert "Available messaging targets:" in out
+        assert "telegram:#general" in out
+        assert "discord:#bot-home" in out
+
+    def test_list_targets_no_targets_prints_hint(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: json.dumps({"targets": ""}),
+        )
+
+        args = SimpleNamespace(gateway_command="send-message", list_targets=True)
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert "No messaging targets available." in out
+        assert "hermes gateway setup" in out
+
+    def test_missing_message_exits_with_error(self, capsys):
+        args = SimpleNamespace(gateway_command="send-message", message="", target="", list_targets=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "message is required" in out
+
+    def test_no_connected_platforms_exits(self, monkeypatch, capsys):
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return []
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+
+        args = SimpleNamespace(gateway_command="send-message", message="hi", target="", list_targets=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "no platforms are connected" in out
+
+    def test_multiple_platforms_requires_target(self, monkeypatch, capsys):
+        from gateway.config import Platform
+
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return [Platform.TELEGRAM, Platform.DISCORD]
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+
+        args = SimpleNamespace(gateway_command="send-message", message="hi", target="", list_targets=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "multiple platforms are connected" in out
+        assert "telegram" in out
+        assert "discord" in out
+
+    def test_single_platform_auto_defaults_target(self, monkeypatch, capsys):
+        from gateway.config import Platform
+
+        calls = []
+
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return [Platform.TELEGRAM]
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: (calls.append(args), json.dumps({"success": True, "note": "home channel"}))[1],
+        )
+
+        args = SimpleNamespace(gateway_command="send-message", message="hello", target="", list_targets=False)
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert calls == [{"action": "send", "target": "telegram", "message": "hello"}]
+        assert "Sent" in out
+
+    def test_explicit_target_used(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: (calls.append(args), json.dumps({"success": True}))[1],
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="discord:#general",
+            list_targets=False,
+        )
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert calls == [{"action": "send", "target": "discord:#general", "message": "hello"}]
+        assert "Sent." in out
+
+    def test_send_error_prints_error_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: json.dumps({"error": "Adapter send failed: rate limited"}),
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="telegram",
+            list_targets=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "Adapter send failed: rate limited" in out
+
+    def test_send_skipped_prints_note(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: json.dumps(
+                {"success": True, "skipped": True, "note": "Skipped because of duplicate target."}
+            ),
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="telegram",
+            list_targets=False,
+        )
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert "Skipped because of duplicate target." in out
+
+    def test_piped_stdin_message(self, monkeypatch, capsys):
+        calls = []
+
+        class FakeStdin:
+            def isatty(self):
+                return False
+            def read(self):
+                return "  piped content  "
+
+        monkeypatch.setattr(gateway.sys, "stdin", FakeStdin())
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: (calls.append(args), json.dumps({"success": True}))[1],
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="",
+            target="telegram",
+            list_targets=False,
+        )
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert calls == [{"action": "send", "target": "telegram", "message": "piped content"}]
+        assert "Sent." in out
+
+    def test_empty_piped_stdin_exits_with_error(self, monkeypatch, capsys):
+        class FakeStdin:
+            def isatty(self):
+                return False
+            def read(self):
+                return "   "
+
+        monkeypatch.setattr(gateway.sys, "stdin", FakeStdin())
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="",
+            target="telegram",
+            list_targets=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "message is required" in out
+        assert "pipe a message" in out
+
+    def test_target_all_broadcasts_to_all_platforms(self, monkeypatch, capsys):
+        from gateway.config import Platform
+
+        calls = []
+
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return [Platform.TELEGRAM, Platform.DISCORD]
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: (calls.append(args), json.dumps({"success": True}))[1],
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="all",
+            list_targets=False,
+        )
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert len(calls) == 2
+        assert {"action": "send", "target": "telegram", "message": "hello"} in calls
+        assert {"action": "send", "target": "discord", "message": "hello"} in calls
+        assert "Sent to 2 platform(s):" in out
+        assert "telegram" in out
+        assert "discord" in out
+
+    def test_target_all_with_some_failures_reports_them(self, monkeypatch, capsys):
+        from gateway.config import Platform
+
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return [Platform.TELEGRAM, Platform.DISCORD]
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+
+        def mock_send(args, **kw):
+            if args.get("target") == "telegram":
+                return json.dumps({"success": True})
+            return json.dumps({"error": "rate limited"})
+
+        monkeypatch.setattr("tools.send_message_tool.send_message_tool", mock_send)
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="all",
+            list_targets=False,
+        )
+        gateway._gateway_send_message(args)
+
+        out = capsys.readouterr().out
+        assert "Sent to 1 platform(s):" in out
+        assert "Failed on 1 platform(s):" in out
+        assert "rate limited" in out
+
+    def test_target_all_all_failures_exits_nonzero(self, monkeypatch, capsys):
+        from gateway.config import Platform
+
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return [Platform.TELEGRAM]
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+        monkeypatch.setattr(
+            "tools.send_message_tool.send_message_tool",
+            lambda args, **kw: json.dumps({"error": "network down"}),
+        )
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="all",
+            list_targets=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "network down" in out
+        assert "Failed on 1 platform(s):" in out
+
+    def test_target_all_no_connected_platforms_exits(self, monkeypatch, capsys):
+        def fake_load_config():
+            class FakeConfig:
+                def get_connected_platforms(self):
+                    return []
+            return FakeConfig()
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", fake_load_config)
+
+        args = SimpleNamespace(
+            gateway_command="send-message",
+            message="hello",
+            target="all",
+            list_targets=False,
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            gateway._gateway_send_message(args)
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "no platforms are connected" in out


### PR DESCRIPTION
## Summary

Add a new CLI subcommand `hermes gateway send-message` that lets users send text messages through the gateway to connected messaging platforms (Telegram, Discord, Slack, Signal, etc.) directly from the shell.

## Features

- **Send to a specific target**: `hermes gateway send-message 'Hi there' --target telegram`
- **Auto-default target**: when only one platform is connected, `--target` is optional
- **Broadcast to all platforms**: `hermes gateway send-message 'Alert!' --target all`
- **List available targets**: `hermes gateway send-message --list`
- **Stdin support for piping**: `echo 'status update' | hermes gateway send-message --target discord`

## Implementation

Reuses the existing `send_message_tool` from `tools/send_message_tool.py` so no platform-specific send logic is duplicated. The tool already handles home-channel fallback, channel-name resolution, smart message chunking, and standalone sender fallbacks when the gateway daemon isn't running.

## Files changed

- `hermes_cli/main.py` — argparse registration
- `hermes_cli/gateway.py` — dispatch logic (`_gateway_send_message`)
- `tests/hermes_cli/test_gateway.py` — 15 new tests covering list, send, stdin, auto-default, `--target all`, and error cases

## Tests

All 42 gateway tests pass locally using `scripts/run_tests.sh`.