### PR TITLE
feat: configurable paste collapse thresholds (TUI + CLI)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12022,7 +12022,8 @@ class HermesCLI:
                 pasted_text = _sanitize_surrogates(pasted_text)
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
-                if line_count >= 5 and not buf.text.strip().startswith('/'):
+                threshold = self.config.get("paste_collapse_threshold", 5)
+                if threshold > 0 and line_count >= threshold and not buf.text.strip().startswith('/'):
                     _paste_counter[0] += 1
                     paste_dir = _hermes_home / "pastes"
                     paste_dir.mkdir(parents=True, exist_ok=True)
@@ -12189,7 +12190,8 @@ class HermesCLI:
             newlines_added = line_count - _prev_newline_count[0]
             _prev_newline_count[0] = line_count
             is_paste = chars_added > 1 or newlines_added >= 4
-            if line_count >= 5 and is_paste and not text.startswith('/'):
+            threshold = self.config.get("paste_collapse_threshold_fallback", 0)
+            if threshold > 0 and line_count >= threshold and is_paste and not text.startswith('/'):
                 _paste_counter[0] += 1
                 paste_dir = _hermes_home / "pastes"
                 paste_dir.mkdir(parents=True, exist_ok=True)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1545,8 +1545,17 @@ DEFAULT_CONFIG = {
         "servers": {},
     },
 
+    # Paste collapse thresholds (TUI + CLI).
+    # collapse_threshold: paste collapses to a file reference when line count
+    #   exceeds this value (bracketed paste, safe: appends to existing text).
+    # collapse_threshold_fallback: same but for the fallback heuristic used
+    #   by terminals without bracketed paste support (destructive: replaces
+    #   entire buffer).  0 = disabled.
+    "paste_collapse_threshold": 5,
+    "paste_collapse_threshold_fallback": 0,
+
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -105,6 +105,7 @@ export interface UiState {
   info: null | SessionInfo
   inlineDiffs: boolean
   mouseTracking: boolean
+  pasteCollapseLines: number
   sections: SectionVisibility
   showCost: boolean
   showReasoning: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -17,6 +17,7 @@ const buildUiState = (): UiState => ({
   info: null,
   inlineDiffs: true,
   mouseTracking: MOUSE_TRACKING,
+  pasteCollapseLines: 5,
   sections: {},
   showCost: false,
   showReasoning: false,

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -8,7 +8,6 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useMemo, useState } from 'react'
 
 import type { PasteEvent } from '../components/textInput.js'
-import { LARGE_PASTE } from '../config/limits.js'
 import type { ImageAttachResponse, InputDetectDropResponse } from '../gatewayTypes.js'
 import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
@@ -190,8 +189,9 @@ export function useComposerState({
       }
 
       const lineCount = cleanedText.split('\n').length
+      const pasteCollapseLines = getUiState().pasteCollapseLines
 
-      if (cleanedText.length < LARGE_PASTE.chars && lineCount < LARGE_PASTE.lines) {
+      if (pasteCollapseLines === 0 || lineCount < pasteCollapseLines) {
         return {
           cursor: cursor + cleanedText.length,
           value: value.slice(0, cursor) + cleanedText + value.slice(cursor)

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -100,6 +100,17 @@ const _voiceRecordKeyFromConfig = (cfg: ConfigFullResponse | null): ParsedVoiceR
   return raw ? parseVoiceRecordKey(raw) : DEFAULT_VOICE_RECORD_KEY
 }
 
+const _pasteCollapseLinesFromConfig = (cfg: ConfigFullResponse | null): number => {
+  if (!cfg?.config) return 5
+  const raw = cfg.config.paste_collapse_threshold
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return Math.round(raw)
+  if (typeof raw === 'string') {
+    const n = parseInt(raw, 10)
+    if (Number.isFinite(n) && n >= 0) return n
+  }
+  return 5
+}
+
 /** Fetch ``config.get full`` and fan the result through ``applyDisplay``.
  *
  * Extracted so the mtime-reload path can be exercised by the test
@@ -143,6 +154,7 @@ export const applyDisplay = (
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
     mouseTracking: normalizeMouseTracking(d),
+    pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
     sections: resolveSections(d.sections),
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -1,4 +1,4 @@
-export const LARGE_PASTE = { chars: 8000, lines: 80 }
+export const LARGE_PASTE = { lines: 5 }
 
 export const LIVE_RENDER_MAX_CHARS = 16_000
 export const LIVE_RENDER_MAX_LINES = 240

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -82,7 +82,7 @@ export interface ConfigVoiceConfig {
 }
 
 export interface ConfigFullResponse {
-  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig }
+  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig; paste_collapse_threshold?: number }
 }
 
 export interface ConfigMtimeResponse {


### PR DESCRIPTION
Adds two new config keys for controlling paste collapse behavior:

- **`paste_collapse_threshold`** (default: `5`) — number of lines above which a bracketed paste gets collapsed to a file reference in both the TUI and CLI. Set to `0` to disable.
- **`paste_collapse_threshold_fallback`** (default: `0`, disabled) — same threshold for the fallback heuristic used by terminals without bracketed paste support. Defaults to disabled because the fallback is destructive (replaces the entire buffer rather than appending).

### Changes

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Added config keys + bumped `_config_version` to 24 |
| `cli.py` | Both paste handlers read from config instead of hardcoded `5` |
| `ui-tui/src/config/limits.ts` | `LARGE_PASTE` now line-only, default 5 |
| `ui-tui/src/app/useComposerState.ts` | Reads `pasteCollapseLines` from uiStore |
| `ui-tui/src/app/useConfigSync.ts` | `_pasteCollapseLinesFromConfig()` helper wired into `applyDisplay` |
| `ui-tui/src/app/uiStore.ts` | `pasteCollapseLines: 5` default |
| `ui-tui/src/app/interfaces.ts` | `pasteCollapseLines: number` in UiState |
| `ui-tui/src/gatewayTypes.ts` | `paste_collapse_threshold?: number` in ConfigFullResponse |

### Related
- Closes #5626
- Related #5623
