### PR TITLE
fix(gemini): add missing content attribute to reasoning-only stream deltas

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -450,7 +450,7 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
+    delta_kwargs: Dict[str, Any] = {"role": "assistant", "content": None}
     if content:
         delta_kwargs["content"] = content
     if tool_call_delta is not None:


### PR DESCRIPTION
## Summary

`_make_stream_chunk()` in `agent/gemini_cloudcode_adapter.py` builds the streamed `delta` `SimpleNamespace` without a `content` key when the chunk carries only reasoning text (Gemini thinking block before any visible content). Downstream consumers accessing `delta.content` raise `AttributeError`.

## Root Cause

The `delta_kwargs` dict is initialized with only `{"role": "assistant"}`. The `content` key is only added when `content` is truthy (`if content:`), so reasoning-only deltas never get it. The sibling `gemini_native_adapter.py` already initializes `delta_kwargs` with `"content": None` — this adapter was simply missed.

## Fix

Initialize `delta_kwargs` with `"content": None` so `delta.content` always exists, returning `None` for reasoning-only chunks — consistent with `gemini_native_adapter.py` and the OpenAI streaming contract.

## Testing

- Manual verification: `_make_stream_chunk(model="m", reasoning="think").choices[0].delta.content` now returns `None` instead of raising `AttributeError`
- All 223 Gemini-related tests pass (`pytest -k gemini`: 223 passed, 4 skipped)

Closes #24974