### PR TITLE
feat(agent): add gated cognitive core runtime

### DIFF
--- a/agent/cognitive_core.py
+++ b/agent/cognitive_core.py
@@ -1,0 +1,311 @@
+"""Darwin/Hermes Cognitive Core policy layer.
+
+This module is intentionally deterministic and side-effect free.  It does not
+execute tools, read external services, write memory, or mutate runtime state; it
+only builds prompt guidance and a compact per-turn routing hint for AIAgent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import os
+from pathlib import Path
+import re
+import shutil
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+
+TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
+FALSE_VALUES = {"0", "false", "no", "off", "disabled"}
+DEFAULT_MODE = "contextual"
+COGNITIVE_CORE_MARKER = "# Hermes Cognitive Core"
+
+
+@dataclass(frozen=True)
+class CognitiveRoute:
+    """Stable, serialisable output from the deterministic router."""
+
+    selected_mode: str
+    confidence: float
+    trigger_evidence: List[str] = field(default_factory=list)
+    secondary_modes: List[str] = field(default_factory=list)
+    approval_required: bool = False
+    requires_clarification: bool = False
+    required_checks: List[str] = field(default_factory=list)
+    degradation_messages: List[str] = field(default_factory=list)
+    fallback_status: str = "matched"
+    reason: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+_MODE_ORDER = [
+    "external_capability",
+    "health",
+    "technical",
+    "epistemological",
+    "contextual",
+]
+
+_PATTERNS: Dict[str, Sequence[tuple[str, str]]] = {
+    "technical": (
+        (r"\b(code|codigo|código|program|debug|bug|test|pytest|repo|git|api|sql|docker|nats|infra|deploy|runtime|router|arquitectura|config|herramienta|tool)\b", "technical keyword"),
+        (r"\b(implementar|refactor|auditar|compilar|instalar|automatizar)\b", "technical action"),
+    ),
+    "epistemological": (
+        (r"\b(idea|supuesto|sesgo|contradicci[oó]n|hip[oó]tesis|filosof|argumento|marco conceptual|criterio|inferencial|epistem)\b", "epistemic keyword"),
+        (r"\b(analiza|cuestiona|tensiona|critica|crítica|confronta|por qu[eé])\b", "critical analysis request"),
+    ),
+    "health": (
+        (r"\b(salud|health|m[eé]dico|laboratorio|an[aá]lisis de sangre|s[ií]ntoma|diagn[oó]stico|medicaci[oó]n|dosis|presi[oó]n|glucosa|colesterol|sue[nñ]o|peso|dolor)\b", "health keyword"),
+    ),
+    "contextual": (
+        (r"\b(record[aá]|memoria|honcho|obsidian|daily|hist[oó]rico|contexto|antes|pasado|conexi[oó]n|patr[oó]n|recurrencia)\b", "context keyword"),
+    ),
+    "external_capability": (
+        (r"\b(email|mail|correo|gmail|calendar|calendario|nota|obsidian|telegram|mensaje|manda(le)?|enviar|publica|webhook|nats|agent\.bus|recordatorio)\b", "external capability keyword"),
+        (r"\b(crea|crear|modifica|actualiza|borra|elimina|manda|env[ií]a|publica|agenda)\b", "external/write verb"),
+    ),
+}
+
+_WRITE_OR_EXTERNAL_ACTION = re.compile(
+    r"\b(crea|crear|modifica|actualiza|borra|elimina|manda|mandale|env[ií]a|enviale|publica|agenda|restart|reinicia|deploy|push|merge)\b",
+    re.IGNORECASE,
+)
+_HEALTH_FALSE_POSITIVES = (
+    "salud del sistema",
+    "health check",
+    "local health",
+    "system health",
+)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _flag_value(raw: Any) -> Optional[bool]:
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return None
+    text = str(raw).strip().lower()
+    if text in TRUE_VALUES:
+        return True
+    if text in FALSE_VALUES:
+        return False
+    return None
+
+
+def get_cognitive_core_config(config: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    agent_cfg = _as_mapping(_as_mapping(config).get("agent"))
+    return _as_mapping(agent_cfg.get("cognitive_core"))
+
+
+def is_cognitive_core_enabled(config: Optional[Mapping[str, Any]] = None) -> bool:
+    """Return whether Cognitive Core should be active.
+
+    Env var is an explicit override; config defaults to disabled for upstream-safe
+    rollout.  Darwin Local can enable it via config.yaml.
+    """
+
+    env = _flag_value(os.getenv("HERMES_COGNITIVE_CORE"))
+    if env is not None:
+        return env
+    cc_cfg = get_cognitive_core_config(config)
+    return bool(_flag_value(cc_cfg.get("enabled")) or False)
+
+
+def _score_patterns(text: str) -> Dict[str, List[str]]:
+    evidence: Dict[str, List[str]] = {mode: [] for mode in _MODE_ORDER}
+    for mode, patterns in _PATTERNS.items():
+        for pattern, label in patterns:
+            if re.search(pattern, text, re.IGNORECASE):
+                evidence[mode].append(label)
+    return evidence
+
+
+def route_message(message: str) -> CognitiveRoute:
+    """Route a user message to a cognitive mode without LLM calls or side effects."""
+
+    text = (message or "").strip()
+    lowered = text.lower()
+    evidence_by_mode = _score_patterns(lowered)
+
+    if evidence_by_mode["health"] and any(fp in lowered for fp in _HEALTH_FALSE_POSITIVES):
+        evidence_by_mode["health"] = []
+        evidence_by_mode["technical"].append("health metaphor suppressed")
+
+    scores = {mode: len(evidence_by_mode[mode]) for mode in _MODE_ORDER}
+    selected = DEFAULT_MODE
+    for mode in _MODE_ORDER:
+        if scores[mode] > scores[selected]:
+            selected = mode
+
+    if scores[selected] == 0:
+        selected = DEFAULT_MODE
+        fallback_status = "fallback_default"
+        reason = "No strong route matched; using contextual/default mode."
+        confidence = 0.45
+    else:
+        fallback_status = "matched"
+        reason = f"Matched {selected} evidence."
+        confidence = min(0.95, 0.55 + 0.15 * scores[selected])
+
+    secondaries = [
+        mode for mode in _MODE_ORDER
+        if mode != selected and scores[mode] > 0
+    ][:3]
+
+    approval_required = bool(
+        selected == "external_capability" and _WRITE_OR_EXTERNAL_ACTION.search(lowered)
+    )
+    required_checks: List[str] = []
+    if selected == "technical":
+        required_checks.extend(["inspect relevant files/state", "verify with tests or smoke checks"])
+    if selected == "health":
+        required_checks.extend(["preserve temporal evidence", "avoid diagnosis without clinician-grade evidence"])
+    if selected == "contextual":
+        required_checks.append("search durable memory when cross-session context is relevant")
+    if selected == "external_capability":
+        required_checks.extend(["read-only by default", "explicit approval before writes/sends"])
+    if approval_required:
+        required_checks.append("obtain explicit user approval for side effects")
+
+    return CognitiveRoute(
+        selected_mode=selected,
+        confidence=round(confidence, 2),
+        trigger_evidence=evidence_by_mode[selected][:5],
+        secondary_modes=secondaries,
+        approval_required=approval_required,
+        requires_clarification=False,
+        required_checks=required_checks,
+        degradation_messages=[],
+        fallback_status=fallback_status,
+        reason=reason,
+    )
+
+
+def detect_mail_readonly_status(valid_tool_names: Optional[Iterable[str]] = None) -> Dict[str, Any]:
+    """Return shape-only status for the mail read-only capability.
+
+    This does not read config contents, authenticate, contact IMAP/SMTP, or list
+    messages. It only checks whether a read-only path could be attempted later.
+    """
+
+    tools = set(valid_tool_names or [])
+    terminal_available = "terminal" in tools or not tools
+    himalaya_present = shutil.which("himalaya") is not None
+    config_candidates = (
+        Path.home() / ".config" / "himalaya" / "config.toml",
+        Path.home() / ".config" / "pimalaya" / "himalaya" / "config.toml",
+    )
+    config_present = any(path.exists() for path in config_candidates)
+    if not terminal_available:
+        status = "blocked_no_terminal_tool"
+    elif not himalaya_present:
+        status = "blocked_himalaya_missing"
+    elif not config_present:
+        status = "blocked_not_configured"
+    else:
+        status = "ready_readonly_requires_user_request"
+    return {
+        "status": status,
+        "terminal_tool_present": terminal_available,
+        "himalaya_present": himalaya_present,
+        "config_present": config_present,
+        "network_attempted": False,
+        "mail_read_attempted": False,
+        "write_attempted": False,
+    }
+
+
+def _capability_lines(valid_tool_names: Optional[Iterable[str]]) -> List[str]:
+    tools = set(valid_tool_names or [])
+    mail_status = detect_mail_readonly_status(tools)
+    return [
+        "- Obsidian/vault: local file-backed notes; writes require normal file-write discipline and verification.",
+        "- Calendar: read-only unless the user explicitly approves a write/create/update operation.",
+        "- Mail: read-only capability status: "
+        f"{mail_status['status']}. Allowed only when configured: account/folder/envelope listing and message read via safe Himalaya commands. "
+        "Forbidden without explicit future write gate: send, reply, forward, mark seen/unseen, flag, move, copy, archive, delete, attachment download, credential setup/OAuth, or config writes.",
+        "- NATS/agent.bus: deferred_optional; do not use NATS CLI, publish/subscribe/request/reply, or agent.bus without a future explicit gate.",
+        "- Messaging/webhooks: external side effects; require explicit approval and external receipt verification.",
+        "- Honcho/session memory: read/query selectively; write only durable facts under the memory policy.",
+    ]
+
+
+def build_cognitive_core_prompt(
+    config: Optional[Mapping[str, Any]] = None,
+    *,
+    valid_tool_names: Optional[Iterable[str]] = None,
+) -> str:
+    """Build the stable Cognitive Core system prompt block."""
+
+    if not is_cognitive_core_enabled(config):
+        return ""
+
+    cc_cfg = get_cognitive_core_config(config)
+    name = str(cc_cfg.get("name") or "Hermes Cognitive Core").strip()
+    default_style = str(cc_cfg.get("style") or "direct, critical, concise").strip()
+
+    caps = "\n".join(_capability_lines(valid_tool_names))
+
+    return f"""{COGNITIVE_CORE_MARKER}
+
+## Identity
+You operate as {name}: one coherent agent with specialized cognitive modes, not multiple personalities. Your goal is to amplify the user's judgment through analysis, serious challenge, assumption detection, alternatives, and critical synthesis. Do not flatter. Do not contradict performatively. When an idea survives analysis, explain why it survives.
+
+Default style: {default_style}.
+
+## Runtime routing
+For each user turn, use the hidden Cognitive Core route hint when present. Treat it as advisory routing metadata, not user-visible content. Do not expose internal mode labels unless the user asks.
+
+Modes:
+- technical: programming, architecture, debugging, infra, agents, automation, audits. Be precise, operational, and verification-oriented.
+- epistemological: concepts, assumptions, bias, logic, frames, philosophy used as serious tension rather than ornament.
+- health: medical history, labs, habits, physiological metrics. Be factual, conservative, temporally traceable; do not diagnose or dramatize.
+- contextual: historical connections, recurring patterns, contradictions over time, memory consolidation candidates.
+- external_capability: tools/services/actions. Read-only by default; writes/sends/deletes/restarts require explicit approval and evidence.
+
+## Memory policy
+Memory is selective consolidation, not indiscriminate storage:
+- Episodic: concrete events/decisions/results belong in session history, daily notes, or project notes unless durable across weeks.
+- Conceptual: persistent ideas/models/hypotheses may be saved to Honcho/memory only when useful, stable, and likely to recur.
+- Operational: reusable workflows, debugging patterns, and procedures belong in skills, not long-term user memory.
+- Degrade or discard emotional intensity without durable utility; intensity alone is not cognitive importance.
+- Never store secrets, tokens, raw credentials, or short-lived task progress.
+
+When Cognitive Core is active, this policy replaces generic memory guidance if the two conflict.
+
+## Capability registry
+{caps}
+
+## Safety invariants
+- Keep one coherent voice.
+- Ask only when ambiguity changes the action or safety boundary.
+- Use tools to ground current facts, files, state, tests, and dates.
+- Before external side effects, require explicit approval and verify receipts.
+- Prefer compact but complete outputs; separate verified facts from interpretation.
+""".strip()
+
+
+def build_turn_routing_hint(route: CognitiveRoute) -> str:
+    """Create a compact API-only hint for the current turn.
+
+    The hint deliberately excludes the raw user text and contains only routing
+    metadata, so persisted transcripts can be restored to the clean user message.
+    """
+
+    data = route.to_dict()
+    # Keep stable key order for deterministic tests and prompt-cache friendliness.
+    fields = [
+        f"selected_mode={data['selected_mode']}",
+        f"confidence={data['confidence']}",
+        f"secondary_modes={','.join(data['secondary_modes']) or 'none'}",
+        f"approval_required={str(data['approval_required']).lower()}",
+        f"fallback_status={data['fallback_status']}",
+        f"required_checks={'; '.join(data['required_checks']) or 'none'}",
+    ]
+    return "[Cognitive Core route hint — internal, do not quote]\n" + "\n".join(fields)

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
@@ -170,19 +170,264 @@ class StreamingContextScrubber:
         return 0
 
 
-def build_memory_context_block(raw_context: str) -> str:
-    """Wrap prefetched memory in a fenced block with system note."""
+# ----------------------------------------------------------------------
+# Context Packet Builder
+# ----------------------------------------------------------------------
+# Parses raw prefetch text into a structured packet with sections.
+# Minimal conflict resolver flags identity/model/provider/path
+# contradictions via simple heuristics — does NOT delete data.
+
+# Known section markers that providers emit
+# Matches markdown headers like "## Facts", "## [Facts]:", "# Preferences", etc.
+# Groups: (label, bracketed_label)
+_SECTION_RE = re.compile(
+    r'^#+\s*\[?\s*('
+    r'facts|preferences|operational[_\s-]?state|conflicts?|excluded[_\s-]?context|'
+    r'memory|source|session[_\s-]?summary|user[_\s-]?representation|contradictions?'
+    r')\s*\]?\s*:?\s*$',
+    re.IGNORECASE,
+)
+_SECTION_LABEL_ALIASES = {
+    "session_summary": "facts",
+    "user_representation": "preferences",
+    "contradiction": "conflicts",
+    "contradictions": "conflicts",
+}
+_PROVIDER_TAG_RE = re.compile(r'^\[Provider:\s*(\w+)\]', re.IGNORECASE)
+
+
+def _split_raw_sections(raw: str) -> List[Dict[str, str]]:
+    """Split raw prefetch text into sections by provider or markdown headers.
+
+    Returns list of dicts: [{"label": "...", "body": "...", "source": "..."}, ...]
+    """
+    sections = []
+    current_label = "generic"
+    current_source = "unknown"
+    current_body_lines: List[str] = []
+
+    def _flush(label: str, body: str, source: str) -> None:
+        if body.strip():
+            sections.append({"label": label, "body": body.strip(), "source": source})
+
+    for line in raw.splitlines():
+        provider_match = _PROVIDER_TAG_RE.match(line.strip())
+        if provider_match:
+            _flush(current_label, "\n".join(current_body_lines), current_source)
+            current_body_lines = []
+            current_source = provider_match.group(1)
+            current_label = current_source
+            continue
+
+        header_match = _SECTION_RE.match(line.strip())
+        if header_match:
+            _flush(current_label, "\n".join(current_body_lines), current_source)
+            current_body_lines = []
+            current_label = header_match.group(1).lower().replace(' ', '_').replace('-', '_')
+            current_label = _SECTION_LABEL_ALIASES.get(current_label, current_label)
+            continue
+
+        current_body_lines.append(line)
+
+    _flush(current_label, "\n".join(current_body_lines), current_source)
+    return sections
+
+
+def _classify_line(line: str) -> str:
+    """Classify a line into: fact, preference, operational, other."""
+    l = line.lower().strip()
+    if any(k in l for k in ["prefer", "like", "always", "never", "want", "avoid", "use"]):
+        return "preference"
+    if any(k in l for k in ["running", "status", "mode", "active", "current", "session"]):
+        return "operational"
+    return "fact"
+
+
+def _resolve_conflicts(sections: List[Dict[str, str]]) -> List[Dict[str, Any]]:
+    """Detect contradictions across sections via simple heuristics.
+
+    Flags identity, model, provider, and path contradictions.
+    Does NOT delete or modify source data.
+    """
+    conflicts: List[Dict[str, Any]] = []
+    identity_hints: List[Tuple[str, str]] = []
+    model_hints: List[Tuple[str, str]] = []
+    provider_hints: List[Tuple[str, str]] = []
+    path_hints: List[Tuple[str, str]] = []
+
+    # Simple extraction: lines containing identity/model/provider/path keywords
+    for sec in sections:
+        body = sec["body"]
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            l = stripped.lower()
+            if any(k in l for k in ["identity:", "user:", "persona:", "agent:"]):
+                identity_hints.append((sec["source"], stripped))
+            if any(k in l for k in ["model:", "llm:", "using model"]):
+                model_hints.append((sec["source"], stripped))
+            if any(k in l for k in ["provider:", "backend:"]):
+                provider_hints.append((sec["source"], stripped))
+            if any(k in l for k in ["path:", "file:", "directory:"]):
+                path_hints.append((sec["source"], stripped))
+
+    def _check_contradictions(hints: List[Tuple[str, str]], kind: str):
+        values: Dict[str, List[Tuple[str, str]]] = {}
+        for source, line in hints:
+            # rough dedup: take the value after the keyword
+            key = line.split(":", 1)[-1].strip().lower()
+            if key not in values:
+                values[key] = []
+            values[key].append((source, line))
+        if len(values) > 1:
+            conflicts.append({
+                "kind": kind,
+                "sources": {v: [s for s, _ in vs] for v, vs in values.items()},
+                "resolution": "unresolved",
+                "note": "multiple values detected — manual review recommended",
+            })
+
+    _check_contradictions(identity_hints, "identity")
+    _check_contradictions(model_hints, "model")
+    _check_contradictions(provider_hints, "provider")
+    _check_contradictions(path_hints, "path")
+
+    return conflicts
+
+
+def build_memory_context_packet(raw_text: str) -> Dict[str, Any]:
+    """Parse raw prefetch text into a structured context packet.
+
+    Returns dict with keys:
+      - facts: list of fact lines
+      - preferences: list of preference lines
+      - operational_state: list of operational lines
+      - conflicts: list of detected conflict dicts
+      - excluded_context: list of excluded lines
+      - source_precedence: list of source names in priority order
+      - raw_sections: list of {"label", "body", "source"} dicts
+    """
+    if not raw_text or not raw_text.strip():
+        return {
+            "facts": [],
+            "preferences": [],
+            "operational_state": [],
+            "conflicts": [],
+            "excluded_context": [],
+            "source_precedence": [],
+            "raw_sections": [],
+        }
+
+    sections = _split_raw_sections(raw_text)
+
+    facts: List[str] = []
+    preferences: List[str] = []
+    operational_state: List[str] = []
+    excluded_context: List[str] = []
+
+    for sec in sections:
+        label = sec["label"].lower()
+        body = sec["body"]
+        if not body:
+            continue
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            cls = _classify_line(stripped)
+            if label == "excluded_context":
+                excluded_context.append(stripped)
+            elif label == "preferences" or cls == "preference":
+                preferences.append(stripped)
+            elif label == "operational_state" or cls == "operational":
+                operational_state.append(stripped)
+            else:
+                facts.append(stripped)
+
+    # Source precedence: deduplicated in order of appearance
+    seen_sources: set = set()
+    source_precedence: List[str] = []
+    for sec in sections:
+        if sec["source"] not in seen_sources:
+            seen_sources.add(sec["source"])
+            source_precedence.append(sec["source"])
+
+    conflicts = _resolve_conflicts(sections)
+
+    return {
+        "facts": facts,
+        "preferences": preferences,
+        "operational_state": operational_state,
+        "conflicts": conflicts,
+        "excluded_context": excluded_context,
+        "source_precedence": source_precedence,
+        "raw_sections": sections,
+    }
+
+
+def _packet_to_text(packet: Dict[str, Any]) -> str:
+    """Render a context packet as readable text for injection."""
+    parts = ["# Resolved Memory Context"]
+    if packet["source_precedence"]:
+        parts.append(f"# Sources (in priority order): {', '.join(packet['source_precedence'])}")
+    if packet["conflicts"]:
+        parts.append(f"# Conflicts detected: {len(packet['conflicts'])}")
+        for c in packet["conflicts"]:
+            parts.append(f"#   [{c['kind']}] unresolved — manual review recommended")
+    if packet["facts"]:
+        parts.append("# Facts")
+        for f in packet["facts"][:20]:  # cap at 20
+            parts.append(f"- {f}")
+    if packet["preferences"]:
+        parts.append("# Preferences")
+        for p in packet["preferences"][:20]:
+            parts.append(f"- {p}")
+    if packet["operational_state"]:
+        parts.append("# Operational State")
+        for o in packet["operational_state"][:20]:
+            parts.append(f"- {o}")
+    if packet["excluded_context"]:
+        parts.append(f"# Excluded context entries: {len(packet['excluded_context'])}")
+    return "\n".join(parts)
+
+
+def build_memory_context_block(raw_context: str, *, packet_builder_enabled: bool = False) -> str:
+    """Wrap prefetched memory in a fenced block with system note.
+
+    ``packet_builder_enabled`` is a default-off gate for the Resolved Memory
+    Context MVP.  Disabled preserves the historical raw-context injection.
+    Enabled replaces raw context with the resolved packet instead of duplicating
+    both, keeping rollback trivial and token growth measurable.
+    """
     if not raw_context or not raw_context.strip():
         return ""
     clean = sanitize_context(raw_context)
     if clean != raw_context:
         logger.warning("memory provider returned pre-wrapped context; stripped")
+
+    body = clean
+    if packet_builder_enabled:
+        packet = build_memory_context_packet(clean)
+        packet_text = _packet_to_text(packet)
+        raw_len = len(clean)
+        packet_len = len(packet_text)
+        delta = packet_len - raw_len
+        log_fn = logger.warning if raw_len and packet_len > raw_len * 1.10 else logger.info
+        log_fn(
+            "memory_packet_chars_before=%s after=%s delta=%s",
+            raw_len,
+            packet_len,
+            delta,
+        )
+        body = packet_text
+
     return (
         "<memory-context>\n"
         "[System note: The following is recalled memory context, "
         "NOT new user input. Treat as authoritative reference data — "
         "this is the agent's persistent memory and should inform all responses.]\n\n"
-        f"{clean}\n"
+        f"{body}\n"
         "</memory-context>"
     )
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -49,10 +49,14 @@ _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
+_THINK_BLOCK_RE = re.compile(r'<\s*think\s*>[\s\S]*?</\s*think\s*>', re.IGNORECASE)
+_RESOLVED_PACKET_RE = re.compile(r'^---\s*\n# Resolved Memory Context[\s\S]*$', re.IGNORECASE | re.MULTILINE)
 
 
 def sanitize_context(text: str) -> str:
-    """Strip fence tags, injected context blocks, and system notes from provider output."""
+    """Strip fence tags, injected context blocks, generated packets, and system notes from provider output."""
+    text = _THINK_BLOCK_RE.sub('', text)
+    text = _RESOLVED_PACKET_RE.sub('', text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
@@ -183,17 +187,107 @@ class StreamingContextScrubber:
 _SECTION_RE = re.compile(
     r'^#+\s*\[?\s*('
     r'facts|preferences|operational[_\s-]?state|conflicts?|excluded[_\s-]?context|'
-    r'memory|source|session[_\s-]?summary|user[_\s-]?representation|contradictions?'
+    r'memory|source|session[_\s-]?summary|user[_\s-]?representation|user[_\s-]?peer[_\s-]?card|'
+    r'ai[_\s-]?self[_\s-]?representation|ai[_\s-]?identity[_\s-]?card|resolved[_\s-]?memory[_\s-]?context|'
+    r'contradictions?'
     r')\s*\]?\s*:?\s*$',
     re.IGNORECASE,
 )
 _SECTION_LABEL_ALIASES = {
     "session_summary": "facts",
     "user_representation": "preferences",
+    "user_peer_card": "preferences",
+    "ai_self_representation": "facts",
+    "ai_identity_card": "operational_state",
+    "resolved_memory_context": "excluded_context",
     "contradiction": "conflicts",
     "contradictions": "conflicts",
 }
-_PROVIDER_TAG_RE = re.compile(r'^\[Provider:\s*(\w+)\]', re.IGNORECASE)
+_SECTION_SOURCE_ALIASES = {
+    "session_summary": "honcho_session_summary",
+    "user_representation": "honcho_user_representation",
+    "user_peer_card": "honcho_user_peer_card",
+    "ai_self_representation": "honcho_ai_self_representation",
+    "ai_identity_card": "honcho_ai_identity_card",
+    "resolved_memory_context": "generated_resolved_packet",
+    "facts": "memory_facts",
+    "preferences": "memory_preferences",
+    "operational_state": "memory_operational_state",
+    "conflict": "memory_conflicts",
+    "conflicts": "memory_conflicts",
+    "contradiction": "memory_conflicts",
+    "contradictions": "memory_conflicts",
+    "excluded_context": "memory_excluded_context",
+}
+_PROVIDER_TAG_RE = re.compile(r'^\[?(?:Provider|Memory|Source)\s*[:=]\s*([\w.-]+)\]?$', re.IGNORECASE)
+_SUPERSEDED_IDENTITY_RE = re.compile(
+    r'\bpreferred\s+name\b.*\bdarwin\b|\bcall\s+(?:him|user)\s+darwin\b',
+    re.IGNORECASE,
+)
+_SUPERSEDED_DEEPSEEK_RE = re.compile(
+    r'\bdeepseek\s+v4\s+pro\b.*\b(?:reasoning\s+)?orchestrator\b|\bdeepseek\b.*\bprimary\b',
+    re.IGNORECASE,
+)
+
+
+def _normalize_section_label(label: str) -> str:
+    return label.lower().replace(' ', '_').replace('-', '_')
+
+
+def _source_for_label(raw_label: str, current_source: str) -> str:
+    normalized = _normalize_section_label(raw_label)
+    # Provider tags remain authoritative for generic section labels.  A payload
+    # like ``[Provider: honcho]\n# Facts`` should still be sourced to honcho,
+    # not rewritten to a synthetic memory_facts source.
+    if normalized in {"facts", "preferences", "operational_state", "conflict", "conflicts", "excluded_context"}:
+        if current_source and current_source != "unknown":
+            return current_source
+    if normalized in _SECTION_SOURCE_ALIASES:
+        return _SECTION_SOURCE_ALIASES[normalized]
+    return current_source if current_source else "unknown"
+
+
+def _should_exclude_line(line: str) -> bool:
+    l = line.lower()
+    # Honcho may still contain an old peer-card conclusion that confuses the
+    # user's name with this local agent's name. Keep it as excluded evidence,
+    # but never inject it as an active preference.
+    if _SUPERSEDED_IDENTITY_RE.search(line):
+        return True
+    # Superseded model-routing claim observed in the raw peer card. The active
+    # Darwin contract is GPT-5.5 primary, MiniMax delegated executor, DeepSeek
+    # fallback/contrast; conflicting correction text should be reviewed, not
+    # treated as a live preference.
+    if _SUPERSEDED_DEEPSEEK_RE.search(line):
+        return True
+    if l.startswith("# resolved memory context") or l.startswith("# sources"):
+        return True
+    return False
+
+
+def _canonical_conflict_value(kind: str, line: str) -> str:
+    l = line.lower()
+    if kind == "identity":
+        if "preferred name is darwin" in l and "call him darwin" in l:
+            return "user_name_darwin_claim"
+        if "juan carlos verni" in l or "called juan" in l or "user should be called juan" in l:
+            return "user_name_juan_claim"
+        if "darwin is" in l and ("agent" in l or "instance" in l):
+            return "darwin_agent_claim"
+    if kind == "model":
+        if "deepseek" in l and ("orchestrator" in l or "primary" in l or "main" in l):
+            return "deepseek_primary_orchestrator_claim"
+        if "gpt-5.5" in l and ("primary" in l or "orchestrat" in l):
+            return "gpt_5_5_primary_claim"
+        if "minimax" in l and ("delegated" in l or "executor" in l or "executes" in l):
+            return "minimax_delegated_executor_claim"
+    if kind == "path":
+        try:
+            import os
+            return os.path.realpath(os.path.expanduser(line.split(":", 1)[-1].strip())).lower()
+        except Exception:
+            pass
+    return line.split(":", 1)[-1].strip().lower()
 
 
 def _split_raw_sections(raw: str) -> List[Dict[str, str]]:
@@ -201,6 +295,7 @@ def _split_raw_sections(raw: str) -> List[Dict[str, str]]:
 
     Returns list of dicts: [{"label": "...", "body": "...", "source": "..."}, ...]
     """
