### PR TITLE
fix(bluebubbles): replace deprecated datetime.utcnow() with timezone-aware alternative

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -380,7 +380,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -436,7 +436,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Problem

`datetime.utcnow()` is deprecated since Python 3.12 and emits `DeprecationWarning`. Two call sites in `gateway/platforms/bluebubbles.py` use it:

- Line 383: `_create_chat_for_handle()` tempGuid generation
- Line 439: `_send_chunk()` tempGuid generation

## Fix

Replace `datetime.utcnow()` with `datetime.now(timezone.utc)`. Both produce equivalent UTC timestamps — `.timestamp()` and `.isoformat()` work identically on timezone-aware datetimes.

```python
# Before (deprecated)
"tempGuid": f"temp-{datetime.utcnow().timestamp()}"

# After (timezone-aware)
"tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}"
```

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| Python 3.12+ | DeprecationWarning | Clean |
| Timestamp value | Identical | Identical |
| Timezone info | Naive UTC | Aware UTC |

## Tests

Zero-functional-change fix. Existing BlueBubbles tests pass without modification.