### PR TITLE
feat(insights): show prompt cache efficiency

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -801,15 +801,21 @@ class InsightsEngine:
         if o.get("total_cache_read_tokens") or o.get("total_cache_write_tokens"):
             lines.append("  🧊 Prompt Cache")
             lines.append("  " + "─" * 56)
+            cache_hit = f"{o['cache_hit_rate']:.1f}%"
+            uncached = f"{o['uncached_input_rate']:.1f}%"
+            fresh_input = f"{o['total_input_tokens']:,}"
+            cache_read = f"{o['total_cache_read_tokens']:,}"
+            cache_write = f"{o['total_cache_write_tokens']:,}"
+            prompt_total = f"{o['total_prompt_tokens']:,}"
+
             lines.append(
-                f"  Cache hit:         {o['cache_hit_rate']:.1f}%"
-                f"          Uncached:        {o['uncached_input_rate']:.1f}%"
+                f"  {'Cache hit:':<17}{cache_hit:<14}  {'Uncached:':<15}{uncached}"
             )
             lines.append(
-                f"  Fresh input:       {o['total_input_tokens']:<12,}  Cache read:      {o['total_cache_read_tokens']:,}"
+                f"  {'Fresh input:':<17}{fresh_input:<14}  {'Cache read:':<15}{cache_read}"
             )
             lines.append(
-                f"  Cache write:       {o['total_cache_write_tokens']:<12,}  Prompt total:    {o['total_prompt_tokens']:,}"
+                f"  {'Cache write:':<17}{cache_write:<14}  {'Prompt total:':<15}{prompt_total}"
             )
             lines.append("")
 

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -414,6 +414,17 @@ class InsightsEngine:
         total_output = sum(s.get("output_tokens") or 0 for s in sessions)
         total_cache_read = sum(s.get("cache_read_tokens") or 0 for s in sessions)
         total_cache_write = sum(s.get("cache_write_tokens") or 0 for s in sessions)
+        total_prompt_tokens = total_input + total_cache_read + total_cache_write
+        cache_hit_rate = (
+            (total_cache_read / total_prompt_tokens * 100)
+            if total_prompt_tokens
+            else 0.0
+        )
+        uncached_input_rate = (
+            (total_input / total_prompt_tokens * 100)
+            if total_prompt_tokens
+            else 0.0
+        )
         total_tokens = total_input + total_output + total_cache_read + total_cache_write
         total_tool_calls = sum(s.get("tool_call_count") or 0 for s in sessions)
         total_messages = sum(s.get("message_count") or 0 for s in sessions)
@@ -464,6 +475,9 @@ class InsightsEngine:
             "total_output_tokens": total_output,
             "total_cache_read_tokens": total_cache_read,
             "total_cache_write_tokens": total_cache_write,
+            "total_prompt_tokens": total_prompt_tokens,
+            "cache_hit_rate": cache_hit_rate,
+            "uncached_input_rate": uncached_input_rate,
             "total_tokens": total_tokens,
             "estimated_cost": total_cost,
             "actual_cost": actual_cost,
@@ -768,6 +782,22 @@ class InsightsEngine:
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
         lines.append("")
 
+        # Prompt cache efficiency
+        if o.get("total_cache_read_tokens") or o.get("total_cache_write_tokens"):
+            lines.append("  🧊 Prompt Cache")
+            lines.append("  " + "─" * 56)
+            lines.append(
+                f"  Cache hit:         {o['cache_hit_rate']:.1f}%"
+                f"          Uncached:        {o['uncached_input_rate']:.1f}%"
+            )
+            lines.append(
+                f"  Fresh input:       {o['total_input_tokens']:<12,}  Cache read:      {o['total_cache_read_tokens']:,}"
+            )
+            lines.append(
+                f"  Cache write:       {o['total_cache_write_tokens']:<12,}  Prompt total:    {o['total_prompt_tokens']:,}"
+            )
+            lines.append("")
+
         # Model breakdown
         if report["models"]:
             lines.append("  🤖 Models Used")
@@ -878,6 +908,11 @@ class InsightsEngine:
         # Overview
         lines.append(f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}")
         lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
+        if o.get("total_cache_read_tokens") or o.get("total_cache_write_tokens"):
+            lines.append(
+                f"**Prompt cache:** {o['cache_hit_rate']:.1f}% hit "
+                f"({o['total_cache_read_tokens']:,} read / {o['total_input_tokens']:,} fresh)"
+            )
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{_format_duration(o['total_hours'] * 3600)} | **Avg session:** ~{_format_duration(o['avg_session_duration'])}")
         lines.append("")

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -525,10 +525,25 @@ class InsightsEngine:
             d["has_pricing"] = _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
             d["cost_status"] = status
 
