### PR TITLE
fix: harden Hermes production readiness flows

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -719,7 +719,12 @@ class _CodexCompletionsAdapter:
 
         def _check_cancelled() -> None:
             if deadline is not None and time.monotonic() >= deadline:
-                timed_out.set()
+                # The polling path can notice the total timeout before the
+                # background Timer gets scheduled.  Close/evict here too;
+                # otherwise the cached Codex wrapper can keep a half-dead
+                # httpx transport and poison the next compression retry.
+                if not timed_out.is_set():
+                    _close_client_on_timeout()
                 raise TimeoutError(_timeout_message())
             try:
                 from tools.interrupt import is_interrupted

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -843,7 +843,13 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: str = None,
+        *,
+        _same_model_retry_attempted: bool = False,
+    ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -1088,6 +1094,32 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     _reason = "timed out"
                 self._fallback_to_main_for_compression(e, _reason)
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
+
+            # If compression is already pinned to the main model, there is no
+            # alternate model to fall back to.  For premature stream closes and
+            # malformed transient responses, retry the SAME provider/model once
+            # before degrading to the deterministic extractive fallback.  Do not
+            # do this for full timeouts: with Edward's quality-first 900s
+            # timeout, a second full timeout would make Telegram appear stalled
+            # for up to 30 minutes.
+            _should_retry_same_model = (
+                (_is_json_decode or (_is_streaming_closed and not _is_timeout))
+                and not _same_model_retry_attempted
+                and (not self.summary_model or self.summary_model == self.model)
+            )
+            if _should_retry_same_model:
+                logging.warning(
+                    "Context compression summary via main model hit transient %s (%s). "
+                    "Retrying same provider/model once before using extractive fallback.",
+                    "invalid JSON" if _is_json_decode else "stream close",
+                    e,
+                )
+                self._summary_failure_cooldown_until = 0.0
+                return self._generate_summary(
+                    turns_to_summarize,
+                    focus_topic=focus_topic,
+                    _same_model_retry_attempted=True,
+                )
 
             # Unknown-error best-effort retry on main model.  Losing N turns of
             # context is almost always worse than one extra summary attempt, so

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -763,6 +763,59 @@ class ContextCompressor(ContextEngine):
 
         return "\n\n".join(parts)
 
+    def _build_extractive_fallback_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        *,
+        n_dropped: int,
+    ) -> str:
+        """Create a deterministic fallback summary when the LLM summary fails.
+
+        The old fallback was an opaque placeholder saying that N messages were
+        removed.  That is honest but operationally weak: an interrupted/timeout
+        compression destroys the middle of the session even though we still have
+        those messages in memory at fallback-construction time.  Preserve a
+        compact, redacted extract instead so continuity degrades gracefully.
+        """
+        err_text = redact_sensitive_text(
+            (self._last_summary_error or "unknown summary-generation error").strip()
+        )
+        if len(err_text) > 220:
+            err_text = err_text[:217].rstrip() + "..."
+
+        serialized = self._serialize_for_summary(turns_to_summarize).strip()
+        # Bound the deterministic fallback independently of the failed LLM call:
+        # enough to retain useful breadcrumbs, small enough to actually reduce
+        # context pressure.  Keep both the beginning and the most recent compacted
+        # source because either can contain decisions/state needed after resume.
+        summary_budget_tokens = self._compute_summary_budget(turns_to_summarize)
+        char_budget = min(24_000, max(4_000, int(summary_budget_tokens * _CHARS_PER_TOKEN * 0.75)))
+        if len(serialized) > char_budget:
+            marker = (
+                "\n\n...[extractive fallback truncated to stay within the "
+                "compression budget; most recent compacted source follows]...\n\n"
+            )
+            head_chars = max(1_200, int(char_budget * 0.35))
+            tail_chars = max(1_200, char_budget - head_chars - len(marker))
+            serialized = serialized[:head_chars].rstrip() + marker + serialized[-tail_chars:].lstrip()
+
+        if not serialized:
+            serialized = "[No textual source content was available in the compacted region.]"
+
+        return (
+            f"{SUMMARY_PREFIX}\n"
+            "## Active Task\n"
+            "Not inferred by the fallback summarizer. Use the latest user message "
+            "after this summary as the active task.\n\n"
+            "## Critical Context\n"
+            f"Summary generation was unavailable ({err_text}). {n_dropped} "
+            "historical message(s) were compacted using an Extractive fallback "
+            "instead of an LLM-written summary, so treat the snippets below as "
+            "source breadcrumbs rather than a complete synthesis.\n\n"
+            "## Extractive fallback source snippets\n"
+            f"{serialized}"
+        )
+
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
         """Switch from a separate ``summary_model`` back to the main model.
 
@@ -1458,20 +1511,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     )
             compressed.append(msg)
 
-        # If LLM summary failed, insert a static fallback so the model
-        # knows context was lost rather than silently dropping everything.
+        # If LLM summary failed, insert a deterministic extractive fallback so
+        # the model gets concrete breadcrumbs from the compacted region instead
+        # of an opaque placeholder.  This keeps compression safe under transient
+        # Codex stream interrupts/timeouts while still reducing context pressure.
         if not summary:
             if not self.quiet_mode:
-                logger.warning("Summary generation failed — inserting static fallback context marker")
+                logger.warning("Summary generation failed — inserting extractive fallback context summary")
             n_dropped = compress_end - compress_start
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
-            summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
+            summary = self._build_extractive_fallback_summary(
+                turns_to_summarize,
+                n_dropped=n_dropped,
             )
 
         _merge_summary_into_tail = False

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -450,9 +450,16 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
-    if content:
-        delta_kwargs["content"] = content
+    # Downstream streaming code treats OpenAI-like deltas as having stable
+    # ``content``/``tool_calls`` attributes even on terminal or reasoning-only
+    # chunks. Keep the shape explicit instead of omitting empty attributes.
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": content if content else None,
+        "tool_calls": None,
+        "reasoning": None,
+        "reasoning_content": None,
+    }
     if tool_call_delta is not None:
         delta_kwargs["tool_calls"] = [SimpleNamespace(
             index=tool_call_delta.get("index", 0),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -450,6 +450,8 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    stt_echo_transcript: bool = False  # Send the transcript back to the user before the agent reply
+    stt_echo_transcript_prefix: str = "🎤 Transcription"  # Visible prefix for transcript echo messages
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -556,6 +558,8 @@ class GatewayConfig:
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
+            "stt_echo_transcript": self.stt_echo_transcript,
+            "stt_echo_transcript_prefix": self.stt_echo_transcript_prefix,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -598,8 +602,17 @@ class GatewayConfig:
             quick_commands = {}
 
         stt_enabled = data.get("stt_enabled")
+        stt_config = data.get("stt") if isinstance(data.get("stt"), dict) else {}
         if stt_enabled is None:
-            stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
+            stt_enabled = stt_config.get("enabled")
+        stt_echo_transcript = data.get("stt_echo_transcript")
+        if stt_echo_transcript is None:
+            stt_echo_transcript = stt_config.get("echo_transcript")
+        stt_echo_transcript_prefix = data.get("stt_echo_transcript_prefix")
+        if stt_echo_transcript_prefix is None:
+            stt_echo_transcript_prefix = stt_config.get("echo_transcript_prefix")
+        if not isinstance(stt_echo_transcript_prefix, str) or not stt_echo_transcript_prefix.strip():
+            stt_echo_transcript_prefix = "🎤 Transcription"
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -624,6 +637,8 @@ class GatewayConfig:
             sessions_dir=sessions_dir,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            stt_echo_transcript=_coerce_bool(stt_echo_transcript, False),
+            stt_echo_transcript_prefix=stt_echo_transcript_prefix.strip(),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -601,6 +601,26 @@ class TelegramAdapter(BasePlatformAdapter):
         except ImportError:
             return False
 
+    @staticmethod
+    def _retry_after_seconds(error: Any) -> Optional[float]:
+        """Extract Telegram RetryAfter seconds from exceptions/SendResult-like errors."""
+        retry_after = getattr(error, "retry_after", None)
+        if retry_after is not None:
+            try:
+                return float(retry_after)
+            except (TypeError, ValueError):
+                return 1.0
+        text = str(error or "")
+        match = re.search(r"(?:flood_control|retry\s+after)[:\s]+(\d+(?:\.\d+)?)", text, re.I)
+        if match:
+            try:
+                return float(match.group(1))
+            except ValueError:
+                return 1.0
+        if "retry after" in text.lower() or "flood" in text.lower():
+            return 1.0
+        return None
+
     @classmethod
     def _should_retry_without_dm_topic_reply_anchor(
         cls,
@@ -1641,19 +1661,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         else:
                             raise
                     except Exception as send_err:
-                        retry_after = getattr(send_err, "retry_after", None)
-                        if retry_after is not None or "retry after" in str(send_err).lower():
-                            if _send_attempt < 2:
-                                wait = float(retry_after) if retry_after is not None else 1.0
-                                logger.warning(
-                                    "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
-                                    self.name,
-                                    _send_attempt + 1,
-                                    wait,
-                                    send_err,
-                                )
-                                await asyncio.sleep(wait)
-                                continue
+                        retry_after = self._retry_after_seconds(send_err)
+                        if retry_after is not None and _send_attempt < 2:
+                            wait = float(retry_after)
+                            logger.warning(
+                                "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
+                                self.name,
+                                _send_attempt + 1,
+                                wait,
+                                send_err,
+                            )
+                            await asyncio.sleep(wait)
+                            continue
                         raise
                 message_ids.append(str(msg.message_id))
             
@@ -1729,6 +1748,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
+                # RetryAfter is flood control, not a Markdown parse failure.
+                if self._retry_after_seconds(fmt_err) is not None:
+                    raise
                 # Fallback: retry without markdown formatting
                 await self._bot.edit_message_text(
                     chat_id=int(chat_id),
@@ -1755,9 +1777,9 @@ class TelegramAdapter(BasePlatformAdapter):
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
-            retry_after = getattr(e, "retry_after", None)
-            if retry_after is not None or "retry after" in err_str:
-                wait = retry_after if retry_after else 1.0
+            retry_after = self._retry_after_seconds(e)
+            if retry_after is not None:
+                wait = float(retry_after)
                 logger.warning(
                     "[%s] Telegram flood control, waiting %.1fs",
                     self.name, wait,
@@ -1832,6 +1854,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
                 except Exception as fmt_err:
+                    if self._retry_after_seconds(fmt_err) is not None:
+                        raise
                     if "not modified" not in str(fmt_err).lower():
                         await self._bot.edit_message_text(
                             chat_id=int(chat_id),
@@ -1878,6 +1902,24 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                     break
                 except Exception as send_err:
+                    retry_after = self._retry_after_seconds(send_err)
+                    if retry_after is not None:
+                        logger.warning(
+                            "[%s] Overflow continuation hit flood control, retrying in %.1fs: %s",
+                            self.name, retry_after, send_err,
+                        )
+                        await asyncio.sleep(float(retry_after))
+                        try:
+                            text = self.format_message(chunk) if use_markdown else chunk
+                            sent_msg = await self._bot.send_message(
+                                chat_id=int(chat_id),
+                                text=text,
+                                parse_mode=ParseMode.MARKDOWN_V2 if use_markdown else None,
+                                reply_to_message_id=int(prev_id) if prev_id else None,
+                            )
+                            break
+                        except Exception as retry_err:
+                            send_err = retry_err
                     if "reply message not found" in str(send_err).lower():
                         # Drop the reply anchor and try again.
                         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1084,8 +1084,36 @@ def _normalize_empty_agent_response(
     Consolidates the existing ``failed`` handler and adds a catch-all for
     the case where the agent did work (api_calls > 0) but returned no text.
     Fix for #18765.
+
+    Intentional user interrupts stay silent here so the queued follow-up can
+    run without a stale duplicate answer. Gateway lifecycle interrupts are
+    different: without a visible fallback the user sees Telegram silence after
+    a restart/shutdown drain timeout.
     """
     if response:
