### PR TITLE
fix(dashboard): hide example plugin from navigation

### DIFF
--- a/plugins/example-dashboard/dashboard/manifest.json
+++ b/plugins/example-dashboard/dashboard/manifest.json
@@ -6,7 +6,8 @@
   "version": "1.0.0",
   "tab": {
     "path": "/example",
-    "position": "after:skills"
+    "position": "after:skills",
+    "hidden": true
   },
   "slots": [],
   "entry": "dist/index.js",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1941,6 +1941,29 @@ class TestDashboardPluginManifestExtensions:
     """Tests for the extended plugin manifest fields (tab.override,
     tab.hidden, slots) read by _discover_dashboard_plugins()."""
 
+    def test_bundled_example_dashboard_plugin_is_hidden_by_default(self):
+        """The example plugin is an API-auth test fixture, not user navigation.
+
+        It intentionally has a backend API route used by auth tests, but no
+        production frontend bundle. Keep it discoverable for API mounting while
+        preventing an unusable "Example" tab from appearing in the dashboard.
+        """
+        import json
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        manifest_file = (
+            repo_root
+            / "plugins"
+            / "example-dashboard"
+            / "dashboard"
+            / "manifest.json"
+        )
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+
+        assert manifest["name"] == "example"
+        assert manifest["tab"]["hidden"] is True
+
     def _write_plugin(self, tmp_path, name, manifest):
         import json
         plug_dir = tmp_path / "plugins" / name / "dashboard"


### PR DESCRIPTION
## What does this PR do?

Hides the bundled `example-dashboard` plugin from dashboard navigation by default.

The `example-dashboard` plugin is intentionally a tiny backend/API fixture used by the test suite for plugin auth coverage (`/api/plugins/example/hello`). It is not a user-facing dashboard feature and currently does not ship a frontend bundle for its declared `dist/index.js` entry. When surfaced in the sidebar, users see an `Example` tab that fails to load its script.

This PR keeps the plugin discoverable for backend API mounting, but marks its tab as hidden so it no longer appears as a broken dashboard navigation item.

## Related Issue / Prior Art

I searched existing issues and PRs before opening this:

- Related but not duplicate: #24116 covers stale dashboard plugin cache after plugin directories are removed.
- Related but not duplicate: #20901 covers cache headers for `/dashboard-plugins/*` assets.
- Related but not duplicate: #22596 discussed plugin asset cache busting and labels.

This PR addresses a different root cause: a bundled test/demo plugin is valid for API auth tests, but should not be visible as a normal dashboard tab without a production frontend bundle.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/example-dashboard/dashboard/manifest.json`
  - Add `tab.hidden: true` for the example plugin.
- `tests/hermes_cli/test_web_server.py`
  - Add a regression test documenting that the bundled example dashboard plugin is an API-auth test fixture, not user navigation.

## Why this approach?

This is intentionally minimal and avoids changing plugin discovery semantics globally:

- It does not remove `example-dashboard`, preserving existing auth coverage that uses its API route.
- It does not special-case plugin names in Python code.
- It uses the already-supported manifest-level `tab.hidden` mechanism.
- It avoids broad behavior changes for third-party/user dashboard plugins.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_web_server.py::TestDashboardPluginManifestExtensions -q
python -m pytest tests/hermes_cli/test_web_server.py::TestPluginAPIAuth -q
python -m pytest tests/hermes_cli/test_web_server.py -q
```

Results locally:

```text
6 passed
7 passed
145 passed
```

Manual verification:

```python
from hermes_cli import web_server
web_server._dashboard_plugins_cache = None
plugins = web_server._get_dashboard_plugins(force_rescan=True)
entry = next(p for p in plugins if p['name'] == 'example')
assert entry['tab']['hidden'] is True
```

## Checklist

### Code

- [x] I've searched existing issues/PRs to avoid a duplicate.
- [x] My commit message follows Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [x] I've added a regression test.
- [x] Relevant tests pass locally.

### Notes

No user config migration is needed. Existing users who manually hid `example` via `dashboard.hidden_plugins` can keep that setting; this change makes the bundled default correct upstream.
