### PR TITLE
fix(gateway): stop Google Chat cross-thread replies under concurrent same-space mentions

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -173,14 +173,9 @@ def _load_google_modules() -> bool:
 
 from gateway.config import Platform, PlatformConfig
 
-# Trigger registration of the dynamic ``google_chat`` enum member at module
-# import time.  ``_missing_()`` caches the pseudo-member in
-# ``_value2member_map_`` *and* ``_member_map_``, so after this call
-# ``Platform.GOOGLE_CHAT`` resolves via attribute access too.  Without this
-# line, any code (including tests) that references ``Platform.GOOGLE_CHAT``
-# before an adapter instance is constructed would hit ``AttributeError``.
-# Built-ins avoid this because they have explicit enum members; plugin
-# platforms earn the attribute by asking for it once.
+# Register the dynamic ``google_chat`` platform member at module import time.
+# Plugin platforms are addressed by value (``Platform("google_chat")``),
+# unlike built-in platforms which have explicit enum attributes.
 Platform("google_chat")
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
@@ -699,6 +694,17 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator()
         self._typing_messages: Dict[str, str] = {}
         self._clarify_state: Dict[str, str] = {}
+        # Sidecar recording the thread each ``_typing_messages[chat_id]``
+        # card was created in. Lets ``send()`` / ``on_processing_complete``
+        # detect a cross-thread mismatch and skip patching a sibling
+        # session's card under concurrent activity in the same space.
+        # Without this check ``messages.patch`` (which cannot change the
+        # thread of an existing message) would silently paste session B's
+        # reply text into session A's typing card, leaving B's reply
+        # stranded in A's thread. Keyed by chat_id only — the slot itself
+        # is still single-slot per chat, so a thread mismatch causes the
+        # second session to fall through to ``_create_message`` instead.
+        self._typing_card_threads: Dict[str, Optional[str]] = {}
         self._shutting_down = False
         self._rate_limit_hits: Dict[str, int] = {}
         # Last-seen inbound thread name per chat_id (space). Google Chat
@@ -1904,9 +1910,18 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 self._last_inbound_thread.pop(space_name, None)
         else:
             session_thread_id = thread_name
-            # Groups always reply in-thread.
-            if thread_name and space_name:
-                self._last_inbound_thread[space_name] = thread_name
+            # Groups always reply in-thread, and ``source.thread_id``
+            # carries ``thread_name`` to the gateway which plumbs it
+            # into outbound metadata via ``_thread_metadata_for_source``.
+            # We deliberately DON'T populate ``_last_inbound_thread`` for
+            # groups: under near-simultaneous mentions in different
+            # threads of the same space, that single-slot dict races and
+            # the slower outbound's ``_resolve_thread_id`` fallback can
+            # route its reply into whichever thread won the cache-write
+            # race. Skipping the cache makes the fallback return None
+            # (top-level reply) instead of the wrong thread, which is
+            # still wrong but visibly broken rather than silently
+            # cross-threaded.
 
         source = self.build_source(
             chat_id=space_name,
@@ -2091,9 +2106,22 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error="empty message")
 
             last_result: Optional[SendResult] = None
-            typing_msg_name = self._typing_messages.pop(chat_id, None)
-            # Treat any earlier sentinel as "no real card to patch" — defensive.
-            if typing_msg_name == _TYPING_CONSUMED_SENTINEL:
+            # Peek before popping: under concurrent sessions in the same
+            # space, the slot may hold a SIBLING session's typing card in
+            # a different thread. ``messages.patch`` cannot change a
+            # message's thread, so patching that card would route this
+            # reply into the sibling's thread. Detect the mismatch and
+            # leave the slot for the owning session to finalize.
+            slot = self._typing_messages.get(chat_id)
+            card_thread = self._typing_card_threads.get(chat_id)
+            if (
+                slot is not None
+                and slot != _TYPING_CONSUMED_SENTINEL
+                and card_thread == thread_id
+            ):
+                typing_msg_name = self._typing_messages.pop(chat_id, None)
+                self._typing_card_threads.pop(chat_id, None)
+            else:
                 typing_msg_name = None
             patched_typing = False
 
