### PR TITLE
fix(agent): prevent mutation verifier false positives from lint diagnostics

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -826,6 +826,19 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
+    # File-mutation tools: successful writes/patches must not be misclassified
+    # as failures just because their result contains nested lint/LSP diagnostics
+    # with "error" or "failed" keys.  Check for known success markers first.
+    if tool_name in ("write_file", "patch"):
+        data = safe_json_loads(result)
+        if isinstance(data, dict):
+            # write_file: bytes_written present and no top-level error → success
+            if data.get("bytes_written") and not data.get("error"):
+                return False, ""
+            # patch: success=True → landed regardless of diagnostics
+            if data.get("success") is True:
+                return False, ""
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -211,6 +211,17 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
+    # File-mutation tools: successful writes/patches must not be misclassified
+    # as failures just because their result contains nested lint/LSP diagnostics
+    # with "error" or "failed" keys.  Check for known success markers first.
+    if tool_name in ("write_file", "patch"):
+        data = safe_json_loads(result)
+        if isinstance(data, dict):
+            if data.get("bytes_written") and not data.get("error"):
+                return False, ""
+            if data.get("success") is True:
+                return False, ""
+
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -255,3 +255,90 @@ class TestEditDiffPreview:
         assert any("a/file2.py" in line for line in rendered)
         assert not any("a/file7.py" in line for line in rendered)
         assert "additional file" in rendered[-1]
+
+
+# =========================================================================
+# Regression tests for _detect_tool_failure
+# =========================================================================
+
+
+class TestDetectToolFailure:
+    """Regression tests for _detect_tool_failure — file-mutation false positives.
+
+    See #24927: successful write_file / patch results with lint or LSP
+    diagnostics containing "error" keys must NOT be classified as failures.
+    """
+
+    def test_write_file_with_bytes_written_is_success(self):
+        """write_file result with bytes_written (no top-level error) is success."""
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({"bytes_written": 42, "dirs_created": True})
+        is_failure, suffix = _detect_tool_failure("write_file", result)
+        assert is_failure is False
+        assert suffix == ""
+
+    def test_write_file_with_lint_diagnostics_still_success(self):
+        """write_file with lint diagnostics containing error keys is still success."""
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({
+            "bytes_written": 100,
+            "lint": {
+                "errors": [{"line": 1, "message": "unused variable", "severity": "error"}],
+                "warnings": []
+            }
+        })
+        is_failure, suffix = _detect_tool_failure("write_file", result)
+        assert is_failure is False
+        assert suffix == ""
+
+    def test_write_file_with_top_level_error_is_failure(self):
+        """write_file with a top-level error key IS a failure."""
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({"error": "Permission denied", "bytes_written": 0})
+        is_failure, suffix = _detect_tool_failure("write_file", result)
+        assert is_failure is True
+        assert "[error]" in suffix
+
+    def test_patch_with_success_true_is_success(self):
+        """patch result with success=True is success even with diagnostics."""
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({
+            "success": True,
+            "diff": "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-old\n+new",
+            "diagnostics": {"error": "type mismatch", "failed": False}
+        })
+        is_failure, suffix = _detect_tool_failure("patch", result)
+        assert is_failure is False
+        assert suffix == ""
+
+    def test_patch_without_success_true_is_failure(self):
+        """patch result without success=True falls through to heuristic."""
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({"error": "old_string not found"})
+        is_failure, suffix = _detect_tool_failure("patch", result)
+        assert is_failure is True
+
+    def test_none_result_is_success(self):
+        from agent.display import _detect_tool_failure
+        assert _detect_tool_failure("write_file", None) == (False, "")
+
+    def test_terminal_nonzero_exit_is_failure(self):
+        from agent.display import _detect_tool_failure
+        import json
+        result = json.dumps({"exit_code": 1, "output": "fail"})
+        is_failure, suffix = _detect_tool_failure("terminal", result)
+        assert is_failure is True
+        assert "[exit 1]" in suffix
+
+    def test_generic_error_still_detected(self):
+        """Non-mutation tools with error keys are still classified as failures."""
+        from agent.display import _detect_tool_failure
+        result = '{"error": "something went wrong"}'
+        is_failure, suffix = _detect_tool_failure("web_search", result)
+        assert is_failure is True
+        assert "[error]" in suffix

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -236,3 +236,48 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+
+# =========================================================================
+# Regression tests for classify_tool_failure
+# =========================================================================
+
+
+class TestClassifyToolFailureMutationFalsePositive:
+    """Regression: file-mutation tools with diagnostics must not be misclassified.
+
+    Mirrors TestDetectToolFailure in test_display.py for the guardrail's
+    classify_tool_failure mirror function.  See #24927.
+    """
+
+    def test_write_file_with_lint_diagnostics_is_success(self):
+        from agent.tool_guardrails import classify_tool_failure
+        import json
+        result = json.dumps({
+            "bytes_written": 200,
+            "lint": {"errors": [{"message": "unused import"}]}
+        })
+        assert classify_tool_failure("write_file", result) == (False, "")
+
+    def test_write_file_top_level_error_is_failure(self):
+        from agent.tool_guardrails import classify_tool_failure
+        import json
+        result = json.dumps({"error": "write failed"})
+        assert classify_tool_failure("write_file", result) == (True, " [error]")
+
+    def test_patch_success_true_is_success(self):
+        from agent.tool_guardrails import classify_tool_failure
+        import json
+        result = json.dumps({
+            "success": True,
+            "diff": "changes",
+            "diagnostics": {"error": "type issue"}
+        })
+        assert classify_tool_failure("patch", result) == (False, "")
+
+    def test_patch_no_success_key_falls_through(self):
+        from agent.tool_guardrails import classify_tool_failure
+        import json
+        result = json.dumps({"error": "not found"})
+        assert classify_tool_failure("patch", result) == (True, " [error]")


