### PR TITLE
fix(session-db): 4-phase sync gap fix — import, WAL retry, health check, visible warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2783,6 +2783,19 @@ class HermesCLI:
             self._session_db = SessionDB()
         except Exception as e:
             logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
+            # Surface to user — they need to know their session won't be
+            # searchable cross-session.  Transient failures (WAL contention
+            # during DB init) are NOT retried at this layer; _ensure_db_session
+            # in run_agent.py handles per-call retries.  If the DB itself can't
+            # even be opened, the user should be warned.
+            try:
+                click.echo(
+                    f"WARNING: SQLite session store unavailable — "
+                    f"this session will NOT appear in session_search. ({e})",
+                    err=True,
+                )
+            except Exception:
+                pass
 
         # Opportunistic state.db maintenance — runs at most once per
         # min_interval_hours, tracked via state_meta in state.db itself so

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -379,6 +379,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
+_gateway_orphan_hint_checked = False
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
@@ -3737,6 +3738,38 @@ class GatewayRunner:
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
+
+        # Opportunistic orphaned-session hint at gateway startup
+        global _gateway_orphan_hint_checked
+        if not _gateway_orphan_hint_checked:
+            _gateway_orphan_hint_checked = True
+            try:
+                from hermes_state import SessionDB
+
+                sessions_dir = _hermes_home / "sessions"
+                if sessions_dir.is_dir():
+                    disk_ids = set()
+                    for fp in sessions_dir.iterdir():
+                        name = fp.name
+                        if name.startswith("session_") and not fp.is_symlink():
+                            if name.endswith(".json.gz"):
+                                disk_ids.add(name.replace("session_", "").replace(".json.gz", ""))
+                            elif name.endswith(".json"):
+                                disk_ids.add(name.replace("session_", "").replace(".json", ""))
+                    if disk_ids:
+                        db = SessionDB()
+                        db_ids = set(db.list_session_ids())
+                        db.close()
+                        orphan_count = len(disk_ids - db_ids)
+                        if orphan_count > 100:
+                            logger.info(
+                                "%d session file(s) on disk are not in the SQLite database. "
+                                "Run 'hermes sessions repair' to import them.",
+                                orphan_count,
+                            )
+            except Exception:
+                pass
+
         
         # Build initial channel directory for send_message name resolution
         try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11460,6 +11460,171 @@ Examples:
     # =========================================================================
     # sessions command
     # =========================================================================