+        return response
+
+    interrupt_message = str(agent_result.get("interrupt_message") or "")
+    interrupt_reason = " ".join(interrupt_message.strip().split()).lower()
+    if agent_result.get("interrupted"):
+        if interrupt_reason == _INTERRUPT_REASON_GATEWAY_RESTART.lower():
+            return (
+                "⚠️ Request interrupted by a gateway restart before a final "
+                "reply was generated. No final answer was delivered; send "
+                "the request again after the gateway reconnects."
+            )
+        if interrupt_reason == _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower():
+            return (
+                "⚠️ Request interrupted because the gateway is shutting down. "
+                "No final answer was delivered; send the request again after "
+                "the gateway reconnects."
+            )
+        if interrupt_reason == _INTERRUPT_REASON_TIMEOUT.lower():
+            return (
+                "⚠️ Request stopped after the gateway inactivity timeout. "
+                "No final answer was delivered; send the request again or "
+                "start a fresh session with /reset."
+            )
         return response
 
     if agent_result.get("failed"):
@@ -1107,7 +1135,7 @@ def _normalize_empty_agent_response(
         )
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
-    if api_calls > 0 and not agent_result.get("interrupted"):
+    if api_calls > 0:
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
             return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
@@ -7606,6 +7634,14 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
+
+            # Normalize before logging so ``response ready`` reflects what the
+            # gateway will actually try to deliver, including lifecycle
+            # interrupt fallbacks that prevent Telegram silence.
+            response = _normalize_empty_agent_response(
+                agent_result, response, history_len=len(history),
+            )
+
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
@@ -7632,12 +7668,6 @@ class GatewayRunner:
                         "clear_resume_pending failed for %s: %s",
                         session_key, _e,
                     )
-
-            # Normalize empty responses: surface errors, partial failures, and
-            # the case where agent did work but returned no text. Fix for #18765.
-            response = _normalize_empty_agent_response(
-                agent_result, response, history_len=len(history),
-            )
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7420,10 +7420,12 @@ class GatewayRunner:
                                         _warn_msg = (
                                             "⚠️ Context compression summary failed "
                                             f"({_err}). {_dropped} historical message(s) "
-                                            "were removed and replaced with a placeholder. "
-                                            "Earlier context is no longer recoverable. "
-                                            "Consider /reset for a clean session, or check "
-                                            "your auxiliary.compression model configuration."
+                                            "were compacted with a deterministic extractive "
+                                            "fallback instead of an LLM-written summary. "
+                                            "Context quality may degrade, but source snippets "
+                                            "were preserved where possible. Consider /reset for "
+                                            "a clean session, or check your auxiliary.compression "
+                                            "model configuration."
                                         )
                                         try:
                                             _adapter = self.adapters.get(source.platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6516,6 +6516,9 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "stt-correct":
+            return await self._handle_stt_correct_command(event)
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
@@ -6798,6 +6801,8 @@ class GatewayRunner:
                 message_text = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
+                    source=source,
+                    event=event,
                 )
                 _stt_fail_markers = (
                     "No STT provider",
@@ -9643,6 +9648,49 @@ class GatewayRunner:
         if hasattr(raw, "guild") and raw.guild:
             return raw.guild.id
         return None
+
+    async def _handle_stt_correct_command(self, event: MessageEvent) -> str:
+        """Handle /stt-correct personal phrase corrections for STT output."""
+        from tools.stt_corrections import (
+            add_correction,
+            apply_stt_corrections,
+            clear_corrections,
+            format_corrections,
+            parse_correction_args,
+            remove_correction,
+            usage_text,
+        )
+
+        raw_args = event.get_command_args().strip()
+        args_lower = raw_args.lower()
+        if not raw_args or args_lower in {"help", "usage"}:
+            return usage_text()
+        if args_lower in {"list", "ls", "status"}:
+            return format_corrections()
+        if args_lower == "clear":
+            count = clear_corrections()
+            return f"🧹 {count} correction(s) STT supprimée(s)."
+        if args_lower.startswith("remove ") or args_lower.startswith("rm "):
+            _, _, index_text = raw_args.partition(" ")
+            try:
+                removed = remove_correction(int(index_text.strip()))
+            except (ValueError, IndexError) as exc:
+                return f"⚠️ Impossible de supprimer la correction STT : {exc}"
+            return f"🗑️ Correction STT supprimée : « {removed['wrong']} » → « {removed['right']} »"
+
+        try:
+            wrong, right = parse_correction_args(raw_args)
+            result = add_correction(wrong, right)
+        except ValueError as exc:
+            return f"⚠️ {exc}\n\n{usage_text()}"
+
+        action = "mise à jour" if result.get("action") == "updated" else "ajoutée"
+        preview = apply_stt_corrections(wrong)
+        return (
+            f"✅ Correction STT {action} #{result['index']} :\n"
+            f"« {wrong} » → « {right} »\n"
+            f"Test : « {preview} »"
+        )
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
@@ -13022,10 +13070,64 @@ class GatewayRunner:
             return prefix
         return user_text
 
+    async def _echo_voice_transcript_if_enabled(
+        self,
+        *,
+        transcript: str,
+        source: Optional[SessionSource],
+        event: Optional[MessageEvent],
+        index: int = 1,
+        total: int = 1,
+    ) -> None:
+        """Send a visible STT transcript echo before the agent reply when enabled."""
+        if not getattr(self.config, "stt_echo_transcript", False):
+            return
+        clean_transcript = (transcript or "").strip()
+        if not clean_transcript or source is None:
+            return
+
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            return
+
+        prefix = str(
+            getattr(self.config, "stt_echo_transcript_prefix", "🎤 Transcription")
+            or "🎤 Transcription"
+        ).strip() or "🎤 Transcription"
+        if total > 1:
+            prefix = f"{prefix} {index}/{total}"
+
+        max_chars = 3500
+        display_transcript = clean_transcript
+        if len(display_transcript) > max_chars:
+            display_transcript = (
+                display_transcript[:max_chars].rstrip()
+                + "… [transcription tronquée]"
+            )
+
+        metadata = None
+        try:
+            reply_anchor = self._reply_anchor_for_event(event) if event is not None else None
+            metadata = self._thread_metadata_for_source(source, reply_anchor)
+        except Exception:
+            logger.debug("Failed to build transcript echo metadata", exc_info=True)
+
+        try:
+            await adapter.send(
+                source.chat_id,
+                f"{prefix} :\n« {display_transcript} »",
+                metadata=metadata,
+            )
+        except Exception:
+            logger.warning("Failed to send STT transcript echo", exc_info=True)
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
         audio_paths: List[str],
+        *,
+        source: Optional[SessionSource] = None,
+        event: Optional[MessageEvent] = None,
     ) -> str:
         """
         Auto-transcribe user voice/audio messages using the configured STT provider
@@ -13053,12 +13155,29 @@ class GatewayRunner:
         from tools.transcription_tools import transcribe_audio
 
         enriched_parts = []
-        for path in audio_paths:
+        total_audio_paths = len(audio_paths)
+        for audio_index, path in enumerate(audio_paths, start=1):
             try:
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
+                    try:
+                        from tools.stt_corrections import apply_stt_corrections
+
+                        corrected_transcript = apply_stt_corrections(transcript)
+                        if corrected_transcript != transcript:
+                            logger.info("Applied personal STT corrections to voice transcript")
+                        transcript = corrected_transcript
+                    except Exception:
+                        logger.debug("Failed to apply personal STT corrections", exc_info=True)
+                    await self._echo_voice_transcript_if_enabled(
+                        transcript=transcript,
+                        source=source,
+                        event=event,
+                        index=audio_index,
+                        total=total_audio_paths,
+                    )
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
                         f'Here\'s what they said: "{transcript}"]'
@@ -16513,7 +16632,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
-        runner.request_restart(detached=False, via_service=True)
+        if sys.platform == "darwin" and not os.environ.get("INVOCATION_ID"):
+            runner.request_restart(detached=True, via_service=False)
+        else:
+            runner.request_restart(detached=False, via_service=True)
     
     loop = asyncio.get_running_loop()
     if threading.current_thread() is threading.main_thread():

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -473,8 +473,8 @@ class GatewayStreamConsumer:
                             self._accumulated, _safe_limit, _len_fn,
                         )
                         split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
+                        if split_at < max(1, _cp_budget // 2):
+                            split_at = _cp_budget
                         chunk = self._accumulated[:split_at]
                         ok = await self._send_or_edit(chunk)
                         if self._fallback_final_send or not ok:
@@ -675,8 +675,8 @@ class GatewayStreamConsumer:
         while len_fn(remaining) > limit:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
             split_at = remaining.rfind("\n", 0, _cp_budget)
-            if split_at < limit // 2:
-                split_at = limit
+            if split_at < max(1, _cp_budget // 2):
+                split_at = _cp_budget
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:
@@ -813,6 +813,18 @@ class GatewayStreamConsumer:
         err = getattr(result, "error", "") or ""
         err_lower = err.lower()
         return "flood" in err_lower or "retry after" in err_lower or "rate" in err_lower
+
+    @staticmethod
+    def _retry_after_seconds(result) -> Optional[float]:
+        """Extract retry-after seconds from a SendResult-like failure, if present."""
+        err = getattr(result, "error", "") or ""
+        match = re.search(r"(?:flood_control|retry\s+after)[:\s]+(\d+(?:\.\d+)?)", err, re.I)
+        if not match:
+            return None
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return None
 
     def _resolve_draft_streaming(self) -> bool:
         """Decide whether this run should use native draft streaming.
@@ -1191,6 +1203,18 @@ class GatewayStreamConsumer:
                         # edits after _MAX_FLOOD_STRIKES consecutive failures.
                         if self._is_flood_error(result):
                             self._flood_strikes += 1
+                            retry_after = self._retry_after_seconds(result)
+                            if retry_after is not None and retry_after > 5.0:
+                                logger.debug(
+                                    "Long flood-control retry_after %.1fs; entering final fallback mode",
+                                    retry_after,
+                                )
+                                self._fallback_prefix = self._visible_prefix()
+                                self._fallback_final_send = True
+                                self._edit_supported = False
+                                self._already_sent = True
+                                self._last_edit_time = time.monotonic()
+                                return False
                             self._current_edit_interval = min(
                                 self._current_edit_interval * 2, 10.0,
                             )

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -189,35 +189,44 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
+    repo_head: Optional[str] = None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    # Read cache — invalidate if the embedded rev or local checkout HEAD has
+    # changed since the last check.  The HEAD guard prevents a stale banner
+    # after a successful git update/rebase that leaves the old cache fresh.
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-            ):
-                return cached.get("behind")
+            cache_is_fresh = now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+            if cache_is_fresh and cached.get("rev") == embedded_rev:
+                if embedded_rev:
+                    return cached.get("behind")
+
+                repo_dir = _resolve_repo_dir()
+                if repo_dir is None:
+                    return None
+                repo_head = _git_short_hash(repo_dir, "HEAD")
+                if repo_head and cached.get("repo_head") == repo_head:
+                    return cached.get("behind")
     except Exception:
         pass
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        repo_dir = repo_dir or _resolve_repo_dir()
+        if repo_dir is None:
             return None
         behind = _check_via_local_git(repo_dir)
+        repo_head = repo_head or _git_short_hash(repo_dir, "HEAD")
 