### PR DESCRIPTION
## Summary

Fixes #24927

Successful file mutations (`write_file`, `patch`) were incorrectly reported as failures when their tool results included nested lint or LSP diagnostics containing `"error"` or `"failed"` keys.

### Problem

The generic heuristic in `_detect_tool_failure()` and `classify_tool_failure()` searches the entire result string for `'"error"'` or `'"failed"'` substrings. This causes false positives when:

- **write_file** returns `{"bytes_written": 100, "lint": {"errors": [{"message": "unused variable", "severity": "error"}]}}` — the nested `"error"` in lint diagnostics triggers the heuristic
- **patch** returns `{"success": true, "diagnostics": {"error": "type mismatch"}}` — the nested `"error"` in LSP diagnostics triggers the heuristic

### Root Cause

Both `_detect_tool_failure()` in `agent/display.py` and its mirror `classify_tool_failure()` in `agent/tool_guardrails.py` apply a generic substring heuristic that doesn't account for file-mutation tools returning structured diagnostic payloads alongside success markers.

### Fix

Added an early-exit check for `write_file` and `patch` tools before the generic heuristic:

- `write_file`: if `bytes_written` is present and no top-level `error` → return success
- `patch`: if `success` is `True` → return success regardless of diagnostics

Genuine failures (top-level `error` key, or no success markers) still fall through to the heuristic correctly.

### Testing

Added 12 regression tests across both files:

- `TestDetectToolFailure` in `test_display.py` (8 tests):
  - write_file with bytes_written → success
  - write_file with lint diagnostics → success  
  - write_file with top-level error → failure
  - patch with success=true → success
  - patch without success → failure
  - None result → success
  - terminal non-zero exit → failure
  - generic tools with error → failure

- `TestClassifyToolFailureMutationFalsePositive` in `test_tool_guardrails.py` (4 tests):
  - Mirror tests for the guardrail classifier

All 53 tests pass (41 existing + 12 new), confirming zero regression.

### Files Changed

- `agent/display.py` — early-exit for mutation tools in `_detect_tool_failure()`
- `agent/tool_guardrails.py` — matching early-exit in `classify_tool_failure()`
- `tests/agent/test_display.py` — 8 new tests
- `tests/agent/test_tool_guardrails.py` — 4 new tests