### PR TITLE
fix(bedrock): route _require_boto3 through lazy_deps.ensure

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -46,7 +46,22 @@ _bedrock_control_client_cache: Dict[str, Any] = {}
 
 
 def _require_boto3():
-    """Import boto3, raising a clear error if not installed."""
+    """Import boto3, lazily installing the ``bedrock`` extra if missing.
+
+    Mirrors :func:`agent.anthropic_adapter._get_anthropic_sdk` — the
+    2026-05-12 policy (see ``pyproject.toml`` comment above ``[all]``)
+    moves ``boto3`` out of the eager install and into
+    ``tools.lazy_deps.LAZY_DEPS["provider.bedrock"]``. Without this
+    ``ensure()`` hop, every fresh install hits the manual-install
+    message below on first Bedrock call.
+    """
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("provider.bedrock", prompt=False)
+    except ImportError:
+        pass  # lazy_deps module itself unavailable — fall through to import
+    except Exception:
+        pass  # FeatureUnavailable (opt-out / offline) — let ImportError below surface it
     try:
         import boto3
         return boto3

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -886,9 +886,18 @@ class TestRequireBoto3LazyInstall:
     than [all]. Without this hop, fresh installs hit the manual-install
     error on the very first Bedrock call even though lazy installs are
     enabled. Mirrors the pattern in agent.anthropic_adapter.