+    cache_payload = {"ts": now, "behind": behind, "rev": embedded_rev}
+    if repo_head:
+        cache_payload["repo_head"] = repo_head
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(json.dumps(cache_payload))
     except Exception:
         pass
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -148,6 +148,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("kaomoji", "emoji", "unicode", "ascii")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("stt-correct", "Manage personal STT phrase corrections", "Configuration",
+               gateway_only=True, aliases=("stt_correct",), args_hint="[list|remove N|clear|wrong => right]"),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1039,6 +1039,8 @@ DEFAULT_CONFIG = {
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "echo_transcript": False,  # If true, gateway sends the transcript back before the agent reply
+        "echo_transcript_prefix": "🎤 Transcription",
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -35,6 +35,8 @@ _PROVIDER_ENV_HINTS = (
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_TOKEN",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
     "OPENAI_BASE_URL",
     "NOUS_API_KEY",
     "GLM_API_KEY",
@@ -249,7 +251,7 @@ def _build_apikey_providers_list() -> list:
     # API-key loop (with custom headers/auth). Skip their pluggable profiles
     # here so the generic Bearer-auth loop doesn't run a duplicate, broken
     # check (e.g. Anthropic native API requires x-api-key, not Bearer).
-    _dedicated_canonical = {"anthropic", "openrouter", "bedrock"}
+    _dedicated_canonical = {"anthropic", "openrouter", "bedrock", "gemini"}
     _known_canonical.update(_dedicated_canonical)
     try:
         from providers import list_providers
@@ -1409,6 +1411,67 @@ def run_doctor(args):
                 [],
             )
 
+    def _probe_gemini_api_key() -> _ConnectivityResult:
+        """Verify Google Gemini API-key auth with the documented REST shape.
+
+        Gemini's native API accepts API keys as a `?key=` query parameter, not
+        as `Authorization: Bearer`. Keep this separate from the generic
+        OpenAI-compatible provider loop to avoid false "invalid API key" doctor
+        failures when direct Gemini REST access is healthy.
+        """
+        key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+        if not key:
+            return _ConnectivityResult("Google / Gemini", [], [])
+        label = "Google / Gemini".ljust(20)
+        try:
+            import httpx
+
+            base = (os.getenv("GEMINI_BASE_URL") or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
+            if base.rstrip("/").endswith("/openai"):
+                # Gemini's OpenAI-compatible endpoint accepts Bearer auth.
+                r = httpx.get(
+                    base + "/models",
+                    headers={
+                        "Authorization": f"Bearer {key}",
+                        "User-Agent": _HERMES_USER_AGENT,
+                    },
+                    timeout=10,
+                )
+            else:
+                # Native Gemini API-key auth: GET /models?key=<API_KEY>
+                r = httpx.get(
+                    base + "/models",
+                    params={"key": key},
+                    headers={"User-Agent": _HERMES_USER_AGENT},
+                    timeout=10,
+                )
+            if r.status_code == 200:
+                return _ConnectivityResult(
+                    "Google / Gemini",
+                    [(color("✓", Colors.GREEN), label, "")],
+                    [],
+                )
+            if r.status_code in (400, 401, 403):
+                return _ConnectivityResult(
+                    "Google / Gemini",
+                    [(color("✗", Colors.RED), label,
+                      color("(invalid API key)", Colors.DIM))],
+                    ["Check GOOGLE_API_KEY/GEMINI_API_KEY in .env"],
+                )
+            return _ConnectivityResult(
+                "Google / Gemini",
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"(HTTP {r.status_code})", Colors.DIM))],
+                [],
+            )
+        except Exception as e:
+            return _ConnectivityResult(
+                "Google / Gemini",
+                [(color("⚠", Colors.YELLOW), label,
+                  color(f"({e})", Colors.DIM))],
+                [],
+            )
+
     def _probe_apikey_provider(pname, env_vars, default_url, base_env,
                                supports_health_check) -> _ConnectivityResult:
         key = ""
@@ -1539,6 +1602,7 @@ def run_doctor(args):
     # Build the probe submission list in display order
     _probes.append(("OpenRouter API", _probe_openrouter))
     _probes.append(("Anthropic API", _probe_anthropic))
+    _probes.append(("Google / Gemini", _probe_gemini_api_key))
 
     global _APIKEY_PROVIDERS_CACHE
     if _APIKEY_PROVIDERS_CACHE is None:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2948,9 +2948,7 @@ def launchd_start():
         print("✓ Service started")
         return
 
-    if refresh_launchd_plist_if_needed():
-        print("✓ Service started")
-        return
+    refresh_launchd_plist_if_needed()
     try:
         subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2809,6 +2809,18 @@ def generate_launchd_plist() -> str:
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
     </dict>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>16384</integer>
+    </dict>
     
     <key>RunAtLoad</key>
     <true/>
@@ -2854,7 +2866,32 @@ def refresh_launchd_plist_if_needed() -> bool:
     label = get_launchd_label()
     # Bootout/bootstrap so launchd picks up the new definition
     subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
+    _wait_for_gateway_exit(timeout=15.0, force_after=5.0)
+    bootstrap = subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if bootstrap.returncode != 0 and not _probe_launchd_service_running():
+        import time
+
+        time.sleep(1.0)
+        bootstrap = subprocess.run(
+            ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    if bootstrap.returncode != 0 and not _probe_launchd_service_running():
+        raise subprocess.CalledProcessError(
+            bootstrap.returncode,
+            bootstrap.args,
+            output=bootstrap.stdout,
+            stderr=bootstrap.stderr,
+        )
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -2911,7 +2948,9 @@ def launchd_start():
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
+    if refresh_launchd_plist_if_needed():
+        print("✓ Service started")
+        return
     try:
         subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -32,6 +32,7 @@ _DEFAULT_API_TIMEOUT = 5.0
 _MIN_CAPTURE_LENGTH = 10
 _MAX_ENTITY_CONTEXT_LENGTH = 1500
 _CONVERSATIONS_URL = "https://api.supermemory.ai/v4/conversations"
+_MEMORIES_URL = "https://api.supermemory.ai/v4/memories"
 _TRIVIAL_RE = re.compile(
     r"^(ok|okay|thanks|thank you|got it|sure|yes|no|yep|nope|k|ty|thx|np)\.?$",
     re.IGNORECASE,
@@ -260,6 +261,26 @@ def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
 
+def _sanitize_metadata(metadata: Optional[dict]) -> dict:
+    """Return Supermemory v4-compatible metadata without dropping useful fields."""
+    if not isinstance(metadata, dict):
+        return {}
+    sanitized: dict[str, Any] = {}
+    for raw_key, raw_value in metadata.items():
+        key = str(raw_key)[:100]
+        value = raw_value
+        if isinstance(value, (str, int, float, bool)):
+            sanitized[key] = value
+        elif isinstance(value, (list, tuple)) and all(isinstance(item, str) for item in value):
+            sanitized[key] = list(value)
+        else:
+            try:
+                sanitized[key] = json.dumps(value, ensure_ascii=False)[:1000]
+            except Exception:
+                sanitized[key] = str(value)[:1000]
+    return sanitized
+
+
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
         from supermemory import Supermemory
@@ -277,6 +298,7 @@ class _SupermemoryClient:
         kwargs: dict[str, Any] = {
             "content": content.strip(),
             "container_tags": [tag],
+            "task_type": "memory",
         }
         if metadata:
             kwargs["metadata"] = metadata
@@ -286,6 +308,44 @@ class _SupermemoryClient:
             kwargs["custom_id"] = custom_id
         result = self._client.documents.add(**kwargs)
         return {"id": getattr(result, "id", "")}
+
+    def create_memory(self, content: str, metadata: Optional[dict] = None, *,
+                      container_tag: Optional[str] = None,
+                      is_static: bool = False) -> dict:
+        """Create an explicit v4 memory and return the real memory id.
+
+        Document ingestion returns document ids, which cannot be passed to the
+        v4 memory forget endpoint and may not be immediately searchable. The
+        explicit memory tool needs a memory id so store -> search -> forget
+        health checks can be exact and safe.
+        """
+        tag = container_tag or self._container_tag
+        memory: dict[str, Any] = {
+            "content": content.strip(),
+            "isStatic": bool(is_static),
+        }
+        clean_metadata = _sanitize_metadata(metadata)
+        if clean_metadata:
+            memory["metadata"] = clean_metadata
+        payload = json.dumps({"memories": [memory], "containerTag": tag}).encode("utf-8")
+        req = urllib.request.Request(
+            _MEMORIES_URL,
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout + 3) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        memories = data.get("memories") or []
+        first = memories[0] if memories else {}
+        return {
+            "id": first.get("id", ""),
+            "memory": first.get("memory", ""),
+            "document_id": data.get("documentId"),
+        }
 
     def search_memories(self, query: str, *, limit: int = 5,
                         container_tag: Optional[str] = None,
@@ -334,19 +394,23 @@ class _SupermemoryClient:
 
     def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
         tag = container_tag or self._container_tag
-        self._client.memories.forget(container_tag=tag, id=memory_id)
+        try:
+            self._client.memories.forget(container_tag=tag, id=memory_id)
+        except Exception as memory_exc:
+            # Backward-compatibility cleanup: historical versions of this
+            # plugin returned document ids from documents.add(). Those ids are
+            # not valid v4 memory ids, so exact-id cleanup must fall back to
+            # document deletion rather than forcing fuzzy query deletion.
+            try:
+                self._client.documents.delete(memory_id)
+            except Exception:
+                raise memory_exc
 
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
-        results = self.search_memories(query, limit=5, container_tag=container_tag)
-        if not results:
-            return {"success": False, "message": "No matching memory found to forget."}
-        target = results[0]
-        memory_id = target.get("id", "")
-        if not memory_id:
-            return {"success": False, "message": "Best matching memory has no id."}
-        self.forget_memory(memory_id, container_tag=container_tag)
-        preview = (target.get("memory") or "")[:100]
-        return {"success": True, "message": f'Forgot: "{preview}"', "id": memory_id}
+        return {
+            "success": False,
+            "message": "Query-based forgetting is disabled because Supermemory search is semantic/fuzzy. Search first, verify the exact id, then forget by id.",
+        }
 
     def ingest_conversation(self, session_id: str, messages: list[dict]) -> None:
         payload = json.dumps({
@@ -395,7 +459,7 @@ SEARCH_SCHEMA = {
 
 FORGET_SCHEMA = {
     "name": "supermemory_forget",
-    "description": "Forget a memory by exact id or by best-match query.",
+    "description": "Forget a memory by exact id. Query-based deletion is disabled because search is semantic/fuzzy.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -622,10 +686,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                self._client.add_memory(
+                self._client.create_memory(
                     content.strip(),
                     metadata={"source": "hermes_memory", "target": target, "type": "explicit_memory"},
-                    entity_context=self._entity_context,
                 )
             except Exception:
                 logger.debug("Supermemory on_memory_write failed", exc_info=True)
@@ -693,7 +756,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         metadata.setdefault("type", _detect_category(content))
         metadata["source"] = "hermes_tool"
         try:
-            result = self._client.add_memory(content, metadata=metadata, entity_context=self._entity_context, container_tag=tag)
+            result = self._client.create_memory(content, metadata=metadata, container_tag=tag)
             preview = content[:80] + ("..." if len(content) > 80 else "")
             resp: dict[str, Any] = {"saved": True, "id": result.get("id", ""), "preview": preview}
             if tag:

--- a/run_agent.py
+++ b/run_agent.py
@@ -10393,7 +10393,7 @@ class AIAgent:
                 self._last_compression_summary_warning = summary_error
                 self._emit_warning(
                     f"⚠ Compression summary failed: {summary_error}. "
-                    "Inserted a fallback context marker."
+                    "Inserted an extractive fallback context summary."
                 )
         else:
             # No hard failure — but did the configured aux model error out
@@ -11882,6 +11882,23 @@ class AIAgent:
         # state registry.  Set BEFORE any tool dispatch so snapshots taken at
         # child-launch time see the parent's real id, not None.
         self._current_task_id = effective_task_id
+
+        # Bind/clear the thread-scoped interrupt flag before *any* preflight
+        # work.  Preflight context compression and memory/provider hooks can
+        # call auxiliary LLMs before the main tool loop starts; the Codex
+        # auxiliary adapter polls tools.interrupt.is_interrupted() while
+        # streaming.  If we wait until the main loop to update
+        # _execution_thread_id, a cached gateway agent may carry a stale thread
+        # id/interrupt bit from a prior turn or restart and compression fails
+        # immediately with "Codex auxiliary Responses stream interrupted".
+        self._execution_thread_id = threading.current_thread().ident
+        _set_interrupt(False, self._execution_thread_id)
+        if self._interrupt_requested:
+            _set_interrupt(True, self._execution_thread_id)
+            self._interrupt_thread_signal_pending = False
+        else:
+            self._interrupt_message = None
+            self._interrupt_thread_signal_pending = False
         
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -661,7 +661,6 @@ class TestAuxiliaryPoolAwareness:
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
             patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="qwen/qwen3.6-plus") as mock_rec,
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
-            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
         ):
             from agent.auxiliary_client import _try_nous
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2094,7 +2094,7 @@ class TestCodexAuxiliaryAdapterTimeout:
                 return False
 
             def __iter__(self):
-                for _ in range(5):
+                for _ in range(50):
                     time.sleep(0.03)
                     yield SimpleNamespace(type="response.in_progress")
 
@@ -2121,7 +2121,8 @@ class TestCodexAuxiliaryAdapterTimeout:
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.5, f"timeout should interrupt the stream early, got {elapsed:.3f}s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -659,6 +659,7 @@ class TestAuxiliaryPoolAwareness:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="qwen/qwen3.6-plus") as mock_rec,
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
             patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
         ):
@@ -667,7 +668,8 @@ class TestAuxiliaryPoolAwareness:
             client, model = _try_nous()
 
         assert client is not None
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "qwen/qwen3.6-plus"
+        assert mock_rec.call_args.kwargs["vision"] is False
         assert mock_openai.call_args.kwargs["api_key"] == "pooled-agent-key"
         assert mock_openai.call_args.kwargs["base_url"] == "https://inference.pool.example/v1"
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -575,29 +575,87 @@ class TestStreamingClosedFallback:
         assert mock_call.call_count == 2
         assert result is not None
 
-    def test_streaming_closed_on_main_uses_short_cooldown(self):
-        """When already on the main model, a streaming-closed error should use
-        the 30s cooldown, not the default 60s — these errors are transient."""
+    def test_streaming_closed_on_main_retries_same_provider_once_and_succeeds(self):
+        """When compression is already pinned to the main model, a premature
+        stream close should get one same-provider retry before falling back to
+        extractive context.  This covers Codex Responses `incomplete chunked
+        read` failures where there is no alternate model to fall back to."""
+        mock_ok = MagicMock()
+        mock_ok.choices = [MagicMock()]
+        mock_ok.choices[0].message.content = "summary after same-provider retry"
         err = Exception("RemoteProtocolError: response ended prematurely")
 
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(
                 model="main-model",
-                # No summary_model_override → no fallback path.
+                summary_model_override="main-model",  # explicit main pin
+                quiet_mode=True,
+            )
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[err, mock_ok],
+        ) as mock_call, patch(
+            "agent.context_compressor._is_connection_error",
+            return_value=True,
+        ):
+            result = c._generate_summary(self._msgs())
+
+        assert mock_call.call_count == 2
+        assert result is not None
+        assert "summary after same-provider retry" in result
+        assert c._summary_failure_cooldown_until == 0.0
+
+    def test_streaming_closed_on_main_uses_short_cooldown_after_retry_fails(self):
+        """When the same-provider retry also fails, keep the short cooldown and
+        allow the caller to insert the deterministic extractive fallback."""
+        err = Exception("RemoteProtocolError: response ended prematurely")
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                # No summary_model_override → no alternate fallback path.
                 quiet_mode=True,
             )
 
         with patch(
             "agent.context_compressor.call_llm",
             side_effect=err,
-        ), patch(
+        ) as mock_call, patch(
             "agent.context_compressor._is_connection_error",
             return_value=True,
         ), patch("agent.context_compressor.time.monotonic", return_value=1000.0):
             result = c._generate_summary(self._msgs())
 
+        assert mock_call.call_count == 2
         assert result is None
-        # Streaming-closed should use the 30s short cooldown.
+        # Streaming-closed should use the 30s short cooldown after retry failure.
+        assert c._summary_failure_cooldown_until == 1030.0
+
+    def test_main_model_timeout_does_not_double_wait(self):
+        """A full timeout on the already-pinned main model should not trigger
+        another full timeout window.  Edward's compression timeout can be 900s,
+        so retrying full timeouts would turn one stall into two."""
+        mock_ok = MagicMock()
+        mock_ok.choices = [MagicMock()]
+        mock_ok.choices[0].message.content = "would be too late"
+        err = TimeoutError("Codex auxiliary Responses stream exceeded 900.0s total timeout")
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                summary_model_override="main-model",
+                quiet_mode=True,
+            )
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[err, mock_ok],
+        ) as mock_call, patch("agent.context_compressor.time.monotonic", return_value=1000.0):
+            result = c._generate_summary(self._msgs())
+
+        assert mock_call.call_count == 1
+        assert result is None
         assert c._summary_failure_cooldown_until == 1030.0
 
     def test_non_streaming_unknown_error_still_uses_long_cooldown(self):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -744,10 +744,17 @@ class TestSummaryFailureTrackingForGatewayWarning:
         assert c._last_summary_dropped_count > 0
         assert c._last_summary_error is not None
         # Result must still be well-formed (fallback summary present).
