### PR TITLE
fix(terminal): suppress background shell job-control noise

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -66,6 +66,64 @@ def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> bool
 
 
 # =========================================================================
+# Shell startup noise / spawn mode
+# =========================================================================
+
+class TestShellNoiseAndSpawnMode:
+    def test_clean_shell_noise_removes_localized_bash_job_control_prefix(self):
+        noisy = (
+            "bash: 터미털 프로세스 그룹(-1)을 설정할 수 없음: "
+            "Inappropriate ioctl for device\n"
+            "bash: 이 셸에 작업 제어 없음\n"
+            "HERMES_BG_OK\n"
+        )
+
+        assert ProcessRegistry._clean_shell_noise(noisy) == "HERMES_BG_OK\n"
+
+    def test_spawn_local_pipe_mode_uses_non_interactive_login_shell(self, registry, tmp_path):
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = MagicMock()
+            proc.stdin = MagicMock()
+            proc.poll.return_value = None
+            return proc
+
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+            patch("tools.process_registry._resolve_shell_init_files", return_value=[]), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=fake_thread), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local("echo hello", cwd=str(tmp_path), use_pty=False)
+
+        assert captured["cmd"] == ["/bin/bash", "-l", "-c", "set +m; echo hello"]
+        assert "-i" not in captured["cmd"]
+        assert captured["kwargs"]["stderr"] is subprocess.STDOUT
+        fake_thread.start.assert_called_once()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell startup noise regression")
+    def test_spawn_local_pipe_mode_live_output_has_no_job_control_noise(self, registry, tmp_path):
+        session = registry.spawn_local("printf HERMES_BG_OK", cwd=str(tmp_path), use_pty=False)
+
+        try:
+            result = registry.wait(session.id, timeout=10)
+            assert result["status"] == "exited", result
+            assert result["exit_code"] == 0
+            assert result["output"] == "HERMES_BG_OK"
+            assert "no job control" not in result["output"]
+            assert "작업 제어 없음" not in result["output"]
+            assert "Inappropriate ioctl" not in result["output"]
+        finally:
+            registry.kill_process(session.id)
+
+
+# =========================================================================
 # Get / Poll
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,13 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _prepend_shell_init,
+    _resolve_safe_cwd,
+    _resolve_shell_init_files,
+    _sanitize_subprocess_env,
+)
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -148,6 +154,10 @@ class ProcessRegistry:
         "no job control in this shell",
         "cannot set terminal process group",
         "tcsetattr: Inappropriate ioctl for device",
+        "Inappropriate ioctl for device",
+        "터미널 프로세스 그룹",
+        "터미털 프로세스 그룹",
+        "작업 제어 없음",
     )
 
     def __init__(self):
@@ -185,6 +195,26 @@ class ProcessRegistry:
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
         return "\n".join(lines)
+
+    @staticmethod
+    def _background_shell_script(command: str) -> str:
+        """Build the script run by a non-PTY background login shell.
+
+        Background pipe mode has no controlling TTY.  Running bash with ``-i``
+        in that context emits localized job-control warnings before the user's
+        command output (for example Korean ``작업 제어 없음``).  Keep the login
+        shell for PATH/profile consistency, explicitly source configured shell
+        init files like ``LocalEnvironment`` does, but do not request an
+        interactive shell.
+        """
+        script = f"set +m; {command}"
+        try:
+            init_files = _resolve_shell_init_files()
+        except Exception:
+            init_files = []
+        if init_files:
+            script = _prepend_shell_init(script, init_files)
+        return script
 
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
@@ -547,7 +577,7 @@ class ProcessRegistry:
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-l", "-c", self._background_shell_script(command)],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
## Summary
- Stop non-PTY background terminal jobs from launching bash as interactive (`-i`) when stdout/stderr are pipes.
- Preserve login-shell/profile behavior by using `bash -l -c` and explicitly sourcing configured shell init files.
- Add localized Korean/English noise filtering as defense-in-depth and regression tests for spawn argv plus live sentinel output.

## Local validation
- `python -m pytest -n0 tests/tools/test_process_registry.py::TestShellNoiseAndSpawnMode -q` → 3 passed
- `python -m pytest -n0 tests/tools/test_process_registry.py tests/tools/test_file_tools_live.py tests/gateway/test_background_process_notifications.py -q` → 132 passed
- `python -m compileall -q tools/process_registry.py tests/tools/test_process_registry.py`
- `git diff --check -- tools/process_registry.py tests/tools/test_process_registry.py`
- Live sentinel via `ProcessRegistry.spawn_local('printf HERMES_BACKGROUND_SENTINEL')` → exact output only, no bash job-control prefix

## Scope / safety
- No LIVE/account/order/secret handling changes.
- This changes only local background terminal process shell startup behavior and tests.
