### PR TITLE
fix(tui): finalize closed sessions in background

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -743,6 +743,11 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         "_notify_session_boundary",
         lambda event, session_id: calls["hooks"].append((event, session_id)),
     )
+    monkeypatch.setattr(
+        server,
+        "_submit_session_close_cleanup",
+        lambda session, end_reason="tui_close": server._cleanup_closed_session(session, end_reason),
+    )
 
     try:
         resp = server.handle_request(
@@ -752,6 +757,36 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_close_returns_before_slow_finalize(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    cleaned = threading.Event()
+
+    def slow_cleanup(session, end_reason="tui_close"):
+        started.set()
+        release.wait(timeout=2)
+        cleaned.set()
+
+    monkeypatch.setattr(server, "_cleanup_closed_session", slow_cleanup)
+    server._sessions["sid"] = _session(history=[{"role": "user", "content": "hello"}])
+
+    try:
+        t0 = time.monotonic()
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
+        )
+        elapsed = time.monotonic() - t0
+        assert resp["result"]["closed"] is True
+        assert elapsed < 0.5
+        assert "sid" not in server._sessions
+        assert started.wait(timeout=1)
+        assert not cleaned.is_set()
+    finally:
+        release.set()
+        cleaned.wait(timeout=2)
         server._sessions.pop("sid", None)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -318,15 +318,41 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             pass
 
 
+def _cleanup_closed_session(session: dict, end_reason: str = "tui_close") -> None:
+    """Finalize and release a TUI session after it has been removed.
+
+    Session finalization can run slow provider hooks (memory extraction / context
+    engine flushes).  Keep the cleanup grouped so ``session.close`` can hand it
+    off without blocking interactive session switches such as ``/new``.
+    """
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        unregister_gateway_notify(session["session_key"])
+    except Exception:
+        pass
+    try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+
+
+def _submit_session_close_cleanup(session: dict, end_reason: str = "tui_close"):
+    return _pool.submit(_cleanup_closed_session, session, end_reason)
+
+
 def _shutdown_sessions() -> None:
     for session in list(_sessions.values()):
-        _finalize_session(session, end_reason="tui_shutdown")
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+        _cleanup_closed_session(session, end_reason="tui_shutdown")
 
 
 atexit.register(_shutdown_sessions)
@@ -2635,25 +2661,7 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
+    _submit_session_close_cleanup(session)
     return _ok(rid, {"closed": True})
 
 


### PR DESCRIPTION
## Summary
- Make TUI `session.close` detach the old session and return immediately.
- Move old-session finalization, memory/context cleanup, approval unregistering, agent close, and slash-worker close into a background cleanup task.
- Add a regression test that simulates slow cleanup and verifies `session.close` returns promptly.

Closes #23642.

## Test Plan
- [x] `./scripts/run_tests.sh tests/test_tui_gateway_server.py::test_session_close_commits_memory_and_fires_finalize_hook tests/test_tui_gateway_server.py::test_session_close_returns_before_slow_finalize`
- [x] `./scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — targeted changes pass; one pre-existing/unrelated browser launch-hint assertion fails on this macOS environment: `test_browser_manage_connect_default_local_reports_launch_hint`