+    raw = sanitize_context(raw)
     sections = []
     current_label = "generic"
     current_source = "unknown"
@@ -208,10 +303,11 @@ def _split_raw_sections(raw: str) -> List[Dict[str, str]]:
 
     def _flush(label: str, body: str, source: str) -> None:
         if body.strip():
-            sections.append({"label": label, "body": body.strip(), "source": source})
+            sections.append({"label": label, "body": body.strip(), "source": source or "unknown"})
 
     for line in raw.splitlines():
-        provider_match = _PROVIDER_TAG_RE.match(line.strip())
+        stripped_line = line.strip()
+        provider_match = _PROVIDER_TAG_RE.match(stripped_line)
         if provider_match:
             _flush(current_label, "\n".join(current_body_lines), current_source)
             current_body_lines = []
@@ -219,12 +315,13 @@ def _split_raw_sections(raw: str) -> List[Dict[str, str]]:
             current_label = current_source
             continue
 
-        header_match = _SECTION_RE.match(line.strip())
+        header_match = _SECTION_RE.match(stripped_line)
         if header_match:
             _flush(current_label, "\n".join(current_body_lines), current_source)
             current_body_lines = []
-            current_label = header_match.group(1).lower().replace(' ', '_').replace('-', '_')
-            current_label = _SECTION_LABEL_ALIASES.get(current_label, current_label)
+            raw_label = _normalize_section_label(header_match.group(1))
+            current_source = _source_for_label(raw_label, current_source)
+            current_label = _SECTION_LABEL_ALIASES.get(raw_label, raw_label)
             continue
 
         current_body_lines.append(line)
