### PR TITLE
feat(context-engine): add preassemble() hook for per-turn rewrite

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -105,6 +105,41 @@ class ContextEngine(ABC):
         """
         return False
 
+    # -- Optional: per-turn assembly hook ----------------------------------
+
+    def preassemble(
+        self,
+        messages: List[Dict[str, Any]],
+        budget_tokens: int = None,
+    ) -> List[Dict[str, Any]]:
+        """Per-turn rewrite hook called immediately before each model API request.
+
+        Engines may return a substituted message list (e.g., replace evicted
+        raw turns with summary stubs while preserving the assistant/tool-call
+        pairing invariant). Default is a no-op: return ``messages`` unchanged.
+
+        Called every turn at the API-call boundary, regardless of
+        ``should_compress()``. Engines that only react to overflow should
+        override ``compress()`` instead and leave this method as the default.
+
+        Args:
+            messages: full in-memory message list at the call boundary.
+                Engines MUST return a valid OpenAI-format message sequence;
+                broken tool_use/tool_result pairing will fail at the provider.
+            budget_tokens: target token budget the host expects to fit under
+                (typically ``self.threshold_tokens`` from the active engine).
+                Engines may use this to decide how aggressively to substitute.
+                ``None`` means "the host did not pre-compute a budget";
+                engines should fall back to their own threshold.
+
+        Returns:
+            A (possibly new) message list. The default no-op returns
+            ``messages`` unchanged. Returning a new list does NOT mutate the
+            stored conversation history — the host applies the result to the
+            per-call API copy only.
+        """
+        return messages
+
     # -- Optional: manual /compress preflight ------------------------------
 
     def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -12395,6 +12395,36 @@ class AIAgent:
             # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
             _sanitize_messages_surrogates(api_messages)
 
+            # Per-turn ContextEngine.preassemble() hook.
+            # Pluggable engines (e.g. LCM) may substitute the api_messages
+            # list every turn — replacing evicted raw turns with summary
+            # stubs, or running a DAG-based assembly. Default no-op for
+            # the built-in ContextCompressor.
+            #
+            # Fires once per turn at the API-call boundary, AFTER all
+            # sanitization but BEFORE the retry loop. Operates on the
+            # per-call api_messages copy only; stored history is unchanged.
+            # System message at index 0 (if present) MUST be preserved by
+            # any engine that overrides this method.
+            try:
+                if (
+                    hasattr(self, "context_compressor")
+                    and self.context_compressor is not None
+                ):
+                    _pre_result = self.context_compressor.preassemble(
+                        api_messages,
+                        budget_tokens=getattr(
+                            self.context_compressor, "threshold_tokens", None
+                        ),
+                    )
+                    if isinstance(_pre_result, list) and _pre_result:
+                        api_messages = _pre_result
+            except Exception as _preassemble_exc:
+                logger.warning(
+                    "ContextEngine.preassemble() failed; using unmodified messages: %s",
+                    _preassemble_exc,
+                )
+
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = estimate_messages_tokens_rough(api_messages)

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -103,6 +103,51 @@ class TestDefaults:
         data = json.loads(result)
         assert "error" in data
 
+    def test_default_preassemble_is_noop(self):
+        """preassemble() default returns messages unchanged."""
+        engine = StubEngine()
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        # Default no-op via super(): the same list object is returned.
+        result = ContextEngine.preassemble(engine, msgs, budget_tokens=1000)
+        assert result is msgs
+
+    def test_default_preassemble_no_budget(self):
+        """preassemble() works when budget_tokens is None."""
+        engine = StubEngine()
+        msgs = [{"role": "user", "content": "hi"}]
+        result = ContextEngine.preassemble(engine, msgs)
+        assert result == msgs
+
+    def test_preassemble_subclass_can_substitute(self):
+        """A subclass overriding preassemble() can return a substituted list."""
+        class SubstitutingEngine(StubEngine):
+            def preassemble(self, messages, budget_tokens=None):
+                # Replace any old turns past the first 2 with a single stub.
+                if len(messages) <= 2:
+                    return messages
+                return messages[:1] + [
+                    {"role": "user", "content": "[stub: 5 prior turns elided]"}
+                ] + messages[-1:]
+
+        engine = SubstitutingEngine()
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "u_current"},
+        ]
+        result = engine.preassemble(msgs, budget_tokens=1000)
+        assert len(result) == 3
+        assert result[0]["role"] == "system"
+        assert "stub" in result[1]["content"]
+        assert result[2]["content"] == "u_current"
+
     def test_default_get_status(self):
         engine = StubEngine()
         engine.last_prompt_tokens = 50000


### PR DESCRIPTION
## Summary

Adds an additive, non-breaking ABC method `ContextEngine.preassemble(messages, budget_tokens=None) -> list[Message]` (default no-op) with a single call site in `run_agent.py` right after sanitization and before the retry loop. Lets pluggable context engines (LCM-style, etc.) substitute the message list every turn — not just on overflow — without breaking session lineage or rotating the SQLite session ID.

**Diff: +110 / 0, 3 files. 22/22 tests pass.**

## Why

Today `ContextEngine.compress()` only fires when `should_compress()` returns True (overflow). Plugin engines that maintain a lossless conversation pyramid (raw + summaries DAG) need to substitute evicted raw turns with summary stubs on **every** prompt build to keep the prompt under budget while preserving long-range recall — not just at the overflow boundary.

The existing `pre_llm_call` hook can't do this: it concatenates plugin output into the current user message and never rewrites the message list (intentional, to preserve the prompt cache prefix). The new `preassemble()` hook gives engines explicit, structured per-turn rewrite capability while keeping `pre_llm_call` semantics unchanged.

This is independent of and complementary to #22929 (Wire \`on_pre_compress\` into the context compression pipeline): \`on_pre_compress\` would fire at compress-time; \`preassemble\` fires at every API call.

## What

- **\`agent/context_engine.py\`**: add \`preassemble()\` method to the ABC. Default returns \`messages\` unchanged.
- **\`run_agent.py\`**: call \`self.context_compressor.preassemble(api_messages, budget_tokens=threshold_tokens)\` after surrogate sanitization and before the retry loop. Exception-safe — failures log a warning and fall back to unmodified messages. Fires once per turn at the API-call boundary (not inside the retry loop).
- **\`tests/agent/test_context_engine.py\`**: 3 new tests covering default no-op behavior (with and without \`budget_tokens\`) and a subclass-override case where \`preassemble\` substitutes a stub for middle turns while preserving the system message at index 0 and the final user message.

## API design

\`\`\`python
def preassemble(
    self,
    messages: List[Dict[str, Any]],
    budget_tokens: int = None,
) -> List[Dict[str, Any]]:
    \"\"\"Per-turn rewrite hook called immediately before each model API request.

    Engines may return a substituted message list (e.g., replace evicted
    raw turns with summary stubs while preserving the assistant/tool-call
    pairing invariant). Default is a no-op: return ``messages`` unchanged.
    ...
    \"\"\"
    return messages
\`\`\`

System message at index 0 (if present) is documented as the engine's responsibility to preserve.

## Impact

- **Additive only.** Default no-op. \`ContextCompressor\` (the built-in engine) keeps the no-op default; zero behavior change for non-plugin users.
- **Test suite**: 22/22 pass (3 new + 19 existing) on \`tests/agent/test_context_engine.py\`.
- **Blast radius (independent verification)**: GitNexus code-graph impact analysis on \`ContextEngine\` shows LOW risk; 4 direct callers (\`ContextCompressor\`, \`hermes_cli/plugins.py\`, \`agent/context_compressor.py\`, \`plugins/context_engine/__init__.py\`); 0 affected processes.
- **Exception-safety**: a misbehaving plugin engine's \`preassemble\` can't break the agent loop — failures are logged and the original \`api_messages\` is sent unchanged.
- **Retry loop**: hook fires once per turn, BEFORE the retry loop. Retries on transient API errors reuse the substituted messages (intended — we don't want to re-substitute on every retry, that would invalidate the prompt cache).

## Context

Drafted as part of [electricsheephq/lossless-hermes](https://github.com/electricsheephq/lossless-hermes) — a community port of Lossless Claw to Python/Hermes. Full design rationale and the ADR-documented fallback (if this isn't merged) live at [docs/adr/010-always-on-assembly.md](https://github.com/electricsheephq/lossless-hermes/blob/main/docs/adr/010-always-on-assembly.md). The fallback is workable but breaks session lineage (forces \`should_compress=True\` every turn → SQLite session ID rotation → memory-provider lineage warnings). This patch eliminates that compromise.

The docstring at \`agent/context_engine.py:5\` already names LCM as a planned tenant of the plugin slot, so this lands on the surface the ABC was designed to support.

## Test plan

- [x] \`pytest tests/agent/test_context_engine.py -x -q\` → 22 passed
- [ ] Hermes maintainer review (this PR)
- [ ] Smoke test in CI on the upstream matrix

## Reversibility

100% reversible: revert the 3-file commit. Zero schema changes, zero external contract changes, zero new dependencies.