### PR TITLE
fix: support MiniMax OAuth for compression auxiliary

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3006,6 +3006,54 @@ def resolve_provider_client(
         logger.warning("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
+    if pconfig.auth_type == "oauth_minimax":
+        try:
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+            from agent.anthropic_adapter import build_anthropic_client
+        except ImportError:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but required "
+                "auth or anthropic support is unavailable"
+            )
+            return None, None
+
+        try:
+            creds = resolve_minimax_oauth_runtime_credentials()
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but OAuth "
+                "credentials are unavailable: %s",
+                exc,
+            )
+            return None, None
+
+        api_key = str(creds.get("api_key") or "").strip()
+        raw_base_url = str(creds.get("base_url") or pconfig.inference_base_url or "").strip().rstrip("/")
+        if not api_key or not raw_base_url:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth returned incomplete runtime credentials"
+            )
+            return None, None
+
+        final_model = _normalize_resolved_model(
+            model or _get_aux_model_for_provider(provider),
+            provider,
+        )
+        logger.debug("resolve_provider_client: minimax-oauth (%s)", final_model)
+        try:
+            real_client = build_anthropic_client(api_key, raw_base_url)
+        except ImportError as exc:
+            logger.warning(
+                "resolve_provider_client: cannot create MiniMax OAuth client: %s",
+                exc,
+            )
+            return None, None
+        sync_client = AnthropicAuxiliaryClient(
+            real_client, final_model, api_key, raw_base_url, is_oauth=False,
+        )
+        return (_to_async_client(sync_client, final_model, is_vision=is_vision) if async_mode
+                else (sync_client, final_model))
+
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
             client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3169,6 +3169,45 @@ class AIAgent:
             "api_mode": getattr(self, "api_mode", "") or "",
         }
 
+    def _compression_provider_auth_hint(self, provider: str) -> str:
+        """Return a compact setup hint for a configured compression provider."""
+        provider = (provider or "").strip().lower()
+        if provider == "openrouter":
+            return "set OPENROUTER_API_KEY"
+        if provider in {"nous", "nous-portal"}:
+            return "run `hermes auth add` or `hermes login --provider nous`"
+        if provider in {"openai-codex", "codex"}:
+            return "run `hermes login --provider openai-codex`"
+        if provider == "custom":
+            return "set auxiliary.compression.base_url and auxiliary.compression.api_key"
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY
+
+            pconfig = PROVIDER_REGISTRY.get(provider)
+            env_vars = getattr(pconfig, "api_key_env_vars", ()) if pconfig else ()
+            if env_vars:
+                return "set " + " or ".join(env_vars)
+        except Exception:
+            pass
+        return f"configure credentials for provider `{provider}`"
+
+    def _compression_missing_provider_warning(self, provider: str) -> str:
+        """Build the startup warning shown when compression has no LLM client."""
+        provider = (provider or "").strip().lower()
+        if provider and provider != "auto":
+            hint = self._compression_provider_auth_hint(provider)
+            return (
+                "⚠ Auxiliary compression provider unavailable "
+                f"(auxiliary.compression.provider={provider}) — context "
+                "compression will drop middle turns without a summary. "
+                f"{hint}, or set auxiliary.compression.provider to auto."
+            )
+        return (
+            "⚠ No auxiliary LLM provider configured — context "
+            "compression will drop middle turns without a summary. "
+            "Run `hermes setup` or set OPENROUTER_API_KEY."
+        )
+
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
         window is smaller than the main model's compression threshold.
@@ -3208,17 +3247,20 @@ class AIAgent:
             except Exception:
                 _aux_cfg_provider = ""
             if client is None or not aux_model:
-                msg = (
-                    "⚠ No auxiliary LLM provider configured — context "
-                    "compression will drop middle turns without a summary. "
-                    "Run `hermes setup` or set OPENROUTER_API_KEY."
-                )
+                msg = self._compression_missing_provider_warning(_aux_cfg_provider)
                 self._compression_warning = msg
                 self._emit_status(msg)