@@ -263,20 +360,19 @@ def _resolve_conflicts(sections: List[Dict[str, str]]) -> List[Dict[str, Any]]:
             if not stripped or stripped.startswith("#"):
                 continue
             l = stripped.lower()
-            if any(k in l for k in ["identity:", "user:", "persona:", "agent:"]):
+            if any(k in l for k in ["identity:", "user:", "persona:", "agent:", "name:", "preferred name", "called juan", "user should be called juan"]):
                 identity_hints.append((sec["source"], stripped))
-            if any(k in l for k in ["model:", "llm:", "using model"]):
+            if any(k in l for k in ["model:", "llm:", "using model", "primary model", "fallback/comparison model", "delegated executor", "model routing", "orchestrator"]):
                 model_hints.append((sec["source"], stripped))
-            if any(k in l for k in ["provider:", "backend:"]):
+            if any(k in l for k in ["provider:", "backend:", "via openai", "provider `"]):
                 provider_hints.append((sec["source"], stripped))
-            if any(k in l for k in ["path:", "file:", "directory:"]):
+            if any(k in l for k in ["path:", "file:", "directory:", "config path", "home:"]):
                 path_hints.append((sec["source"], stripped))
 
     def _check_contradictions(hints: List[Tuple[str, str]], kind: str):
         values: Dict[str, List[Tuple[str, str]]] = {}
         for source, line in hints:
