### PR TITLE
feat: paplay audio bell + notify_on_interact for Wayland terminals (#25022)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -932,12 +932,24 @@ display:
   background_process_notifications: all
 
 
-  # Play terminal bell when agent finishes a response.
+  # Play notification sound when agent finishes a response.
   # Useful for long-running tasks — your terminal will ding when the agent is done.
-  # Works over SSH. Most terminals can be configured to flash the taskbar or play a sound.
-  #   true:  Ring the terminal bell on each response
+  # Combines ASCII BEL (works over SSH and through tmux) with paplay
+  # (covers Wayland-native terminals like Foot/Kitty/ghostty where
+  # \a is silently dropped).  paplay falls back gracefully if missing.
+  #   true:  Ring the bell on each response
   #   false: Silent (default)
   bell_on_complete: false
+
+  # Play notification sound when the agent needs user input
+  # (clarify questions, dangerous-command approvals, sudo password
+  # prompts, secret captures).  Same two-pronged paplay + ASCII BEL
+  # strategy as bell_on_complete.  Useful when you've alt-tabbed away
+  # from the terminal and want an audible cue when the agent is
+  # waiting on you.
+  #   true:  Ring on every interactive prompt
+  #   false: Silent (default)
+  notify_on_interact: false
 
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.

--- a/cli.py
+++ b/cli.py
@@ -125,6 +125,57 @@ _REASONING_TAGS = (
 )
 
 
+# Default sound played by ``_ring_bell`` when paplay is available.
+# message-new-instant.oga ships with the freedesktop sound theme on
+# every desktop Linux distro using PulseAudio / PipeWire (the package
+# is `sound-theme-freedesktop` and is part of the default install on
+# Ubuntu / Fedora / Arch / openSUSE / Debian).
+_BELL_SOUND_PATH = "/usr/share/sounds/freedesktop/stereo/message-new-instant.oga"
+
+
+def _ring_bell() -> None:
+    """Play a notification sound for the user's terminal.
+
+    Two-pronged best-effort strategy so users get an audible cue on
+    every common Linux setup without breaking SSH / non-Linux paths:
+
+    1. Write the ASCII BEL (``\\a``) to stdout — works in legacy
+       terminals (xterm, gnome-terminal, Konsole, classic iTerm2)
+       that respect the bell sequence and propagates over SSH.
+    2. Fire ``paplay`` with the freedesktop "message-new-instant"
+       sound — covers Wayland-native terminals (Foot, Kitty,
+       ghostty) where ``\\a`` is silently swallowed or only
+       triggers a visual flash.
+
+    Both paths are wrapped in broad ``except`` handlers — a missing
+    binary, sandboxed audio device, headless CI, or closed stdout
+    must NEVER crash the agent loop. paplay is invoked detached so
+    the parent process doesn't block on the audio backend.
+    """
+    import subprocess
+
+    try:
+        sys.stdout.write("\a")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+    paplay = shutil.which("paplay")
+    if not paplay:
+        return
+
+    try:
+        subprocess.Popen(
+            [paplay, _BELL_SOUND_PATH],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception:
+        pass
+
+
 def _strip_reasoning_tags(text: str) -> str:
     """Remove reasoning/thinking blocks from displayed text.
 
@@ -2325,6 +2376,12 @@ class HermesCLI:
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # notify_on_interact: play a notification sound whenever the agent
+        # asks for user input (clarify, approval, sudo password, secret).
+        # Uses the same ``_ring_bell()`` two-pronged strategy as
+        # bell_on_complete (ASCII BEL + paplay) so Wayland users on Foot /
+        # Kitty / ghostty actually hear something.  Default off — opt-in.
+        self.notify_on_interact = CLI_CONFIG["display"].get("notify_on_interact", False)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         _configure_output_history(
@@ -7821,10 +7878,8 @@ class HermesCLI:
                 else:
                     _cprint("  (No response generated)")
 
-                # Play bell if enabled
                 if self.bell_on_complete:
-                    sys.stdout.write("\a")
-                    sys.stdout.flush()
+                    _ring_bell()
 
             except Exception as e:
                 # Same TUI refresh pattern as success path (#2718)
@@ -9789,6 +9844,12 @@ class HermesCLI:
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
 
+        # Audible cue so users browsing other windows actually notice the
+        # prompt — gated behind ``display.notify_on_interact`` (off by
+        # default).  Same two-pronged strategy as ``bell_on_complete``.
+        if getattr(self, "notify_on_interact", False):
+            _ring_bell()
+
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
 
@@ -9850,6 +9911,9 @@ class HermesCLI:
         }
         self._sudo_deadline = _time.monotonic() + timeout
 
+        if getattr(self, "notify_on_interact", False):
+            _ring_bell()
+
         self._invalidate()
 
         while True:
@@ -9906,6 +9970,9 @@ class HermesCLI:
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
+
+            if getattr(self, "notify_on_interact", False):
+                _ring_bell()
 
             self._invalidate()
 
@@ -10724,11 +10791,12 @@ class HermesCLI:
                     ))
 
 
-            # Play terminal bell when agent finishes (if enabled).
-            # Works over SSH — the bell propagates to the user's terminal.
+            # Play notification sound when the agent finishes (if enabled).
+            # ``_ring_bell()`` writes ASCII BEL (works over SSH) and also
+            # tries paplay so Wayland terminals that swallow the bell get
+            # an audible cue.
             if self.bell_on_complete:
-                sys.stdout.write("\a")
-                sys.stdout.flush()
+                _ring_bell()
 
             # Notify when iteration budget was hit
             if result and not result.get("completed") and not result.get("interrupted"):

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -15,6 +15,23 @@ from hermes_cli.config import save_env_value_secure
 from hermes_constants import display_hermes_home
 
 
+def _maybe_ring_interact_bell(cli) -> None:
+    """Ring the notification bell when ``display.notify_on_interact`` is on.
+
+    Imported lazily to avoid an import-time cycle between
+    ``cli.py`` and ``hermes_cli/callbacks.py``.  The helper is a no-op
+    when the config flag is off or when the CLI hasn't loaded its
+    config yet (defensive ``getattr``).
+    """
+    if not getattr(cli, "notify_on_interact", False):
+        return
+    try:
+        from cli import _ring_bell
+        _ring_bell()
+    except Exception:
+        pass
+
+
 def clarify_callback(cli, question, choices):
     """Prompt for clarifying question through the TUI.
 
@@ -35,6 +52,8 @@ def clarify_callback(cli, question, choices):
     }
     cli._clarify_deadline = _time.monotonic() + timeout
     cli._clarify_freetext = is_open_ended
+
+    _maybe_ring_interact_bell(cli)
 
     if hasattr(cli, "_app") and cli._app:
         cli._app.invalidate()
@@ -74,6 +93,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
             cli._secret_state = None
         if not hasattr(cli, "_secret_deadline"):
             cli._secret_deadline = 0
+        _maybe_ring_interact_bell(cli)
         try:
             value = getpass.getpass(f"{prompt} (hidden, ESC or empty Enter to skip): ")
         except (EOFError, KeyboardInterrupt):
@@ -109,6 +129,7 @@ def prompt_for_secret(cli, var_name: str, prompt: str, metadata=None) -> dict:
         "response_queue": response_queue,
     }
     cli._secret_deadline = _time.monotonic() + timeout