-        assert any(
-            isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
+        fallback_contents = [
+            m.get("content", "")
             for m in result
-        )
+            if isinstance(m.get("content"), str)
+            and "Summary generation was unavailable" in m["content"]
+        ]
+        assert fallback_contents
+        # The fallback must preserve some extractive source context instead of
+        # replacing the whole compressed region with an opaque placeholder.
+        assert "Extractive fallback" in fallback_contents[0]
+        assert "msg 3" in fallback_contents[0]
 
     def test_compress_clears_fallback_flag_on_subsequent_success(self):
         mock_response = MagicMock()

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -912,6 +912,26 @@ class TestTranslateStreamEvent:
         )
         assert chunks[-1].choices[0].finish_reason == "tool_calls"
 
+    def test_terminal_and_reasoning_chunks_have_stable_delta_shape(self):
+        from agent.gemini_cloudcode_adapter import _translate_stream_event
+
+        chunks = _translate_stream_event(
+            {"response": {"candidates": [{
+                "content": {"parts": [{"thought": True, "text": "thinking"}]},
+                "finishReason": "STOP",
+            }]}},
+            model="m",
+            tool_call_counter=[0],
+        )
+
+        assert chunks
+        for chunk in chunks:
+            delta = chunk.choices[0].delta
+            assert hasattr(delta, "content")
+            assert hasattr(delta, "tool_calls")
+            assert hasattr(delta, "reasoning")
+            assert hasattr(delta, "reasoning_content")
+
 
 class TestGeminiCloudCodeClient:
     def test_client_exposes_openai_interface(self):

--- a/tests/gateway/test_empty_response_normalization.py
+++ b/tests/gateway/test_empty_response_normalization.py
@@ -1,0 +1,73 @@
+"""Tests for gateway empty-response normalization."""
+
+from gateway.run import (
+    _INTERRUPT_REASON_GATEWAY_RESTART,
+    _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+    _INTERRUPT_REASON_STOP,
+    _normalize_empty_agent_response,
+)
+
+
+def test_gateway_restart_interrupt_gets_visible_fallback():
+    response = _normalize_empty_agent_response(
+        {
+            "interrupted": True,
+            "interrupt_message": _INTERRUPT_REASON_GATEWAY_RESTART,
+            "api_calls": 18,
+        },
+        "",
+    )
+
+    assert response
+    assert "gateway restart" in response.lower()
+    assert "no final answer" in response.lower()
+
+
+def test_gateway_shutdown_interrupt_gets_visible_fallback():
+    response = _normalize_empty_agent_response(
+        {
+            "interrupted": True,
+            "interrupt_message": _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+            "api_calls": 4,
+        },
+        "",
+    )
+
+    assert response
+    assert "gateway is shutting down" in response.lower()
+
+
+def test_user_followup_interrupt_stays_silent_for_queued_message():
+    response = _normalize_empty_agent_response(
+        {
+            "interrupted": True,
+            "interrupt_message": "new user follow-up while the agent is running",
+            "api_calls": 3,
+        },
+        "",
+    )
+
+    assert response == ""
+
+
+def test_stop_control_interrupt_stays_silent_to_avoid_duplicate_stop_reply():
+    response = _normalize_empty_agent_response(
+        {
+            "interrupted": True,
+            "interrupt_message": _INTERRUPT_REASON_STOP,
+            "api_calls": 3,
+        },
+        "",
+    )
+
+    assert response == ""
+
+
+def test_non_interrupted_empty_after_api_calls_still_gets_generic_fallback():
+    response = _normalize_empty_agent_response(
+        {"interrupted": False, "api_calls": 2},
+        "",
+    )
+
+    assert response
+    assert "no response was generated" in response.lower()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -65,6 +65,18 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class FloodingProgressCaptureAdapter(ProgressCaptureAdapter):
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=False, error="flood_control:23")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -81,6 +93,27 @@ class FakeAgent:
             time.sleep(0.35)
             cb("tool.started", "browser_navigate", "https://example.com", {})
             time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FloodProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "first command", {})
+            time.sleep(0.35)
+            cb("tool.started", "browser_navigate", "https://example.com", {})
+            time.sleep(0.35)
+            cb("tool.started", "terminal", "third command", {})
+            time.sleep(0.1)
         return {
             "final_response": "done",
             "messages": [],
@@ -209,6 +242,50 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     ]
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_telegram_progress_flood_mutes_followup_progress_sends(monkeypatch, tmp_path):
+    """After Telegram flood-control on progress edit, do not fallback-send every progress line."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FloodProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = FloodingProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-flood-progress",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    # Only the initial progress bubble should be sent. Flood-control after the
+    # first edit should mute/coalesce later progress rather than sending each
+    # update as a separate Telegram message during the retry window.
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == '💻 terminal: "first command"'
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -398,8 +398,8 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
 @pytest.mark.asyncio
 async def test_session_hygiene_warns_user_when_summary_generation_fails(monkeypatch, tmp_path):
     """When auxiliary compression's summary LLM call fails, the compressor
-    inserts a static fallback and the dropped turns are unrecoverable.
-    Gateway must surface a visible ⚠️ warning to the user, including
+    inserts an extractive fallback and gateway surfaces the degradation.
+    Gateway must deliver a visible ⚠️ warning to the user, including
     thread_id metadata so it lands in the originating topic/thread."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -415,7 +415,7 @@ async def test_session_hygiene_warns_user_when_summary_generation_fails(monkeypa
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock()
             # Simulate a compressor that hit summary-generation failure
