### PR TITLE
fix(cron): use now as croniter base for cron-schedule jobs to prevent stuck loop

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -380,14 +380,13 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 schedule.get("expr"),
             )
             return None
-        # Use last_run_at as the croniter base when available, consistent
-        # with interval jobs.  This ensures that after a crash/restart,
-        # the next run is anchored to the actual last execution time
-        # rather than to an arbitrary restart time.
-        base_time = now
-        if last_run_at:
-            base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        # Use the current time as the croniter base so next_run always lands
+        # in the future.  Anchoring to last_run_at causes a bug: for cron
+        # expressions like \"*/5 * * * *\", if last_run is not aligned to the
+        # cron tick grid, croniter can return a time in the past — the
+        # scheduler then fast-forwards it, but re-computes the same past
+        # time, creating a stuck loop where the job never fires.
+        cron = croniter(schedule["expr"], now)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 


### PR DESCRIPTION
## Problem

When compute_next_run() uses last_run_at as the croniter base time for cron-schedule jobs (e.g. */5 * * * *), and last_run_at is not aligned to the cron tick grid (e.g. 19:14:59 instead of 19:15:00), croniter(base_time=last_run_at).get_next() returns a time in the past (19:15:00).

The scheduler's grace/fast-forward logic then re-computes this same past time, creating a stuck loop where the job **never fires automatically**.

## Reproduction

Schedule: */5 * * * *
After manual cronjob run at 19:14:59, last_run_at = 19:14:59
compute_next_run() computes croniter(base_time=19:14:59).get_next() = 19:15:00
19:15:00 is already past, scheduler fast-forwards, but computes the same past time again, stuck.

## Fix

For cron-kind schedules, always use _hermes_now() as the croniter base instead of last_run_at, so next_run always lands in the future.

Interval-kind schedules still use last_run_at + interval (correct behavior for relative intervals).

## Impact

- Fixes cron jobs with expressions like */N * * * *, 0 9 * * *, etc. that silently stop auto-running after manual cronjob run or scheduler restart.
- No breaking changes, interval-schedule jobs are unaffected.