+    _maybe_ring_interact_bell(cli)
     # Avoid storing stale draft input as the secret when Enter is pressed.
     if hasattr(cli, "_clear_secret_input_buffer"):
         try:
@@ -215,6 +236,8 @@ def approval_callback(cli, command: str, description: str) -> str:
             "response_queue": response_queue,
         }
         cli._approval_deadline = _time.monotonic() + timeout
+
+        _maybe_ring_interact_bell(cli)
 
         if hasattr(cli, "_app") and cli._app:
             cli._app.invalidate()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -912,6 +912,12 @@ DEFAULT_CONFIG = {
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
         "bell_on_complete": False,
+        # Play a notification sound when the agent needs user input
+        # (clarify, approval, sudo, secret prompts).  Uses paplay on
+        # PulseAudio/PipeWire systems with an ASCII BEL fallback for
+        # other terminals; safe to enable on macOS / Wayland / X11.
+        # Default off so existing users aren't surprised.
+        "notify_on_interact": False,
         "show_reasoning": False,
         "streaming": False,
         "timestamps": False,      # Show [HH:MM] on user and assistant labels
@@ -4743,6 +4749,7 @@ def show_config():
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Interact bell:{'on' if display.get('notify_on_interact', False) else 'off'}")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -106,6 +106,7 @@ TIPS = [
 
     # --- Configuration ---
     "Set display.bell_on_complete: true in config.yaml to hear a bell when long tasks finish.",
+    "Set display.notify_on_interact: true to play a sound whenever the agent needs your input.",
     "Set display.streaming: true to see tokens appear in real time as the model generates.",
     "Set display.show_reasoning: true to watch the model's chain-of-thought reasoning.",
     "Set display.compact: true to reduce whitespace in output for denser information.",

--- a/tests/cli/test_ring_bell.py
+++ b/tests/cli/test_ring_bell.py
@@ -1,0 +1,149 @@
+"""Tests for ``cli._ring_bell`` and the ``notify_on_interact`` plumbing.
+
+The two-pronged paplay + ASCII BEL strategy is what makes the
+notification land on Wayland-native terminals (Foot/Kitty/ghostty),
+where the bare BEL is silently swallowed.  These tests make sure
+the helper:
+
+1. Always writes ASCII BEL ("\\a") and flushes stdout — keeps the
+   classic over-SSH and tmux-passthrough paths working.
+2. Spawns ``paplay`` when it is on PATH, with the freedesktop sound
+   asset, in a detached process group so the agent thread never
+   blocks on the audio backend.
+3. Skips the spawn cleanly when ``paplay`` is not installed.
+4. Never propagates errors from a missing binary, broken stdout, or
+   sandboxed audio device — the bell is a UX nicety, not a load-
+   bearing dependency.
+
+It also pins the wire from the new ``display.notify_on_interact``
+config flag through ``_maybe_ring_interact_bell`` in
+``hermes_cli/callbacks`` to ``cli._ring_bell``.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import cli
+from hermes_cli import callbacks
+
+
+def test_ring_bell_writes_ascii_bel_and_flushes():
+    """The ASCII BEL leg must always run regardless of paplay state."""
+    fake_stdout = io.StringIO()
+    flush = MagicMock()
+    fake_stdout.flush = flush
+
+    with patch.object(cli, "sys", SimpleNamespace(stdout=fake_stdout)), \
+         patch.object(cli.shutil, "which", return_value=None):
+        cli._ring_bell()
+
+    assert fake_stdout.getvalue() == "\a"
+    flush.assert_called_once()
+
+
+def test_ring_bell_invokes_paplay_when_available():
+    """When paplay is on PATH we fire it detached with the freedesktop sound."""
+    fake_stdout = io.StringIO()
+    fake_stdout.flush = MagicMock()
+    popen = MagicMock()
+
+    with patch.object(cli, "sys", SimpleNamespace(stdout=fake_stdout)), \
+         patch.object(cli.shutil, "which", return_value="/usr/bin/paplay"), \
+         patch("subprocess.Popen", popen):
+        cli._ring_bell()
+
+    popen.assert_called_once()
+    args, kwargs = popen.call_args
+    cmd = args[0]
+    assert cmd[0] == "/usr/bin/paplay"
+    assert cmd[1] == cli._BELL_SOUND_PATH
+    # Detached + silenced I/O so the agent thread never blocks on PulseAudio.
+    assert kwargs.get("start_new_session") is True
+    assert "stdout" in kwargs and "stderr" in kwargs and "stdin" in kwargs
+
+
+def test_ring_bell_skips_paplay_when_missing():
+    """``shutil.which`` returning None must short-circuit the spawn."""
+    fake_stdout = io.StringIO()
+    fake_stdout.flush = MagicMock()
+    popen = MagicMock()
+
+    with patch.object(cli, "sys", SimpleNamespace(stdout=fake_stdout)), \
+         patch.object(cli.shutil, "which", return_value=None), \
+         patch("subprocess.Popen", popen):
+        cli._ring_bell()
+
+    popen.assert_not_called()
+
+
+def test_ring_bell_swallows_paplay_failure():
+    """A broken paplay binary must never crash the agent loop."""
+    fake_stdout = io.StringIO()
+    fake_stdout.flush = MagicMock()
+
+    def boom(*_a, **_kw):
+        raise OSError("audio device busy")
+
+    with patch.object(cli, "sys", SimpleNamespace(stdout=fake_stdout)), \
+         patch.object(cli.shutil, "which", return_value="/usr/bin/paplay"), \
+         patch("subprocess.Popen", side_effect=boom):
+        cli._ring_bell()
+
+    assert fake_stdout.getvalue() == "\a"
+
+
+def test_ring_bell_swallows_stdout_failure():
+    """A closed stdout must not stop us from at least trying paplay."""
+    bad_stdout = MagicMock()
+    bad_stdout.write.side_effect = ValueError("I/O on closed file")
+    popen = MagicMock()
+
+    with patch.object(cli, "sys", SimpleNamespace(stdout=bad_stdout)), \
+         patch.object(cli.shutil, "which", return_value="/usr/bin/paplay"), \
+         patch("subprocess.Popen", popen):
+        cli._ring_bell()
+
+    popen.assert_called_once()
+
+
+def test_maybe_ring_interact_bell_respects_config_flag():
+    """``notify_on_interact = False`` must not invoke the bell helper at all."""
+    cli_stub = SimpleNamespace(notify_on_interact=False)
+
+    with patch.object(cli, "_ring_bell") as ring:
+        callbacks._maybe_ring_interact_bell(cli_stub)
+
+    ring.assert_not_called()
+
+
+def test_maybe_ring_interact_bell_fires_when_enabled():
+    """``notify_on_interact = True`` must reach ``cli._ring_bell``."""
+    cli_stub = SimpleNamespace(notify_on_interact=True)
+
+    with patch.object(cli, "_ring_bell") as ring:
+        callbacks._maybe_ring_interact_bell(cli_stub)
+
+    ring.assert_called_once_with()
+
+
+def test_maybe_ring_interact_bell_handles_missing_attribute():
+    """A CLI without the attribute (e.g. legacy stub) must not raise."""
+    cli_stub = SimpleNamespace()  # no notify_on_interact
+
+    with patch.object(cli, "_ring_bell") as ring:
+        callbacks._maybe_ring_interact_bell(cli_stub)
+
+    ring.assert_not_called()
+
+
+def test_default_config_includes_notify_on_interact_off():
+    """Documented default is False — opt-in only."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["display"]["notify_on_interact"] is False
+    # Sibling sanity — same default as bell_on_complete so users get a
+    # consistent off-by-default experience for both audible cues.
+    assert DEFAULT_CONFIG["display"]["bell_on_complete"] is False

--- a/ui-tui/src/__tests__/notify.test.ts
+++ b/ui-tui/src/__tests__/notify.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { _resetPaplayMissing, ringBell } from '../lib/notify.js'
+
+const spawnMock = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args)
+}))
+
+const makeFakeChild = () => {
+  const child = {
+    on: vi.fn(),
+    unref: vi.fn()
+  }
+  return child
+}
+
+describe('ringBell', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    _resetPaplayMissing()
+    spawnMock.mockReturnValue(makeFakeChild())
+  })
+
+  afterEach(() => {
+    _resetPaplayMissing()
+  })
+
+  it('writes ASCII BEL when stdout is a TTY', () => {
+    const stdout = { isTTY: true, write: vi.fn() } as unknown as NodeJS.WriteStream
+
+    ringBell({ stdout })
+
+    expect(stdout.write).toHaveBeenCalledWith('\x07')
+  })
+
+  it('skips ASCII BEL when stdout is not a TTY', () => {
+    const stdout = { isTTY: false, write: vi.fn() } as unknown as NodeJS.WriteStream
+
+    ringBell({ stdout })
+
+    expect(stdout.write).not.toHaveBeenCalled()
+  })
+
+  it('skips ASCII BEL when stdout is missing entirely', () => {
+    expect(() => ringBell()).not.toThrow()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('spawns paplay detached with ignored stdio so the agent thread never blocks', () => {
+    ringBell()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    const [cmd, args, opts] = spawnMock.mock.calls[0]
+    expect(cmd).toBe('paplay')
+    expect(args).toEqual(['/usr/share/sounds/freedesktop/stereo/message-new-instant.oga'])
+    expect(opts).toMatchObject({ detached: true, stdio: 'ignore' })
+  })
+
+  it('forwards a custom soundPath when supplied', () => {
+    ringBell({ soundPath: '/tmp/custom.oga' })
+
+    const [, args] = spawnMock.mock.calls[0]
+    expect(args).toEqual(['/tmp/custom.oga'])
+  })
+
+  it('caches paplayMissing on ENOENT so we do not spawn again', () => {
+    const child = makeFakeChild()
+    spawnMock.mockReturnValueOnce(child)
+
+    ringBell()
+
+    // Find the 'error' listener and trigger ENOENT.
+    const errorEntry = child.on.mock.calls.find(([event]) => event === 'error')
+    expect(errorEntry).toBeTruthy()
+    const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' })
+    errorEntry?.[1](enoent)
+
+    spawnMock.mockClear()
+    ringBell()
+    ringBell()
+
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps trying spawn after non-ENOENT errors', () => {
+    const child = makeFakeChild()
+    spawnMock.mockReturnValueOnce(child)
+
+    ringBell()
+
+    const errorEntry = child.on.mock.calls.find(([event]) => event === 'error')
+    errorEntry?.[1](Object.assign(new Error('busy'), { code: 'EBUSY' }))
+
+    spawnMock.mockClear()
+    ringBell()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows synchronous spawn() throws (sandboxed environments)', () => {
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('sandbox blocked')
+    })
+
+    expect(() => ringBell()).not.toThrow()
+  })
+
+  it('swallows stdout.write failures so a closed pipe never crashes the caller', () => {
+    const stdout = {
+      isTTY: true,
+      write: vi.fn(() => {
+        throw new Error('EPIPE')
+      })
+    } as unknown as NodeJS.WriteStream
+
+    expect(() => ringBell({ stdout })).not.toThrow()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -269,6 +269,66 @@ describe('applyDisplay → busy_input_mode', () => {
   })
 })
 
