### PR TITLE
feat(deepseek): enable native thinking mode via extra_body.thinking + provider profile

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -348,6 +348,17 @@ class ChatCompletionsTransport(ProviderTransport):
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
             }
 
+        # DeepSeek extra_body.thinking
+        is_deepseek = params.get("is_deepseek", False)
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
+            }
+
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.
         if params.get("supports_reasoning", False) and not params.get("is_lmstudio", False):

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,9 +1,36 @@
-"""DeepSeek provider profile."""
+"""DeepSeek provider profile.
+
+DeepSeek native Chat Completions API (api.deepseek.com/v1).
+Thinking mode is enabled via ``extra_body={\"thinking\": {\"type\": \"enabled\"}}``.
+"""
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-deepseek = ProviderProfile(
+
+class DeepSeekProfile(ProviderProfile):
+    """DeepSeek native API — thinking mode via extra_body.thinking."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Translate Hermes reasoning_config to DeepSeek thinking parameter.
+
+        DeepSeek API requires ``extra_body={\"thinking\": {\"type\": \"enabled\"}}``
+        to return reasoning_content in chat completions responses.
+        """
+        extra_body: dict[str, Any] = {}
+        if reasoning_config is not None and reasoning_config.get("enabled", True):
+            extra_body["thinking"] = {"type": "enabled"}
+        return extra_body, {}
+
+
+deepseek = DeepSeekProfile(
     name="deepseek",
     aliases=("deepseek-chat",),
     env_vars=("DEEPSEEK_API_KEY",),

--- a/run_agent.py
+++ b/run_agent.py
@@ -9528,6 +9528,7 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = base_url_host_matches(self.base_url, "api.deepseek.com")
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
 
@@ -9639,6 +9640,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
             is_custom_provider=self.provider == "custom",

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -288,3 +288,27 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+
+class TestDeepSeekProfile:
+    def test_thinking_enabled(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+        # DeepSeek doesn't use reasoning_effort top-level (unlike Kimi)
+        assert "reasoning_effort" not in tl
+
+    def test_thinking_disabled_no_extra_body(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking" not in eb
+
+    def test_no_config_omits_thinking(self):
+        """When reasoning_config is None, no thinking parameter emitted."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config=None)
+        assert "thinking" not in eb

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -257,3 +257,27 @@ class TestCustomOllamaParity:
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+
+class TestDeepSeekParity:
+    """DeepSeek native API: thinking via extra_body.thinking."""
+
+    def test_thinking_enabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking" not in kw.get("extra_body", {})


### PR DESCRIPTION
## Problem

DeepSeek's native Chat Completions API requires  to return reasoning_content. Hermes already handled the response-side (reasoning_content placeholder fixes in bfb704684, #15478), but the request-side — sending extra_body.thinking to the API — was missing.

**Kimi** already had full thinking support via . DeepSeek was simply overlooked.

## Changes

| File | Change |
|------|--------|
|  |  with  (follows Kimi pattern) |
|  | Legacy-path  fallback (parity with  path) |
|  |  detection +  param forwarding |
|  |  (3 tests) |
|  |  (2 tests) |

## How it works

1. **Provider profile path** (primary):  emits  when  is true
2. **Legacy path** (fallback): When the profile isnt loaded, the  flag in  handles it — same pattern as the existing  path

## Verification

