### PR TITLE
fix: Phase 1 security hardening — 3 critical fixes

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5109,6 +5109,13 @@ class TelegramAdapter(BasePlatformAdapter):
             allowed = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
             if not allowed:
                 return True
+            # Only apply user-based allowlist to actual private/DM chats.
+            # Channel posts and other non-group types use
+            # TELEGRAM_ALLOWED_CHATS for access control instead.
+            chat = getattr(message, "chat", None)
+            chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+            if chat_type not in ("dm", "private"):
+                return True
             allowed_ids = {uid.strip() for uid in allowed.split(",") if uid.strip()}
             if "*" in allowed_ids:
                 return True

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5085,7 +5085,8 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
-        DMs remain unrestricted. Group/supergroup messages are accepted when:
+        DMs remain unrestricted unless TELEGRAM_ALLOWED_USERS is set.
+        Group/supergroup messages are accepted when:
         - the chat passes the ``allowed_chats`` whitelist (when set), or
           ``guest_mode`` is enabled and the bot is explicitly mentioned
         - the chat is explicitly allowlisted in ``free_response_chats``
@@ -5105,6 +5106,12 @@ class TelegramAdapter(BasePlatformAdapter):
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
         if not self._is_group_chat(message):
+            allowed = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
+            if allowed and message.from_user:
+                uid = str(message.from_user.id)
+                allowed_ids = {uid.strip() for uid in allowed.split(",") if uid.strip()}
+                if uid not in allowed_ids:
+                    return False
             return True
 
         thread_id = getattr(message, "message_thread_id", None)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5107,12 +5107,15 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._is_group_chat(message):
             allowed = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
-            if allowed and message.from_user:
-                uid = str(message.from_user.id)
-                allowed_ids = {uid.strip() for uid in allowed.split(",") if uid.strip()}
-                if uid not in allowed_ids:
-                    return False
-            return True
+            if not allowed:
+                return True
+            allowed_ids = {uid.strip() for uid in allowed.split(",") if uid.strip()}
+            if "*" in allowed_ids:
+                return True
+            if not message.from_user:
+                return False
+            uid = str(message.from_user.id)
+            return uid in allowed_ids
 
         thread_id = getattr(message, "message_thread_id", None)
         allowed_topics = self._telegram_allowed_topics()

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -85,9 +85,9 @@ class TestHermesToolsGeneration(unittest.TestCase):
             self.assertIn(f"def {tool}(", src)
 
     def test_generates_subset(self):
-        src = generate_hermes_tools_module(["terminal", "web_search"])
-        self.assertIn("def terminal(", src)
+        src = generate_hermes_tools_module(["web_search", "write_file"])
         self.assertIn("def web_search(", src)
+        self.assertIn("def write_file(", src)
         self.assertNotIn("def read_file(", src)
 
     def test_empty_list_generates_nothing(self):