-            # and inserted the static fallback placeholder.
+            # and inserted the extractive fallback summary.
             self.context_compressor = SimpleNamespace(
                 _last_summary_fallback_used=True,
                 _last_summary_dropped_count=42,

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -538,6 +538,36 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer.already_sent
 
     @pytest.mark.asyncio
+    async def test_retry_after_flood_does_not_immediately_final_edit_before_wait(self):
+        """A long RetryAfter should pause edits and use final-tail fallback, not retry edit immediately."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.edit_message = AsyncMock(side_effect=[
+            SimpleNamespace(success=False, error="flood_control:23"),
+            AssertionError("final edit should wait for retry_after, not fire immediately"),
+        ])
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Hello")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(" world")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        assert adapter.edit_message.call_count == 1
+        assert adapter.send.call_count == 2
+        assert adapter.send.call_args_list[1][1]["content"].strip() == "world"
+        assert consumer.final_response_sent is True
+
+    @pytest.mark.asyncio
     async def test_segment_break_clears_failed_edit_fallback_state(self):
         """A tool boundary after edit failure must flush the undelivered tail
         without duplicating the prefix the user already saw (#8124)."""
@@ -1768,6 +1798,17 @@ class TestUtf16OverflowDetection:
         assert call_kwargs.get("len_fn") is utf16_len, (
             f"truncate_message called without utf16_len: {call_kwargs}"
         )
+
+    def test_split_text_chunks_respects_custom_len_fn_codepoint_budget(self):
+        """Fallback chunk splitting must not use UTF-16 budgets as codepoint indexes."""
+        from gateway.platforms.base import utf16_len
+
+        text = "🚀" * 800
+        chunks = GatewayStreamConsumer._split_text_chunks(text, 1000, len_fn=utf16_len)
+
+        assert len(chunks) == 2
+        assert "".join(chunks) == text
+        assert all(utf16_len(chunk) <= 1000 for chunk in chunks)
 
     def test_codepoint_only_adapter_falls_back_to_len(self):
         """Adapters without message_len_fn override (or test MagicMocks)

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -16,6 +16,21 @@ def test_gateway_config_stt_disabled_from_dict_nested():
     assert config.stt_enabled is False
 
 
+def test_gateway_config_reads_stt_echo_transcript_options():
+    config = GatewayConfig.from_dict(
+        {
+            "stt": {
+                "enabled": True,
+                "echo_transcript": True,
+                "echo_transcript_prefix": "🎤 Transcription STT",
+            }
+        }
+    )
+
+    assert config.stt_echo_transcript is True
+    assert config.stt_echo_transcript_prefix == "🎤 Transcription STT"
+
+
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -114,3 +129,134 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_echoes_voice_transcript_when_enabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.config.stt_echo_transcript = True
+    runner.config.stt_echo_transcript_prefix = "🎤 Transcription"
+    adapter = AsyncMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        thread_id="11",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+        message_id="voice-msg-1",
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "queued voice transcript",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "queued voice transcript" in result
+    adapter.send.assert_awaited_once()
+    args, kwargs = adapter.send.await_args
+    assert args[0] == "123"
+    assert "🎤 Transcription" in args[1]
+    assert "queued voice transcript" in args[1]
+    assert kwargs["metadata"] == {
+        "thread_id": "11",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "voice-msg-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_applies_personal_stt_corrections(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    from tools.stt_corrections import add_correction
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    add_correction("gétoueur du Christart", "GetHooked starter kit")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.config.stt_echo_transcript = True
+    runner.config.stt_echo_transcript_prefix = "🎤 Transcription"
+    adapter = AsyncMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="group")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/queued-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "Le gétoueur du Christart est prêt",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "GetHooked starter kit" in result
+    assert "gétoueur du Christart" not in result
+    args, _kwargs = adapter.send.await_args
+    assert "GetHooked starter kit" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_handle_stt_correct_command_adds_personal_correction(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    from tools.stt_corrections import apply_stt_corrections
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="group")
+    event = MessageEvent(
+        text="/stt-correct gétoueur du Christart => GetHooked starter kit",
+        source=source,
+    )
+
+    response = await runner._handle_stt_correct_command(event)
+
+    assert "Correction STT ajoutée" in response
+    assert apply_stt_corrections("gétoueur du Christart") == "GetHooked starter kit"

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -1042,9 +1042,14 @@ async def test_thread_fallback_only_fires_once():
 
 
 @pytest.mark.asyncio
-async def test_send_retries_retry_after_errors():
+async def test_send_retries_retry_after_errors(monkeypatch):
     """Telegram flood control should back off and retry instead of failing fast."""
     adapter = _make_adapter()
+    sleeps = []
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", fake_sleep)
 
     attempt = [0]
 
@@ -1061,3 +1066,74 @@ async def test_send_retries_retry_after_errors():
     assert result.success is True
     assert result.message_id == "300"
     assert attempt[0] == 2
+    assert sleeps == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_edit_retries_retry_after_errors_before_markdown_fallback(monkeypatch):
+    """RetryAfter during a final Markdown edit is flood control, not a Markdown parse error."""
+    adapter = _make_adapter()
+    sleeps = []
+    calls = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    async def mock_edit_message_text(**kwargs):
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            raise FakeRetryAfter(2)
+        return SimpleNamespace(message_id=301)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", fake_sleep)
+    adapter._bot = SimpleNamespace(edit_message_text=mock_edit_message_text)
+
+    result = await adapter.edit_message(
+        chat_id="123",
+        message_id="456",
+        content="**final** message",
+        finalize=True,
+    )
+
+    assert result.success is True
+    assert result.message_id == "456"
+    assert len(calls) == 2
+    assert sleeps == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_edit_overflow_continuation_retries_retry_after(monkeypatch):
+    """Overflow continuations must respect RetryAfter instead of stopping partial delivery."""
+    adapter = _make_adapter()
+    sleeps = []
+    send_calls = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    async def mock_edit_message_text(**kwargs):
+        return SimpleNamespace(message_id=300)
+
+    async def mock_send_message(**kwargs):
+        send_calls.append(dict(kwargs))
+        if len(send_calls) == 1:
+            raise FakeRetryAfter(2)
+        return SimpleNamespace(message_id=301)
+
+    monkeypatch.setattr("gateway.platforms.telegram.asyncio.sleep", fake_sleep)
+    adapter._bot = SimpleNamespace(
+        edit_message_text=mock_edit_message_text,
+        send_message=mock_send_message,
+    )
+
+    result = await adapter.edit_message(
+        chat_id="123",
+        message_id="456",
+        content="A" * 5000,
+        finalize=False,
+    )
+
+    assert result.success is True
+    assert result.message_id == "301"
+    assert len(send_calls) == 2
+    assert sleeps == [2.0]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -46,6 +46,10 @@ class TestProviderEnvDetection:
         content = "KIMI_CN_API_KEY=sk-test\n"
         assert _has_provider_env_config(content)
 
+    def test_detects_gemini_api_keys(self):
+        assert _has_provider_env_config("GOOGLE_API_KEY=AIza-test\n")
+        assert _has_provider_env_config("GEMINI_API_KEY=AIza-test\n")
+
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)

--- a/tests/hermes_cli/test_doctor_dedicated_provider_skip.py
+++ b/tests/hermes_cli/test_doctor_dedicated_provider_skip.py
@@ -1,12 +1,13 @@
 """Regression: hermes doctor must not run a generic Bearer-auth health
 check for providers that already have a dedicated check (Anthropic,
-OpenRouter, Bedrock).
+OpenRouter, Bedrock, Gemini).
 
 Anthropic's native API requires `x-api-key` + `anthropic-version` headers;
-the generic loop sends `Authorization: Bearer ...` which Anthropic answers
-with HTTP 404. The dedicated check at hermes_cli/doctor.py already covers
-Anthropic with the right headers, so the pluggable profile must be
-skipped by `_build_apikey_providers_list()`.
+the generic loop sends `Authorization: Bearer ...`, which Anthropic answers
+with HTTP 404. Gemini's native API uses `?key=<API_KEY>`, not Bearer auth.
+Dedicated checks at hermes_cli/doctor.py cover these providers with the right
+headers/auth, so the pluggable profiles must be skipped by
+`_build_apikey_providers_list()`.
 
 See: NousResearch/hermes-agent#22346
 """
@@ -35,6 +36,10 @@ def test_build_apikey_providers_list_skips_dedicated_check_providers():
     assert not any("bedrock" in name for name in names), (
         f"Bedrock uses AWS SDK creds, not Bearer auth; generic loop must skip. "
         f"Got: {sorted(names)}"
+    )
+    assert not any("gemini" in name or "google" in name for name in names), (
+        f"Gemini native API-key auth uses ?key=, not Bearer auth; generic loop "
+        f"must skip it. Got: {sorted(names)}"
     )
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -65,6 +65,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *a, **kw: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -88,6 +89,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *a, **kw: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -737,6 +739,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _skip_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *a, **kw: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -26,14 +26,42 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "repo_head": "abc12345"}))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.banner._git_short_hash", return_value="abc12345") as mock_head, \
+         patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
     assert result == 3
+    mock_head.assert_called_once()
     mock_run.assert_not_called()
+
+
+def test_check_for_updates_invalidates_cache_when_repo_head_changes(tmp_path, monkeypatch):
+    """A fresh update cache from an old checkout must not survive a local rebase/update."""
+    import hermes_cli.banner as banner
+
+    project_root = tmp_path / "project"
+    (project_root / "hermes_cli").mkdir(parents=True)
+    (project_root / "hermes_cli" / "banner.py").touch()
+    (project_root / ".git").mkdir()
+    monkeypatch.setattr(banner, "__file__", str(project_root / "hermes_cli" / "banner.py"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 30, "repo_head": "oldhead"}))
+
+    with patch("hermes_cli.banner._git_short_hash", return_value="newhead") as mock_head, \
+         patch("hermes_cli.banner._check_via_local_git", return_value=0) as mock_check:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    mock_head.assert_called()
+    mock_check.assert_called_once_with(project_root)
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["repo_head"] == "newhead"
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
@@ -55,7 +83,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count >= 2  # git fetch + git rev-list (+ optional HEAD cache key)
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -37,6 +37,23 @@ def _no_restart_verify_sleep(monkeypatch):
     monkeypatch.setattr(_real_time, "sleep", lambda *_a, **_k: None)
 
 
+def _expire_service_active_polls(monkeypatch):
+    """Make cmd_update's systemd survival polling expire instantly.
+
+    These tests intentionally keep ``systemctl is-active`` inactive. Without
+    advancing monotonic time, each simulated failure waits for the real 10s
+    timeout and the suite-level alarm can interrupt before the terminal user
+    message is printed.
+    """
+    clock = {"now": 0.0}
+
+    def fake_monotonic():
+        clock["now"] += 11.0
+        return clock["now"]
+
+    monkeypatch.setattr(cli_main._time, "monotonic", fake_monotonic)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1545,6 +1562,7 @@ class TestCmdUpdateResetFailedBeforeRestart:
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        _expire_service_active_polls(monkeypatch)
 
         # is-active toggles:
         #   first call (discovery / check active)  -> "active"
@@ -1623,6 +1641,7 @@ class TestCmdUpdateResetFailedBeforeRestart:
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        _expire_service_active_polls(monkeypatch)
 
         is_active_calls = {"n": 0}
 

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -36,6 +36,9 @@ class FakeClient:
         })
         return {"id": "mem_123"}
 
+    def create_memory(self, content, metadata=None, *, container_tag=None, is_static=False):
+        return self.add_memory(content, metadata=metadata, container_tag=container_tag)
+
     def search_memories(self, query, *, limit=5, container_tag=None, search_mode=None):
         return self.search_results
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -415,6 +415,57 @@ class TestHTTP413Compression:
 class TestPreflightCompression:
     """Preflight compression should compress history before the first API call."""
 
+    def test_preflight_clears_stale_interrupt_before_compressing(self, agent):
+        """Preflight compression must not inherit a stale thread interrupt.
+
+        Regression for gateway sessions where an earlier interrupt/restart left
+        the current worker thread marked interrupted before preflight compression
+        ran.  The Codex auxiliary adapter polls ``tools.interrupt.is_interrupted``
+        while streaming summaries; if run_conversation() has not yet rebound and
+        cleared the execution thread, the summary fails immediately with
+        "Codex auxiliary Responses stream interrupted" and the compressor drops
+        history into its fallback path.
+        """
+        from tools.interrupt import is_interrupted, set_interrupt
+
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 2000
+        agent.context_compressor.threshold_tokens = 200
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} with padding"})
+            big_history.append({"role": "assistant", "content": f"Response {i} with padding"})
+
+        ok_resp = _mock_response(content="After preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        def _fake_compress(*args, **kwargs):
+            assert not is_interrupted(), (
+                "preflight compression inherited a stale tools.interrupt flag"
+            )
+            return ([{"role": "user", "content": "compressed"}], "new system prompt")
+
+        # Simulate a stale interrupt bit on the current worker thread.  Patch
+        # hydration to avoid the legacy incidental clear there; the production
+        # fix belongs at run_conversation() startup before any preflight work.
+        set_interrupt(True)
+        try:
+            with (
+                patch.object(agent, "_hydrate_todo_store", lambda _history: None),
+                patch.object(agent, "_compress_context", side_effect=_fake_compress) as mock_compress,
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                result = agent.run_conversation("hello", conversation_history=big_history)
+        finally:
+            set_interrupt(False)
+
+        mock_compress.assert_called()
+        assert result["completed"] is True
+        assert result["final_response"] == "After preflight"
+
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2935,6 +2935,53 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after remint"
 
+    def test_preflight_compression_clears_stale_interrupt_before_compress(self, agent):
+        """Preflight compression happens before the normal API loop, so it must
+        bind and clear this turn's interrupt flag first; otherwise a stale
+        gateway/restart interrupt can abort the Codex auxiliary summary stream."""
+        self._setup_agent(agent)
+        agent.compression_enabled = True
+        agent.context_compressor.threshold_tokens = 1
+        agent.context_compressor.protect_first_n = 1
+        agent.context_compressor.protect_last_n = 3
+        agent.context_compressor.tail_token_budget = 10
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer", finish_reason="stop"
+        )
+        history = []
+        for i in range(8):
+            history.extend([
+                {"role": "user", "content": f"old question {i}"},
+                {"role": "assistant", "content": f"old answer {i}"},
+            ])
+        interrupt_calls = []
+
+        def _record_interrupt(flag, thread_id=None):
+            interrupt_calls.append((flag, thread_id))
+
+        def _assert_interrupt_was_cleared(messages, system_message, **kwargs):
+            assert agent._execution_thread_id is not None
+            assert interrupt_calls
+            assert interrupt_calls[-1] == (False, agent._execution_thread_id)
+            agent.context_compressor.threshold_tokens = 999_999
+            return ([{"role": "user", "content": "hello"}], "compressed system prompt")
+
+        with (
+            patch("run_agent._set_interrupt", side_effect=_record_interrupt),
+            # Keep this regression focused on run_conversation's preflight
+            # interrupt binding, not the incidental legacy clear in todo
+            # hydration.
+            patch.object(agent, "_hydrate_todo_store", return_value=None),
+            patch.object(agent, "_compress_context", side_effect=_assert_interrupt_was_cleared) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=history)
+
+        mock_compress.assert_called_once()
+        assert result["final_response"] == "Final answer"
+
     def test_context_compression_triggered(self, agent):
         """When compressor says should_compress, compression runs."""
         self._setup_agent(agent)

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -63,6 +63,12 @@ class TestSchema:
         assert props["element"]["type"] == "integer"
         assert props["coordinate"]["type"] == "array"
 
+    def test_schema_supports_window_title_filter_for_ambiguous_apps(self):
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+        props = COMPUTER_USE_SCHEMA["parameters"]["properties"]
+        assert "window_title" in props
+        assert props["window_title"]["type"] == "string"
+
     def test_schema_lists_all_expected_actions(self):
         from tools.computer_use.schema import COMPUTER_USE_SCHEMA
         actions = set(COMPUTER_USE_SCHEMA["parameters"]["properties"]["action"]["enum"])
@@ -155,6 +161,121 @@ class TestDispatch:
         click_kw = next(c[1] for c in noop_backend.calls if c[0] == "click")
         assert click_kw["button"] == "right"
 
+    def test_capture_after_reuses_active_window_when_backend_supports_it(self):
+        from tools.computer_use.backend import ActionResult, CaptureResult
+        from tools.computer_use import tool as cu_tool
+
+        fake_png = "iVBORw0KGgo="
+
+        class FakeBackend:
+            def __init__(self):
+                self.used_active_capture = False
+            def start(self): pass
+            def stop(self): pass
+            def is_available(self): return True
+            def capture(self, mode="som", app=None):
+                return CaptureResult(mode=mode, width=800, height=600, png_b64=fake_png,
+                                     elements=[], app="LM Studio", window_title="wrong")
+            def capture_active(self, mode="som"):
+                self.used_active_capture = True
+                return CaptureResult(mode=mode, width=800, height=600, png_b64=fake_png,
+                                     elements=[], app="Google Chrome", window_title="right")
+            def click(self, **kw):
+                return ActionResult(ok=True, action="click", message="clicked")
+            def drag(self, **kw): ...
+            def scroll(self, **kw): ...
+            def type_text(self, text): ...
+            def key(self, keys): ...
+            def set_value(self, value, element=None): ...
+            def list_apps(self): return []
+            def focus_app(self, app, raise_window=False): ...
+
+        backend = FakeBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            out = cu_tool.handle_computer_use({"action": "click", "element": 17, "capture_after": True})
+
+        assert backend.used_active_capture is True
+        assert isinstance(out, dict)
+        text_part = next(p for p in out["content"] if p.get("type") == "text")
+        assert "app=Google Chrome" in text_part["text"]
+        assert "right" in text_part["text"]
+
+    def test_capture_routes_window_title_filter_to_backend(self):
+        from tools.computer_use.backend import CaptureResult
+        from tools.computer_use import tool as cu_tool
+
+        class FakeBackend:
+            def __init__(self):
+                self.capture_args = None
+            def start(self): pass
+            def stop(self): pass
+            def is_available(self): return True
+            def capture(self, mode="som", app=None, window_title=None):
+                self.capture_args = {"mode": mode, "app": app, "window_title": window_title}
+                return CaptureResult(mode=mode, width=800, height=600, png_b64="iVBORw0KGgo=",
+                                     elements=[], app=app or "Google Chrome",
+                                     window_title=window_title or "")
+            def click(self, **kw): ...
+            def drag(self, **kw): ...
+            def scroll(self, **kw): ...
+            def type_text(self, text): ...
+            def key(self, keys): ...
+            def set_value(self, value, element=None): ...
+            def list_apps(self): return []
+            def focus_app(self, app, raise_window=False): ...
+
+        backend = FakeBackend()
+        cu_tool.reset_backend_for_tests()
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            cu_tool.handle_computer_use({
+                "action": "capture", "mode": "som", "app": "Google Chrome",
+                "window_title": "Hermes Computer Use Probe",
+            })
+
+        assert backend.capture_args == {
+            "mode": "som", "app": "Google Chrome",
+            "window_title": "Hermes Computer Use Probe",
+        }
+
+    def test_cua_capture_filters_same_app_by_window_title(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+
+            def call_tool(self, name, args):
+                self.calls.append((name, args))
+                if name == "list_windows":
+                    return {
+                        "data": "",
+                        "images": [],
+                        "structuredContent": {
+                            "windows": [
+                                {"app_name": "Google Chrome", "pid": 111, "window_id": 11,
+                                 "is_on_screen": True, "title": "Mutual Dropshipping", "z_index": 0},
+                                {"app_name": "Google Chrome", "pid": 222, "window_id": 22,
+                                 "is_on_screen": True, "title": "Hermes Computer Use Probe - Google Chrome", "z_index": 1},
+                            ]
+                        },
+                        "isError": False,
+                    }
+                if name == "get_window_state":
+                    assert args == {"pid": 222, "window_id": 22}
+                    return {"data": '✅ Google Chrome — 0 elements\nAXWindow "Hermes Computer Use Probe - Google Chrome"',
+                            "images": ["iVBORw0KGgo="], "structuredContent": None, "isError": False}
+                raise AssertionError(name)
+
+        backend = CuaDriverBackend()
+        backend._session = FakeSession()
+
+        cap = backend.capture(mode="som", app="Google Chrome", window_title="Hermes Computer Use Probe")
+
+        assert backend._active_pid == 222
+        assert backend._active_window_id == 22
+        assert cap.window_title == "Hermes Computer Use Probe - Google Chrome"
+
 
 # ---------------------------------------------------------------------------
 # Safety guards (type / key block lists)
@@ -199,6 +320,27 @@ class TestSafetyGuards:
         out = handle_computer_use({"action": "type", "text": ""})
         parsed = json.loads(out)
         assert "error" not in parsed
+
+    def test_cua_backend_type_uses_installed_type_text_tool(self):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+
+            def call_tool(self, name, args):
+                self.calls.append((name, args))
+                return {"data": "typed", "images": [], "structuredContent": None, "isError": False}
+
+        backend = CuaDriverBackend()
+        fake_session = FakeSession()
+        backend._session = fake_session
+        backend._active_pid = 123
+
+        res = backend.type_text("hello")
+
+        assert res.ok is True
+        assert fake_session.calls == [("type_text", {"pid": 123, "text": "hello"})]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_stt_corrections.py
+++ b/tests/tools/test_stt_corrections.py
@@ -1,0 +1,45 @@
+"""Personal STT correction/glossary tests."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_add_and_apply_stt_correction_replaces_phrase_case_insensitively(hermes_home):
+    from tools.stt_corrections import add_correction, apply_stt_corrections, list_corrections
+
+    result = add_correction("gétoueur du christart", "GetHooked starter kit")
+
+    assert result["action"] == "added"
+    assert list_corrections()[0]["wrong"] == "gétoueur du christart"
+    assert (
+        apply_stt_corrections("Le GÉTOUEUR du Christart est lent.")
+        == "Le GetHooked starter kit est lent."
+    )
+
+
+def test_parse_stt_correction_args_accepts_arrow_separator(hermes_home):
+    from tools.stt_corrections import parse_correction_args
+
+    wrong, right = parse_correction_args("gétoueur du Christart => GetHooked starter kit")
+
+    assert wrong == "gétoueur du Christart"
+    assert right == "GetHooked starter kit"
+
+
+def test_remove_stt_correction_by_one_based_index(hermes_home):
+    from tools.stt_corrections import add_correction, list_corrections, remove_correction
+
+    add_correction("mutuelle", "Mutual")
+    removed = remove_correction(1)
+
+    assert removed["wrong"] == "mutuelle"
+    assert list_corrections() == []

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -11,6 +11,7 @@ import pytest
 
 from tools.vision_tools import (
     _detect_video_mime_type,
+    _video_analysis_looks_unavailable,
     _video_to_base64_data_url,
     _handle_video_analyze,
     _MAX_VIDEO_BASE64_BYTES,
@@ -182,6 +183,11 @@ class TestVideoAnalyzeTool:
     def _run(self, coro):
         return asyncio.get_event_loop().run_until_complete(coro)
 
+    def test_unavailable_heuristic_handles_curly_apostrophe_no_video_response(self):
+        assert _video_analysis_looks_unavailable(
+            "I can’t see any video or frames attached here. Please upload the short video."
+        ) is True
+
     def test_local_file_success(self, tmp_path, monkeypatch):
         """Analyze a local video file — happy path."""
         video = tmp_path / "demo.mp4"
@@ -307,6 +313,55 @@ class TestVideoAnalyzeTool:
         assert content[1]["type"] == "video_url"
         assert "video_url" in content[1]
         assert content[1]["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+    def test_native_unavailable_response_falls_back_to_frame_contact_sheet(self, tmp_path):
+        """If the native model says it cannot access the video, use ffmpeg→vision fallback."""
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"\x00" * 100)
+        sheet = tmp_path / "sheet.jpg"
+        sheet.write_bytes(b"\xff\xd8\xff\xd9")
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "I cannot access or view the local MP4 file."
+
+        with patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response):
+            with patch("tools.vision_tools.extract_content_or_reasoning", return_value="I cannot access or view the local MP4 file."):
+                with patch("tools.vision_tools._build_video_contact_sheet", return_value=sheet) as mock_sheet:
+                    with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_vision:
+                        mock_vision.return_value = json.dumps({"success": True, "analysis": "Frame 1: square. Frame 2: check. Frame 3: X."})
+                        result = self._run(video_analyze_tool(str(video), "Describe frames"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["fallback_used"] is True
+        assert data["fallback_method"] == "ffmpeg_contact_sheet_to_vision"
+        assert "square" in data["analysis"].lower()
+        assert data["contact_sheet_path"] == str(sheet)
+        mock_sheet.assert_called_once()
+        assert mock_vision.call_args[0][0] == str(sheet)
+        assert "contact sheet" in mock_vision.call_args[0][1].lower()
+
+    def test_native_exception_falls_back_to_frame_contact_sheet(self, tmp_path):
+        """A provider-side video_url rejection should not kill video analysis when ffmpeg fallback works."""
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"\x00" * 100)
+        sheet = tmp_path / "sheet.jpg"
+        sheet.write_bytes(b"\xff\xd8\xff\xd9")
+
+        async def fail_llm(**kwargs):
+            raise ValueError("video_url is not supported by this model")
+
+        with patch("tools.vision_tools.async_call_llm", side_effect=fail_llm):
+            with patch("tools.vision_tools._build_video_contact_sheet", return_value=sheet):
+                with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock) as mock_vision:
+                    mock_vision.return_value = json.dumps({"success": True, "analysis": "Fallback saw sampled frames."})
+                    result = self._run(video_analyze_tool(str(video), "Describe video"))
+
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["fallback_used"] is True
+        assert "sampled frames" in data["analysis"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -188,6 +188,12 @@ class TestVideoAnalyzeTool:
             "I can’t see any video or frames attached here. Please upload the short video."
         ) is True
 
+    def test_unavailable_heuristic_handles_french_no_video_response(self):
+        assert _video_analysis_looks_unavailable(
+            "Je n’ai pas accès à la vidéo ni à des images extraites/contact-sheet dans cette conversation, "
+            "donc impossible à déterminer sans la vidéo."
+        ) is True
+
     def test_local_file_success(self, tmp_path, monkeypatch):
         """Analyze a local video file — happy path."""
         video = tmp_path / "demo.mp4"

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -86,7 +86,12 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -337,8 +337,13 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        """Capture the frontmost on-screen window (optionally filtered by app name).
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult:
+        """Capture the frontmost on-screen window (optionally filtered by app/title).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
@@ -376,6 +381,14 @@ class CuaDriverBackend(ComputerUseBackend):
         if app:
             app_lower = app.lower()
             filtered = [w for w in windows if app_lower in w["app_name"].lower()]
+            if filtered:
+                windows = filtered
+
+        # Filter by window title substring when requested. This prevents drift
+        # between multiple Chrome windows with the same app name.
+        if window_title:
+            title_lower = window_title.lower()
+            filtered = [w for w in windows if title_lower in (w.get("title") or "").lower()]
             if filtered:
                 windows = filtered
 
@@ -433,6 +446,77 @@ class CuaDriverBackend(ComputerUseBackend):
             mode=mode,
             width=width,
             height=height,
+            png_b64=png_b64,
+            elements=elements,
+            app=app_name,
+            window_title=window_title,
+            png_bytes_len=png_bytes_len,
+        )
+
+    def capture_active(self, mode: str = "som") -> CaptureResult:
+        """Capture the sticky pid/window_id selected by the last capture/focus.
+
+        Follow-up verification after background actions must inspect the same
+        target window. A plain capture() with no app filter can drift to the
+        user's frontmost app even when the action correctly hit the active pid.
+        """
+        if self._active_pid is None or self._active_window_id is None:
+            return self.capture(mode=mode)
+
+        pid = self._active_pid
+        window_id = self._active_window_id
+        app_name = ""
+
+        lw_out = self._session.call_tool("list_windows", {"on_screen_only": False})
+        sc = lw_out.get("structuredContent") or {}
+        raw_windows = sc.get("windows") if sc else None
+        if raw_windows:
+            for w in raw_windows:
+                try:
+                    if int(w.get("pid", 0)) == pid and int(w.get("window_id", 0)) == window_id:
+                        app_name = w.get("app_name", "") or ""
+                        break
+                except (TypeError, ValueError):
+                    continue
+
+        png_b64: Optional[str] = None
+        elements: List[UIElement] = []
+        window_title = ""
+
+        if mode == "vision":
+            sc_out = self._session.call_tool(
+                "screenshot",
+                {"window_id": window_id, "format": "jpeg", "quality": 85},
+            )
+            if sc_out["images"]:
+                png_b64 = sc_out["images"][0]
+        else:
+            gws_out = self._session.call_tool(
+                "get_window_state",
+                {"pid": pid, "window_id": window_id},
+            )
+            text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
+            _, tree = _split_tree_text(text)
+            if tree and not gws_out["images"]:
+                elements = _parse_elements_from_tree(tree)
+            elif gws_out["images"]:
+                png_b64 = gws_out["images"][0]
+                elements = _parse_elements_from_tree(tree)
+            wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
+            if wt:
+                window_title = wt.group(1)
+
+        png_bytes_len = 0
+        if png_b64:
+            try:
+                png_bytes_len = len(base64.b64decode(png_b64, validate=False))
+            except Exception:
+                png_bytes_len = len(png_b64) * 3 // 4
+
+        return CaptureResult(
+            mode=mode,
+            width=0,
+            height=0,
             png_b64=png_b64,
             elements=elements,
             app=app_name,
@@ -529,10 +613,7 @@ class CuaDriverBackend(ComputerUseBackend):
         if pid is None:
             return ActionResult(ok=False, action="type_text",
                                 message="No active window — call capture() first.")
-        # Safari WebKit AXTextField does not accept AX attribute writes (type_text),
-        # so use type_text_chars which synthesises individual key events instead.
-        # This works universally across all macOS apps in background mode.
-        return self._action("type_text_chars", {"pid": pid, "text": text})
+        return self._action("type_text", {"pid": pid, "text": text})
 
     def key(self, keys: str) -> ActionResult:
         pid = self._active_pid

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -75,6 +75,14 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "frontmost app's window or the whole screen."
                 ),
             },
