### PR TITLE
fix(cron): use TERMINAL_CWD for system prompt working directory

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -772,7 +772,8 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            _effective_cwd = os.environ.get("TERMINAL_CWD", "").strip() or os.getcwd()
+            host_lines.append(f"Current working directory: {_effective_cwd}")
         except OSError:
             pass
 


### PR DESCRIPTION
## Summary

When a cron job is registered with `--workdir <PATH>`, the scheduler correctly sets `TERMINAL_CWD` so terminal/file tools run from the right directory. However, `build_environment_hints()` in `agent/prompt_builder.py` uses `os.getcwd()` unconditionally for the `Current working directory` line in the system prompt, which reports the scheduler's own cwd (typically `~/.hermes/hermes-agent`) instead of the job's configured workdir.

Since the model trusts the system prompt over `pwd`, it often starts by `cd`-ing to the wrong directory, silently operating on the wrong filesystem location.

## Root Cause

`prompt_builder.py:775` calls `os.getcwd()` without checking the `TERMINAL_CWD` environment variable that the cron scheduler sets at `scheduler.py:1265`.

## Fix

Check `os.environ.get("TERMINAL_CWD")` first, falling back to `os.getcwd()` — consistent with how the terminal tools already resolve working directory.

## Testing

- 121 prompt_builder/environment_hints tests pass (5 skipped)
- Manual: `TERMINAL_CWD=/tmp python -c "from agent.prompt_builder import build_environment_hints; print(build_environment_hints())"` now shows `/tmp`

Closes #24969