### PR TITLE
test(gateway): isolate DingTalk SDK mocks

### DIFF
--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -10,6 +10,71 @@ import pytest
 from gateway.config import Platform, PlatformConfig
 
 
+class _FakeDingTalkModel:
+    """Tiny stand-in for Alibaba SDK request/header model classes.
+
+    The DingTalk unit tests assert the adapter's behaviour, not the SDK's
+    constructor internals.  CI intentionally installs ``.[all,dev]`` without
+    the optional ``dingtalk`` extra, so tests that exercise card code must
+    provide deterministic model objects instead of depending on whichever
+    optional SDK packages happened to be present in the environment.
+    """
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _FakeChatbotMessage:
+    """Minimal ChatbotMessage used by _IncomingHandler.process tests."""
+
+    @classmethod
+    def from_dict(cls, data):
+        msg = cls()
+        msg.message_id = data.get("msgId", "")
+        msg.conversation_id = data.get("conversationId", "")
+        msg.conversation_type = data.get("conversationType", "1")
+        msg.sender_id = data.get("senderId", "")
+        msg.sender_staff_id = data.get("senderStaffId", "")
+        msg.sender_nick = data.get("senderNick", "")
+        msg.text = data.get("text", {})
+        msg.session_webhook = data.get("sessionWebhook", "")
+        msg.session_webhook_expired_time = data.get("sessionWebhookExpiredTime", 0)
+        msg.is_in_at_list = data.get("isInAtList", False)
+        msg.at_users = data.get("atUsers", [])
+        return msg
+
+
+@pytest.fixture
+def dingtalk_card_sdk_models(monkeypatch):
+    """Patch optional DingTalk card SDK globals with deterministic fakes."""
+    from types import SimpleNamespace
+    import gateway.platforms.dingtalk as dingtalk
+
+    model_names = [
+        "CreateCardRequest",
+        "CreateCardRequestCardData",
+        "CreateCardRequestImGroupOpenSpaceModel",
+        "CreateCardRequestImRobotOpenSpaceModel",
+        "CreateCardHeaders",
+        "DeliverCardRequest",
+        "DeliverCardRequestImGroupOpenDeliverModel",
+        "DeliverCardRequestImRobotOpenDeliverModel",
+        "DeliverCardHeaders",
+        "StreamingUpdateRequest",
+        "StreamingUpdateHeaders",
+    ]
+    card_models = SimpleNamespace(
+        **{name: _FakeDingTalkModel for name in model_names}
+    )
+    tea_models = SimpleNamespace(RuntimeOptions=_FakeDingTalkModel)
+
+    monkeypatch.setattr(dingtalk, "CARD_SDK_AVAILABLE", True)
+    monkeypatch.setattr(dingtalk, "dingtalk_card_models", card_models)
+    monkeypatch.setattr(dingtalk, "tea_util_models", tea_models)
+    return card_models
+
+
 # ---------------------------------------------------------------------------
 # Requirements check
 # ---------------------------------------------------------------------------
