### PR TITLE
feat: update cmux workspace title from goals

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -34,6 +34,7 @@ from hermes_cli.browser_connect import (
     launch_chrome_debug,
     manual_chrome_debug_command,
 )
+from hermes_cli.cmux_integration import rename_cmux_workspace_for_goal
 
 
 class CLICommandsMixin:
@@ -2107,6 +2108,11 @@ class CLICommandsMixin:
             _cprint(f"  Invalid goal: {exc}")
             return
 
+        rename_cmux_workspace_for_goal(
+            state.goal,
+            config=getattr(self, "config", None),
+        )
+
         _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
         if state.has_contract():
             _cprint(f"  {_DIM}Completion contract:{_RST}")
@@ -2150,6 +2156,11 @@ class CLICommandsMixin:
         except ValueError as exc:
             _cprint(f"  Invalid goal: {exc}")
             return
+
+        rename_cmux_workspace_for_goal(
+            state.goal,
+            config=getattr(self, "config", None),
+        )
 
         _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
         if state.has_contract():

--- a/hermes_cli/cmux_integration.py
+++ b/hermes_cli/cmux_integration.py
@@ -1,0 +1,112 @@
+"""Small optional integrations with the cmux terminal multiplexer.
+
+This module is deliberately dependency-free and fail-soft. Hermes should behave
+exactly the same outside cmux, when the cmux CLI is missing, or when the socket
+is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PREFIX = "Goal: "
+_DEFAULT_MAX_CHARS = 60
+_TIMEOUT_SECONDS = 2.0
+_WHITESPACE_RE = re.compile(r"\s+")
+_MARKDOWN_BULLET_RE = re.compile(r"^[-*+]\s+")
+
+
+def _compact_goal_text(goal: str) -> str:
+    """Return a single-line, title-friendly version of a goal string."""
+    text = str(goal or "").strip()
+    if text.lower().startswith("/goal"):
+        text = text[5:].strip()
+    # Prefer the first meaningful line over concatenating a detailed checklist.
+    for line in text.splitlines():
+        candidate = line.strip()
+        if not candidate:
+            continue
+        candidate = _MARKDOWN_BULLET_RE.sub("", candidate).strip()
+        if candidate:
+            text = candidate
+            break
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return text.strip("`*_#[](){}<>\"'“”‘’") or "Goal"
+
+
+def build_goal_workspace_title(
+    goal: str,
+    *,
+    max_chars: int = _DEFAULT_MAX_CHARS,
+    prefix: str = _DEFAULT_PREFIX,
+) -> str:
+    """Build a compact cmux workspace title for a standing goal."""
+    safe_prefix = str(prefix or "")
+    try:
+        limit = int(max_chars or _DEFAULT_MAX_CHARS)
+    except Exception:
+        limit = _DEFAULT_MAX_CHARS
+    limit = max(8, limit)
+
+    title = f"{safe_prefix}{_compact_goal_text(goal)}"
+    if len(title) <= limit:
+        return title
+
+    ellipsis = "…"
+    cutoff = max(1, limit - len(ellipsis))
+    return title[:cutoff].rstrip() + ellipsis
+
+
+def _cmux_config(config: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    section = (config or {}).get("cmux") if isinstance(config, Mapping) else None
+    return section if isinstance(section, Mapping) else {}
+
+
+def rename_cmux_workspace_for_goal(
+    goal: str,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+    env: Optional[Mapping[str, str]] = None,
+    runner: Optional[Callable[..., subprocess.CompletedProcess]] = None,
+) -> Optional[str]:
+    """Rename the current cmux workspace for a newly-set goal.
+
+    Returns the title when a rename command was attempted, otherwise ``None``.
+    All failures are swallowed and logged at debug level because cmux is an
+    optional host UI nicety, not part of Hermes goal semantics.
+    """
+    cfg = _cmux_config(config)
+    if cfg.get("auto_rename_workspace_on_goal", True) is False:
+        return None
+
+    active_env = os.environ if env is None else env
+    workspace_id = str(active_env.get("CMUX_WORKSPACE_ID") or "").strip()
+    if not workspace_id:
+        return None
+
+    title = build_goal_workspace_title(
+        goal,
+        max_chars=cfg.get("goal_title_max_chars", _DEFAULT_MAX_CHARS),
+        prefix=cfg.get("goal_title_prefix", _DEFAULT_PREFIX),
+    )
+    cmd = ["cmux", "rename-workspace", "--workspace", workspace_id, title]
+    call = runner or subprocess.run
+    try:
+        call(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        logger.debug("cmux workspace rename for goal failed: %s", exc)
+        return None
+    return title

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2284,6 +2284,15 @@ DEFAULT_CONFIG = {
         "max_turns": 20,
     },
 
+    # cmux — optional host UI niceties when Hermes runs inside cmux.
+    # The workspace rename is fail-soft: outside cmux or without the cmux CLI,
+    # Hermes goal semantics are unchanged.
+    "cmux": {
+        "auto_rename_workspace_on_goal": True,
+        "goal_title_prefix": "Goal: ",
+        "goal_title_max_chars": 60,
+    },
+
     # Mixture of Agents — named presets used by /moa. A preset is an execution
     # mode around the main model, not a provider/model itself: references +
     # aggregator synthesize private guidance before each main-model iteration.

--- a/tests/cli/test_cli_goal_cmux_title.py
+++ b/tests/cli/test_cli_goal_cmux_title.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import queue
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _make_cli(session_id: str = "sid-cmux-goal-title"):
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = session_id
+    cli._goal_manager = None
+    cli._pending_input = queue.Queue()
+    cli.config = {
+        "cmux": {
+            "auto_rename_workspace_on_goal": True,
+            "goal_title_prefix": "Goal: ",
+            "goal_title_max_chars": 60,
+        }
+    }
+    return cli
+
+
+def test_goal_command_updates_cmux_workspace_title(hermes_home):
+    cli = _make_cli()
+
+    with patch("hermes_cli.cli_commands_mixin.rename_cmux_workspace_for_goal") as rename:
+        cli._handle_goal_command("/goal Improve cmux workspace titles")
+
+    rename.assert_called_once_with(
+        "Improve cmux workspace titles",
+        config=cli.config,
+    )
+    assert cli._pending_input.get_nowait() == "Improve cmux workspace titles"
+
+
+def test_goal_draft_command_updates_cmux_workspace_title(hermes_home):
+    cli = _make_cli(session_id="sid-cmux-goal-draft")
+
+    with (
+        patch(
+            "hermes_cli.goals.draft_contract",
+            return_value=None,
+        ),
+        patch("hermes_cli.cli_commands_mixin.rename_cmux_workspace_for_goal") as rename,
+    ):
+        cli._handle_goal_command("/goal draft Improve cmux draft titles")
+
+    rename.assert_called_once_with(
+        "Improve cmux draft titles",
+        config=cli.config,
+    )
+    assert cli._pending_input.get_nowait() == "Improve cmux draft titles"

--- a/tests/hermes_cli/test_cmux_integration.py
+++ b/tests/hermes_cli/test_cmux_integration.py
@@ -1,0 +1,90 @@
+import subprocess
+
+
+def test_build_goal_workspace_title_compacts_goal_text():
+    from hermes_cli.cmux_integration import build_goal_workspace_title
+
+    title = build_goal_workspace_title(
+        "  /goal  Ship cmux workspace auto-title support\n\n"
+        "- update classic CLI\n"
+        "- update TUI\n",
+        max_chars=48,
+    )
+
+    assert title == "Goal: Ship cmux workspace auto-title support"
+    assert "\n" not in title
+    assert len(title) <= 48
+
+
+def test_build_goal_workspace_title_truncates_at_character_boundary():
+    from hermes_cli.cmux_integration import build_goal_workspace_title
+
+    title = build_goal_workspace_title(
+        "cmux の workspace タイトルを /goal の内容に合わせて自動更新する",
+        max_chars=24,
+    )
+
+    assert title.startswith("Goal: cmux の workspace")
+    assert title.endswith("…")
+    assert len(title) <= 24
+
+
+def test_rename_cmux_workspace_for_goal_runs_cmux_when_inside_cmux():
+    from hermes_cli.cmux_integration import rename_cmux_workspace_for_goal
+
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0)
+
+    title = rename_cmux_workspace_for_goal(
+        "Improve the /goal title handoff",
+        config={"cmux": {"auto_rename_workspace_on_goal": True}},
+        env={"CMUX_WORKSPACE_ID": "workspace:12"},
+        runner=runner,
+    )
+
+    assert title == "Goal: Improve the /goal title handoff"
+    assert calls == [
+        (
+            [
+                "cmux",
+                "rename-workspace",
+                "--workspace",
+                "workspace:12",
+                "Goal: Improve the /goal title handoff",
+            ],
+            {"check": False, "capture_output": True, "text": True, "timeout": 2.0},
+        )
+    ]
+
+
+def test_rename_cmux_workspace_for_goal_skips_outside_cmux():
+    from hermes_cli.cmux_integration import rename_cmux_workspace_for_goal
+
+    calls = []
+    title = rename_cmux_workspace_for_goal(
+        "No cmux env",
+        config={"cmux": {"auto_rename_workspace_on_goal": True}},
+        env={},
+        runner=lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    assert title is None
+    assert calls == []
+
+
+def test_rename_cmux_workspace_for_goal_respects_disabled_config():
+    from hermes_cli.cmux_integration import rename_cmux_workspace_for_goal
+
+    calls = []
+    title = rename_cmux_workspace_for_goal(
+        "Disabled",
+        config={"cmux": {"auto_rename_workspace_on_goal": False}},
+        env={"CMUX_WORKSPACE_ID": "workspace:12"},
+        runner=lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    assert title is None
+    assert calls == []

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -182,6 +182,38 @@ def test_goal_requires_session(server):
     assert r["error"]["code"] == 4001
 
 
+def test_goal_set_updates_cmux_workspace_title(server, session, monkeypatch):
+    sid, _, s = session
+    s["session_key"] = "tui-goal-session-cmux-title"
+    config = {
+        "cmux": {
+            "auto_rename_workspace_on_goal": True,
+            "goal_title_prefix": "Goal: ",
+            "goal_title_max_chars": 60,
+        }
+    }
+    monkeypatch.setattr(server, "_load_cfg", lambda: config)
+    calls = []
+
+    def _rename(goal, *, config=None):
+        calls.append((goal, config))
+        return "Goal: Improve cmux workspace titles"
+
+    monkeypatch.setattr(server, "rename_cmux_workspace_for_goal", _rename)
+
+    r = _call(
+        server,
+        "command.dispatch",
+        name="goal",
+        arg="Improve cmux workspace titles",
+        session_id=sid,
+    )
+
+    assert r["result"]["type"] == "send"
+    assert r["result"]["message"] == "Improve cmux workspace titles"
+    assert calls == [("Improve cmux workspace titles", config)]
+
+
 # ── slash.exec /goal routing ──────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -24,6 +24,7 @@ from hermes_constants import (
     set_hermes_home_override,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.cmux_integration import rename_cmux_workspace_for_goal
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
@@ -12196,6 +12197,11 @@ def _(rid, params: dict) -> dict:
             state = mgr.set(arg)
         except ValueError as exc:
             return _err(rid, 4004, f"invalid goal: {exc}")
+
+        rename_cmux_workspace_for_goal(
+            state.goal,
+            config=_load_cfg(),
+        )
 
         notice = (
             f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}\n"

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -181,6 +181,14 @@ goals:
   # /goal resume. Default 20. Lower this if you want tighter loops;
   # raise it for long-running refactors.
   max_turns: 20
+
+cmux:
+  # When Hermes runs inside cmux, setting /goal <text> renames the current
+  # workspace to a compact title derived from the goal, e.g.
+  # "Goal: Fix failing CLI tests". Outside cmux this is ignored.
+  auto_rename_workspace_on_goal: true
+  goal_title_prefix: "Goal: "
+  goal_title_max_chars: 60
 ```
 
 ### Choosing the judge model


### PR DESCRIPTION
## Summary
- Fail-soft cmux integration renames the current workspace when `/goal` sets a new standing goal.
- Compact configurable title defaults to `Goal: <goal>`.
- Wired into classic CLI normal + draft set paths and TUI goal dispatch.

## Review response
Addresses https://github.com/NousResearch/hermes-agent/pull/24941#pullrequestreview-4681687036:
1. Ported classic CLI call off the old `cli.py` hunk onto `hermes_cli/cli_commands_mixin.py`.
2. Call rename after both current `mgr.set(...)` sites: normal `/goal` and `/goal draft`.
3. Kept the TUI hook after gateway `mgr.set(...)`; test lives in `tests/tui_gateway/test_goal_command.py`.
4. No `scripts/release.py` changes (GitHub noreply author).

## Test Plan
- `python -m pytest tests/hermes_cli/test_cmux_integration.py tests/cli/test_cli_goal_cmux_title.py tests/tui_gateway/test_goal_command.py -q` (23 passed)
- `git diff --check`