### PR TITLE
Fix Kanban dashboard initial board selection

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -413,7 +413,7 @@
 
   function KanbanPage() {
     const { t } = useI18n();
-    const [board, setBoard] = useState(() => readSelectedBoard() || "default");
+    const [board, setBoard] = useState(() => readSelectedBoard() || null);
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -494,11 +494,16 @@
       return SDK.fetchJSON(withBoard(`${API}/boards`, board))
         .then(function (data) {
           const boards = (data && data.boards) || [];
+          const storedBoard = readSelectedBoard();
           setBoardList(boards);
+          if (!storedBoard && !board && data && data.current) {
+            setBoard(data.current);
+            return;
+          }
           // If the stored slug isn't in the list any longer (board was
           // deleted in the CLI while dashboard was open), fall back to
           // default so the UI doesn't hang on a 404.
-          if (board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
+          if (board && board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
             setBoard("default");
             writeSelectedBoard("default");
           }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -164,6 +164,25 @@ def test_dashboard_client_side_filtering_includes_tenant_filter():
     assert "[boardData, tenantFilter, assigneeFilter, search]" in js
 
 
+def test_dashboard_initial_board_uses_backend_current_when_unpinned():
+    """Fresh browsers should open the backend current board, not default.
+
+    Explicit dashboard selections are stored in localStorage and should still
+    win, but an empty localStorage state must adopt the API's ``current`` board
+    so multi-board installs do not look empty on first load.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert 'useState(() => readSelectedBoard() || null)' in js
+    assert "const storedBoard = readSelectedBoard();" in js
+    assert "if (!storedBoard && !board && data && data.current)" in js
+    assert "setBoard(data.current);" in js
+    assert 'readSelectedBoard() || "default"' not in js
+
+
 # ---------------------------------------------------------------------------
 # GET /tasks/:id returns body + comments + events + links
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- make fresh Kanban dashboard sessions adopt the backend current board instead of hard-pinning default\n- keep explicit browser board selections persisted in localStorage\n- add regression coverage for the shipped dashboard bundle\n\n## Tests\n- python3 -m pytest -q -o addopts='' tests/plugins/test_kanban_dashboard_plugin.py\n