@@ -2696,6 +2724,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     # in the meantime (e.g. send() racing ahead of us).
                     if chat_id not in self._typing_messages:
                         self._typing_messages[chat_id] = result.message_id
+                        self._typing_card_threads[chat_id] = thread_id
                     else:
                         # Slot already populated — likely send() patched
                         # something or another create completed first.
@@ -2787,7 +2816,23 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return
         chat_id = event.source.chat_id
         try:
-            current = self._typing_messages.pop(chat_id, None)
+            # Only reap the slot if its card belongs to THIS session's
+            # thread. Under concurrent same-space activity, the slot may
+            # hold a sibling session's card — popping it here would
+            # leave that sibling's send() unable to patch its own card.
+            current = self._typing_messages.get(chat_id)
+            card_thread = self._typing_card_threads.get(chat_id)
+            our_thread = getattr(event.source, "thread_id", None)
+            slot_is_ours = (
+                current == _TYPING_CONSUMED_SENTINEL
+                or current is None
+                or card_thread == our_thread
+            )
+            if slot_is_ours:
+                current = self._typing_messages.pop(chat_id, None)
+                self._typing_card_threads.pop(chat_id, None)
+            else:
+                current = None
             if current and current != _TYPING_CONSUMED_SENTINEL:
                 # Real message_name still in slot — send() never ran. Patch
                 # with a benign final state instead of deleting (no tombstone).
@@ -2824,7 +2869,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # Attachment send paths
     # ------------------------------------------------------------------
     async def _consume_typing_card_with_text(
-        self, chat_id: str, text: str
+        self, chat_id: str, text: str,
+        *, thread_id: Optional[str] = None,
     ) -> Optional[SendResult]:
         """Patch the tracked typing card with ``text`` (no tombstone).
 
@@ -2838,12 +2884,21 @@ class GoogleChatAdapter(BasePlatformAdapter):
         the slot to keep the base class's ``_keep_typing`` loop from
         creating a fresh "Hermes is thinking…" card during any subsequent
         attachment send (which would later be reaped as "(no reply)").
+
+        Thread guard: ``messages.patch`` cannot change a message's
+        thread, so a card created in a sibling session's thread is
+        unusable here — return None and let the caller create a fresh
+        message in the correct thread.
         """
         current = self._typing_messages.get(chat_id)
         if not current or current == _TYPING_CONSUMED_SENTINEL:
             return None
-        # Real msg_id — pop and patch.
+        card_thread = self._typing_card_threads.get(chat_id)
+        if card_thread != thread_id:
+            return None
+        # Real msg_id and threads match — pop and patch.
         self._typing_messages.pop(chat_id, None)
+        self._typing_card_threads.pop(chat_id, None)
         try:
             result = await self._patch_message(current, {"text": text})
             self._typing_messages[chat_id] = _TYPING_CONSUMED_SENTINEL
@@ -2877,7 +2932,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         text = "\n".join(text_parts)
 
         try:
-            patched = await self._consume_typing_card_with_text(chat_id, text)
+            patched = await self._consume_typing_card_with_text(
+                chat_id, text, thread_id=thread_id,
+            )
             if patched is not None:
                 return patched
             body: Dict[str, Any] = {"text": text}
@@ -3157,9 +3214,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         # Pre-patch the typing card with the caption (or single space) so
         # it retires without a tombstone before the attachment message is
-        # posted.
+        # posted. Threads match guard inside _consume_typing_card_with_text
+        # protects against patching a sibling session's card from the
+        # same chat.
         try:
