### PR TITLE
fix(agent): add circuit-breaker to _try_activate_fallback to prevent tight retry loops

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8600,6 +8600,14 @@ class AIAgent:
 
     # ── Provider fallback ──────────────────────────────────────────────────
 
+    # Circuit-breaker thresholds: prevent tight fallback-switch loops when
+    # every provider in the chain fails back-to-back (incident: depleted
+    # primary credits + rate-limited fallback A + 400-rejected fallback B
+    # caused hundreds of activations per second and host swap exhaustion).
+    _FALLBACK_THROTTLE_INTERVAL_S = 2.0
+    _FALLBACK_BREAKER_WINDOW_S = 60.0
+    _FALLBACK_BREAKER_LIMIT = 5
+
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Switch to the next fallback model/provider in the chain.
 
@@ -8612,6 +8620,33 @@ class AIAgent:
         auth resolution and client construction — no duplicated provider→key
         mappings.
         """
+        # Circuit-breaker: throttle consecutive activations and trip the
+        # breaker (returning False, which existing call sites already handle
+        # as "chain exhausted") if too many fire in a short window.
+        if not hasattr(self, "_fallback_activations"):
+            self._fallback_activations: list[float] = []
+        now = time.monotonic()
+        self._fallback_activations = [
+            t for t in self._fallback_activations
+            if now - t < self._FALLBACK_BREAKER_WINDOW_S
+        ]
+        if len(self._fallback_activations) >= self._FALLBACK_BREAKER_LIMIT:
+            self._emit_status(
+                f"🛑 Circuit-breaker tripped: {self._FALLBACK_BREAKER_LIMIT} fallback "
+                f"activations in {int(self._FALLBACK_BREAKER_WINDOW_S)}s. "
+                f"Aborting to prevent retry storm."
+            )
+            return False
+        if self._fallback_activations:
+            elapsed = now - self._fallback_activations[-1]
+            if elapsed < self._FALLBACK_THROTTLE_INTERVAL_S:
+                wait = self._FALLBACK_THROTTLE_INTERVAL_S - elapsed
+                self._emit_status(
+                    f"⏸️ Circuit-breaker: sleeping {wait:.1f}s before fallback switch"
+                )
+                time.sleep(wait)
+        self._fallback_activations.append(time.monotonic())
+
         if reason in {FailoverReason.rate_limit, FailoverReason.billing}:
             # Only start cooldown when leaving the primary provider.  If we're
             # already on a fallback and chain-switching, the primary wasn't the


### PR DESCRIPTION
## Summary

Adds a circuit-breaker to `AIAgent._try_activate_fallback` so that when every provider in the fallback chain returns non-retryable errors back-to-back, the function self-throttles and ultimately trips, preventing host memory exhaustion from a runaway retry loop.

Two protections, both at the top of the function:

1. **Throttle**: enforce ≥2s between consecutive activations
2. **Breaker**: ≥5 activations in a 60s rolling window → return `False`, which existing call sites already handle as "chain exhausted"

Thresholds exposed as class constants (`_FALLBACK_THROTTLE_INTERVAL_S`, `_FALLBACK_BREAKER_WINDOW_S`, `_FALLBACK_BREAKER_LIMIT`) for easy tuning.

## Motivation

Refs #24996.

When the primary provider returns a non-retryable error (HTTP 402 — depleted credits, HTTP 400 — request rejected, etc.) and the fallback chain has providers that themselves fail non-retryably (rate-limited, model-incompatible request shape), the existing code resets `retry_count = 0` and `continue`s the outer loop. There is no minimum interval between activations and no cap. On a large accumulated session context (~80k tokens), each iteration re-marshals the context, and hundreds of activations per second can pile up in under a second of wall-clock time, exhausting RAM + swap on constrained hosts (single-board / self-hosted setups).

The existing #1630 guard ("Skipping session persistence for large failed session") prevents context growth across persisted-restart cycles. This PR addresses a complementary failure mode: rapid in-process activation churn.

## How it works

```python
_FALLBACK_THROTTLE_INTERVAL_S = 2.0
_FALLBACK_BREAKER_WINDOW_S = 60.0
_FALLBACK_BREAKER_LIMIT = 5

def _try_activate_fallback(self, reason=None) -> bool:
    # ... docstring ...
    if not hasattr(self, "_fallback_activations"):
        self._fallback_activations = []
    now = time.monotonic()
    # Drop activations older than the breaker window
    self._fallback_activations = [t for t in self._fallback_activations
                                  if now - t < self._FALLBACK_BREAKER_WINDOW_S]
    if len(self._fallback_activations) >= self._FALLBACK_BREAKER_LIMIT:
        self._emit_status("🛑 Circuit-breaker tripped: ...")
        return False
    if self._fallback_activations:
        elapsed = now - self._fallback_activations[-1]
        if elapsed < self._FALLBACK_THROTTLE_INTERVAL_S:
            time.sleep(self._FALLBACK_THROTTLE_INTERVAL_S - elapsed)
    self._fallback_activations.append(time.monotonic())
    # ... existing logic (rate-limit cooldown etc.) continues ...
```

Return value `False` reaches existing handlers cleanly — every `if self._try_activate_fallback(): continue` call site already has the fall-through "fallback exhausted" path.

## Notes / open questions

- **Recursive intra-chain skips** (e.g., the existing `return self._try_activate_fallback()` for invalid/duplicate entries) will increment the activation counter under this implementation. In practice this is harmless: those recursive calls are cheap (no API call) and rare (mis-configured fallback entries). If maintainers prefer, the counter could be scoped to only external entries via a recursion-depth flag.
- **No tests added yet** — happy to add one modeled on `tests/run_agent/test_1630_context_overflow_loop.py` if the approach is accepted.
- **Thresholds** are conservative defaults (`2s` interval, `5/60s` limit). Tuning may be warranted based on the expected legitimate fallback velocity.

## Closes / Refs

Refs #24996.
