### PR TITLE
fix(picker): validate Copilot token format before showing as authenticated

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1156,6 +1156,28 @@ def list_authenticated_providers(
         except Exception:
             return False
 
+
+    def _validate_env_token(hermes_slug: str, env_vars: tuple[str, ...] | list[str]) -> bool:
+        """Return False if the provider has env-var creds but the token format is invalid.
+
+        Currently only validates GitHub Copilot tokens (rejects classic PATs ghp_*).
+        For other providers, returns True (no validation needed).
+        """
+        if hermes_slug not in {"copilot", "copilot-acp"}:
+            return True
+        try:
+            from hermes_cli.copilot_auth import validate_copilot_token
+            for ev in env_vars:
+                val = os.environ.get(ev, "").strip()
+                if val:
+                    valid, _ = validate_copilot_token(val)
+                    if valid:
+                        return True
+            # All env var tokens failed validation
+            return False
+        except Exception:
+            # If validation itself fails, allow the provider through
+            return True
     data = fetch_models_dev()
 
     # Build curated model lists keyed by hermes provider ID
@@ -1228,6 +1250,9 @@ def list_authenticated_providers(
 
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
+        # Validate token format for providers with strict requirements.
+        if has_creds and not _validate_env_token(hermes_id, env_vars):
+            has_creds = False
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -1290,13 +1315,16 @@ def list_authenticated_providers(
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
+            if has_creds and not _validate_env_token(hermes_slug, overlay.extra_env_vars):
+                has_creds = False
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
         if not has_creds and overlay.auth_type == "api_key":
             for _key in (pid, hermes_slug):
                 pcfg = _auth_registry.get(_key)
                 if pcfg and pcfg.api_key_env_vars:
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
-                        has_creds = True
+                        if _validate_env_token(hermes_slug, pcfg.api_key_env_vars):
+                            has_creds = True
                         break
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
@@ -1404,6 +1432,9 @@ def list_authenticated_providers(
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+            # Validate token format for providers with strict requirements (e.g. copilot rejects ghp_*).
+            if _cp_has_creds and not _validate_env_token(_cp.slug, _cp_config.api_key_env_vars):
+                _cp_has_creds = False
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/tests/hermes_cli/test_model_switch_token_validation.py
+++ b/tests/hermes_cli/test_model_switch_token_validation.py
@@ -1,0 +1,121 @@
+"""Regression tests for token format validation in /model provider picker.
+
+When GITHUB_TOKEN is set to a classic PAT (ghp_*), the Copilot provider
+should NOT appear as authenticated in the /model picker, because classic
+PATs are not supported by the Copilot API.
+
+See: https://github.com/NousResearch/hermes-agent/issues/8826
+"""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def _no_creds_pool():
+    """Mock credential pool with no credentials."""
+    m = MagicMock()
+    m.has_credentials.return_value = False
+    return m
+
+
+def _empty_auth_store():
+    """Mock auth store with no providers or pool entries."""
+    return {"version": 1, "providers": {}, "credential_pool": {}}
+
+
+# -- Classic PAT (ghp_*) should be rejected -----------------------------------
+
+@patch("hermes_cli.auth._load_auth_store", _empty_auth_store)
+@patch("agent.credential_pool.load_pool", return_value=_no_creds_pool())
+@patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_abc123classicPAT"}, clear=False)
+def test_copilot_classic_pat_not_shown(mock_pool):
+    """Copilot with ghp_* token must NOT appear in provider list."""
+    for ev in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN"):
+        os.environ.pop(ev, None)
+
+    providers = list_authenticated_providers()
+    copilot_entries = [p for p in providers if p.get("slug") == "copilot"]
+    assert len(copilot_entries) == 0, (
+        f"Copilot should NOT appear with classic PAT, but got: {copilot_entries}"
+    )
+
+
+@patch("hermes_cli.auth._load_auth_store", _empty_auth_store)
+@patch("agent.credential_pool.load_pool", return_value=_no_creds_pool())
+@patch.dict(
+    os.environ,
+    {"COPILOT_GITHUB_TOKEN": "ghp_classic", "GH_TOKEN": "ghp_also_classic"},
+    clear=False,
+)
+def test_copilot_all_env_vars_classic_pat_not_shown(mock_pool):
+    """Even when all three copilot env vars hold ghp_* tokens, hide the provider."""
+    os.environ.pop("GITHUB_TOKEN", None)
+
+    providers = list_authenticated_providers()
+    copilot_entries = [p for p in providers if p.get("slug") == "copilot"]
+    assert len(copilot_entries) == 0
+
+
+# -- Valid tokens (gho_*, github_pat_*) should still work ---------------------
+
+@patch.dict(os.environ, {"COPILOT_GITHUB_TOKEN": "gho_valid_oauth"}, clear=False)
+def test_copilot_oauth_token_shown():
+    """Copilot with gho_* token SHOULD appear in provider list."""
+    for ev in ("GH_TOKEN", "GITHUB_TOKEN"):
+        os.environ.pop(ev, None)
+
+    providers = list_authenticated_providers(current_provider="copilot")
+    copilot = next((p for p in providers if p.get("slug") == "copilot"), None)
+    assert copilot is not None, "Copilot SHOULD appear with valid OAuth token"
+    assert copilot["total_models"] > 0
+
+
+@patch.dict(
+    os.environ,
+    {"GITHUB_TOKEN": "github_pat_fine_grained_token"},
+    clear=False,
+)
+def test_copilot_fine_grained_pat_shown():
+    """Copilot with github_pat_* token SHOULD appear in provider list."""
+    for ev in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN"):
+        os.environ.pop(ev, None)
+
+    providers = list_authenticated_providers(current_provider="copilot")
+    copilot = next((p for p in providers if p.get("slug") == "copilot"), None)
+    assert copilot is not None, "Copilot SHOULD appear with fine-grained PAT"
+
+
+# -- Non-copilot providers unaffected -----------------------------------------
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test123"}, clear=False)
+def test_non_copilot_provider_unaffected():
+    """Non-copilot providers should not be affected by token validation."""
+    for ev in ("GITHUB_TOKEN", "COPILOT_GITHUB_TOKEN", "GH_TOKEN"):
+        os.environ.pop(ev, None)
+
+    providers = list_authenticated_providers()
+    assert isinstance(providers, list)
+
+
+# -- Mixed: valid token in one env var overrides invalid in another -----------
+
+@patch("hermes_cli.auth._load_auth_store", _empty_auth_store)
+@patch("agent.credential_pool.load_pool", return_value=_no_creds_pool())
+@patch.dict(
+    os.environ,
+    {"GITHUB_TOKEN": "ghp_invalid", "GH_TOKEN": "gho_valid"},
+    clear=False,
+)
+def test_copilot_mixed_tokens_valid_wins(mock_pool):
+    """If at least one env var has a valid token, copilot should appear."""
+    os.environ.pop("COPILOT_GITHUB_TOKEN", None)
+
+    providers = list_authenticated_providers(current_provider="copilot")
+    copilot = next((p for p in providers if p.get("slug") == "copilot"), None)
+    assert copilot is not None, (
+        "Copilot SHOULD appear when at least one env var has a valid token"
+    )


### PR DESCRIPTION
## Summary

Fixes #8826

The `/model` provider picker listed GitHub Copilot as "authenticated" when `GITHUB_TOKEN` was set to a classic PAT (`ghp_*`), even though classic PATs are not supported by the Copilot API. This created a misleading UX where the provider appeared available but would fail immediately upon use.

## Root Cause

`list_authenticated_providers()` used a simple truthiness check (`any(os.environ.get(ev) for ev in env_vars)`) at four credential discovery points without validating token format. Any non-empty string was treated as a valid credential.

## Changes

**`hermes_cli/model_switch.py`** — Added `_validate_env_token()` nested helper that calls `validate_copilot_token()` for `copilot`/`copilot-acp` providers. Applied at all four credential discovery points:

| Section | Check | Line |
|---------|-------|------|
| 1 (mapped providers) | `PROVIDER_TO_MODELS_DEV` env var check | ~1254 |
| 2 (overlays) | `extra_env_vars` check | ~1318 |
| 2 (overlays) | `api_key_env_vars` check | ~1326 |
| 2b (canonical) | `CANONICAL_PROVIDERS` env var check | ~1436 |

Non-copilot providers are unaffected — the validator returns `True` immediately for any other slug.

**`tests/hermes_cli/test_model_switch_token_validation.py`** — 6 new regression tests:

| Test | Token | Expected |
|------|-------|----------|
| `test_copilot_classic_pat_not_shown` | `GITHUB_TOKEN=ghp_*` | Hidden ✓ |
| `test_copilot_all_env_vars_classic_pat_not_shown` | All 3 vars = `ghp_*` | Hidden ✓ |
| `test_copilot_oauth_token_shown` | `COPILOT_GITHUB_TOKEN=gho_*` | Shown ✓ |
| `test_copilot_fine_grained_pat_shown` | `GITHUB_TOKEN=github_pat_*` | Shown ✓ |
| `test_copilot_mixed_tokens_valid_wins` | `ghp_*` + `gho_*` | Shown ✓ |
| `test_non_copilot_provider_unaffected` | `OPENAI_API_KEY=sk-*` | Unaffected ✓ |

## Test Results

```
6 passed in 12.56s
144 existing model_switch tests passed (3 pre-existing env-specific failures unrelated to this change)
```

## Design Notes

- Reuses existing `validate_copilot_token()` from `hermes_cli/copilot_auth.py` — no new validation logic
- Graceful fallback: if `validate_copilot_token()` import fails, the validator returns `True` (allow the provider through)
- If at least one env var has a valid token, the provider shows up (supports mixed setups)