+
+    def _cmd_sessions_repair(args) -> None:
+        """Scan on-disk session files and import any missing from the SQLite DB."""
+        import gzip as _gzip
+
+        sessions_dir = get_hermes_home() / "sessions"
+        if not sessions_dir.is_dir():
+            print("No sessions directory found.")
+            return
+
+        dry_run = getattr(args, "dry_run", False)
+        limit = getattr(args, "limit", 0) or 0
+
+        try:
+            from hermes_state import SessionDB
+        except Exception as e:
+            print(f"Error: Could not open session database: {e}")
+            return
+
+        # Gather all session IDs from the database
+        db = SessionDB()
+        db_session_ids = set()
+        try:
+            db_session_ids = set(db.list_session_ids())
+        except Exception as e:
+            print(f"Error reading session database: {e}")
+            db.close()
+            return
+
+        # Scan on-disk session files
+        orphans = []
+        for fp in sorted(sessions_dir.iterdir()):
+            # Skip symlinks (could cause infinite loops)
+            if fp.is_symlink():
+                continue
+            name = fp.name
+            if name.startswith("session_") and (
+                name.endswith(".json") or name.endswith(".json.gz")
+            ):
+                if name.endswith(".json.gz"):
+                    sid = name.replace("session_", "").replace(".json.gz", "")
+                else:
+                    sid = name.replace("session_", "").replace(".json", "")
+
+                if sid not in db_session_ids:
+                    orphans.append(fp)
+
+        if not orphans:
+            print("No orphaned session files found. All on-disk sessions are in the database.")
+            db.close()
+            return
+
+        print(f"Found {len(orphans)} orphaned session file(s) not in the database.")
+
+        # Skip request_dump files (not full session transcripts)
+        orphans = [f for f in orphans if "request_dump" not in f.name]
+        if limit > 0:
+            orphans = orphans[:limit]
+
+        if dry_run:
+            print(f"\nDry run — would import {len(orphans)} session(s):")
+            for fp in orphans[:10]:
+                name = fp.name
+                if name.endswith(".json.gz"):
+                    sid = name.replace("session_", "").replace(".json.gz", "")
+                else:
+                    sid = name.replace("session_", "").replace(".json", "")
+                print(f"  {sid}  ({fp.stat().st_size / 1024:.1f} KB)")
+            if len(orphans) > 10:
+                print(f"  ... and {len(orphans) - 10} more")
+            print(f"\nRun without --dry-run to import.")
+            db.close()
+            return
+
+        # Import orphaned sessions
+        imported = 0
+        skipped = 0
+        errors = 0
+        total_messages = 0
+
+        for i, fp in enumerate(orphans, 1):
+            name = fp.name
+            if name.endswith(".json.gz"):
+                sid = name.replace("session_", "").replace(".json.gz", "")
+            else:
+                sid = name.replace("session_", "").replace(".json", "")
+
+            # Skip if already in DB (re-entrant safety)
+            if sid in db_session_ids:
+                skipped += 1
+                continue
+
+            try:
+                # Read the session file
+                if name.endswith(".json.gz"):
+                    with _gzip.open(fp, "rt", encoding="utf-8") as f:
+                        data = json.loads(f.read())
+                else:
+                    with open(fp, "r", encoding="utf-8") as f:
+                        data = json.loads(f.read())
+
+                msgs = data.get("messages", [])
+                if not msgs:
+                    skipped += 1
+                    continue
+
+                # Import into DB
+                started_at_str = data.get("session_start", "")
+                started_at_ts = None
+                if started_at_str:
+                    from datetime import datetime
+                    try:
+                        dt = datetime.fromisoformat(started_at_str.replace("Z", "+00:00"))
+                        started_at_ts = dt.timestamp()
+                    except (ValueError, OSError):
+                        pass
+
+                imported_count = db.batch_import_session(
+                    session_id=sid,
+                    source=data.get("platform", "cli"),
+                    model=data.get("model"),
+                    model_config=None,
+                    system_prompt=data.get("system_prompt"),
+                    parent_session_id=None,
+                    started_at=started_at_ts,
+                    messages=msgs,
+                )
+
+                if imported_count > 0:
+                    imported += 1
+                    total_messages += imported_count
+                    db_session_ids.add(sid)  # prevent re-count
+                    if i % 50 == 0 or i == len(orphans):
+                        print(f"  Progress: {i}/{len(orphans)} files processed, {imported} imported, {total_messages} messages...")
+                else:
+                    skipped += 1
+
+            except _gzip.BadGzipFile:
+                errors += 1
+                if errors <= 5:
+                    print(f"  ERROR importing {sid}: corrupt gzip file (likely truncated download or rename)")
+
+            except PermissionError:
+                errors += 1
+                if errors <= 5:
+                    print(f"  ERROR importing {sid}: permission denied")
+
+            except json.JSONDecodeError:
+                errors += 1
+                if errors <= 5:
+                    print(f"  ERROR importing {sid}: invalid JSON (file may be corrupted)")
+
+            except Exception as e:
+                errors += 1
+                if errors <= 5:
+                    print(f"  ERROR importing {sid}: {e}")
+
+        db.close()
+
+        print(f"\nRepair complete:")
+        print(f"  Session files scanned: {len(orphans)}")
+        print(f"  Newly imported: {imported} sessions, {total_messages} messages")
+        print(f"  Already present: {skipped}")
+        print(f"  Errors: {errors}")
+
     sessions_parser = subparsers.add_parser(
         "sessions",
         help="Manage session history (list, rename, export, prune, delete)",
@@ -11521,6 +11686,22 @@ Examples:
     )
     sessions_browse.add_argument(
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
+    )
+
+    sessions_repair = sessions_subparsers.add_parser(
+        "repair",
+        help="Scan on-disk session files and import any missing from the SQLite database",
+    )
+    sessions_repair.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report orphaned sessions without importing them",
+    )
+    sessions_repair.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Import at most N orphaned sessions (0 = all)",
     )
 
     def _confirm_prompt(prompt: str) -> bool:
@@ -11689,6 +11870,10 @@ Examples:
             if db_path.exists():
                 size_mb = os.path.getsize(db_path) / (1024 * 1024)
                 print(f"Database size: {size_mb:.1f} MB")
+
+        elif action == "repair":
+            db.close()  # close before repair opens its own connection
+            _cmd_sessions_repair(args)
 
         else:
             sessions_parser.print_help()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1596,6 +1596,116 @@ class SessionDB:
 
         self._execute_write(_do)
 
+    def batch_import_session(
+        self,
+        session_id: str,
+        source: str,
+        model: str = None,
+        model_config: dict = None,
+        system_prompt: str = None,
+        parent_session_id: str = None,
+        started_at: float = None,
+        messages: List[Dict[str, Any]] = None,
+    ) -> int:
+        """Import a full session (row + messages) in a single transaction.
+
+        Uses INSERT OR IGNORE for the session row so re-imports are safe.
+        Returns the number of messages imported, or 0 if the session already
+        existed (already imported by a previous run).
+        """
+        messages = messages or []
+        now_ts = started_at or time.time()
+
+        def _do(conn):
+            nonlocal now_ts
+            # Check if session already exists — skip entire import if so.
+            cursor = conn.execute(
+                "SELECT 1 FROM sessions WHERE id = ?", (session_id,)
+            )
+            if cursor.fetchone() is not None:
+                return 0  # already present
+
+            # Create session row with original timestamp
+            conn.execute(
+                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                   system_prompt, parent_session_id, started_at, ended_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    source,
+                    None,
+                    model,
+                    json.dumps(model_config) if model_config else None,
+                    system_prompt,
+                    parent_session_id,
+                    now_ts,
+                    now_ts + 1,
+                ),
+            )
+
+            # Batch insert all messages
+            total_messages = 0
+            total_tool_calls = 0
+            for msg in messages:
+                role = msg.get("role", "unknown")
+                raw_content = msg.get("content")
+                tool_calls = msg.get("tool_calls")
+                reasoning = msg.get("reasoning") if role == "assistant" else None
+                reasoning_content = msg.get("reasoning_content") if role == "assistant" else None
+                reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+                codex_reasoning_items = msg.get("codex_reasoning_items") if role == "assistant" else None
+                codex_message_items = msg.get("codex_message_items") if role == "assistant" else None
+
+                reasoning_details_json = (
+                    json.dumps(reasoning_details) if reasoning_details else None
+                )
+                codex_items_json = (
+                    json.dumps(codex_reasoning_items) if codex_reasoning_items else None
+                )
+                codex_message_items_json = (
+                    json.dumps(codex_message_items) if codex_message_items else None
+                )
+                tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                stored_content = self._encode_content(raw_content)
+
+                conn.execute(
+                    """INSERT INTO messages (session_id, role, content, tool_call_id,
+                       tool_calls, tool_name, timestamp, token_count, finish_reason,
+                       reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                       codex_message_items)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        role,
+                        stored_content,
+                        msg.get("tool_call_id"),
+                        tool_calls_json,
+                        msg.get("tool_name"),
+                        now_ts,
+                        msg.get("token_count"),
+                        msg.get("finish_reason"),
+                        reasoning,
+                        reasoning_content,
+                        reasoning_details_json,
+                        codex_items_json,
+                        codex_message_items_json,
+                    ),
+                )
+                total_messages += 1
+                if tool_calls is not None:
+                    total_tool_calls += (
+                        len(tool_calls) if isinstance(tool_calls, list) else 1
+                    )
+                now_ts += 1e-6
+
+            conn.execute(
+                "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+                (total_messages, total_tool_calls, session_id),
+            )
+            return total_messages
+
+        return self._execute_write(_do)
+
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by insertion order."""
         with self._lock:
@@ -2209,6 +2319,12 @@ class SessionDB:
             else:
                 cursor = self._conn.execute("SELECT COUNT(*) FROM messages")
             return cursor.fetchone()[0]
+
+    def list_session_ids(self) -> List[str]:
+        """Return all session IDs currently in the database."""
+        with self._lock:
+            cursor = self._conn.execute("SELECT id FROM sessions")
+            return [row[0] for row in cursor]
 
     # =========================================================================
     # Export and cleanup

--- a/run_agent.py
+++ b/run_agent.py
@@ -41,9 +41,11 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import pathlib
 import random
 import re
 import ssl
+import sqlite3
 import sys
 import tempfile
 import time
@@ -116,6 +118,58 @@ if _loaded_env_paths:
         logger.info("Loaded environment variables from %s", _env_path)
 else:
     logger.info("No .env file found. Using system environment variables.")
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic orphaned-session startup hint (P2)
+# ---------------------------------------------------------------------------
+
+_orphan_hint_checked = False
+
+
+def _check_orphaned_sessions_hint() -> None:
+    """Light-weight startup check: if >50 sessions exist on disk but are
+    missing from the SQLite DB, log a one-line hint suggesting
+    ``hermes sessions repair``. Runs at most once per process.
+    """
+    global _orphan_hint_checked
+    if _orphan_hint_checked:
+        return
+    _orphan_hint_checked = True
+    try:
+        from hermes_state import SessionDB
+
+        sessions_dir = get_hermes_home() / "sessions"
+        if not sessions_dir.is_dir():
+            return
+
+        # Count on-disk session files
+        disk_ids: set[str] = set()
+        for fp in sessions_dir.iterdir():
+            name = fp.name
+            if name.startswith("session_") and not fp.is_symlink():
+                if name.endswith(".json.gz"):
+                    disk_ids.add(name.replace("session_", "").replace(".json.gz", ""))
+                elif name.endswith(".json"):
+                    disk_ids.add(name.replace("session_", "").replace(".json", ""))
+
+        if not disk_ids:
+            return
+
+        db = SessionDB()
+        db_ids = set(db.list_session_ids())
+        db.close()
+
+        orphan_count = len(disk_ids - db_ids)
+        if orphan_count > 50:
+            logger.info(
+                "%d session file(s) on disk are not in the SQLite database. "
+                "Run 'hermes sessions repair' to import them.",
+                orphan_count,
+            )
+    except Exception:
+        # Never block startup on a DB or I/O issue.
+        pass
 
 
 # Import our tool system
@@ -2511,6 +2565,9 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
+        # Opportunistic orphaned-session hint (runs once per process)
+        _check_orphaned_sessions_hint()
+
     def _get_session_db_for_recall(self):
         """Return a SessionDB for recall, lazily creating it if an entrypoint forgot.
 
@@ -4508,12 +4565,42 @@ class AIAgent:
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
+        Post-flush: verifies the session row exists in DB and that the message
+        count matches our in-memory transcript. If there's a gap, the JSON log
+        on disk can be recovered via ``hermes sessions repair`` later.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+        self._verify_session_db_health(messages)
+
+    def _verify_session_db_health(self, messages: List[Dict]) -> None:
+        """Light-weight post-flush integrity check. Warns if the DB session
+        row doesn't exist or message counts diverge from the in-memory
+        transcript.  Does NOT block session exit — the JSON log is the
+        durable fallback."""
+        if not self._session_db:
+            return
+        try:
+            imported_count = self._session_db.message_count(self.session_id)
+            expected_count = len(messages)
+            if imported_count == 0 and expected_count > 0:
+                logger.warning(
+                    "Session DB POST-FLUSH: 0 messages for %s (expected %d). "
+                    "Session file on disk is the fallback; import with: "
+                    "hermes sessions repair",
+                    self.session_id, expected_count,
+                )
+            elif imported_count > 0 and imported_count < expected_count // 2:
+                logger.warning(
+                    "Session DB POST-FLUSH: only %d messages for %s (expected ~%d). "
+                    "Partial flush — may be recoverable on next turn.",
+                    imported_count, self.session_id, expected_count,
+                )
+        except Exception as e:
+            logger.warning("Session DB health check failed: %s", e)
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -4674,58 +4761,77 @@ class AIAgent:
         Uses _last_flushed_db_idx to track which messages have already been
         written, so repeated calls (from multiple exit paths) only write
         truly new messages — preventing the duplicate-write bug (#860).
+
+        Retries the entire flush up to 3 times with exponential backoff on
+        WAL write-lock contention, protecting against transient SQLite lock
+        errors when multiple CLI sessions + gateway share one state.db.
         """
         if not self._session_db:
             return
         self._apply_persist_user_message_override(messages)
-        try:
-            # Retry row creation if the earlier attempt failed transiently.
-            if not self._session_db_created:
-                self._ensure_db_session()
-            start_idx = len(conversation_history) if conversation_history else 0
-            flush_from = max(start_idx, self._last_flushed_db_idx)
-            for msg in messages[flush_from:]:
-                role = msg.get("role", "unknown")
-                content = msg.get("content")
-                # Persist multimodal tool results as their text summary only —
-                # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
-                if _is_multimodal_tool_result(content):
-                    content = _multimodal_text_summary(content)
-                elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
-                    _txt = []
-                    for p in content:
-                        if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
-                tool_calls_data = None
-                if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
-                    tool_calls_data = [
-                        {"name": tc.function.name, "arguments": tc.function.arguments}
-                        for tc in msg.tool_calls
-                    ]
-                elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
-                self._session_db.append_message(
-                    session_id=self.session_id,
-                    role=role,
-                    content=content,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                )
-            self._last_flushed_db_idx = len(messages)
-        except Exception as e:
-            logger.warning("Session DB append_message failed: %s", e)
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                # Retry row creation if the earlier attempt failed transiently.
+                if not self._session_db_created:
+                    self._ensure_db_session()
+                start_idx = len(conversation_history) if conversation_history else 0
+                flush_from = max(start_idx, self._last_flushed_db_idx)
+                for msg in messages[flush_from:]:
+                    role = msg.get("role", "unknown")
+                    content = msg.get("content")
+                    if _is_multimodal_tool_result(content):
+                        content = _multimodal_text_summary(content)
+                    elif isinstance(content, list):
+                        _txt = []
+                        for p in content:
+                            if isinstance(p, dict) and p.get("type") == "text":
+                                _txt.append(str(p.get("text", "")))
+                            elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
+                                _txt.append("[screenshot]")
+                        content = "\n".join(_txt) if _txt else None
+                    tool_calls_data = None
+                    if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
+                        tool_calls_data = [
+                            {"name": tc.function.name, "arguments": tc.function.arguments}
+                            for tc in msg.tool_calls
+                        ]
+                    elif isinstance(msg.get("tool_calls"), list):
+                        tool_calls_data = msg["tool_calls"]
+                    self._session_db.append_message(
+                        session_id=self.session_id,
+                        role=role,
+                        content=content,
+                        tool_name=msg.get("tool_name"),
+                        tool_calls=tool_calls_data,
+                        tool_call_id=msg.get("tool_call_id"),
+                        finish_reason=msg.get("finish_reason"),
+                        reasoning=msg.get("reasoning") if role == "assistant" else None,
+                        reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                        codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    )
+                self._last_flushed_db_idx = len(messages)
+                break  # Success
+            except sqlite3.OperationalError as exc:
+                err_msg = str(exc).lower()
+                if ("locked" in err_msg or "busy" in err_msg) and attempt < max_retries - 1:
+                    import random as _rand  # local import for agent startup size
+                    delay = 0.05 * (2 ** attempt) + _rand.uniform(0, 0.02)
+                    logger.warning(
+                        "Session DB flush locked (attempt %d/%d), retrying in %.2fs: %s",
+                        attempt + 1, max_retries, delay, exc,
+                    )
+                    time.sleep(delay)
+                    continue
+                # Non-lock error or retries exhausted — log and move on
+                logger.warning("Session DB append_message failed (attempt %d/%d): %s", attempt + 1, max_retries, exc)
+                break
+            except Exception as e:
+                logger.warning("Session DB append_message failed: %s", e)
+                break
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -300,3 +300,268 @@ class TestFlushIdxInit:
         agent._flush_messages_to_session_db(messages, [])
         # Should not crash, idx should remain 0
         assert agent._last_flushed_db_idx == 0
+
+
+class TestFlushWalRetry:
+    """Tests for WAL contention retry in _flush_messages_to_session_db."""
+
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="test-session-retry",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent._ensure_db_session()
+        return agent
+
+    def test_wal_lock_retry_succeeds(self):
+        """OperationalError: database is locked should retry then succeed."""
+        import sqlite3
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "lock_retry.db")
+            agent = self._make_agent(db)
+            agent._last_flushed_db_idx = 0
+            agent._session_db_created = True
+
+            messages = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ]
+
+            call_count = [0]
+            orig_append = db.append_message
+
+            def flaky_append(*args, **kwargs):
+                call_count[0] += 1
+                if call_count[0] <= 2:
+                    raise sqlite3.OperationalError("database is locked")
+                return orig_append(*args, **kwargs)
+
+            conversation_history = []
+            with patch.object(db, "append_message", side_effect=flaky_append):
+                agent._flush_messages_to_session_db(messages, conversation_history)
+
+            rows = db.get_messages(agent.session_id)
+            assert len(rows) == 2
+
+    def test_wal_lock_retry_exhausted_warns_but_doesnt_crash(self):
+        """After 3 failed retries the method returns without crashing."""
+        import sqlite3
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "lock_exhaust.db")
+            agent = self._make_agent(db)
+            agent._last_flushed_db_idx = 0
+            agent._session_db_created = True
+
+            messages = [{"role": "user", "content": "hello"}]
+            conversation_history = []
+
+            def always_locked(*args, **kwargs):
+                raise sqlite3.OperationalError("database is locked")
+
+            with patch.object(db, "append_message", side_effect=always_locked):
+                agent._flush_messages_to_session_db(messages, conversation_history)
+
+            assert agent._last_flushed_db_idx == 0  # no flush happened
+
+
+class TestVerifySessionDbHealth:
+    """Tests for _verify_session_db_health — post-flush integrity check."""
+
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="test-session-health",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_health_check_no_warning_when_db_matches(self):
+        """No POST-FLUSH warning when DB already has all messages."""
+        from hermes_state import SessionDB
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "health.db")
+            agent = self._make_agent(db)
+            agent._ensure_db_session()
+
+            messages = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ]
+            agent._flush_messages_to_session_db(messages, [])
+            assert db.message_count(agent.session_id) == 2
+
+            import run_agent
+            with patch.object(run_agent.logger, "warning"):
+                # Should not produce POST-FLUSH warning
+                agent._verify_session_db_health(messages)
+
+    def test_health_check_warns_on_zero_messages(self):
+        """Warns when DB has 0 messages but in-memory has messages."""
+        from hermes_state import SessionDB
+        import run_agent
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "health2.db")
+            agent = self._make_agent(db)
+            agent._ensure_db_session()
+
+            messages = [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+                {"role": "user", "content": "follow up"},
+                {"role": "assistant", "content": "answer"},
+            ]
+
+            with patch.object(run_agent.logger, "warning") as mock_warn:
+                agent._verify_session_db_health(messages)
+                health_warnings = [
+                    c for c in mock_warn.call_args_list
+                    if c and "POST-FLUSH" in str(c)
+                ]
+                assert len(health_warnings) == 1
+                assert "0 messages" in str(health_warnings[0])
+
+
+class TestOrphanedSessionsHint:
+    """Tests for _check_orphaned_sessions_hint — startup hint (P2 repair)."""
+
+    def test_hint_logs_when_orphans_above_threshold(self, tmp_path):
+        """When >50 sessions exist on disk but not in DB, hint fires."""
+        import run_agent
+        from hermes_state import SessionDB
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db_path = tmp_path / "test.db"
+
+        # Create 55 orphan session files on disk
+        for i in range(55):
+            sid = f"{i:08d}-orph"
+            (sessions_dir / f"session_{sid}.json").write_text(
+                '{"messages": [{"role": "user", "content": "hi"}]}'
+            )
+
+        # Create a DB with only 3 sessions (55 - 3 = 52 orphans)
+        db = SessionDB(db_path=db_path)
+        for s in ("a", "b", "c"):
+            db.create_session(session_id=f"sess-{s}", source="cli")
+        db.close()
+
+        run_agent._orphan_hint_checked = False
+        with patch.object(run_agent, "get_hermes_home", return_value=tmp_path), \
+             patch("hermes_state.SessionDB", return_value=SessionDB(db_path=db_path)):
+            with patch.object(run_agent.logger, "info") as mock_info:
+                run_agent._check_orphaned_sessions_hint()
+                hint_calls = [
+                    c for c in mock_info.call_args_list
+                    if c[0] and "repair" in str(c[0][0])
+                ]
+                assert len(hint_calls) == 1
+
+    def test_hint_does_not_fire_when_under_threshold(self, tmp_path):
+        """When <50 orphans, no hint fires."""
+        import run_agent
+        from hermes_state import SessionDB
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db_path = tmp_path / "test2.db"
+
+        # Only 5 orphan files
+        for i in range(5):
+            sid = f"{i:08d}-orph"
+            (sessions_dir / f"session_{sid}.json").write_text(
+                '{"messages": []}'
+            )
+
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        run_agent._orphan_hint_checked = False
+        with patch.object(run_agent, "get_hermes_home", return_value=tmp_path), \
+             patch("hermes_state.SessionDB", return_value=SessionDB(db_path=db_path)):
+            with patch.object(run_agent.logger, "info") as mock_info:
+                run_agent._check_orphaned_sessions_hint()
+                hint_calls = [
+                    c for c in mock_info.call_args_list
+                    if c[0] and "repair" in str(c[0][0])
+                ]
+                assert len(hint_calls) == 0
+
+    def test_hint_fire_once_per_process(self, tmp_path):
+        """Second call does not log even if orphans still exist."""
+        import run_agent
+        from hermes_state import SessionDB
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db_path = tmp_path / "test3.db"
+
+        for i in range(60):
+            sid = f"{i:08d}-orph"
+            (sessions_dir / f"session_{sid}.json").write_text(
+                '{"messages": []}'
+            )
+
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        run_agent._orphan_hint_checked = False
+        with patch.object(run_agent, "get_hermes_home", return_value=tmp_path), \
+             patch("hermes_state.SessionDB", return_value=SessionDB(db_path=db_path)):
+            with patch.object(run_agent.logger, "info") as mock_info:
+                run_agent._check_orphaned_sessions_hint()
+                run_agent._check_orphaned_sessions_hint()
+                run_agent._check_orphaned_sessions_hint()
+                hint_calls = [
+                    c for c in mock_info.call_args_list
+                    if c[0] and "repair" in str(c[0][0])
+                ]
+                assert len(hint_calls) == 1
+
+    def test_hint_skips_symlinks(self, tmp_path):
+        """Symlinks to session files are ignored."""
+        import run_agent
+        from hermes_state import SessionDB
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db_path = tmp_path / "test4.db"
+
+        # Create one real file and a symlink to it
+        (sessions_dir / "session_real.json").write_text('{"messages": []}')
+        (sessions_dir / "session_00000099-symlink.json").symlink_to(
+            sessions_dir / "session_real.json"
+        )
+
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        run_agent._orphan_hint_checked = False
+        with patch.object(run_agent, "get_hermes_home", return_value=tmp_path), \
+             patch("hermes_state.SessionDB", return_value=SessionDB(db_path=db_path)):
+            with patch.object(run_agent.logger, "info") as mock_info:
+                run_agent._check_orphaned_sessions_hint()
+                hint_calls = [
+                    c for c in mock_info.call_args_list
+                    if c[0] and "repair" in str(c[0][0])
+                ]
+                # Only 1 orphan (symlink skipped), below threshold of 50
+                assert len(hint_calls) == 0

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2943,3 +2943,80 @@ class TestFTS5ToolCallMigration:
         finally:
             session_db.close()
 
