### PR TITLE
fix(gateway): add chat_id to session:start, session:end, and session:reset hook contexts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7029,6 +7029,7 @@ class GatewayRunner:
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
@@ -8161,6 +8162,7 @@ class GatewayRunner:
         await self.hooks.emit("session:end", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
             "session_key": session_key,
         })
 
@@ -8168,6 +8170,7 @@ class GatewayRunner:
         await self.hooks.emit("session:reset", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
             "session_key": session_key,
         })
 

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -101,6 +101,40 @@ async def test_reset_fires_reset_hook(mock_invoke_hook):
 
 @pytest.mark.asyncio
 @patch("hermes_cli.plugins.invoke_hook")
+async def test_session_end_hook_includes_chat_id(mock_invoke_hook):
+    """session:end gateway hook must carry chat_id so hook authors can route replies."""
+    runner = _make_runner()
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    end_calls = [
+        c for c in runner.hooks.emit.call_args_list
+        if c.args and c.args[0] == "session:end"
+    ]
+    assert end_calls, "session:end was not emitted"
+    ctx = end_calls[0].args[1]
+    assert ctx.get("chat_id") == "c1"
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_session_reset_hook_includes_chat_id(mock_invoke_hook):
+    """session:reset gateway hook must carry chat_id so hook authors can route replies."""
+    runner = _make_runner()
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    reset_calls = [
+        c for c in runner.hooks.emit.call_args_list
+        if c.args and c.args[0] == "session:reset"
+    ]
+    assert reset_calls, "session:reset was not emitted"
+    ctx = reset_calls[0].args[1]
+    assert ctx.get("chat_id") == "c1"
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
 async def test_finalize_before_reset(mock_invoke_hook):
     """on_session_finalize must fire before on_session_reset."""
     runner = _make_runner()


### PR DESCRIPTION
## What does this PR do?

Root cause: `_handle_message_with_agent()` emits `session:start` and `_handle_reset_command()` emits `session:end` and `session:reset`, but none of them included `chat_id` in the hook context. Hook authors who subscribe to session lifecycle events cannot identify which conversation the session belongs to, making routing (e.g. sending a welcome message on `session:start` or cleanup on `session:end`) impossible without it.

Fix: mirror the `"chat_id": source.chat_id or ""` field added to `agent:start` by #24710 into the three sibling session hooks. `source` is in scope at all three emit sites and `chat_id` is a required `str` field on `SessionSource`, so no guard is needed beyond the existing `or ""` fallback.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/run.py`: add `"chat_id"` to `session:start` (+1 line), `session:end` (+1 line), `session:reset` (+1 line) hook contexts
- `tests/gateway/test_session_boundary_hooks.py`: two new tests asserting `chat_id` is present in `session:end` and `session:reset` contexts

## How to Test

```
pytest tests/gateway/test_session_boundary_hooks.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A