### PR TITLE
feat: upgrade bundled Node.js from 22 to 24

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,7 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
-NODE_VERSION="22"
+NODE_VERSION="24"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -18,13 +18,13 @@
 #   if [ "$HERMES_NODE_AVAILABLE" = true ]; then ...; fi
 #
 # Env inputs (set before sourcing to override defaults):
-#   HERMES_NODE_MIN_VERSION   (default: 20)   — accepted on PATH
-#   HERMES_NODE_TARGET_MAJOR  (default: 22)   — installed when we install
+#   HERMES_NODE_MIN_VERSION   (default: 22)   — accepted on PATH
+#   HERMES_NODE_TARGET_MAJOR  (default: 24)   — installed when we install
 #   HERMES_HOME               (default: $HOME/.hermes)
 # ============================================================================
 
-HERMES_NODE_MIN_VERSION="${HERMES_NODE_MIN_VERSION:-20}"
-HERMES_NODE_TARGET_MAJOR="${HERMES_NODE_TARGET_MAJOR:-22}"
+HERMES_NODE_MIN_VERSION="${HERMES_NODE_MIN_VERSION:-22}"
+HERMES_NODE_TARGET_MAJOR="${HERMES_NODE_TARGET_MAJOR:-24}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 HERMES_NODE_AVAILABLE=false
 


### PR DESCRIPTION
## Summary

Upgrades the bundled Node.js version from **22** to **24** across the installer and bootstrap scripts.

Node 24 entered Active LTS in **October 2025** (supported through April 2028). Node 20 (the previous minimum) has been EOL since April 2026.

## Changes

- `scripts/install.sh`: `NODE_VERSION` 22 → 24
- `scripts/lib/node-bootstrap.sh`: 
  - `HERMES_NODE_MIN_VERSION` 20 → 22 (minimum accepted on PATH)
  - `HERMES_NODE_TARGET_MAJOR` 22 → 24 (installed when we install)
  - Updated comments to reflect new defaults

## Why

- Node 24 has been Active LTS for over 7 months
- Node 20 (previous minimum) is already EOL
- Newer V8 engine brings performance improvements for TUI (React/Ink), WhatsApp bridge, and browser tools
- Keeps the project current and avoids a last-minute rush before Node 22 EOL (April 2027)

## Testing

Verified that the changed files have correct syntax and the version references are consistent across all three locations.

Closes #25012