+describe('applyDisplay → notify_on_interact', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('threads display.notify_on_interact through the optional setter', () => {
+    const setBell = vi.fn()
+    const setNotify = vi.fn()
+
+    applyDisplay(
+      { config: { display: { notify_on_interact: true } } },
+      setBell,
+      undefined,
+      setNotify
+    )
+
+    expect(setNotify).toHaveBeenCalledWith(true)
+  })
+
+  it('falls back to false when the key is missing', () => {
+    const setBell = vi.fn()
+    const setNotify = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell, undefined, setNotify)
+
+    expect(setNotify).toHaveBeenCalledWith(false)
+  })
+
+  it('is a no-op when the setter is not passed (back-compat)', () => {
+    const setBell = vi.fn()
+
+    expect(() =>
+      applyDisplay({ config: { display: { notify_on_interact: true } } }, setBell)
+    ).not.toThrow()
+    // bell still applied
+    expect(setBell).toHaveBeenCalledWith(false)
+  })
+
+  it('coerces non-boolean values to booleans', () => {
+    const setBell = vi.fn()
+    const setNotify = vi.fn()
+
+    applyDisplay(
+      { config: { display: { notify_on_interact: 1 as unknown as boolean } } },
+      setBell,
+      undefined,
+      setNotify
+    )
+    expect(setNotify).toHaveBeenCalledWith(true)
+
+    applyDisplay(
+      { config: { display: { notify_on_interact: 0 as unknown as boolean } } },
+      setBell,
+      undefined,
+      setNotify
+    )
+    expect(setNotify).toHaveBeenLastCalledWith(false)
+  })
+})
+
 describe('applyDisplay → tui_status_indicator', () => {
   beforeEach(() => {
     resetUiState()

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -9,6 +9,7 @@ import type {
   GatewaySkin,
   SessionMostRecentResponse
 } from '../gatewayTypes.js'
+import { ringBell } from '../lib/notify.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatToolCall, stripAnsi } from '../lib/text.js'
@@ -57,7 +58,13 @@ const pushTool = pushUnique(8)
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
   const { rpc } = ctx.gateway
   const { STARTUP_RESUME_ID, newSession, resumeById, setCatalog } = ctx.session
-  const { bellOnComplete, stdout, sys } = ctx.system
+  const { bellOnComplete, notifyOnInteract, stdout, sys } = ctx.system
+
+  const ringInteractBell = () => {
+    if (notifyOnInteract) {
+      ringBell({ stdout })
+    }
+  }
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
   const { submitRef } = ctx.submission
@@ -521,6 +528,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           clarify: { choices: ev.payload.choices, question: ev.payload.question, requestId: ev.payload.request_id }
         })
         setStatus('waiting for input…')
+        ringInteractBell()
 
         return
       case 'approval.request': {
@@ -528,6 +536,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         patchOverlayState({ approval: { command: String(ev.payload.command ?? ''), description } })
         setStatus('approval needed')
+        ringInteractBell()
 
         return
       }
@@ -535,6 +544,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'sudo.request':
         patchOverlayState({ sudo: { requestId: ev.payload.request_id } })
         setStatus('sudo password needed')
+        ringInteractBell()
 
         return
 
@@ -543,6 +553,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           secret: { envVar: ev.payload.env_var, prompt: ev.payload.prompt, requestId: ev.payload.request_id }
         })
         setStatus('secret input needed')
