### PR TITLE
Use backticks instead of quotes for tool preview in gateway messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14322,7 +14322,7 @@ class GatewayRunner:
                         args_str = args_str[:_pl - 3] + "..."
                     msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
                 elif preview:
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                    msg = f"{emoji} {tool_name}: `{preview}`"
                 else:
                     msg = f"{emoji} {tool_name}..."
                 progress_queue.put(msg)
@@ -14337,7 +14337,7 @@ class GatewayRunner:
                 _cap = _pl if _pl > 0 else 40
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                msg = f"{emoji} {tool_name}: `{preview}`"
             else:
                 msg = f"{emoji} {tool_name}..."
             


### PR DESCRIPTION
## Summary

Changed tool preview formatting in gateway messages from double quotes to backticks.

**Before:**
```
💻 terminal: "cat ~/.hermes/example.txt && ..."
```

**After:**
```
💻 terminal: `cat ~/.hermes/example.txt && ...`
```

## Why

Backticks trigger Discord (and other platforms) inline code formatting, which renders more consistently — especially when the preview content itself contains quotes or special characters. The old double-quote wrapping could produce visually confusing output when the command being previewed included quoted strings.

## Changes

Two lines in `gateway/run.py`, both in the progress callback closure:

- Line ~14325 (verbose mode preview path)
- Line ~14340 (all/new mode preview path)

```diff
-                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                    msg = f"{emoji} {tool_name}: `{preview}`"
```

## Testing

Patched locally and ran against live Discord gateway. Tool previews render correctly with backtick inline code formatting.

## Screenshots

Sometimes URLs get truncated but still anchor-linked by Discord which makes them broken
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/722be1ca-e0b5-4d20-8bdd-f8ab06142a1b" />

When the bash logical "OR" double-pipe (`||`) is used more than once in sequence, Discord interprets it as a spoiler
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/950752af-47c1-436d-a45d-d7522dad594d" />
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/ed92f918-60e8-4984-a73e-53e11ae10a3e" />

Python conventional filenames such as `__init__.py` are interpreted by Discord as underline syntax
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/693bf178-6aa3-43e3-894d-13f3579f64ac" />

After the change, backticks allow all of these things to display as intended within Discord's display interface
<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/413c781b-6732-4447-b976-6162a56baba7" />
