### PR TITLE
fix(qqbot): add WebSocket heartbeat to prevent 60s idle timeout disconnects

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -447,6 +447,7 @@ class QQAdapter(BasePlatformAdapter):
             },
             timeout=CONNECT_TIMEOUT_SECONDS,
             proxy=ws_proxy,
+            heartbeat=50.0,  # Transport-level WebSocket PING every 50s (below QQ's ~60s server timeout)
         )
         logger.info("[%s] WebSocket connected to %s", self._log_tag, gateway_url)
 
@@ -761,8 +762,8 @@ class QQAdapter(BasePlatformAdapter):
         if op == 10:
             d_data = d if isinstance(d, dict) else {}
             interval_ms = d_data.get("heartbeat_interval", 30000)
-            # Send heartbeats at 80% of the server interval to stay safe
-            self._heartbeat_interval = interval_ms / 1000.0 * 0.8
+            # Send heartbeats at 60% of the server interval to stay safe
+            self._heartbeat_interval = interval_ms / 1000.0 * 0.6
             logger.debug(
                 "[%s] Hello received, heartbeat_interval=%dms (sending every %.1fs)",
                 self._log_tag,


### PR DESCRIPTION
## Summary

QQ Bot WebSocket connections were disconnecting every ~60 seconds due to the QQ server closing idle connections. The adapter was sending application-level op 1 heartbeats but no transport-layer WebSocket PING frames, causing intermediate network infrastructure (proxies, NAT gateways) to treat the connection as inactive.

## Changes

### 1. Transport-level heartbeat (primary fix)
Added `heartbeat=50.0` to `ws_connect()` in `_open_ws()`:
- aiohttp sends WebSocket PING frames every 50 seconds at the transport layer
- 50s < QQ server's ~60s idle timeout → server no longer closes connections
- Reference: #20531, #21633

### 2. Application-level heartbeat (secondary)
Reduced application heartbeat factor from `0.8` to `0.6`:
- More aggressive op 1 heartbeat sending (~18-25s interval vs ~24-33s before)
- Complements transport-level PING for double-layer keepalive

## Verification

| Metric | Before | After |
|--------|--------|-------|
| Disconnections in 10 min | ~10 | 0 |
| Connection stability | Unstable (every 60s) | Stable |

Gateway restart after patch → new session established successfully, no disconnects observed in 10+ minute observation window.

## Testing

- [x] Gateway restart: ✓
- [x] QQ Bot reconnection: ✓
- [x] 10-minute stability test: ✓ (0 disconnects)
- [ ] 24-hour long-term observation (recommended)

## Notes

- These changes are protocol-compliant (QQ officially supports WebSocket PING/PONG)
- The existing application-level heartbeat (op 1) is preserved — it serves a different purpose (QQ protocol session keepalive with seq tracking)
- The `heartbeat` parameter uses aiohttp's built-in WebSocket PING mechanism, no custom implementation needed
