### PR TITLE
fix(gateway): expand env vars in fallback_providers/fallback_model config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2431,21 +2431,19 @@ class GatewayRunner:
 
     @staticmethod
     def _load_fallback_model() -> list | dict | None:
-        """Load fallback provider chain from config.yaml.
+        """Load fallback provider chain from config.yaml with env expansion.
 
         Returns a list of provider dicts (``fallback_providers``), a single
         dict (legacy ``fallback_model``), or None if not configured.
         AIAgent.__init__ normalizes both formats into a chain.
+        Uses load_config() so ${VAR} env references are expanded.
         """
         try:
-            import yaml as _y
-            cfg_path = _hermes_home / "config.yaml"
-            if cfg_path.exists():
-                with open(cfg_path, encoding="utf-8") as _f:
-                    cfg = _y.safe_load(_f) or {}
-                fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
-                if fb:
-                    return fb
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
+            if fb:
+                return fb
         except Exception:
             pass
         return None


### PR DESCRIPTION
## Summary

`_load_fallback_model()` was reading `config.yaml` via `yaml.safe_load()` directly, bypassing the `_expand_env_vars()` step that resolves `${VAR}` references from `.env` / `credential_pool`. This caused fallback activation to send the literal string `'${VAR}'` as the API key, resulting in 401 errors.

Switch to `load_config()` which already handles env expansion, aligning this loader with `cli.py:load_cli_config()` and all other config paths.

## Changes

- **gateway/run.py**: Replace raw `yaml.safe_load()` with `load_config()` in `_load_fallback_model()`

## Related

- Fixes #20974
- Also addresses #12239 (fallback_model ignores api_key from config)

## Verification

- `load_config()` is used by the CLI config bridge (`cli.py:454`) and correctly expands `${VAR}` references
- `AIAgent.__init__` normalizes both `fallback_providers` (list) and `fallback_model` (legacy dict) formats
- No behavior change for users with hardcoded API keys
