### PR TITLE
fix(lsp): add idle-subprocess reaper to reclaim memory during long sessions

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -134,6 +134,12 @@ class _BackgroundLoop:
         self._loop = None
         self._thread = None
 
+    def schedule(self, coro) -> Optional[asyncio.Task]:
+        """Schedule a coroutine on the background loop without blocking."""
+        if self._loop is None:
+            return None
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+
 
 class LSPService:
     """The process-wide LSP service.
@@ -187,6 +193,11 @@ class LSPService:
         # out anything in the baseline so the agent only sees errors
         # introduced by the current edit.
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
+
+        # Start idle-subprocess reaper
+        self._reaper_handle = None
+        if self._enabled:
+            self._reaper_handle = self._loop.schedule(self._reaper_loop())
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -436,10 +447,42 @@ class LSPService:
         if not already_broken:
             eventlog.log_spawn_failed(srv.server_id, per_server_root, exc)
 
+    # ------------------------------------------------------------------
+    # idle reaper
+    # ------------------------------------------------------------------
+
+    async def _reaper_loop(self) -> None:
+        """Periodically reap LSP subprocesses that have been idle too long."""
+        while True:
+            await asyncio.sleep(self._idle_timeout / 2)
+            await self._reap_idle()
+
+    async def _reap_idle(self) -> None:
+        """Single pass: shut down clients idle for longer than *_idle_timeout*."""
+        now = time.time()
+        to_reap: list = []
+        with self._state_lock:
+            for key, last in list(self._last_used.items()):
+                if now - last > self._idle_timeout:
+                    client = self._clients.pop(key, None)
+                    self._last_used.pop(key, None)
+                    if client is not None:
+                        to_reap.append(client)
+        for client in to_reap:
+            try:
+                await client.shutdown()
+                logger.info("Reaped idle LSP server %s (%s)", client.server_id, client.workspace_root)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Error reaping LSP client: %s", e)
+
     def shutdown(self) -> None:
         """Tear down all clients and stop the background loop."""
         if not self._enabled:
             return
+        # Cancel the reaper before tearing down clients
+        if self._reaper_handle is not None:
+            self._reaper_handle.cancel()
+            self._reaper_handle = None
         try:
             self._loop.run(self._shutdown_async(), timeout=10.0)
         except Exception as e:  # noqa: BLE001

--- a/tests/agent/lsp/test_reaper.py
+++ b/tests/agent/lsp/test_reaper.py
@@ -1,0 +1,81 @@
+"""Tests for the LSP idle-subprocess reaper."""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.lsp.manager import LSPService
+
+
+def _make_service(idle_timeout: float = 1.0) -> LSPService:
+    """Create a minimal LSPService with a short idle timeout for testing."""
+    with patch("agent.lsp.manager._BackgroundLoop") as MockLoop:
+        mock_loop = MagicMock()
+        mock_loop.schedule = MagicMock(return_value=None)
+        MockLoop.return_value = mock_loop
+        svc = LSPService(
+            enabled=True,
+            wait_mode="document",
+            wait_timeout=5.0,
+            install_strategy="skip",
+            idle_timeout=idle_timeout,
+        )
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_removes_stale_clients():
+    """Clients idle beyond the timeout are shut down and removed."""
+    svc = _make_service(idle_timeout=1.0)
+    mock_client = AsyncMock()
+    mock_client.server_id = "pyright"
+    mock_client.workspace_root = "/tmp/test"
+
+    key = ("pyright", "/tmp/test")
+    svc._clients[key] = mock_client
+    svc._last_used[key] = time.time() - 10  # way past timeout
+
+    await svc._reap_idle()
+
+    assert key not in svc._clients
+    assert key not in svc._last_used
+    mock_client.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_keeps_active_clients():
+    """Recently used clients are not reaped."""
+    svc = _make_service(idle_timeout=600.0)
+    mock_client = AsyncMock()
+    mock_client.server_id = "pyright"
+    mock_client.workspace_root = "/tmp/test"
+
+    key = ("pyright", "/tmp/test")
+    svc._clients[key] = mock_client
+    svc._last_used[key] = time.time()
+
+    await svc._reap_idle()
+
+    assert key in svc._clients
+    mock_client.shutdown.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_handles_shutdown_error():
+    """Reaper continues even if client.shutdown() raises."""
+    svc = _make_service(idle_timeout=1.0)
+    mock_client = AsyncMock()
+    mock_client.server_id = "pyright"
+    mock_client.workspace_root = "/tmp/test"
+    mock_client.shutdown.side_effect = RuntimeError("boom")
+
+    key = ("pyright", "/tmp/test")
+    svc._clients[key] = mock_client
+    svc._last_used[key] = time.time() - 10
+
+    await svc._reap_idle()  # should not raise
+
+    assert key not in svc._clients


### PR DESCRIPTION
## Summary

`LSPService` defines `DEFAULT_IDLE_TIMEOUT = 600` and tracks `_last_used` timestamps per `(server_id, workspace_root)` key, but no reaper coroutine ever consumes them. Idle LSP subprocesses live forever inside a long-running gateway/CLI session, accumulating hundreds of MB of dead memory.

## Changes

- **`agent/lsp/manager.py`**:
  - Add `_BackgroundLoop.schedule()` method to fire-and-forget a coroutine on the background event loop.
  - Add `LSPService._reaper_loop()` — an async loop that wakes every `idle_timeout / 2` seconds and calls `_reap_idle()`.
  - Add `LSPService._reap_idle()` — single pass that iterates `_last_used`, shuts down clients idle beyond `_idle_timeout`, and removes them from `_clients` and `_last_used`.
  - Start the reaper in `__init__` when LSP is enabled; cancel it in `shutdown()`.

- **`tests/agent/lsp/test_reaper.py`** (new): 3 unit tests covering:
  - Stale clients are reaped and `shutdown()` is awaited.
  - Active clients are preserved.
  - Reaper continues gracefully if `client.shutdown()` raises.

## Test Results

All existing LSP tests pass; 3 new tests pass.

Fixes #25016