### PR TITLE
fix(gateway): kickstart launchd after SIGUSR1 self-restart on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2996,14 +2996,21 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            return
         if pid is not None:
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
+            # Prefer SIGUSR1 (graceful drain → exit 75) when the gateway is
+            # an ancestor of this process, otherwise SIGTERM. Either way we
+            # MUST fall through to `_wait_for_gateway_exit` + `launchctl
+            # kickstart -k`: when the gateway exits inside its own process
+            # tree (e.g. `hermes update` invoked by the agent via the
+            # terminal tool), launchd has been observed to leave the domain
+            # in "on-demand-only mode" and never issue WILL_SPAWN, so an
+            # explicit kickstart is required to actually relaunch the
+            # service. See #11932.
+            if not _request_gateway_self_restart(pid):
+                try:
+                    terminate_pid(pid, force=False)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pid = None
             if pid is not None:
                 exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
                 if not exited:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -580,9 +580,15 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_self_request_waits_then_kickstarts(self, monkeypatch):
+        """When the gateway is our ancestor, SIGUSR1 → drain → `launchctl
+        kickstart -k`. Returning immediately after SIGUSR1 leaves the
+        gateway dead because launchd does not always relaunch after the
+        in-process-tree exit (#11932)."""
         calls = []
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -593,15 +599,29 @@ class TestLaunchdServiceRecovery:
             lambda pid: calls.append(("self", pid)) or True,
         )
         monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(("wait", timeout, force_after)) or True,
         )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: (_ for _ in ()).throw(AssertionError("SIGTERM should not run when SIGUSR1 succeeded")),
+        )
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        assert calls == [
+            ("self", 321),
+            ("wait", 12.0, None),
+            ["launchctl", "kickstart", "-k", target],
+        ]
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""


### PR DESCRIPTION
Fix the macOS `launchd_restart()` path that left the gateway permanently dead when `hermes update` ran inside the gateway process tree.

## What changed and why

- `hermes_cli/gateway.py` — `launchd_restart()` no longer returns immediately after sending SIGUSR1. Both the SIGUSR1 path (when the gateway is an ancestor of the current process) and the SIGTERM path (when it is not) now fall through to `_wait_for_gateway_exit` and then `launchctl kickstart -k`. This mirrors the systemd restart path and matches what the issue author proposed.
- The bug: when an agent invoked `hermes update` via its terminal tool, the gateway was an ancestor of the update process, so `_request_gateway_self_restart` succeeded and the function returned. The gateway drained and exited with code 75, but macOS launchd was observed to leave the domain in "on-demand-only mode" with no follow-up `WILL_SPAWN`, so the service stayed dead until manual `hermes gateway start`. Issuing `launchctl kickstart -k` unconditionally — which talks to launchd over XPC and works even after our ancestor process exits — restores the relaunch.
- `tests/hermes_cli/test_gateway_service.py` — the existing `test_launchd_restart_self_requests_graceful_restart_without_kickstart` test was asserting precisely the buggy behavior (that `launchctl should not run`). It is replaced with `test_launchd_restart_self_request_waits_then_kickstarts`, which asserts the corrected sequence: SIGUSR1 request → `_wait_for_gateway_exit` with the drain timeout → `launchctl kickstart -k <target>`. The complementary `test_launchd_restart_drains_running_gateway_before_kickstart` (Path B, gateway not an ancestor) is unchanged and still passes.

## How to test

- `pytest tests/hermes_cli/test_gateway_service.py -k launchd_restart -q` — all 3 `launchd_restart` cases pass.
- `pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_gateway_restart.py -q` — 158 tests pass. 3 pre-existing systemd test failures on this Darwin host (`UserSystemdUnavailableError: User D-Bus session is not available`) are unrelated to this change and also fail on `main`.
- Manual repro on a macOS host with the gateway running under launchd: from a Telegram conversation, ask the agent to run `hermes update` via the terminal tool. Before the fix, the gateway would exit with code 75 and not come back. After the fix, `launchctl kickstart -k` runs after the drain and the new gateway process is spawned within seconds.

## What platforms tested on

- macOS on darwin-arm64 (local) — unit tests; manual launchd repro is described above but requires a real LaunchAgent-managed gateway to verify.
- Linux paths (`systemd_restart`) are untouched and were not exercised.

Fixes #11932

<!-- autocontrib:worker-id=issue-new-cf2064fa kind=pr-open -->