-            await self._consume_typing_card_with_text(chat_id, caption or " ")
+            await self._consume_typing_card_with_text(
+                chat_id, caption or " ", thread_id=thread_id,
+            )
         except Exception:
             logger.debug(
                 "[GoogleChat] _send_file pre-patch typing-card failed",

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -373,6 +373,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator()
         self._shutting_down = False
         self._typing_messages: Dict[str, str] = {}
+        # The typing-card slot is per chat, so retain its originating thread
+        # and never patch it from a sibling session in the same space.
+        self._typing_card_threads: Dict[str, Optional[str]] = {}
         self._clarify_state, self._rate_limit_hits = {}, {}
         # Last inbound thread per space: DMs get a NEW thread per top-level message but users
         # see one conversation, so thread_id leaves the source (stable session key) and is cached here.
@@ -912,8 +915,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 self._last_inbound_thread.pop(space_name, None)
         else:
             session_thread_id = thread_name
-            if thread_name and space_name:
-                self._last_inbound_thread[space_name] = thread_name
+            # Group replies receive their thread through source metadata. Do
+            # not write the shared fallback cache here: simultaneous mentions
+            # in different threads would let one reply take the other's slot.
         source = self.build_source(
             chat_id=space_name, chat_name=space.get("displayName") or space.get("name") or "", chat_type=chat_type,
             # Email is the canonical id (allowlists use emails); the ``users/{id}``
@@ -1003,8 +1007,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
             if not chunks:
                 return SendResult(success=False, error="empty message")
             last_result: Optional[SendResult] = None
-            typing_msg_name = self._typing_messages.pop(chat_id, None)
-            if typing_msg_name == _TYPING_CONSUMED_SENTINEL:
+            # A sibling session may own this chat-scoped typing card. Patching
+            # it would put this reply in the sibling's immutable thread.
+            slot = self._typing_messages.get(chat_id)
+            if slot and slot != _TYPING_CONSUMED_SENTINEL and self._typing_card_threads.get(chat_id) == thread_id:
+                typing_msg_name = self._typing_messages.pop(chat_id)
+                self._typing_card_threads.pop(chat_id, None)
+            else:
                 typing_msg_name = None
             patched_typing = False
             for idx, chunk in enumerate(chunks):
@@ -1244,6 +1253,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 if result.success and result.message_id:
                     if chat_id not in self._typing_messages:
                         self._typing_messages[chat_id] = result.message_id
+                        self._typing_card_threads[chat_id] = thread_id
                     else:
                         # send() or another create claimed the slot first: orphan;
                         # on_processing_complete cleans it up.
@@ -1278,7 +1288,17 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return
         chat_id = event.source.chat_id
         try:
-            current = self._typing_messages.pop(chat_id, None)
+            current = self._typing_messages.get(chat_id)
+            our_thread = getattr(event.source, "thread_id", None)
+            if (
+                current is None
+                or current == _TYPING_CONSUMED_SENTINEL
+                or self._typing_card_threads.get(chat_id) == our_thread
+            ):
+                current = self._typing_messages.pop(chat_id, None)
+                self._typing_card_threads.pop(chat_id, None)
+            else:
+                current = None
             if current and current != _TYPING_CONSUMED_SENTINEL:
                 label = "(interrupted)" if outcome == ProcessingOutcome.CANCELLED else "(no reply)"
                 await self._patch_quietly(current, label, "[GoogleChat] on_processing_complete patch fallback failed")
@@ -1288,14 +1308,19 @@ class GoogleChatAdapter(BasePlatformAdapter):
             logger.debug("[GoogleChat] cleanup in on_processing_complete failed", exc_info=True)
 
     # -- attachments ---------------------------------------------------------
-    async def _consume_typing_card_with_text(self, chat_id: str, text: str) -> Optional[SendResult]:
+    async def _consume_typing_card_with_text(
+        self, chat_id: str, text: str, *, thread_id: Optional[str] = None,
+    ) -> Optional[SendResult]:
         """Patch the tracked typing card with ``text`` (no tombstone); None when there is no
         real card (caller creates a message) — the SENTINEL stays so ``_keep_typing`` doesn't
         post a fresh card during a subsequent attachment send. Raises transient HttpErrors."""
         current = self._typing_messages.get(chat_id)
         if not current or current == _TYPING_CONSUMED_SENTINEL:
             return None
+        if self._typing_card_threads.get(chat_id) != thread_id:
+            return None
         self._typing_messages.pop(chat_id, None)
+        self._typing_card_threads.pop(chat_id, None)
         try:
             result = await self._patch_message(current, {"text": text})
             self._typing_messages[chat_id] = _TYPING_CONSUMED_SENTINEL
@@ -1313,7 +1338,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         thread_id = self._resolve_thread_id(reply_to, metadata, chat_id=chat_id)
         text = "\n".join(([caption] if caption else []) + [image_url])
         try:
-            patched = await self._consume_typing_card_with_text(chat_id, text)
+            patched = await self._consume_typing_card_with_text(
+                chat_id, text, thread_id=thread_id,
+            )
             if patched is not None:
                 return patched
             return await self._create_message(chat_id, _thread_body(text, thread_id))
@@ -1436,7 +1463,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         if chat_api is None:
             return await self._post_attachment_fallback(chat_id, path, filename, caption, thread_id)
         try:
-            await self._consume_typing_card_with_text(chat_id, caption or " ")
+            await self._consume_typing_card_with_text(
+                chat_id, caption or " ", thread_id=thread_id,
+            )
         except Exception:
             logger.debug("[GoogleChat] _send_file pre-patch typing-card failed", exc_info=True)
 

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -139,7 +139,6 @@ from plugins.platforms.google_chat.adapter import (  # noqa: E402
 )
 from plugins.platforms.google_chat.cards import card_spec_to_cards_v2  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -777,6 +776,9 @@ class TestSend:
     @pytest.mark.asyncio
     async def test_with_typing_card_patches_instead_of_creating(self, adapter):
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/THINK"
+        # Card lives in the same thread as the outbound — the
+        # cross-thread guard in send() only patches matching cards.
+        adapter._typing_card_threads["spaces/S"] = "spaces/S/threads/T"
         adapter._patch_message = AsyncMock(
             return_value=type("R", (), {"success": True,
                                         "message_id": "spaces/S/messages/THINK",
@@ -936,6 +938,7 @@ class TestTypingLifecycle:
         event = MagicMock()
         event.source = MagicMock()
         event.source.chat_id = "spaces/S"
+        event.source.thread_id = None
         await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         # Both orphans patched (typing_messages cleared too).
         assert adapter._patch_message.await_count == 2
@@ -961,12 +964,12 @@ class TestTypingLifecycle:
         assert adapter._typing_messages["spaces/S"] == "spaces/S/messages/THINK"
         delete_mock.assert_not_called()
 
-
     @pytest.mark.asyncio
     async def test_on_processing_complete_patches_stranded_card(self, adapter):
         """CANCELLED path: send() never ran. Patch the typing card with a
         benign final state instead of deleting (no tombstone)."""
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/THINK"
+        adapter._typing_card_threads["spaces/S"] = None
         adapter._patch_message = AsyncMock(
             return_value=type("R", (), {"success": True,
                                         "message_id": "spaces/S/messages/THINK",
@@ -975,6 +978,7 @@ class TestTypingLifecycle:
         event = MagicMock()
         event.source = MagicMock()
         event.source.chat_id = "spaces/S"
+        event.source.thread_id = None
         await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
         adapter._patch_message.assert_awaited_once()
         # Patched with a final-state label, not deleted.
@@ -1150,10 +1154,10 @@ class TestUserOAuthHelper:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         users_dir = tmp_path / "google_chat_user_tokens"
         users_dir.mkdir(parents=True)
-        (users_dir / "alice@example.com.json").write_text("{}")
-        (users_dir / "bob@example.com.json").write_text("{}")
+        (users_dir / "alice@example.com.json").write_text("{}", encoding="utf-8")
+        (users_dir / "bob@example.com.json").write_text("{}", encoding="utf-8")
         # Legacy file should NOT appear in the list.
-        (tmp_path / "google_chat_user_token.json").write_text("{}")
+        (tmp_path / "google_chat_user_token.json").write_text("{}", encoding="utf-8")
 
         from plugins.platforms.google_chat.oauth import list_authorized_emails
         assert list_authorized_emails() == [
@@ -1292,7 +1296,7 @@ class TestThreadCountStore:
         as fresh, move on. The next incr() will overwrite."""
         from plugins.platforms.google_chat.adapter import _ThreadCountStore
         path = tmp_path / "counts.json"
-        path.write_text("not valid json {")
+        path.write_text("not valid json {", encoding="utf-8")
         store = _ThreadCountStore(path)
         store.load()
         assert store.get("spaces/X", "spaces/X/threads/T") == 0
@@ -1301,7 +1305,7 @@ class TestThreadCountStore:
         assert prev == 0
         # File now has valid JSON.
         import json
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert data == {"spaces/X": {"spaces/X/threads/T": 1}}
 
 
@@ -1408,6 +1412,116 @@ class TestOutboundThreadRouting:
             chat_id="spaces/X",
         )
         assert result == "spaces/X/threads/CACHED"
+
+
+class TestConcurrentSpaceThreadRouting:
+    """Regression coverage for the same-space cross-thread race —
+    concurrent @-mentions in different threads of the same Google Chat
+    space must NOT route either reply into the other thread (Issue
+    #24964). Two independent mechanisms can cause the symptom:
+
+      1. The single-slot ``_last_inbound_thread[chat_id]`` cache races
+         when two inbound messages land in different threads within the
+         same space — the slower outbound's ``_resolve_thread_id``
+         fallback would return whichever thread won the cache-write
+         race.
+      2. The single-slot ``_typing_messages[chat_id]`` typing-card
+         tracker may hold a card belonging to a SIBLING session in a
+         different thread. ``messages.patch`` cannot change a message's
+         thread, so patching that card would visibly drop the reply
+         into the sibling's thread.
+    """
+
+    @pytest.mark.asyncio
+    async def test_group_does_not_populate_inbound_thread_cache(self, adapter):
+        """In group spaces ``source.thread_id`` always carries the
+        thread to the outbound metadata, so the cache fallback is
+        unnecessary AND racy under concurrent mentions. Build the event
+        and verify the cache stays empty for groups."""
+        env = _make_chat_envelope(text="hi", thread_name="spaces/G/threads/T1")
+        env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+        env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        msg = env["chat"]["messagePayload"]["message"]
+        event = await adapter._build_message_event(msg, env)
+        assert event.source.chat_type == "group"
+        assert event.source.thread_id == "spaces/G/threads/T1"
+        # The single-slot cache MUST stay empty for groups — populating
+        # it under concurrent inbound messages in different threads is
+        # what cross-threads the slower reply.
+        assert "spaces/G" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
+    async def test_group_second_thread_does_not_overwrite_first(self, adapter):
+        """Two inbound mentions in DIFFERENT threads of the same space:
+        the second must not race the first by overwriting
+        ``_last_inbound_thread``."""
+        for tid in ("T1", "T2"):
+            env = _make_chat_envelope(
+                text=f"msg in {tid}",
+                thread_name=f"spaces/G/threads/{tid}",
+            )
+            env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+            env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+            await adapter._build_message_event(
+                env["chat"]["messagePayload"]["message"], env,
+            )
+        # Neither thread should have leaked into the single-slot cache.
+        assert "spaces/G" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_patch_sibling_thread_typing_card(self, adapter):
+        """Session A's typing card lives in thread T_A. Session B finishes
+        first and calls ``send()`` with metadata pointing at T_B. The slot
+        still holds A's card. Patching would silently route B's reply
+        into T_A (``messages.patch`` cannot change the thread). The
+        thread-guard in ``send()`` must skip the patch and create a fresh
+        message in T_B instead."""
+        adapter._typing_messages["spaces/G"] = "spaces/G/messages/A_CARD"
+        adapter._typing_card_threads["spaces/G"] = "spaces/G/threads/T_A"
+        adapter._patch_message = AsyncMock()
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/G/messages/B_REPLY",
+                                        "error": None})()
+        )
+        result = await adapter.send(
+            "spaces/G", "B's reply",
+            metadata={"thread_id": "spaces/G/threads/T_B"},
+        )
+        adapter._patch_message.assert_not_called()
+        adapter._create_message.assert_awaited_once()
+        # New message body must carry T_B's thread name.
+        _, args, kwargs = adapter._create_message.mock_calls[0]
+        body = args[1]
+        assert body.get("thread") == {"name": "spaces/G/threads/T_B"}
+        assert result.success is True
+        # A's card must STILL be in the slot so A's own send() / cleanup
+        # can finalize it.
+        assert adapter._typing_messages["spaces/G"] == "spaces/G/messages/A_CARD"
+        assert (
+            adapter._typing_card_threads["spaces/G"] == "spaces/G/threads/T_A"
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_skips_sibling_thread_card(self, adapter):
+        """When session B's processing completes and the slot holds
+        session A's card in a different thread, the cleanup must NOT
+        pop or patch A's card — that would leave A unable to finalize
+        its own card on its turn."""
+        adapter._typing_messages["spaces/G"] = "spaces/G/messages/A_CARD"
+        adapter._typing_card_threads["spaces/G"] = "spaces/G/threads/T_A"
+        adapter._patch_message = AsyncMock()
+        event = MagicMock()
+        event.source = MagicMock()
+        event.source.chat_id = "spaces/G"
+        event.source.thread_id = "spaces/G/threads/T_B"
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        adapter._patch_message.assert_not_called()
+        # Sibling's slot left intact.
+        assert adapter._typing_messages["spaces/G"] == "spaces/G/messages/A_CARD"
+        assert (
+            adapter._typing_card_threads["spaces/G"] == "spaces/G/threads/T_A"
+        )
 
 
 # ===========================================================================
@@ -1841,4 +1955,3 @@ class TestGoogleChatStandaloneSend:
         assert url == "https://chat.googleapis.com/v1/spaces/AAAA-BBBB/messages"
         assert kwargs["headers"]["Authorization"] == "Bearer the-token"
         assert kwargs["json"] == {"text": "hello cron"}
-

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -139,7 +139,6 @@ from plugins.platforms.google_chat.adapter import (  # noqa: E402
     check_google_chat_requirements,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -722,6 +721,9 @@ class TestSend:
     @pytest.mark.asyncio
     async def test_with_typing_card_patches_instead_of_creating(self, adapter):
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/THINK"
+        # Card lives in the same thread as the outbound — the
+        # cross-thread guard in send() only patches matching cards.
+        adapter._typing_card_threads["spaces/S"] = "spaces/S/threads/T"
         adapter._patch_message = AsyncMock(
             return_value=type("R", (), {"success": True,
                                         "message_id": "spaces/S/messages/THINK",
@@ -881,6 +883,7 @@ class TestTypingLifecycle:
         event = MagicMock()
         event.source = MagicMock()
         event.source.chat_id = "spaces/S"
+        event.source.thread_id = None
         await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         # Both orphans patched (typing_messages cleared too).
         assert adapter._patch_message.await_count == 2
@@ -906,12 +909,12 @@ class TestTypingLifecycle:
         assert adapter._typing_messages["spaces/S"] == "spaces/S/messages/THINK"
         delete_mock.assert_not_called()
 
-
     @pytest.mark.asyncio
     async def test_on_processing_complete_patches_stranded_card(self, adapter):
         """CANCELLED path: send() never ran. Patch the typing card with a
         benign final state instead of deleting (no tombstone)."""
         adapter._typing_messages["spaces/S"] = "spaces/S/messages/THINK"
+        adapter._typing_card_threads["spaces/S"] = None
         adapter._patch_message = AsyncMock(
             return_value=type("R", (), {"success": True,
                                         "message_id": "spaces/S/messages/THINK",
@@ -920,6 +923,7 @@ class TestTypingLifecycle:
         event = MagicMock()
         event.source = MagicMock()
         event.source.chat_id = "spaces/S"
+        event.source.thread_id = None
         await adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
         adapter._patch_message.assert_awaited_once()
         # Patched with a final-state label, not deleted.
@@ -1095,10 +1099,10 @@ class TestUserOAuthHelper:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         users_dir = tmp_path / "google_chat_user_tokens"
         users_dir.mkdir(parents=True)
-        (users_dir / "alice@example.com.json").write_text("{}")
-        (users_dir / "bob@example.com.json").write_text("{}")
+        (users_dir / "alice@example.com.json").write_text("{}", encoding="utf-8")
+        (users_dir / "bob@example.com.json").write_text("{}", encoding="utf-8")
         # Legacy file should NOT appear in the list.
-        (tmp_path / "google_chat_user_token.json").write_text("{}")
+        (tmp_path / "google_chat_user_token.json").write_text("{}", encoding="utf-8")
 
         from plugins.platforms.google_chat.oauth import list_authorized_emails
         assert list_authorized_emails() == [
@@ -1237,7 +1241,7 @@ class TestThreadCountStore:
         as fresh, move on. The next incr() will overwrite."""
         from plugins.platforms.google_chat.adapter import _ThreadCountStore
         path = tmp_path / "counts.json"
-        path.write_text("not valid json {")
+        path.write_text("not valid json {", encoding="utf-8")
         store = _ThreadCountStore(path)
         store.load()
         assert store.get("spaces/X", "spaces/X/threads/T") == 0
@@ -1246,7 +1250,7 @@ class TestThreadCountStore:
         assert prev == 0
         # File now has valid JSON.
         import json
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         assert data == {"spaces/X": {"spaces/X/threads/T": 1}}
 
 
@@ -1310,6 +1314,116 @@ class TestOutboundThreadRouting:
             chat_id="spaces/X",
         )
         assert result == "spaces/X/threads/CACHED"
+
+
+class TestConcurrentSpaceThreadRouting:
+    """Regression coverage for the same-space cross-thread race —
+    concurrent @-mentions in different threads of the same Google Chat
+    space must NOT route either reply into the other thread (Issue
+    #24964). Two independent mechanisms can cause the symptom:
+
+      1. The single-slot ``_last_inbound_thread[chat_id]`` cache races
+         when two inbound messages land in different threads within the
+         same space — the slower outbound's ``_resolve_thread_id``
+         fallback would return whichever thread won the cache-write
+         race.
+      2. The single-slot ``_typing_messages[chat_id]`` typing-card
+         tracker may hold a card belonging to a SIBLING session in a
+         different thread. ``messages.patch`` cannot change a message's
+         thread, so patching that card would visibly drop the reply
+         into the sibling's thread.
+    """
+
+    @pytest.mark.asyncio
+    async def test_group_does_not_populate_inbound_thread_cache(self, adapter):
+        """In group spaces ``source.thread_id`` always carries the
+        thread to the outbound metadata, so the cache fallback is
+        unnecessary AND racy under concurrent mentions. Build the event
+        and verify the cache stays empty for groups."""
+        env = _make_chat_envelope(text="hi", thread_name="spaces/G/threads/T1")
+        env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+        env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+        msg = env["chat"]["messagePayload"]["message"]
+        event = await adapter._build_message_event(msg, env)
+        assert event.source.chat_type == "group"
+        assert event.source.thread_id == "spaces/G/threads/T1"
+        # The single-slot cache MUST stay empty for groups — populating
+        # it under concurrent inbound messages in different threads is
+        # what cross-threads the slower reply.
+        assert "spaces/G" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
+    async def test_group_second_thread_does_not_overwrite_first(self, adapter):
+        """Two inbound mentions in DIFFERENT threads of the same space:
+        the second must not race the first by overwriting
+        ``_last_inbound_thread``."""
+        for tid in ("T1", "T2"):
+            env = _make_chat_envelope(
+                text=f"msg in {tid}",
+                thread_name=f"spaces/G/threads/{tid}",
+            )
+            env["chat"]["messagePayload"]["space"]["spaceType"] = "SPACE"
+            env["chat"]["messagePayload"]["message"]["space"]["spaceType"] = "SPACE"
+            await adapter._build_message_event(
+                env["chat"]["messagePayload"]["message"], env,
+            )
+        # Neither thread should have leaked into the single-slot cache.
+        assert "spaces/G" not in adapter._last_inbound_thread
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_patch_sibling_thread_typing_card(self, adapter):
+        """Session A's typing card lives in thread T_A. Session B finishes
+        first and calls ``send()`` with metadata pointing at T_B. The slot
+        still holds A's card. Patching would silently route B's reply
+        into T_A (``messages.patch`` cannot change the thread). The
+        thread-guard in ``send()`` must skip the patch and create a fresh
+        message in T_B instead."""
+        adapter._typing_messages["spaces/G"] = "spaces/G/messages/A_CARD"
+        adapter._typing_card_threads["spaces/G"] = "spaces/G/threads/T_A"
+        adapter._patch_message = AsyncMock()
+        adapter._create_message = AsyncMock(
+            return_value=type("R", (), {"success": True,
+                                        "message_id": "spaces/G/messages/B_REPLY",
+                                        "error": None})()
+        )
+        result = await adapter.send(
+            "spaces/G", "B's reply",
+            metadata={"thread_id": "spaces/G/threads/T_B"},
+        )
+        adapter._patch_message.assert_not_called()
+        adapter._create_message.assert_awaited_once()
+        # New message body must carry T_B's thread name.
+        _, args, kwargs = adapter._create_message.mock_calls[0]
+        body = args[1]
+        assert body.get("thread") == {"name": "spaces/G/threads/T_B"}
+        assert result.success is True
+        # A's card must STILL be in the slot so A's own send() / cleanup
+        # can finalize it.
+        assert adapter._typing_messages["spaces/G"] == "spaces/G/messages/A_CARD"
+        assert (
+            adapter._typing_card_threads["spaces/G"] == "spaces/G/threads/T_A"
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_processing_complete_skips_sibling_thread_card(self, adapter):
+        """When session B's processing completes and the slot holds
+        session A's card in a different thread, the cleanup must NOT
+        pop or patch A's card — that would leave A unable to finalize
+        its own card on its turn."""
+        adapter._typing_messages["spaces/G"] = "spaces/G/messages/A_CARD"
+        adapter._typing_card_threads["spaces/G"] = "spaces/G/threads/T_A"
+        adapter._patch_message = AsyncMock()
+        event = MagicMock()
+        event.source = MagicMock()
+        event.source.chat_id = "spaces/G"
+        event.source.thread_id = "spaces/G/threads/T_B"
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+        adapter._patch_message.assert_not_called()
+        # Sibling's slot left intact.
+        assert adapter._typing_messages["spaces/G"] == "spaces/G/messages/A_CARD"
+        assert (
+            adapter._typing_card_threads["spaces/G"] == "spaces/G/threads/T_A"
+        )
 
 
 # ===========================================================================
@@ -1738,5 +1852,3 @@ class TestGoogleChatStandaloneSend:
         assert url == "https://chat.googleapis.com/v1/spaces/AAAA-BBBB/messages"
         assert kwargs["headers"]["Authorization"] == "Bearer the-token"
         assert kwargs["json"] == {"text": "hello cron"}
-
-


### PR DESCRIPTION
Scopes Google Chat adapter thread state per-thread so concurrent @-mentions in different threads of the same space stop crossing replies between threads (#24964).

## What changed and why
- Drop the `_last_inbound_thread[chat_id]` write in the group branch of `_build_message_event`. For groups, `source.thread_id` already carries the inbound thread name onto the `MessageEvent`, and the gateway plumbs it into outbound metadata via `_thread_metadata_for_source` — so the cache is redundant. Under near-simultaneous mentions in different threads of the same space, the single-slot cache races and the slower outbound's `_resolve_thread_id` fallback would otherwise return whichever thread won the cache-write race. Skipping the cache makes the fallback return `None` (top-level reply) for groups when metadata is missing, which is still wrong but visibly broken rather than silently cross-threaded.
- Add a `_typing_card_threads: Dict[str, Optional[str]]` sidecar recording the thread each `_typing_messages[chat_id]` card was created in. `send()`, `on_processing_complete`, and `_consume_typing_card_with_text` now compare the recorded card thread against the current session's outbound thread and refuse to patch on mismatch. `messages.patch` cannot change a message's thread, so patching a sibling's card would have silently dropped the reply text into the sibling's thread; the guard falls through to `_create_message` in the correct thread instead and leaves the sibling's card in the slot for its own `send()` / cleanup to finalize.
- DM behavior is unchanged: `_last_inbound_thread` is still populated for DM side-threads, the DM main-flow vs side-thread heuristic still drives session isolation, and the anti-tombstone typing-card lifecycle still works.

## How to test
- `pytest tests/gateway/test_google_chat.py -q` — all 161 tests pass, including four new regression tests in `TestConcurrentSpaceThreadRouting` covering: (1) groups no longer leak threads into the single-slot cache, (2) two different threads in the same space don't overwrite each other, (3) `send()` refuses to patch a sibling-thread typing card and creates a new message in its own thread, (4) `on_processing_complete` leaves a sibling-thread card in place.
- `ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py` — clean.

## What platforms tested on
- macOS on darwin-arm64 (local pytest run)

Fixes #24964

<!-- autocontrib:worker-id=issue-new-3ad1f0f5 kind=pr-open -->