### PR TITLE
feat: add YouTube transcripts and Discord thread presets

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -550,6 +550,9 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
 
+    # Interval (seconds) for the periodic Discord gateway health log line.
+    HEALTH_LOG_INTERVAL = 60
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
@@ -582,6 +585,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        # Periodic gateway-health logger (diagnostics for silent disconnects).
+        self._discord_health_task: Optional[asyncio.Task] = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -709,6 +714,59 @@ class DiscordAdapter(BasePlatformAdapter):
                     adapter_self._post_connect_task.cancel()
                 adapter_self._post_connect_task = asyncio.create_task(
                     adapter_self._run_post_connect_initialization()
+                )
+
+                # (Re)start the periodic gateway-health diagnostic log. Cancel
+                # any previous instance from an earlier ready cycle first so
+                # we never run more than one health task at a time.
+                if (
+                    adapter_self._discord_health_task is not None
+                    and not adapter_self._discord_health_task.done()
+                ):
+                    adapter_self._discord_health_task.cancel()
+                adapter_self._discord_health_task = asyncio.create_task(
+                    adapter_self._discord_health_loop()
+                )
+
+            @self._client.event
+            async def on_disconnect():
+                client = adapter_self._client
+                try:
+                    latency = client.latency if client is not None else None
+                except Exception:
+                    latency = None
+                logger.warning(
+                    "[%s] Discord gateway on_disconnect "
+                    "(latency=%s closed=%s running=%s ready=%s)",
+                    adapter_self.name,
+                    latency,
+                    client.is_closed() if client is not None else None,
+                    adapter_self._running,
+                    adapter_self._ready_event.is_set(),
+                )
+
+            @self._client.event
+            async def on_resumed():
+                client = adapter_self._client
+                try:
+                    latency = client.latency if client is not None else None
+                except Exception:
+                    latency = None
+                logger.info(
+                    "[%s] Discord gateway on_resumed (latency=%s running=%s)",
+                    adapter_self.name,
+                    latency,
+                    adapter_self._running,
+                )
+
+            @self._client.event
+            async def on_error(event_method, *args, **kwargs):
+                # discord.py invokes this for any unhandled exception in an
+                # event handler; sys.exc_info() is set inside the call.
+                logger.exception(
+                    "[%s] Discord gateway on_error in event %s",
+                    adapter_self.name,
+                    event_method,
                 )
 
             @self._client.event
@@ -885,14 +943,60 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._discord_health_task and not self._discord_health_task.done():
+            self._discord_health_task.cancel()
+            try:
+                await self._discord_health_task
+            except asyncio.CancelledError:
+                pass
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._discord_health_task = None
 
         self._release_platform_lock()
 
         logger.info("[%s] Disconnected", self.name)
