### PR TITLE
fix(gateway): stop typing task before post-delivery callback to prevent indefinite typing indicator

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3380,15 +3380,16 @@ class BasePlatformAdapter(ABC):
                 )
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
+            # Stop typing indicator first — must not be delayed by a
+            # stuck post-delivery callback (see #24971).
+            await _stop_typing_task()
             if callable(_post_cb):
                 try:
                     _post_result = _post_cb()
                     if inspect.isawaitable(_post_result):
-                        await _post_result
-                except Exception:
+                        await asyncio.wait_for(_post_result, timeout=30.0)
+                except (asyncio.TimeoutError, Exception):
                     pass
-            # Stop typing indicator
-            await _stop_typing_task()
             # Also cancel any platform-level persistent typing tasks (e.g. Discord)
             # that may have been recreated by _keep_typing after the last stop_typing()
             try:

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -198,3 +198,100 @@ class TestKeepTypingTimeoutPerTick:
         assert calls == [], (
             f"send_typing was called on a paused chat: {calls}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: _keep_typing must stop even when post-delivery callback hangs
+# See: https://github.com/NousResearch/hermes-agent/issues/24971
+# ---------------------------------------------------------------------------
+
+
+class TestPostDeliveryCallbackTimeout:
+    """_stop_typing_task must run before the post-delivery callback, and the
+    callback must be bounded by a timeout so a hanging coroutine cannot prevent
+    typing cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_typing_stopped_before_callback(self):
+        """_stop_typing_task is called even if the callback hangs."""
+        adapter = _StubAdapter()
+        callback_entered = asyncio.Event()
+
+        async def _handler(_event):
+            return "ok"
+
+        async def _slow_callback():
+            callback_entered.set()
+            # Simulate a hung callback (e.g. dead Telegram socket)
+            await asyncio.sleep(3600)
+
+        adapter.set_message_handler(_handler)
+        adapter._post_delivery_callbacks = {"test-session": _slow_callback}
+
+        async def _tracking_keep_typing(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        adapter._keep_typing = _tracking_keep_typing
+
+        event = MagicMock()
+        event.source.chat_id = "test-chat"
+        event.source.thread_id = None
+        event.source.user_id = "user-1"
+        event.text = "hello"
+        event.raw = {}
+
+        # The fix adds asyncio.wait_for(..., timeout=30.0) around the
+        # callback.  Patch to a very short timeout so the test completes
+        # in reasonable time.
+        _real_wait_for = asyncio.wait_for
+
+        async def _fast_wait_for(coro, timeout=None):
+            return await _real_wait_for(coro, timeout=0.05)
+
+        import gateway.platforms.base as _base
+        _orig = _base.asyncio.wait_for
+        _base.asyncio.wait_for = _fast_wait_for
+        try:
+            await _real_wait_for(
+                adapter._process_message_background(event, "test-session"),
+                timeout=10.0,
+            )
+        finally:
+            _base.asyncio.wait_for = _orig
+
+        # If we got here, the function didn't hang — the timeout worked.
+        assert callback_entered.is_set()
+
+    @pytest.mark.asyncio
+    async def test_fast_callback_still_runs(self):
+        """A fast (non-hanging) callback should still execute normally."""
+        adapter = _StubAdapter()
+        callback_ran = asyncio.Event()
+
+        async def _handler(_event):
+            return "ok"
+
+        async def _fast_callback():
+            callback_ran.set()
+
+        adapter.set_message_handler(_handler)
+        adapter._post_delivery_callbacks = {"test-session": _fast_callback}
+
+        async def _hold_typing(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        adapter._keep_typing = _hold_typing
+
+        event = MagicMock()
+        event.source.chat_id = "test-chat"
+        event.source.thread_id = None
+        event.source.user_id = "user-1"
+        event.text = "hello"
+        event.raw = {}
+
+        await asyncio.wait_for(
+            adapter._process_message_background(event, "test-session"),
+            timeout=5.0,
+        )
+
+        assert callback_ran.is_set()


### PR DESCRIPTION
## What does this PR do?

Fixes the `_keep_typing` background task running indefinitely after the agent has already replied, leaving the bot stuck in the "typing" indicator state.


### Root Cause

In `gateway/platforms/base.py`, `_process_message_background`'s `finally` block executes the post-delivery callback **before** calling `_stop_typing_task()`:

```python
# previous order (broken)
finally:
    if callable(_post_cb):
        await _post_result        # ← can hang
    await _stop_typing_task()     # ← never reached if callback hangs
```

If the callback coroutine hangs — for example, `_send_goal_status_notice()` making an HTTP call over a Telegram socket in `CLOSE-WAIT` state — `_stop_typing_task()` is never called. The `_keep_typing` task keeps refreshing `sendChatAction(typing)` every 2 seconds indefinitely.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A