+        ringInteractBell()
 
         return
 
@@ -667,8 +678,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           const msgs: Msg[] = finalMessages.length ? finalMessages : [{ role: 'assistant', text: finalText }]
           msgs.forEach(appendMessage)
 
-          if (bellOnComplete && stdout?.isTTY) {
-            stdout.write('\x07')
+          if (bellOnComplete) {
+            // ringBell pairs ASCII BEL with paplay so Wayland-native
+            // terminals (Foot/Kitty/ghostty) get an audible cue
+            // even when the bell sequence is silently dropped.
+            ringBell({ stdout })
           }
         }
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -242,6 +242,7 @@ export interface GatewayEventHandlerContext {
   }
   system: {
     bellOnComplete: boolean
+    notifyOnInteract: boolean
     stdout?: NodeJS.WriteStream
     sys: (text: string) => void
   }

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -110,21 +110,32 @@ const _voiceRecordKeyFromConfig = (cfg: ConfigFullResponse | null): ParsedVoiceR
 export async function hydrateFullConfig(
   gw: GatewayClient,
   setBell: (v: boolean) => void,
-  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
+  setNotifyOnInteract?: (v: boolean) => void
 ): Promise<ConfigFullResponse | null> {
   const cfg = await quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' })
-  applyDisplay(cfg, setBell, setVoiceRecordKey)
+  applyDisplay(cfg, setBell, setVoiceRecordKey, setNotifyOnInteract)
   return cfg
 }
 
 export const applyDisplay = (
   cfg: ConfigFullResponse | null,
   setBell: (v: boolean) => void,
-  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
+  setNotifyOnInteract?: (v: boolean) => void
 ) => {
   const d = cfg?.config?.display ?? {}
 
   setBell(!!d.bell_on_complete)
+
+  // notify_on_interact is a sibling of bell_on_complete — same on/off
+  // semantics, same default (off).  Pushed through an optional setter
+  // so back-compat call sites that only care about the bell don't
+  // have to thread a second callback.
+  if (setNotifyOnInteract) {
+    setNotifyOnInteract(!!d.notify_on_interact)
+  }
+
   // Only push the voice record key when the RPC actually returned a
   // config payload. ``quietRpc()`` collapses failures to ``null``; if we
   // reset the cached shortcut on every null we would clobber a custom
@@ -154,6 +165,7 @@ export const applyDisplay = (
 export function useConfigSync({
   gw,
   setBellOnComplete,
+  setNotifyOnInteract,
   setVoiceEnabled,
   setVoiceRecordKey,
   sid
@@ -173,8 +185,8 @@ export function useConfigSync({
     quietRpc<ConfigMtimeResponse>(gw, 'config.get', { key: 'mtime' }).then(r => {
       mtimeRef.current = Number(r?.mtime ?? 0)
     })
-    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
-  }, [gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid])
+    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setNotifyOnInteract)
+  }, [gw, setBellOnComplete, setNotifyOnInteract, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
     if (!sid) {
@@ -202,17 +214,18 @@ export function useConfigSync({
         quietRpc<ReloadMcpResponse>(gw, 'reload.mcp', { session_id: sid, confirm: true }).then(
           r => r && turnController.pushActivity('MCP reloaded after config change')
         )
-        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
+        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, setNotifyOnInteract)
       })
     }, MTIME_POLL_MS)
 
     return () => clearInterval(id)
-  }, [gw, setBellOnComplete, setVoiceRecordKey, sid])
+  }, [gw, setBellOnComplete, setNotifyOnInteract, setVoiceRecordKey, sid])
 }
 
 export interface UseConfigSyncOptions {
   gw: GatewayClient
   setBellOnComplete: (v: boolean) => void
+  setNotifyOnInteract?: (v: boolean) => void
   setVoiceEnabled: (v: boolean) => void
   setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
   sid: null | string

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -109,6 +109,7 @@ export function useMainApp(gw: GatewayClient) {
   const [turnStartedAt, setTurnStartedAt] = useState<null | number>(null)
   const [goodVibesTick, setGoodVibesTick] = useState(0)
   const [bellOnComplete, setBellOnComplete] = useState(false)
+  const [notifyOnInteract, setNotifyOnInteract] = useState(false)
 
   const ui = useStore($uiState)
   const overlay = useStore($overlayState)
@@ -401,7 +402,14 @@ export function useMainApp(gw: GatewayClient) {
     }
   }, [ui.busy])
 