-                logger.warning(
-                    "No auxiliary LLM provider for compression — "
-                    "summaries will be unavailable."
-                )
+                if _aux_cfg_provider and _aux_cfg_provider != "auto":
+                    logger.warning(
+                        "Auxiliary compression provider %s unavailable — "
+                        "summaries will be unavailable.",
+                        _aux_cfg_provider,
+                    )
+                else:
+                    logger.warning(
+                        "No auxiliary LLM provider for compression — "
+                        "summaries will be unavailable."
+                    )
                 return
 
             aux_base_url = str(getattr(client, "base_url", ""))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -40,6 +40,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     # teknium (multiple emails)
+    "ronaldrj@gmail.com": "rarf",
     "teknium1@gmail.com": "teknium1",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -348,6 +348,35 @@ class TestBuildCodexClient:
         assert mock_openai.call_count == 2
 
 
+class TestMiniMaxOAuthAuxiliaryClient:
+    def test_resolve_provider_client_uses_minimax_oauth_credentials(self):
+        real_client = MagicMock(name="minimax-anthropic-client")
+        with (
+            patch("hermes_cli.auth.resolve_minimax_oauth_runtime_credentials", return_value={
+                "api_key": "minimax-oauth-token",
+                "base_url": "https://api.minimax.io/anthropic",
+            }) as mock_creds,
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=real_client) as mock_build,
+        ):
+            from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+            client, model = resolve_provider_client("minimax-oauth", "MiniMax-M2.7")
+
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert model == "MiniMax-M2.7"
+        mock_creds.assert_called_once()
+        mock_build.assert_called_once_with("minimax-oauth-token", "https://api.minimax.io/anthropic")
+        assert client.api_key == "minimax-oauth-token"
+        assert client.base_url == "https://api.minimax.io/anthropic"
+
+    def test_minimax_oauth_missing_credentials_returns_none(self):
+        with patch("hermes_cli.auth.resolve_minimax_oauth_runtime_credentials", side_effect=RuntimeError("login required")):
+            client, model = resolve_provider_client("minimax-oauth", "MiniMax-M2.7")
+
+        assert client is None
+        assert model is None
+
+
 class TestExpiredCodexFallback:
     """Test that expired Codex tokens don't block the auto chain."""
 

--- a/tests/run_agent/test_compression_aux_warning.py
+++ b/tests/run_agent/test_compression_aux_warning.py
@@ -1,0 +1,42 @@
+"""Regression tests for compression auxiliary provider startup warnings."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _bare_agent():
+    agent = object.__new__(AIAgent)
+    agent.compression_enabled = True
+    agent.model = "anthropic/claude-sonnet-4-6"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "or-key"
+    agent.api_mode = "chat_completions"
+    agent._aux_compression_context_length_config = None
+    agent.context_compressor = SimpleNamespace(threshold_tokens=100_000)
+    agent._compression_warning = None
+    emitted = []
+    agent._emit_status = emitted.append
+    return agent, emitted
+
+
+def test_missing_explicit_compression_provider_warning_names_provider_and_env_var():
+    agent, emitted = _bare_agent()
+
+    with (
+        patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(None, None)),
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("minimax", "mini-max-01", None, None, None),
+        ),
+    ):
+        agent._check_compression_model_feasibility()
+
+    assert emitted
+    warning = emitted[0]
+    assert "auxiliary.compression.provider=minimax" in warning
+    assert "MINIMAX_API_KEY" in warning
+    assert "OPENROUTER_API_KEY" not in warning
+    assert agent._compression_warning == warning


### PR DESCRIPTION
## Summary
- clarify compression auxiliary warnings for explicit provider overrides
- add MiniMax OAuth support to auxiliary provider resolution
- keep OpenAI Codex auxiliary path requiring explicit model (e.g. gpt-5.4-mini)

## Testing
- python -m pytest -q tests/agent/test_auxiliary_client.py::TestBuildCodexClient tests/agent/test_auxiliary_client.py::TestMiniMaxOAuthAuxiliaryClient tests/run_agent/test_compression_aux_warning.py

## Notes
- MiniMax OAuth now resolves via resolve_minimax_oauth_runtime_credentials() and uses the Anthropic Messages adapter against the MiniMax /anthropic endpoint.
- OpenAI Codex already works for auxiliary compression when auxiliary.compression.provider=openai-codex and auxiliary.compression.model is explicit.