### PR TITLE
fix(prompt_builder): use TERMINAL_CWD over os.getcwd() in environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -772,7 +772,8 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            effective_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+            host_lines.append(f"Current working directory: {effective_cwd}")
         except OSError:
             pass
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -948,6 +948,39 @@ class TestEnvironmentHints:
                 f"info is suppressed in the system prompt"
             )
 
+    def test_build_environment_hints_prefers_terminal_cwd(self, monkeypatch):
+        """TERMINAL_CWD env var should take precedence over os.getcwd()."""
+        import os as _os
+        import agent.prompt_builder as _pb
+        import sys, platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", "/custom/configured/path")
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Current working directory: /custom/configured/path" in result
+        # Ensure os.getcwd() is NOT used when TERMINAL_CWD is set
+        assert f"Current working directory: {_os.getcwd()}" not in result or _os.getcwd() == "/custom/configured/path"
+
+    def test_build_environment_hints_falls_back_to_getcwd(self, monkeypatch):
+        """When TERMINAL_CWD is not set, fall back to os.getcwd()."""
+        import os as _os
+        import agent.prompt_builder as _pb
+        import sys, platform
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Current working directory:" in result
+        assert f"Current working directory: {_os.getcwd()}" in result
+
 
 # =========================================================================
 # Conditional skill activation


### PR DESCRIPTION
## Summary

Fixes #24882

The system prompt's `"Current working directory"` line used `os.getcwd()` directly, ignoring the `TERMINAL_CWD` environment variable that the gateway bridges from `config.yaml`'s `terminal.cwd` setting.

### Problem

On macOS launchd-launched gateways, `os.getcwd()` returns the launchd `WorkingDirectory` (e.g. `~/.hermes/hermes-agent/`) instead of the user's configured `terminal.cwd` path. This causes the agent to use the wrong working directory when instructed to "clone to the current directory" or perform other path-relative operations.

### Root Cause

In `agent/prompt_builder.py`, the `build_environment_hints()` function's local-backend path used:

```python
host_lines.append(f"Current working directory: {os.getcwd()}")
```

The gateway already bridges `terminal.cwd` from config to `TERMINAL_CWD` env var at startup (see `gateway/run.py:444`), but `build_environment_hints()` never checked it.

### Fix

Prefer `os.getenv("TERMINAL_CWD")` over `os.getcwd()`, falling back to `os.getcwd()` when the env var is not set (CLI mode, where the process cwd is correct).

```python
effective_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
host_lines.append(f"Current working directory: {effective_cwd}")
```

### Testing

Added 2 new regression tests in `TestEnvironmentHints`:

- `test_build_environment_hints_prefers_terminal_cwd` — verifies TERMINAL_CWD takes precedence
- `test_build_environment_hints_falls_back_to_getcwd` — verifies os.getcwd() fallback when no env var

All 10 tests in `TestEnvironmentHints` pass (8 existing + 2 new), confirming no regression.

### Files Changed

- `agent/prompt_builder.py` — 1-line fix (+1 line for the variable)
- `tests/agent/test_prompt_builder.py` — 2 new test methods