### PR TITLE
fix(gateway): verify macOS launchd restart handoff

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8653,8 +8653,13 @@ class GatewayRunner:
         # service restart path: exit with code 75 so the service manager
         # restarts us.  The detached subprocess approach (setsid + bash)
         # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # processes in the cgroup, including the detached helper.  macOS
+        # launchd similarly owns the gateway process and may not preserve a
+        # detached helper during service teardown, so detect both managers.
+        xpc_service_name = os.environ.get("XPC_SERVICE_NAME", "")
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or xpc_service_name.startswith(
+            "ai.hermes.gateway"
+        )
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -858,6 +858,62 @@ def _wait_for_systemd_service_restart(
     return False
 
 
+def _wait_for_launchd_service_restart(
+    *,
+    previous_pid: int | None = None,
+    timeout: float = 60.0,
+) -> bool:
+    """Wait for a launchd-managed gateway to come back after restart.
+
+    launchctl can accept a kickstart/restart request before the new gateway is
+    actually healthy. Treat a restart as complete only after the PID changes
+    and the gateway runtime status reports ``gateway_state=running``.
+    """
+    import time
+
+    deadline = time.monotonic() + timeout
+    printed_runtime_wait = False
+
+    while time.monotonic() < deadline:
+        try:
+            from gateway.status import get_running_pid
+
+            new_pid = get_running_pid()
+        except Exception:
+            new_pid = None
+
+        if new_pid and (previous_pid is None or new_pid != previous_pid):
+            runtime_state = _gateway_runtime_status_for_pid(new_pid)
+            gateway_state = (runtime_state or {}).get("gateway_state")
+            if gateway_state == "running":
+                print(f"✓ Service restarted (PID {new_pid})")
+                return True
+            if gateway_state == "startup_failed":
+                reason = (runtime_state or {}).get("exit_reason") or "startup failed"
+                print(
+                    f"⚠ Service process restarted (PID {new_pid}), "
+                    f"but gateway startup failed: {reason}"
+                )
+                return False
+            if not printed_runtime_wait:
+                print(
+                    f"⏳ Service process started (PID {new_pid}); "
+                    "waiting for gateway runtime..."
+                )
+                printed_runtime_wait = True
+
+        time.sleep(1)
+
+    from hermes_constants import display_hermes_home as _dhh
+
+    print(
+        f"⚠ Service did not report a healthy replacement process within {int(timeout)}s.\n"
+        "  Check status: hermes gateway status\n"
+        f"  Check logs:   tail -80 {_dhh()}/logs/gateway.log"
+    )
+    return False
+
+
 def _systemd_unit_is_start_limited(props: dict[str, str]) -> bool:
     result = props.get("Result", "").lower()
     sub_state = props.get("SubState", "").lower()
@@ -2994,31 +3050,35 @@ def launchd_restart():
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
+    pid = get_running_pid()
+    if pid is not None:
+        print(f"⏳ Service restarting gracefully (PID {pid})...")
+        if _request_gateway_self_restart(pid):
+            if _wait_for_launchd_service_restart(previous_pid=pid):
+                return
+            print("⚠ Service restart request was not verified; forcing launchd restart...")
+        elif _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
+            if _wait_for_launchd_service_restart(previous_pid=pid):
+                return
+            print("⚠ Service restart was not verified; forcing launchd restart...")
+        else:
+            print(
+                f"⚠ Graceful restart did not complete within {int(drain_timeout + 5)}s; "
+                "forcing launchd restart..."
+            )
+
     try:
-        pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            return
-        if pid is not None:
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
-        print("✓ Service restarted")
+        _wait_for_launchd_service_restart(previous_pid=pid)
     except subprocess.CalledProcessError as e:
         if e.returncode not in (3, 113):
             raise
-        # Job not loaded — bootstrap and start fresh
+        # Job not loaded — bootstrap and start fresh.
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
-        print("✓ Service restarted")
+        _wait_for_launchd_service_restart(previous_pid=pid)
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -38,6 +38,29 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
 
 
 @pytest.mark.asyncio
+async def test_restart_command_while_busy_requests_service_restart_under_launchd(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m1-launchd",
+    )
+    session_key = build_session_key(event.source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    result = await runner._handle_message(event)
+
+    assert result == "⏳ Draining 1 active agent(s) before restart..."
+    running_agent.interrupt.assert_not_called()
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
 async def test_drain_queue_mode_queues_follow_up_without_interrupt():
     runner, adapter = make_restart_runner()
     runner._draining = True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -554,14 +554,25 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_gracefully_signals_and_waits_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(
+                ("wait", previous_pid, timeout)
+            )
+            or True,
+        )
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -576,11 +587,12 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
-            ("term", 321, False),
+            ("graceful", 321, 17.0),
             ["launchctl", "kickstart", "-k", target],
+            ("wait", 321, 60.0),
         ]
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_self_request_waits_for_verified_replacement(self, monkeypatch, capsys):
         calls = []
 
         monkeypatch.setattr(
@@ -593,6 +605,14 @@ class TestLaunchdServiceRecovery:
             lambda pid: calls.append(("self", pid)) or True,
         )
         monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_launchd_service_restart",
+            lambda previous_pid=None, timeout=60.0: calls.append(
+                ("wait", previous_pid, timeout)
+            )
+            or True,
+        )
+        monkeypatch.setattr(
             gateway_cli.subprocess,
             "run",
             lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
@@ -600,8 +620,22 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        assert calls == [("self", 321), ("wait", 321, 60.0)]
+        assert "restarting gracefully" in capsys.readouterr().out.lower()
+
+    def test_wait_for_launchd_restart_waits_for_runtime_running(self, monkeypatch, capsys):
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 999)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_gateway_runtime_status_for_pid",
+            lambda pid: {"pid": pid, "gateway_state": "running"},
+        )
+
+        assert (
+            gateway_cli._wait_for_launchd_service_restart(previous_pid=321, timeout=0.1)
+            is True
+        )
+        assert "restarted (pid 999)" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""


### PR DESCRIPTION
## Summary
- Detect macOS launchd-managed gateway processes via `XPC_SERVICE_NAME` so `/restart` uses the service restart path instead of spawning a detached helper.
- Make `hermes gateway restart` on launchd wait for a replacement gateway PID and `gateway_state=running` before reporting success.
- Fall back to `launchctl kickstart -k` / bootstrap recovery if the graceful restart handoff is not verified.

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/gateway/test_restart_drain.py -q -o 'addopts='`
- `python -m py_compile gateway/run.py hermes_cli/gateway.py tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check -- gateway/run.py hermes_cli/gateway.py tests/gateway/test_restart_drain.py tests/hermes_cli/test_gateway_service.py`

## Notes
A broader local run of `tests/hermes_cli/test_gateway_service.py tests/gateway/test_restart_drain.py` on macOS hit pre-existing systemd-only tests that call `_preflight_user_systemd()` and fail because macOS has no user systemd session. The launchd-specific class and restart-drain tests pass.