### PR TITLE
fix(cron): include yuanbao in _HOME_TARGET_ENV_VARS

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -112,6 +112,7 @@ _HOME_TARGET_ENV_VARS = {
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
     "whatsapp": "WHATSAPP_HOME_CHANNEL",
+    "yuanbao": "YUANBAO_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7029,6 +7029,7 @@ class GatewayRunner:
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
@@ -8161,6 +8162,7 @@ class GatewayRunner:
         await self.hooks.emit("session:end", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
             "session_key": session_key,
         })
 
@@ -8168,6 +8170,7 @@ class GatewayRunner:
         await self.hooks.emit("session:reset", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
             "session_key": session_key,
         })
 

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -101,6 +101,40 @@ async def test_reset_fires_reset_hook(mock_invoke_hook):
 
 @pytest.mark.asyncio
 @patch("hermes_cli.plugins.invoke_hook")
+async def test_session_end_hook_includes_chat_id(mock_invoke_hook):
+    """session:end gateway hook must carry chat_id so hook authors can route replies."""
+    runner = _make_runner()
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    end_calls = [
+        c for c in runner.hooks.emit.call_args_list
+        if c.args and c.args[0] == "session:end"
+    ]
+    assert end_calls, "session:end was not emitted"
+    ctx = end_calls[0].args[1]
+    assert ctx.get("chat_id") == "c1"
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_session_reset_hook_includes_chat_id(mock_invoke_hook):
+    """session:reset gateway hook must carry chat_id so hook authors can route replies."""
+    runner = _make_runner()
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    reset_calls = [
+        c for c in runner.hooks.emit.call_args_list
+        if c.args and c.args[0] == "session:reset"
+    ]
+    assert reset_calls, "session:reset was not emitted"
+    ctx = reset_calls[0].args[1]
+    assert ctx.get("chat_id") == "c1"
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
 async def test_finalize_before_reset(mock_invoke_hook):
     """on_session_finalize must fire before on_session_reset."""
     runner = _make_runner()


### PR DESCRIPTION
## Summary

- `yuanbao` is listed in `_KNOWN_DELIVERY_PLATFORMS` but was absent from `_HOME_TARGET_ENV_VARS`
- `_get_home_target_chat_id("yuanbao")` always returned `""`, making Yuanbao cron home-channel delivery silently fail
- `YUANBAO_HOME_CHANNEL` is already read by `gateway/config.py`, `gateway/platforms/yuanbao.py`, and `hermes_cli/config.py` — the env var is fully wired, it just needed one entry here

Same omission pattern fixed for WhatsApp in d8c4460.

## Root cause

`_HOME_TARGET_ENV_VARS` and `_KNOWN_DELIVERY_PLATFORMS` drifted out of sync when Yuanbao cron delivery was added. WhatsApp had the identical gap and was patched in the same file today; Yuanbao was missed.

## Test plan

- [ ] Set `YUANBAO_HOME_CHANNEL=<group_code>` and schedule a cron job with `deliver: home` on a Yuanbao-connected gateway — message should arrive in the configured group
- [ ] Existing cron delivery tests pass: `pytest tests/gateway/ -k cron`
- [ ] `_get_home_target_chat_id("yuanbao")` returns the env var value when `YUANBAO_HOME_CHANNEL` is set