+
+    Tests stub boto3 via sys.modules so they run in minimal CI environments
+    where the real boto3 isn't installed (per the 2026-05-12 policy that
+    removed it from [all]).
     """
 
+    def _fake_boto3(self):
+        import types
+        return types.ModuleType("boto3")
+
     def test_require_boto3_calls_ensure_provider_bedrock(self):
+        import sys
         from agent import bedrock_adapter
 
         calls = []
@@ -896,9 +905,12 @@ class TestRequireBoto3LazyInstall:
         def fake_ensure(feature, prompt=True):
             calls.append((feature, prompt))
 
-        with patch("tools.lazy_deps.ensure", side_effect=fake_ensure):
-            bedrock_adapter._require_boto3()
+        fake = self._fake_boto3()
+        with patch.dict(sys.modules, {"boto3": fake}), \
+             patch("tools.lazy_deps.ensure", side_effect=fake_ensure):
+            result = bedrock_adapter._require_boto3()
 
+        assert result is fake
         assert ("provider.bedrock", False) in calls, (
             "_require_boto3 should call ensure('provider.bedrock', prompt=False); "
             f"got {calls!r}"
@@ -908,16 +920,18 @@ class TestRequireBoto3LazyInstall:
         # If ensure() raises (e.g. FeatureUnavailable because lazy installs
         # are disabled, or offline), _require_boto3 must fall through to the
         # normal import attempt rather than propagating.
+        import sys
         from agent import bedrock_adapter
 
-        with patch(
-            "tools.lazy_deps.ensure",
-            side_effect=RuntimeError("lazy installs disabled"),
-        ):
-            # boto3 is importable in the test env, so this should succeed
-            # despite ensure() blowing up.
+        fake = self._fake_boto3()
+        with patch.dict(sys.modules, {"boto3": fake}), \
+             patch(
+                 "tools.lazy_deps.ensure",
+                 side_effect=RuntimeError("lazy installs disabled"),
+             ):
             mod = bedrock_adapter._require_boto3()
-            assert mod is not None
+
+        assert mod is fake
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -879,6 +879,47 @@ class TestClientCache:
         assert len(_bedrock_control_client_cache) == 0
 
 
+class TestRequireBoto3LazyInstall:
+    """Regression: _require_boto3 must route through tools.lazy_deps.ensure.
+
+    Post-2026-05-12, boto3 lives in LAZY_DEPS["provider.bedrock"] rather
+    than [all]. Without this hop, fresh installs hit the manual-install
+    error on the very first Bedrock call even though lazy installs are
+    enabled. Mirrors the pattern in agent.anthropic_adapter.
+    """
+
+    def test_require_boto3_calls_ensure_provider_bedrock(self):
+        from agent import bedrock_adapter
+
+        calls = []
+
+        def fake_ensure(feature, prompt=True):
+            calls.append((feature, prompt))
+
+        with patch("tools.lazy_deps.ensure", side_effect=fake_ensure):
+            bedrock_adapter._require_boto3()
+
+        assert ("provider.bedrock", False) in calls, (
+            "_require_boto3 should call ensure('provider.bedrock', prompt=False); "
+            f"got {calls!r}"
+        )
+
+    def test_require_boto3_tolerates_ensure_failure(self):
+        # If ensure() raises (e.g. FeatureUnavailable because lazy installs
+        # are disabled, or offline), _require_boto3 must fall through to the
+        # normal import attempt rather than propagating.
+        from agent import bedrock_adapter
+
+        with patch(
+            "tools.lazy_deps.ensure",
+            side_effect=RuntimeError("lazy installs disabled"),
+        ):
+            # boto3 is importable in the test env, so this should succeed
+            # despite ensure() blowing up.
+            mod = bedrock_adapter._require_boto3()
+            assert mod is not None
+
+
 # ---------------------------------------------------------------------------
 # Streaming with callbacks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Restores the lazy-install path for `boto3`. The 2026-05-12 supply-chain-hardening pass (#24515) relocated `boto3` from the `[all]` extra into `LAZY_DEPS["provider.bedrock"]`, but `agent/bedrock_adapter.py::_require_boto3` was not updated alongside the other adapters and still does a bare `try: import boto3 / except ImportError: raise`. Fresh installs therefore hit the manual-install error on the very first Bedrock call, even with `security.allow_lazy_installs` left at the default `true`.

This PR mirrors the pattern already used by `agent/anthropic_adapter.py::_get_anthropic_sdk` — call `tools.lazy_deps.ensure("provider.bedrock", prompt=False)` before the import, swallowing `ImportError` (the `tools.lazy_deps` module itself unavailable — e.g. minimal packaging) and generic `Exception` (`FeatureUnavailable` when the user has opted out of lazy installs or is offline). The existing manual-install `ImportError` survives as the final fallback when lazy install is unavailable or fails.

## Related Issue

Fixes #24967

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py` — `_require_boto3()` now calls `tools.lazy_deps.ensure("provider.bedrock", prompt=False)` before the `import boto3` attempt, matching `_get_anthropic_sdk` in `anthropic_adapter.py`.
- `tests/agent/test_bedrock_adapter.py` — new `TestRequireBoto3LazyInstall` class:
  - `test_require_boto3_calls_ensure_provider_bedrock` patches `tools.lazy_deps.ensure` and asserts it is called with `("provider.bedrock", prompt=False)`.
  - `test_require_boto3_tolerates_ensure_failure` confirms the import still succeeds when `ensure()` itself raises (FeatureUnavailable fallback).
  - Both tests stub `boto3` via `patch.dict(sys.modules, {"boto3": <fake>})` so they run in the minimal CI environment that #24515 / #24601 established (i.e. without the real `boto3` installed).

## How to Test

1. On a clean venv with no `boto3` installed and `security.allow_lazy_installs` at the default `true`, configure the Bedrock provider and start a chat.
2. The first user message should trigger `tools.lazy_deps.ensure` → pip-install `boto3==1.42.89` → normal Converse call, not the manual-install `ImportError`.
3. Focused regression (with and without boto3):
   ```
   # with boto3 present
   pytest tests/agent/test_bedrock_adapter.py::TestRequireBoto3LazyInstall -v
   # 2 passed
   
   # without boto3 (matches CI environment)
   uv pip uninstall boto3 botocore
   pytest tests/agent/test_bedrock_adapter.py::TestRequireBoto3LazyInstall -v
   # 2 passed
   ```
4. Adjacent suites still green:
   ```
   pytest tests/agent/test_bedrock_adapter.py tests/tools/test_lazy_deps.py
   # 163 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `test(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#24601 is an adjacent CI-fix PR but doesn't touch `_require_boto3`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected test suites and all tests pass (`pytest tests/agent/test_bedrock_adapter.py tests/tools/test_lazy_deps.py` → 163 passed, both with and without `boto3` installed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.2.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing doc changes)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — N/A (pure-Python import path, same on Linux/macOS/Windows)
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

Before this PR, on a fresh install with `security.allow_lazy_installs: true` (default):

```
API call failed (attempt 1/3): ImportError
   Provider: bedrock  Model: arn:aws:bedrock:us-west-2:<REDACTED>:application-inference-profile/<REDACTED>
   Endpoint: https://bedrock-runtime.us-east-1.amazonaws.com
   Error: The 'boto3' package is required for the AWS Bedrock provider.
          Install it with: pip install boto3
          Or install Hermes with Bedrock support: pip install -e '.[bedrock]'
```

The retry loop exhausts without ever attempting a lazy install. Also reproduced earlier in the session from the model-discovery path:

```
WARNING agent.bedrock_adapter: Failed to create Bedrock client for model discovery:
The 'boto3' package is required for the AWS Bedrock provider. ...
```

Both paths go through `_require_boto3`, so the single-point fix in this PR resolves discovery and chat together.