### PR TITLE
fix(gateway): stop typing indicator before post-delivery callback to prevent indefinite typing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3380,14 +3380,9 @@ class BasePlatformAdapter(ABC):
                 )
             else:
                 _post_cb = getattr(self, "_post_delivery_callbacks", {}).pop(session_key, None)
-            if callable(_post_cb):
-                try:
-                    _post_result = _post_cb()
-                    if inspect.isawaitable(_post_result):
-                        await _post_result
-                except Exception:
-                    pass
-            # Stop typing indicator
+            # Stop typing indicator FIRST — must not be delayed by callback work.
+            # If the post-delivery callback hangs (e.g. dead socket), the typing
+            # task would run indefinitely.  See issue #24971.
             await _stop_typing_task()
             # Also cancel any platform-level persistent typing tasks (e.g. Discord)
             # that may have been recreated by _keep_typing after the last stop_typing()
@@ -3396,6 +3391,13 @@ class BasePlatformAdapter(ABC):
                     await self.stop_typing(event.source.chat_id)
             except Exception:
                 pass
+            if callable(_post_cb):
+                try:
+                    _post_result = _post_cb()
+                    if inspect.isawaitable(_post_result):
+                        await asyncio.wait_for(_post_result, timeout=30.0)
+                except (asyncio.TimeoutError, Exception):
+                    pass
             # Late-arrival drain: a message may have arrived during the
             # cleanup awaits above (typing_task cancel, stop_typing).  Such
             # messages passed the Level-1 guard (entry still live, Event


### PR DESCRIPTION
## Summary

Move `_stop_typing_task()` and `stop_typing()` calls **before** the post-delivery callback in `_process_message_background`'s `finally` block. If the callback hangs (e.g. dead Telegram socket in `CLOSE-WAIT` state), the typing indicator task would previously run indefinitely since `_stop_typing_task()` was never reached.

Also wrap the awaitable callback result with `asyncio.wait_for(timeout=30)` so a slow/stuck callback cannot block the cleanup path indefinitely.

## Changes

**`gateway/platforms/base.py`**
- Reorder the `finally` block: call `_stop_typing_task()` + `stop_typing()` before executing the post-delivery callback
- Add `asyncio.wait_for(_post_result, timeout=30.0)` to bound awaitable callbacks
- Catch `asyncio.TimeoutError` alongside generic `Exception`

## Root Cause

The post-delivery callback (e.g. `_send_goal_status_notice()`) can hang indefinitely when making HTTP calls over a dead Telegram socket that entered `CLOSE-WAIT` state after a network error. Since `_stop_typing_task()` was placed **after** the callback await, it was never reached, causing `_keep_typing` to refresh `sendChatAction(typing)` every 2 seconds forever.

## Testing

- All 51 typing-related tests pass
- All 23 post_delivery/stop_typing tests pass
- Consistent with existing pattern at line ~3310 where `_stop_typing_task()` is already called before the drain task

Fixes #24971