### PR TITLE
fix(cli): show actual missing module when hermes acp ImportError isn't acp

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -302,6 +302,38 @@ from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
 
 
+def _format_acp_import_error(exc: ImportError) -> list[str]:
+    """Map an ImportError raised while starting the ACP adapter to
+    user-facing message lines.
+
+    The acp adapter imports the third-party ``acp`` package (provided by
+    ``agent-client-protocol``) lazily inside ``acp_adapter.entry.main``.
+    Any ImportError raised from there used to be reported as "ACP
+    dependencies not installed", even when the failing module was
+    unrelated — masking real install corruption behind a "reinstall the
+    extra" suggestion that doesn't actually fix the problem.
+    """
+    missing = getattr(exc, "name", None) or ""
+    if missing == "acp" or missing.startswith("acp."):
+        return [
+            "ACP dependencies not installed.",
+            "Install them with:  pip install -e '.[acp]'",
+        ]
+    if not missing:
+        return [
+            f"hermes acp failed to start: {exc}",
+            "The failing import could not be identified; this may not be an "
+            "ACP packaging issue.",
+            "Check your hermes install with:  pip install -e '.[acp]'",
+        ]
+    return [
+        f"hermes acp failed to start: {exc}",
+        f"An unrelated module ({missing}) could not be imported — this is not "
+        "an ACP packaging issue.",
+        "Check your hermes install with:  pip install -e '.[acp]'",
+    ]
+
+
 def _require_tty(command_name: str) -> None:
     """Exit with a clear error if stdin is not a terminal.
 
@@ -13015,9 +13047,9 @@ def cmd_acp(args):
         if getattr(args, "assume_yes", False):
             acp_argv.append("--yes")
         acp_main(acp_argv)
-    except ImportError:
-        print("ACP dependencies not installed.", file=sys.stderr)
-        print("Install them with:  pip install -e '.[acp]'", file=sys.stderr)
+    except ImportError as e:
+        for line in _format_acp_import_error(e):
+            print(line, file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/hermes_cli/test_acp_import_error.py
+++ b/tests/hermes_cli/test_acp_import_error.py
@@ -1,0 +1,43 @@
+"""Tests for ``_format_acp_import_error`` — the helper that turns
+ImportError raised during ``hermes acp`` startup into user-facing messages.
+
+Regression coverage for issue #24959: a fresh hermes install (with a
+pre-existing ``marker-pdf`` in the same env that conflicts with the
+project's openai pin) reported "ACP dependencies not installed" even
+when the actual import failure was elsewhere, sending users in circles
+reinstalling the ``[acp]`` extra.
+"""
+
+from hermes_cli.main import _format_acp_import_error
+
+
+def test_missing_acp_module_reports_install_extra():
+    exc = ImportError("No module named 'acp'", name="acp")
+    lines = _format_acp_import_error(exc)
+    assert lines[0] == "ACP dependencies not installed."
+    assert any("pip install -e '.[acp]'" in line for line in lines)
+
+
+def test_missing_acp_submodule_reports_install_extra():
+    exc = ImportError("No module named 'acp.schema'", name="acp.schema")
+    lines = _format_acp_import_error(exc)
+    assert lines[0] == "ACP dependencies not installed."
+
+
+def test_unrelated_missing_module_does_not_blame_acp_extra():
+    exc = ImportError("No module named 'pydantic'", name="pydantic")
+    lines = _format_acp_import_error(exc)
+    joined = "\n".join(lines)
+    assert "ACP dependencies not installed" not in joined
+    assert "pydantic" in joined
+    assert "not an ACP packaging issue" in joined
+
+
+def test_missing_name_attribute_still_renders():
+    exc = ImportError("cannot import name 'Foo'")
+    lines = _format_acp_import_error(exc)
+    joined = "\n".join(lines)
+    assert "hermes acp failed to start" in joined
+    assert "cannot import name 'Foo'" in joined
+    assert "failing import could not be identified" in joined
+    assert "unrelated module" not in joined


### PR DESCRIPTION
Stop reporting unrelated ImportErrors during `hermes acp` startup as "ACP dependencies not installed".

## What changed and why
- `hermes acp` (`hermes_cli/main.py:cmd_acp`) used to catch every `ImportError` raised while loading the adapter and print `ACP dependencies not installed. Install them with: pip install -e '.[acp]'`. The adapter imports `acp` (the `agent-client-protocol` Python package) lazily inside `acp_adapter.entry.main`, so any unrelated `ImportError` raised after the env / logging setup runs is reported as an `[acp]` extra problem — sending users in circles reinstalling an extra that isn't the cause.
- New module-level helper `_format_acp_import_error` inspects `ImportError.name`. If the missing module is `acp` or starts with `acp.`, it keeps the existing "install the extra" message (which is the real diagnosis in that case). For any other missing module it surfaces the actual failing import and clarifies that this is **not** an `[acp]` packaging issue, so users can investigate the real install corruption instead.
- This is what surfaces in #24959: pip warned about a pre-installed `marker-pdf` clashing with the project's `openai==2.24.0` pin (a soft post-install warning, not a fatal error), and then `hermes acp` reported "ACP dependencies not installed" — making it look like the install actually failed. With this change, if the underlying problem is e.g. a different broken transitive, the user sees what it is rather than reinstalling the `[acp]` extra over and over.

## How to test
- `pytest tests/hermes_cli/test_acp_import_error.py -v` exercises all four branches: missing `acp`, missing `acp.<sub>`, missing unrelated module, and `ImportError` without a `name` attribute.
- `pytest tests/acp tests/acp_adapter` still green (226 tests).
- `ruff check .` clean.

## What platforms tested on
- macOS on darwin-arm64 (local) — `ruff check`, the new test, and the existing acp/acp_adapter suites.
- The reporter is on Windows 11; the helper is pure-Python string formatting with no platform-specific paths, so behavior is identical there.

Fixes #24959

<!-- autocontrib:worker-id=issue-new-c3b31805 kind=pr-open -->