### PR TITLE
fix(lsp): default to opt-in (enabled=False, install_strategy=manual) (#25015)

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -201,10 +201,14 @@ class LSPService:
         if not isinstance(lsp_cfg, dict):
             lsp_cfg = {}
 
-        enabled = bool(lsp_cfg.get("enabled", True))
+        # Match ``hermes_cli/config.py`` DEFAULT_CONFIG["lsp"] for users
+        # whose config.yaml predates the section (else they'd get the
+        # pre-opt-in defaults at runtime while ``hermes init`` writes
+        # opt-in defaults — divergent and surprising).
+        enabled = bool(lsp_cfg.get("enabled", False))
         wait_mode = lsp_cfg.get("wait_mode", "document")
         wait_timeout = float(lsp_cfg.get("wait_timeout", DIAGNOSTICS_DOCUMENT_WAIT))
-        install_strategy = lsp_cfg.get("install_strategy", "auto")
+        install_strategy = lsp_cfg.get("install_strategy", "manual")
         servers_cfg = lsp_cfg.get("servers") or {}
         disabled = []
         binary_overrides: Dict[str, List[str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1510,10 +1510,14 @@ DEFAULT_CONFIG = {
     # tier — handy for Telegram/Discord chats where the cwd is the
     # user's home directory.
     "lsp": {
-        # Master toggle.  Setting this to false disables the entire
-        # subsystem — no servers spawn, no background event loop, no
-        # cost.
-        "enabled": True,
+        # Master toggle.  Opt-in: set this to true to enable the
+        # subsystem.  When false, no servers spawn, no background
+        # event loop, no cost.  Defaults off because spawning
+        # language servers (pyright ~200 MB, gopls ~80 MB,
+        # tsserver ~150 MB) on the first file edit is a surprise
+        # for users in audited environments where any background
+        # process or package install needs explicit consent.
+        "enabled": False,
 
         # Diagnostic-wait mode for the post-write check.
         # ``"document"`` waits up to ``wait_timeout`` seconds for the
@@ -1525,9 +1529,15 @@ DEFAULT_CONFIG = {
         # How to handle missing server binaries.
         # ``"auto"`` — try to install via npm/go/pip into
         #              ``<HERMES_HOME>/lsp/bin/`` on first use.
-        # ``"manual"`` — only use binaries already on PATH.
+        # ``"manual"`` — only use binaries already on PATH; no
+        #               background installs.  Default, so a user
+        #               who flips ``enabled`` on without also
+        #               opting in to auto-install still gets
+        #               diagnostics from any server already on
+        #               PATH (pyright, gopls, etc.) and a clear
+        #               error otherwise.
         # ``"off"`` — alias for ``manual``.
-        "install_strategy": "auto",
+        "install_strategy": "manual",
 
         # Per-server overrides.  Each key is a server_id from the
         # registry (``pyright``, ``typescript``, ``gopls``,

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -755,15 +755,13 @@ class TestLSPOptInDefaults:
         # The fallbacks MUST match the canonical defaults in
         # ``DEFAULT_CONFIG["lsp"]`` so users on an older config get
         # the same opt-in behaviour as fresh installs.
-        from agent.lsp import manager as lsp_manager
-        import inspect
+        from agent.lsp.manager import LSPService
 
-        src = inspect.getsource(lsp_manager.LSPService.create_from_config)
-        assert 'lsp_cfg.get("enabled", False)' in src, (
-            "agent/lsp/manager.py:create_from_config must default "
-            "`enabled` to False to match DEFAULT_CONFIG['lsp']"
-        )
-        assert 'lsp_cfg.get("install_strategy", "manual")' in src, (
-            "agent/lsp/manager.py:create_from_config must default "
-            "`install_strategy` to 'manual' to match DEFAULT_CONFIG['lsp']"
-        )
+        with patch("hermes_cli.config.load_config", return_value={}):
+            service = LSPService.create_from_config()
+
+        assert service is not None
+        assert service.is_active() is False
+        status = service.get_status()
+        assert status["enabled"] is False
+        assert status["install_strategy"] == "manual"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -732,3 +732,38 @@ class TestUserMessagePreviewConfig:
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+
+
+class TestLSPOptInDefaults:
+    """Defaults for the LSP subsystem must be opt-in (#25015).
+
+    A fresh install must not silently spawn pyright/gopls/etc. or
+    auto-install language servers via npm/go/pip on the first file
+    edit. Users opt in via ``lsp.enabled: true`` (and, separately,
+    ``lsp.install_strategy: auto``) in their config.yaml.
+    """
+
+    def test_default_lsp_enabled_is_false(self):
+        assert DEFAULT_CONFIG["lsp"]["enabled"] is False
+
+    def test_default_lsp_install_strategy_is_manual(self):
+        assert DEFAULT_CONFIG["lsp"]["install_strategy"] == "manual"
+
+    def test_manager_fallbacks_match_config_defaults(self):
+        # ``LSPService.create_from_config`` falls back to its own
+        # defaults when ``config.yaml`` predates the lsp section.
+        # The fallbacks MUST match the canonical defaults in
+        # ``DEFAULT_CONFIG["lsp"]`` so users on an older config get
+        # the same opt-in behaviour as fresh installs.
+        from agent.lsp import manager as lsp_manager
+        import inspect
+
+        src = inspect.getsource(lsp_manager.LSPService.create_from_config)
+        assert 'lsp_cfg.get("enabled", False)' in src, (
+            "agent/lsp/manager.py:create_from_config must default "
+            "`enabled` to False to match DEFAULT_CONFIG['lsp']"
+        )
+        assert 'lsp_cfg.get("install_strategy", "manual")' in src, (
+            "agent/lsp/manager.py:create_from_config must default "
+            "`install_strategy` to 'manual' to match DEFAULT_CONFIG['lsp']"
+        )


### PR DESCRIPTION
## Summary

Flips the two canonical LSP defaults in `DEFAULT_CONFIG["lsp"]` to opt-in
so a fresh install never silently spawns pyright / gopls / tsserver or
auto-installs language servers via `npm` / `go` / `pip` on the first
file edit.

- `enabled: True` → `False`
- `install_strategy: "auto"` → `"manual"`

Also flips the matching fallbacks in `LSPService.create_from_config()`
so users on a `config.yaml` that predates the `lsp:` section see the
same opt-in behaviour at runtime.

Fixes #25015.

## The bug

`hermes_cli/config.py:1516,1530` shipped with `enabled: True` +
`install_strategy: "auto"`. With LSP gated only on git-workspace
detection, the first `.py` / `.go` / `.rs` / `.ts` edit inside any
git repo silently triggers:

- `npm install -g pyright@latest` (or `go install gopls@latest`,
  `cargo install rust-analyzer`, etc.) into
  `<HERMES_HOME>/lsp/bin/`
- a long-lived language-server subprocess (pyright ~200 MB,
  gopls ~80 MB, tsserver ~150 MB)

For users in audited environments (SOC 2, ISO 27001) this falls under
the same compliance umbrella that already gates `pip` / `npm` installs
in CI: any background process or package fetch needs explicit consent.

Reported as defect D5 in scubamount's #24467 and verified-real on
current `main` by @kshitijk4poor when that PR was split into three
focused issues. This is the standalone follow-up they asked for.

## The fix

Two literal flips in the canonical defaults, plus matching fallback
flips in the consumer so existing configs behave the same way:

```diff
 # hermes_cli/config.py
 "lsp": {
-    "enabled": True,
+    "enabled": False,
-    "install_strategy": "auto",
+    "install_strategy": "manual",
 }
```

```diff
 # agent/lsp/manager.py — LSPService.create_from_config
-enabled = bool(lsp_cfg.get("enabled", True))
-install_strategy = lsp_cfg.get("install_strategy", "auto")
+enabled = bool(lsp_cfg.get("enabled", False))
+install_strategy = lsp_cfg.get("install_strategy", "manual")
```

Why also flip the manager fallbacks: `LSPService.create_from_config()`
defaults are what kicks in when `config.yaml` predates the `lsp:`
section. Flipping only `DEFAULT_CONFIG` would mean fresh installs get
opt-in defaults while existing users silently keep `enabled=True` /
`install_strategy="auto"` — divergent behaviour for the same product
state, and the worst of both worlds.

Why `"manual"` and not `"off"`: `"manual"` preserves existing-binary
discovery. A user who opts back in with `enabled: true` (without also
opting in to auto-install) still gets diagnostics from any pyright /
gopls / tsserver already on `PATH`, with a clear "not installed" error
otherwise. `"off"` would be a stronger downgrade that punishes users
who already have the binaries.

## Test plan

- [x] Focused regression test (`TestLSPOptInDefaults`, 3 tests):
  asserts `DEFAULT_CONFIG["lsp"]["enabled"] is False`,
  `install_strategy == "manual"`, and that the manager fallbacks match.
- [x] Adjacent suite: `tests/hermes_cli/test_config.py` +
  `tests/agent/lsp/` → 169 passed locally.
- [x] Regression guard: confirmed in-process that the old defaults
  (`True` / `"auto"`) would fail the new assertions, and the new
  defaults pass.

## Related

- Source analysis: scubamount's closed #24467 (defect D5).
- Sibling issues filed alongside #25015 by the same split:
  - #25016 — idle-subprocess reaper (already in flight as
    luyao618's #25021).
  - #25017 — `INSTALL_RECIPES` `@latest` pinning.

> Sibling code paths that may need the same conservative-default
> treatment: `agent/lsp/servers.py` `INSTALL_RECIPES` (currently pulls
> `@latest`, #25017). Intentionally left out of this PR's scope to
> keep the diff focused on the opt-in toggle — happy to widen if
> preferred.