@@ -96,8 +96,8 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def _call(", src)  # infrastructure still present
 
     def test_non_allowed_tools_ignored(self):
-        src = generate_hermes_tools_module(["vision_analyze", "terminal"])
-        self.assertIn("def terminal(", src)
+        src = generate_hermes_tools_module(["vision_analyze", "web_search"])
+        self.assertIn("def web_search(", src)
         self.assertNotIn("def vision_analyze(", src)
 
     def test_rpc_infrastructure_present(self):

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -794,7 +794,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_none_enabled_tools_uses_all(self):
         """When enabled_tools is None, all sandbox tools should be available."""
         code = (
-            "from hermes_tools import terminal, web_search, read_file\n"
+            "from hermes_tools import web_search, read_file, write_file\n"
             "print('all imports ok')\n"
         )
         with patch("model_tools.handle_function_call",
@@ -808,7 +808,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_empty_enabled_tools_uses_all(self):
         """When enabled_tools is [] (empty), all sandbox tools should be available."""
         code = (
-            "from hermes_tools import terminal, web_search\n"
+            "from hermes_tools import web_search, read_file\n"
             "print('imports ok')\n"
         )
         with patch("model_tools.handle_function_call",
@@ -823,7 +823,7 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
         should fall back to all allowed tools."""
         code = (
-            "from hermes_tools import terminal\n"
+            "from hermes_tools import web_search\n"
             "print('fallback ok')\n"
         )
         with patch("model_tools.handle_function_call",

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -53,25 +53,29 @@ def _clean_state():
 
 
 # ---------------------------------------------------------------------------
-# Container skip
+# Container environments now go through command guards (defense-in-depth)
 # ---------------------------------------------------------------------------
 
 class TestContainerSkip:
-    def test_docker_skips_both(self):
+    def test_docker_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "docker")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_singularity_skips_both(self):
+    def test_singularity_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "singularity")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_modal_skips_both(self):
+    def test_modal_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "modal")
-        assert result["approved"] is True
+        assert result["approved"] is False
 
-    def test_daytona_skips_both(self):
+    def test_daytona_blocks_hardline(self):
         result = check_all_command_guards("rm -rf /", "daytona")
-        assert result["approved"] is True
+        assert result["approved"] is False
+
+    def test_vercel_sandbox_blocks_hardline(self):
+        result = check_all_command_guards("rm -rf /", "vercel_sandbox")
+        assert result["approved"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -220,8 +220,8 @@ class TestCronDenyModeAllGuards:
 class TestCronModeInteractions:
     """Cron mode should NOT interfere with other approval bypass mechanisms."""
 
-    def test_container_env_still_auto_approves(self, monkeypatch):
-        """Docker/sandbox environments bypass approvals regardless of cron_mode."""
+    def test_container_env_enforces_hardline(self, monkeypatch):
+        """Container environments now enforce hardline command blocks (defense-in-depth)."""
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
@@ -230,7 +230,7 @@ class TestCronModeInteractions:
         from unittest.mock import patch as mock_patch
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
             result = check_dangerous_command("rm -rf /", "docker")
-            assert result["approved"]
+            assert not result["approved"]
 
     def test_yolo_overrides_cron_deny(self, monkeypatch):
         """--yolo still bypasses cron_mode=deny for dangerous (non-hardline) commands."""

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -239,7 +239,7 @@ def test_container_backends_now_enforce_guards(clean_session):
 
     Hardline and dangerous command detection applies to all environments.
     """
-    for env in ("docker", "singularity", "modal", "daytona"):
+    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         r1 = check_dangerous_command("rm -rf /", env)
         assert r1["approved"] is False, f"container {env} should block hardline"
         r2 = check_all_command_guards("rm -rf /", env)

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -234,16 +234,16 @@ def test_cron_approve_mode_cannot_bypass_hardline(clean_session, monkeypatch):
     assert result.get("hardline") is True
 
 
-def test_container_backends_still_bypass(clean_session):
-    """Containerized backends remain bypass-approved — they can't touch the host.
+def test_container_backends_now_enforce_guards(clean_session):
+    """Containerized backends now go through command guards (defense-in-depth).
 
-    Hardline only protects environments with real host impact (local, ssh).
+    Hardline and dangerous command detection applies to all environments.
     """
     for env in ("docker", "singularity", "modal", "daytona"):
         r1 = check_dangerous_command("rm -rf /", env)
-        assert r1["approved"] is True, f"container {env} should still bypass"
+        assert r1["approved"] is False, f"container {env} should block hardline"
         r2 = check_all_command_guards("rm -rf /", env)
-        assert r2["approved"] is True, f"container {env} should still bypass"
+        assert r2["approved"] is False, f"container {env} should block hardline"
 
 
 def test_hardline_runs_before_dangerous_detection(clean_session):
@@ -368,9 +368,9 @@ def test_sudo_stdin_guard_not_blocked_by_yolo(clean_session, monkeypatch):
         assert result["approved"] is False, f"yolo leaked sudo guard on {cmd!r}"
 
 
-def test_sudo_stdin_guard_container_bypass(clean_session):
-    """Containerized backends still bypass — they can't touch the host."""
-    for env in ("docker", "singularity", "modal", "daytona"):
+def test_sudo_stdin_guard_blocks_in_containers(clean_session):
+    """Containerized backends now enforce the sudo stdin guard (defense-in-depth)."""
+    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
-            assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+            assert result["approved"] is False, f"container {env} should block sudo guard on {cmd!r}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1049,9 +1049,6 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
-    if env_type in {"docker", "singularity", "modal", "daytona"}:
-        return {"approved": True, "message": None}
-
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
     # to raw device, shutdown/reboot, fork bomb, kill -1) are blocked
     # unconditionally, BEFORE the yolo bypass.  Opting into yolo is

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1276,10 +1276,6 @@ def check_all_command_guards(command: str, env_type: str,
     a gateway force=True replay from bypassing one check when only the
     other was shown to the user.
     """
-    # Skip containers for both checks
-    if env_type in {"docker", "singularity", "modal", "daytona"}:
-        return {"approved": True, "message": None}
-
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
     # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 
 SANDBOX_AVAILABLE = True
 
-# The 7 tools allowed inside the sandbox. The intersection of this list
+# The tools allowed inside the sandbox. The intersection of this list
 # and the session's enabled tools determines which stubs are generated.
 SANDBOX_ALLOWED_TOOLS = frozenset([
     "web_search",
@@ -65,7 +65,6 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "write_file",
     "search_files",
     "patch",
-    "terminal",
 ])
 
 # Resource limit defaults (overridable via config.yaml → code_execution.*)


### PR DESCRIPTION
Title: fix: Phase 1 security hardening — remove container approval bypass, sandbox terminal, gate Telegram auth

What does this PR do?

These 3 fixes map to issues:
1. Container approval bypass — referenced in Security Audit #7826 (finding C3: "Approval bypass for containerized environments"), also #4146 (sandbox code exec bypass)
2. Sandbox terminal removal — #41 (Critical: execute_code sandbox bypass), #4146
3. Telegram auth gate — #23778 (Gateway auth bypass — unauthorized messages processed)

Three independent security fixes from the Phase 1 audit (issues 003, 005, 027):

1. Container approval bypass removed — check_dangerous_command() no longer returns {"approved": True} unconditionally for docker/singularity/modal/daytona backends. These backends now go through full dangerous-command detection just like local. YOLO mode still bypasses if explicitly enabled.

2. Terminal removed from sandbox tools — SANDBOX_ALLOWED_TOOLS no longer includes "terminal". LLM-generated Python code inside the sandbox cannot call terminal("rm -rf /") via the RPC stub, closing the confused-deputy RCE vector.

3. Telegram DMs gated by TELEGRAM_ALLOWED_USERS — _should_process_message() now checks TELEGRAM_ALLOWED_USERS for DMs. Unauthorized users are rejected at the adapter level before the message is ever queued for processing. No pairing code sent, no agent processing.
Related Issue


Type of Change
- [x] 🔒 Security fix


Changes Made
- tools/approval.py — Removed 2-line unconditional bypass for container backends (docker/singularity/modal/daytona). Defense-in-depth: containers isolate runtime, not intent.

- tools/code_execution_tool.py — Removed "terminal" from SANDBOX_ALLOWED_TOOLS frozenset. Sandbox code retains read_file/write_file/search_files/patch/web_search/web_extract — no shell access.

- gateway/platforms/telegram.py — Added TELEGRAM_ALLOWED_USERS check in _should_process_message() for non-group chats. Only checked when env var is set (no-op when absent, preserving existing pairing flow).


How to Test
1. env_type: docker → run rm -rf / via terminal → should prompt for approval (not auto-approve)
2. Call execute_code with Python that calls terminal("id") → sandbox RPC returns tool-not-found error
3. Set TELEGRAM_ALLOWED_USERS=your_id → DM from different Telegram user → silently ignored (no response)
4. Unset TELEGRAM_ALLOWED_USERS → DM from new user → pairing code works as before (no regression)