-        result = [
-            {"model": model, **data}
-            for model, data in model_data.items()
-        ]
+        result = []
+        for model, data in model_data.items():
+            prompt_tokens = (
+                data["input_tokens"]
+                + data["cache_read_tokens"]
+                + data["cache_write_tokens"]
+            )
+            data["prompt_tokens"] = prompt_tokens
+            data["cache_hit_rate"] = (
+                data["cache_read_tokens"] / prompt_tokens * 100
+                if prompt_tokens
+                else 0.0
+            )
+            data["uncached_input_rate"] = (
+                data["input_tokens"] / prompt_tokens * 100
+                if prompt_tokens
+                else 0.0
+            )
+            result.append({"model": model, **data})
         # Sort by tokens first, fall back to session count when tokens are 0
         result.sort(key=lambda x: (x["total_tokens"], x["sessions"]), reverse=True)
         return result
@@ -802,10 +817,13 @@ class InsightsEngine:
         if report["models"]:
             lines.append("  🤖 Models Used")
             lines.append("  " + "─" * 56)
-            lines.append(f"  {'Model':<30} {'Sessions':>8} {'Tokens':>12}")
+            lines.append(f"  {'Model':<24} {'Sessions':>8} {'Tokens':>12} {'Cache':>8}")
             for m in report["models"]:
-                model_name = m["model"][:28]
-                lines.append(f"  {model_name:<30} {m['sessions']:>8} {m['total_tokens']:>12,}")
+                model_name = m["model"][:22]
+                cache = f"{m['cache_hit_rate']:.1f}%" if m.get("prompt_tokens") else "—"
+                lines.append(
+                    f"  {model_name:<24} {m['sessions']:>8} {m['total_tokens']:>12,} {cache:>8}"
+                )
             lines.append("")
 
         # Platform breakdown
@@ -921,7 +939,11 @@ class InsightsEngine:
         if report["models"]:
             lines.append("**🤖 Models:**")
             for m in report["models"][:5]:
-                lines.append(f"  {m['model'][:25]} — {m['sessions']} sessions, {m['total_tokens']:,} tokens")
+                cache = f", cache {m['cache_hit_rate']:.1f}%" if m.get("prompt_tokens") else ""
+                lines.append(
+                    f"  {m['model'][:25]} — {m['sessions']} sessions, "
+                    f"{m['total_tokens']:,} tokens{cache}"
+                )
             lines.append("")
 
         # Platforms (if multi-platform)

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -37,7 +37,13 @@ def populated_db(db):
     db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 's1'", (now - 2 * day,))
     db.end_session("s1", end_reason="user_exit")
     db._conn.execute("UPDATE sessions SET ended_at = ? WHERE id = 's1'", (now - 2 * day + 3600,))
-    db.update_token_counts("s1", input_tokens=50000, output_tokens=15000)
+    db.update_token_counts(
+        "s1",
+        input_tokens=50000,
+        output_tokens=15000,
+        cache_read_tokens=100000,
+        cache_write_tokens=10000,
+    )
     db.append_message("s1", role="user", content="Hello, help me fix a bug")
     db.append_message("s1", role="assistant", content="Sure, let me look into that.")
     db.append_message("s1", role="assistant", content="Let me search the files.",
@@ -66,7 +72,12 @@ def populated_db(db):
     db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = 's2'", (now - 5 * day,))
     db.end_session("s2", end_reason="timeout")
     db._conn.execute("UPDATE sessions SET ended_at = ? WHERE id = 's2'", (now - 5 * day + 1800,))
-    db.update_token_counts("s2", input_tokens=20000, output_tokens=8000)
+    db.update_token_counts(
+        "s2",
+        input_tokens=20000,
+        output_tokens=8000,
+        cache_read_tokens=20000,
+    )
     db.append_message("s2", role="user", content="Search the web for something")
     db.append_message("s2", role="assistant", content="Searching...",
                       tool_calls=[{"function": {"name": "web_search"}}])
@@ -285,9 +296,17 @@ class TestInsightsPopulated:
 
         expected_input = 50000 + 20000 + 100000 + 10000
         expected_output = 15000 + 8000 + 40000 + 5000
+        expected_cache_read = 100000 + 20000
+        expected_cache_write = 10000
         assert overview["total_input_tokens"] == expected_input
         assert overview["total_output_tokens"] == expected_output
-        assert overview["total_tokens"] == expected_input + expected_output
+        assert overview["total_cache_read_tokens"] == expected_cache_read
+        assert overview["total_cache_write_tokens"] == expected_cache_write
+        assert overview["total_prompt_tokens"] == expected_input + expected_cache_read + expected_cache_write
+        assert overview["total_tokens"] == expected_input + expected_output + expected_cache_read + expected_cache_write
+        assert overview["cache_hit_rate"] == pytest.approx(
+            expected_cache_read / overview["total_prompt_tokens"] * 100
+        )
 
     def test_overview_cost_positive(self, populated_db):
         engine = InsightsEngine(populated_db)
@@ -447,6 +466,7 @@ class TestTerminalFormatting:
 
         assert "Hermes Insights" in text
         assert "Overview" in text
+        assert "Prompt Cache" in text
         assert "Models Used" in text
         assert "Top Tools" in text
         assert "Top Skills" in text
@@ -460,10 +480,12 @@ class TestTerminalFormatting:
 
         assert "Input tokens" in text
         assert "Output tokens" in text
-        # Cost and cache metrics are intentionally hidden (pricing was unreliable).
+        assert "Cache hit" in text
+        assert "Cache read" in text
+        assert "Cache write" in text
+        assert "Prompt total" in text
+        # Cost metrics are intentionally hidden (pricing was unreliable).
         assert "Est. cost" not in text
-        assert "Cache read" not in text
-        assert "Cache write" not in text
 
     def test_terminal_format_shows_platforms(self, populated_db):
         engine = InsightsEngine(populated_db)
@@ -514,13 +536,13 @@ class TestGatewayFormatting:
         assert "**" in text  # Markdown bold
 
     def test_gateway_format_hides_cost(self, populated_db):
-        """Gateway format omits dollar figures and internal cache details."""
+        """Gateway format omits dollar figures but includes concise cache efficiency."""
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)
         text = engine.format_gateway(report)
 
         assert "$" not in text
