### PR TITLE
feat(tui): make status bar segments configurable

### DIFF
--- a/ui-tui/src/__tests__/appChrome.test.ts
+++ b/ui-tui/src/__tests__/appChrome.test.ts
@@ -1,6 +1,62 @@
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { PassThrough } from 'stream'
 import { describe, expect, it } from 'vitest'
 
-import { effortLabel, modelLabel } from '../components/appChrome.js'
+import { effortLabel, modelLabel, StatusRule } from '../components/appChrome.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const renderStatusRule = (statusBarSegments: readonly string[]) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 120, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(
+    React.createElement(StatusRule, {
+      bgCount: 0,
+      busy: false,
+      cols: 120,
+      cwdLabel: '~/workspace',
+      model: 'gpt-5.5',
+      modelFast: false,
+      modelReasoningEffort: 'medium',
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusBarSegments,
+      statusColor: DEFAULT_THEME.color.statusFg,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: {
+        context_max: 272_000,
+        context_percent: 0,
+        context_used: 0,
+        total: 0
+      },
+      voiceLabel: 'voice off'
+    }),
+    {
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
 
 describe('status bar model label', () => {
   it('keeps medium reasoning visible as @med', () => {
@@ -20,5 +76,25 @@ describe('status bar model label', () => {
 
   it('keeps fast as a separate suffix after the effort', () => {
     expect(modelLabel('gpt-5.5', 'medium', true)).toBe('gpt 5.5@med fast')
+  })
+})
+
+describe('StatusRule segment rendering', () => {
+  it('can hide only the context meter while keeping tokens and percent', () => {
+    const output = renderStatusRule(['indicator', 'model', 'context_tokens', 'context_percent', 'voice'])
+
+    expect(output).toContain('ready')
+    expect(output).toContain('gpt 5.5@med')
+    expect(output).toContain('0/272k')
+    expect(output).toContain('0%')
+    expect(output).toContain('voice off')
+    expect(output).not.toContain('[░░░░░░░░░░]')
+  })
+
+  it('renders the context meter only when context_bar is enabled', () => {
+    const output = renderStatusRule(['context_tokens', 'context_bar', 'context_percent'])
+
+    expect(output).toContain('0/272k')
+    expect(output).toContain('[░░░░░░░░░░] 0%')
   })
 })

--- a/ui-tui/src/__tests__/appChrome.test.ts
+++ b/ui-tui/src/__tests__/appChrome.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { effortLabel, modelLabel } from '../components/appChrome.js'
+
+describe('status bar model label', () => {
+  it('keeps medium reasoning visible as @med', () => {
+    expect(modelLabel('gpt-5.5', 'medium')).toBe('gpt 5.5@med')
+  })
+
+  it('shortens minimal reasoning and keeps explicit efforts adjacent to the model', () => {
+    expect(modelLabel('openai/gpt-5.5', 'minimal')).toBe('gpt 5.5@min')
+    expect(modelLabel('openai/gpt-5.5', 'xhigh')).toBe('gpt 5.5@xhigh')
+  })
+
+  it('omits only neutral/default effort labels', () => {
+    expect(effortLabel('default')).toBe('')
+    expect(effortLabel('normal')).toBe('')
+    expect(modelLabel('gpt-5.5')).toBe('gpt 5.5')
+  })
+
+  it('keeps fast as a separate suffix after the effort', () => {
+    expect(modelLabel('gpt-5.5', 'medium', true)).toBe('gpt 5.5@med fast')
+  })
+})

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -301,6 +301,28 @@ describe('fromSkin', () => {
     expect(fromSkin({}, {}, 'LOGO', 'HERO').bannerHero).toBe('HERO')
   })
 
+  it('maps status bar color keys from skins', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+    const { color } = fromSkin(
+      {
+        status_bar_bg: '#010203',
+        status_bar_text: '#0ADAF5',
+        status_bar_good: '#112233',
+        status_bar_warn: '#445566',
+        status_bar_bad: '#778899',
+        status_bar_critical: '#AABBCC'
+      },
+      {}
+    )
+
+    expect(color.statusBg).toBe('#010203')
+    expect(color.statusFg).toBe('#0ADAF5')
+    expect(color.statusGood).toBe('#112233')
+    expect(color.statusWarn).toBe('#445566')
+    expect(color.statusBad).toBe('#778899')
+    expect(color.statusCritical).toBe('#AABBCC')
+  })
+
   it('maps ui_ color keys + cascades to status', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
     const { color } = fromSkin({ ui_ok: '#008000' }, {})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $uiState, resetUiState } from '../app/uiStore.js'
+import { DEFAULT_STATUS_BAR_SEGMENTS } from '../app/interfaces.js'
 import {
   applyDisplay,
   hydrateFullConfig,
   normalizeBusyInputMode,
   normalizeIndicatorStyle,
   normalizeMouseTracking,
-  normalizeStatusBar
+  normalizeStatusBar,
+  normalizeStatusBarSegments
 } from '../app/useConfigSync.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
 
@@ -151,6 +153,50 @@ describe('applyDisplay', () => {
 
     applyDisplay({ config: { display: { tui_statusbar: 'top' } } }, setBell)
     expect($uiState.get().statusBar).toBe('top')
+  })
+
+  it('threads display.tui_statusbar_segments into $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          display: {
+            tui_statusbar_segments: ['indicator', 'model', 'unknown', 'cost', 'model']
+          }
+        }
+      },
+      setBell
+    )
+
+    expect($uiState.get().statusBarSegments).toEqual(['indicator', 'model', 'cost'])
+  })
+})
+
+describe('normalizeStatusBarSegments', () => {
+  it('defaults missing or malformed values to the built-in segment order', () => {
+    expect(normalizeStatusBarSegments(undefined)).toEqual(DEFAULT_STATUS_BAR_SEGMENTS)
+    expect(normalizeStatusBarSegments(null)).toEqual(DEFAULT_STATUS_BAR_SEGMENTS)
+    expect(normalizeStatusBarSegments('model')).toEqual(DEFAULT_STATUS_BAR_SEGMENTS)
+  })
+
+  it('trims, lowercases, filters unknown values, expands legacy context, and de-duplicates', () => {
+    expect(normalizeStatusBarSegments([' Model ', 'context', 'bogus', 'MODEL', 7, 'cost'])).toEqual([
+      'model',
+      'context_tokens',
+      'context_bar',
+      'context_percent',
+      'cost'
+    ])
+  })
+
+  it('allows hiding only the context bar while retaining context tokens and percent', () => {
+    expect(normalizeStatusBarSegments(['context_tokens', 'context_percent'])).toEqual(['context_tokens', 'context_percent'])
+  })
+
+  it('allows an empty segment list to hide the configurable left side', () => {
+    expect(normalizeStatusBarSegments([])).toEqual([])
+    expect(normalizeStatusBarSegments(['bogus'])).toEqual([])
   })
 })
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -28,6 +28,24 @@ export interface StateSetter<T> {
 
 export type StatusBarMode = 'bottom' | 'off' | 'top'
 
+export const STATUS_BAR_SEGMENTS = [
+  'indicator',
+  'model',
+  'context_tokens',
+  'context_bar',
+  'context_percent',
+  'account_usage',
+  'session_duration',
+  'compressions',
+  'subagents',
+  'voice',
+  'bg_tasks',
+  'rate_limit',
+  'cost'
+] as const
+export type StatusBarSegment = (typeof STATUS_BAR_SEGMENTS)[number]
+export const DEFAULT_STATUS_BAR_SEGMENTS: readonly StatusBarSegment[] = STATUS_BAR_SEGMENTS
+
 export type BusyInputMode = 'interrupt' | 'queue' | 'steer'
 
 // Single source of truth for indicator style names.  Union type is
@@ -112,6 +130,7 @@ export interface UiState {
   sid: null | string
   status: string
   statusBar: StatusBarMode
+  statusBarSegments: readonly StatusBarSegment[]
   streaming: boolean
   theme: Theme
   usage: Usage

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -4,7 +4,11 @@ import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
 import { DEFAULT_THEME } from '../theme.js'
 
-import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
+import {
+  DEFAULT_INDICATOR_STYLE,
+  DEFAULT_STATUS_BAR_SEGMENTS,
+  type UiState
+} from './interfaces.js'
 
 const buildUiState = (): UiState => ({
   bgTasks: new Set(),
@@ -23,6 +27,7 @@ const buildUiState = (): UiState => ({
   sid: null,
   status: 'summoning hermes…',
   statusBar: 'top',
+  statusBarSegments: DEFAULT_STATUS_BAR_SEGMENTS,
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -17,9 +17,12 @@ import { asRpcResult } from '../lib/rpc.js'
 import {
   type BusyInputMode,
   DEFAULT_INDICATOR_STYLE,
+  DEFAULT_STATUS_BAR_SEGMENTS,
   INDICATOR_STYLES,
   type IndicatorStyle,
-  type StatusBarMode
+  STATUS_BAR_SEGMENTS,
+  type StatusBarMode,
+  type StatusBarSegment
 } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { patchUiState } from './uiStore.js'
@@ -56,6 +59,10 @@ export const normalizeBusyInputMode = (raw: unknown): BusyInputMode => {
 }
 
 const INDICATOR_STYLE_SET: ReadonlySet<IndicatorStyle> = new Set(INDICATOR_STYLES)
+const STATUS_BAR_SEGMENT_SET: ReadonlySet<StatusBarSegment> = new Set(STATUS_BAR_SEGMENTS)
+const LEGACY_STATUS_BAR_SEGMENTS: Readonly<Record<string, readonly StatusBarSegment[]>> = {
+  context: ['context_tokens', 'context_bar', 'context_percent']
+}
 
 export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
   if (typeof raw !== 'string') {
@@ -65,6 +72,33 @@ export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
   const v = raw.trim().toLowerCase() as IndicatorStyle
 
   return INDICATOR_STYLE_SET.has(v) ? v : DEFAULT_INDICATOR_STYLE
+}
+
+export const normalizeStatusBarSegments = (raw: unknown): readonly StatusBarSegment[] => {
+  if (!Array.isArray(raw)) {
+    return DEFAULT_STATUS_BAR_SEGMENTS
+  }
+
+  const out: StatusBarSegment[] = []
+  const seen = new Set<StatusBarSegment>()
+
+  for (const item of raw) {
+    if (typeof item !== 'string') {
+      continue
+    }
+
+    const rawSegment = item.trim().toLowerCase()
+    const segments = LEGACY_STATUS_BAR_SEGMENTS[rawSegment] ?? [rawSegment as StatusBarSegment]
+
+    for (const segment of segments) {
+      if (STATUS_BAR_SEGMENT_SET.has(segment) && !seen.has(segment)) {
+        seen.add(segment)
+        out.push(segment)
+      }
+    }
+  }
+
+  return out
 }
 
 const FALSEY_MOUSE = new Set(['0', 'false', 'no', 'off'])
@@ -147,6 +181,7 @@ export const applyDisplay = (
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
+    statusBarSegments: normalizeStatusBarSegments(d.tui_statusbar_segments),
     streaming: d.streaming !== false
   })
 }

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -54,17 +54,20 @@ const capHistory = (items: Msg[]): Msg[] => {
   return items[0]?.kind === 'intro' ? [items[0]!, ...items.slice(-(MAX_HISTORY - 1))] : items.slice(-MAX_HISTORY)
 }
 
-const statusColorOf = (status: string, t: { error: string; muted: string; ok: string; warn: string }) => {
+const statusColorOf = (
+  status: string,
+  t: { error: string; muted: string; statusCritical: string; statusGood: string; statusWarn: string }
+) => {
   if (status === 'ready') {
-    return t.ok
+    return t.statusGood
   }
 
   if (status.startsWith('error')) {
-    return t.error
+    return t.statusCritical
   }
 
   if (status === 'interrupted') {
-    return t.warn
+    return t.statusWarn
   }
 
   return t.muted

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } 
 import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
-import type { IndicatorStyle } from '../app/interfaces.js'
+import type { IndicatorStyle, StatusBarSegment } from '../app/interfaces.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { FACES } from '../content/faces.js'
@@ -224,15 +224,27 @@ function SessionDuration({ startedAt }: { startedAt: number }) {
   return fmtDuration(now - startedAt)
 }
 
-const effortLabel = (effort?: string) => {
+export const effortLabel = (effort?: string) => {
   const value = String(effort ?? '')
     .trim()
     .toLowerCase()
 
-  return value && value !== 'medium' && value !== 'normal' && value !== 'default' ? value : ''
+  if (!value || value === 'normal' || value === 'default') {
+    return ''
+  }
+
+  if (value === 'medium') {
+    return 'med'
+  }
+
+  if (value === 'minimal') {
+    return 'min'
+  }
+
+  return value
 }
 
-const shortModelLabel = (model: string) =>
+export const shortModelLabel = (model: string) =>
   model
     .split('/')
     .pop()!
@@ -242,8 +254,13 @@ const shortModelLabel = (model: string) =>
     .replace(/\b(\d+)\s+(\d+)\b/g, '$1.$2')
     .trim()
 
-const modelLabel = (model: string, effort?: string, fast?: boolean) =>
-  [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
+export const modelLabel = (model: string, effort?: string, fast?: boolean) => {
+  const base = shortModelLabel(model)
+  const effortSuffix = effortLabel(effort)
+  const speedSuffix = fast ? ' fast' : ''
+
+  return `${base}${effortSuffix ? `@${effortSuffix}` : ''}${speedSuffix}`
+}
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
@@ -283,6 +300,7 @@ export function StatusRule({
   bgCount,
   sessionStartedAt,
   showCost,
+  statusBarSegments,
   turnStartedAt,
   voiceLabel,
   t
@@ -296,56 +314,105 @@ export function StatusRule({
       ? `${fmtK(usage.total)} tok`
       : ''
 
-  const bar = usage.context_max ? ctxBar(pct) : ''
+  const contextBarLabel = usage.context_max ? ctxBar(pct) : ''
+  const contextPercentLabel = usage.context_max && pct != null ? `${pct}%` : ''
+  const accountUsageLabel = usage.account_usage_status?.trim()
+  const rateLimitLabel = usage.rate_limit_status?.trim()
   const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
+  const statusPieces: ReactNode[] = []
+  let previousVisibleSegment: StatusBarSegment | null = null
+
+  const appendSegment = (segment: StatusBarSegment, node: ReactNode, color = t.color.statusFg, joiner = ' │ ') => {
+    const prefix = statusPieces.length === 0 ? '' : joiner
+
+    statusPieces.push(
+      <Text key={`${segment}-${statusPieces.length}`} color={color}>
+        {prefix}
+        {node}
+      </Text>
+    )
+    previousVisibleSegment = segment
+  }
+
+  for (const segment of statusBarSegments) {
+    switch (segment) {
+      case 'account_usage':
+        if (accountUsageLabel) {
+          appendSegment(segment, accountUsageLabel)
+        }
+        break
+      case 'bg_tasks':
+        if (bgCount > 0) {
+          appendSegment(segment, `${bgCount} bg`)
+        }
+        break
+      case 'compressions':
+        if (typeof usage.compressions === 'number' && usage.compressions > 0) {
+          appendSegment(
+            segment,
+            <Text color={usage.compressions >= 10 ? t.color.statusCritical : usage.compressions >= 5 ? t.color.statusWarn : t.color.statusFg}>
+              cmp {usage.compressions}
+            </Text>
+          )
+        }
+        break
+      case 'context_bar':
+        if (contextBarLabel) {
+          appendSegment(segment, `[${contextBarLabel}]`, barColor)
+        }
+        break
+      case 'context_percent':
+        if (contextPercentLabel) {
+          appendSegment(segment, contextPercentLabel, barColor, previousVisibleSegment === 'context_bar' ? ' ' : ' │ ')
+        }
+        break
+      case 'context_tokens':
+        if (ctxLabel) {
+          appendSegment(segment, ctxLabel)
+        }
+        break
+      case 'cost':
+        if (showCost && typeof usage.cost_usd === 'number') {
+          appendSegment(segment, `$${usage.cost_usd.toFixed(4)}`)
+        }
+        break
+      case 'indicator':
+        appendSegment(segment, busy ? <FaceTicker color={statusColor} startedAt={turnStartedAt} /> : status, statusColor)
+        break
+      case 'model':
+        appendSegment(segment, modelLabel(model, modelReasoningEffort, modelFast))
+        break
+      case 'rate_limit':
+        if (rateLimitLabel) {
+          appendSegment(segment, rateLimitLabel)
+        }
+        break
+      case 'session_duration':
+        if (sessionStartedAt) {
+          appendSegment(segment, <SessionDuration startedAt={sessionStartedAt} />)
+        }
+        break
+      case 'subagents':
+        statusPieces.push(<SpawnHud key={`${segment}-${statusPieces.length}`} t={t} />)
+        break
+      case 'voice':
+        if (voiceLabel) {
+          appendSegment(
+            segment,
+            voiceLabel,
+            voiceLabel.startsWith('●') ? t.color.statusCritical : voiceLabel.startsWith('◉') ? t.color.statusWarn : t.color.statusFg
+          )
+        }
+        break
+    }
+  }
 
   return (
     <Box height={1}>
       <Box flexShrink={1} width={leftWidth}>
         <Text color={t.color.border} wrap="truncate-end">
           {'─ '}
-          {busy ? (
-            <FaceTicker color={statusColor} startedAt={turnStartedAt} />
-          ) : (
-            <Text color={statusColor}>{status}</Text>
-          )}
-          <Text color={t.color.muted}> │ {modelLabel(model, modelReasoningEffort, modelFast)}</Text>
-          {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
-          {bar ? (
-            <Text color={t.color.muted}>
-              {' │ '}
-              <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
-            </Text>
-          ) : null}
-          {sessionStartedAt ? (
-            <Text color={t.color.muted}>
-              {' │ '}
-              <SessionDuration startedAt={sessionStartedAt} />
-            </Text>
-          ) : null}
-          {typeof usage.compressions === 'number' && usage.compressions > 0 ? (
-            <Text color={t.color.muted}>
-              {' │ '}
-              <Text color={usage.compressions >= 10 ? t.color.error : usage.compressions >= 5 ? t.color.warn : t.color.muted}>
-                cmp {usage.compressions}
-              </Text>
-            </Text>
-          ) : null}
-          <SpawnHud t={t} />
-          {voiceLabel ? (
-            <Text
-              color={
-                voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
-              }
-            >
-              {' │ '}
-              {voiceLabel}
-            </Text>
-          ) : null}
-          {bgCount > 0 ? <Text color={t.color.muted}> │ {bgCount} bg</Text> : null}
-          {showCost && typeof usage.cost_usd === 'number' ? (
-            <Text color={t.color.muted}> │ ${usage.cost_usd.toFixed(4)}</Text>
-          ) : null}
+          {statusPieces}
         </Text>
       </Box>
 
@@ -464,6 +531,7 @@ interface StatusRuleProps {
   sessionStartedAt?: null | number
   showCost: boolean
   status: string
+  statusBarSegments: readonly StatusBarSegment[]
   statusColor: string
   t: Theme
   turnStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -361,6 +361,7 @@ const StatusRulePane = memo(function StatusRulePane({
         sessionStartedAt={status.sessionStartedAt}
         showCost={ui.showCost}
         status={ui.status}
+        statusBarSegments={ui.statusBarSegments}
         statusColor={status.statusColor}
         t={ui.theme}
         turnStartedAt={status.turnStartedAt}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -66,6 +66,7 @@ export interface ConfigDisplayConfig {
   tui_compact?: boolean
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
+  tui_statusbar_segments?: unknown
   // Forward-compat: backend may send styles this client doesn't know yet —
   // `normalizeIndicatorStyle` falls back to 'kaomoji' for those — but the
   // wire type is documented as `string` so consumers don't get a false
@@ -168,11 +169,13 @@ export interface SessionUsageResponse {
   context_max?: number
   context_percent?: number
   context_used?: number
+  account_usage_status?: string
   cost_status?: 'estimated' | 'exact'
   cost_usd?: number
   input?: number
   model?: string
   output?: number
+  rate_limit_status?: string
   total?: number
 }
 

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -558,12 +558,12 @@ export function fromSkin(
       sessionLabel: c('session_label') ?? muted,
       sessionBorder: c('session_border') ?? muted,
 
-      statusBg: d.color.statusBg,
-      statusFg: d.color.statusFg,
-      statusGood: c('ui_ok') ?? d.color.statusGood,
-      statusWarn: c('ui_warn') ?? d.color.statusWarn,
-      statusBad: d.color.statusBad,
-      statusCritical: d.color.statusCritical,
+      statusBg: c('status_bar_bg') ?? d.color.statusBg,
+      statusFg: c('status_bar_text') ?? d.color.statusFg,
+      statusGood: c('status_bar_good') ?? c('ui_ok') ?? d.color.statusGood,
+      statusWarn: c('status_bar_warn') ?? c('ui_warn') ?? d.color.statusWarn,
+      statusBad: c('status_bar_bad') ?? d.color.statusBad,
+      statusCritical: c('status_bar_critical') ?? d.color.statusCritical,
       selectionBg: c('selection_bg') ?? c('completion_menu_current_bg') ?? (hasSkinColors ? completionCurrentBg : d.color.selectionBg),
 
       diffAdded: d.color.diffAdded,

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -164,11 +164,13 @@ export interface Usage {
   context_max?: number
   context_percent?: number
   context_used?: number
+  account_usage_status?: string
   cost_status?: string
   cost_usd?: number
   input: number
   output: number
   reasoning?: number
+  rate_limit_status?: string
   total: number
 }
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -158,6 +158,25 @@ The status line also shows:
 
 - **Working directory with git branch** — `~/projects/hermes-agent (docs/two-week-gap-sweep)`. The branch suffix updates when you `git checkout` in a side terminal (mtime-cached) so the TUI reflects your actual active branch, not whatever it was at launch.
 - **Per-prompt elapsed time** — `⏱ 12s/3m 45s` while the turn is running (live), frozen to `⏲ 32s / 3m 45s` after the turn completes. First number is time since last user message; second is total session duration. Resets on every new prompt.
+- **Configurable segments** — choose the left-side status pieces and order with `display.tui_statusbar_segments`. Unknown segment names are ignored so newer configs remain safe on older clients. The context display is split into `context_tokens`, `context_bar`, and `context_percent`; omit `context_bar` to keep the percentage without the visual meter. The legacy `context` segment expands to all three context pieces.
+
+```yaml
+display:
+  tui_statusbar_segments:
+    - indicator
+    - model
+    - context_tokens
+    - context_bar      # omit to hide only the [████░░] meter
+    - context_percent
+    - account_usage
+    - session_duration
+    - compressions
+    - subagents
+    - voice
+    - bg_tasks
+    - rate_limit
+    - cost
+```
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add `display.tui_statusbar_segments` for TUI status line customization
- split context display into `context_tokens`, `context_bar`, and `context_percent` so the meter can be hidden independently
- wire status-bar skin colors through the TUI theme and document the config

## Test Plan
- `npm test -- --run src/__tests__/useConfigSync.test.ts src/__tests__/appChrome.test.ts`
- `npm run type-check`
- `npm run build`
- `env -u SSH_CONNECTION -u SSH_CLIENT -u SSH_TTY npm test -- --run`
