### PR TITLE
salvage: batch 2 LSP-related fixes (#24738 lsp gating + #24929 mutation diagnostics false positive)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -14,6 +14,7 @@ from difflib import unified_diff
 from pathlib import Path
 
 from utils import safe_json_loads
+from agent.tool_result_classification import file_mutation_result_landed
 
 # ANSI escape codes for coloring tool failure indicators
 _RED = "\033[31m"
@@ -809,6 +810,8 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     failures.  On success, returns ``(False, "")``.
     """
     if result is None:
+        return False, ""
+    if file_mutation_result_landed(tool_name, result):
         return False, ""
 
     if tool_name == "terminal":

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
+from agent.tool_result_classification import file_mutation_result_landed
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -195,6 +196,8 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     (tests, tooling) still get consistent behavior.
     """
     if result is None:
+        return False, ""
+    if file_mutation_result_landed(tool_name, result):
         return False, ""
 
     if tool_name == "terminal":

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -1,0 +1,26 @@
+"""Shared helpers for classifying tool result payloads."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
+
+
+def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
+    """Return True when a file mutation result proves the write landed."""
+    if tool_name not in FILE_MUTATING_TOOL_NAMES or not isinstance(result, str):
+        return False
+    try:
+        data = json.loads(result.strip())
+    except Exception:
+        return False
+    if not isinstance(data, dict) or data.get("error"):
+        return False
+    if tool_name == "write_file":
+        return "bytes_written" in data
+    if tool_name == "patch":
+        return data.get("success") is True
+    return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9188,10 +9188,10 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
-        "kanban", "login", "logout", "logs", "mcp", "memory", "model",
-        "pairing", "plugins", "profile", "sessions", "setup", "skills",
-        "slack", "status", "tools", "uninstall", "update", "version",
-        "webhook", "whatsapp", "chat",
+        "kanban", "login", "logout", "logs", "lsp", "mcp", "memory",
+        "model", "pairing", "plugins", "profile", "sessions", "setup",
+        "skills", "slack", "status", "tools", "uninstall", "update",
+        "version", "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an
         # expensive eager import of every bundled plugin module.

--- a/run_agent.py
+++ b/run_agent.py
@@ -181,7 +181,10 @@ from agent.tool_guardrails import (
     append_toolguard_guidance,
     toolguard_synthetic_result,
 )
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
+    file_mutation_result_landed,
+)
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -350,7 +353,7 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 
 # Tools that mutate files on disk.  Used by the per-turn verifier that
 # surfaces silently-failed file edits so the model can't over-claim success.
-_FILE_MUTATING_TOOLS = frozenset({"write_file", "patch"})
+# Imported above as `_FILE_MUTATING_TOOLS` from `agent.tool_result_classification`.
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 _MAX_TOOL_WORKERS = 8

--- a/run_agent.py
+++ b/run_agent.py
@@ -181,6 +181,7 @@ from agent.tool_guardrails import (
     append_toolguard_guidance,
     toolguard_synthetic_result,
 )
+from agent.tool_result_classification import file_mutation_result_landed
 from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
@@ -5347,7 +5348,8 @@ class AIAgent:
         targets = _extract_file_mutation_targets(tool_name, args)
         if not targets:
             return
-        if is_error:
+        landed = file_mutation_result_landed(tool_name, result)
+        if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -1,6 +1,7 @@
 """Tests for agent/display.py — build_tool_preview() and inline diff previews."""
 
 import os
+import json
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -148,6 +149,27 @@ class TestCuteToolMessagePreviewLength:
 
         assert path in line
         assert "..." not in line
+
+    def test_write_file_lint_error_result_is_not_marked_failed(self):
+        result = json.dumps({
+            "bytes_written": 12,
+            "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+        })
+
+        line = get_cute_tool_message("write_file", {"path": "/tmp/a.py"}, 0.1, result=result)
+
+        assert "[error]" not in line
+
+    def test_patch_lsp_diagnostics_result_is_not_marked_failed(self):
+        result = json.dumps({
+            "success": True,
+            "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+            "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+        })
+
+        line = get_cute_tool_message("patch", {"path": "/tmp/a.py"}, 0.1, result=result)
+
+        assert "[error]" not in line
 
 
 class TestEditDiffPreview:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -7,6 +7,7 @@ from agent.tool_guardrails import (
     ToolCallGuardrailController,
     ToolCallSignature,
     canonical_tool_args,
+    classify_tool_failure,
 )
 
 
@@ -129,6 +130,21 @@ def test_success_resets_exact_signature_failure_streak():
     assert controller.before_call("web_search", args).action == "allow"
     controller.after_call("web_search", args, '{"error":"boom"}', failed=True)
     assert controller.before_call("web_search", args).action == "allow"
+
+
+def test_file_mutation_lint_error_result_is_not_a_tool_failure():
+    write_result = json.dumps({
+        "bytes_written": 12,
+        "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+    })
+    patch_result = json.dumps({
+        "success": True,
+        "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+        "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+    })
+
+    assert classify_tool_failure("write_file", write_result) == (False, "")
+    assert classify_tool_failure("patch", patch_result) == (False, "")
 
 
 def test_same_tool_varying_args_warns_by_default_without_halting():

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -1,0 +1,30 @@
+"""Tests for shared tool result classification helpers."""
+
+import json
+
+from agent.tool_result_classification import file_mutation_result_landed
+
+
+def test_write_file_with_nested_lint_error_counts_as_landed():
+    result = json.dumps({
+        "bytes_written": 12,
+        "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+    })
+
+    assert file_mutation_result_landed("write_file", result) is True
+
+
+def test_patch_with_nested_lsp_diagnostics_counts_as_landed():
+    result = json.dumps({
+        "success": True,
+        "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+        "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+    })
+
+    assert file_mutation_result_landed("patch", result) is True
+
+
+def test_top_level_file_mutation_error_does_not_count_as_landed():
+    result = json.dumps({"success": True, "error": "post-write verification failed"})
+
+    assert file_mutation_result_landed("patch", result) is False

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -166,6 +166,56 @@ class TestRecordFileMutationResult:
         )
         assert agent._turn_failed_file_mutations == {}
 
+    def test_write_file_with_lint_error_counts_as_landed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.py", "content": "bad"},
+            json.dumps({"error": "write failed"}),
+            is_error=True,
+        )
+        assert "/tmp/a.py" in agent._turn_failed_file_mutations
+
+        result = json.dumps({
+            "bytes_written": 24,
+            "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
+        })
+
+        agent._record_file_mutation_result(
+            "write_file",
+            {"path": "/tmp/a.py", "content": "def nope(:\n"},
+            result,
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
+    def test_patch_with_lsp_diagnostics_counts_as_landed(self):
+        agent = _bare_agent()
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.py", "old_string": "x", "new_string": "y"},
+            json.dumps({"error": "Could not find old_string"}),
+            is_error=True,
+        )
+        assert "/tmp/a.py" in agent._turn_failed_file_mutations
+
+        result = json.dumps({
+            "success": True,
+            "diff": "--- a/tmp.py\n+++ b/tmp.py\n",
+            "files_modified": ["/tmp/a.py"],
+            "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
+        })
+
+        agent._record_file_mutation_result(
+            "patch",
+            {"mode": "replace", "path": "/tmp/a.py", "old_string": "x", "new_string": "y"},
+            result,
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+
     def test_repeated_failure_keeps_first_error(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(


### PR DESCRIPTION
## Salvage of two independent LSP-related fixes

Cherry-picks two small, unrelated bug fixes from open PRs onto current `main`. Both authors are preserved as commit authors and are already in `AUTHOR_MAP`.

| Original PR | Author | Subsystem | Fix |
|---|---|---|---|
| #24738 | @briandevans | CLI startup gating | Adds `lsp` to `_BUILTIN_SUBCOMMANDS` so `hermes lsp …` skips the ~500-650ms plugin-discovery pass. |
| #24929 | @GodsBoy | Tool result classification | Stops misclassifying successful `write_file`/`patch` results as failures when their JSON payload contains nested lint or LSP diagnostics with `"error"` keys (issue #24927). |

Two independent fixes are batched here because each is small, the diffs touch disjoint files, and neither has interactions with the other. Each retains its original contributor as commit author.

### #24738 — `lsp` missing from `_BUILTIN_SUBCOMMANDS`

The parity guard added in #22120 (`tests/hermes_cli/test_startup_plugin_gating.py::test_builtin_set_covers_every_registered_subcommand`) has been failing on `main` since `lsp` shipped via #24168. Verified empirically:

```
$ bash scripts/run_tests.sh tests/hermes_cli/test_startup_plugin_gating.py
FAILED test_builtin_set_covers_every_registered_subcommand
  AssertionError: _BUILTIN_SUBCOMMANDS is missing these live subcommands: ['lsp'].
```

After the fix: 37 passed.

### #24929 — File mutation false positive on diagnostic-bearing results (#24927)

`_detect_tool_failure()` and `classify_tool_failure()` substring-match `'"error"'` and `'"failed"'` over the full result string. After PR #24168 wired post-write LSP diagnostics into `write_file` and `patch`, any successful mutation whose result includes nested lint/LSP errors gets a `[error]` failure tag in the CLI display, plus a turn-end verifier footer claiming the write didn't land — even though it did.

This PR introduces a shared `agent/tool_result_classification.py::file_mutation_result_landed()` helper and patches three callsites:

- `agent/display.py::_detect_tool_failure()` — CLI failure tag
- `agent/tool_guardrails.py::classify_tool_failure()` — guardrail mirror
- `run_agent.py::_record_file_mutation_result()` — turn-end verifier upstream

A duplicate PR (#24960) was filed against the same issue. It has a real bug (`data.get("bytes_written")` truthiness check, which misclassifies an empty 0-byte write with lint diagnostics as a failure). #24929 uses `"bytes_written" in data` (presence check) which is correct. We are closing #24960 in favor of this salvage.

### Test plan

```bash
bash scripts/run_tests.sh \
  tests/hermes_cli/test_startup_plugin_gating.py \
  tests/agent/test_display.py \
  tests/agent/test_tool_guardrails.py \
  tests/agent/test_tool_result_classification.py \
  tests/run_agent/test_file_mutation_verifier.py
```

Result: **117 passed**.

E2E sanity:
- `'lsp' in _BUILTIN_SUBCOMMANDS` → True
- `_detect_tool_failure("write_file", '{"bytes_written": 0, "lint": {"errors": [{"severity": "error"}]}}')` → `(False, "")` (would be `(True, " [error]")` without the fix; this is the case PR #24960 mishandles)
- `_detect_tool_failure("write_file", '{"error": "Permission denied"}')` → `(True, " [error]")` (genuine failures still detected)
- `_detect_tool_failure("patch", '{"success": true, "lsp_diagnostics": "<diagnostics>ERROR foo</diagnostics>"}')` → `(False, "")`

Closes #24927 (via #24929).
Supersedes #24738, #24929, #24960.

cc @briandevans @GodsBoy — your commits are preserved as-is in this salvage; original authorship intact in `git log`.