-        assert "cache" not in text.lower()
+        assert "Prompt cache" in text
 
     def test_gateway_format_shows_models(self, populated_db):
         engine = InsightsEngine(populated_db)

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -336,6 +336,18 @@ class TestInsightsPopulated:
         # Claude-sonnet has 2 sessions (s1 + s4)
         claude = next(m for m in models if "claude-sonnet" in m["model"])
         assert claude["sessions"] == 2
+        expected_prompt = 50000 + 10000 + 100000 + 10000
+        assert claude["prompt_tokens"] == expected_prompt
+        assert claude["cache_hit_rate"] == pytest.approx(100000 / expected_prompt * 100)
+        assert claude["uncached_input_rate"] == pytest.approx(60000 / expected_prompt * 100)
+
+        gpt = next(m for m in models if m["model"] == "gpt-4o")
+        assert gpt["prompt_tokens"] == 40000
+        assert gpt["cache_hit_rate"] == pytest.approx(50.0)
+
+        deepseek = next(m for m in models if m["model"] == "deepseek-chat")
+        assert deepseek["prompt_tokens"] == 100000
+        assert deepseek["cache_hit_rate"] == 0.0
 
     def test_platform_breakdown(self, populated_db):
         engine = InsightsEngine(populated_db)
@@ -551,6 +563,8 @@ class TestGatewayFormatting:
 
         assert "Models" in text
         assert "sessions" in text
+        assert "cache" in text
+        assert "50.0%" in text
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Adds a small prompt cache efficiency section to Hermes Insights so users can see how much of their prompt/input token volume is served from provider prompt cache instead of fresh input.

The existing session store already records `input_tokens`, `cache_read_tokens`, and `cache_write_tokens`; this PR surfaces that data directly in both terminal and gateway insights output.

## Related Issue

No issue filed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/insights.py`
  - Computes `total_prompt_tokens`, `cache_hit_rate`, and `uncached_input_rate` from existing session token counters.
  - Adds a terminal `🧊 Prompt Cache` section with cache hit %, uncached %, fresh input, cache read/write, and prompt total.
  - Adds a concise gateway/Markdown line showing prompt cache hit rate.
- `tests/agent/test_insights.py`
  - Adds cache read/write fixture data.
  - Verifies cache totals, prompt total, and cache hit rate calculations.
  - Updates terminal/gateway formatting assertions.

## How to Test

1. Run the targeted insights tests:
   ```bash
   python -m pytest tests/agent/test_insights.py -q -o 'addopts='
   ```
2. Compile the changed Python files:
   ```bash
   python -m py_compile agent/insights.py tests/agent/test_insights.py
   ```
3. Smoke-test CLI output:
   ```bash
   hermes insights --days 7
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests:

```text
56 passed in 15.15s
```

Example CLI output shape:

```text
🧊 Prompt Cache
────────────────────────────────────────────────────────
Cache hit:         94.0%          Uncached:        6.0%
Fresh input:       18,497,095     Cache read:      291,136,000
Cache write:       0              Prompt total:    309,633,095
```