+            "window_title": {
+                "type": "string",
+                "description": (
+                    "Optional capture filter. When several windows from the "
+                    "same app exist, choose the window whose title contains "
+                    "this text (case-insensitive), e.g. 'Hermes Computer Use Probe'."
+                ),
+            },
             # ── click / drag / scroll targeting ────────────────────
             "element": {
                 "type": "integer",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -167,10 +167,20 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        self.calls.append(("capture", {"mode": mode, "app": app}))
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult:
+        self.calls.append(("capture", {"mode": mode, "app": app, "window_title": window_title}))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
-                             elements=[], app=app or "", window_title="")
+                             elements=[], app=app or "", window_title=window_title or "")
+
+    def capture_active(self, mode: str = "som") -> CaptureResult:
+        self.calls.append(("capture_active", {"mode": mode}))
+        return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
+                             elements=[], app="", window_title="")
 
     def click(self, **kw) -> ActionResult:
         self.calls.append(("click", kw))
@@ -316,7 +326,10 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        capture_kwargs = {"mode": mode, "app": args.get("app")}
+        if args.get("window_title"):
+            capture_kwargs["window_title"] = args.get("window_title")
+        cap = backend.capture(**capture_kwargs)
         return _capture_response(cap)
 
     if action == "wait":
@@ -457,7 +470,11 @@ def _maybe_follow_capture(
     if not do_capture:
         return _text_response(res)
     try:
-        cap = backend.capture(mode="som")
+        capture_active = getattr(backend, "capture_active", None)
+        if callable(capture_active):
+            cap = capture_active(mode="som")
+        else:
+            cap = backend.capture(mode="som")
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)