-  useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
+  useConfigSync({
+    gw,
+    setBellOnComplete,
+    setNotifyOnInteract,
+    setVoiceEnabled,
+    setVoiceRecordKey,
+    sid: ui.sid
+  })
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
   const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
@@ -569,7 +577,7 @@ export function useMainApp(gw: GatewayClient) {
           setCatalog
         },
         submission: { submitRef },
-        system: { bellOnComplete, stdout, sys },
+        system: { bellOnComplete, notifyOnInteract, stdout, sys },
         transcript: { appendMessage, panel, setHistoryItems },
         voice: {
           setProcessing: setVoiceProcessing,
@@ -583,6 +591,7 @@ export function useMainApp(gw: GatewayClient) {
       clearSelection,
       composerActions.setInput,
       gateway,
+      notifyOnInteract,
       panel,
       session.newSession,
       session.resetSession,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -57,6 +57,7 @@ export interface ConfigDisplayConfig {
   details_mode?: string
   inline_diffs?: boolean
   mouse_tracking?: boolean | null | number | string
+  notify_on_interact?: boolean
   sections?: Record<string, string>
   show_cost?: boolean
   show_reasoning?: boolean

--- a/ui-tui/src/lib/notify.ts
+++ b/ui-tui/src/lib/notify.ts
@@ -1,0 +1,78 @@
+import { spawn } from 'node:child_process'
+
+// freedesktop sound theme path used by ringBell().  The
+// `sound-theme-freedesktop` package is part of the default install
+// on every major desktop Linux distro using PulseAudio / PipeWire
+// (Ubuntu, Fedora, Arch, Debian, openSUSE), so we lean on it as a
+// safe always-present fallback.
+const BELL_SOUND_PATH = '/usr/share/sounds/freedesktop/stereo/message-new-instant.oga'
+
+const PAPLAY_BIN = process.env.HERMES_PAPLAY_BIN || 'paplay'
+
+let paplayMissing = false
+
+interface RingBellOptions {
+  /** Optional stdout stream — when provided and a TTY, we also fire ASCII BEL. */
+  stdout?: NodeJS.WriteStream
+  /** Override for the sound asset (mostly for tests). */
+  soundPath?: string
+}
+
+/** Fire-and-forget audible notification for the user.
+ *
+ * Two-pronged best-effort strategy that mirrors the Python side
+ * (`cli._ring_bell`) so CLI and TUI users get the same behaviour:
+ *
+ *  1. Write `\x07` (ASCII BEL) to stdout when it's a TTY — keeps
+ *     legacy / SSH / classic iTerm2 paths working and propagates
+ *     through tmux passthrough.
+ *  2. `spawn('paplay', [...])` with the freedesktop
+ *     "message-new-instant" sound — covers Wayland-native terminals
+ *     (Foot, Kitty, ghostty) where the BEL is silently swallowed
+ *     or only flashes the screen.
+ *
+ * Both legs are wrapped so a missing `paplay` binary, headless
+ * environment, locked audio device, or closed stdout never throws
+ * — the audible cue is a UX nicety, not a load-bearing dependency.
+ *
+ * After the first ENOENT we remember the binary is missing and skip
+ * future spawn attempts so we don't pay the fork cost once per
+ * notification on a system that simply doesn't have paplay.
+ */
+export function ringBell(options: RingBellOptions = {}): void {
+  const { stdout, soundPath = BELL_SOUND_PATH } = options
+
+  if (stdout?.isTTY) {
+    try {
+      stdout.write('\x07')
+    } catch {
+      // Closed/broken stdout — nothing reasonable to do here.
+    }
+  }
+
+  if (paplayMissing) {
+    return
+  }
+
+  try {
+    const child = spawn(PAPLAY_BIN, [soundPath], {
+      detached: true,
+      stdio: 'ignore'
+    })
+
+    child.on('error', err => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        paplayMissing = true
+      }
+    })
+
+    child.unref()
+  } catch {
+    // Some sandboxes throw synchronously on spawn — same swallow.
+  }
+}
+
+/** Reset the cached "paplay is missing" flag.  Test-only helper. */
+export function _resetPaplayMissing(): void {
+  paplayMissing = false
+}

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -410,7 +410,7 @@ When a background task finishes, the result appears as a panel in your terminal:
 ╰──────────────────────────────────────────────────────────────╯
 ```
 
-If the task fails, you'll see an error notification instead. If `display.bell_on_complete` is enabled in your config, the terminal bell rings when the task finishes.
+If the task fails, you'll see an error notification instead. If `display.bell_on_complete` is enabled in your config, an audible notification (`paplay` on PulseAudio/PipeWire systems, ASCII BEL elsewhere) plays when the task finishes — Wayland terminals like Foot/Kitty/ghostty that swallow `\a` are explicitly covered. The sibling `display.notify_on_interact` flag uses the same two-pronged strategy whenever the agent pauses for clarify/approval/sudo/secret input, so you can alt-tab away during a long run and still hear when the agent needs you.
 
 ### Use Cases
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1196,7 +1196,8 @@ display:
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
-  bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
+  bell_on_complete: false # Notification sound when agent finishes (paplay + ASCII BEL — works on Wayland)
+  notify_on_interact: false  # Notification sound on clarify/approval/sudo/secret prompts (same paplay + BEL pair)
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar


### PR DESCRIPTION
## What does this PR do?

Closes #25022.

Fixes the silent `bell_on_complete` on Wayland-native terminals (Foot, Kitty, ghostty) where the bare ASCII BEL (`\a`) is silently swallowed or only triggers a visual flash, and adds a sibling `display.notify_on_interact` config flag (default `false`) that fires the same audible cue whenever the agent pauses for user input (clarify / approval / sudo / secret prompts).

Two-pronged best-effort strategy in a shared helper on each surface — Python `cli._ring_bell()` and TUI `ui-tui/src/lib/notify.ts → ringBell()`:

- Write `\a` (ASCII BEL) to stdout — keeps legacy / SSH / tmux passthrough / classic iTerm2 paths working.
- Spawn `paplay /usr/share/sounds/freedesktop/stereo/message-new-instant.oga` detached (`start_new_session=True`, `/dev/null` I/O) — covers Wayland / PipeWire / PulseAudio terminals.

Both legs are wrapped: missing `paplay`, sandboxed audio device, headless CI, and closed stdout never crash the agent loop. After the first `ENOENT` the TUI side caches `paplayMissing = true` so subsequent notifications skip the spawn cost on systems without paplay.

## Related Issue

Closes #25022 — `feat: paplay audio bell + notify-on-interact for Wayland terminals`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Four conventional-commits commits, all single-author, no behavior change for users who don't opt in:

- **commit 1 — `feat(cli)`** (`cli.py`, `hermes_cli/config.py`, `hermes_cli/callbacks.py`, +105 / -7): new `_ring_bell()` helper; both `bell_on_complete` call sites in `cli.py` route through it; `notify_on_interact` attribute populated from `display.notify_on_interact` (default `false`); `_clarify_callback`, `_sudo_password_callback`, `_approval_callback` (cli.py) and `clarify_callback`, `prompt_for_secret`, `approval_callback` (callbacks.py) ring the bell when the flag is on.
- **commit 2 — `feat(tui)`** (`ui-tui/src/lib/notify.ts` new + `createGatewayEventHandler.ts`, `useMainApp.ts`, `useConfigSync.ts`, `interfaces.ts`, `gatewayTypes.ts`, +128 / -12): TUI parity. `ringBell({ stdout })` from `message.complete` (when `bell_on_complete`) and from the four `*.request` events (when `notify_on_interact`); `applyDisplay` / `hydrateFullConfig` get an optional `setNotifyOnInteract` setter so existing 3-arg call sites stay green.
- **commit 3 — `docs`** (`cli-config.yaml.example`, `website/docs/user-guide/configuration.md`, `website/docs/user-guide/cli.md`, `hermes_cli/tips.py`, +19 / -5): first-run config dump documents `notify_on_interact`; user guide explains the paplay + ASCII BEL pair and the Wayland coverage; rotating tip points at the new flag next to the existing `bell_on_complete` tip.
- **commit 4 — `test`** (`tests/cli/test_ring_bell.py` new — 9 cases, `ui-tui/src/__tests__/notify.test.ts` new — 9 cases, `ui-tui/src/__tests__/useConfigSync.test.ts` — +4 cases, +330 lines):
  - **`test_ring_bell.py`** (Python, 9 cases) — ASCII BEL always written + flushed; `paplay` invoked detached with `/dev/null` I/O when on PATH; `shutil.which → None` short-circuits cleanly; `OSError` from `subprocess.Popen` and `ValueError` from a closed stdout are both swallowed; `_maybe_ring_interact_bell` respects the flag, fires `_ring_bell` when on, no-ops on stub CLIs missing the attribute (back-compat); `DEFAULT_CONFIG` ships `notify_on_interact = bell_on_complete = False`.
  - **`notify.test.ts`** (TS, 9 cases) — ASCII BEL only when `stdout.isTTY`; canonical `spawn(paplay, [sound], { detached: true, stdio: 'ignore' })` invocation; custom `soundPath` option threads through; `ENOENT` trips the `paplayMissing` cache so subsequent calls skip spawn; non-`ENOENT` errors do **not** trip the cache (transient audio contention shouldn't disable the feature); synchronous `spawn()` throws and `stdout.write` throws are both swallowed.
  - **`useConfigSync.test.ts → applyDisplay → notify_on_interact`** (TS, 4 cases) — optional `setNotifyOnInteract` setter fires with the bool value, defaults to `false` when key missing, no-ops when omitted (back-compat with existing 3-arg call sites), coerces `0`/`1` to booleans the same way `bell_on_complete` does.

No production code modified outside the commits listed above; no new runtime dependency added (`paplay` ships with PulseAudio/PipeWire on every major distro's default install via `sound-theme-freedesktop`).

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`.
2. Run the new Python tests on their own:
   ```
   scripts/run_tests.sh tests/cli/test_ring_bell.py -v
   ```
   Expected: 9 passed.
3. Run the approval-UI suite to confirm no regression in the existing prompt callbacks:
   ```
   scripts/run_tests.sh tests/cli/test_cli_approval_ui.py tests/cli/test_ring_bell.py
   ```
   Expected: 20 passed.
4. Run the TUI tests:
   ```
   cd ui-tui && npx vitest run src/__tests__/notify.test.ts src/__tests__/useConfigSync.test.ts
   ```
   Expected: 44 passed.
5. Manual smoke on a Wayland terminal (Foot / Kitty / ghostty):
   - `display.bell_on_complete: true` — terminal rings audibly via `paplay` after each agent response (was a silent flash before).
   - `display.notify_on_interact: true` — terminal rings on each clarify / sudo / approval / secret prompt.
   - Both flags `false` (default) — completely silent, identical to today's behavior.
   - `paplay` not installed — falls back to `\a` only, no errors logged, agent loop unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli)`, `feat(tui)`, `docs`, `test` for the four commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/cli/test_ring_bell.py` and all tests pass
