### PR TITLE
fix(gateway): reconcile partial streamed finals

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16617,12 +16617,25 @@ class GatewayRunner:
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     _previewed = bool(result.get("response_previewed"))
+                    first_response = result.get("final_response", "")
+                    _reconciled_stream = False
+                    if _sc and first_response:
+                        _reconcile = getattr(_sc, "try_finalize_with_text", None)
+                        if callable(_reconcile):
+                            try:
+                                _reconciled_stream = bool(await _reconcile(first_response))
+                            except Exception as e:
+                                logger.debug(
+                                    "Queued follow-up stream final reconcile failed: %s",
+                                    e,
+                                    exc_info=True,
+                                )
                     _already_streamed = bool(
-                        (_sc and getattr(_sc, "final_response_sent", False))
+                        _reconciled_stream
+                        or (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
                         or (_sc and getattr(_sc, "final_content_delivered", False))
                     )
-                    first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
                             logger.info(
@@ -16782,13 +16795,29 @@ class GatewayRunner:
             # response_previewed means the interim_assistant_callback already
             # sent the final text via the adapter (non-streaming path).
             _previewed = bool(response.get("response_previewed"))
+            _reconciled_stream = False
+            if _sc and _final:
+                _reconcile = getattr(_sc, "try_finalize_with_text", None)
+                if callable(_reconcile):
+                    try:
+                        _reconciled_stream = bool(await _reconcile(_final))
+                    except Exception as e:
+                        logger.debug(
+                            "Stream final reconcile failed for session %s: %s",
+                            session_key or "?",
+                            e,
+                            exc_info=True,
+                        )
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
-            if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+            if not _is_empty_sentinel and (
+                _reconciled_stream or _streamed or _previewed or _content_delivered
+            ):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (reconciled=%s streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",
+                    _reconciled_stream,
                     _streamed,
                     _previewed,
                     _content_delivered,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -197,6 +197,62 @@ class GatewayStreamConsumer:
         the subsequent cosmetic edit (cursor removal) failed."""
         return self._final_content_delivered
 
+    @property
+    def editable_message_id(self) -> Optional[str]:
+        """Return the current streamed message id when it can be edited."""
+        if not self._message_id or self._message_id == "__no_edit__":
+            return None
+        if not self._edit_supported:
+            return None
+        return self._message_id
+
+    async def try_finalize_with_text(self, final_response: str) -> bool:
+        """Best-effort edit of the streamed message to the final response.
+
+        Gateway callers use this when streaming showed partial text but did
+        not confirm final delivery.  Editable platforms should reconcile the
+        existing streamed message first; callers fall back to a normal send
+        when this returns False.
+        """
+        text = self._clean_for_display(final_response or "")
+        if not text or text == "(empty)":
+            return False
+        if self._final_response_sent and self._last_sent_text == text:
+            return True
+        if self._last_sent_text == text and (self._final_content_delivered or self._already_sent):
+            self._final_response_sent = True
+            self._final_content_delivered = True
+            self._already_sent = True
+            return True
+
+        message_id = self.editable_message_id
+        if not message_id:
+            return False
+
+        try:
+            result = await self.adapter.edit_message(
+                chat_id=self.chat_id,
+                message_id=message_id,
+                content=text,
+                finalize=True,
+            )
+        except Exception as exc:
+            logger.debug("Final stream reconcile edit failed: %s", exc, exc_info=True)
+            return False
+
+        if not getattr(result, "success", False):
+            return False
+
+        new_message_id = getattr(result, "message_id", None)
+        if new_message_id:
+            self._message_id = str(new_message_id)
+        self._last_sent_text = text
+        self._already_sent = True
+        self._final_content_delivered = True
+        self._final_response_sent = True
+        self._flood_strikes = 0
+        return True
+
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
         self._queue.put(_NEW_SEGMENT)

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -379,6 +379,58 @@ class TestQueuedMessageAlreadyStreamed:
 
         assert _already_streamed is False
 
+    @pytest.mark.asyncio
+    async def test_queued_path_reconciles_partial_stream_before_resend(self):
+        """Editable streamed partials should be finalized before resend."""
+        _sc = SimpleNamespace(
+            final_response_sent=False,
+            final_content_delivered=False,
+            try_finalize_with_text=AsyncMock(return_value=True),
+        )
+        response = {"final_response": "complete answer", "response_previewed": False}
+
+        first_response = response.get("final_response", "")
+        _reconciled_stream = False
+        if _sc and first_response:
+            _reconcile = getattr(_sc, "try_finalize_with_text", None)
+            if callable(_reconcile):
+                _reconciled_stream = bool(await _reconcile(first_response))
+        _already_streamed = bool(
+            _reconciled_stream
+            or (_sc and getattr(_sc, "final_response_sent", False))
+            or bool(response.get("response_previewed"))
+            or (_sc and getattr(_sc, "final_content_delivered", False))
+        )
+
+        _sc.try_finalize_with_text.assert_awaited_once_with("complete answer")
+        assert _already_streamed is True
+
+    @pytest.mark.asyncio
+    async def test_queued_path_resends_when_reconcile_fails(self):
+        """Failed reconcile must leave the normal first-response send active."""
+        _sc = SimpleNamespace(
+            final_response_sent=False,
+            final_content_delivered=False,
+            try_finalize_with_text=AsyncMock(return_value=False),
+        )
+        response = {"final_response": "complete answer", "response_previewed": False}
+
+        first_response = response.get("final_response", "")
+        _reconciled_stream = False
+        if _sc and first_response:
+            _reconcile = getattr(_sc, "try_finalize_with_text", None)
+            if callable(_reconcile):
+                _reconciled_stream = bool(await _reconcile(first_response))
+        _already_streamed = bool(
+            _reconciled_stream
+            or (_sc and getattr(_sc, "final_response_sent", False))
+            or bool(response.get("response_previewed"))
+            or (_sc and getattr(_sc, "final_content_delivered", False))
+        )
+
+        _sc.try_finalize_with_text.assert_awaited_once_with("complete answer")
+        assert _already_streamed is False
+
 
 # ===================================================================
 # Test 4: stream_consumer.py — cancellation handler delivery confirmation

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -133,6 +133,75 @@ class TestFinalizeCapabilityGate:
         assert picky.edit_message.call_args[1]["finalize"] is True
 
 
+class TestFinalResponseReconcileEdit:
+    """Final send reconciliation should edit existing streamed messages first."""
+
+    @pytest.mark.asyncio
+    async def test_reconcile_edits_partial_stream_to_final_response(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("partial")
+
+        ok = await consumer.try_finalize_with_text("partial plus final")
+
+        assert ok is True
+        adapter.edit_message.assert_called_once_with(
+            chat_id="chat_123",
+            message_id="msg_1",
+            content="partial plus final",
+            finalize=True,
+        )
+        assert consumer.final_response_sent is True
+        assert consumer.final_content_delivered is True
+        assert consumer.already_sent is True
+
+    @pytest.mark.asyncio
+    async def test_reconcile_failure_leaves_gateway_fallback_available(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=False, error="edit failed",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("partial")
+
+        ok = await consumer.try_finalize_with_text("complete final")
+
+        assert ok is False
+        assert consumer.final_response_sent is False
+        assert consumer.final_content_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_reconcile_ignores_non_editable_stream_messages(self):
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id=None,
+        ))
+        adapter.edit_message = AsyncMock()
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("partial")
+
+        ok = await consumer.try_finalize_with_text("complete final")
+
+        assert ok is False
+        adapter.edit_message.assert_not_called()
+        assert consumer.final_response_sent is False
+
+
 class TestEditMessageFinalizeSignature:
     """Every concrete platform adapter must accept the ``finalize`` kwarg.
 
@@ -1780,4 +1849,3 @@ class TestUtf16OverflowDetection:
         # auto-attr mock. Verified indirectly by all the other tests in
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
-


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway streaming delivery edge case where a partial streamed message can remain visible while the complete final response is not delivered cleanly.

When a platform supports editing bot messages, the gateway should not treat this as a choice between:

- leaving only the partial streamed text visible, or
- sending a second full final message and leaving the partial above it.

This PR adds a reconciliation step: if streaming showed partial text but did not confirm final delivery, Hermes first tries to edit the existing streamed message to the complete `final_response`. If that edit succeeds, the normal final send is suppressed. If the edit is unavailable or fails, the existing fallback path still sends the full final response so the user is not left with a truncated answer.

This uses the existing platform `edit_message()` abstraction already implemented by editable gateway platforms such as Telegram, Discord, and Slack. It does not add platform-specific delivery logic.

## Related Issue

Fixes #25010

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `GatewayStreamConsumer.editable_message_id` so gateway code can distinguish editable streamed messages from non-editable sends.
- Added `GatewayStreamConsumer.try_finalize_with_text(final_response)`:
  - cleans display-only text the same way streaming sends do
  - edits the current streamed message to the complete final response when possible
  - marks final delivery confirmed only after the edit succeeds
  - returns `False` for empty sentinels, non-editable messages, or edit failures so the gateway can fall back to normal send
- Updated the normal gateway final-send suppression path to try stream-final reconciliation before deciding whether to suppress the final send.
- Updated the queued follow-up path to reconcile the first response before processing the queued message.
- Added regression coverage for:
  - editing a partial streamed message into the complete final response
  - preserving fallback delivery when the edit fails
  - ignoring non-editable streamed messages
  - queued follow-up delivery decisions after successful or failed reconciliation

## Reproduction

Before this fix, a streaming gateway path could reach this visible state:

```text
streamed message on platform:
partial

agent result:
final_response = "partial plus final"
```

If the gateway treated the partial streamed delivery as enough proof that the final answer was already handled, the complete final response could be suppressed. A safer fallback is to send the full final response, but that can leave users with:

```text
partial
partial plus final
```

After this fix, editable platforms first reconcile the existing streamed message:

```text
edit_message(message_id="msg_1", content="partial plus final", finalize=True)
```

When the edit succeeds, the user sees one updated complete message and the normal final send is skipped. When the edit fails or the message is not editable, Hermes keeps the existing fallback behavior and sends the full final response.

## How to Test

Focused stream reconciliation tests:

```text
/tmp/hermes-provider-refresh-venv/bin/python -m pytest -o addopts= tests/gateway/test_stream_consumer.py::TestFinalResponseReconcileEdit tests/gateway/test_duplicate_reply_suppression.py::TestQueuedMessageAlreadyStreamed -q
```

Result:

```text
10 passed in 9.17s
```

Related gateway streaming and duplicate-suppression tests:

```text
/tmp/hermes-provider-refresh-venv/bin/python -m pytest -o addopts= tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py -q
```

Result:

```text
118 passed in 18.65s
```

Syntax check:

```text
/tmp/hermes-provider-refresh-venv/bin/python -m py_compile gateway/stream_consumer.py gateway/run.py tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py
```

Result: passed.

Diff hygiene:

```text
git diff --check -- gateway/stream_consumer.py gateway/run.py tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py
```

Result: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

This is gateway delivery-state logic covered by the focused unit tests above.