--- a/tools/stt_corrections.py
+++ b/tools/stt_corrections.py
@@ -1,0 +1,178 @@
+"""Personal STT correction/glossary helpers.
+
+This module stores small deterministic phrase corrections for speech-to-text
+output. It intentionally does not call an LLM: corrections are fast, local, and
+safe to run before the agent sees the transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+_CORRECTIONS_FILE = "stt_corrections.json"
+_VERSION = 1
+_SEPARATORS = ("=>", "->", "=")
+
+
+def _corrections_path(path: str | Path | None = None) -> Path:
+    if path is not None:
+        return Path(path)
+    return get_hermes_home() / _CORRECTIONS_FILE
+
+
+def _load(path: str | Path | None = None) -> dict[str, Any]:
+    p = _corrections_path(path)
+    if not p.exists():
+        return {"version": _VERSION, "corrections": []}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"version": _VERSION, "corrections": []}
+    if not isinstance(data, dict):
+        return {"version": _VERSION, "corrections": []}
+    corrections = data.get("corrections")
+    if not isinstance(corrections, list):
+        corrections = []
+    clean: list[dict[str, Any]] = []
+    for item in corrections:
+        if not isinstance(item, dict):
+            continue
+        wrong = str(item.get("wrong") or "").strip()
+        right = str(item.get("right") or "").strip()
+        if not wrong or not right:
+            continue
+        clean.append(
+            {
+                "wrong": wrong,
+                "right": right,
+                "case_sensitive": bool(item.get("case_sensitive", False)),
+                "created_at": str(item.get("created_at") or ""),
+            }
+        )
+    return {"version": _VERSION, "corrections": clean}
+
+
+def _save(data: dict[str, Any], path: str | Path | None = None) -> None:
+    p = _corrections_path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": _VERSION,
+        "corrections": data.get("corrections", []),
+    }
+    p.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_correction_args(args: str) -> tuple[str, str]:
+    """Parse `/stt-correct wrong => right` style arguments."""
+    raw = (args or "").strip()
+    for sep in _SEPARATORS:
+        if sep in raw:
+            wrong, right = raw.split(sep, 1)
+            wrong = wrong.strip().strip("\"'“”‘’")
+            right = right.strip().strip("\"'“”‘’")
+            if wrong and right:
+                return wrong, right
+    raise ValueError("Format attendu : /stt-correct phrase entendue => phrase correcte")
+
+
+def list_corrections(path: str | Path | None = None) -> list[dict[str, Any]]:
+    """Return stored corrections in insertion order."""
+    return list(_load(path).get("corrections", []))
+
+
+def add_correction(
+    wrong: str,
+    right: str,
+    *,
+    case_sensitive: bool = False,
+    path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Add or replace a phrase correction."""
+    wrong = (wrong or "").strip()
+    right = (right or "").strip()
+    if not wrong or not right:
+        raise ValueError("La phrase source et la correction doivent être non vides.")
+
+    data = _load(path)
+    corrections = data.setdefault("corrections", [])
+    key = wrong if case_sensitive else wrong.casefold()
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    entry = {
+        "wrong": wrong,
+        "right": right,
+        "case_sensitive": bool(case_sensitive),
+        "created_at": now,
+    }
+    for idx, item in enumerate(corrections):
+        existing_key = item["wrong"] if item.get("case_sensitive") else item["wrong"].casefold()
+        if existing_key == key:
+            corrections[idx] = entry
+            _save(data, path)
+            return {"action": "updated", **entry, "index": idx + 1}
+    corrections.append(entry)
+    _save(data, path)
+    return {"action": "added", **entry, "index": len(corrections)}
+
+
+def remove_correction(index: int, path: str | Path | None = None) -> dict[str, Any]:
+    """Remove a correction by one-based index."""
+    data = _load(path)
+    corrections = data.setdefault("corrections", [])
+    if index < 1 or index > len(corrections):
+        raise IndexError("Index de correction STT invalide.")
+    removed = corrections.pop(index - 1)
+    _save(data, path)
+    return removed
+
+
+def clear_corrections(path: str | Path | None = None) -> int:
+    """Remove all corrections and return how many were cleared."""
+    data = _load(path)
+    count = len(data.get("corrections", []))
+    _save({"version": _VERSION, "corrections": []}, path)
+    return count
+
+
+def apply_stt_corrections(transcript: str, path: str | Path | None = None) -> str:
+    """Apply deterministic phrase corrections to a transcript."""
+    text = transcript or ""
+    corrections = list_corrections(path)
+    # Longer phrases first prevents short glossary terms from disrupting a
+    # longer, more specific correction.
+    corrections.sort(key=lambda item: len(item["wrong"]), reverse=True)
+    for item in corrections:
+        wrong = item["wrong"]
+        right = item["right"]
+        flags = 0 if item.get("case_sensitive") else re.IGNORECASE
+        text = re.sub(re.escape(wrong), lambda _m: right, text, flags=flags)
+    return text
+
+
+def format_corrections(path: str | Path | None = None) -> str:
+    corrections = list_corrections(path)
+    if not corrections:
+        return "Aucune correction STT enregistrée."
+    lines = ["Corrections STT enregistrées :"]
+    for idx, item in enumerate(corrections, start=1):
+        lines.append(f"{idx}. « {item['wrong']} » → « {item['right']} »")
+    return "\n".join(lines)
+
+
+def usage_text() -> str:
+    return (
+        "Usage :\n"
+        "• /stt-correct phrase entendue => phrase correcte\n"
+        "• /stt-correct list\n"
+        "• /stt-correct remove 1\n"
+        "• /stt-correct clear"
+    )

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -31,7 +31,10 @@ Usage:
 import base64
 import json
 import logging
