### PR TITLE
fix(cli): batch resize history replay

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1473,6 +1473,7 @@ def _replay_output_history() -> None:
         return
     _OUTPUT_HISTORY_REPLAYING = True
     try:
+        rendered_lines = []
         for entry in tuple(_OUTPUT_HISTORY):
             if callable(entry):
                 try:
@@ -1483,8 +1484,15 @@ def _replay_output_history() -> None:
                     lines = lines.splitlines()
             else:
                 lines = [entry]
-            for line in lines:
-                _pt_print(_PT_ANSI(str(line)))
+            rendered_lines.extend(str(line) for line in lines)
+        if rendered_lines:
+            # Replay after resize can contain hundreds of history lines. A
+            # per-line prompt_toolkit print forces one synchronous terminal I/O
+            # and redraw cycle per line, which users perceive as a waterfall of
+            # old output. Keep the existing history contents unchanged, but
+            # emit the replay as one ANSI payload so resize recovery does a
+            # single prompt_toolkit print/redraw.
+            _pt_print(_PT_ANSI("\n".join(rendered_lines)))
     except Exception:
         pass
     finally:

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -258,8 +258,23 @@ def test_replay_output_history_rerenders_callable_entries(monkeypatch):
     cli._replay_output_history()
 
     assert widths_seen == ["called"]
-    assert printed == ["top border", "body"]
+    assert printed == ["top border\nbody"]
     assert list(cli._OUTPUT_HISTORY) == [_render_current_width]
+
+
+def test_replay_output_history_batches_rendered_lines_into_one_print(monkeypatch):
+    cli._configure_output_history(True, 10)
+    cli._record_output_history("first line")
+    cli._record_output_history("second line")
+    cli._record_output_history_entry(lambda: ["third line", "fourth line"])
+    printed = []
+
+    monkeypatch.setattr(cli, "_pt_print", lambda value: printed.append(value))
+    monkeypatch.setattr(cli, "_PT_ANSI", lambda text: text)
+
+    cli._replay_output_history()
+
+    assert printed == ["first line\nsecond line\nthird line\nfourth line"]
 
 
 def test_suspend_output_history_blocks_recording():


### PR DESCRIPTION
## What does this PR do?

This PR reduces visible “waterfall” redraw during classic CLI terminal resize/redraw recovery.

Before this change, `_replay_output_history()` replayed recent output history one rendered line at a time. During terminal resize recovery, that meant every history line was sent through prompt_toolkit separately, causing the previous conversation output to visibly reappear line-by-line. This looked like the conversation was being streamed from the beginning again, and it also forced prompt_toolkit to restore/redraw the prompt chrome repeatedly.

This change keeps the existing output-history data model and recording semantics unchanged, but changes the replay transport: replay lines are rendered first, joined into a single ANSI payload, and printed once. That preserves the existing resize/redraw recovery behavior while avoiding the repeated per-line print/redraw loop.

This is intentionally scoped to the most disruptive UX symptom: output-history replay waterfall during classic CLI resize/redraw recovery. It does not attempt to solve full width-aware semantic reflow, ghost-line cleanup, live assistant streaming smoothness, toolbar flicker, or Ink TUI (`--tui`) resize behavior.

## Related Issue

Addresses the output-history rapid replay symptom discussed in:

- #21972 — describes `_OUTPUT_HISTORY` being replayed after resize, making recent output look like it is “re-streaming from the beginning”.
- #19280 — includes follow-up context that `_replay_output_history()` rapidly reprints recent output lines after SIGWINCH.

Related umbrella tracking issue:

- #24164 — broader smooth terminal reflow/parity tracking issue. This PR only handles one replay-transport symptom and should not close the umbrella issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Batch `_replay_output_history()` output into one joined ANSI payload instead of printing each replay line separately.
  - Preserve the existing output-history entries and callable-entry rendering behavior.
  - Keep replay output disabled while replaying, as before, so replayed content is not re-recorded into history.

- `tests/cli/test_cprint_bg_thread.py`
  - Update the replay test expectation from multiple per-line prints to one batched print.
  - Add coverage for batching rendered output-history lines into a single prompt_toolkit print call.

## How to Test

1. Run the targeted regression tests:

   ```bash
   uv run pytest tests/cli/test_cprint_bg_thread.py tests/cli/test_resume_display.py -q -o 'addopts='
   ```

   Expected result from local verification:

   ```text
   49 passed in 1.90s
   ```

2. Manually reproduce the original UX issue in the classic CLI:

   ```bash
   uv run hermes
   ```

   Then generate enough output to fill several lines, and resize the terminal window wider/narrower or trigger a redraw/recovery path.

3. Verify that recent history is restored as a single redraw rather than visibly replaying line-by-line like a waterfall.

4. Confirm that normal live assistant streaming is unchanged. This PR only changes output-history replay during resize/redraw recovery; it does not batch normal model streaming output.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests run locally:

```text
uv run pytest tests/cli/test_cprint_bg_thread.py tests/cli/test_resume_display.py -q -o 'addopts='
.................................................                        [100%]
49 passed in 1.90s
```

Local manual verification:

- In classic CLI mode, terminal resize after long output restores recent output in one redraw instead of line-by-line waterfall replay.
- Normal live assistant response streaming remains separate and unchanged.