@@ -631,6 +696,12 @@ class TestIncomingHandlerProcess:
     and dispatches message processing as a background task (fire-and-forget)
     so the SDK ACK is returned immediately."""
 
+    @pytest.fixture(autouse=True)
+    def chatbot_message_model(self, monkeypatch):
+        import gateway.platforms.dingtalk as dingtalk
+
+        monkeypatch.setattr(dingtalk, "ChatbotMessage", _FakeChatbotMessage)
+
     @pytest.mark.asyncio
     async def test_process_extracts_session_webhook(self):
         """session_webhook must be populated from callback data."""
@@ -794,9 +865,8 @@ class TestMessageContextIsolation:
 
 
 class TestCardLifecycle:
-
     @pytest.fixture
-    def adapter_with_card(self):
+    def adapter_with_card(self, dingtalk_card_sdk_models):
         from gateway.platforms.dingtalk import DingTalkAdapter
         a = DingTalkAdapter(PlatformConfig(
             enabled=True,
@@ -987,7 +1057,14 @@ class TestDingTalkAdapterAICards:
         return msg
 
     @pytest.mark.asyncio
-    async def test_send_uses_ai_card_if_configured(self, config, mock_stream_client, mock_http_client, mock_message):
+    async def test_send_uses_ai_card_if_configured(
+        self,
+        config,
+        mock_stream_client,
+        mock_http_client,
+        mock_message,
+        dingtalk_card_sdk_models,
+    ):
         from gateway.platforms.dingtalk import DingTalkAdapter
 
         adapter = DingTalkAdapter(config)


### PR DESCRIPTION
## What does this PR do?

Makes the DingTalk gateway unit tests deterministic when the optional `dingtalk` extra is not installed.

The failing CI symptom was that card/incoming-message tests exercised DingTalk SDK paths while module-level optional imports were `None`, producing errors such as:

```text
AttributeError: 'NoneType' object has no attribute 'RuntimeOptions'
AttributeError: 'NoneType' object has no attribute 'from_dict'
```

Root cause: `tests/gateway/test_dingtalk.py` replaces the network-facing SDK clients with mocks, but some tests still rely on optional SDK model classes:

- `_IncomingHandler.process()` calls `ChatbotMessage.from_dict()`.
- AI Card send/edit lifecycle code constructs Alibaba Card SDK request/header/runtime model objects.

In a clean `.[all,dev]` install without the optional `dingtalk` extra, those module-level imports are `None`, so otherwise isolated unit tests fail before reaching the behaviour under test.

This PR keeps the fix test-only: it adds deterministic fake SDK model objects for the tests and does not change production DingTalk adapter behaviour.

## Related Issue

No dedicated issue found.

Related / prior art:

- #25014 added lazy dependency installation for Slack/Matrix/DingTalk/Feishu adapters. This PR is complementary: it keeps DingTalk unit tests isolated from optional SDK installation state.
- I searched for existing DingTalk RuntimeOptions / ChatbotMessage test-failure issues or PRs and did not find a duplicate.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_dingtalk.py`
  - Add tiny fake DingTalk SDK model classes for request/header/runtime objects.
  - Patch `ChatbotMessage` in `_IncomingHandler.process` tests.
  - Patch `dingtalk_card_models` and `tea_util_models.RuntimeOptions` in AI Card lifecycle tests.
  - Keep the tests independent from whether optional DingTalk SDK packages are installed in the environment.

## How to Test

Clean CI-like venv with `.[all,dev]` and no preinstalled `dingtalk` extra:

```bash
uv venv /tmp/hermes-ci-dingtalk-venv2 --python 3.11
source /tmp/hermes-ci-dingtalk-venv2/bin/activate
uv pip install -e '.[all,dev]'
python -m pytest tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card -q -o 'addopts=' --tb=short
python -m pytest \
  tests/gateway/test_dingtalk.py::TestIncomingHandlerProcess::test_process_extracts_session_webhook \
  tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured \
  -q -o 'addopts=' --tb=short
python -m pytest tests/gateway/test_dingtalk.py -q -o 'addopts=' --tb=short
```

Results:

```text
1 passed
2 passed
65 passed
```

Local project venv:

```bash
python -m ruff check tests/gateway/test_dingtalk.py
python -m pytest tests/gateway/test_dingtalk.py -q -o 'addopts=' --tb=short
```

Results:

```text
All checks passed!
65 passed
```

Broader gateway note:

```bash
python -m pytest tests/gateway/test_dingtalk.py tests/gateway/test_feishu_bot_admission.py -q -o 'addopts=' --tb=short
```

This still exposes an unrelated existing Feishu failure:

```text
tests/gateway/test_feishu_bot_admission.py::test_hydrate_bot_identity_populates_self_ids_from_bot_v3_info
KeyError: 'uri'
```

This PR intentionally does not expand scope beyond DingTalk test isolation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux CI-like Python 3.11 venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before this change, in a clean `.[all,dev]` venv without optional DingTalk SDK packages, the targeted DingTalk card lifecycle test failed with:

```text
AttributeError: 'NoneType' object has no attribute 'RuntimeOptions'
```

After this change:

```text
65 passed
```