- [x] I've added tests for my changes (9 Python + 9 TS + 4 `applyDisplay` = 22 new test cases)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12, Node 22.15.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/configuration.md`, `website/docs/user-guide/cli.md`, `hermes_cli/tips.py`
- [x] I've updated `cli-config.yaml.example` for the new `notify_on_interact` key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architectural change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `paplay` leg is Linux-only; macOS/Windows fall through to the ASCII BEL path with no errors. Both helpers gate on `shutil.which` / `paplayMissing` before spawning, so no missing-binary noise on non-Linux.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (display-only feature, no tool surface)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/cli/test_ring_bell.py -v
4 workers [9 items]
============================== 9 passed in 1.46s ==============================

$ scripts/run_tests.sh tests/cli/test_cli_approval_ui.py tests/cli/test_ring_bell.py
============================== 20 passed in 1.46s ==============================

$ cd ui-tui && npx vitest run src/__tests__/notify.test.ts src/__tests__/useConfigSync.test.ts
 Test Files  2 passed (2)
      Tests  44 passed (44)

$ cd ui-tui && npm run type-check
> tsc --noEmit -p tsconfig.json
(clean)

$ cd ui-tui && npx vitest run
 Test Files  63 passed | 1 skipped (64)
      Tests  698 passed | 3 skipped (701)
```
