### PR TITLE
Fix send_message fallback for resolved channel targets

### DIFF
--- a/agent_bridge_v1_commit_massage.md
+++ b/agent_bridge_v1_commit_massage.md
@@ -1,0 +1,861 @@
+feat(agent_bridge): 新增本机多 Agent 群聊桥接 v1
+
+## 为什么需要这个 commit
+
+当前存在两个 Hermes Agent，它们部署在同一台 Linux 服务器的不同用户下：
+
+- `/home/azuto` 用户下运行的是“小鸡毛”
+- `/home/yixin` 用户下运行的是“猪分身”
+
+这两个 Agent 都可以接入同一个企业微信或 QQ 群聊。人工用户在群里直接 `@小鸡毛`
+或 `@猪分身` 时，平台会把人工消息转发到对应 bot，Hermes Gateway 可以正常触发
+对应 Agent 回复。
+
+但问题出现在 Agent 之间互相 `@`：
+
+- 小鸡毛在群里发出 `@猪分身 ...`
+- 或猪分身在群里发出 `@小鸡毛 ...`
+
+这类消息的作者本身是 bot。企业微信、QQ 或中间 adapter 不一定会把 bot 发出的
+`@` 消息再次作为可触发事件投递给另一个 bot。结果就是：从真实群聊界面看，小鸡毛
+似乎已经 `@猪分身` 了，但从猪分身的 API/Gateway 视角看，它可能根本没有收到这条
+可触发消息。
+
+因此，这不是模型“不想回复”，而是外部平台没有稳定提供“bot 发消息唤醒另一个 bot”
+这个事件链路。
+
+同时，不能简单地用“消息文本里出现另一个 Agent 的名字”来触发。比如人工用户发送：
+
+```text
+@小鸡毛 你去叫一下猪分身
+```
+
+这句话的真实含义是：人工用户在指挥小鸡毛。它虽然出现了“猪分身”三个字，但并不是
+人工用户直接要求猪分身回答。如果 bridge 只按关键词匹配，就会导致猪分身也被误触发，
+让群聊行为变得很不自然。
+
+这个 commit 的目标是实现一个本机 Agent-to-Agent bridge，让两个 Hermes Gateway
+在服务器内部共享群聊事件流：
+
+- 人工用户在外部群里发出的消息可以进入两个 Agent 的上下文
+- Agent 在外部群里的可见回复也可以进入另一个 Agent 的上下文
+- 只有 Agent 消息中显式包含目标 Agent 的 wake `@mention` 时，才会触发目标 Agent
+  回复
+- 裸名字只作为上下文观察，不自动唤醒
+- 两个 Agent 的对话、人工插话、Agent 回复都尽量保留在同一个 Hermes session 语境里，
+  表现得更像真实多人群聊
+
+## 总体框架
+
+这个 commit 引入的 v1 框架分成五层：
+
+1. 外部平台层
+
+   企业微信、QQ 等平台仍然负责真实的人类群聊入口和 Agent 最终可见回复展示。
+   人工用户从群里 `@bot` 的消息仍然走原有 Gateway adapter。
+
+2. Hermes Gateway hook 层
+
+   Gateway 在两个关键时机暴露插件 hook：
+
+   - `gateway_startup`
+   - `post_gateway_response`
+
+   加上已有的 `pre_gateway_dispatch` 和 `pre_llm_call`，agent_bridge 可以观察 Gateway
+   生命周期、真实入站消息、LLM 调用前上下文、以及 Agent 最终回复。
+
+3. agent_bridge 插件层
+
+   `plugins/agent_bridge/__init__.py` 是主要插件逻辑。它负责：
+
+   - 读取当前用户的 `~/.hermes/config.yaml`
+   - 在 Gateway 启动时向本机 bridge server 注册当前 Agent
+   - 将真实人工消息发布到 bridge
+   - 将当前 Agent 的最终回复发布到 bridge
+   - 从 bridge 轮询其他 Agent 或人工消息
+   - 决定收到的 bridge event 是“只观察”还是“注入 Gateway 触发回复”
+   - 给 LLM 注入群聊规则上下文
+   - 注册一个格式化 wake mention 的工具
+
+4. 本机 bridge server 层
+
+   `plugins/agent_bridge/server.py` 提供一个只依赖 Python 标准库的本机 HTTP server。
+   默认监听：
+
+   ```text
+   http://127.0.0.1:8791
+   ```
+
+   两个用户下的 Gateway 都连接同一个 server。server 负责 room、participants、
+   event queue、thread、去重和 bot-to-bot 轮数限制。
+
+5. Hermes session/transcript 层
+
+   bridge 收到其他参与者消息后，不是简单丢给模型。它会根据消息类型和 wake 规则：
+
+   - 对需要当前 Agent 回复的消息，构造内部 `MessageEvent`，走 Hermes Gateway 的正常
+     message handling 流程
+   - 对不需要回复的消息，追加到当前 session transcript，作为群聊上下文观察
+
+   这样人工消息、Agent 回复、Agent 之间的交流可以尽量落在同一个 session 语境里，
+   而不是分裂成互相看不见的独立对话。
+
+## 本次改动包含哪些文件
+
+### `plugins/agent_bridge/plugin.yaml`
+
+新增插件声明：
+
+- 插件名：`agent_bridge`
+- 版本：`0.1.0`
+- 描述：本机多 Agent 群聊协调 bridge
+- 声明需要的 hooks：
+  - `gateway_startup`
+  - `pre_gateway_dispatch`
+  - `post_gateway_response`
+- 声明需要环境变量：
+  - `HERMES_AGENT_BRIDGE_TOKEN`
+
+### `plugins/agent_bridge/server.py`
+
+新增本机 bridge server。它提供以下 HTTP 接口：
+
+```text
+GET  /health
+POST /v1/register
+POST /v1/events
+GET  /v1/events?agent_id=...
+```
+
+server 的核心职责：
+
+- 保存已注册 Agent：
+  - `agent_id`
+  - `display_name`
+  - 更新时间
+- 保存 room 配置：
+  - `external_targets`
+  - `participants`
+  - `max_bot_messages`
+  - `idle_timeout_seconds`
+- 为每个 Agent 维护独立事件队列
+- 根据 participants 将事件投递给其他 Agent
+- 避免把事件投回作者自身
+- 根据 `origin_agent_id` 避免投回事件来源 Agent
+- 用 `seen_ids` 做短窗口去重
+- 为每条群聊链路维护 `thread_id`
+- 用 `max_bot_messages` 限制 bot-to-bot 连续回复轮数，避免无限互相唤醒
+- 用 `idle_timeout_seconds` 控制长时间空闲后的 thread 状态重置
+
+server 只使用 Python 标准库，方便在两个 Linux 用户之间共享，不额外引入依赖。
+
+### `plugins/agent_bridge/__init__.py`
+
+新增 agent_bridge 插件核心逻辑。
+
+主要结构包括：
+
+- `RoomConfig`
+  描述一个 bridge room。
+
+- `BridgeConfig`
+  描述当前 Agent 的 bridge 配置。
+
+- `_load_bridge_config()`
+  从当前用户的 Hermes 配置中读取 `agent_bridge` 配置。
+
+- `_Runtime`
+  保存当前插件运行时状态，包括：
+  - 当前配置
+  - Gateway 引用
+  - Gateway 所在线程的 asyncio loop
+  - bridge poller 线程
+  - 已处理 event id
+  - session 到 thread 的映射
+
+- `_on_gateway_startup()`
+  Gateway 启动后启动 bridge runtime 并注册当前 Agent。
+
+- `_on_pre_gateway_dispatch()`
+  观察真实平台进入的人工消息，把它发布到 bridge。
+
+- `_on_post_gateway_response()`
+  观察当前 Agent 的最终回复，把它发布到 bridge。
+
+- `_handle_bridge_event()`
+  处理从 bridge server 收到的事件，决定注入触发或只追加 transcript。
+
+- `_agent_bridge_llm_context()`
+  给 LLM 注入 Agent bridge 群聊规则。
+
+- `agent_bridge_format_wake_message`
+  注册给 LLM 的工具，用来生成正确的目标 Agent wake 文本。
+
+### `gateway/run.py`
+
+新增两个插件调用点：
+
+- Gateway 启动后触发 `gateway_startup`
+- Agent 生成最终回复后触发 `post_gateway_response`
+
+这让 agent_bridge 可以观察 Gateway 生命周期和 Agent 最终回复，而不需要把自己伪装
+成一个平台 adapter。
+
+### `hermes_cli/plugins.py`
+
+在合法 hook 列表里新增：
+
+```text
+gateway_startup
+post_gateway_response
+```
+
+这样 `plugins/agent_bridge/plugin.yaml` 中声明的 hook 可以被插件系统接受。
+
+### `hermes_cli/config.py`
+
+新增默认配置：
+
+```yaml
+agent_bridge:
+  enabled: false
+  agent_id: ""
+  display_name: ""
+  server_url: "http://127.0.0.1:8791"
+  token_env: "HERMES_AGENT_BRIDGE_TOKEN"
+  rooms: {}
+```
+
+并在可选环境变量中新增：
+
+```text
+HERMES_AGENT_BRIDGE_TOKEN
+```
+
+注意：这里是默认配置和环境变量说明。实际启用时，不应该直接改
+`hermes_cli/config.py`，而是分别改两个用户自己的配置文件：
+
+```text
+/home/azuto/.hermes/config.yaml
+/home/yixin/.hermes/config.yaml
+```
+
+### `tests/gateway/test_agent_bridge.py`
+
+新增测试覆盖：
+
+- 新 hook 是否已声明
+- bridge server 是否只把事件投递给其他 Agent
+- human event 是否创建新的 thread
+- bot-to-bot thread 是否受 `max_bot_messages` 限制
+- wake name 与裸名字的触发差异
+- slash command 是否跳过 bridge 发布
+- wake message tool 是否按当前 Agent 身份生成正确 wake_text
+- 工具错误信息是否返回可用 peer Agent
+- pre_llm_call 是否注入工具和 peer Agent 上下文
+- 显式 wake 的 Agent 消息是否注入内部 Gateway event
+- 人工消息是否只观察不触发
+- Agent 消息只写裸名字时是否只观察不触发
+
+## 核心语义：`agent_id` 不是 Linux 用户名
+
+`agent_bridge.agent_id` 是 bridge 内部用于识别 Agent 的稳定唯一 ID，不是 Linux 用户名。
+
+也就是说：
+
+- `azuto` 是运行小鸡毛的 Linux 用户
+- `yixin` 是运行猪分身的 Linux 用户
+- `xiaojimao` 可以是小鸡毛在 bridge 内部的 Agent ID
+- `zhufenshen` 可以是猪分身在 bridge 内部的 Agent ID
+
+只要两个用户的配置里对同一个 Agent 使用同一个 `agent_id`，bridge 就能正常工作。
+
+推荐配置：
+
+```yaml
+# 小鸡毛
+agent_id: "xiaojimao"
+display_name: "小鸡毛"
+
+# 猪分身
+agent_id: "zhufenshen"
+display_name: "猪分身"
+```
+
+`agent_id` 的实际用途包括：
+
+1. 向 bridge server 注册当前 Agent
+
+   ```text
+   POST /v1/register
+   agent_id = xiaojimao
+   ```
+
+2. 轮询属于自己的事件队列
+
+   ```text
+   GET /v1/events?agent_id=xiaojimao
+   ```
+
+3. 判断 participants 中哪一项是自己
+
+   ```text
+   participant.agent_id == current_config.agent_id
+   ```
+
+4. 发布自己回复时作为 `author_id` 和 `origin_agent_id`
+
+   ```text
+   author_id = xiaojimao
+   origin_agent_id = xiaojimao
+   ```
+
+5. 作为工具 `agent_bridge_format_wake_message` 的目标 ID
+
+   ```json
+   {
+     "target_agent_id": "zhufenshen",
+     "message": "你来接一下这个问题"
+   }
+   ```
+
+最重要的配置规则：
+
+```text
+当前配置里的 agent_bridge.agent_id 必须等于 participants 里代表自己的那一项 agent_id。
+```
+
+例如，`/home/azuto/.hermes/config.yaml` 里小鸡毛这样配置：
+
+```yaml
+agent_bridge:
+  agent_id: "xiaojimao"
+  display_name: "小鸡毛"
+  rooms:
+    home:
+      participants:
+        - agent_id: "xiaojimao"
+          display_name: "小鸡毛"
+        - agent_id: "zhufenshen"
+          display_name: "猪分身"
+```
+
+`/home/yixin/.hermes/config.yaml` 里猪分身这样配置：
+
+```yaml
+agent_bridge:
+  agent_id: "zhufenshen"
+  display_name: "猪分身"
+  rooms:
+    home:
+      participants:
+        - agent_id: "xiaojimao"
+          display_name: "小鸡毛"
+        - agent_id: "zhufenshen"
+          display_name: "猪分身"
+```
+
+如果把 `agent_id` 写成 Linux 用户名也可以工作，但语义上不如使用稳定的 Agent ID 清晰。
+例如 `agent_id: azuto` 能工作，是因为 participants 也写了 `azuto`。但更推荐用
+`xiaojimao`，因为这个字段代表的是 Agent 身份，不是操作系统用户。
+
+## 触发规则
+
+agent_bridge v1 的触发规则是：
+
+1. 人工用户直接在外部群聊 `@小鸡毛`
+
+   外部平台正常触发小鸡毛。bridge 会把这条人工消息发布给猪分身，但猪分身只观察，
+   不会因为人工消息自动触发。
+
+2. 人工用户直接在外部群聊 `@猪分身`
+
+   外部平台正常触发猪分身。bridge 会把这条人工消息发布给小鸡毛，但小鸡毛只观察，
+   不会因为人工消息自动触发。
+
+3. 小鸡毛的最终可见回复里显式包含 `@猪分身`
+
+   bridge 会把这条 Agent 消息投递给猪分身。猪分身检测到自己的 wake mention 后，
+   会把这条消息注入为内部 Gateway event，从而触发猪分身回复。
+
+4. 猪分身的最终可见回复里显式包含 `@小鸡毛`
+
+   同理，bridge 会触发小鸡毛。
+
+5. 只出现裸名字，不触发
+
+   例如：
+
+   ```text
+   我觉得猪分身之前说得对
+   ```
+
+   这只会进入猪分身的 transcript 作为观察上下文，不会触发猪分身回复。
+
+6. 人工命令中提到另一个 Agent，不触发另一个 Agent
+
+   例如：
+
+   ```text
+   @小鸡毛 你去叫一下猪分身
+   ```
+
+   这只触发小鸡毛。猪分身只观察这条上下文。只有小鸡毛最终回复里显式写出
+   `@猪分身 ...`，猪分身才会被 bridge 唤醒。
+
+## 为什么需要 LLM 工具，而不是插件硬编码判断
+
+之前的一个风险是：插件如果用规则判断“这句话是否希望另一个 Agent 回复”，很容易误判。
+
+例如：
+
+```text
+我刚才提到了猪分身，但不需要它回复。
+```
+
+或者：
+
+```text
+猪分身这个名字在这里是讨论对象，不是收信人。
+```
+
+插件层很难可靠理解这些语义。如果简单用关键词，会不智能；如果堆复杂规则，又容易在
+边界情况出错。
+
+因此这个 commit 采用 LLM + tool 的方式：
+
+- 插件只负责确定机制：
+  - 什么文本能唤醒
+  - 如何生成 wake 文本
+  - 如何投递和注入事件
+- LLM 负责判断意图：
+  - 当前是否真的想让另一个 Agent 回复
+  - 是否需要交接、提问、邀请另一个 Agent
+- 工具负责把 LLM 的意图转换成稳定格式：
+  - 返回 `wake_text`
+  - 确保 wake mention 使用目标 Agent 配置里的 `wake_names`
+
+工具名：
+
+```text
+agent_bridge_format_wake_message
+```
+
+工具输入示例：
+
+```json
+{
+  "target_agent_id": "zhufenshen",
+  "message": "你来接一下这个问题"
+}
+```
+
+工具输出示例：
+
+```json
+{
+  "success": true,
+  "wake_text": "@猪分身 你来接一下这个问题",
+  "target_agent_id": "zhufenshen",
+  "target_display_name": "猪分身",
+  "target_wake_name": "@猪分身",
+  "room_id": "home",
+  "instruction": "Include wake_text verbatim in your final visible reply if you want this agent to respond."
+}
+```
+
+LLM 最终应该把 `wake_text` 原样放进可见回复中。这样 bridge 不需要猜测复杂语义，只需要
+检测最终可见回复里是否有目标 Agent 的 wake mention。
+
+## Hermes session 行为
+
+这个 commit 的核心目标之一是让群聊上下文看起来像真实多人群聊。
+
+因此 bridge event 的处理分成两种：
+
+### 需要当前 Agent 回复
+
+条件：
+
+- 消息作者是另一个 Agent
+- bridge server 返回 `allow_auto_reply = true`
+- 消息文本包含当前 Agent 的 wake mention
+
+处理方式：
+
+- 构造内部 `MessageEvent`
+- 设置 `internal=True`
+- `raw_message` 中带上 `agent_bridge` 元数据
+- 优先调用对应平台 adapter 的 `handle_message(event)`
+- 让 Hermes Gateway 正常处理这条消息
+
+这会让目标 Agent 像收到一条真实群聊消息一样回复。
+
+### 不需要当前 Agent 回复
+
+条件包括：
+
+- 人工消息
+- Agent 消息但没有显式 wake 当前 Agent
+- 只出现裸名字
+- bot-to-bot 轮数超过 `max_bot_messages`
+
+处理方式：
+
+- 不触发 Gateway 回复
+- 只追加到当前 session transcript
+- 如果当前 session 是 shared multi-user session，则内容会带上说话人前缀，例如：
+
+  ```text
+  [小鸡毛] @猪分身 你来接一下这个问题
+  ```
+
+这样当前 Agent 后续被真正唤醒时，仍然能看到之前群聊上下文。
+
+## slash command 行为
+
+bridge 会识别直接发给当前 Agent 的 slash command，例如：
+
+```text
+/new
+@小鸡毛 /new
+```
+
+这类命令不会发布到 bridge，也不会触发另一个 Agent。
+
+因此，人工在群里给小鸡毛执行 `/new` 时，默认只影响小鸡毛自己的 Hermes session；
+猪分身不会自动同步 `/new`。如果需要两个 Agent 都开启新 session，需要分别对两个
+Agent 执行对应命令，或者后续再实现专门的群体 session 管理能力。
+
+同时，bridge 注入内部事件时，如果文本本身以 `/` 开头，会自动加零宽字符转义，
+避免被 Gateway 当作真正 slash command 执行。
+
+## 如何配置
+
+实际配置位置是每个 Linux 用户自己的 Hermes 配置文件，而不是源码里的默认配置。
+
+### 1. 配置共享 token
+
+两个 Gateway 和 bridge server 必须使用同一个 token。
+
+azuto 用户：
+
+```text
+/home/azuto/.hermes/.env
+```
+
+添加：
+
+```env
+HERMES_AGENT_BRIDGE_TOKEN=suzijieyixin
+```
+
+yixin 用户：
+
+```text
+/home/yixin/.hermes/.env
+```
+
+添加：
+
+```env
+HERMES_AGENT_BRIDGE_TOKEN=suzijieyixin
+```
+
+如果当前启动方式不会自动加载 `.env`，启动前手动执行：
+
+```bash
+export HERMES_AGENT_BRIDGE_TOKEN='suzijieyixin'
+```
+
+### 2. 配置小鸡毛
+
+编辑：
+
+```text
+/home/azuto/.hermes/config.yaml
+```
+
+添加或修改：
+
+```yaml
+agent_bridge:
+  enabled: true
+  agent_id: "xiaojimao"
+  display_name: "小鸡毛"
+  server_url: "http://127.0.0.1:8791"
+  token_env: "HERMES_AGENT_BRIDGE_TOKEN"
+  rooms:
+    home:
+      external_targets:
+        - platform: "wecom"
+          chat_id: "<企业微信群 chat_id>"
+      participants:
+        - agent_id: "xiaojimao"
+          display_name: "小鸡毛"
+          wake_names: ["@小鸡毛"]
+          mention_names: ["小鸡毛", "@小鸡毛"]
+        - agent_id: "zhufenshen"
+          display_name: "猪分身"
+          wake_names: ["@猪分身"]
+          mention_names: ["猪分身", "@猪分身"]
+      max_bot_messages: 16
+      idle_timeout_seconds: 1800
+```
+
+注意：
+
+- 这份配置属于 azuto Linux 用户
+- 但 `agent_id` 推荐写成 `xiaojimao`
+- `display_name` 写成 `小鸡毛`
+- participants 中代表小鸡毛的那一项也必须是 `agent_id: "xiaojimao"`
+
+### 3. 配置猪分身
+
+编辑：
+
+```text
+/home/yixin/.hermes/config.yaml
+```
+
+添加或修改：
+
+```yaml
+agent_bridge:
+  enabled: true
+  agent_id: "zhufenshen"
+  display_name: "猪分身"
+  server_url: "http://127.0.0.1:8791"
+  token_env: "HERMES_AGENT_BRIDGE_TOKEN"
+  rooms:
+    home:
+      external_targets:
+        - platform: "wecom"
+          chat_id: "<企业微信群 chat_id>"
+      participants:
+        - agent_id: "xiaojimao"
+          display_name: "小鸡毛"
+          wake_names: ["@小鸡毛"]
+          mention_names: ["小鸡毛", "@小鸡毛"]
+        - agent_id: "zhufenshen"
+          display_name: "猪分身"
+          wake_names: ["@猪分身"]
+          mention_names: ["猪分身", "@猪分身"]
+      max_bot_messages: 16
+      idle_timeout_seconds: 1800
+```
+
+注意：
+
+- 这份配置属于 yixin Linux 用户
+- 但 `agent_id` 推荐写成 `zhufenshen`
+- `display_name` 写成 `猪分身`
+- participants 建议和小鸡毛那份保持一致
+- `server_url` 必须指向同一个 bridge server
+- `token_env` 必须和 `.env` 中的变量名一致
+
+### 4. `wake_names` 和 `mention_names`
+
+`wake_names` 表示真正能唤醒 Agent 的名字：
+
+```yaml
+wake_names: ["@猪分身"]
+```
+
+bridge 只用 `wake_names` 判断是否要触发回复。
+
+`mention_names` 表示这个 Agent 的可识别名字，主要用于上下文、工具提示和展示：
+
+```yaml
+mention_names: ["猪分身", "@猪分身"]
+```
+
+推荐规则：
+
+- `wake_names` 只放真正代表“叫你回复”的 `@` 名称
+- `mention_names` 可以同时放裸名字和 `@` 名称
+- 不要把裸名字放进 `wake_names`，否则会重新引入误触发
+
+## 如何启动
+
+### 1. 启动 bridge server
+
+只需要启动一个 bridge server。推荐放在 azuto 用户下启动：
+
+```bash
+cd /home/azuto/.hermes/hermes-agent
+export HERMES_AGENT_BRIDGE_TOKEN='suzijieyixin'
+./venv/bin/python plugins/agent_bridge/server.py --token-env HERMES_AGENT_BRIDGE_TOKEN
+```
+
+如果 8791 端口已被占用：
+
+```bash
+ss -ltnp 'sport = :8791'
+```
+
+检查健康状态：
+
+```bash
+curl -i -H "Authorization: Bearer suzijieyixin" \
+  http://127.0.0.1:8791/health
+```
+
+预期响应：
+
+```json
+{"ok": true}
+```
+
+### 2. 启动小鸡毛 Gateway
+
+azuto 用户：
+
+```bash
+cd /home/azuto/.hermes/hermes-agent
+export HERMES_AGENT_BRIDGE_TOKEN='suzijieyixin'
+./venv/bin/hermes gateway
+```
+
+如果 Gateway 已经运行：
+
+```bash
+./venv/bin/hermes gateway stop
+./venv/bin/hermes gateway
+```
+
+### 3. 启动猪分身 Gateway
+
+yixin 用户：
+
+```bash
+cd /home/yixin/hermes-agent
+export HERMES_AGENT_BRIDGE_TOKEN='suzijieyixin'
+./venv/bin/hermes gateway
+```
+
+## 如何使用
+
+### 人工叫小鸡毛
+
+群里发送：
+
+```text
+@小鸡毛 你去问一下猪分身
+```
+
+结果：
+
+- 小鸡毛被外部平台正常触发
+- 这条人工消息会通过 bridge 进入猪分身上下文
+- 猪分身只观察，不自动回复
+
+### 小鸡毛希望猪分身回复
+
+小鸡毛最终可见回复必须包含：
+
+```text
+@猪分身 ...
+```
+
+例如：
+
+```text
+@猪分身 你来接一下这个问题
+```
+
+结果：
+
+- bridge 检测到小鸡毛的 Agent 消息显式 wake 猪分身
+- 猪分身收到内部 Gateway event
+- 猪分身回复
+
+### 猪分身希望小鸡毛回复
+
+猪分身最终可见回复必须包含：
+
+```text
+@小鸡毛 ...
+```
+
+结果：
+
+- bridge 检测到猪分身的 Agent 消息显式 wake 小鸡毛
+- 小鸡毛收到内部 Gateway event
+- 小鸡毛回复
+
+### 只提到裸名字
+
+例如：
+
+```text
+我觉得小鸡毛刚才说的方向可以继续。
+```
+
+结果：
+
+- 小鸡毛只观察
+- 不触发回复
+
+## 如何验证
+
+运行测试：
+
+```bash
+pytest tests/gateway/test_agent_bridge.py
+```
+
+手动验证：
+
+1. 启动 bridge server
+2. 启动小鸡毛 Gateway
+3. 启动猪分身 Gateway
+4. 在群里发送：
+
+   ```text
+   @小鸡毛 你去叫一下猪分身
+   ```
+
+5. 确认猪分身不会因为裸名字“猪分身”自动回复
+6. 让小鸡毛最终回复中包含：
+
+   ```text
+   @猪分身 ...
+   ```
+
+7. 确认猪分身被 bridge 唤醒并回复
+8. 再测试只出现“小鸡毛”或“猪分身”裸名字时，对方只观察不回复
+
+## 这个 commit 的边界
+
+这个 v1 版本解决的是同机多 Hermes Agent 的本机桥接问题，不试图替代外部平台 adapter。
+
+它不做这些事情：
+
+- 不改变企业微信或 QQ 的真实消息投递规则
+- 不要求平台必须支持 bot-to-bot mention 转发
+- 不把裸名字当成自动触发条件
+- 不自动同步所有 Agent 的 `/new` 等 session 管理命令
+- 不在插件层用复杂规则猜测 LLM 是否想让另一个 Agent 回复
+
+它提供的是一个稳定机制：
+
+- 外部群聊仍然是人类可见的主界面
+- 本机 bridge 负责补齐平台缺失的 bot-to-bot 可触发链路
+- LLM 负责判断是否需要交接给另一个 Agent
+- 工具负责生成正确 wake mention
+- Hermes session transcript 保留群聊上下文
+
+## 使用这个文件提交
+
+可以直接用这个 Markdown 文件作为 commit message：
+
+```bash
+git commit -F agent_bridge_v1_commit_massage.md
+```
+
+如果想先预览：
+
+```bash
+sed -n '1,220p' agent_bridge_v1_commit_massage.md
+```

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -53,6 +53,76 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
     return f"{base_name} / {topic_label}"
 
 
