### PR TITLE
fix(gemini): keep tool_call JSON valid across streaming SSE replays

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -616,6 +616,26 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
 
 
 def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
+    # Tool-call streaming strategy
+    # ----------------------------
+    # OpenAI streaming clients reconstruct tool_call.function.arguments by
+    # concatenating successive `delta.tool_calls[].function.arguments`
+    # fragments grouped by `index`. That works cleanly only when every
+    # subsequent fragment is a strict suffix of the cumulative string.
+    #
+    # Gemini's native API doesn't honour that contract for SSE replay: it
+    # tends to re-send the whole functionCall (with the full args dict) in
+    # repeated events, and may even mutate the args mid-stream. Naively
+    # emitting `json.dumps(args)` every time produces concatenations like
+    # `{"q":"A"}{"q":"AB"}` which fail JSON parsing on the consumer side
+    # and silently discard the tool call.
+    #
+    # Approach: on the first sighting of a (part_index, name, signature) tuple
+    # we open the slot by emitting a "header" chunk with name+id and empty
+    # arguments. We cache the latest args in the slot. When the finishReason
+    # arrives we flush the final args in a single chunk per slot before the
+    # finish chunk. This keeps the consumer's JSON valid regardless of how
+    # many times Gemini re-emits the call or how the args evolve.
     candidates = event.get("candidates") or []
     if not candidates:
         return []
@@ -648,36 +668,56 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 sort_keys=True,
             )
             slot = tool_call_indices.get(call_key)
+            extra_content = _tool_call_extra_from_part(part)
             if slot is None:
                 slot = {
                     "index": len(tool_call_indices),
                     "id": f"call_{uuid.uuid4().hex[:12]}",
-                    "last_arguments": "",
+                    "name": name,
+                    "args_str": args_str,
+                    "extra_content": extra_content,
+                    "header_emitted": False,
+                    "args_flushed": False,
                 }
                 tool_call_indices[call_key] = slot
-            emitted_arguments = args_str
-            last_arguments = str(slot.get("last_arguments") or "")
-            if last_arguments:
-                if args_str == last_arguments:
-                    emitted_arguments = ""
-                elif args_str.startswith(last_arguments):
-                    emitted_arguments = args_str[len(last_arguments):]
-            slot["last_arguments"] = args_str
-            chunks.append(
-                _make_stream_chunk(
-                    model=model,
-                    tool_call_delta={
-                        "index": slot["index"],
-                        "id": slot["id"],
-                        "name": name,
-                        "arguments": emitted_arguments,
-                        "extra_content": _tool_call_extra_from_part(part),
-                    },
+            else:
+                slot["args_str"] = args_str
+                if extra_content:
+                    slot["extra_content"] = extra_content
+            if not slot["header_emitted"]:
+                chunks.append(
+                    _make_stream_chunk(
+                        model=model,
+                        tool_call_delta={
+                            "index": slot["index"],
+                            "id": slot["id"],
+                            "name": name,
+                            "arguments": "",
+                            "extra_content": slot["extra_content"],
+                        },
+                    )
                 )
-            )
+                slot["header_emitted"] = True
 
     finish_reason_raw = str(cand.get("finishReason") or "")
     if finish_reason_raw:
+        for slot in tool_call_indices.values():
+            if slot.get("args_flushed"):
+                continue
+            args_str = slot.get("args_str") or ""
+            if args_str:
+                chunks.append(
+                    _make_stream_chunk(
+                        model=model,
+                        tool_call_delta={
+                            "index": slot["index"],
+                            "id": slot["id"],
+                            "name": slot.get("name") or "",
+                            "arguments": args_str,
+                        },
+                    )
+                )
+            slot["args_flushed"] = True
         mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
         finish_chunk = _make_stream_chunk(model=model, finish_reason=mapped)
         # Attach usage from this event's usageMetadata so the streaming

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -296,12 +296,32 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
     first = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
     second = translate_stream_event(event, model="gemini-2.5-flash", tool_call_indices=tool_call_indices)
 
-    assert first[0].choices[0].delta.tool_calls[0].index == 0
-    assert second[0].choices[0].delta.tool_calls[0].index == 0
-    assert first[0].choices[0].delta.tool_calls[0].id == second[0].choices[0].delta.tool_calls[0].id
-    assert first[0].choices[0].delta.tool_calls[0].function.arguments == '{"q": "abc"}'
-    assert second[0].choices[0].delta.tool_calls[0].function.arguments == ""
+    def _tool_call_chunks(chunks):
+        return [
+            tc
+            for chunk in chunks
+            for tc in (chunk.choices[0].delta.tool_calls or [])
+        ]
+
+    first_tcs = _tool_call_chunks(first)
+    second_tcs = _tool_call_chunks(second)
+
+    # Replay of the same event must not re-open or re-emit args for the slot:
+    # the consumer already received a full picture from the first translation.
+    assert second_tcs == []
+
+    # Indices and ids are stable across emissions of the slot.
+    assert {tc.index for tc in first_tcs} == {0}
+    ids = {tc.id for tc in first_tcs}
+    assert len(ids) == 1
+
+    # Concatenating arguments per OpenAI streaming protocol reconstructs the full args.
+    assert _collect_arguments_for_index(first, index=0) == '{"q": "abc"}'
+
+    # Finish chunk is present in both translations of an event carrying finishReason,
+    # and signals tool_calls when any slot is open.
     assert first[-1].choices[0].finish_reason == "tool_calls"
+    assert second[-1].choices[0].finish_reason == "tool_calls"
 
 
 def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
@@ -326,3 +346,124 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].index == 0
     assert tool_chunks[1].choices[0].delta.tool_calls[0].index == 1
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
+
+
+def _collect_arguments_for_index(chunks, index):
+    """OpenAI streaming protocol: client concatenates delta.tool_calls[].function.arguments
+    fragments per index to reconstruct the full JSON args string."""
+    fragments = []
+    for chunk in chunks:
+        deltas = chunk.choices[0].delta.tool_calls or []
+        for tc in deltas:
+            if getattr(tc, "index", None) == index:
+                fragments.append(getattr(tc.function, "arguments", "") or "")
+    return "".join(fragments)
+
+
+def test_stream_event_translation_handles_non_prefix_args_change():
+    """Bug repro: when Gemini re-emits a functionCall across SSE events with
+    args that are NOT a prefix extension of the previous version, the adapter
+    must not produce concatenated fragments that yield invalid JSON.
+
+    OpenAI streaming clients concatenate `delta.tool_calls[].function.arguments`
+    by index. Emitting full `{"q":"AB"}` after full `{"q":"A"}` yields
+    `{"q":"A"}{"q":"AB"}` — invalid JSON, crashing the consumer.
+    """
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event_one = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "search", "args": {"q": "A"}}}
+                    ]
+                },
+            }
+        ]
+    }
+    event_two = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "search", "args": {"q": "AB"}}}
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+
+    chunks_one = translate_stream_event(
+        event_one, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+    )
+    chunks_two = translate_stream_event(
+        event_two, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+    )
+
+    all_chunks = chunks_one + chunks_two
+    args_concat = _collect_arguments_for_index(all_chunks, index=0)
+
+    # Primary protocol guarantee: concat must be valid JSON.
+    parsed = json.loads(args_concat)
+
+    # Slot must remain a single tool_call (no spurious split into two index slots).
+    indices_seen = {
+        tc.index
+        for chunk in all_chunks
+        for tc in (chunk.choices[0].delta.tool_calls or [])
+    }
+    assert indices_seen == {0}, f"expected single slot, got {indices_seen}"
+
+    # Final args should be one of the emitted versions (either keep first or last —
+    # implementation choice, but must be deterministic and valid).
+    assert parsed in ({"q": "A"}, {"q": "AB"})
+
+
+def test_stream_event_translation_handles_prefix_grow_args():
+    """Gemini may stream tool_call args token-by-token (cumulative prefix).
+    Adapter should emit only the delta suffix so concat yields the final args.
+    """
+    from agent.gemini_native_adapter import translate_stream_event
+
+    tool_call_indices = {}
+    event_one = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"name": "search", "args": {"q": "abc"}}}
+                    ]
+                },
+            }
+        ]
+    }
+    event_two = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "search",
+                                "args": {"q": "abcdef"},
+                            }
+                        }
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ]
+    }
+
+    chunks_one = translate_stream_event(
+        event_one, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+    )
+    chunks_two = translate_stream_event(
+        event_two, model="gemini-2.5-flash", tool_call_indices=tool_call_indices
+    )
+
+    args_concat = _collect_arguments_for_index(chunks_one + chunks_two, index=0)
+    assert json.loads(args_concat) == {"q": "abcdef"}