+import math
 import os
+import shutil
+import subprocess
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -1091,6 +1094,170 @@ def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None)
     return f"data:{mime};base64,{encoded}"
 
 
+def _video_analysis_looks_unavailable(analysis: str) -> bool:
+    """Heuristic for wrapper-success/native-failure video responses.
+
+    Several providers accept the request shape but treat the `video_url` part as
+    text or unsupported media, returning a fluent explanation that the video or
+    local path is not accessible. In that case, the tool should fall back to
+    ffmpeg frame sampling instead of reporting false success.
+    """
+    if not isinstance(analysis, str) or not analysis.strip():
+        return True
+    text = analysis.lower().replace("’", "'").replace("‘", "'")
+    unavailable_markers = (
+        "cannot access", "can't access", "cannot view", "can't view",
+        "unable to access", "unable to view", "do not have access",
+        "don't have access", "no access to", "not able to access",
+        "not able to view", "cannot directly access", "can't directly access",
+        "i can't see", "i cannot see", "i can't watch", "i cannot watch",
+        "can't see any video", "cannot see any video", "video or frames attached",
+        "please upload the video", "please upload the short video",
+        "local mp4", "local file", "file path", "video file was not provided",
+        "no video", "without the video", "video_url is not supported",
+        "does not support video", "not support video", "unsupported video",
+    )
+    return any(marker in text for marker in unavailable_markers)
+
+
+def _probe_video_duration_seconds(video_path: Path) -> Optional[float]:
+    """Best-effort ffprobe duration. Returns None when ffprobe is unavailable."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                ffprobe,
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                str(video_path),
+            ],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+        if proc.returncode != 0:
+            logger.debug("ffprobe duration failed: %s", proc.stderr[:200])
+            return None
+        duration = float((proc.stdout or "").strip())
+        return duration if duration > 0 else None
+    except Exception as exc:
+        logger.debug("ffprobe duration failed: %s", exc)
+        return None
+
+
+def _build_video_contact_sheet(
+    video_path: Path,
+    output_path: Optional[Path] = None,
+    *,
+    max_frames: int = 12,
+    frame_width: int = 320,
+) -> Path:
+    """Extract sampled video frames into one JPEG contact sheet using ffmpeg.
+
+    The sheet is intentionally simple and dependency-light: no drawtext filter
+    (often missing on minimal ffmpeg builds), no OCR assumptions, and no GUI.
+    Frames are sampled approximately evenly by duration and laid out
+    left-to-right/top-to-bottom for downstream image vision analysis.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required for video frame fallback but was not found in PATH")
+    if not video_path.is_file():
+        raise FileNotFoundError(str(video_path))
+
+    max_frames = max(1, min(int(max_frames or 12), 36))
+    frame_width = max(96, min(int(frame_width or 320), 960))
+    cols = max(1, int(math.ceil(math.sqrt(max_frames))))
+    rows = max(1, int(math.ceil(max_frames / cols)))
+    duration = _probe_video_duration_seconds(video_path)
+    # Use fps sampling instead of drawtext/select expressions because it works
+    # across more ffmpeg builds. For unknown/very-short duration, at least one
+    # frame per second is safe; tile flushes a partial sheet at EOF.
+    fps = max_frames / duration if duration and duration > 0 else 1.0
+    fps = max(0.05, min(fps, 8.0))
+
+    if output_path is None:
+        out_dir = get_hermes_dir("cache/video", "contact_sheets")
+        output_path = out_dir / f"video_contact_sheet_{uuid.uuid4()}.jpg"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    vf = (
+        f"fps=fps={fps:.4f}:round=up,"
+        f"scale={frame_width}:-1,"
+        f"tile={cols}x{rows}:padding=8:margin=8:color=black"
+    )
+    proc = subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner", "-loglevel", "error", "-y",
+            "-i", str(video_path),
+            "-an",
+            "-vf", vf,
+            "-frames:v", "1",
+            str(output_path),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0 or not output_path.is_file() or output_path.stat().st_size <= 0:
+        raise RuntimeError(f"ffmpeg contact sheet failed: {proc.stderr[:500]}")
+    return output_path
+
+
+def _build_video_frame_fallback_prompt(user_prompt: str, video_path: Path) -> str:
+    """Prompt used when analyzing sampled video frames as an image."""
+    duration = _probe_video_duration_seconds(video_path)
+    duration_text = f" Duration: {duration:.2f}s." if duration else ""
+    return (
+        "This image is a contact sheet of frames sampled from a video. "
+        "Read it left-to-right, top-to-bottom as approximate timeline order. "
+        "Describe visible objects, text, colors, scene changes, and inferred motion. "
+        "Be explicit that this is frame-based analysis if temporal/audio details are uncertain."
+        f"{duration_text}\n\nQuestion about the original video:\n{user_prompt}"
+    )
+
+
+async def _analyze_video_via_frame_fallback(
+    video_path: Path,
+    user_prompt: str,
+    *,
+    source_video_url: str,
+    model: Optional[str] = None,
+    native_error: Optional[str] = None,
+) -> str:
+    """Analyze video by ffmpeg contact-sheet extraction plus vision_analyze_tool."""
+    sheet = _build_video_contact_sheet(video_path)
+    fallback_prompt = _build_video_frame_fallback_prompt(user_prompt, video_path)
+    vision_result_raw = await vision_analyze_tool(str(sheet), fallback_prompt, model)
+    try:
+        vision_result = json.loads(vision_result_raw)
+    except Exception:
+        vision_result = {"success": False, "analysis": vision_result_raw}
+
+    success = bool(vision_result.get("success"))
+    result = {
+        "success": success,
+        "analysis": vision_result.get("analysis") or "Frame fallback did not return an analysis.",
+        "fallback_used": True,
+        "fallback_method": "ffmpeg_contact_sheet_to_vision",
+        "contact_sheet_path": str(sheet),
+        "source_video_url": source_video_url[:500],
+    }
+    if native_error:
+        result["native_video_error"] = native_error[:1000]
+    if not success and vision_result.get("error"):
+        result["error"] = vision_result.get("error")
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
 async def _download_video(video_url: str, destination: Path, max_retries: int = 3) -> Path:
     """Download video from URL with SSRF protection and retry."""
     import asyncio
@@ -1289,20 +1456,48 @@ async def video_analyze_tool(
         if model:
             call_kwargs["model"] = model
 
-        response = await async_call_llm(**call_kwargs)
-        analysis = extract_content_or_reasoning(response)
-
-        if not analysis:
-            logger.warning("Empty video response, retrying once")
+        try:
             response = await async_call_llm(**call_kwargs)
             analysis = extract_content_or_reasoning(response)
+
+            if not analysis:
+                logger.warning("Empty video response, retrying once")
+                response = await async_call_llm(**call_kwargs)
+                analysis = extract_content_or_reasoning(response)
+        except Exception as native_exc:
+            logger.warning(
+                "Native video analysis failed; falling back to ffmpeg contact sheet: %s",
+                native_exc,
+                exc_info=True,
+            )
+            return await _analyze_video_via_frame_fallback(
+                temp_video_path,
+                user_prompt,
+                source_video_url=video_url,
+                model=model,
+                native_error=str(native_exc),
+            )
 
         analysis_length = len(analysis) if analysis else 0
         logger.info("Video analysis completed (%s characters)", analysis_length)
 
+        if _video_analysis_looks_unavailable(analysis or ""):
+            logger.warning(
+                "Native video analysis returned an unavailable/unsupported response; "
+                "falling back to ffmpeg contact sheet"
+            )
+            return await _analyze_video_via_frame_fallback(
+                temp_video_path,
+                user_prompt,
+                source_video_url=video_url,
+                model=model,
+                native_error=analysis or "empty native video response",
+            )
+
         result = {
             "success": True,
             "analysis": analysis or "There was a problem with the request and the video could not be analyzed.",
+            "fallback_used": False,
         }
 
         debug_call_data["success"] = True

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -35,6 +35,7 @@ import math
 import os
 import shutil
 import subprocess
+import unicodedata
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
@@ -1105,6 +1106,10 @@ def _video_analysis_looks_unavailable(analysis: str) -> bool:
     if not isinstance(analysis, str) or not analysis.strip():
         return True
     text = analysis.lower().replace("’", "'").replace("‘", "'")
+    text_ascii = "".join(
+        ch for ch in unicodedata.normalize("NFKD", text)
+        if not unicodedata.combining(ch)
+    )
     unavailable_markers = (
         "cannot access", "can't access", "cannot view", "can't view",
         "unable to access", "unable to view", "do not have access",
@@ -1116,8 +1121,12 @@ def _video_analysis_looks_unavailable(analysis: str) -> bool:
         "local mp4", "local file", "file path", "video file was not provided",
         "no video", "without the video", "video_url is not supported",
         "does not support video", "not support video", "unsupported video",
+        # French/translated refusal strings from providers routed through Hermes.
+        "je n'ai pas acces", "pas acces a la video", "pas acces aux frames",
+        "aucune image extraite", "aucun frame", "aucune frame",
+        "impossible a determiner sans la video", "sans la video",
     )
-    return any(marker in text for marker in unavailable_markers)
+    return any(marker in text or marker in text_ascii for marker in unavailable_markers)
 
 
 def _probe_video_duration_seconds(video_path: Path) -> Optional[float]:


### PR DESCRIPTION
## Summary

This PR upstreams a production-readiness hardening bundle that was developed and tested in a live Hermes gateway setup.

Key areas:
- Gateway/Telegram resilience: flood-control handling, progress overflow behavior, STT transcript echo/corrections, and launchd refresh/restart hardening.
- Context/compression resilience: preserve extractive, redacted context when auxiliary compression fails instead of losing continuity.
- Provider diagnostics: use Gemini query-key auth in `hermes doctor`; stabilize Nous auxiliary pool model handling.
- Memory: align SuperMemory explicit stores with v4 memory IDs and avoid unsafe fuzzy query deletion.
- Computer Use/video: add window-title targeting and fallback video analysis when native video access returns an unavailable-response.
- Update UX: invalidate update-check cache when checkout/HEAD changes.

I opened this as a draft because the bundle spans multiple production surfaces and maintainers may prefer splitting it by domain.

## Test plan

Targeted suite on macOS / Python 3.14.3:

```text
1193 passed, 1 warning in 289.42s
```

Command:

```bash
PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider -q -o 'addopts=' \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_context_compressor.py \
  tests/agent/test_gemini_cloudcode.py \
  tests/gateway/test_empty_response_normalization.py \
  tests/gateway/test_run_progress_topics.py \
  tests/gateway/test_session_hygiene.py \
  tests/gateway/test_stream_consumer.py \
  tests/gateway/test_stt_config.py \
  tests/gateway/test_telegram_thread_fallback.py \
  tests/hermes_cli/test_doctor.py \
  tests/hermes_cli/test_doctor_dedicated_provider_skip.py \
  tests/hermes_cli/test_update_check.py \
  tests/hermes_cli/test_update_gateway_restart.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/plugins/memory/test_supermemory_provider.py \
  tests/run_agent/test_413_compression.py \
  tests/run_agent/test_run_agent.py \
  tests/tools/test_computer_use.py \
  tests/tools/test_stt_corrections.py \
  tests/tools/test_video_analyze.py
```

Lint on changed files:

```text
ruff 0.15.10
All checks passed
```

## Notes

- No real secrets or local machine paths are included in the diff.
- The latest commit fixes test drift exposed by the targeted pre-PR suite: duplicate model mock, systemd preflight mocking in service tests, deterministic restart-poll timeouts, SuperMemory fake-client v4 interface, and launchd `kickstart` after plist refresh.