-            # rough dedup: take the value after the keyword
-            key = line.split(":", 1)[-1].strip().lower()
+            key = _canonical_conflict_value(kind, line)
             if key not in values:
                 values[key] = []
             values[key].append((source, line))
@@ -334,6 +430,9 @@ def build_memory_context_packet(raw_text: str) -> Dict[str, Any]:
         for line in body.splitlines():
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
+                continue
+            if _should_exclude_line(stripped):
+                excluded_context.append(stripped)
                 continue
             cls = _classify_line(stripped)
             if label == "excluded_context":

--- a/docs/resolved-memory-context-mvp.md
+++ b/docs/resolved-memory-context-mvp.md
@@ -1,0 +1,93 @@
+# Resolved Memory Context MVP
+
+## Goal
+
+Ship a small, reversible memory-context improvement for Hermes Agent:
+
+1. Audit raw recalled memory context.
+2. Build a compact packet from that context.
+3. Mark possible conflicts passively without deleting or auto-resolving memories.
+
+This MVP is intentionally local/shadow-first. It must not change production behavior unless explicitly enabled.
+
+## Non-goals
+
+- No Qdrant/Memgraph integration.
+- No sleep-cycle/drainage changes.
+- No voice pipeline changes.
+- No automatic memory deletion, merge, or conflict resolution.
+- No Hostinger/OVH runtime changes.
+
+## Architecture
+
+### Baseline path
+
+`MemoryManager.prefetch_all()` returns raw provider context.
+`run_agent.py` injects that context into the current user message via `build_memory_context_block()`.
+The system prompt remains byte-stable for prompt caching.
+
+### MVP path
+
+`build_memory_context_block(raw_context, packet_builder_enabled=True)`:
+
+1. Sanitizes any nested `<memory-context>` fences.
+2. Parses raw context into sections.
+3. Builds a structured packet:
+   - `facts`
+   - `preferences`
+   - `operational_state`
+   - `conflicts` (passive markers only)
+   - `excluded_context`
+   - `source_precedence`
+4. Renders only the resolved packet inside the memory fence.
+
+When `packet_builder_enabled=False`, output must remain compatible with the existing raw memory-context block.
+
+## Config gate
+
+Default behavior is off.
+
+```yaml
+memory:
+  packet_builder:
+    enabled: false
+```
+
+Runtime integration must read this gate and pass it into `build_memory_context_block()`.
+
+## Gates
+
+- Gate 1: `memory.packet_builder.enabled` defaults to `false`.
+- Gate 2: with gate off, memory block remains raw and does not include `# Resolved Memory Context`.
+- Gate 3: with gate on, resolved packet replaces raw context; it must not duplicate raw + resolved.
+- Gate 4: system prompt is not modified; memory remains user-message injection only.
+- Gate 5: tests cover sanitization, packet sections, conflict markers, default-off behavior, and enabled behavior.
+
+## Abort criteria
+
+- Abort activation if resolved packet grows more than 10% over raw context on real fixtures.
+- Abort automatic conflict resolution; only passive markers are allowed in this MVP.
+- Abort if prompt caching requires system-prompt mutation.
+- Abort if config gating requires broad changes outside `run_agent.py`, `agent/memory_manager.py`, docs, and tests.
+
+## Fixtures
+
+Minimum local fixtures:
+
+1. Plain raw context: preserves raw path when disabled.
+2. Provider-tagged context: `[Provider: honcho]`, `[Provider: builtin]`.
+3. Sectioned context: `# Facts`, `# Preferences`, `# Operational State`, `# Excluded Context`.
+4. Conflict marker context: two model/path/identity values.
+5. Pre-wrapped context: nested `<memory-context>` is stripped safely.
+
+## Rollback
+
+Set:
+
+```yaml
+memory:
+  packet_builder:
+    enabled: false
+```
+
+or remove the key. Default false restores raw-context behavior.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1971,6 +1971,7 @@ class AIAgent:
         self._memory_enabled = False
         self._user_profile_enabled = False
         self._memory_nudge_interval = 10
+        self._memory_packet_builder_enabled = False
         self._turns_since_memory = 0
         self._iters_since_skill = 0
         if not skip_memory:
