### PR TITLE
fix(skills): normalize datetime in skill_view metadata for JSON serialization

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -66,6 +66,7 @@ Usage:
     content = skill_view("axolotl", "references/dataset-formats.md")
 """
 
+import datetime
 import json
 import logging
 
@@ -441,6 +442,23 @@ def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     """
     from agent.skill_utils import parse_frontmatter
     return parse_frontmatter(content)
+
+
+def _strip_datetime(obj: Any) -> Any:
+    """Recursively strip datetime/date objects from a metadata dict for JSON serialization.
+
+    yaml.safe_load parses unquoted YAML dates into datetime.date or
+    datetime.datetime objects. json.dumps can't serialize these without
+    ``default=str``. Rather than relying on the json.dumps fallback everywhere,
+    we normalize at the source so returned metadata is always JSON-safe.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_datetime(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_strip_datetime(item) for item in obj]
+    if isinstance(obj, (datetime.datetime, datetime.date)):
+        return obj.isoformat()
+    return obj
 
 
 def _get_category_from_path(skill_path: Path) -> Optional[str]:
@@ -1396,9 +1414,9 @@ def skill_view(
         if frontmatter.get("compatibility"):
             result["compatibility"] = frontmatter["compatibility"]
         if isinstance(metadata, dict):
-            result["metadata"] = metadata
+            result["metadata"] = _strip_datetime(metadata)
 
-        return json.dumps(result, ensure_ascii=False)
+        return json.dumps(result, ensure_ascii=False, default=str)
 
     except Exception as e:
         return tool_error(str(e), success=False)


### PR DESCRIPTION

## Bug

 returns the skill's frontmatter  dict verbatim in its JSON response.  parses unquoted YAML dates (e.g. `patched: 2026-05-12`) into  objects.  without  raises `TypeError: Object of type date is not JSON serializable`. This silently breaks  for any skill that has a date in its metadata field.

## Fix

1. `_strip_datetime()` — recursively converts `datetime`/`date` objects to ISO strings before storing in the result dict
2. `json.dumps(..., default=str)` — belt-and-suspenders fallback for any other non-serializable types that slip through

## Test

```python
from tools.skills_tool import skill_view
import json
result = json.loads(skill_view('kanban-worker', preprocess=False))
assert result['success']
assert isinstance(result['metadata']['hermes']['patched'], str)  # ISO string, not date
```