+
+# =========================================================================
+# Batch import & repair (session DB sync gap fix)
+# =========================================================================
+
+class TestBatchImport:
+    """Tests for batch_import_session — the repair command's core import method."""
+
+    def test_batch_import_creates_session_and_messages(self, db):
+        """Batch import creates session row and inserts all messages."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+            {"role": "tool", "content": "tool result", "tool_call_id": "tc1"},
+        ]
+        count = db.batch_import_session(
+            session_id="import-1",
+            source="cli",
+            model="test/model",
+            system_prompt="be helpful",
+            started_at=1_700_000_000.0,
+            messages=messages,
+        )
+        assert count == 3
+        assert db.message_count("import-1") == 3
+        session = db.get_session("import-1")
+        assert session is not None
+        assert session["source"] == "cli"
+
+    def test_batch_import_idempotent(self, db):
+        """Re-importing the same session returns 0 and doesn't duplicate."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        first = db.batch_import_session(
+            session_id="idem-1", source="cli", messages=messages, model=None,
+            model_config=None, system_prompt=None, parent_session_id=None, started_at=None,
+        )
+        assert first == 2
+        second = db.batch_import_session(
+            session_id="idem-1", source="cli", messages=messages, model=None,
+            model_config=None, system_prompt=None, parent_session_id=None, started_at=None,
+        )
+        assert second == 0
+        assert db.message_count("idem-1") == 2
+
+    def test_batch_import_handles_empty_messages(self, db):
+        """Import with no messages returns 0 without error."""
+        count = db.batch_import_session(
+            session_id="empty-1", source="cli", messages=[], model=None,
+            model_config=None, system_prompt=None, parent_session_id=None, started_at=None,
+        )
+        assert count == 0
+
+
+class TestListSessionIds:
+    """Tests for list_session_ids — public API for the repair command."""
+
+    def test_returns_empty_list(self, db):
+        assert db.list_session_ids() == []
+
+    def test_returns_session_ids(self, db):
+        db.create_session(session_id="aaa", source="cli")
+        db.create_session(session_id="bbb", source="telegram")
+        ids = db.list_session_ids()
+        assert set(ids) == {"aaa", "bbb"}
+
+    def test_after_batch_import(self, db):
+        db.batch_import_session(
+            session_id="import-xx", source="cli", messages=[
+                {"role": "user", "content": "test"}
+            ], model=None, model_config=None, system_prompt=None,
+            parent_session_id=None, started_at=None,
+        )
+        assert "import-xx" in db.list_session_ids()
+


### PR DESCRIPTION
## Session DB Sync Gap Fix

### Problem
60.7% of session files on disk (461/761) were absent from `state.db`, making them invisible to `session_search` (FTS5-based cross-session recall).

### Root Causes
1. `SessionDB()` init failures silently caught — warning only in `agent.log`
2. WAL contention from multiple processes sharing one `state.db`
3. No retroactive sync between JSON session files and SQLite

### Fix (4 phases, 1 commit, 4 files)

**Phase 1 — Hardened DB init** (`cli.py`)
- SessionDB init failure now surfaced to user via `click.echo(err=True)`

**Phase 2 — `hermes sessions repair` CLI** (`hermes_state.py` + `hermes_cli/main.py`)
- `batch_import_session()`: single-transaction import preserving original timestamps
- `repair` subcommand with `--dry-run` and `--limit` flags
- Successfully recovered 463 sessions / 72,924 messages

**Phase 3 — WAL retry** (`run_agent.py`)
- 3-attempt exponential backoff retry on `OperationalError: database is locked`
- Structured warning instead of silent failure

**Phase 4 — Post-flush health check** (`run_agent.py`)
- `_verify_session_db_health()` in `_persist_session` exit path
- Warns if DB message count diverges from transcript