### PR TITLE
fix(weixin): update iLink protocol handshake

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -72,8 +72,8 @@ from utils import atomic_json_write
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WEIXIN_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
 ILINK_APP_ID = "bot"
-CHANNEL_VERSION = "2.2.0"
-ILINK_APP_CLIENT_VERSION = (2 << 16) | (2 << 8) | 0
+CHANNEL_VERSION = "2.4.3"
+ILINK_APP_CLIENT_VERSION = (2 << 16) | (4 << 8) | 3
 
 EP_GET_UPDATES = "ilink/bot/getupdates"
 EP_SEND_MESSAGE = "ilink/bot/sendmessage"
@@ -82,6 +82,8 @@ EP_GET_CONFIG = "ilink/bot/getconfig"
 EP_GET_UPLOAD_URL = "ilink/bot/getuploadurl"
 EP_GET_BOT_QR = "ilink/bot/get_bot_qrcode"
 EP_GET_QR_STATUS = "ilink/bot/get_qrcode_status"
+EP_NOTIFY_START = "ilink/bot/msg/notifystart"
+EP_NOTIFY_STOP = "ilink/bot/msg/notifystop"
 
 LONG_POLL_TIMEOUT_MS = 35_000
 API_TIMEOUT_MS = 15_000
@@ -204,7 +206,7 @@ def _random_wechat_uin() -> str:
 
 
 def _base_info() -> Dict[str, Any]:
-    return {"channel_version": CHANNEL_VERSION}
+    return {"channel_version": CHANNEL_VERSION, "bot_agent": ""}
 
 
 def _headers(token: Optional[str], body: str) -> Dict[str, str]:
@@ -482,6 +484,38 @@ async def _send_typing(
             "typing_ticket": typing_ticket,
             "status": status,
         },
+        token=token,
+        timeout_ms=CONFIG_TIMEOUT_MS,
+    )
+
+
+async def _notify_start(
+    session: "aiohttp.ClientSession",
+    *,
+    base_url: str,
+    token: str,
+) -> Dict[str, Any]:
+    return await _api_post(
+        session,
+        base_url=base_url,
+        endpoint=EP_NOTIFY_START,
+        payload={},
+        token=token,
+        timeout_ms=CONFIG_TIMEOUT_MS,
+    )
+
+
+async def _notify_stop(
+    session: "aiohttp.ClientSession",
+    *,
+    base_url: str,
+    token: str,
+) -> Dict[str, Any]:
+    return await _api_post(
+        session,
+        base_url=base_url,
+        endpoint=EP_NOTIFY_STOP,
+        payload={},
         token=token,
         timeout_ms=CONFIG_TIMEOUT_MS,
     )
@@ -1273,6 +1307,10 @@ class WeixinAdapter(BasePlatformAdapter):
         _no_aiohttp_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
         self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
+        try:
+            await _notify_start(self._send_session, base_url=self._base_url, token=self._token)
+        except Exception as exc:
+            logger.warning("[%s] notifyStart failed (continuing startup): %s", self.name, exc)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
         _LIVE_ADAPTERS[self._token] = self
@@ -1300,6 +1338,11 @@ class WeixinAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+        if self._send_session and not self._send_session.closed:
+            try:
+                await _notify_stop(self._send_session, base_url=self._base_url, token=self._token)
+            except Exception as exc:
+                logger.warning("[%s] notifyStop failed during disconnect: %s", self.name, exc)
         if self._poll_session and not self._poll_session.closed:
             await self._poll_session.close()
         self._poll_session = None

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -239,6 +239,73 @@ class TestWeixinConfig:
         assert config.get_connected_platforms() == []
 
 
+class TestWeixinProtocol:
+    def test_ilink_protocol_version_and_base_info_match_openclaw_2_4_3(self):
+        assert weixin.CHANNEL_VERSION == "2.4.3"
+        assert weixin.ILINK_APP_CLIENT_VERSION == (2 << 16) | (4 << 8) | 3
+        assert weixin._base_info() == {"channel_version": "2.4.3", "bot_agent": ""}
+
+    @pytest.mark.asyncio
+    async def test_connect_sends_notify_start_before_polling(self):
+        adapter = _make_adapter()
+        poll_session = AsyncMock()
+        poll_session.closed = False
+        send_session = AsyncMock()
+        send_session.closed = False
+
+        with patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.CRYPTO_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls, \
+             patch("gateway.platforms.weixin._make_ssl_connector", return_value=None), \
+             patch("gateway.platforms.weixin._notify_start", new_callable=AsyncMock) as notify_start_mock, \
+             patch("gateway.platforms.weixin._notify_stop", new_callable=AsyncMock), \
+             patch.object(WeixinAdapter, "_poll_loop", new_callable=AsyncMock) as poll_loop_mock:
+            session_cls.side_effect = [poll_session, send_session]
+
+            async def _assert_notify_start_before_poll(*_args, **_kwargs):
+                assert not poll_loop_mock.called
+                return {}
+
+            notify_start_mock.side_effect = _assert_notify_start_before_poll
+
+            assert await adapter.connect() is True
+            await adapter.disconnect()
+
+        notify_start_mock.assert_awaited_once_with(
+            send_session,
+            base_url=adapter._base_url,
+            token="test-token",
+        )
+        assert poll_loop_mock.called
+
+    @pytest.mark.asyncio
+    async def test_disconnect_sends_notify_stop_and_still_closes_on_failure(self):
+        adapter = _make_adapter()
+        send_session = AsyncMock()
+        send_session.closed = False
+        poll_session = AsyncMock()
+        poll_session.closed = False
+        adapter._send_session = send_session
+        adapter._poll_session = poll_session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+
+        with patch("gateway.platforms.weixin._notify_stop", new_callable=AsyncMock) as notify_stop_mock:
+            notify_stop_mock.side_effect = RuntimeError("iLink unavailable")
+
+            await adapter.disconnect()
+
+        notify_stop_mock.assert_awaited_once_with(
+            send_session,
+            base_url="https://weixin.example.com",
+            token="test-token",
+        )
+        poll_session.close.assert_awaited_once()
+        send_session.close.assert_awaited_once()
+        assert adapter._poll_session is None
+        assert adapter._send_session is None
+
+
 class TestWeixinStatePersistence:
     def test_save_weixin_account_preserves_existing_file_on_replace_failure(self, tmp_path, monkeypatch):
         account_path = tmp_path / "weixin" / "accounts" / "acct.json"


### PR DESCRIPTION
## Summary
- Update Weixin iLink protocol version/client header to 2.4.3
- Include `bot_agent` in `base_info` for iLink requests
- Add best-effort notifyStart/notifyStop lifecycle calls around the poll loop
- Add protocol and lifecycle tests for the Weixin adapter

## Test Plan
- `uv run pytest tests/gateway/test_weixin.py -q`

Closes #24989