+def _configured_aliases(platform_name: str) -> List[Dict[str, Any]]:
+    """Return user-configured channel aliases for a platform.
+
+    ``channel_aliases`` accepts either ``alias: chat_id`` or
+    ``alias: {chat_id/id, thread_id, type}`` entries under a platform's extra
+    config.  Aliases are additive, so they can provide friendly names for
+    session-discovered opaque IDs without hiding the raw session entry.
+    """
+    try:
+        from gateway.config import Platform, load_gateway_config
+        platform = Platform(platform_name)
+        config = load_gateway_config()
+        pconfig = config.platforms.get(platform)
+    except Exception:
+        return []
+
+    extra = getattr(pconfig, "extra", {}) if pconfig is not None else {}
+    aliases = extra.get("channel_aliases") if isinstance(extra, dict) else None
+    if not isinstance(aliases, dict):
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for alias, target in aliases.items():
+        alias_name = str(alias).strip()
+        if not alias_name:
+            continue
+
+        thread_id = None
+        chat_type = "group"
+        if isinstance(target, dict):
+            chat_id = target.get("chat_id") or target.get("id")
+            thread_id = target.get("thread_id")
+            chat_type = str(target.get("type") or chat_type)
+        else:
+            chat_id = target
+
+        chat_id = str(chat_id or "").strip()
+        if not chat_id:
+            continue
+
+        entry_id = f"{chat_id}:{thread_id}" if thread_id else chat_id
+        entries.append({
+            "id": entry_id,
+            "name": alias_name,
+            "type": chat_type,
+            "thread_id": thread_id,
+            "source": "alias",
+        })
+
+    return entries
+
+
+def _with_configured_aliases(platform_name: str, channels: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    aliases = _configured_aliases(platform_name)
+    if not aliases:
+        return channels
+
+    seen = {
+        (str(ch.get("id")), str(ch.get("name")), str(ch.get("thread_id") or ""))
+        for ch in channels
+    }
+    missing_aliases = []
+    for alias in aliases:
+        key = (str(alias.get("id")), str(alias.get("name")), str(alias.get("thread_id") or ""))
+        if key not in seen:
+            missing_aliases.append(alias)
+            seen.add(key)
+    return missing_aliases + channels
+
+
 # ---------------------------------------------------------------------------
 # Build / refresh
 # ---------------------------------------------------------------------------
@@ -84,7 +154,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         plat_name = plat.value
         if plat_name in _SKIP_SESSION_DISCOVERY or plat_name in platforms:
             continue
-        platforms[plat_name] = _build_from_sessions(plat_name)
+        platforms[plat_name] = _configured_aliases(plat_name) + _build_from_sessions(plat_name)
 
     # Include plugin-registered platforms (dynamic enum members aren't in
     # Platform.__members__, so the loop above misses them).
@@ -92,7 +162,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             if entry.name not in _SKIP_SESSION_DISCOVERY and entry.name not in platforms:
-                platforms[entry.name] = _build_from_sessions(entry.name)
+                platforms[entry.name] = _configured_aliases(entry.name) + _build_from_sessions(entry.name)
     except Exception:
         pass
 
@@ -274,7 +344,10 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     - Slack: "engineering", "#engineering"
     """
     directory = load_directory()
-    channels = directory.get("platforms", {}).get(platform_name, [])
+    channels = _with_configured_aliases(
+        platform_name,
+        list(directory.get("platforms", {}).get(platform_name, [])),
+    )
     if not channels:
         return None
 
@@ -315,6 +388,11 @@ def format_directory_for_display() -> str:
     """Format the channel directory as a human-readable list for the model."""
     directory = load_directory()
     platforms = directory.get("platforms", {})
+    for plat_name in set(platforms.keys()) | {"wecom"}:
+        platforms[plat_name] = _with_configured_aliases(
+            plat_name,
+            list(platforms.get(plat_name, [])),
+        )
 
     if not any(platforms.values()):
         return "No messaging platforms connected or no channels discovered yet."

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -748,6 +748,10 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    if plat_name == Platform.WECOM.value:
+                        for _wecom_extra_key in ("channel_aliases", "allow_standalone_send"):
+                            if _wecom_extra_key in plat_block:
+                                merged_extra[_wecom_extra_key] = plat_block[_wecom_extra_key]
                     if plat_name == Platform.SLACK.value and "enabled" in plat_block:
                         merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
@@ -799,6 +803,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
+                if plat == Platform.WECOM:
+                    for _wecom_extra_key in ("channel_aliases", "allow_standalone_send"):
+                        if _wecom_extra_key in platform_cfg:
+                            bridged[_wecom_extra_key] = platform_cfg[_wecom_extra_key]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3615,9 +3615,19 @@ class GatewayRunner:
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
             logger.info("%s hook(s) loaded", hook_count)
+        _startup_platforms = [p.value for p in self.adapters.keys()]
         await self.hooks.emit("gateway:startup", {
-            "platforms": [p.value for p in self.adapters.keys()],
+            "platforms": _startup_platforms,
         })
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "gateway_startup",
+                gateway=self,
+                platforms=_startup_platforms,
+            )
+        except Exception as _hook_exc:
+            logger.warning("gateway_startup plugin hook failed: %s", _hook_exc)
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
@@ -7687,6 +7697,20 @@ class GatewayRunner:
                 **hook_ctx,
                 "response": (response or "")[:500],
             })
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "post_gateway_response",
+                    event=event,
+                    source=source,
+                    session_key=session_key,
+                    session_id=session_entry.session_id,
+                    response=response or "",
+                    gateway=self,
+                    already_sent=bool(agent_result.get("already_sent")),
+                )
+            except Exception as _hook_exc:
+                logger.warning("post_gateway_response invocation failed: %s", _hook_exc)
             
             # Check for pending process watchers (check_interval on background processes)
             try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1322,6 +1322,15 @@ DEFAULT_CONFIG = {
     # See `website/docs/user-guide/features/hooks.md` for schema + examples.
     "hooks": {},
 
+    "agent_bridge": {
+        "enabled": False,
+        "agent_id": "",
+        "display_name": "",
+        "server_url": "http://127.0.0.1:8791",
+        "token_env": "HERMES_AGENT_BRIDGE_TOKEN",
+        "rooms": {},
+    },
+
     # Auto-accept shell-hook registrations without a TTY prompt.  Also
     # toggleable per-invocation via --accept-hooks or HERMES_ACCEPT_HOOKS=1.
     # Gateway / cron / non-interactive runs need this (or one of the other
@@ -2234,6 +2243,14 @@ OPTIONAL_ENV_VARS = {
         "url": None,
         "password": False,
         "category": "tool",
+        "advanced": True,
+    },
+    "HERMES_AGENT_BRIDGE_TOKEN": {
+        "description": "Shared token for the local Hermes agent bridge",
+        "prompt": "Hermes agent bridge token",
+        "url": None,
+        "password": True,
+        "category": "messaging",
         "advanced": True,
     },
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -151,6 +151,15 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Gateway lifecycle/response hooks for plugins that need to observe the
+    # messaging runtime without becoming a platform adapter.
+    # Kwargs for gateway_startup: gateway: GatewayRunner, platforms: list[str].
+    "gateway_startup",
+    # Fired after the gateway agent produced its final response text and before
+    # the platform adapter delivers the normal non-streamed response.
+    # Kwargs: event, source, session_key, session_id, response, gateway,
+    # already_sent.
+    "post_gateway_response",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/plugins/agent_bridge/__init__.py
+++ b/plugins/agent_bridge/__init__.py
@@ -1,0 +1,785 @@
+"""Local bridge for Hermes agents sharing a visible group-chat room.
+
+The plugin keeps bot-to-bot turns inside Hermes when external platforms do not
+forward bot-originated mentions to other bots. Real human messages still flow
+through the platform adapter; synthetic bridge events are marked internal and
+fed back through the normal adapter processing path so transcripts and delivery
+stay aligned with regular gateway behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+from urllib import error, parse, request
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SERVER_URL = "http://127.0.0.1:8791"
+_DEFAULT_TOKEN_ENV = "HERMES_AGENT_BRIDGE_TOKEN"
+_TOOLSET_NAME = "agent_bridge"
+_FORMAT_WAKE_TOOL_NAME = "agent_bridge_format_wake_message"
+
+
+@dataclass
+class RoomConfig:
+    room_id: str
+    external_targets: list[dict[str, Any]]
+    participants: list[dict[str, Any]]
+    max_bot_messages: int = 16
+    idle_timeout_seconds: int = 1800
+
+
+@dataclass
+class BridgeConfig:
+    enabled: bool
+    agent_id: str
+    display_name: str
+    server_url: str
+    token: str
+    rooms: dict[str, RoomConfig]
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_bridge_config() -> BridgeConfig:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("agent_bridge config load failed: %s", exc)
+        cfg = {}
+
+    raw = cfg.get("agent_bridge") if isinstance(cfg, dict) else {}
+    if not isinstance(raw, dict):
+        raw = {}
+
+    token_env = str(raw.get("token_env") or _DEFAULT_TOKEN_ENV)
+    token = str(os.environ.get(token_env) or raw.get("token") or "")
+    agent_id = str(raw.get("agent_id") or os.environ.get("USER") or "agent").strip()
+    display_name = str(raw.get("display_name") or agent_id).strip()
+    rooms: dict[str, RoomConfig] = {}
+    for room_id, room_raw in (raw.get("rooms") or {}).items():
+        if not isinstance(room_raw, dict):
+            continue
+        targets = room_raw.get("external_targets") or []
+        if not isinstance(targets, list):
+            targets = []
+        participants = room_raw.get("participants") or []
+        if not isinstance(participants, list):
+            participants = []
+        rooms[str(room_id)] = RoomConfig(
+            room_id=str(room_id),
+            external_targets=[t for t in targets if isinstance(t, dict)],
+            participants=[p for p in participants if isinstance(p, dict)],
+            max_bot_messages=max(1, _as_int(room_raw.get("max_bot_messages"), 16)),
+            idle_timeout_seconds=max(30, _as_int(room_raw.get("idle_timeout_seconds"), 1800)),
+        )
+
+    return BridgeConfig(
+        enabled=_as_bool(raw.get("enabled")),
+        agent_id=agent_id,
+        display_name=display_name,
+        server_url=str(raw.get("server_url") or _DEFAULT_SERVER_URL).rstrip("/"),
+        token=token,
+        rooms=rooms,
+    )
+
+
+def _platform_value(platform: Any) -> str:
+    return str(getattr(platform, "value", platform) or "").lower()
+
+
+def _target_matches_source(target: dict[str, Any], source: Any) -> bool:
+    target_platform = str(target.get("platform") or "").lower()
+    if target_platform and target_platform != _platform_value(getattr(source, "platform", "")):
+        return False
+    target_chat = target.get("chat_id")
+    if target_chat is not None and str(target_chat) != str(getattr(source, "chat_id", "")):
+        return False
+    target_thread = target.get("thread_id")
+    if target_thread is not None and str(target_thread) != str(getattr(source, "thread_id", "")):
+        return False
+    return True
+
+
+def _room_for_source(cfg: BridgeConfig, source: Any) -> Optional[RoomConfig]:
+    for room in cfg.rooms.values():
+        if any(_target_matches_source(target, source) for target in room.external_targets):
+            return room
+    return None
+
+
+def _room_payload(room: RoomConfig) -> dict[str, Any]:
+    return {
+        "room_id": room.room_id,
+        "external_targets": room.external_targets,
+        "participants": room.participants,
+        "max_bot_messages": room.max_bot_messages,
+        "idle_timeout_seconds": room.idle_timeout_seconds,
+    }
+
+
+def _participant_is_self(participant: dict[str, Any], cfg: BridgeConfig) -> bool:
+    return str(participant.get("agent_id") or "") == cfg.agent_id
+
+
+def _known_agent_ids(room: RoomConfig) -> set[str]:
+    return {str(p.get("agent_id")) for p in room.participants if p.get("agent_id")}
+
+
+def _participant_agent_id(participant: dict[str, Any]) -> str:
+    return str(participant.get("agent_id") or "").strip()
+
+
+def _participant_display_name(participant: dict[str, Any]) -> str:
+    return str(participant.get("display_name") or _participant_agent_id(participant)).strip()
+
+
+def _wake_names_for_participant(participant: dict[str, Any]) -> list[str]:
+    names: set[str] = set()
+    explicit_wake_names = participant.get("wake_names") or []
+    for value in explicit_wake_names:
+        value = str(value or "").strip()
+        if value:
+            names.add(value)
+    if not explicit_wake_names:
+        for value in participant.get("mention_names") or []:
+            value = str(value or "").strip()
+            if value.startswith("@"):
+                names.add(value)
+        for value in (_participant_display_name(participant), _participant_agent_id(participant)):
+            if value:
+                names.add(f"@{value}")
+    return sorted(names, key=len, reverse=True)
+
+
+def _preferred_wake_name_for_participant(participant: dict[str, Any]) -> str:
+    for value in participant.get("wake_names") or []:
+        value = str(value or "").strip()
+        if value:
+            return value
+    for value in participant.get("mention_names") or []:
+        value = str(value or "").strip()
+        if value.startswith("@"):
+            return value
+    display_name = _participant_display_name(participant)
+    if display_name:
+        return f"@{display_name}"
+    agent_id = _participant_agent_id(participant)
+    if agent_id:
+        return f"@{agent_id}"
+    return ""
+
+
+def _wake_names_for_self(room: RoomConfig, cfg: BridgeConfig) -> list[str]:
+    names: set[str] = set()
+    matched_participant = False
+    for participant in room.participants:
+        if not _participant_is_self(participant, cfg):
+            continue
+        matched_participant = True
+        names.update(_wake_names_for_participant(participant))
+    if not matched_participant:
+        for value in (cfg.display_name, cfg.agent_id):
+            value = str(value or "").strip()
+            if value:
+                names.add(f"@{value}")
+    return sorted(names, key=len, reverse=True)
+
+
+def _wakes_self(text: str, room: RoomConfig, cfg: BridgeConfig) -> bool:
+    folded = str(text or "").casefold()
+    return any(name.casefold() in folded for name in _wake_names_for_self(room, cfg) if name)
+
+
+def _mentions_self(text: str, room: RoomConfig, cfg: BridgeConfig) -> bool:
+    return _wakes_self(text, room, cfg)
+
+
+def _escape_gateway_command(text: str) -> str:
+    if str(text or "").startswith("/"):
+        return "\u200b" + text
+    return text
+
+
+def _is_gateway_slash_command(text: str, room: RoomConfig, cfg: BridgeConfig) -> bool:
+    stripped = str(text or "").lstrip()
+    if stripped.startswith("/"):
+        return True
+    folded = stripped.casefold()
+    for name in _wake_names_for_self(room, cfg):
+        if not name:
+            continue
+        if folded.startswith(name.casefold()):
+            return stripped[len(name):].lstrip().startswith("/")
+    return False
+
+
+def _event_id(prefix: str, *parts: Any) -> str:
+    digest = hashlib.sha256("\x1f".join(str(p or "") for p in parts).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}-{digest}"
+
+
+def _bridge_request(cfg: BridgeConfig, method: str, path: str, payload: Optional[dict[str, Any]] = None, timeout: float = 2.0) -> dict[str, Any]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if cfg.token:
+        headers["Authorization"] = f"Bearer {cfg.token}"
+    req = request.Request(f"{cfg.server_url}{path}", data=data, headers=headers, method=method)
+    with request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8")
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+def _room_for_tool(cfg: BridgeConfig, room_id: str = "") -> tuple[Optional[RoomConfig], str]:
+    room_id = str(room_id or "").strip()
+    if room_id:
+        room = cfg.rooms.get(room_id)
+        if room is not None:
+            return room, ""
+        return None, f"Unknown agent_bridge room_id: {room_id}"
+    rooms = list(cfg.rooms.values())
+    if not rooms:
+        return None, "agent_bridge has no configured rooms"
+    if len(rooms) > 1:
+        return None, "room_id is required because agent_bridge has multiple rooms"
+    return rooms[0], ""
+
+
+def _available_peer_agents(room: RoomConfig, cfg: BridgeConfig) -> list[dict[str, str]]:
+    peers: list[dict[str, str]] = []
+    for participant in room.participants:
+        agent_id = _participant_agent_id(participant)
+        if not agent_id or agent_id == cfg.agent_id:
+            continue
+        peers.append({
+            "agent_id": agent_id,
+            "display_name": _participant_display_name(participant),
+            "wake_name": _preferred_wake_name_for_participant(participant),
+            "room_id": room.room_id,
+        })
+    return peers
+
+
+def _format_wake_message_payload(args: dict[str, Any], cfg: BridgeConfig) -> dict[str, Any]:
+    if not cfg.enabled:
+        return {"success": False, "error": "agent_bridge is disabled"}
+
+    target_agent_id = str(args.get("target_agent_id") or "").strip()
+    message = str(args.get("message") or "").strip()
+    if not target_agent_id:
+        return {"success": False, "error": "target_agent_id is required"}
+    if not message:
+        return {"success": False, "error": "message is required"}
+
+    room, error_message = _room_for_tool(cfg, str(args.get("room_id") or ""))
+    if room is None:
+        return {"success": False, "error": error_message}
+    if target_agent_id == cfg.agent_id:
+        return {"success": False, "error": "target_agent_id must be a different agent"}
+
+    target = None
+    for participant in room.participants:
+        if _participant_agent_id(participant) == target_agent_id:
+            target = participant
+            break
+    if target is None:
+        return {
+            "success": False,
+            "error": f"Unknown target_agent_id: {target_agent_id}",
+            "available_agents": _available_peer_agents(room, cfg),
+        }
+
+    wake_names = _wake_names_for_participant(target)
+    preferred_wake_name = _preferred_wake_name_for_participant(target)
+    if not preferred_wake_name:
+        return {"success": False, "error": f"target_agent_id has no wake name: {target_agent_id}"}
+
+    folded_message = message.casefold()
+    already_wakes_target = any(name.casefold() in folded_message for name in wake_names if name)
+    wake_text = message if already_wakes_target else f"{preferred_wake_name} {message}"
+
+    return {
+        "success": True,
+        "wake_text": wake_text,
+        "target_agent_id": target_agent_id,
+        "target_display_name": _participant_display_name(target),
+        "target_wake_name": preferred_wake_name,
+        "room_id": room.room_id,
+        "instruction": "Include wake_text verbatim in your final visible reply if you want this agent to respond.",
+    }
+
+
+def _agent_bridge_format_wake_message(args: dict[str, Any], **_: Any) -> str:
+    cfg = _load_bridge_config()
+    payload = _format_wake_message_payload(args, cfg)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _agent_bridge_llm_context(cfg: BridgeConfig) -> str:
+    if not cfg.enabled:
+        return ""
+    peers: list[dict[str, str]] = []
+    for room in cfg.rooms.values():
+        peers.extend(_available_peer_agents(room, cfg))
+    if not peers:
+        return ""
+
+    seen: set[tuple[str, str]] = set()
+    peer_lines: list[str] = []
+    for peer in peers:
+        key = (peer["room_id"], peer["agent_id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        peer_lines.append(
+            f"- {peer['display_name']} (agent_id: {peer['agent_id']}, wake: {peer['wake_name']}, room_id: {peer['room_id']})"
+        )
+
+    return "\n".join([
+        "Agent bridge group-chat rule:",
+        f"- You are {cfg.display_name} (agent_id: {cfg.agent_id}).",
+        "- If you want another bridge agent to reply, your final visible group message must explicitly include that agent's wake @mention.",
+        "- Bare names are only observed and will not wake another agent.",
+        f"- When handing off, asking, or inviting another agent to answer, call `{_FORMAT_WAKE_TOOL_NAME}` and include the returned wake_text verbatim in your final reply.",
+        "- Available peer agents:",
+        *peer_lines,
+    ])
+
+
+def _on_pre_llm_call(**_: Any) -> Optional[dict[str, str]]:
+    context = _agent_bridge_llm_context(_load_bridge_config())
+    if not context:
+        return None
+    return {"context": context}
+
+
+def _check_agent_bridge_available() -> bool:
+    cfg = _load_bridge_config()
+    return bool(cfg.enabled and cfg.rooms)
+
+
+_FORMAT_WAKE_TOOL_SCHEMA = {
+    "name": _FORMAT_WAKE_TOOL_NAME,
+    "description": (
+        "Format a visible group-chat wake message for another Hermes bridge agent. "
+        "Use this when you want that agent to reply. Include the returned wake_text "
+        "verbatim in your final response."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target_agent_id": {
+                "type": "string",
+                "description": "The agent_id of the bridge agent that should reply.",
+            },
+            "message": {
+                "type": "string",
+                "description": "The message to send to the target agent, without needing to manually add @.",
+            },
+            "room_id": {
+                "type": "string",
+                "description": "Optional bridge room_id. Required only when multiple bridge rooms are configured.",
+            },
+        },
+        "required": ["target_agent_id", "message"],
+    },
+}
+
+
+class _Runtime:
+    def __init__(self) -> None:
+        self.lock = threading.RLock()
+        self.cfg = _load_bridge_config()
+        self.gateway = None
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.poller: Optional[threading.Thread] = None
+        self.stop_event = threading.Event()
+        self.registered = False
+        self.last_error_log = 0.0
+        self.seen_event_ids: set[str] = set()
+        self.last_thread_by_session: dict[str, str] = {}
+
+    def refresh(self) -> BridgeConfig:
+        cfg = _load_bridge_config()
+        with self.lock:
+            self.cfg = cfg
+        return cfg
+
+    def maybe_start(self, gateway: Any = None) -> Optional[BridgeConfig]:
+        cfg = self.refresh()
+        if not cfg.enabled:
+            return None
+        if not cfg.agent_id:
+            logger.warning("agent_bridge is enabled but agent_id is empty")
+            return None
+        if gateway is not None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            with self.lock:
+                self.gateway = gateway
+                if loop is not None:
+                    self.loop = loop
+                if self.poller is None or not self.poller.is_alive():
+                    self.stop_event.clear()
+                    self.poller = threading.Thread(
+                        target=self._poll_loop,
+                        name="hermes-agent-bridge",
+                        daemon=True,
+                    )
+                    self.poller.start()
+            self._register_best_effort(cfg)
+        return cfg
+
+    def _log_error(self, message: str, exc: Exception) -> None:
+        now = time.time()
+        if now - self.last_error_log > 30:
+            logger.warning("%s: %s", message, exc)
+            self.last_error_log = now
+        else:
+            logger.debug("%s: %s", message, exc)
+
+    def _register_best_effort(self, cfg: BridgeConfig) -> None:
+        payload = {
+            "agent_id": cfg.agent_id,
+            "display_name": cfg.display_name,
+            "rooms": {rid: _room_payload(room) for rid, room in cfg.rooms.items()},
+        }
+        try:
+            _bridge_request(cfg, "POST", "/v1/register", payload, timeout=1.5)
+            self.registered = True
+        except Exception as exc:
+            self._log_error("agent_bridge register failed", exc)
+
+    def _poll_loop(self) -> None:
+        while not self.stop_event.is_set():
+            with self.lock:
+                cfg = self.cfg
+                loop = self.loop
+            if not cfg.enabled or loop is None:
+                self.stop_event.wait(2.0)
+                continue
+            query = parse.urlencode({"agent_id": cfg.agent_id, "timeout": 25, "limit": 20})
+            try:
+                data = _bridge_request(cfg, "GET", f"/v1/events?{query}", timeout=30.0)
+                for event in data.get("events") or []:
+                    future = asyncio.run_coroutine_threadsafe(_handle_bridge_event(event), loop)
+                    future.add_done_callback(_log_future_error)
+            except (error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+                self._log_error("agent_bridge poll failed", exc)
+                self.stop_event.wait(5.0)
+            except Exception as exc:
+                self._log_error("agent_bridge poll failed", exc)
+                self.stop_event.wait(5.0)
+
+
+_RUNTIME = _Runtime()
+
+
+def _log_future_error(future: Any) -> None:
+    try:
+        future.result()
+    except Exception as exc:
+        logger.warning("agent_bridge event handling failed: %s", exc)
+
+
+def _current_runtime(gateway: Any = None) -> tuple[Optional[_Runtime], Optional[BridgeConfig]]:
+    cfg = _RUNTIME.maybe_start(gateway)
+    if cfg is None:
+        return None, None
+    return _RUNTIME, cfg
+
+
+def _publish_event(
+    *,
+    cfg: BridgeConfig,
+    room: RoomConfig,
+    source: Any,
+    author_id: str,
+    author_name: str,
+    author_type: str,
+    text: str,
+    origin_agent_id: str,
+    message_id: str,
+    thread_id: str = "",
+) -> dict[str, Any]:
+    payload = {
+        "id": _event_id("bridge", room.room_id, author_id, message_id, text),
+        "room_id": room.room_id,
+        "room": _room_payload(room),
+        "origin_agent_id": origin_agent_id,
+        "author_id": author_id,
+        "author_name": author_name,
+        "author_type": author_type,
+        "text": text,
+        "platform": _platform_value(getattr(source, "platform", "")),
+        "chat_id": str(getattr(source, "chat_id", "")),
+        "chat_name": getattr(source, "chat_name", None),
+        "chat_type": getattr(source, "chat_type", None) or "group",
+        "thread_id": thread_id,
+        "external_message_id": message_id,
+        "timestamp": datetime.now().isoformat(),
+    }
+    return _bridge_request(cfg, "POST", "/v1/events", payload, timeout=1.5)
+
+
+def _on_gateway_startup(gateway: Any = None, platforms: Optional[list[str]] = None, **_: Any) -> None:
+    del platforms
+    _current_runtime(gateway)
+
+
+def _on_pre_gateway_dispatch(event: Any, gateway: Any = None, session_store: Any = None, **_: Any) -> None:
+    del session_store
+    runtime, cfg = _current_runtime(gateway)
+    if runtime is None or cfg is None or event is None:
+        return None
+    source = getattr(event, "source", None)
+    if source is None:
+        return None
+    room = _room_for_source(cfg, source)
+    if room is None:
+        return None
+
+    # Real callbacks from known bridge agents are allowed to continue through
+    # Hermes, but are not re-published into the bridge to avoid duplicates on
+    # platforms that *do* forward bot messages.
+    known_agent_ids = _known_agent_ids(room)
+    source_user_id = str(getattr(source, "user_id", "") or "")
+    if bool(getattr(source, "is_bot", False)) or source_user_id in known_agent_ids:
+        return None
+
+    text = str(getattr(event, "text", "") or "")
+    if _is_gateway_slash_command(text, room, cfg):
+        return None
+    message_id = str(getattr(event, "message_id", "") or getattr(source, "message_id", "") or _event_id("human", source_user_id, text, time.time()))
+    try:
+        result = _publish_event(
+            cfg=cfg,
+            room=room,
+            source=source,
+            author_id=source_user_id or str(getattr(source, "user_name", "") or "human"),
+            author_name=str(getattr(source, "user_name", "") or source_user_id or "human"),
+            author_type="human",
+            text=text,
+            origin_agent_id=cfg.agent_id,
+            message_id=message_id,
+        )
+        thread_id = str(result.get("thread_id") or "")
+        if thread_id and gateway is not None:
+            try:
+                session_key = gateway._session_key_for_source(source)
+                runtime.last_thread_by_session[session_key] = thread_id
+            except Exception:
+                pass
+    except Exception as exc:
+        runtime._log_error("agent_bridge publish inbound failed", exc)
+    return None
+
+
+def _on_post_gateway_response(
+    *,
+    event: Any = None,
+    source: Any = None,
+    session_key: str = "",
+    session_id: str = "",
+    response: str = "",
+    gateway: Any = None,
+    already_sent: bool = False,
+    **_: Any,
+) -> None:
+    del session_id, already_sent
+    runtime, cfg = _current_runtime(gateway)
+    if runtime is None or cfg is None or source is None or not str(response or "").strip():
+        return None
+    room = _room_for_source(cfg, source)
+    if room is None:
+        return None
+
+    raw = getattr(event, "raw_message", None) or {}
+    bridge_meta = raw.get("agent_bridge") if isinstance(raw, dict) else None
+    thread_id = ""
+    if isinstance(bridge_meta, dict):
+        thread_id = str(bridge_meta.get("thread_id") or "")
+    if not thread_id and session_key:
+        thread_id = runtime.last_thread_by_session.get(session_key, "")
+
+    source_message_id = str(getattr(event, "message_id", "") or getattr(source, "message_id", "") or "")
+    message_id = _event_id("agent", cfg.agent_id, source_message_id, response)
+    try:
+        result = _publish_event(
+            cfg=cfg,
+            room=room,
+            source=source,
+            author_id=cfg.agent_id,
+            author_name=cfg.display_name,
+            author_type="agent",
+            text=str(response),
+            origin_agent_id=cfg.agent_id,
+            message_id=message_id,
+            thread_id=thread_id,
+        )
+        returned_thread = str(result.get("thread_id") or "")
+        if returned_thread and session_key:
+            runtime.last_thread_by_session[session_key] = returned_thread
+    except Exception as exc:
+        runtime._log_error("agent_bridge publish response failed", exc)
+    return None
+
+
+def _source_from_payload(payload: dict[str, Any]):
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    return SessionSource(
+        platform=Platform(str(payload.get("platform") or "wecom")),
+        chat_id=str(payload.get("chat_id") or ""),
+        chat_name=payload.get("chat_name"),
+        chat_type=str(payload.get("chat_type") or "group"),
+        user_id=str(payload.get("author_id") or ""),
+        user_name=str(payload.get("author_name") or payload.get("author_id") or ""),
+        message_id=f"agent_bridge:{payload.get('id')}",
+        is_bot=str(payload.get("author_type") or "") == "agent",
+    )
+
+
+def _content_for_transcript(payload: dict[str, Any], source: Any, gateway: Any) -> str:
+    text = str(payload.get("text") or "")
+    try:
+        from gateway.session import is_shared_multi_user_session
+
+        shared = is_shared_multi_user_session(
+            source,
+            group_sessions_per_user=getattr(gateway.config, "group_sessions_per_user", True),
+            thread_sessions_per_user=getattr(gateway.config, "thread_sessions_per_user", False),
+        )
+    except Exception:
+        shared = True
+    if shared and getattr(source, "user_name", None):
+        return f"[{source.user_name}] {text}"
+    return text
+
+
+def _append_observed_event(payload: dict[str, Any], gateway: Any) -> None:
+    source = _source_from_payload(payload)
+    entry = gateway.session_store.get_or_create_session(source)
+    gateway.session_store.append_to_transcript(
+        entry.session_id,
+        {
+            "role": "user",
+            "content": _content_for_transcript(payload, source, gateway),
+            "timestamp": datetime.now().isoformat(),
+            "agent_bridge_event_id": payload.get("id"),
+            "agent_bridge_observed": True,
+        },
+    )
+
+
+async def _inject_addressed_event(payload: dict[str, Any], gateway: Any) -> None:
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    source = _source_from_payload(payload)
+    event = MessageEvent(
+        text=_escape_gateway_command(str(payload.get("text") or "")),
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message={"agent_bridge": payload},
+        message_id=f"agent_bridge:{payload.get('id')}",
+        internal=True,
+    )
+    adapter = gateway.adapters.get(source.platform)
+    if adapter is not None and hasattr(adapter, "handle_message"):
+        await adapter.handle_message(event)
+        return
+    response = await gateway._handle_message(event)
+    if response:
+        logger.warning(
+            "agent_bridge produced a response for %s but no %s adapter is available to deliver it",
+            source.chat_id,
+            _platform_value(source.platform),
+        )
+
+
+async def _handle_bridge_event(payload: dict[str, Any]) -> None:
+    runtime, cfg = _current_runtime()
+    if runtime is None or cfg is None:
+        return
+    event_id = str(payload.get("id") or "")
+    if not event_id:
+        return
+    with runtime.lock:
+        if event_id in runtime.seen_event_ids:
+            return
+        runtime.seen_event_ids.add(event_id)
+        gateway = runtime.gateway
+    if gateway is None:
+        return
+    if str(payload.get("author_id") or "") == cfg.agent_id:
+        return
+    room = cfg.rooms.get(str(payload.get("room_id") or ""))
+    if room is None:
+        room_payload = payload.get("room") or {}
+        if isinstance(room_payload, dict):
+            room = RoomConfig(
+                room_id=str(payload.get("room_id") or room_payload.get("room_id") or ""),
+                external_targets=room_payload.get("external_targets") or [],
+                participants=room_payload.get("participants") or [],
+                max_bot_messages=max(1, _as_int(room_payload.get("max_bot_messages"), 16)),
+                idle_timeout_seconds=max(30, _as_int(room_payload.get("idle_timeout_seconds"), 1800)),
+            )
+    if room is None:
+        return
+    should_reply = (
+        str(payload.get("author_type") or "") == "agent"
+        and bool(payload.get("allow_auto_reply", True))
+        and _wakes_self(str(payload.get("text") or ""), room, cfg)
+    )
+    if should_reply:
+        await _inject_addressed_event(payload, gateway)
+    else:
+        await asyncio.to_thread(_append_observed_event, payload, gateway)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("gateway_startup", _on_gateway_startup)
+    ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)
+    ctx.register_hook("post_gateway_response", _on_post_gateway_response)
+    ctx.register_tool(
+        name=_FORMAT_WAKE_TOOL_NAME,
+        toolset=_TOOLSET_NAME,
+        schema=_FORMAT_WAKE_TOOL_SCHEMA,
+        handler=_agent_bridge_format_wake_message,
+        check_fn=_check_agent_bridge_available,
+        description="Format visible @mention messages that wake peer bridge agents.",
+        emoji="@",
+    )