### PR DESCRIPTION
## Summary

- The native Gemini adapter emits `json.dumps(args)` on every SSE event that carries a `functionCall`. Gemini re-sends the same call across repeated events and may mutate args mid-stream, so the consumer (which concatenates `delta.tool_calls[].function.arguments` by index per OpenAI streaming protocol) ends up with invalid JSON like `{"q": "A"}{"q": "AB"}`, silently discarding the tool call.
- The previous `args_str.startswith(last_arguments)` prefix-grow guard rarely fires on JSON: the trailing `"` / `}` mean a longer args dict almost never has the shorter one as a textual prefix (e.g. `{"q":"abcdef"}` doesn't start with `{"q":"abc"}`), so the fallback path emits the full new args.
- Switch to a flush-on-finish strategy: on first sighting of a `(part_index, name, signature)` slot, emit a header chunk with `name`/`id` and empty arguments; cache the latest args across subsequent events; when `finishReason` arrives, emit one chunk per slot with the final full args, then the finish chunk. Concatenation by the consumer yields a single valid JSON string per slot, regardless of how often Gemini re-emits or mutates the call.

## Test plan

- [x] `tests/agent/test_gemini_native_adapter.py` — full file passes (13/13)
- [x] New `test_stream_event_translation_handles_non_prefix_args_change` — reproduces the bug (would FAIL on `main`: ``json.decoder.JSONDecodeError: Extra data: line 1 column 11 (char 10)`` on `'{"q": "A"}{"q": "AB"}'`) and PASSES with this fix
- [x] New `test_stream_event_translation_handles_prefix_grow_args` — final concat equals final args for the growing-args case
- [x] `test_stream_event_translation_emits_tool_call_delta_with_stable_index` rewritten to assert on protocol-level concat instead of fragile per-chunk ordering — still passes
- [x] `test_stream_event_translation_keeps_identical_calls_in_distinct_parts` — unchanged, still passes
- [x] End-to-end smoke test on a live Telegram-bot deployment: a single user turn that triggers `mcp_context7_resolve_library_id` + `web_search` + `delegate_task` in one assistant response. Pre-fix: tool-call args garbled into concatenated JSON, agent silently fell back to default behaviour. Post-fix: all three calls dispatched correctly and the structured answer returned.

## Notes

The header chunk carries `arguments: ""` so consumers can open the tool-call slot (and UIs that surface "agent is calling X…" still get the signal), while the actual args land in a single chunk just before the finish chunk. This sidesteps both the dedup and the partial-args cases without needing the consumer to handle non-prefix-preserving fragments.