+
+    async def _discord_health_loop(self) -> None:
+        """Emit a single-line gateway health log once per ``HEALTH_LOG_INTERVAL`` seconds.
+
+        Diagnoses silent-disconnect scenarios where Discord stops delivering
+        events but the bot believes it is still connected. Logs no secrets and
+        is always cancellable.
+        """
+        try:
+            while True:
+                client = self._client
+                try:
+                    latency = client.latency if client is not None else None
+                except Exception:
+                    latency = None
+                try:
+                    is_closed = client.is_closed() if client is not None else None
+                except Exception:
+                    is_closed = None
+                try:
+                    guild_count = len(client.guilds) if client is not None else 0
+                except Exception:
+                    guild_count = 0
+                logger.info(
+                    "[%s] Discord gateway health "
+                    "latency=%s closed=%s running=%s ready=%s guilds=%s",
+                    self.name,
+                    latency,
+                    is_closed,
+                    self._running,
+                    self._ready_event.is_set(),
+                    guild_count,
+                )
+                await asyncio.sleep(self.HEALTH_LOG_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception("[%s] Discord health loop crashed", self.name)
 
     def _command_sync_state_path(self) -> _Path:
         from hermes_constants import get_hermes_home
@@ -3021,21 +3125,60 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_deny(interaction: discord.Interaction, scope: str = ""):
             await self._run_simple_slash(interaction, f"/deny {scope}".strip())
 
-        @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
+        @tree.command(name="thread", description="Create a repo/general thread and start a Hermes session in it")
         @discord.app_commands.describe(
-            name="Thread name",
-            message="Optional first message to send to Hermes in the thread",
+            target="Thread preset",
+            task="Optional task suffix for the thread name, e.g. orders-api",
+            message="Optional initial request to append after the preset starter",
             auto_archive_duration="Auto-archive in minutes (60, 1440, 4320, 10080)",
         )
+        @discord.app_commands.choices(target=[
+            discord.app_commands.Choice(name="general", value="general"),
+            discord.app_commands.Choice(name="kody-workspace", value="kody-workspace"),
+            discord.app_commands.Choice(name="kody-frontend", value="kody-frontend"),
+            discord.app_commands.Choice(name="kody-backend", value="kody-backend"),
+            discord.app_commands.Choice(name="divebase", value="divebase"),
+            discord.app_commands.Choice(name="honbabseoul", value="honbabseoul"),
+            discord.app_commands.Choice(name="nexus", value="nexus"),
+            discord.app_commands.Choice(name="bestst", value="bestst"),
+            discord.app_commands.Choice(name="hermes-core", value="hermes-core"),
+        ])
         async def slash_thread(
             interaction: discord.Interaction,
-            name: str,
+            target: str,
+            task: str = "",
             message: str = "",
             auto_archive_duration: int = 1440,
         ):
             # defer() is performed inside the handler *after* the auth gate
             # so a rejected invoker can receive an ephemeral rejection.
-            await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
+            #
+            # Diagnostic: log the invocation envelope (preset metadata + ids
+            # only — no message body, to avoid leaking user content/secrets).
+            try:
+                _ch = getattr(interaction, "channel", None)
+                _gu = getattr(interaction, "guild", None)
+                _us = getattr(interaction, "user", None)
+                logger.info(
+                    "[%s] /thread invoked target=%s task=%s "
+                    "channel=%s(%s) guild=%s(%s) user=%s(%s) "
+                    "auto_archive=%s message_provided=%s",
+                    self.name,
+                    target,
+                    task,
+                    getattr(_ch, "id", None),
+                    getattr(_ch, "name", None),
+                    getattr(_gu, "id", None),
+                    getattr(_gu, "name", None),
+                    getattr(_us, "id", None),
+                    getattr(_us, "name", None),
+                    auto_archive_duration,
+                    bool(message),
+                )
+            except Exception:
+                logger.debug("[%s] /thread invocation log failed", self.name, exc_info=True)
+            name, starter = self._build_preset_thread(target, task, message)
+            await self._handle_thread_create_slash(interaction, name, starter, auto_archive_duration)
 
         @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
         @discord.app_commands.describe(prompt="The prompt to queue")
@@ -3446,6 +3589,181 @@ class DiscordAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Thread creation helpers
     # ------------------------------------------------------------------
+
+    _THREAD_PRESETS: Dict[str, Dict[str, str]] = {
+        "general": {
+            "name": "general",
+            "starter": """This thread is for general Hermes conversation.
+
+No repo is anchored for this thread.
+Treat repo-specific work as ambiguous and ask for the target repo path before reading, editing, testing, or running repo-specific commands.
+Do not print secrets, .env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "kody-workspace": {
+            "name": "kody-workspace",
+            "starter": """This thread is for KODY orchestration root.
+Repo path: /Users/qnb/dev/workouts/kody-workspace
+
+Use this repo for planning, cross-repo gates, routing, and closeout only.
+Route product implementation to kody-backend or kody-frontend threads.
+Reply to me in Korean.""",
+        },
+        "kody-frontend": {
+            "name": "kody-frontend",
+            "starter": """This thread is for kody-frontend.
+Repo path: /Users/qnb/dev/workouts/kody-workspace/kody-frontend
+
+Use this repo as cwd for frontend inspection, tests, and implementation.
+Preserve prototype/mock-data discipline unless integration work is explicitly approved.
+Do not print secrets, .env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "kody-backend": {
+            "name": "kody-backend",
+            "starter": """This thread is for kody-backend.
+Repo path: /Users/qnb/dev/workouts/kody-workspace/kody-backend
+
+Use this repo as cwd for backend inspection, tests, and implementation.
+Do not print secrets, .env contents, auth tokens, or API keys.
+Do not run Prisma schema/migration commands unless explicitly approved.
+Reply to me in Korean.""",
+        },
+        "divebase": {
+            "name": "divebase",
+            "starter": """This thread is for divebase.
+Repo path: /Users/qnb/dev/workouts/divebase
+
+Use this repo as cwd for DiveBase inspection, Flutter analysis, tests, and implementation.
+Do not print secrets, .env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "honbabseoul": {
+            "name": "honbabseoul",
+            "starter": """This thread is for honbabseoul.
+Repo path: /Users/qnb/dev/workouts/honbabseoul
+
+Use this repo as cwd for repo-specific inspection, tests, and implementation.
+Do not print secrets, .env.local contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "nexus": {
+            "name": "nexus",
+            "starter": """This thread is for nexus.
+Repo path: /Users/qnb/dev/workouts/nexus
+
+Use this repo as cwd for repo-specific inspection, tests, and implementation.
+Do not print secrets, env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "bestst": {
+            "name": "bestst",
+            "starter": """This thread is for bestst.
+Repo path: /Users/qnb/dev/workouts/beststcad
+
+Use this repo as cwd for repo-specific inspection, tests, and implementation.
+Do not print secrets, env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+        "hermes-core": {
+            "name": "hermes-core",
+            "starter": """This thread is for hermes-core.
+Repo path: /Users/qnb/dev/templates/hermes-core
+
+Treat this as Hermes operating-layer template work, not product work.
+Do not change policy/workflow artifacts without explicit scoped approval.
+Do not print secrets, env contents, auth tokens, or API keys.
+Reply to me in Korean.""",
+        },
+    }
+
+    _THREAD_TITLE_MAX = 100
+    _THREAD_TITLE_SUFFIX_MAX = 60
+    _THREAD_TITLE_SEPARATOR = " · "
+
+    def _build_preset_thread(self, target: str, task: str = "", message: str = "") -> Tuple[str, str]:
+        """Return the thread name and starter prompt for a preset Discord thread.
+
+        The preset name stays as the stable prefix, while an explicit ``task``
+        or the optional initial request supplies a short, human-readable suffix
+        so multiple threads for the same repo are distinguishable at a glance.
+        """
+        key = (target or "").strip().lower()
+        preset = self._THREAD_PRESETS.get(key)
+        if not preset:
+            allowed = ", ".join(sorted(self._THREAD_PRESETS))
+            raise ValueError(f"Unknown thread preset '{target}'. Choose one of: {allowed}")
+
+        base_name = preset["name"]
+        suffix = self._summarize_thread_title_suffix(task or message)
+        name = self._format_preset_thread_name(base_name, suffix)
+
+        starter = preset["starter"].strip()
+        extra = (message or "").strip()
+        if extra:
+            starter = f"{starter}\n\nInitial request:\n{extra}"
+        return name, starter
+
+    @classmethod
+    def _format_preset_thread_name(cls, base_name: str, suffix: str = "") -> str:
+        """Compose a Discord thread title from a preset prefix and optional suffix."""
+        base = (base_name or "Hermes").strip() or "Hermes"
+        suffix = (suffix or "").strip()
+        if not suffix:
+            return base[: cls._THREAD_TITLE_MAX].rstrip(" -._·") or base
+
+        name = f"{base}{cls._THREAD_TITLE_SEPARATOR}{suffix}"
+        if len(name) <= cls._THREAD_TITLE_MAX:
+            return name
+
+        available = cls._THREAD_TITLE_MAX - len(base) - len(cls._THREAD_TITLE_SEPARATOR)
+        if available < 8:
+            return base[: cls._THREAD_TITLE_MAX].rstrip(" -._·") or base
+        shortened = suffix[: max(0, available - 1)].rstrip(" -._·")
+        return f"{base}{cls._THREAD_TITLE_SEPARATOR}{shortened}…"
+
+    @classmethod
+    def _summarize_thread_title_suffix(cls, text: str) -> str:
+        """Derive a safe short suffix from a user-provided task or message.
+
+        This intentionally uses deterministic cleanup/truncation rather than an
+        LLM call: slash-command registration and thread creation should stay
+        fast, predictable, and offline. If the input looks like it may contain
+        secrets, return an empty suffix rather than exposing the content in a
+        public Discord thread title.
+        """
+        raw = (text or "").strip()
+        if not raw:
+            return ""
+
+        if re.search(
+            r"(?i)(api[_-]?key|auth[_-]?token|bearer\s+|password|passwd|secret|\.env|sk-[A-Za-z0-9])",
+            raw,
+        ):
+            return ""
+
+        # Drop code blocks/inline code and platform markup that make poor
+        # titles. Keep normal Korean/English text readable.
+        cleaned = re.sub(r"```.*?```", " ", raw, flags=re.DOTALL)
+        cleaned = re.sub(r"`([^`]*)`", r"\1", cleaned)
+        cleaned = re.sub(r"<@[!&]?\d+>", " ", cleaned)
+        cleaned = re.sub(r"<#\d+>", " ", cleaned)
+        cleaned = re.sub(r"https?://\S+", " link ", cleaned)
+        cleaned = re.sub(r"(?im)^\s*(initial request|request|task|repo path)\s*:\s*", "", cleaned)
+
+        # Prefer the first meaningful line; starter prompts often contain
+        # multiple instruction lines before/after the actual request.
+        lines = [re.sub(r"\s+", " ", line).strip(" \t-–—:;,.!?/\\") for line in cleaned.splitlines()]
+        line = next((part for part in lines if part), "")
+        if not line:
+            return ""
+
+        words = line.split()
+        if len(words) > 8:
+            line = " ".join(words[:8])
+        if len(line) > cls._THREAD_TITLE_SUFFIX_MAX:
+            line = line[: cls._THREAD_TITLE_SUFFIX_MAX - 1].rstrip(" -._·") + "…"
+        return line
 
     async def _handle_thread_create_slash(
         self,

--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -59,8 +59,11 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
-2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
+1. **Fetch** the transcript. Prefer the built-in `youtube_transcript` tool when it is available. Otherwise use the helper script with `--text-only --timestamps`.
+   - Use `languages` for fallback chains such as `ko,en`.
+   - Use `max_chars` for long videos; check `truncated` and `text_stats` before summarizing.
+   - Use returned `metadata`, `is_generated`, and `is_translatable` as quality/context signals.
+2. **Validate**: confirm the output is non-empty and in the expected language. If the tool returns `success=false`, inspect `error_code` and `available_languages`; retry with a listed language when appropriate. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
 5. **Verify**: re-read the transformed output to check for coherence, correct timestamps, and completeness before presenting.

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -11,6 +11,7 @@ import pytest
 
 from tests.e2e.conftest import (
     BOT_USER_ID,
+    DiscordAdapter,
     E2E_MESSAGE_SETTLE_DELAY,
     get_response_text,
     make_discord_message,
@@ -77,6 +78,48 @@ class TestMentionStrippedCommandDispatch:
         response = get_response_text(discord_adapter)
         assert response is not None
         assert "/new" in response
+
+
+class TestPresetThreadNaming:
+    async def test_explicit_task_becomes_human_readable_suffix(self):
+        name, starter = DiscordAdapter._build_preset_thread(
+            object.__new__(DiscordAdapter),
+            "kody-backend",
+            task="orders api",
+            message="Please inspect the shipment flow.",
+        )
+
+        assert name == "kody-backend · orders api"
+        assert "Initial request:\nPlease inspect the shipment flow." in starter
+
+    async def test_initial_message_supplies_suffix_when_task_is_empty(self):
+        name, _starter = DiscordAdapter._build_preset_thread(
+            object.__new__(DiscordAdapter),
+            "hermes-core",
+            message="Improve Discord thread names from the first request and target metadata.",
+        )
+
+        assert name == "hermes-core · Improve Discord thread names from the first request"
+        assert len(name) <= 100
+
+    async def test_korean_initial_message_is_preserved_and_trimmed(self):
+        name, _starter = DiscordAdapter._build_preset_thread(
+            object.__new__(DiscordAdapter),
+            "general",
+            message="쓰레드 기능을 사용해서 만들어지는 이름이 단순히 레포 이름이라 구분이 어려워",
+        )
+
+        assert name.startswith("general · 쓰레드 기능을 사용해서")
+        assert len(name) <= 100
+
+    async def test_secret_like_initial_message_does_not_leak_into_thread_name(self):
+        name, _starter = DiscordAdapter._build_preset_thread(
+            object.__new__(DiscordAdapter),
+            "general",
+            message="Use API_KEY=DUMMY_VALUE to debug the gateway",
+        )
+
+        assert name == "general"
 
 
 class TestAutoThreadingPreservesCommand:

--- a/tests/tools/test_youtube_tool.py
+++ b/tests/tools/test_youtube_tool.py
@@ -1,0 +1,195 @@
+"""Tests for tools.youtube_tool."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+from tools import youtube_tool
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ?t=42", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/live/dQw4w9WgXcQ?feature=share", "dQw4w9WgXcQ"),
+    ],
+)
+def test_extract_video_id(url, expected):
+    assert youtube_tool.extract_video_id(url) == expected
+
+
+def test_extract_video_id_rejects_invalid():
+    with pytest.raises(ValueError):
+        youtube_tool.extract_video_id("https://example.com/not-youtube")
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [(0, "0:00"), (9.9, "0:09"), (65, "1:05"), (3661, "1:01:01")],
+)
+def test_format_timestamp(seconds, expected):
+    assert youtube_tool.format_timestamp(seconds) == expected
+
+
+def test_youtube_transcript_tool_fetches_and_formats_v1_api(monkeypatch):
+    class Segment:
+        def __init__(self, text, start, duration):
+            self.text = text
+            self.start = start
+            self.duration = duration
+
+    class FetchedTranscript(list):
+        language_code = "en"
+
+    fetched = FetchedTranscript([
+        Segment("hello\nworld", 0.0, 2.5),
+        Segment("second line", 65.0, 3.0),
+    ])
+
+    class MockApi:
+        def fetch(self, video_id, languages=None):
+            assert video_id == "dQw4w9WgXcQ"
+            assert languages == ["en", "ko"]
+            return fetched
+
+    mock_mod = types.SimpleNamespace(YouTubeTranscriptApi=MockApi)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", mock_mod)
+
+    raw = youtube_tool.youtube_transcript_tool(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        languages="en,ko",
+        include_timestamps=True,
+        include_segments=True,
+        include_metadata=False,
+    )
+    result = json.loads(raw)
+
+    assert result["success"] is True
+    assert result["video_id"] == "dQw4w9WgXcQ"
+    assert result["language"] == "en"
+    assert result["is_generated"] is None
+    assert result["requested_languages"] == ["en", "ko"]
+    assert result["segment_count"] == 2
+    assert result["duration"] == "1:08"
+    assert result["full_text"] == "hello world second line"
+    assert result["timestamped_text"] == "0:00 hello world\n1:05 second line"
+    assert result["segments"][0] == {"text": "hello world", "start": 0.0, "duration": 2.5}
+
+
+def test_youtube_transcript_tool_supports_legacy_get_transcript(monkeypatch):
+    class LegacyApi:
+        @staticmethod
+        def get_transcript(video_id, languages=None):
+            assert video_id == "dQw4w9WgXcQ"
+            assert languages is None
+            return [{"text": "legacy text", "start": 1, "duration": 2}]
+
+        def fetch(self, *args, **kwargs):
+            raise TypeError("old api has no instance fetch")
+
+    mock_mod = types.SimpleNamespace(YouTubeTranscriptApi=LegacyApi)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", mock_mod)
+
+    raw = youtube_tool.youtube_transcript_tool(
+        "dQw4w9WgXcQ", include_timestamps=False, include_metadata=False)
+    result = json.loads(raw)
+
+    assert result["success"] is True
+    assert result["full_text"] == "legacy text"
+    assert "timestamped_text" not in result
+
+
+def test_youtube_transcript_tool_returns_structured_error_for_bad_url():
+    result = json.loads(youtube_tool.youtube_transcript_tool("not a youtube url"))
+
+    assert result["success"] is False
+    assert result["error_code"] == "INVALID_URL"
+    assert result["error_message"] == result["error"]
+    assert "Expected a YouTube URL" in result["error"]
+
+
+def test_youtube_transcript_tool_truncates_text_fields(monkeypatch):
+    class MockApi:
+        def fetch(self, video_id, languages=None):
+            return [
+                {"text": "alpha beta gamma", "start": 0, "duration": 1},
+                {"text": "delta epsilon zeta", "start": 2, "duration": 1},
+            ]
+
+    mock_mod = types.SimpleNamespace(YouTubeTranscriptApi=MockApi)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", mock_mod)
+
+    result = json.loads(youtube_tool.youtube_transcript_tool(
+        "dQw4w9WgXcQ",
+        include_metadata=False,
+        include_timestamps=True,
+        max_chars=20,
+    ))
+
+    assert result["success"] is True
+    assert result["truncated"] is True
+    assert result["text_stats"]["max_chars"] == 20
+    assert result["text_stats"]["full_text_truncated"] is True
+    assert result["text_stats"]["timestamped_text_truncated"] is True
+    assert len(result["full_text"]) <= 20
+    assert len(result["timestamped_text"]) <= 20
+
+
+def test_youtube_transcript_tool_maps_errors_and_lists_languages(monkeypatch):
+    class Transcript:
+        language = "English"
+        language_code = "en"
+        is_generated = False
+        is_translatable = True
+
+    class MockApi:
+        def fetch(self, video_id, languages=None):
+            raise RuntimeError("No transcript found")
+
+        def list(self, video_id):
+            return [Transcript()]
+
+    mock_mod = types.SimpleNamespace(YouTubeTranscriptApi=MockApi)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", mock_mod)
+
+    result = json.loads(youtube_tool.youtube_transcript_tool(
+        "dQw4w9WgXcQ", include_metadata=False))
+
+    assert result["success"] is False
+    assert result["error_code"] == "NO_TRANSCRIPT_FOUND"
+    assert result["video_id"] == "dQw4w9WgXcQ"
+    assert result["available_languages"] == [
+        {
+            "language": "English",
+            "language_code": "en",
+            "is_generated": False,
+            "is_translatable": True,
+        }
+    ]
+
+
+def test_youtube_transcript_tool_includes_oembed_metadata(monkeypatch):
+    class MockApi:
+        def fetch(self, video_id, languages=None):
+            return [{"text": "hello", "start": 0, "duration": 1}]
+
+    mock_mod = types.SimpleNamespace(YouTubeTranscriptApi=MockApi)
+    monkeypatch.setitem(sys.modules, "youtube_transcript_api", mock_mod)
+    monkeypatch.setattr(
+        youtube_tool,
+        "_fetch_oembed_metadata",
+        lambda video_id: {"title": "Demo", "author_name": "Channel"},
+    )
+
+    result = json.loads(youtube_tool.youtube_transcript_tool("dQw4w9WgXcQ"))
+
+    assert result["success"] is True
+    assert result["metadata"] == {"title": "Demo", "author_name": "Channel"}

--- a/tools/youtube_tool.py
+++ b/tools/youtube_tool.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""YouTube transcript tool for Hermes.
+
+The tool intentionally focuses on transcript retrieval rather than doing the
+summary itself.  That keeps the side-effect surface small: the model can call
+``youtube_transcript`` to ground itself in the video's subtitles, then transform
+that transcript into a summary, chapters, quotes, or any other requested format.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterable, Optional
+from urllib.parse import parse_qs, quote, urlparse
+from urllib.request import urlopen
+
+from tools.registry import registry, tool_result
+
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+DEFAULT_MAX_CHARS = 20_000
+OEMBED_TIMEOUT_SECONDS = 5
+
+
+class YouTubeTranscriptDependencyError(RuntimeError):
+    """Raised when youtube-transcript-api cannot be imported or lazily installed."""
+
+
+ERROR_MESSAGES = {
+    "INVALID_URL": "Expected a YouTube URL or 11-character video ID",
+    "DEPENDENCY_MISSING": (
+        "youtube-transcript-api is not installed. Enable the youtube extra "
+        "or run: pip install youtube-transcript-api"
+    ),
+    "TRANSCRIPTS_DISABLED": "Transcripts are disabled for this video.",
+    "NO_TRANSCRIPT_FOUND": (
+        "No transcript could be retrieved for this video. Try another language "
+        "or verify subtitles are available."
+    ),
+    "VIDEO_UNAVAILABLE": "The YouTube video is unavailable or private.",
+    "AGE_RESTRICTED": "The YouTube video appears to be age restricted.",
+    "IP_BLOCKED": "YouTube blocked transcript access from this network/IP.",
+    "UNKNOWN_ERROR": "Failed to retrieve the YouTube transcript.",
+}
+
+
+def extract_video_id(url_or_id: str) -> str:
+    """Extract a YouTube 11-character video ID from common URL forms.
+
+    Supports normal watch URLs, youtu.be short links, Shorts, embeds, live
+    links, and raw IDs.  Raises ``ValueError`` when no valid ID can be found.
+    """
+    candidate = (url_or_id or "").strip()
+    if _VIDEO_ID_RE.fullmatch(candidate):
+        return candidate
+
+    parsed = urlparse(candidate)
+    host = parsed.netloc.lower()
+    path = parsed.path.strip("/")
+
+    if host.endswith("youtube.com") or host.endswith("youtube-nocookie.com"):
+        query_id = parse_qs(parsed.query).get("v", [None])[0]
+        if query_id and _VIDEO_ID_RE.fullmatch(query_id):
+            return query_id
+
+        parts = [part for part in path.split("/") if part]
+        for marker in ("shorts", "embed", "live"):
+            if marker in parts:
+                idx = parts.index(marker)
+                if idx + 1 < len(parts) and _VIDEO_ID_RE.fullmatch(parts[idx + 1]):
+                    return parts[idx + 1]
+
+    if host.endswith("youtu.be"):
+        first = path.split("/", 1)[0]
+        if _VIDEO_ID_RE.fullmatch(first):
+            return first
+
+    # Last-resort regex for pasted URLs with extra wrapping text.
+    match = re.search(r"(?:v=|youtu\.be/|shorts/|embed/|live/)([A-Za-z0-9_-]{11})", candidate)
+    if match:
+        return match.group(1)
+
+    raise ValueError(ERROR_MESSAGES["INVALID_URL"])
+
+
+def format_timestamp(seconds: float) -> str:
+    """Convert seconds to ``M:SS`` or ``H:MM:SS``."""
+    total = max(0, int(seconds or 0))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def _coerce_languages(languages: Optional[str | Iterable[str]]) -> Optional[list[str]]:
+    if languages is None:
+        return None
+    if isinstance(languages, str):
+        items = languages.split(",")
+    else:
+        items = list(languages)
+    cleaned = [str(item).strip() for item in items if str(item).strip()]
+    return cleaned or None
+
+
+def _coerce_max_chars(max_chars: Optional[int]) -> Optional[int]:
+    """Normalize max_chars.
+
+    ``None`` disables truncation for internal callers.  Public schema defaults to
+    ``DEFAULT_MAX_CHARS`` to protect context windows for long videos.
+    """
+    if max_chars is None:
+        return None
+    try:
+        value = int(max_chars)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_CHARS
+    if value <= 0:
+        return DEFAULT_MAX_CHARS
+    return value
+
+
+def _load_youtube_transcript_api():
+    """Import youtube-transcript-api, lazily installing the pinned extra if allowed."""
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+        return YouTubeTranscriptApi
+    except ImportError:
+        try:
+            from tools.lazy_deps import ensure
+            ensure("skill.youtube", prompt=False)
+            from youtube_transcript_api import YouTubeTranscriptApi
+            return YouTubeTranscriptApi
+        except Exception as exc:  # pragma: no cover - exact exception depends on env/config
+            raise YouTubeTranscriptDependencyError(ERROR_MESSAGES["DEPENDENCY_MISSING"]) from exc
+
+
+def _snippet_to_dict(segment: Any) -> dict[str, Any]:
+    """Normalize dict snippets and youtube-transcript-api objects."""
+    if isinstance(segment, dict):
+        text = segment.get("text", "")
+        start = segment.get("start", 0.0)
+        duration = segment.get("duration", 0.0)
+    else:
+        text = getattr(segment, "text", "")
+        start = getattr(segment, "start", 0.0)
+        duration = getattr(segment, "duration", 0.0)
+    return {
+        "text": str(text).replace("\n", " ").strip(),
+        "start": float(start or 0.0),
+        "duration": float(duration or 0.0),
+    }
+
+
+def _transcript_metadata(transcript: Any) -> dict[str, Any]:
+    """Extract stable metadata from transcript-api transcript/list objects."""
+    return {
+        "language": getattr(transcript, "language", None),
+        "language_code": getattr(transcript, "language_code", None),
+        "is_generated": getattr(transcript, "is_generated", None),
+        "is_translatable": getattr(transcript, "is_translatable", None),
+    }
+
+
+def _available_languages(video_id: str) -> list[dict[str, Any]]:
+    """Return available transcript languages when the API supports listing.
+
+    Best effort only: callers should treat an empty list as "unknown", not as a
+    proof that no languages exist.
+    """
+    try:
+        api_cls = _load_youtube_transcript_api()
+        api = api_cls()
+        transcript_list = api.list(video_id)
+    except TypeError:
+        return []
+    except Exception:
+        return []
+
+    languages: list[dict[str, Any]] = []
+    try:
+        iterator = iter(transcript_list)
+    except TypeError:
+        return languages
+    for transcript in iterator:
+        info = _transcript_metadata(transcript)
+        if info.get("language_code"):
+            languages.append(info)
+    return languages
+
+
+def _fetch_segments(
+    video_id: str,
+    languages: Optional[list[str]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Fetch and normalize transcript segments.
+
+    Handles youtube-transcript-api v1.x (``YouTubeTranscriptApi().fetch``) and
+    older class/static APIs used by some tests and existing environments.
+    """
+    api_cls = _load_youtube_transcript_api()
+    fetched: Any
+
+    try:
+        api = api_cls()
+        fetched = api.fetch(video_id, languages=languages) if languages else api.fetch(video_id)
+    except TypeError:
+        # Older youtube-transcript-api exposed get_transcript as a static/class method.
+        fetched = api_cls.get_transcript(video_id, languages=languages) if languages else api_cls.get_transcript(video_id)
+
+    metadata = _transcript_metadata(fetched)
+    segments = [_snippet_to_dict(segment) for segment in fetched]
+    return segments, metadata
+
+
+def _truncate_text(text: str, max_chars: Optional[int]) -> tuple[str, bool, int, int]:
+    """Return ``(returned_text, truncated, original_chars, returned_chars)``."""
+    original_chars = len(text)
+    if max_chars is None or original_chars <= max_chars:
+        return text, False, original_chars, original_chars
+    marker = "\n...[truncated]"
+    if max_chars <= len(marker):
+        truncated = text[:max_chars]
+    else:
+        truncated = text[: max_chars - len(marker)].rstrip() + marker
+    return truncated, True, original_chars, len(truncated)
+
+
+def _classify_error(exc: Exception) -> tuple[str, str]:
+    """Map transcript API failures to stable error codes and user-safe messages."""
+    if isinstance(exc, YouTubeTranscriptDependencyError):
+        return "DEPENDENCY_MISSING", ERROR_MESSAGES["DEPENDENCY_MISSING"]
+
+    raw = str(exc) or type(exc).__name__
+    lower = raw.lower()
+    if "disabled" in lower:
+        return "TRANSCRIPTS_DISABLED", ERROR_MESSAGES["TRANSCRIPTS_DISABLED"]
+    if "no transcript" in lower or "could not retrieve" in lower or "notranscript" in lower:
+        return "NO_TRANSCRIPT_FOUND", ERROR_MESSAGES["NO_TRANSCRIPT_FOUND"]
+    if "unavailable" in lower or "private" in lower or "video unavailable" in lower:
+        return "VIDEO_UNAVAILABLE", ERROR_MESSAGES["VIDEO_UNAVAILABLE"]
+    if "age" in lower and "restrict" in lower:
+        return "AGE_RESTRICTED", ERROR_MESSAGES["AGE_RESTRICTED"]
+    if "ip" in lower and ("block" in lower or "ban" in lower):
+        return "IP_BLOCKED", ERROR_MESSAGES["IP_BLOCKED"]
+    if "too many requests" in lower or "429" in lower:
+        return "IP_BLOCKED", ERROR_MESSAGES["IP_BLOCKED"]
+    return "UNKNOWN_ERROR", raw
+
+
+def _error_result(
+    code: str,
+    message: str,
+    *,
+    video_id: Optional[str] = None,
+    available_languages: Optional[list[dict[str, Any]]] = None,
+) -> str:
+    payload: dict[str, Any] = {
+        "success": False,
+        "error": message,
+        "error_code": code,
+        "error_message": message,
+    }
+    if video_id is not None:
+        payload["video_id"] = video_id
+    if available_languages is not None:
+        payload["available_languages"] = available_languages
+    return tool_result(payload)
+
+
+def _fetch_oembed_metadata(video_id: str) -> Optional[dict[str, Any]]:
+    """Fetch lightweight public YouTube metadata via keyless oEmbed.
+
+    Failure is non-fatal because the transcript is the primary evidence source.
+    """
+    canonical_url = f"https://www.youtube.com/watch?v={video_id}"
+    endpoint = f"https://www.youtube.com/oembed?url={quote(canonical_url, safe='')}&format=json"
+    try:
+        with urlopen(endpoint, timeout=OEMBED_TIMEOUT_SECONDS) as response:  # noqa: S310 - fixed HTTPS endpoint
+            data = json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return None
+
+    return {
+        "title": data.get("title"),
+        "author_name": data.get("author_name"),
+        "author_url": data.get("author_url"),
+        "provider_name": data.get("provider_name"),
+        "provider_url": data.get("provider_url"),
+        "thumbnail_url": data.get("thumbnail_url"),
+    }
+
+
+def youtube_transcript_tool(
+    url: str,
+    languages: Optional[str | Iterable[str]] = None,
+    include_timestamps: bool = True,
+    include_segments: bool = False,
+    max_chars: Optional[int] = DEFAULT_MAX_CHARS,
+    include_metadata: bool = True,
+) -> str:
+    """Fetch a YouTube transcript as JSON for downstream model analysis."""
+    try:
+        video_id = extract_video_id(url)
+    except ValueError as exc:
+        return _error_result("INVALID_URL", str(exc))
+
+    language_list = _coerce_languages(languages)
+    normalized_max_chars = _coerce_max_chars(max_chars)
+    try:
+        segments, transcript_metadata = _fetch_segments(video_id, language_list)
+    except Exception as exc:
+        code, message = _classify_error(exc)
+        return _error_result(
+            code,
+            message,
+            video_id=video_id,
+            available_languages=_available_languages(video_id),
+        )
+
+    full_text_raw = " ".join(segment["text"] for segment in segments if segment["text"]).strip()
+    timestamped_text_raw = "\n".join(
+        f"{format_timestamp(segment['start'])} {segment['text']}"
+        for segment in segments
+        if segment["text"]
+    )
+    full_text, full_truncated, full_chars, returned_full_chars = _truncate_text(
+        full_text_raw, normalized_max_chars)
+    timestamped_text, timestamps_truncated, timestamp_chars, returned_timestamp_chars = _truncate_text(
+        timestamped_text_raw, normalized_max_chars)
+
+    duration_seconds = 0.0
+    if segments:
+        last = segments[-1]
+        duration_seconds = float(last["start"]) + float(last["duration"])
+
+    language_code = transcript_metadata.get("language_code")
+    result: dict[str, Any] = {
+        "success": True,
+        "video_id": video_id,
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+        "analysis_source": "youtube_transcript",
+        "source_limitations": [
+            "Transcript-based understanding only; video frames and audio are not analyzed.",
+            "Automatically generated captions may contain recognition errors.",
+        ],
+        "language": language_code,
+        "requested_languages": language_list,
+        "is_generated": transcript_metadata.get("is_generated"),
+        "is_translatable": transcript_metadata.get("is_translatable"),
+        "segment_count": len(segments),
+        "duration": format_timestamp(duration_seconds),
+        "duration_seconds": duration_seconds,
+        "full_text": full_text,
+        "truncated": full_truncated or timestamps_truncated,
+        "text_stats": {
+            "max_chars": normalized_max_chars,
+            "full_text_chars": full_chars,
+            "returned_full_text_chars": returned_full_chars,
+            "full_text_truncated": full_truncated,
+            "timestamped_text_chars": timestamp_chars,
+            "returned_timestamped_text_chars": returned_timestamp_chars,
+            "timestamped_text_truncated": timestamps_truncated,
+        },
+    }
+    if transcript_metadata.get("language") is not None:
+        result["language_name"] = transcript_metadata.get("language")
+    if include_metadata:
+        result["metadata"] = _fetch_oembed_metadata(video_id)
+    if include_timestamps:
+        result["timestamped_text"] = timestamped_text
+    if include_segments:
+        result["segments"] = segments
+    return tool_result(result)
+
+
+YOUTUBE_TRANSCRIPT_SCHEMA = {
+    "name": "youtube_transcript",
+    "description": (
+        "Fetch the transcript/subtitles for a YouTube video URL or video ID so the "
+        "assistant can understand and summarize the video. Use this before answering "
+        "requests about YouTube content. It returns transcript text, stable metadata, "
+        "truncation stats, and optionally timestamped lines or raw segments; the "
+        "assistant should then produce the requested summary, chapters, quotes, or analysis."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "A YouTube URL (watch, youtu.be, shorts, embed, live) or raw 11-character video ID.",
+            },
+            "languages": {
+                "type": "string",
+                "description": "Optional comma-separated transcript language preference/fallback chain, e.g. 'ko,en' or 'en'. Leave empty for YouTube's default selection.",
+            },
+            "include_timestamps": {
+                "type": "boolean",
+                "description": "Whether to include timestamped transcript lines. Defaults to true.",
+            },
+            "include_segments": {
+                "type": "boolean",
+                "description": "Whether to include raw segment objects with start/duration. Defaults to false to keep output compact.",
+            },
+            "max_chars": {
+                "type": "integer",
+                "description": "Maximum characters to return for each transcript text field. Defaults to 20000 to protect context windows; set higher for long-video analysis.",
+            },
+            "include_metadata": {
+                "type": "boolean",
+                "description": "Whether to fetch lightweight public video metadata via YouTube oEmbed. Defaults to true.",
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+
+registry.register(
+    name="youtube_transcript",
+    toolset="web",
+    schema=YOUTUBE_TRANSCRIPT_SCHEMA,
+    handler=lambda args, **kw: youtube_transcript_tool(
+        url=args.get("url", ""),
+        languages=args.get("languages"),
+        include_timestamps=args.get("include_timestamps", True),
+        include_segments=args.get("include_segments", False),
+        max_chars=args.get("max_chars", DEFAULT_MAX_CHARS),
+        include_metadata=args.get("include_metadata", True),
+    ),
+    emoji="▶️",
+    max_result_size_chars=120_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "youtube_transcript",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -78,8 +78,8 @@ _HERMES_CORE_TOOLS = [
 TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
-        "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "description": "Web research and content extraction tools, including YouTube transcripts",
+        "tools": ["web_search", "web_extract", "youtube_transcript"],
         "includes": []  # No other toolsets included
     },
     


### PR DESCRIPTION
## Summary
- Add a built-in youtube_transcript tool with transcript metadata, truncation stats, timestamped output, and tests
- Include youtube_transcript in the web/core toolset and update the YouTube content skill workflow
- Add Discord /thread presets, safer title suffix generation, invocation diagnostics, and gateway health logging

## Test Plan
- python -m pytest tests/tools/test_youtube_tool.py tests/e2e/test_discord_adapter.py -o 'addopts=' -q

## Notes
- Upstream push from this checkout is read-only for 0xMegg, so this PR is opened from the fork branch.