### PR TITLE
fix: MiniMax-CN vision support + browser env reload + SOCKS proxy wor…

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -126,6 +126,12 @@ def decide_image_input_mode(
     supports = _lookup_supports_vision(provider, model)
     if supports is True:
         return "native"
+
+    # MiniMax-CN uses Anthropic-compatible endpoints that support vision natively.
+    # The models.dev metadata may not reflect this — override based on provider.
+    if provider in {"minimax", "minimax-cn", "minimax-oauth"}:
+        return "native"
+
     return "text"
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -70,6 +70,14 @@ from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 from hermes_cli.config import cfg_get
 
+# Reload .env so newly added env vars (e.g. AGENT_BROWSER_CHROME_FLAGS added
+# after gateway startup) are visible to browser tool subprocesses without requiring
+# a full gateway restart.
+try:
+    from hermes_cli.env_loader import load_hermes_dotenv as _load_dotenv
+except ImportError:
+    _load_dotenv = lambda: None  # noqa: E731 -- fail-open in standalone tool contexts
+
 try:
     from tools.website_policy import check_website_access
 except Exception:
@@ -1756,6 +1764,9 @@ def _run_browser_command(
     Returns:
         Parsed JSON response from agent-browser
     """
+    # Reload .env so newly added env vars are visible to this subprocess request.
+    _load_dotenv()
+
     if timeout is None:
         timeout = _get_command_timeout()
     args = args or []

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -376,8 +376,27 @@ def _load_local_whisper_model(model_name: str):
 
     We try ``auto`` first (fast CUDA path when it works), and on any CUDA
     library load failure fall back to CPU + int8.
+
+    SOCKS proxy note: ``ALL_PROXY`` / ``all_proxy`` set to ``socks5://`` can cause
+    URL parsing errors in huggingface_hub/requests (``Unknown scheme socks://``).
+    We temporarily clear SOCKS proxy vars during model load to work around this.
     """
     from faster_whisper import WhisperModel
+
+    # Save and clear SOCKS proxy vars to avoid URL parsing errors in huggingface_hub.
+    # The SOCKS proxy scheme ``socks://`` (without ``4`` or ``5``) is invalid and
+    # can appear when ``ALL_PROXY=socks5://...`` is misparsed by urllib3/requests.
+    _saved_proxies = {
+        k: v
+        for k in ("ALL_PROXY", "all_proxy", "HTTPS_PROXY", "HTTP_PROXY",
+                  "https_proxy", "http_proxy", "NO_PROXY", "no_proxy",
+                  "ALL_PROXY", "all_proxy")
+        if (v := os.environ.get(k))
+    }
+    # Clear SOCKS-related proxy vars before model load (huggingface_hub download).
+    for _k in ("ALL_PROXY", "all_proxy", "HTTPS_PROXY", "https_proxy"):
+        os.environ.pop(_k, None)
+
     try:
         return WhisperModel(model_name, device="auto", compute_type="auto")
     except Exception as exc:
@@ -389,6 +408,9 @@ def _load_local_whisper_model(model_name: str):
             exc,
         )
         return WhisperModel(model_name, device="cpu", compute_type="int8")
+    finally:
+        # Restore proxy environment.
+        os.environ.update(_saved_proxies)
 
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -460,6 +460,10 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
         return True
 
+    # Anthropic-compatible providers (MiniMax-CN uses Anthropic-compatible endpoints)
+    if p in {"minimax", "minimax-cn", "minimax-oauth"}:
+        return True
+
     # Gemini — gate on model name; older Gemini variants did not support
     # multimodal functionResponse. Gemini 3.x does.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:


### PR DESCRIPTION
…karound

- agent/image_routing.py: MiniMax-CN uses Anthropic-compatible endpoints, override vision detection
- tools/browser_tool.py: reload .env before reading AGENT_BROWSER_CHROME_FLAGS (hot-reload fix)
- tools/transcription_tools.py: clear SOCKS proxy vars during faster-whisper model load to avoid URL parsing errors
- tools/vision_tools.py: MiniMax-CN supports media in tool results (Anthropic-compatible endpoints)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