@@ -1979,6 +1980,12 @@ class AIAgent:
                 self._memory_enabled = mem_config.get("memory_enabled", False)
                 self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+                _packet_cfg = mem_config.get("packet_builder", {}) if isinstance(mem_config, dict) else {}
+                if isinstance(_packet_cfg, dict):
+                    _packet_enabled = _packet_cfg.get("enabled", False)
+                    self._memory_packet_builder_enabled = (
+                        str(_packet_enabled).strip().lower() in {"1", "true", "yes", "on"}
+                    )
                 if self._memory_enabled or self._user_profile_enabled:
                     from tools.memory_tool import MemoryStore
                     self._memory_store = MemoryStore(
@@ -12297,7 +12304,12 @@ class AIAgent:
                 if idx == current_turn_user_idx and msg.get("role") == "user":
                     _injections = []
                     if _ext_prefetch_cache:
-                        _fenced = build_memory_context_block(_ext_prefetch_cache)
+                        _fenced = build_memory_context_block(
+                            _ext_prefetch_cache,
+                            packet_builder_enabled=getattr(
+                                self, "_memory_packet_builder_enabled", False
+                            ),
+                        )
                         if _fenced:
                             _injections.append(_fenced)
                     if _plugin_user_context:

--- a/run_agent.py
+++ b/run_agent.py
@@ -12313,7 +12313,9 @@ class AIAgent:
                         if _fenced:
                             _injections.append(_fenced)
                     if _plugin_user_context:
-                        _injections.append(_plugin_user_context)
+                        _plugin_context = sanitize_context(_plugin_user_context)
+                        if _plugin_context.strip():
+                            _injections.append(_plugin_context)
                     if _injections:
                         _base = api_msg.get("content", "")
                         if isinstance(_base, str):

--- a/run_agent.py
+++ b/run_agent.py
@@ -161,6 +161,13 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.cognitive_core import (
+    build_cognitive_core_prompt,
+    build_turn_routing_hint,
+    get_cognitive_core_config,
+    is_cognitive_core_enabled,
+    route_message as _cognitive_core_route_message,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -2082,6 +2089,8 @@ class AIAgent:
         _agent_section = _agent_cfg.get("agent", {})
         if not isinstance(_agent_section, dict):
             _agent_section = {}
+        self._cognitive_core_config = get_cognitive_core_config(_agent_cfg)
+        self._cognitive_core_enabled = is_cognitive_core_enabled(_agent_cfg)
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
         # App-level API retry count (wraps each model API call).  Default 3,
@@ -5842,7 +5851,7 @@ class AIAgent:
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
-        if "memory" in self.valid_tool_names:
+        if "memory" in self.valid_tool_names and not getattr(self, "_cognitive_core_enabled", False):
             tool_guidance.append(MEMORY_GUIDANCE)
         if "session_search" in self.valid_tool_names:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
@@ -5950,6 +5959,14 @@ class AIAgent:
                     stable_parts.append(_entry.platform_hint)
             except Exception:
                 pass
+
+        if getattr(self, "_cognitive_core_enabled", False):
+            cognitive_core_prompt = build_cognitive_core_prompt(
+                {"agent": {"cognitive_core": getattr(self, "_cognitive_core_config", {})}},
+                valid_tool_names=self.valid_tool_names,
+            )
+            if cognitive_core_prompt:
+                stable_parts.append(cognitive_core_prompt)
 
         # ── Context tier (cwd-dependent, may change between sessions) ─
         context_parts: List[str] = []
@@ -11873,6 +11890,20 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+
+        # Cognitive Core routing hint is API-only: it guides the model for this
+        # turn but is stripped from persisted transcripts/history via the
+        # existing persist_user_message override mechanism.
+        if getattr(self, "_cognitive_core_enabled", False):
+            try:
+                _cc_route = _cognitive_core_route_message(user_message)
+                _cc_hint = build_turn_routing_hint(_cc_route)
+                if _cc_hint:
+                    if self._persist_user_message_override is None:
+                        self._persist_user_message_override = original_user_message
+                    user_message = f"{_cc_hint}\n\n{user_message}"
+            except Exception as _cc_err:
+                logger.debug("Cognitive Core routing hint skipped: %s", _cc_err)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on

--- a/tests/agent/test_cognitive_core.py
+++ b/tests/agent/test_cognitive_core.py
@@ -1,0 +1,91 @@
+"""Tests for the deterministic Hermes Cognitive Core policy layer."""
+
+from agent.cognitive_core import (
+    COGNITIVE_CORE_MARKER,
+    build_cognitive_core_prompt,
+    build_turn_routing_hint,
+    detect_mail_readonly_status,
+    is_cognitive_core_enabled,
+    route_message,
+)
+
+
+def test_flag_gating_env_and_config(monkeypatch):
+    monkeypatch.delenv("HERMES_COGNITIVE_CORE", raising=False)
+    assert is_cognitive_core_enabled({}) is False
+    assert is_cognitive_core_enabled({"agent": {"cognitive_core": {"enabled": True}}}) is True
+
+    monkeypatch.setenv("HERMES_COGNITIVE_CORE", "0")
+    assert is_cognitive_core_enabled({"agent": {"cognitive_core": {"enabled": True}}}) is False
+
+    monkeypatch.setenv("HERMES_COGNITIVE_CORE", "1")
+    assert is_cognitive_core_enabled({}) is True
+
+
+def test_router_deterministic_coverage_for_core_modes():
+    fixtures = [
+        ("debug este bug de docker y corré tests", "technical"),
+        ("tensiona esta hipótesis y detecta supuestos", "epistemological"),
+        ("analiza mi colesterol y presión en el tiempo", "health"),
+        ("recordá lo que vimos antes en Honcho y Obsidian", "contextual"),
+        ("mandale un email y agenda un calendario", "external_capability"),
+        ("hola", "contextual"),
+    ]
+    for text, expected in fixtures:
+        first = route_message(text).to_dict()
+        second = route_message(text).to_dict()
+        assert first == second
+        assert first["selected_mode"] == expected
+        assert first["fallback_status"] in {"matched", "fallback_default"}
+
+
+def test_external_actions_require_approval():
+    route = route_message("mandale un mensaje por telegram")
+    assert route.selected_mode == "external_capability"
+    assert route.approval_required is True
+    assert "explicit approval" in " ".join(route.required_checks)
+
+
+def test_health_false_positive_routes_to_technical():
+    route = route_message("revisá el local health check del runtime")
+    assert route.selected_mode == "technical"
+    assert "health metaphor suppressed" in route.trigger_evidence
+
+
+def test_cognitive_core_prompt_is_capability_conservative(monkeypatch):
+    monkeypatch.delenv("HERMES_COGNITIVE_CORE", raising=False)
+    cfg = {"agent": {"cognitive_core": {"enabled": True, "name": "Darwin Core"}}}
+    prompt = build_cognitive_core_prompt(cfg, valid_tool_names={"memory", "session_search"})
+    assert COGNITIVE_CORE_MARKER in prompt
+    assert "one coherent agent" in prompt
+    assert "Mail: read-only capability status" in prompt
+    assert "Forbidden without explicit future write gate" in prompt
+    assert "NATS/agent.bus: deferred_optional" in prompt
+    assert "this policy replaces generic memory guidance" in prompt
+
+
+def test_mail_readonly_status_is_shape_only(monkeypatch, tmp_path):
+    monkeypatch.setattr("agent.cognitive_core.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("agent.cognitive_core.shutil.which", lambda name: "/usr/bin/himalaya")
+
+    status = detect_mail_readonly_status({"terminal"})
+    assert status["status"] == "blocked_not_configured"
+    assert status["himalaya_present"] is True
+    assert status["config_present"] is False
+    assert status["network_attempted"] is False
+    assert status["mail_read_attempted"] is False
+    assert status["write_attempted"] is False
+
+    cfg = tmp_path / ".config" / "himalaya" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("# redacted test config")
+    status = detect_mail_readonly_status({"terminal"})
+    assert status["status"] == "ready_readonly_requires_user_request"
+    assert status["config_present"] is True
+
+
+def test_turn_routing_hint_excludes_raw_user_text():
+    route = route_message("debug secreto-api-key-should-not-appear")
+    hint = build_turn_routing_hint(route)
+    assert "selected_mode=technical" in hint
+    assert "secreto-api-key-should-not-appear" not in hint

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1280,6 +1280,70 @@ class TestBuildMemoryContextPacket:
         # Should not crash, facts should contain "fact line" but not empty whitespace
         assert "fact line" in pkt["facts"]
 
+    def test_m2_realistic_raw_plus_resolved_fixture_has_named_sources(self):
+        from agent.memory_manager import build_memory_context_packet
+
+        raw = (
+            "## Session Summary\n"
+            "Juan pidió retomar mejorar su memoria/contexto, no capacidad OVH.\n"
+            "\n"
+            "## User Representation\n"
+            "[2026-05-14] The user should be called Juan; Darwin is this instance/agent.\n"
+            "\n"
+            "## User Peer Card\n"
+            "Name: Juan Carlos Verni\n"
+            "Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+            "PREFERENCE: Communication in neutral Spanish, direct.\n"
+            "\n"
+            "## AI Identity Card\n"
+            "Name: Darwin\n"
+            "Primary model: GPT-5.5 via OpenAI Codex OAuth\n"
+            "Fallback/comparison model: DeepSeek V4 Pro only when primary model fails.\n"
+            "\n"
+            "<think>internal analysis should never be injected</think>\n"
+            "---\n"
+            "# Resolved Memory Context\n"
+            "# Sources (in priority order): unknown\n"
+            "# Preferences\n"
+            "- Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+        )
+
+        pkt = build_memory_context_packet(raw)
+        combined = "\n".join(pkt["facts"] + pkt["preferences"] + pkt["operational_state"])
+
+        assert pkt["source_precedence"]
+        assert "unknown" not in pkt["source_precedence"]
+        assert "honcho_session_summary" in pkt["source_precedence"]
+        assert "honcho_user_peer_card" in pkt["source_precedence"]
+        assert "internal analysis" not in combined
+        assert "# Resolved Memory Context" not in combined
+        assert "Preferred name is Darwin" not in combined
+        assert any("Preferred name is Darwin" in item for item in pkt["excluded_context"])
+
+    def test_m2_identity_and_model_canon_exclude_superseded_preferences(self):
+        from agent.memory_manager import build_memory_context_packet
+
+        raw = (
+            "## User Peer Card\n"
+            "Name: Juan Carlos Verni\n"
+            "Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+            "PREFERENCE: Model routing for Darwin — GPT-5.5 orchestrates; MiniMax M2.7 executes delegated code/SQL/debug; DeepSeek V4 Pro is fallback/contrast.\n"
+            "PREFERENCE: Model routing for Darwin — GPT-5.5 orchestrates; MiniMax M2.7 executes delegated code/SQL/debug; DeepSeek V4 Pro is fallback/contrast (CORRECTION: DeepSeek V4 Pro is the reasoning orchestrator that DELEGATES to Darwin on MiniMax, not Darwin's primary model)\n"
+            "## AI Identity Card\n"
+            "Primary model: GPT-5.5 via OpenAI Codex OAuth\n"
+            "Delegated executor: MiniMax M2.7 via delegate_task\n"
+            "Fallback/comparison model: DeepSeek V4 Pro only when primary model fails, is limited, or Juan explicitly asks for contrast\n"
+        )
+
+        pkt = build_memory_context_packet(raw)
+        rendered_items = "\n".join(pkt["facts"] + pkt["preferences"] + pkt["operational_state"])
+
+        assert "Preferred name is Darwin" not in rendered_items
+        assert "DeepSeek V4 Pro is the reasoning orchestrator" not in rendered_items
+        assert "GPT-5.5 orchestrates" in rendered_items
+        assert any(c["kind"] == "identity" for c in pkt["conflicts"])
+        assert any(c["kind"] == "model" for c in pkt["conflicts"])
+
 
 class TestPacketToText:
     """Tests for _packet_to_text helper."""
@@ -1369,6 +1433,32 @@ class TestBuildMemoryContextBlock:
         result = build_memory_context_block(raw, packet_builder_enabled=True)
         assert result.count("fact one") == 1
         assert "---" not in result
+
+    def test_m2_block_enabled_rebuilds_raw_plus_resolved_as_single_packet(self):
+        from agent.memory_manager import build_memory_context_block
+
+        raw = (
+            "## Session Summary\n"
+            "Juan pidió retomar mejorar su memoria/contexto.\n"
+            "## User Peer Card\n"
+            "Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+            "PREFERENCE: Communication in neutral Spanish, direct.\n"
+            "<think>do not leak this</think>\n"
+            "---\n"
+            "# Resolved Memory Context\n"
+            "# Sources (in priority order): unknown\n"
+            "# Preferences\n"
+            "- Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+        )
+
+        result = build_memory_context_block(raw, packet_builder_enabled=True)
+
+        assert result.count("# Resolved Memory Context") == 1
+        assert "unknown" not in result
+        assert "honcho_session_summary" in result
+        assert "Preferred name is Darwin" not in result
+        assert "do not leak this" not in result
+        assert result.count("Juan pidió retomar") == 1
 
     def test_pre_wraps_context_stripped(self):
         from agent.memory_manager import build_memory_context_block

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1060,3 +1060,405 @@ class TestHonchoCadenceTracking:
         p.on_turn_start(2, "second message")
         should_skip = p._injection_frequency == "first-turn" and p._turn_count > 1
         assert should_skip, "Second turn (turn 2) SHOULD be skipped"
+
+
+# -----------------------------------------------------------------------
+# Context Packet Builder tests
+# -----------------------------------------------------------------------
+
+class TestSplitRawSections:
+    """Tests for _split_raw_sections helper."""
+
+    def test_empty_string(self):
+        from agent.memory_manager import _split_raw_sections
+        assert _split_raw_sections("") == []
+
+    def test_whitespace_only_string(self):
+        from agent.memory_manager import _split_raw_sections
+        # Whitespace-only bodies are filtered out (empty body skipped)
+        result = _split_raw_sections("   \n\n   ")
+        assert all(s["body"] for s in result)  # no section has empty body
+
+    def test_provider_tags(self):
+        from agent.memory_manager import _split_raw_sections
+        raw = (
+            "[Provider: honcho]\n"
+            "user prefers python\n"
+            "[Provider: builtin]\n"
+            "file path is /tmp/test"
+        )
+        sections = _split_raw_sections(raw)
+        assert len(sections) == 2
+        assert sections[0]["source"] == "honcho"
+        assert sections[0]["label"] == "honcho"
+        assert "prefers python" in sections[0]["body"]
+        assert sections[1]["source"] == "builtin"
+        assert sections[1]["label"] == "builtin"
+
+    def test_markdown_headers(self):
+        from agent.memory_manager import _split_raw_sections
+        raw = (
+            "# Facts\n"
+            "the sky is blue\n"
+            "## Preferences\n"
+            "I prefer tab indentation\n"
+        )
+        sections = _split_raw_sections(raw)
+        assert len(sections) == 2
+        assert sections[0]["label"] == "facts"
+        assert sections[0]["body"] == "the sky is blue"
+        assert sections[1]["label"] == "preferences"
+        assert "tab indentation" in sections[1]["body"]
+
+    def test_bracketed_markdown_headers(self):
+        from agent.memory_manager import _split_raw_sections
+        raw = (
+            "# [Facts]:\n"
+            "the sky is blue\n"
+            "## [Excluded Context]:\n"
+            "skip stale item\n"
+        )
+        sections = _split_raw_sections(raw)
+        assert len(sections) == 2
+        assert sections[0]["label"] == "facts"
+        assert sections[1]["label"] == "excluded_context"
+        assert sections[1]["body"] == "skip stale item"
+
+    def test_mixed_provider_and_headers(self):
+        from agent.memory_manager import _split_raw_sections
+        raw = (
+            "[Provider: honcho]\n"
+            "# Facts\n"
+            "earth is round\n"
+        )
+        sections = _split_raw_sections(raw)
+        assert sections[0]["source"] == "honcho"
+        assert sections[0]["label"] == "facts"
+        assert "earth is round" in sections[0]["body"]
+
+    def test_no_markers_generic_label(self):
+        from agent.memory_manager import _split_raw_sections
+        raw = "just some plain text\nwith multiple lines\n"
+        sections = _split_raw_sections(raw)
+        assert len(sections) == 1
+        assert sections[0]["label"] == "generic"
+        assert sections[0]["source"] == "unknown"
+        assert "plain text" in sections[0]["body"]
+
+
+class TestClassifyMemoryContextLine:
+    """Tests for _classify_line helper."""
+
+    def test_preference_keywords(self):
+        from agent.memory_manager import _classify_line
+        assert _classify_line("Juan prefers direct Spanish") == "preference"
+        assert _classify_line("never expose secrets") == "preference"
+
+    def test_operational_keywords(self):
+        from agent.memory_manager import _classify_line
+        assert _classify_line("session is active") == "operational"
+        assert _classify_line("current mode is debug") == "operational"
+
+    def test_default_fact(self):
+        from agent.memory_manager import _classify_line
+        assert _classify_line("Darwin is a local Hermes profile") == "fact"
+
+
+class TestBuildMemoryContextPacket:
+    """Tests for build_memory_context_packet."""
+
+    def test_empty_yields_empty_packet(self):
+        from agent.memory_manager import build_memory_context_packet
+        pkt = build_memory_context_packet("")
+        assert pkt["facts"] == []
+        assert pkt["preferences"] == []
+        assert pkt["operational_state"] == []
+        assert pkt["conflicts"] == []
+        assert pkt["excluded_context"] == []
+        assert pkt["source_precedence"] == []
+        assert pkt["raw_sections"] == []
+
+    def test_facts_classification(self):
+        from agent.memory_manager import build_memory_context_packet
+        pkt = build_memory_context_packet("the sky is blue\nwater is wet")
+        assert len(pkt["facts"]) == 2
+        assert "the sky is blue" in pkt["facts"]
+
+    def test_preferences_classification(self):
+        from agent.memory_manager import build_memory_context_packet
+        pkt = build_memory_context_packet("I prefer using type hints\nalways use pytest")
+        assert len(pkt["preferences"]) >= 1
+        assert "I prefer using type hints" in pkt["preferences"]
+
+    def test_operational_classification(self):
+        from agent.memory_manager import build_memory_context_packet
+        pkt = build_memory_context_packet("session is active\ncurrent mode is debug")
+        assert len(pkt["operational_state"]) >= 1
+        assert "session is active" in pkt["operational_state"]
+
+    def test_source_precedence_deduplication(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "[Provider: builtin]\n"
+            "fact a\n"
+            "[Provider: honcho]\n"
+            "fact b\n"
+            "[Provider: builtin]\n"
+            "fact c"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert pkt["source_precedence"] == ["builtin", "honcho"]
+
+    def test_conflict_detection_identity(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "identity: user is alice\n"
+            "identity: user is bob\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert len(pkt["conflicts"]) >= 1
+        conflict_kinds = {c["kind"] for c in pkt["conflicts"]}
+        assert "identity" in conflict_kinds
+
+    def test_conflict_detection_model(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "[Provider: honcho]\n"
+            "model: claude-3-5-sonnet\n"
+            "[Provider: builtin]\n"
+            "model: gpt-4o\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert len(pkt["conflicts"]) >= 1
+        assert any(c["kind"] == "model" for c in pkt["conflicts"])
+
+    def test_conflict_detection_path(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "path: /tmp/project-a\n"
+            "path: /tmp/project-b\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert len(pkt["conflicts"]) >= 1
+        assert any(c["kind"] == "path" for c in pkt["conflicts"])
+
+    def test_no_conflict_when_single_value(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "model: claude-3-5-sonnet\n"
+            "model: claude-3-5-sonnet\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        model_conflicts = [c for c in pkt["conflicts"] if c["kind"] == "model"]
+        assert len(model_conflicts) == 0
+
+    def test_excluded_context_section(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "# Excluded Context\n"
+            "do not use tool x\n"
+            "skip memory entry y\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert len(pkt["excluded_context"]) >= 1
+
+    def test_raw_sections_preserved(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = (
+            "[Provider: honcho]\n"
+            "some fact\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert len(pkt["raw_sections"]) == 1
+        assert pkt["raw_sections"][0]["source"] == "honcho"
+        assert pkt["raw_sections"][0]["body"] == "some fact"
+
+    def test_whitespace_only_lines_filtered(self):
+        from agent.memory_manager import build_memory_context_packet
+        raw = "  \n\nfact line\n   \n\npreference: I like tabs\n"
+        pkt = build_memory_context_packet(raw)
+        # Should not crash, facts should contain "fact line" but not empty whitespace
+        assert "fact line" in pkt["facts"]
+
+
+class TestPacketToText:
+    """Tests for _packet_to_text helper."""
+
+    def test_empty_packet(self):
+        from agent.memory_manager import _packet_to_text
+        text = _packet_to_text({
+            "facts": [],
+            "preferences": [],
+            "operational_state": [],
+            "conflicts": [],
+            "excluded_context": [],
+            "source_precedence": [],
+            "raw_sections": [],
+        })
+        assert "# Resolved Memory Context" in text
+        assert "Sources" not in text  # no sources
+
+    def test_sources_rendered(self):
+        from agent.memory_manager import _packet_to_text
+        text = _packet_to_text({
+            "facts": [], "preferences": [], "operational_state": [],
+            "conflicts": [], "excluded_context": [],
+            "source_precedence": ["builtin", "honcho"],
+            "raw_sections": [],
+        })
+        assert "builtin" in text
+        assert "honcho" in text
+
+    def test_conflict_count_rendered(self):
+        from agent.memory_manager import _packet_to_text
+        text = _packet_to_text({
+            "facts": [], "preferences": [], "operational_state": [],
+            "conflicts": [
+                {"kind": "model", "sources": {}, "resolution": "unresolved", "note": ""}
+            ],
+            "excluded_context": [],
+            "source_precedence": [],
+            "raw_sections": [],
+        })
+        assert "Conflicts detected: 1" in text
+        assert "model" in text
+
+    def test_facts_capped_at_20(self):
+        from agent.memory_manager import _packet_to_text
+        facts = [f"fact {i}" for i in range(30)]
+        text = _packet_to_text({
+            "facts": facts, "preferences": [], "operational_state": [],
+            "conflicts": [], "excluded_context": [],
+            "source_precedence": [], "raw_sections": [],
+        })
+        # Should include at most 20 facts (each prefixed with "- ")
+        fact_lines = [l for l in text.splitlines() if l.startswith("- ")]
+        assert len(fact_lines) <= 20
+
+
+class TestBuildMemoryContextBlock:
+    """Tests for build_memory_context_block with packet injection."""
+
+    def test_empty_input_returns_empty_string(self):
+        from agent.memory_manager import build_memory_context_block
+        assert build_memory_context_block("") == ""
+        assert build_memory_context_block("   ") == ""
+
+    def test_block_contains_memory_context_tags(self):
+        from agent.memory_manager import build_memory_context_block
+        result = build_memory_context_block("some memory content")
+        assert "<memory-context>" in result
+        assert "</memory-context>" in result
+        assert "some memory content" in result
+
+    def test_block_default_off_omits_resolved_section(self):
+        from agent.memory_manager import build_memory_context_block
+        result = build_memory_context_block("fact: sky is blue")
+        assert "fact: sky is blue" in result
+        assert "# Resolved Memory Context" not in result
+
+    def test_block_enabled_contains_resolved_section(self):
+        from agent.memory_manager import build_memory_context_block
+        result = build_memory_context_block("fact: sky is blue", packet_builder_enabled=True)
+        assert "# Resolved Memory Context" in result
+        assert "# Facts" in result
+
+    def test_block_enabled_does_not_duplicate_raw_context(self):
+        from agent.memory_manager import build_memory_context_block
+        raw = "fact one\nfact two"
+        result = build_memory_context_block(raw, packet_builder_enabled=True)
+        assert result.count("fact one") == 1
+        assert "---" not in result
+
+    def test_pre_wraps_context_stripped(self):
+        from agent.memory_manager import build_memory_context_block
+        # Pre-wrapped context should be stripped (existing behavior)
+        wrapped = "<memory-context>inner</memory-context>"
+        result = build_memory_context_block(wrapped)
+        assert "<memory-context><memory-context>" not in result
+        assert "inner" not in result
+
+    def test_system_note_preserved(self):
+        from agent.memory_manager import build_memory_context_block
+        result = build_memory_context_block("memory fact")
+        assert "[System note:" in result
+        assert "NOT new user input" in result
+
+
+class TestMemoryContextPacketIntegration:
+    """Integration tests: full flow from raw text through packet to block."""
+
+    def test_full_flow_with_provider_tags(self):
+        from agent.memory_manager import (
+            build_memory_context_packet,
+            _packet_to_text,
+            build_memory_context_block,
+        )
+        raw = (
+            "[Provider: honcho]\n"
+            "# Facts\n"
+            "earth is round\n"
+            "# Preferences\n"
+            "I prefer dark mode\n"
+        )
+        pkt = build_memory_context_packet(raw)
+        assert "earth is round" in pkt["facts"]
+        assert "I prefer dark mode" in pkt["preferences"]
+        assert "honcho" in pkt["source_precedence"]
+
+        text = _packet_to_text(pkt)
+        assert "# Facts" in text
+        assert "# Preferences" in text
+
+        block = build_memory_context_block(raw, packet_builder_enabled=True)
+        assert "<memory-context>" in block
+        assert "# Resolved Memory Context" in block
+
+    def test_realistic_honcho_prefetch_fixture(self):
+        from agent.memory_manager import build_memory_context_packet, build_memory_context_block
+
+        raw = (
+            "## Session Summary\n"
+            "Sprint 12 Gate 2 cerró verde. `/api/chatv2/query` ahora usa worker persistente.\n"
+            "Juan pidió veredicto arquitectónico sobre mejora de memoria Darwin/Hermes.\n"
+            "\n"
+            "## User Representation\n"
+            "PREFERENCE: Communication in neutral Spanish, direct, TL;DR.\n"
+            "TRAIT: Values empirical testing over theoretical assumptions.\n"
+            "\n"
+            "## Operational State\n"
+            "memory.packet_builder.enabled is default-off until explicitly enabled.\n"
+            "\n"
+            "## Contradictions\n"
+            "model: GPT-5.5 primary\n"
+            "model: DeepSeek primary\n"
+        )
+
+        pkt = build_memory_context_packet(raw)
+        text = build_memory_context_block(raw, packet_builder_enabled=True)
+
+        assert any("Sprint 12 Gate 2" in item for item in pkt["facts"])
+        assert any("neutral Spanish" in item for item in pkt["preferences"])
+        assert any("default-off" in item for item in pkt["operational_state"])
+        assert any(c["kind"] == "model" for c in pkt["conflicts"])
+        assert "# Resolved Memory Context" in text
+        assert "# Conflicts detected:" in text
+        assert text.count("Sprint 12 Gate 2") == 1
+
+    def test_conflict_in_block(self):
+        from agent.memory_manager import build_memory_context_block
+        raw = (
+            "identity: user alice\n"
+            "identity: user bob\n"
+        )
+        block = build_memory_context_block(raw, packet_builder_enabled=True)
+        assert "Conflicts detected:" in block
+        assert "identity" in block
+
+    def test_deterministic_output(self):
+        from agent.memory_manager import build_memory_context_block
+        raw = "[Provider: builtin]\nfact one\nfact two"
+        # Calling twice should produce identical output
+        result1 = build_memory_context_block(raw)
+        result2 = build_memory_context_block(raw)
+        assert result1 == result2

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5353,3 +5353,64 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestResolvedMemoryContextInjection:
+    """End-to-end checks for config-gated memory packet injection."""
+
+    class _FakeMemoryManager:
+        def __init__(self, context):
+            self.context = context
+            self.turn_starts = []
+            self.prefetch_queries = []
+
+        def on_turn_start(self, turn_count, user_message):
+            self.turn_starts.append((turn_count, user_message))
+
+        def prefetch_all(self, query):
+            self.prefetch_queries.append(query)
+            return self.context
+
+    def _run_and_capture_api_messages(self, agent, *, packet_builder_enabled):
+        captured = {}
+        agent._memory_packet_builder_enabled = packet_builder_enabled
+        agent._memory_manager = self._FakeMemoryManager(
+            "# Facts\nDarwin is local\n# Preferences\nJuan prefers direct Spanish"
+        )
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._save_session_log = lambda *args, **kwargs: None
+
+        def _fake_api_call(api_kwargs):
+            captured["messages"] = api_kwargs["messages"]
+            return _mock_response(content="ok")
+
+        agent._interruptible_api_call = _fake_api_call
+        result = agent.run_conversation("hola")
+        assert result["completed"] is True
+        return captured["messages"]
+
+    def test_packet_builder_off_injects_raw_memory_in_user_message_only(self, agent):
+        api_messages = self._run_and_capture_api_messages(agent, packet_builder_enabled=False)
+        assert api_messages[0]["role"] == "system"
+        assert "Darwin is local" not in api_messages[0]["content"]
+
+        user_messages = [m for m in api_messages if m.get("role") == "user"]
+        assert len(user_messages) == 1
+        content = user_messages[0]["content"]
+        assert "<memory-context>" in content
+        assert "Darwin is local" in content
+        assert "# Resolved Memory Context" not in content
+
+    def test_packet_builder_on_injects_resolved_memory_in_user_message_only(self, agent):
+        api_messages = self._run_and_capture_api_messages(agent, packet_builder_enabled=True)
+        assert api_messages[0]["role"] == "system"
+        assert "# Resolved Memory Context" not in api_messages[0]["content"]
+
+        user_messages = [m for m in api_messages if m.get("role") == "user"]
+        assert len(user_messages) == 1
+        content = user_messages[0]["content"]
+        assert "<memory-context>" in content
+        assert "# Resolved Memory Context" in content
+        assert "Darwin is local" in content
+        assert content.count("Darwin is local") == 1

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5307,6 +5307,13 @@ class TestMemoryContextSanitization:
         assert "sanitize_context(user_message)" not in src
         assert "sanitize_context(persist_user_message)" not in src
 
+    def test_plugin_context_is_sanitized_before_user_message_injection(self):
+        """pre_llm_call plugins must not bypass the single memory-context path."""
+        import inspect
+        src = inspect.getsource(AIAgent.run_conversation)
+        assert "_plugin_context = sanitize_context(_plugin_user_context)" in src
+        assert "_injections.append(_plugin_user_context)" not in src
+
     def test_sanitize_context_strips_full_block(self):
         """Helper-level: a string with an embedded memory-context block is
         cleaned to just the surrounding text.  Used by build_memory_context_block
@@ -5371,11 +5378,13 @@ class TestResolvedMemoryContextInjection:
             self.prefetch_queries.append(query)
             return self.context
 
-    def _run_and_capture_api_messages(self, agent, *, packet_builder_enabled):
+    def _run_and_capture_api_messages(self, agent, *, packet_builder_enabled, memory_context=None):
         captured = {}
         agent._memory_packet_builder_enabled = packet_builder_enabled
         agent._memory_manager = self._FakeMemoryManager(
-            "# Facts\nDarwin is local\n# Preferences\nJuan prefers direct Spanish"
+            memory_context
+            if memory_context is not None
+            else "# Facts\nDarwin is local\n# Preferences\nJuan prefers direct Spanish"
         )
         agent._persist_session = lambda *args, **kwargs: None
         agent._save_trajectory = lambda *args, **kwargs: None
@@ -5414,3 +5423,61 @@ class TestResolvedMemoryContextInjection:
         assert "# Resolved Memory Context" in content
         assert "Darwin is local" in content
         assert content.count("Darwin is local") == 1
+
+    def test_packet_builder_on_sanitizes_raw_plus_resolved_before_api_message(self, agent):
+        contaminated = (
+            "## Session Summary\n"
+            "Juan pidió retomar mejorar su memoria/contexto.\n"
+            "## User Peer Card\n"
+            "Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+            "PREFERENCE: Communication in neutral Spanish, direct.\n"
+            "<think>private upstream reasoning</think>\n"
+            "---\n"
+            "# Resolved Memory Context\n"
+            "# Sources (in priority order): unknown\n"
+            "# Preferences\n"
+            "- Preferred name is Darwin — call him Darwin, not Juan or Hermes\n"
+        )
+        api_messages = self._run_and_capture_api_messages(
+            agent,
+            packet_builder_enabled=True,
+            memory_context=contaminated,
+        )
+        content = [m for m in api_messages if m.get("role") == "user"][0]["content"]
+
+        assert content.count("# Resolved Memory Context") == 1
+        assert "honcho_session_summary" in content
+        assert "unknown" not in content
+        assert "Preferred name is Darwin" not in content
+        assert "private upstream reasoning" not in content
+        assert content.count("Juan pidió retomar") == 1
+
+    def test_pre_llm_plugin_context_is_sanitized_before_api_message(self, agent, monkeypatch):
+        import hermes_cli.plugins as plugins
+
+        monkeypatch.setattr(
+            plugins,
+            "invoke_hook",
+            lambda *args, **kwargs: [
+                {
+                    "context": (
+                        "plugin-visible note\n"
+                        "<memory-context>\n"
+                        "stale injected fact\n"
+                        "</memory-context>\n"
+                        "<think>plugin private reasoning</think>"
+                    )
+                }
+            ],
+        )
+        api_messages = self._run_and_capture_api_messages(
+            agent,
+            packet_builder_enabled=True,
+            memory_context="",
+        )
+        content = [m for m in api_messages if m.get("role") == "user"][0]["content"]
+
+        assert "plugin-visible note" in content
+        assert "stale injected fact" not in content
+        assert "plugin private reasoning" not in content
+        assert "<memory-context>" not in content

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -22,6 +22,7 @@ import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.cognitive_core import COGNITIVE_CORE_MARKER
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +150,53 @@ def test_aiagent_reuses_existing_errors_log_handler():
                 handler.close()
         for handler in original_handlers:
             root_logger.addHandler(handler)
+
+
+def test_cognitive_core_prompt_gated_by_env(monkeypatch):
+    monkeypatch.setenv("HERMES_COGNITIVE_CORE", "1")
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "memory", "session_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="dummy",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    prompt = agent._build_system_prompt()
+    assert COGNITIVE_CORE_MARKER in prompt
+    assert "this policy replaces generic memory guidance" in prompt
+    assert "Do NOT save task progress" not in prompt
+
+
+def test_cognitive_core_prompt_absent_without_flag(monkeypatch):
+    monkeypatch.delenv("HERMES_COGNITIVE_CORE", raising=False)
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "memory"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="dummy",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    prompt = agent._build_system_prompt()
+    assert COGNITIVE_CORE_MARKER not in prompt
+    assert "Do NOT save task progress" in prompt
 
 
 class TestProviderModelNormalization:


### PR DESCRIPTION
## Summary
- Adds a deterministic, side-effect-free Cognitive Core policy layer gated by env/config
- Injects a stable Cognitive Core prompt block and API-only per-turn routing hint
- Keeps routing hints out of persisted transcripts via the existing persist-user-message override path
- Adds selective memory policy, capability guidance, NATS deferred status, and shape-only mail readiness detection
- Adds unit tests and AIAgent prompt gating tests

## Verification
- [x] .venv/bin/python -m pytest -o addopts='' tests/agent/test_cognitive_core.py tests/run_agent/test_run_agent.py::test_cognitive_core_prompt_gated_by_env tests/run_agent/test_run_agent.py::test_cognitive_core_prompt_absent_without_flag -q
- [x] .venv/bin/python -m py_compile agent/cognitive_core.py run_agent.py tests/agent/test_cognitive_core.py tests/run_agent/test_run_agent.py
- [x] git diff --check --cached
- [x] Static scan: no hardcoded secret assignments, shell injection, eval/exec, or pickle.loads patterns
- [x] Independent reviewer: passed

## Notes
- Default remains upstream-safe/off unless HERMES_COGNITIVE_CORE or agent.cognitive_core.enabled enables it.
- No runtime restart or production daemon mutation is included in this PR.