--- a/plugins/agent_bridge/plugin.yaml
+++ b/plugins/agent_bridge/plugin.yaml
@@ -1,0 +1,10 @@
+name: agent_bridge
+version: "0.1.0"
+description: "Local bridge for multi-agent group-chat style coordination across Hermes gateways."
+author: NousResearch
+hooks:
+  - gateway_startup
+  - pre_gateway_dispatch
+  - post_gateway_response
+requires_env:
+  - HERMES_AGENT_BRIDGE_TOKEN

--- a/plugins/agent_bridge/server.py
+++ b/plugins/agent_bridge/server.py
@@ -1,0 +1,266 @@
+"""Small local HTTP bridge for Hermes agent-to-agent group chat.
+
+Run with:
+
+    python plugins/agent_bridge/server.py --token-env HERMES_AGENT_BRIDGE_TOKEN
+
+The server intentionally uses only the Python standard library so two Hermes
+profiles can share it without installing extra dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import threading
+import time
+import uuid
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib import parse
+
+
+class BridgeState:
+    def __init__(self) -> None:
+        self.condition = threading.Condition(threading.RLock())
+        self.rooms: dict[str, dict[str, Any]] = {}
+        self.agents: dict[str, dict[str, Any]] = {}
+        self.queues: dict[str, list[dict[str, Any]]] = {}
+        self.seen_ids: set[str] = set()
+        self.threads: dict[str, dict[str, Any]] = {}
+
+    def register(self, payload: dict[str, Any]) -> dict[str, Any]:
+        agent_id = str(payload.get("agent_id") or "").strip()
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        rooms = payload.get("rooms") or {}
+        if not isinstance(rooms, dict):
+            rooms = {}
+        with self.condition:
+            self.agents[agent_id] = {
+                "agent_id": agent_id,
+                "display_name": payload.get("display_name") or agent_id,
+                "updated_at": time.time(),
+            }
+            self.queues.setdefault(agent_id, [])
+            for room_id, room in rooms.items():
+                if isinstance(room, dict):
+                    self._merge_room_locked(str(room_id), room)
+            self.condition.notify_all()
+        return {"ok": True}
+
+    def publish(self, payload: dict[str, Any]) -> dict[str, Any]:
+        event_id = str(payload.get("id") or uuid.uuid4().hex)
+        room_id = str(payload.get("room_id") or "")
+        if not room_id:
+            raise ValueError("room_id is required")
+        with self.condition:
+            room_payload = payload.get("room")
+            if isinstance(room_payload, dict):
+                self._merge_room_locked(room_id, room_payload)
+            room = self.rooms.setdefault(room_id, self._default_room(room_id))
+            if event_id in self.seen_ids:
+                thread_id = str(payload.get("thread_id") or event_id)
+                return {"ok": True, "duplicate": True, "id": event_id, "thread_id": thread_id}
+            self.seen_ids.add(event_id)
+            self._prune_seen_locked()
+
+            event = dict(payload)
+            event["id"] = event_id
+            event["room_id"] = room_id
+            event["room"] = room
+            thread_id, allow_auto_reply = self._update_thread_locked(event, room)
+            event["thread_id"] = thread_id
+            event["allow_auto_reply"] = allow_auto_reply
+
+            author_id = str(event.get("author_id") or "")
+            origin_agent_id = str(event.get("origin_agent_id") or "")
+            targets = self._target_agents_locked(room)
+            for agent_id in targets:
+                if agent_id and agent_id not in {author_id, origin_agent_id}:
+                    self.queues.setdefault(agent_id, []).append(event)
+            self.condition.notify_all()
+        return {"ok": True, "id": event_id, "thread_id": thread_id, "allow_auto_reply": allow_auto_reply}
+
+    def poll(self, agent_id: str, timeout: float = 25.0, limit: int = 20) -> dict[str, Any]:
+        deadline = time.time() + max(0.0, timeout)
+        with self.condition:
+            queue = self.queues.setdefault(agent_id, [])
+            while not queue:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                self.condition.wait(timeout=remaining)
+            events = queue[:limit]
+            del queue[:len(events)]
+        return {"ok": True, "events": events}
+
+    def _merge_room_locked(self, room_id: str, room: dict[str, Any]) -> None:
+        current = self.rooms.setdefault(room_id, self._default_room(room_id))
+        for key in ("external_targets", "participants"):
+            value = room.get(key)
+            if isinstance(value, list):
+                current[key] = value
+        for key, default in (("max_bot_messages", 16), ("idle_timeout_seconds", 1800)):
+            try:
+                current[key] = max(1, int(room.get(key, current.get(key, default))))
+            except (TypeError, ValueError):
+                current[key] = current.get(key, default)
+
+    @staticmethod
+    def _default_room(room_id: str) -> dict[str, Any]:
+        return {
+            "room_id": room_id,
+            "external_targets": [],
+            "participants": [],
+            "max_bot_messages": 16,
+            "idle_timeout_seconds": 1800,
+        }
+
+    def _target_agents_locked(self, room: dict[str, Any]) -> list[str]:
+        participants = room.get("participants") or []
+        targets = [str(p.get("agent_id")) for p in participants if isinstance(p, dict) and p.get("agent_id")]
+        return targets or list(self.agents.keys())
+
+    def _update_thread_locked(self, event: dict[str, Any], room: dict[str, Any]) -> tuple[str, bool]:
+        now = time.time()
+        author_type = str(event.get("author_type") or "human")
+        max_bot_messages = max(1, int(room.get("max_bot_messages") or 16))
+        idle_timeout = max(30, int(room.get("idle_timeout_seconds") or 1800))
+        requested_thread = str(event.get("thread_id") or "")
+        if author_type == "human" or not requested_thread:
+            thread_id = requested_thread or str(event.get("id") or uuid.uuid4().hex)
+            self.threads[thread_id] = {
+                "room_id": event.get("room_id"),
+                "bot_count": 0,
+                "updated_at": now,
+                "max_bot_messages": max_bot_messages,
+                "idle_timeout_seconds": idle_timeout,
+            }
+            return thread_id, True
+
+        thread_id = requested_thread
+        thread = self.threads.get(thread_id)
+        if not thread or now - float(thread.get("updated_at") or 0) > idle_timeout:
+            thread = {
+                "room_id": event.get("room_id"),
+                "bot_count": 0,
+                "updated_at": now,
+                "max_bot_messages": max_bot_messages,
+                "idle_timeout_seconds": idle_timeout,
+            }
+            self.threads[thread_id] = thread
+        thread["bot_count"] = int(thread.get("bot_count") or 0) + 1
+        thread["updated_at"] = now
+        return thread_id, int(thread["bot_count"]) < max_bot_messages
+
+    def _prune_seen_locked(self) -> None:
+        # Keep memory bounded. The seen set is only for short-window de-dupe.
+        if len(self.seen_ids) > 10000:
+            self.seen_ids = set(list(self.seen_ids)[-5000:])
+
+
+class BridgeHandler(BaseHTTPRequestHandler):
+    server_version = "HermesAgentBridge/0.1"
+
+    @property
+    def state(self) -> BridgeState:
+        return self.server.state  # type: ignore[attr-defined]
+
+    @property
+    def token(self) -> str:
+        return self.server.token  # type: ignore[attr-defined]
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if not self._authorized():
+            return self._json({"ok": False, "error": "unauthorized"}, HTTPStatus.UNAUTHORIZED)
+        parsed = parse.urlparse(self.path)
+        if parsed.path == "/health":
+            return self._json({"ok": True})
+        if parsed.path != "/v1/events":
+            return self._json({"ok": False, "error": "not found"}, HTTPStatus.NOT_FOUND)
+        query = parse.parse_qs(parsed.query)
+        agent_id = (query.get("agent_id") or [""])[0]
+        if not agent_id:
+            return self._json({"ok": False, "error": "agent_id is required"}, HTTPStatus.BAD_REQUEST)
+        timeout = _float((query.get("timeout") or [25])[0], 25.0)
+        limit = max(1, min(100, int(_float((query.get("limit") or [20])[0], 20))))
+        return self._json(self.state.poll(agent_id, timeout=timeout, limit=limit))
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if not self._authorized():
+            return self._json({"ok": False, "error": "unauthorized"}, HTTPStatus.UNAUTHORIZED)
+        try:
+            payload = self._read_json()
+            if self.path == "/v1/register":
+                result = self.state.register(payload)
+            elif self.path == "/v1/events":
+                result = self.state.publish(payload)
+            else:
+                return self._json({"ok": False, "error": "not found"}, HTTPStatus.NOT_FOUND)
+        except ValueError as exc:
+            return self._json({"ok": False, "error": str(exc)}, HTTPStatus.BAD_REQUEST)
+        return self._json(result)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        if getattr(self.server, "verbose", False):  # type: ignore[attr-defined]
+            super().log_message(fmt, *args)
+
+    def _authorized(self) -> bool:
+        if not self.token:
+            return True
+        return self.headers.get("Authorization") == f"Bearer {self.token}"
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length > 2_000_000:
+            raise ValueError("payload too large")
+        raw = self.rfile.read(length) if length else b"{}"
+        data = json.loads(raw.decode("utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("JSON object required")
+        return data
+
+    def _json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(int(status))
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def build_server(host: str, port: int, token: str = "", verbose: bool = False) -> ThreadingHTTPServer:
+    server = ThreadingHTTPServer((host, port), BridgeHandler)
+    server.state = BridgeState()  # type: ignore[attr-defined]
+    server.token = token  # type: ignore[attr-defined]
+    server.verbose = verbose  # type: ignore[attr-defined]
+    return server
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the local Hermes agent bridge server.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8791)
+    parser.add_argument("--token", default="")
+    parser.add_argument("--token-env", default="HERMES_AGENT_BRIDGE_TOKEN")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    token = args.token or os.environ.get(args.token_env, "")
+    server = build_server(args.host, args.port, token=token, verbose=args.verbose)
+    print(f"Hermes agent bridge listening on http://{args.host}:{args.port}", flush=True)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_agent_bridge.py
+++ b/tests/gateway/test_agent_bridge.py
@@ -1,0 +1,467 @@
+"""Tests for the local Hermes agent bridge plugin/server."""
+
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from hermes_cli.plugins import VALID_HOOKS
+from plugins.agent_bridge import (
+    BridgeConfig,
+    RoomConfig,
+    _FORMAT_WAKE_TOOL_NAME,
+    _agent_bridge_format_wake_message,
+    _agent_bridge_llm_context,
+    _escape_gateway_command,
+    _format_wake_message_payload,
+    _is_gateway_slash_command,
+    _on_pre_llm_call,
+    _wakes_self,
+)
+from plugins.agent_bridge.server import BridgeState
+
+
+def _room(max_bot_messages: int = 16):
+    return {
+        "room_id": "pig_king",
+        "external_targets": [{"platform": "wecom", "chat_id": "room-1"}],
+        "participants": [
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+        "max_bot_messages": max_bot_messages,
+        "idle_timeout_seconds": 1800,
+    }
+
+
+def test_agent_bridge_hooks_are_declared():
+    assert "gateway_startup" in VALID_HOOKS
+    assert "post_gateway_response" in VALID_HOOKS
+
+
+def test_bridge_server_queues_human_message_only_for_other_agents():
+    state = BridgeState()
+    state.register({"agent_id": "agent-a", "display_name": "Agent A", "rooms": {"pig_king": _room()}})
+    state.register({"agent_id": "agent-b", "display_name": "Agent B", "rooms": {"pig_king": _room()}})
+
+    result = state.publish({
+        "id": "human-1",
+        "room_id": "pig_king",
+        "room": _room(),
+        "origin_agent_id": "agent-a",
+        "author_id": "human-1",
+        "author_name": "Human",
+        "author_type": "human",
+        "text": "hello @AgentB",
+        "platform": "wecom",
+        "chat_id": "room-1",
+    })
+
+    assert result["thread_id"] == "human-1"
+    assert state.poll("agent-a", timeout=0)["events"] == []
+    events = state.poll("agent-b", timeout=0)["events"]
+    assert len(events) == 1
+    assert events[0]["allow_auto_reply"] is True
+    assert events[0]["text"] == "hello @AgentB"
+
+
+def test_bridge_server_caps_bot_to_bot_thread():
+    state = BridgeState()
+    room = _room(max_bot_messages=2)
+    state.register({"agent_id": "agent-a", "display_name": "Agent A", "rooms": {"pig_king": room}})
+    state.register({"agent_id": "agent-b", "display_name": "Agent B", "rooms": {"pig_king": room}})
+
+    human = state.publish({
+        "id": "human-1",
+        "room_id": "pig_king",
+        "room": room,
+        "origin_agent_id": "agent-a",
+        "author_id": "human",
+        "author_type": "human",
+        "text": "start @AgentB",
+        "platform": "wecom",
+        "chat_id": "room-1",
+    })
+    first_bot = state.publish({
+        "id": "bot-1",
+        "room_id": "pig_king",
+        "room": room,
+        "origin_agent_id": "agent-a",
+        "author_id": "agent-a",
+        "author_type": "agent",
+        "thread_id": human["thread_id"],
+        "text": "@AgentB your turn",
+        "platform": "wecom",
+        "chat_id": "room-1",
+    })
+    second_bot = state.publish({
+        "id": "bot-2",
+        "room_id": "pig_king",
+        "room": room,
+        "origin_agent_id": "agent-b",
+        "author_id": "agent-b",
+        "author_type": "agent",
+        "thread_id": human["thread_id"],
+        "text": "@AgentA back to you",
+        "platform": "wecom",
+        "chat_id": "room-1",
+    })
+
+    assert first_bot["allow_auto_reply"] is True
+    assert second_bot["allow_auto_reply"] is False
+
+
+def test_agent_bridge_wake_names_and_command_escape():
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[{"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["Agent B", "@AgentB"]}],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-b",
+        display_name="Agent B",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+
+    assert _wakes_self("hello @AgentB", room, cfg)
+    assert not _wakes_self("hello Agent B", room, cfg)
+    assert not _wakes_self("hello @AgentA", room, cfg)
+    assert _escape_gateway_command("/reset") == f"{chr(0x200B)}/reset"
+    assert _is_gateway_slash_command("/new", room, cfg)
+    assert _is_gateway_slash_command("  /approve", room, cfg)
+    assert _is_gateway_slash_command("@AgentB /new", room, cfg)
+    assert not _is_gateway_slash_command("please discuss /new behavior", room, cfg)
+
+
+def test_agent_bridge_pre_dispatch_skips_slash_commands(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    runtime = SimpleNamespace(
+        last_thread_by_session={},
+        _log_error=lambda message, exc: None,
+    )
+    source = SimpleNamespace(
+        platform=Platform.WECOM,
+        chat_id="room-1",
+        chat_type="group",
+        thread_id="",
+        user_id="human-1",
+        user_name="Human",
+        is_bot=False,
+    )
+    event = SimpleNamespace(source=source, text="/new", message_id="msg-1")
+    gateway = SimpleNamespace(_session_key_for_source=lambda source: "session-1")
+    published = []
+
+    monkeypatch.setattr(bridge, "_current_runtime", lambda gateway=None: (runtime, cfg))
+    monkeypatch.setattr(bridge, "_publish_event", lambda **kwargs: published.append(kwargs))
+
+    assert bridge._on_pre_gateway_dispatch(event, gateway=gateway) is None
+    assert published == []
+
+
+def test_agent_bridge_format_wake_message_uses_current_config_identity():
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["Agent A", "@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["Agent B", "@AgentB"]},
+        ],
+    )
+    cfg_a = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    cfg_b = BridgeConfig(
+        enabled=True,
+        agent_id="agent-b",
+        display_name="Agent B",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+
+    from_a = _format_wake_message_payload({"target_agent_id": "agent-b", "message": "what do you think?"}, cfg_a)
+    from_b = _format_wake_message_payload({"target_agent_id": "agent-a", "message": "your turn"}, cfg_b)
+    already_tagged = _format_wake_message_payload({"target_agent_id": "agent-b", "message": "@AgentB already tagged"}, cfg_a)
+
+    assert from_a["success"] is True
+    assert from_a["wake_text"] == "@AgentB what do you think?"
+    assert from_b["success"] is True
+    assert from_b["wake_text"] == "@AgentA your turn"
+    assert already_tagged["wake_text"] == "@AgentB already tagged"
+
+
+def test_agent_bridge_format_wake_message_errors_are_actionable():
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    multi_room_cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room, "second": room},
+    )
+
+    unknown = _format_wake_message_payload({"target_agent_id": "agent-x", "message": "hello"}, cfg)
+    missing_room = _format_wake_message_payload({"target_agent_id": "agent-b", "message": "hello"}, multi_room_cfg)
+
+    assert unknown["success"] is False
+    assert unknown["available_agents"][0]["agent_id"] == "agent-b"
+    assert missing_room["success"] is False
+    assert "room_id is required" in missing_room["error"]
+
+
+def test_agent_bridge_format_wake_message_tool_wrapper(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    monkeypatch.setattr(bridge, "_load_bridge_config", lambda: cfg)
+
+    result = json.loads(_agent_bridge_format_wake_message({"target_agent_id": "agent-b", "message": "please answer"}))
+
+    assert result["success"] is True
+    assert result["wake_text"] == "@AgentB please answer"
+    assert result["instruction"]
+
+
+def test_agent_bridge_llm_context_mentions_tool_and_peers(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-a",
+        display_name="Agent A",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    monkeypatch.setattr(bridge, "_load_bridge_config", lambda: cfg)
+
+    context = _agent_bridge_llm_context(cfg)
+    hook_result = _on_pre_llm_call()
+
+    assert _FORMAT_WAKE_TOOL_NAME in context
+    assert "agent-a" in context
+    assert "agent-b" in context
+    assert "@AgentB" in context
+    assert hook_result == {"context": context}
+
+
+@pytest.mark.asyncio
+async def test_bridge_event_mention_injects_internal_adapter_event(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-b",
+        display_name="Agent B",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    gateway = SimpleNamespace(
+        adapters={Platform.WECOM: adapter},
+        config=GatewayConfig(group_sessions_per_user=False),
+    )
+    runtime = SimpleNamespace(
+        lock=threading.RLock(),
+        seen_event_ids=set(),
+        gateway=gateway,
+    )
+    monkeypatch.setattr(bridge, "_current_runtime", lambda gateway=None: (runtime, cfg))
+
+    await bridge._handle_bridge_event({
+        "id": "evt-1",
+        "room_id": "pig_king",
+        "author_id": "agent-a",
+        "author_name": "Agent A",
+        "author_type": "agent",
+        "text": "please answer @AgentB",
+        "platform": "wecom",
+        "chat_id": "room-1",
+        "chat_type": "group",
+        "allow_auto_reply": True,
+    })
+
+    adapter.handle_message.assert_awaited_once()
+    injected = adapter.handle_message.await_args.args[0]
+    assert injected.internal is True
+    assert injected.source.user_name == "Agent A"
+    assert injected.text == "please answer @AgentB"
+
+
+@pytest.mark.asyncio
+async def test_bridge_human_mention_is_observed_not_injected(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-b",
+        display_name="Agent B",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    gateway = SimpleNamespace(
+        adapters={Platform.WECOM: adapter},
+        config=GatewayConfig(group_sessions_per_user=False),
+    )
+    runtime = SimpleNamespace(
+        lock=threading.RLock(),
+        seen_event_ids=set(),
+        gateway=gateway,
+    )
+    observed = []
+    monkeypatch.setattr(bridge, "_current_runtime", lambda gateway=None: (runtime, cfg))
+    monkeypatch.setattr(bridge, "_append_observed_event", lambda payload, gateway: observed.append(payload))
+
+    await bridge._handle_bridge_event({
+        "id": "evt-human-1",
+        "room_id": "pig_king",
+        "author_id": "human-1",
+        "author_name": "Human",
+        "author_type": "human",
+        "text": "@AgentA please call @AgentB",
+        "platform": "wecom",
+        "chat_id": "room-1",
+        "chat_type": "group",
+        "allow_auto_reply": True,
+    })
+
+    adapter.handle_message.assert_not_awaited()
+    assert [event["id"] for event in observed] == ["evt-human-1"]
+
+
+@pytest.mark.asyncio
+async def test_bridge_bot_bare_name_is_observed_not_injected(monkeypatch):
+    import plugins.agent_bridge as bridge
+
+    room = RoomConfig(
+        room_id="pig_king",
+        external_targets=[{"platform": "wecom", "chat_id": "room-1"}],
+        participants=[
+            {"agent_id": "agent-a", "display_name": "Agent A", "mention_names": ["@AgentA"]},
+            {"agent_id": "agent-b", "display_name": "Agent B", "mention_names": ["Agent B", "@AgentB"]},
+        ],
+    )
+    cfg = BridgeConfig(
+        enabled=True,
+        agent_id="agent-b",
+        display_name="Agent B",
+        server_url="http://127.0.0.1:8791",
+        token="",
+        rooms={"pig_king": room},
+    )
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    gateway = SimpleNamespace(
+        adapters={Platform.WECOM: adapter},
+        config=GatewayConfig(group_sessions_per_user=False),
+    )
+    runtime = SimpleNamespace(
+        lock=threading.RLock(),
+        seen_event_ids=set(),
+        gateway=gateway,
+    )
+    observed = []
+    monkeypatch.setattr(bridge, "_current_runtime", lambda gateway=None: (runtime, cfg))
+    monkeypatch.setattr(bridge, "_append_observed_event", lambda payload, gateway: observed.append(payload))
+
+    await bridge._handle_bridge_event({
+        "id": "evt-bot-bare-1",
+        "room_id": "pig_king",
+        "author_id": "agent-a",
+        "author_name": "Agent A",
+        "author_type": "agent",
+        "text": "Agent B was mentioned as a topic, not addressed.",
+        "platform": "wecom",
+        "chat_id": "room-1",
+        "chat_type": "group",
+        "allow_auto_reply": True,
+    })
+
+    adapter.handle_message.assert_not_awaited()
+    assert [event["id"] for event in observed] == ["evt-bot-bare-1"]

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -15,6 +15,7 @@ from gateway.channel_directory import (
     load_directory,
     _build_from_sessions,
     _build_slack,
+    _configured_aliases,
     DIRECTORY_PATH,
 )
 
@@ -69,6 +70,51 @@ class TestBuildChannelDirectoryWrites:
             result = load_directory()
 
         assert result == previous
+
+
+class TestConfiguredAliases:
+    def _write_config(self, tmp_path, body):
+        (tmp_path / "config.yaml").write_text(body)
+
+    def test_wecom_aliases_load_from_top_level_platform_section(self, tmp_path):
+        self._write_config(tmp_path, 'wecom:\n  channel_aliases:\n    XXX群: wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q\n')
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _configured_aliases("wecom")
+
+        assert entries == [{
+            "id": "wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q",
+            "name": "XXX群",
+            "type": "group",
+            "thread_id": None,
+            "source": "alias",
+        }]
+
+    def test_wecom_alias_resolves_without_cached_directory_entry(self, tmp_path):
+        self._write_config(tmp_path, 'wecom:\n  channel_aliases:\n    XXX群: wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q\n')
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", tmp_path / "missing.json"):
+            assert resolve_channel_name("wecom", "XXX群") == "wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q"
+            assert resolve_channel_name("wecom", "XXX群 (group)") == "wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q"
+
+    def test_format_directory_does_not_duplicate_configured_alias(self, tmp_path):
+        self._write_config(tmp_path, 'wecom:\n  channel_aliases:\n    XXX群: wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q\n')
+        cache_file = _write_directory(tmp_path, {
+            "wecom": [{
+                "id": "wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q",
+                "name": "XXX群",
+                "type": "group",
+                "thread_id": None,
+                "source": "alias",
+            }]
+        })
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), \
+             patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = format_directory_for_display()
+
+        assert result.count("wecom:XXX群") == 1
 
 
 class TestResolveChannelName:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -290,6 +290,44 @@ class TestLoadGatewayConfig:
 
         assert config.thread_sessions_per_user is True
 
+    def test_bridges_wecom_aliases_and_standalone_flag_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "wecom:\n"
+            "  channel_aliases:\n"
+            "    XXX群: wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q\n"
+            "  allow_standalone_send: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.WECOM].extra
+        assert extra["channel_aliases"] == {"XXX群": "wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q"}
+        assert extra["allow_standalone_send"] is True
+
+    def test_bridges_wecom_aliases_from_platforms_shortcut(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  wecom:\n"
+            "    channel_aliases:\n"
+            "      Ops Group: group-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WECOM].extra["channel_aliases"] == {"Ops Group": "group-1"}
+
     def test_thread_sessions_per_user_defaults_to_false(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -182,6 +182,43 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_resolved_wecom_display_label_keeps_non_explicit_chat_id(self):
+        wecom_cfg = SimpleNamespace(enabled=True, token="", extra={})
+        home = SimpleNamespace(chat_id="dm-user-home")
+        config = SimpleNamespace(
+            platforms={Platform.WECOM: wecom_cfg},
+            get_home_channel=lambda _platform: home,
+        )
+        resolved_group_id = "wecomGroupABC123xyz"
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", return_value=resolved_group_id), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "wecom:Project Room (group)",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert "note" not in result
+        send_mock.assert_awaited_once_with(
+            Platform.WECOM,
+            wecom_cfg,
+            resolved_group_id,
+            "hello",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
     def test_mirror_receives_current_session_user_id(self):
         config, _telegram_cfg = _make_config()
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2091,6 +2091,115 @@ class TestSendSignalChunking:
         assert len(params["attachments"]) == 1
 
 
+# ── WeCom live adapter delivery ───────────────────────────────────────────
+
+
+class TestWeComSendMessageDelivery:
+    @pytest.mark.asyncio
+    async def test_wecom_send_uses_live_gateway_adapter(self, monkeypatch):
+        from tools.send_message_tool import _send_wecom
+
+        adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-1"))
+        )
+        runner = SimpleNamespace(adapters={Platform.WECOM: adapter})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_wecom(SimpleNamespace(extra={}), "group-1", "hello")
+
+        assert result == {
+            "success": True,
+            "platform": "wecom",
+            "chat_id": "group-1",
+            "message_id": "msg-1",
+        }
+        adapter.send.assert_awaited_once_with(chat_id="group-1", content="hello")
+
+    @pytest.mark.asyncio
+    async def test_wecom_send_marshals_to_gateway_loop(self, monkeypatch):
+        import threading
+        from tools.send_message_tool import _send_wecom
+
+        gateway_loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=gateway_loop.run_forever)
+        thread.start()
+        observed = {}
+
+        async def fake_send(*, chat_id, content):
+            observed["loop"] = asyncio.get_running_loop()
+            observed["chat_id"] = chat_id
+            observed["content"] = content
+            return SimpleNamespace(success=True, message_id="msg-loop")
+
+        runner = SimpleNamespace(
+            adapters={Platform.WECOM: SimpleNamespace(send=fake_send)},
+            _gateway_loop=gateway_loop,
+        )
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        try:
+            result = await _send_wecom(SimpleNamespace(extra={}), "group-1", "hello")
+        finally:
+            gateway_loop.call_soon_threadsafe(gateway_loop.stop)
+            thread.join(timeout=2)
+            gateway_loop.close()
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-loop"
+        assert observed == {
+            "loop": gateway_loop,
+            "chat_id": "group-1",
+            "content": "hello",
+        }
+
+    @pytest.mark.asyncio
+    async def test_wecom_send_reports_stale_gateway_loop(self, monkeypatch):
+        from tools.send_message_tool import _send_wecom
+
+        gateway_loop = asyncio.new_event_loop()
+        runner = SimpleNamespace(
+            adapters={Platform.WECOM: SimpleNamespace(send=AsyncMock())},
+            _gateway_loop=gateway_loop,
+        )
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        try:
+            result = await _send_wecom(SimpleNamespace(extra={}), "group-1", "hello")
+        finally:
+            gateway_loop.close()
+
+        assert result == {"error": "WeCom live adapter gateway event loop is not running"}
+        runner.adapters[Platform.WECOM].send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wecom_send_without_live_adapter_blocks_standalone_by_default(self, monkeypatch):
+        from tools.send_message_tool import _send_wecom
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        standalone = AsyncMock(return_value={"success": True})
+        monkeypatch.setattr("tools.send_message_tool._send_wecom_standalone", standalone)
+
+        result = await _send_wecom(SimpleNamespace(extra={}), "group-1", "hello")
+
+        assert "error" in result
+        assert "live gateway adapter" in result["error"]
+        standalone.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wecom_send_can_opt_into_standalone_fallback(self, monkeypatch):
+        from tools.send_message_tool import _send_wecom
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        standalone = AsyncMock(return_value={"success": True, "message_id": "legacy-1"})
+        monkeypatch.setattr("tools.send_message_tool._send_wecom_standalone", standalone)
+        pconfig = SimpleNamespace(extra={"allow_standalone_send": "true", "bot_id": "bot"})
+
+        result = await _send_wecom(pconfig, "group-1", "hello")
+
+        assert result == {"success": True, "message_id": "legacy-1"}
+        standalone.assert_awaited_once_with(pconfig.extra, "group-1", "hello")
+
+
 # ── _send_via_adapter standalone fallback ────────────────────────────────
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -188,7 +188,9 @@ def _handle_send(args):
             from gateway.channel_directory import resolve_channel_name
             resolved = resolve_channel_name(platform_name, target_ref)
             if resolved:
-                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_name, resolved)
+                chat_id = parsed_chat_id if resolved_is_explicit else resolved
+                thread_id = parsed_thread_id
             else:
                 return json.dumps({
                     "error": f"Could not resolve '{target_ref}' on {platform_name}. "

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -725,7 +725,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.FEISHU:
             result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
-            result = await _send_wecom(pconfig.extra, chat_id, chunk)
+            result = await _send_wecom(pconfig, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
@@ -1630,8 +1630,77 @@ async def _send_dingtalk(extra, chat_id, message):
         return _error(f"DingTalk send failed: {e}")
 
 
-async def _send_wecom(extra, chat_id, message):
-    """Send via WeCom using the adapter's WebSocket send pipeline."""
+def _wecom_extra_from_config(pconfig) -> dict:
+    extra = getattr(pconfig, "extra", None)
+    return extra if isinstance(extra, dict) else {}
+
+
+def _wecom_allow_standalone_send(pconfig) -> bool:
+    value = _wecom_extra_from_config(pconfig).get("allow_standalone_send", False)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+async def _send_wecom(pconfig, chat_id, message):
+    """Send via the running WeCom gateway adapter.
+
+    A standalone WeComAdapter opens a second AI Bot WebSocket for the same
+    bot credentials, which can invalidate the main gateway subscription. Keep
+    send_message on the live adapter by default so it reuses cached reply
+    req_ids and the existing subscribed connection.
+    """
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform.WECOM) if runner is not None else None
+    except Exception:
+        adapter = None
+
+    if adapter is not None:
+        try:
+            gateway_loop = getattr(runner, "_gateway_loop", None)
+            try:
+                current_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+
+            if gateway_loop is not None and gateway_loop is not current_loop:
+                if gateway_loop.is_closed() or not gateway_loop.is_running():
+                    return _error("WeCom live adapter gateway event loop is not running")
+                future = asyncio.run_coroutine_threadsafe(
+                    adapter.send(chat_id=chat_id, content=message),
+                    gateway_loop,
+                )
+                result = await asyncio.wrap_future(future)
+            else:
+                result = await adapter.send(chat_id=chat_id, content=message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            return _error(f"WeCom live adapter send failed: {e}")
+        if result.success:
+            return {
+                "success": True,
+                "platform": "wecom",
+                "chat_id": chat_id,
+                "message_id": result.message_id,
+            }
+        return _error(f"WeCom live adapter send failed: {result.error}")
+
+    if not _wecom_allow_standalone_send(pconfig):
+        return _error(
+            "WeCom send_message requires the live gateway adapter. Start the "
+            "gateway with WeCom enabled, or set wecom.allow_standalone_send: "
+            "true to permit the legacy standalone WebSocket fallback."
+        )
+
+    return await _send_wecom_standalone(_wecom_extra_from_config(pconfig), chat_id, message)
+
+
+async def _send_wecom_standalone(extra, chat_id, message):
+    """Legacy standalone WeCom sender, gated by allow_standalone_send."""
     try:
         from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
         if not check_wecom_requirements():

--- a/website/docs/user-guide/messaging/wecom.md
+++ b/website/docs/user-guide/messaging/wecom.md
@@ -107,6 +107,8 @@ Set these in `config.yaml` under `platforms.wecom.extra`:
 | `allow_from` | `[]` | User IDs allowed for DMs (when dm_policy=allowlist) |
 | `group_allow_from` | `[]` | Group IDs allowed (when group_policy=allowlist) |
 | `groups` | `{}` | Per-group configuration (see below) |
+| `channel_aliases` | `{}` | Friendly names for opaque WeCom chat IDs used by `send_message` |
+| `allow_standalone_send` | `false` | Allow legacy out-of-process `send_message` delivery by opening a temporary WeCom WebSocket |
 
 ## Access Policies
 
@@ -177,6 +179,19 @@ platforms:
 
 If no `allow_from` is configured for a group, all users in that group are allowed (assuming the group itself passes the top-level policy check).
 
+### Channel Aliases for `send_message`
+
+WeCom group chat IDs are opaque. If you want the agent to understand requests like "send this to Ops Group", add aliases in `config.yaml`:
+
+```yaml
+wecom:
+  channel_aliases:
+    Ops Group: wr7TcDcQAA9GylAWFpUDz0tAwLMN8g6Q
+    Test Group: wr7TcDcQAAkEDOfbIDtDbTMQvW9FhWcQ
+```
+
+Aliases are added to the channel directory used by `send_message(action="list")` and name resolution. The advanced `platforms.wecom.extra.channel_aliases` form is also supported.
+
 ## Media Support
 
 ### Inbound (receiving)
@@ -231,6 +246,8 @@ When the bot receives a message via the WeCom callback, the adapter remembers th
 If the inbound request context has expired or is unavailable, the adapter falls back to proactive message sending via `aibot_send_msg`.
 
 Reply-mode also works for media: uploaded media can be sent as a reply to the originating message.
+
+For the `send_message` tool, Hermes reuses the live WeCom gateway adapter by default. This avoids opening a second AI Bot WebSocket for the same bot credentials, and lets proactive sends reuse any recent chat request IDs cached by the running gateway. If you explicitly need legacy out-of-process delivery, set `wecom.allow_standalone_send: true`, but this may create a temporary WebSocket and should be used carefully.
 
 ## Connection and Reconnection
 


### PR DESCRIPTION
## Summary
- preserve channel-directory resolutions when the resolved target is not recognized by platform-specific explicit target parsing
- prevent resolved WeCom group display labels from falling back to the configured home channel
- add a regression test using a fake WeCom group ID and display label

## Tests
- venv/bin/pytest tests/tools/test_send_message_tool.py -q