### PR TITLE
feat(cohere): native v2 chat provider + Embed/Rerank tools

### DIFF
--- a/agent/cohere_adapter.py
+++ b/agent/cohere_adapter.py
@@ -1,0 +1,366 @@
+"""Cohere v2 chat adapter for Hermes Agent.
+
+Thin wrapper around the ``cohere`` SDK that:
+
+  - lazy-imports ``cohere`` so non-Cohere sessions don't pay the import cost
+    or the ``provider.cohere`` lazy-install probe;
+  - constructs ``cohere.ClientV2`` instances with the right timeouts and
+    base-URL handling;
+  - processes a ``chat_stream`` SSE event iterator into an OpenAI-shaped
+    ``SimpleNamespace`` response (so the agent loop can treat streaming and
+    non-streaming Cohere responses identically, same pattern as the Bedrock
+    adapter).
+
+All format conversion (messages, tools, request kwargs, response
+normalization) lives in :mod:`agent.transports.cohere`. This module owns
+only the SDK lifecycle and the streaming event-pump.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, List, Optional
+
+from utils import base_url_host_matches, normalize_proxy_env_vars
+
+logger = logging.getLogger(__name__)
+
+# Lazy SDK accessor — mirrors the pattern in anthropic_adapter._get_anthropic_sdk.
+_cohere_sdk: Any = ...  # sentinel — None means "tried and missing"
+
+
+def _get_cohere_sdk():
+    """Return the ``cohere`` SDK module, importing lazily.
+
+    Returns None when the package is not installed and the lazy-install
+    path also failed (offline / opted out). Callers must handle None
+    with a clear error message.
+    """
+    global _cohere_sdk
+    if _cohere_sdk is ...:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+
+            _lazy_ensure("provider.cohere", prompt=False)
+        except ImportError:
+            pass
+        except Exception:
+            # FeatureUnavailable — fall through to the ImportError handling below
+            pass
+        try:
+            import cohere as _sdk
+
+            _cohere_sdk = _sdk
+        except ImportError:
+            _cohere_sdk = None
+    return _cohere_sdk
+
+
+def is_cohere_url(base_url: str | None) -> bool:
+    """Return True when *base_url* points at Cohere's public API host."""
+    if not base_url:
+        return False
+    return base_url_host_matches(base_url, "api.cohere.com") or base_url_host_matches(
+        base_url, "api.cohere.ai"
+    )
+
+
+def build_cohere_client(
+    api_key: str,
+    base_url: str | None = None,
+    timeout: float | None = None,
+):
+    """Construct a ``cohere.ClientV2`` instance.
+
+    The Cohere SDK accepts a ``client_name`` for usage telemetry; we tag
+    every request with ``hermes-agent`` so Cohere can attribute traffic
+    and so users can identify their requests in dashboards.
+
+    Args:
+        api_key: Cohere API key. Required — Cohere has no anonymous tier.
+        base_url: Optional override (defaults to ``https://api.cohere.com``).
+            Useful for staging / proxy / self-hosted Cohere deployments.
+        timeout: Read timeout in seconds. ``None`` uses the SDK default.
+
+    Raises:
+        ImportError: if the ``cohere`` package is not installed and the
+            lazy-install path is unavailable.
+    """
+    sdk = _get_cohere_sdk()
+    if sdk is None:
+        raise ImportError(
+            "The 'cohere' package is required for the Cohere provider. "
+            "Install it with: pip install cohere>=5.13\n"
+            "Or install Hermes with Cohere support: pip install -e '.[cohere]'"
+        )
+
+    normalize_proxy_env_vars()
+
+    kwargs: Dict[str, Any] = {
+        "api_key": api_key,
+        "client_name": "hermes-agent",
+    }
+    if base_url:
+        kwargs["base_url"] = base_url
+    if isinstance(timeout, (int, float)) and timeout > 0:
+        kwargs["timeout"] = float(timeout)
+
+    return sdk.ClientV2(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Streaming: turn a chat_stream event iterator into a non-streaming response.
+# ---------------------------------------------------------------------------
+
+
+def _coerce_event(event: Any) -> Dict[str, Any]:
+    """Return a dict view of a Cohere stream event.
+
+    The SDK emits typed Pydantic objects; we accept dicts as well so tests
+    can drive this with hand-built fixtures. Falls back to ``__dict__`` if
+    the object exposes neither ``.model_dump()`` nor ``.dict()``.
+    """
+    if isinstance(event, dict):
+        return event
+    for attr in ("model_dump", "dict"):
+        fn = getattr(event, attr, None)
+        if callable(fn):
+            try:
+                value = fn()
+                if isinstance(value, dict):
+                    return value
+            except Exception:
+                continue
+    return getattr(event, "__dict__", {}) or {}
+
+
+def _event_type(event_dict: Dict[str, Any]) -> str:
+    """Extract the canonical event type string from a stream event."""
+    t = event_dict.get("type") or event_dict.get("event_type") or ""
+    return str(t)
+
+
+def _nested_get(d: Dict[str, Any], *path: str) -> Any:
+    """Walk a nested dict by key path, returning None on the first miss."""
+    cur: Any = d
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def stream_chat_with_callbacks(
+    stream_iter,
+    on_text_delta: Optional[Callable[[str], None]] = None,
+    on_tool_start: Optional[Callable[[str], None]] = None,
+    on_reasoning_delta: Optional[Callable[[str], None]] = None,
+    on_citation: Optional[Callable[[Dict[str, Any]], None]] = None,
+    on_interrupt_check: Optional[Callable[[], bool]] = None,
+) -> SimpleNamespace:
+    """Process a Cohere ``chat_stream`` event iterator with real-time callbacks.
+
+    Mirrors the shape of ``stream_converse_with_callbacks`` in
+    ``bedrock_adapter.py``: builds up tool calls, text, reasoning, and
+    citations as events arrive, then returns an OpenAI-shaped response
+    object so the rest of the agent loop is provider-agnostic.
+
+    Event types we handle (from the Cohere v2 streaming spec):
+      - ``message-start``           → ignored (response id available later)
+      - ``content-start`` / ``content-end``
+      - ``content-delta``           → ``delta.message.content.text`` chunks
+      - ``tool-plan-delta``         → ``delta.message.tool_plan`` chunks (reasoning)
+      - ``tool-call-start``         → start of a tool call (id + name)
+      - ``tool-call-delta``         → ``delta.message.tool_calls.function.arguments``
+      - ``tool-call-end``
+      - ``citation-start`` / ``citation-end``
+      - ``message-end``             → ``delta.finish_reason``, ``delta.usage``
+
+    Args:
+        stream_iter: An iterable of stream events from ``ClientV2.chat_stream``.
+        on_text_delta: Called with each text chunk while no tool call is in
+            flight. Same semantics as the Anthropic and Bedrock paths — once
+            a tool call starts, text deltas are buffered but not fired.
+        on_tool_start: Called with the tool name when a tool call begins.
+        on_reasoning_delta: Called with each tool_plan chunk (Cohere's
+            equivalent of Anthropic's thinking deltas).
+        on_citation: Called once per emitted citation event with the raw
+            citation dict (start/end offsets, sources, text).
+        on_interrupt_check: Called on each event; truthy return aborts.
+    """
+    text_parts: List[str] = []
+    reasoning_parts: List[str] = []
+    citations: List[Dict[str, Any]] = []
+    tool_calls: List[SimpleNamespace] = []
+    current_tool: Optional[Dict[str, Any]] = None
+    has_tool_use = False
+    finish_reason_raw = "COMPLETE"
+    usage_data: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+    response_id = ""
+
+    for raw in stream_iter:
+        if on_interrupt_check and on_interrupt_check():
+            break
+
+        event = _coerce_event(raw)
+        etype = _event_type(event)
+
+        if etype == "message-start":
+            response_id = str(event.get("id") or _nested_get(event, "message", "id") or "")
+
+        elif etype == "content-delta":
+            text = _nested_get(event, "delta", "message", "content", "text")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+                if on_text_delta and not has_tool_use:
+                    try:
+                        on_text_delta(text)
+                    except Exception:
+                        pass
+
+        elif etype == "tool-plan-delta":
+            chunk = _nested_get(event, "delta", "message", "tool_plan")
+            if isinstance(chunk, str) and chunk:
+                reasoning_parts.append(chunk)
+                if on_reasoning_delta:
+                    try:
+                        on_reasoning_delta(chunk)
+                    except Exception:
+                        pass
+
+        elif etype == "tool-call-start":
+            has_tool_use = True
+            tool_call = _nested_get(event, "delta", "message", "tool_calls") or {}
+            fn = tool_call.get("function") or {}
+            current_tool = {
+                "id": tool_call.get("id", "") or "",
+                "name": fn.get("name", "") or "",
+                "arguments": fn.get("arguments", "") or "",
+            }
+            if on_tool_start and current_tool["name"]:
+                try:
+                    on_tool_start(current_tool["name"])
+                except Exception:
+                    pass
+
+        elif etype == "tool-call-delta":
+            if current_tool is not None:
+                fn = _nested_get(event, "delta", "message", "tool_calls", "function") or {}
+                args_chunk = fn.get("arguments")
+                if isinstance(args_chunk, str):
+                    current_tool["arguments"] += args_chunk
+
+        elif etype == "tool-call-end":
+            if current_tool is not None:
+                args_str = current_tool["arguments"] or "{}"
+                # Validate JSON; if Cohere streamed a malformed args object
+                # we still emit the tool call with the raw string so the
+                # agent's tool dispatcher can surface a useful error.
+                try:
+                    json.loads(args_str)
+                except (json.JSONDecodeError, TypeError):
+                    args_str = current_tool["arguments"] or "{}"
+                tool_calls.append(
+                    SimpleNamespace(
+                        id=current_tool["id"],
+                        type="function",
+                        function=SimpleNamespace(
+                            name=current_tool["name"],
+                            arguments=args_str,
+                        ),
+                    )
+                )
+                current_tool = None
+
+        elif etype == "citation-start":
+            citation = _nested_get(event, "delta", "message", "citations") or {}
+            if isinstance(citation, dict) and citation:
+                citations.append(citation)
+                if on_citation:
+                    try:
+                        on_citation(citation)
+                    except Exception:
+                        pass
+
+        elif etype == "message-end":
+            fr = _nested_get(event, "delta", "finish_reason")
+            if isinstance(fr, str) and fr:
+                finish_reason_raw = fr
+            tokens = _nested_get(event, "delta", "usage", "tokens") or {}
+            if isinstance(tokens, dict):
+                usage_data["input_tokens"] = int(tokens.get("input_tokens") or 0)
+                usage_data["output_tokens"] = int(tokens.get("output_tokens") or 0)
+
+    # Flush a partial tool call if the stream ended mid-flight — preserves
+    # the same lossy-but-useful behaviour the Bedrock adapter has.
+    if current_tool is not None:
+        tool_calls.append(
+            SimpleNamespace(
+                id=current_tool.get("id", ""),
+                type="function",
+                function=SimpleNamespace(
+                    name=current_tool.get("name", ""),
+                    arguments=current_tool.get("arguments", "") or "{}",
+                ),
+            )
+        )
+
+    finish_reason = _cohere_finish_reason_to_openai(finish_reason_raw)
+    if tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
+
+    msg = SimpleNamespace(
+        role="assistant",
+        content="".join(text_parts) if text_parts else None,
+        tool_calls=tool_calls if tool_calls else None,
+        reasoning_content="".join(reasoning_parts) if reasoning_parts else None,
+        citations=citations or None,
+        tool_plan="".join(reasoning_parts) if reasoning_parts else None,
+    )
+
+    usage = SimpleNamespace(
+        prompt_tokens=usage_data["input_tokens"],
+        completion_tokens=usage_data["output_tokens"],
+        total_tokens=usage_data["input_tokens"] + usage_data["output_tokens"],
+    )
+
+    choice = SimpleNamespace(
+        index=0,
+        message=msg,
+        finish_reason=finish_reason,
+    )
+
+    return SimpleNamespace(
+        id=response_id,
+        choices=[choice],
+        usage=usage,
+        model="",
+        finish_reason=finish_reason_raw,
+        message=msg,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finish reason mapping — shared between transport and adapter.
+# ---------------------------------------------------------------------------
+
+# Cohere finish_reason → OpenAI finish_reason
+COHERE_FINISH_REASON_MAP: Dict[str, str] = {
+    "COMPLETE": "stop",
+    "STOP_SEQUENCE": "stop",
+    "MAX_TOKENS": "length",
+    "TOOL_CALL": "tool_calls",
+    "ERROR": "stop",
+    "ERROR_TOXIC": "content_filter",
+    "ERROR_LIMIT": "length",
+    "USER_CANCEL": "stop",
+}
+
+
+def _cohere_finish_reason_to_openai(raw: str) -> str:
+    """Map a Cohere ``finish_reason`` enum value to its OpenAI equivalent."""
+    if not raw:
+        return "stop"
+    return COHERE_FINISH_REASON_MAP.get(str(raw).upper(), "stop")

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,7 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        import agent.transports.cohere  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/cohere.py
+++ b/agent/transports/cohere.py
@@ -1,0 +1,479 @@
+"""Cohere v2 chat transport.
+
+Owns format conversion and response normalization for ``api_mode="cohere_chat"``.
+Client construction, streaming, and credential handling live elsewhere:
+
+  - SDK lifecycle + streaming pump → :mod:`agent.cohere_adapter`
+  - Client construction + retry/timeout policy → :mod:`run_agent`
+
+The transport bridges Hermes's internal OpenAI-shaped message/tool format
+to Cohere's native ``ClientV2.chat`` request shape and back. Cohere v2 is
+close to OpenAI's chat schema, with three notable deltas:
+
+  1. Tool result messages carry a list of ``document`` content blocks
+     instead of a plain string.
+  2. Responses surface ``message.tool_plan`` (chain-of-thought) and
+     ``message.citations`` (RAG grounding) in addition to ``content`` and
+     ``tool_calls``. We map ``tool_plan`` → ``reasoning`` and stash
+     ``citations`` in ``provider_data``.
+  3. ``finish_reason`` uses Cohere's enum (``COMPLETE``/``TOOL_CALL``/...).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.transports.base import ProviderTransport
+from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+logger = logging.getLogger(__name__)
+
+
+# OpenAI fields on tool schemas that Cohere's v2 chat endpoint does not
+# accept. Stripping them keeps callers that pass through the canonical
+# OpenAI-shaped tool list working without per-call manual scrubbing.
+_TOOL_FIELDS_TO_STRIP = ("strict", "cache_control")
+
+
+def _strip_tool_fields(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a deep-copied tool list with Cohere-incompatible fields removed."""
+    cleaned: List[Dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        t = copy.deepcopy(tool)
+        for field_name in _TOOL_FIELDS_TO_STRIP:
+            t.pop(field_name, None)
+            fn = t.get("function")
+            if isinstance(fn, dict):
+                fn.pop(field_name, None)
+        cleaned.append(t)
+    return cleaned
+
+
+def _coerce_tool_result_content(content: Any) -> List[Dict[str, Any]]:
+    """Normalize an OpenAI tool-message ``content`` field to Cohere's shape.
+
+    Cohere expects tool results as a list of ``{"type": "document",
+    "document": {"data": <str>}}`` blocks. OpenAI tool messages carry a
+    plain string (or sometimes a list of content parts when the producer
+    is gemini-via-openai). We accept both and emit the Cohere shape.
+    """
+    if isinstance(content, str):
+        data = content
+    elif isinstance(content, list):
+        # Best-effort flattening of OpenAI content-parts → a single string.
+        parts: List[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                if isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+                elif isinstance(part.get("data"), str):
+                    parts.append(part["data"])
+        data = "\n".join(parts)
+    elif content is None:
+        data = ""
+    else:
+        try:
+            data = json.dumps(content, ensure_ascii=False)
+        except (TypeError, ValueError):
+            data = str(content)
+    return [{"type": "document", "document": {"data": data}}]
+
+
+def _convert_message(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate a single OpenAI-shape message to Cohere v2."""
+    role = msg.get("role")
+    if role == "tool":
+        # tool_call_id + content (string or content parts) → Cohere doc blocks
+        return {
+            "role": "tool",
+            "tool_call_id": msg.get("tool_call_id") or msg.get("id") or "",
+            "content": _coerce_tool_result_content(msg.get("content")),
+        }
+
+    if role == "assistant" and msg.get("tool_calls"):
+        # Re-emit assistant tool-call turns in Cohere's shape. Tool plan
+        # (reasoning) is preserved when the caller stored it on the
+        # message via the canonical ``reasoning`` field.
+        out: Dict[str, Any] = {"role": "assistant"}
+        content = msg.get("content")
+        if isinstance(content, str) and content:
+            out["content"] = content
+        tool_plan = msg.get("reasoning") or msg.get("tool_plan")
+        if isinstance(tool_plan, str) and tool_plan:
+            out["tool_plan"] = tool_plan
+        out_tool_calls: List[Dict[str, Any]] = []
+        for tc in msg["tool_calls"]:
+            if not isinstance(tc, dict):
+                tc_id = getattr(tc, "id", "") or ""
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", "") if fn is not None else ""
+                arguments = getattr(fn, "arguments", "") if fn is not None else ""
+            else:
+                tc_id = tc.get("id") or ""
+                fn = tc.get("function") or {}
+                name = fn.get("name", "") if isinstance(fn, dict) else ""
+                arguments = fn.get("arguments", "") if isinstance(fn, dict) else ""
+            if isinstance(arguments, (dict, list)):
+                arguments = json.dumps(arguments)
+            out_tool_calls.append(
+                {
+                    "id": tc_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments or "{}"},
+                }
+            )
+        out["tool_calls"] = out_tool_calls
+        return out
+
+    # System / user / assistant (text-only) — pass through. Strip
+    # OpenAI-specific extras Cohere ignores or rejects.
+    cleaned: Dict[str, Any] = {"role": role}
+    content = msg.get("content")
+    if content is not None:
+        cleaned["content"] = content
+    name = msg.get("name")
+    if isinstance(name, str) and name:
+        cleaned["name"] = name
+    return cleaned
+
+
+class CohereTransport(ProviderTransport):
+    """Transport for ``api_mode="cohere_chat"``."""
+
+    @property
+    def api_mode(self) -> str:
+        return "cohere_chat"
+
+    # ── Message + tool conversion ─────────────────────────────────
+
+    def convert_messages(
+        self, messages: List[Dict[str, Any]], **kwargs
+    ) -> List[Dict[str, Any]]:
+        """Translate OpenAI-shape messages to Cohere v2 chat shape.
+
+        Empty / None messages are dropped to keep Cohere from rejecting
+        empty assistant turns produced by upstream sanitisation.
+        """
+        out: List[Dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            converted = _convert_message(msg)
+            out.append(converted)
+        return out
+
+    def convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Cohere v2 accepts the OpenAI function-tool shape — strip extras only."""
+        if not tools:
+            return []
+        return _strip_tool_fields(tools)
+
+    # ── Request kwargs ────────────────────────────────────────────
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        **params,
+    ) -> Dict[str, Any]:
+        """Assemble ``ClientV2.chat`` kwargs.
+
+        Recognised params (all optional):
+            max_tokens: int
+            temperature: float
+            top_p: float
+            stop_sequences: list[str]
+            reasoning_config: dict | None — Hermes generic reasoning knob
+            tool_choice: "auto" | "any" | "none"
+            provider_profile: ProviderProfile | None — drives extra_body
+            # Cohere-only knobs, may also flow via provider_profile.build_extra_body
+            safety_mode: str
+            citation_options: dict
+            documents: list
+            connectors: list
+            force_single_step: bool
+            thinking_token_budget: int | None
+        """
+        kwargs: Dict[str, Any] = {
+            "model": model,
+            "messages": self.convert_messages(messages),
+        }
+
+        converted_tools = self.convert_tools(tools or [])
+        if converted_tools:
+            kwargs["tools"] = converted_tools
+
+        max_tokens = params.get("max_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            kwargs["max_tokens"] = max_tokens
+
+        temperature = params.get("temperature")
+        if isinstance(temperature, (int, float)):
+            kwargs["temperature"] = float(temperature)
+
+        top_p = params.get("top_p")
+        if isinstance(top_p, (int, float)):
+            kwargs["p"] = float(top_p)
+
+        stop_sequences = params.get("stop_sequences")
+        if isinstance(stop_sequences, list) and stop_sequences:
+            kwargs["stop_sequences"] = [str(s) for s in stop_sequences]
+
+        tool_choice = params.get("tool_choice")
+        if isinstance(tool_choice, str) and tool_choice in {"auto", "any", "none"}:
+            kwargs["tool_choice"] = tool_choice.upper() if tool_choice != "auto" else "AUTO"
+
+        # ── Cohere-native knobs via provider profile ──────────────
+        profile = params.get("provider_profile")
+        extra_body: Dict[str, Any] = {}
+        if profile is not None:
+            try:
+                profile_body = profile.build_extra_body(
+                    session_id=params.get("session_id"),
+                    model=model,
+                    reasoning_config=params.get("reasoning_config"),
+                    safety_mode=params.get("safety_mode"),
+                    citation_options=params.get("citation_options"),
+                    documents=params.get("documents"),
+                    connectors=params.get("connectors"),
+                    force_single_step=params.get("force_single_step"),
+                    thinking_token_budget=params.get("thinking_token_budget"),
+                )
+                if isinstance(profile_body, dict):
+                    extra_body.update(profile_body)
+            except Exception as exc:
+                logger.debug("CohereProfile.build_extra_body failed: %s", exc)
+
+        # Allow direct override from params even when the profile path
+        # isn't taken (e.g. unit tests that exercise the transport in
+        # isolation).
+        for key in (
+            "safety_mode",
+            "citation_options",
+            "documents",
+            "connectors",
+            "force_single_step",
+            "thinking",
+        ):
+            if key in extra_body:
+                continue
+            value = params.get(key)
+            if value is None:
+                continue
+            if key == "force_single_step":
+                if value is True:
+                    extra_body["force_single_step"] = True
+            elif key == "safety_mode":
+                if isinstance(value, str) and value.strip():
+                    extra_body["safety_mode"] = value.strip().upper()
+            elif key in {"citation_options"}:
+                if isinstance(value, dict) and value:
+                    extra_body[key] = value
+            elif key in {"documents", "connectors"}:
+                if isinstance(value, list) and value:
+                    extra_body[key] = value
+            elif key == "thinking":
+                if isinstance(value, dict) and value:
+                    extra_body[key] = value
+
+        # Apply Cohere-native fields as top-level kwargs (the SDK uses
+        # these names on ClientV2.chat directly).
+        for key, value in extra_body.items():
+            kwargs[key] = value
+
+        return kwargs
+
+    # ── Response normalization ────────────────────────────────────
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        """Translate a Cohere ``ClientV2.chat`` response to ``NormalizedResponse``."""
+        message = getattr(response, "message", None)
+
+        # Text content — Cohere returns content as a list of typed blocks
+        # ([{type: "text", text: "..."}] for assistant text, possibly
+        # multiple blocks when citations chunk the response).
+        text_parts: List[str] = []
+        if message is not None:
+            content_blocks = getattr(message, "content", None)
+            if isinstance(content_blocks, list):
+                for block in content_blocks:
+                    block_type = getattr(block, "type", None) or (
+                        block.get("type") if isinstance(block, dict) else None
+                    )
+                    if block_type == "text":
+                        text = getattr(block, "text", None)
+                        if text is None and isinstance(block, dict):
+                            text = block.get("text")
+                        if isinstance(text, str):
+                            text_parts.append(text)
+            elif isinstance(content_blocks, str):
+                text_parts.append(content_blocks)
+
+        # Reasoning — Cohere's tool_plan is the model's chain of thought
+        # before issuing tool calls. Surfacing it as `reasoning` lines up
+        # with how Anthropic thinking blocks are exposed.
+        reasoning_text: Optional[str] = None
+        if message is not None:
+            tp = getattr(message, "tool_plan", None)
+            if isinstance(tp, str) and tp:
+                reasoning_text = tp
+
+        # Tool calls
+        tool_calls: List[ToolCall] = []
+        if message is not None:
+            raw_tool_calls = getattr(message, "tool_calls", None) or []
+            for tc in raw_tool_calls:
+                tc_id = getattr(tc, "id", None) or (
+                    tc.get("id") if isinstance(tc, dict) else None
+                )
+                fn = getattr(tc, "function", None)
+                if fn is None and isinstance(tc, dict):
+                    fn = tc.get("function")
+                name = ""
+                arguments: Any = ""
+                if fn is not None:
+                    name = getattr(fn, "name", None) or (
+                        fn.get("name") if isinstance(fn, dict) else ""
+                    ) or ""
+                    arguments = getattr(fn, "arguments", None)
+                    if arguments is None and isinstance(fn, dict):
+                        arguments = fn.get("arguments")
+                if isinstance(arguments, (dict, list)):
+                    arguments_str = json.dumps(arguments)
+                else:
+                    arguments_str = arguments or "{}"
+                tool_calls.append(
+                    ToolCall(
+                        id=tc_id,
+                        name=name,
+                        arguments=arguments_str,
+                    )
+                )
+
+        # Citations — RAG grounding metadata. Stash in provider_data so
+        # protocol-aware consumers can surface them without polluting
+        # the shared NormalizedResponse surface.
+        citations: List[Any] = []
+        if message is not None:
+            raw_citations = getattr(message, "citations", None)
+            if isinstance(raw_citations, list):
+                for c in raw_citations:
+                    if hasattr(c, "model_dump") and callable(c.model_dump):
+                        try:
+                            citations.append(c.model_dump())
+                            continue
+                        except Exception:
+                            pass
+                    if isinstance(c, dict):
+                        citations.append(c)
+                    else:
+                        citations.append(getattr(c, "__dict__", {}) or {})
+
+        # Finish reason
+        raw_finish = getattr(response, "finish_reason", None) or ""
+        from agent.cohere_adapter import _cohere_finish_reason_to_openai
+
+        finish_reason = _cohere_finish_reason_to_openai(raw_finish)
+        if tool_calls and finish_reason == "stop":
+            finish_reason = "tool_calls"
+
+        # Usage
+        usage: Optional[Usage] = None
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is not None:
+            tokens = getattr(raw_usage, "tokens", None) or raw_usage
+            input_tokens = (
+                getattr(tokens, "input_tokens", None)
+                if not isinstance(tokens, dict)
+                else tokens.get("input_tokens")
+            )
+            output_tokens = (
+                getattr(tokens, "output_tokens", None)
+                if not isinstance(tokens, dict)
+                else tokens.get("output_tokens")
+            )
+            if input_tokens is not None or output_tokens is not None:
+                input_n = int(input_tokens or 0)
+                output_n = int(output_tokens or 0)
+                usage = Usage(
+                    prompt_tokens=input_n,
+                    completion_tokens=output_n,
+                    total_tokens=input_n + output_n,
+                )
+
+        provider_data: Dict[str, Any] = {}
+        if citations:
+            provider_data["citations"] = citations
+        if reasoning_text:
+            # Mirror what other transports do so reasoning_content is
+            # available via NormalizedResponse.reasoning_content.
+            provider_data["reasoning_content"] = reasoning_text
+
+        return NormalizedResponse(
+            content="".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls or None,
+            finish_reason=finish_reason,
+            reasoning=reasoning_text,
+            usage=usage,
+            provider_data=provider_data or None,
+        )
+
+    def validate_response(self, response: Any) -> bool:
+        """Empty text is valid when the model is handing off to tools."""
+        if response is None:
+            return False
+        message = getattr(response, "message", None)
+        if message is None:
+            return False
+        # Tool-call turns may have no text content; assistant text turns
+        # must have non-empty content (mirrors Anthropic's behaviour).
+        content_blocks = getattr(message, "content", None)
+        has_text = False
+        if isinstance(content_blocks, list):
+            for block in content_blocks:
+                btype = getattr(block, "type", None) or (
+                    block.get("type") if isinstance(block, dict) else None
+                )
+                if btype == "text":
+                    text = getattr(block, "text", None)
+                    if text is None and isinstance(block, dict):
+                        text = block.get("text")
+                    if isinstance(text, str) and text.strip():
+                        has_text = True
+                        break
+        elif isinstance(content_blocks, str) and content_blocks.strip():
+            has_text = True
+
+        if has_text:
+            return True
+
+        tool_calls = getattr(message, "tool_calls", None)
+        if tool_calls:
+            return True
+
+        raw_finish = str(getattr(response, "finish_reason", "") or "").upper()
+        return raw_finish == "TOOL_CALL"
+
+    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
+        """Cohere does not expose prompt-cache statistics."""
+        return None
+
+    def map_finish_reason(self, raw_reason: str) -> str:
+        """Map Cohere's finish_reason enum to the OpenAI vocabulary."""
+        from agent.cohere_adapter import _cohere_finish_reason_to_openai
+
+        return _cohere_finish_reason_to_openai(raw_reason)
+
+
+# Auto-register on import
+from agent.transports import register_transport  # noqa: E402
+
+register_transport("cohere_chat", CohereTransport)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -780,6 +780,34 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Cohere native v2 chat provider configuration.
+    # Only used when model.provider is "cohere" (api_mode="cohere_chat").
+    # These fields are forwarded by CohereTransport.build_kwargs() into
+    # cohere.ClientV2.chat() on every request. Leave defaults alone unless
+    # you want to opt in to a specific Cohere-only feature.
+    "cohere": {
+        # safety_mode: one of "CONTEXTUAL" (default), "STRICT", "OFF". STRICT
+        # enables Cohere's most restrictive content filtering; OFF disables it.
+        # See: https://docs.cohere.com/docs/safety-modes
+        "safety_mode": "CONTEXTUAL",
+        # citation_options.mode: "FAST" | "ACCURATE" | "OFF". When you pass
+        # documents=[...] via request_overrides, Cohere returns citation
+        # spans linking each generated phrase back to a source document.
+        "citation_options": {"mode": "ACCURATE"},
+        # force_single_step: when true, the model emits at most one tool
+        # call per turn. Leave false for multi-step / agentic loops.
+        "force_single_step": False,
+        # connectors: list of Cohere hosted retrievers attached to every
+        # request. Example: [{"id": "web-search"}] enables hosted web
+        # search; results are surfaced as citations.
+        "connectors": [],
+        # thinking_token_budget: override the budget for Command A Reasoning
+        # models. When unset, the budget is derived from
+        # reasoning_config.effort (low=2048 / medium=8192 / high=16384 /
+        # xhigh=32768). Set to a positive integer to pin a specific budget.
+        "thinking_token_budget": None,
+    },
+
     # Auxiliary model config — provider:model for each side task.
     # Format: provider is the provider name, model is the model slug.
     # "auto" for provider = auto-detect best available provider.
@@ -1761,6 +1789,23 @@ OPTIONAL_ENV_VARS = {
     "GMI_BASE_URL": {
         "description": "GMI Cloud base URL override",
         "prompt": "GMI Cloud base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "COHERE_API_KEY": {
+        "description": "Cohere API key (enables provider=cohere, cohere_embed, cohere_rerank)",
+        "prompt": "Cohere API key",
+        "url": "https://dashboard.cohere.com/api-keys",
+        "password": True,
+        "tools": ["cohere_embed", "cohere_rerank"],
+        "category": "provider",
+        "advanced": True,
+    },
+    "COHERE_BASE_URL": {
+        "description": "Cohere base URL override (defaults to https://api.cohere.com)",
+        "prompt": "Cohere base URL (leave empty for default)",
         "url": None,
         "password": False,
         "category": "provider",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -199,6 +199,15 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    # Cohere — native v2 chat API via the cohere SDK (ClientV2). The
+    # transport is "cohere_chat" so determine_api_mode() routes through
+    # CohereTransport instead of the OpenAI chat_completions path.
+    "cohere": HermesOverlay(
+        transport="cohere_chat",
+        extra_env_vars=("COHERE_API_KEY", "CO_API_KEY"),
+        base_url_override="https://api.cohere.com",
+        base_url_env_var="COHERE_BASE_URL",
+    ),
 }
 
 
@@ -329,6 +338,12 @@ ALIASES: Dict[str, str] = {
     "arcee-ai": "arcee",
     "arceeai": "arcee",
 
+    # cohere
+    "command": "cohere",
+    "command-r": "cohere",
+    "command-a": "cohere",
+    "cohere-ai": "cohere",
+
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
@@ -361,6 +376,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
+    "cohere": "Cohere",
 }
 
 
@@ -371,6 +387,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
     "bedrock_converse": "bedrock_converse",
+    "cohere_chat": "cohere_chat",
 }
 
 
@@ -500,6 +517,8 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
                 return "anthropic_messages"
             if "api.openai.com" in url_lower:
                 return "codex_responses"
+            if "api.cohere.com" in url_lower or "api.cohere.ai" in url_lower:
+                return "cohere_chat"
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
 
     # Direct provider checks for providers not in HERMES_OVERLAYS
@@ -516,6 +535,8 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
             return "anthropic_messages"
         if hostname == "api.openai.com":
             return "codex_responses"
+        if hostname == "api.cohere.com" or hostname == "api.cohere.ai":
+            return "cohere_chat"
         if hostname.startswith("bedrock-runtime.") and base_url_host_matches(base_url, "amazonaws.com"):
             return "bedrock_converse"
 

--- a/plugins/model-providers/cohere/__init__.py
+++ b/plugins/model-providers/cohere/__init__.py
@@ -1,0 +1,162 @@
+"""Native Cohere provider profile.
+
+Cohere ships a v2 chat API at ``api.cohere.com/v2/chat`` that supports
+tool calling, streaming, RAG documents with citations, hosted connectors
+(e.g. web-search), safety modes, and extended-thinking models. This
+profile routes Hermes through the ``cohere`` Python SDK
+(``cohere.ClientV2``) via the ``cohere_chat`` api_mode and the
+``CohereTransport`` in :mod:`agent.transports.cohere`.
+
+The profile is declarative — it carries auth/endpoint metadata and a
+``build_extra_body`` hook that surfaces Cohere-only request fields
+(``safety_mode``, ``documents``, ``connectors``, ``citation_options``,
+``force_single_step``, ``thinking``). Client construction lives in
+``run_agent.py`` (via :mod:`agent.cohere_adapter`).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+
+# Hermes reasoning effort → Cohere thinking token_budget. Mirrors the
+# THINKING_BUDGET map in anthropic_adapter so users get comparable
+# behaviour when toggling between providers.
+_COHERE_THINKING_BUDGET = {
+    "low": 2048,
+    "medium": 8192,
+    "high": 16384,
+    "xhigh": 32768,
+}
+
+
+def _model_supports_thinking(model: str) -> bool:
+    """Return True when the model accepts Cohere's ``thinking`` field.
+
+    Cohere documents extended thinking on the ``command-a-reasoning``
+    family. Other Command models reject the field with HTTP 400, so
+    we only attach it for reasoning-capable models.
+    """
+    m = (model or "").strip().lower()
+    return "command-a-reasoning" in m or "command-r-reasoning" in m
+
+
+class CohereProfile(ProviderProfile):
+    """Cohere v2 chat — native SDK, native tool_plan + citations."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Fetch chat-capable models from Cohere's ``/v1/models`` endpoint.
+
+        Cohere accepts ``Bearer`` auth on the REST models endpoint and
+        supports an ``endpoint=chat`` filter so we drop embed/rerank
+        models. Returns ``None`` on any failure so the caller falls
+        back to ``self.fallback_models``.
+        """
+        if not api_key:
+            return None
+        url = "https://api.cohere.com/v1/models?endpoint=chat&page_size=200"
+        try:
+            req = urllib.request.Request(url)
+            req.add_header("Authorization", f"Bearer {api_key}")
+            req.add_header("Accept", "application/json")
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            models = data.get("models", [])
+            return [
+                m["name"]
+                for m in models
+                if isinstance(m, dict) and isinstance(m.get("name"), str)
+            ]
+        except Exception as exc:
+            logger.debug("fetch_models(cohere): %s", exc)
+            return None
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Surface Cohere-only request fields read from the call context.
+
+        The transport's ``build_kwargs`` reads these straight from
+        ``extra_body`` (rather than top-level kwargs) so the same plumbing
+        path used by every other provider feeds through cleanly. Keys
+        that are unset / empty are omitted so we never send empty
+        ``documents=[]`` or ``connectors=[]`` to Cohere (the API treats
+        the presence of those fields as an instruction).
+        """
+        body: dict[str, Any] = {}
+
+        safety_mode = context.get("safety_mode")
+        if isinstance(safety_mode, str) and safety_mode.strip():
+            body["safety_mode"] = safety_mode.strip().upper()
+
+        documents = context.get("documents")
+        if isinstance(documents, list) and documents:
+            body["documents"] = documents
+
+        connectors = context.get("connectors")
+        if isinstance(connectors, list) and connectors:
+            body["connectors"] = connectors
+
+        citation_options = context.get("citation_options")
+        if isinstance(citation_options, dict) and citation_options:
+            body["citation_options"] = citation_options
+
+        if context.get("force_single_step") is True:
+            body["force_single_step"] = True
+
+        # Reasoning: Hermes uses a generic ``reasoning_config`` dict
+        # ({"enabled": bool, "effort": "low|medium|high|xhigh"}). For
+        # Command A Reasoning models we translate this to Cohere's
+        # ``thinking`` field. ``cohere.thinking_token_budget`` from
+        # config.yaml overrides the effort-derived budget.
+        reasoning_config = context.get("reasoning_config")
+        explicit_budget = context.get("thinking_token_budget")
+        model = context.get("model") or ""
+        if _model_supports_thinking(model):
+            token_budget: int | None = None
+            if isinstance(explicit_budget, int) and explicit_budget > 0:
+                token_budget = explicit_budget
+            elif isinstance(reasoning_config, dict) and reasoning_config.get("enabled", True):
+                effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
+                token_budget = _COHERE_THINKING_BUDGET.get(effort, _COHERE_THINKING_BUDGET["medium"])
+            if token_budget is not None:
+                body["thinking"] = {"type": "enabled", "token_budget": int(token_budget)}
+
+        return body
+
+
+cohere = CohereProfile(
+    name="cohere",
+    aliases=("command", "command-r", "command-a", "cohere-ai"),
+    api_mode="cohere_chat",
+    display_name="Cohere",
+    description="Cohere — native v2 chat API (tool_plan, citations, connectors, safety_mode)",
+    signup_url="https://dashboard.cohere.com/api-keys",
+    env_vars=("COHERE_API_KEY", "CO_API_KEY"),
+    base_url="https://api.cohere.com",
+    hostname="api.cohere.com",
+    auth_type="api_key",
+    default_aux_model="command-r7b-12-2024",
+    fallback_models=(
+        "command-a-03-2025",
+        "command-a-reasoning-08-2025",
+        "command-r-plus-08-2024",
+        "command-r-08-2024",
+        "command-r7b-12-2024",
+    ),
+)
+
+register_provider(cohere)

--- a/plugins/model-providers/cohere/plugin.yaml
+++ b/plugins/model-providers/cohere/plugin.yaml
@@ -1,0 +1,5 @@
+name: cohere-provider
+kind: model-provider
+version: 1.0.0
+description: Cohere (Command R, Command A, Command A Reasoning) via the native v2 chat API
+author: Nous Research

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ dependencies = [
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
 anthropic = ["anthropic==0.86.0"]
+# Native Cohere provider — only needed when provider=cohere (uses Cohere's
+# native v2 chat API via cohere.ClientV2 for tool_plan / citations /
+# connectors / safety_mode / thinking, plus the cohere_embed and
+# cohere_rerank tools).
+cohere = ["cohere==5.13.0"]
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -1267,7 +1267,7 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
-        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
+        if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "cohere_chat"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
@@ -1297,6 +1297,14 @@ class AIAgent:
             # AWS Bedrock — auto-detect from provider name or base URL
             # (bedrock-runtime.<region>.amazonaws.com).
             self.api_mode = "bedrock_converse"
+        elif self.provider == "cohere" or (
+            provider_name is None
+            and self._base_url_hostname in ("api.cohere.com", "api.cohere.ai")
+        ):
+            # Cohere native v2 chat — routes through CohereTransport and
+            # cohere.ClientV2 instead of the OpenAI chat_completions path.
+            self.api_mode = "cohere_chat"
+            self.provider = "cohere"
         else:
             self.api_mode = "chat_completions"
 
@@ -1631,6 +1639,49 @@ class AIAgent:
             if not self.quiet_mode:
                 _gr_label = " + Guardrails" if self._bedrock_guardrail_config else ""
                 print(f"🤖 AI Agent initialized with model: {self.model} (AWS Bedrock, {self._bedrock_region}{_gr_label})")
+        elif self.api_mode == "cohere_chat":
+            # Cohere native v2 chat — uses cohere.ClientV2 directly. No
+            # OpenAI client needed; client lifecycle is owned by the
+            # cohere SDK. Auth is API-key only.
+            from agent.cohere_adapter import build_cohere_client
+            self._cohere_api_key = api_key or ""
+            self._cohere_base_url = base_url or "https://api.cohere.com"
+            try:
+                self._cohere_client = build_cohere_client(
+                    self._cohere_api_key,
+                    self._cohere_base_url,
+                    timeout=_provider_timeout,
+                )
+            except ImportError:
+                # Defer the failure to first use rather than crashing
+                # at construction — keeps lazy-install paths usable.
+                self._cohere_client = None
+            # Snapshot Cohere-only request knobs from config.yaml so the
+            # transport can pass them through build_extra_body without
+            # an extra config read on every call.
+            self._cohere_runtime_config: dict = {}
+            try:
+                from hermes_cli.config import load_config as _load_co_cfg
+                _co = _load_co_cfg().get("cohere", {}) or {}
+                if isinstance(_co, dict):
+                    if isinstance(_co.get("safety_mode"), str) and _co["safety_mode"].strip():
+                        self._cohere_runtime_config["safety_mode"] = _co["safety_mode"].strip().upper()
+                    if isinstance(_co.get("citation_options"), dict) and _co["citation_options"]:
+                        self._cohere_runtime_config["citation_options"] = _co["citation_options"]
+                    if isinstance(_co.get("connectors"), list) and _co["connectors"]:
+                        self._cohere_runtime_config["connectors"] = _co["connectors"]
+                    if _co.get("force_single_step") is True:
+                        self._cohere_runtime_config["force_single_step"] = True
+                    if isinstance(_co.get("thinking_token_budget"), int) and _co["thinking_token_budget"] > 0:
+                        self._cohere_runtime_config["thinking_token_budget"] = _co["thinking_token_budget"]
+            except Exception:
+                pass
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                print(f"🤖 AI Agent initialized with model: {self.model} (Cohere native v2)")
+                if self._cohere_api_key and len(self._cohere_api_key) > 12:
+                    print(f"🔑 Using key: {self._cohere_api_key[:8]}...{self._cohere_api_key[-4:]}")
         else:
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
@@ -2480,6 +2531,11 @@ class AIAgent:
                 "anthropic_api_key": self._anthropic_api_key,
                 "anthropic_base_url": self._anthropic_base_url,
                 "is_anthropic_oauth": self._is_anthropic_oauth,
+            })
+        elif self.api_mode == "cohere_chat":
+            self._primary_runtime.update({
+                "cohere_api_key": getattr(self, "_cohere_api_key", ""),
+                "cohere_base_url": getattr(self, "_cohere_base_url", ""),
             })
 
     def _get_session_db_for_recall(self):
@@ -7363,6 +7419,23 @@ class AIAgent:
             self._try_refresh_anthropic_client_credentials()
         return self._anthropic_client.messages.create(**api_kwargs)
 
+    def _cohere_chat_create(self, api_kwargs: dict):
+        """Call ``cohere.ClientV2.chat`` for a non-streaming Cohere request.
+
+        The client is constructed once at __init__; this thin wrapper exists
+        so the dispatch site in ``_interruptible_api_call`` mirrors the
+        anthropic / bedrock branches symmetrically and so credential-refresh
+        hooks (if Cohere ever grows OAuth) have a single insertion point.
+        """
+        if self._cohere_client is None:
+            from agent.cohere_adapter import build_cohere_client
+            self._cohere_client = build_cohere_client(
+                self._cohere_api_key,
+                getattr(self, "_cohere_base_url", None),
+                timeout=get_provider_request_timeout(self.provider, self.model),
+            )
+        return self._cohere_client.chat(**api_kwargs)
+
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt or stale call.
 
@@ -7420,6 +7493,11 @@ class AIAgent:
                     )
                 elif self.api_mode == "anthropic_messages":
                     result["response"] = self._anthropic_messages_create(api_kwargs)
+                elif self.api_mode == "cohere_chat":
+                    # Cohere uses cohere.ClientV2 directly — no OpenAI client
+                    # needed. The transport already built api_kwargs in the
+                    # SDK's expected shape.
+                    result["response"] = self._cohere_chat_create(api_kwargs)
                 elif self.api_mode == "bedrock_converse":
                     # Bedrock uses boto3 directly — no OpenAI client needed.
                     # normalize_converse_response produces an OpenAI-compatible
@@ -7803,6 +7881,65 @@ class AIAgent:
                 t.join(timeout=0.3)
                 if self._interrupt_requested:
                     raise InterruptedError("Agent interrupted during Bedrock API call")
+            if result["error"] is not None:
+                raise result["error"]
+            return result["response"]
+
+        # Cohere v2 uses cohere.ClientV2.chat_stream() with SSE events; the
+        # adapter pump normalizes those into an OpenAI-shaped response so
+        # the rest of the agent loop is provider-agnostic.
+        if self.api_mode == "cohere_chat":
+            result = {"response": None, "error": None}
+            first_delta_fired = {"done": False}
+
+            def _fire_first_co():
+                if not first_delta_fired["done"] and on_first_delta:
+                    first_delta_fired["done"] = True
+                    try:
+                        on_first_delta()
+                    except Exception:
+                        pass
+
+            def _cohere_call():
+                try:
+                    from agent.cohere_adapter import stream_chat_with_callbacks
+                    if self._cohere_client is None:
+                        from agent.cohere_adapter import build_cohere_client
+                        self._cohere_client = build_cohere_client(
+                            self._cohere_api_key,
+                            getattr(self, "_cohere_base_url", None),
+                            timeout=get_provider_request_timeout(self.provider, self.model),
+                        )
+                    stream_iter = self._cohere_client.chat_stream(**api_kwargs)
+
+                    def _on_text(text):
+                        _fire_first_co()
+                        self._fire_stream_delta(text)
+
+                    def _on_tool(name):
+                        _fire_first_co()
+                        self._fire_tool_gen_started(name)
+
+                    def _on_reasoning(text):
+                        _fire_first_co()
+                        self._fire_reasoning_delta(text)
+
+                    result["response"] = stream_chat_with_callbacks(
+                        stream_iter,
+                        on_text_delta=_on_text if self._has_stream_consumers() else None,
+                        on_tool_start=_on_tool,
+                        on_reasoning_delta=_on_reasoning if self.reasoning_callback or self.stream_delta_callback else None,
+                        on_interrupt_check=lambda: self._interrupt_requested,
+                    )
+                except Exception as e:
+                    result["error"] = e
+
+            t = threading.Thread(target=_cohere_call, daemon=True)
+            t.start()
+            while t.is_alive():
+                t.join(timeout=0.3)
+                if self._interrupt_requested:
+                    raise InterruptedError("Agent interrupted during Cohere API call")
             if result["error"] is not None:
                 raise result["error"]
             return result["response"]
@@ -9480,6 +9617,31 @@ class AIAgent:
                 max_tokens=self.max_tokens or 4096,
                 region=region,
                 guardrail_config=guardrail,
+            )
+
+        # Cohere native v2 chat — bypasses the OpenAI client entirely. The
+        # transport handles OpenAI → Cohere conversion (tool-result document
+        # blocks, tool_plan reasoning, citations) and reads the runtime
+        # config snapshot captured at __init__ for Cohere-only knobs.
+        if self.api_mode == "cohere_chat":
+            from providers import get_provider_profile
+            _co_transport = self._get_transport()
+            _co_profile = get_provider_profile(self.provider or "cohere")
+            _co_runtime = getattr(self, "_cohere_runtime_config", {}) or {}
+            return _co_transport.build_kwargs(
+                model=self.model,
+                messages=api_messages,
+                tools=tools_for_api,
+                max_tokens=self.max_tokens,
+                reasoning_config=self.reasoning_config,
+                session_id=getattr(self, "session_id", None),
+                provider_profile=_co_profile,
+                safety_mode=_co_runtime.get("safety_mode"),
+                citation_options=_co_runtime.get("citation_options"),
+                connectors=_co_runtime.get("connectors"),
+                force_single_step=_co_runtime.get("force_single_step"),
+                thinking_token_budget=_co_runtime.get("thinking_token_budget"),
+                documents=(self.request_overrides or {}).get("documents") if self.request_overrides else None,
             )
 
         if self.api_mode == "codex_responses":

--- a/tests/agent/test_cohere_adapter.py
+++ b/tests/agent/test_cohere_adapter.py
@@ -1,0 +1,181 @@
+"""Tests for the Cohere adapter helpers (streaming + finish-reason map)."""
+
+from __future__ import annotations
+
+from agent.cohere_adapter import (
+    _cohere_finish_reason_to_openai,
+    is_cohere_url,
+    stream_chat_with_callbacks,
+)
+
+
+# ── is_cohere_url ───────────────────────────────────────────────────────
+
+
+class TestIsCohereUrl:
+    def test_official_host(self):
+        assert is_cohere_url("https://api.cohere.com/v2") is True
+
+    def test_legacy_host(self):
+        assert is_cohere_url("https://api.cohere.ai/v1") is True
+
+    def test_other_host(self):
+        assert is_cohere_url("https://api.openai.com/v1") is False
+
+    def test_empty_and_none(self):
+        assert is_cohere_url("") is False
+        assert is_cohere_url(None) is False
+
+
+# ── finish_reason map ──────────────────────────────────────────────────
+
+
+class TestFinishReasonMap:
+    def test_complete(self):
+        assert _cohere_finish_reason_to_openai("COMPLETE") == "stop"
+
+    def test_max_tokens(self):
+        assert _cohere_finish_reason_to_openai("MAX_TOKENS") == "length"
+
+    def test_tool_call(self):
+        assert _cohere_finish_reason_to_openai("TOOL_CALL") == "tool_calls"
+
+    def test_error_toxic(self):
+        assert _cohere_finish_reason_to_openai("ERROR_TOXIC") == "content_filter"
+
+    def test_lowercase_input(self):
+        assert _cohere_finish_reason_to_openai("complete") == "stop"
+
+    def test_empty(self):
+        assert _cohere_finish_reason_to_openai("") == "stop"
+
+
+# ── stream pump ─────────────────────────────────────────────────────────
+
+
+def _ev(t: str, **delta_message_fields):
+    """Helper: build a dict-shaped stream event for the pump."""
+    return {
+        "type": t,
+        "delta": {"message": delta_message_fields} if delta_message_fields else {},
+    }
+
+
+class TestStreamChatWithCallbacks:
+    def test_text_only_stream(self):
+        events = [
+            {"type": "message-start", "id": "msg_1"},
+            _ev("content-delta", content={"text": "Hello"}),
+            _ev("content-delta", content={"text": " world"}),
+            {
+                "type": "message-end",
+                "delta": {
+                    "finish_reason": "COMPLETE",
+                    "usage": {"tokens": {"input_tokens": 5, "output_tokens": 2}},
+                },
+            },
+        ]
+        texts = []
+        out = stream_chat_with_callbacks(events, on_text_delta=texts.append)
+        assert texts == ["Hello", " world"]
+        assert out.choices[0].message.content == "Hello world"
+        assert out.choices[0].finish_reason == "stop"
+        assert out.usage.prompt_tokens == 5
+        assert out.usage.completion_tokens == 2
+
+    def test_tool_call_stream_with_tool_plan(self):
+        events = [
+            _ev("tool-plan-delta", tool_plan="I should "),
+            _ev("tool-plan-delta", tool_plan="check the weather."),
+            _ev(
+                "tool-call-start",
+                tool_calls={
+                    "id": "tc_1",
+                    "function": {"name": "get_weather", "arguments": ""},
+                },
+            ),
+            _ev(
+                "tool-call-delta",
+                tool_calls={"function": {"arguments": '{"city":'}},
+            ),
+            _ev(
+                "tool-call-delta",
+                tool_calls={"function": {"arguments": ' "Tokyo"}'}},
+            ),
+            _ev("tool-call-end"),
+            {
+                "type": "message-end",
+                "delta": {
+                    "finish_reason": "TOOL_CALL",
+                    "usage": {"tokens": {"input_tokens": 8, "output_tokens": 3}},
+                },
+            },
+        ]
+        tool_starts = []
+        reasoning = []
+        text_deltas = []
+        out = stream_chat_with_callbacks(
+            events,
+            on_text_delta=text_deltas.append,
+            on_tool_start=tool_starts.append,
+            on_reasoning_delta=reasoning.append,
+        )
+        assert tool_starts == ["get_weather"]
+        assert "".join(reasoning) == "I should check the weather."
+        # No text deltas fire because a tool call is in flight
+        assert text_deltas == []
+        assert out.choices[0].finish_reason == "tool_calls"
+        tc = out.choices[0].message.tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert tc.function.arguments == '{"city": "Tokyo"}'
+
+    def test_interrupt_aborts_stream(self):
+        # Build an infinite stream-like list that the interrupt callback
+        # should stop processing after the first event.
+        events = [
+            _ev("content-delta", content={"text": "first"}),
+            _ev("content-delta", content={"text": "second"}),
+        ]
+        flag = {"interrupt": False}
+
+        def _interrupted():
+            interrupted = flag["interrupt"]
+            flag["interrupt"] = True
+            return interrupted
+
+        out = stream_chat_with_callbacks(events, on_interrupt_check=_interrupted)
+        # First call returns False so the first event processes; the
+        # second call returns True and the loop breaks before the second
+        # event is consumed.
+        assert out.choices[0].message.content == "first"
+
+    def test_partial_tool_call_flushed_at_end(self):
+        """If the stream ends mid tool-call (no tool-call-end), the
+        adapter should still flush the partial state instead of dropping it."""
+        events = [
+            _ev(
+                "tool-call-start",
+                tool_calls={
+                    "id": "tc_1",
+                    "function": {"name": "do_thing", "arguments": '{"k": "v"}'},
+                },
+            ),
+            # No tool-call-end here.
+        ]
+        out = stream_chat_with_callbacks(events)
+        tcs = out.choices[0].message.tool_calls
+        assert tcs is not None and len(tcs) == 1
+        assert tcs[0].function.name == "do_thing"
+        assert tcs[0].function.arguments == '{"k": "v"}'
+
+    def test_citation_event_fires_callback(self):
+        citation = {"start": 0, "end": 5, "text": "hello", "sources": ["doc-1"]}
+        events = [
+            _ev("content-delta", content={"text": "hello world"}),
+            _ev("citation-start", citations=citation),
+            {"type": "message-end", "delta": {"finish_reason": "COMPLETE"}},
+        ]
+        seen = []
+        out = stream_chat_with_callbacks(events, on_citation=seen.append)
+        assert seen == [citation]
+        assert out.choices[0].finish_reason == "stop"

--- a/tests/agent/test_cohere_transport.py
+++ b/tests/agent/test_cohere_transport.py
@@ -1,0 +1,459 @@
+"""Tests for the Cohere v2 chat transport.
+
+Covers:
+  - registration in the transport registry
+  - convert_messages: tool-result document wrapping + assistant tool-call shape
+  - convert_tools: stripping unsupported OpenAI fields
+  - build_kwargs: native-knob plumbing (safety_mode, citation_options,
+    documents, connectors, force_single_step, thinking via reasoning_config)
+  - normalize_response: text + tool_plan reasoning + tool_calls + citations
+  - validate_response: empty-content + TOOL_CALL finish_reason is valid
+  - map_finish_reason: COMPLETE/TOOL_CALL/MAX_TOKENS → OpenAI vocabulary
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports import get_transport
+from agent.transports.cohere import CohereTransport, _convert_message, _strip_tool_fields
+
+
+# ── Registry ────────────────────────────────────────────────────────────
+
+
+class TestCohereTransportRegistry:
+    def test_registered_on_import(self):
+        import agent.transports.cohere  # noqa: F401
+        t = get_transport("cohere_chat")
+        assert t is not None
+        assert isinstance(t, CohereTransport)
+        assert t.api_mode == "cohere_chat"
+
+
+# ── convert_messages ────────────────────────────────────────────────────
+
+
+class TestConvertMessages:
+    def test_user_message_passthrough(self):
+        t = CohereTransport()
+        out = t.convert_messages([{"role": "user", "content": "hi"}])
+        assert out == [{"role": "user", "content": "hi"}]
+
+    def test_system_message_passthrough(self):
+        t = CohereTransport()
+        out = t.convert_messages([{"role": "system", "content": "be helpful"}])
+        assert out == [{"role": "system", "content": "be helpful"}]
+
+    def test_tool_result_string_wrapped_as_document(self):
+        msg = {"role": "tool", "tool_call_id": "call_1", "content": "the answer is 42"}
+        out = _convert_message(msg)
+        assert out["role"] == "tool"
+        assert out["tool_call_id"] == "call_1"
+        assert isinstance(out["content"], list)
+        assert out["content"][0] == {
+            "type": "document",
+            "document": {"data": "the answer is 42"},
+        }
+
+    def test_tool_result_list_flattened(self):
+        msg = {
+            "role": "tool",
+            "tool_call_id": "call_2",
+            "content": [
+                {"type": "text", "text": "part one"},
+                {"type": "text", "text": "part two"},
+            ],
+        }
+        out = _convert_message(msg)
+        assert out["content"][0]["document"]["data"] == "part one\npart two"
+
+    def test_assistant_with_tool_calls(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "I should call the weather tool",
+            "tool_calls": [
+                {
+                    "id": "tc_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Tokyo"}'},
+                }
+            ],
+        }
+        out = _convert_message(msg)
+        assert out["role"] == "assistant"
+        assert out["tool_plan"] == "I should call the weather tool"
+        assert out["tool_calls"][0]["id"] == "tc_1"
+        assert out["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert out["tool_calls"][0]["function"]["arguments"] == '{"city": "Tokyo"}'
+
+    def test_assistant_tool_calls_with_dict_arguments_serialized(self):
+        msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "tc_x",
+                    "function": {"name": "do_thing", "arguments": {"k": "v"}},
+                }
+            ],
+        }
+        out = _convert_message(msg)
+        args_str = out["tool_calls"][0]["function"]["arguments"]
+        assert json.loads(args_str) == {"k": "v"}
+
+    def test_drops_non_dict_entries(self):
+        t = CohereTransport()
+        out = t.convert_messages([{"role": "user", "content": "hi"}, "junk", None])
+        assert len(out) == 1
+
+
+# ── convert_tools ───────────────────────────────────────────────────────
+
+
+class TestConvertTools:
+    def test_empty_tools(self):
+        t = CohereTransport()
+        assert t.convert_tools([]) == []
+        assert t.convert_tools(None) == []
+
+    def test_passthrough_basic(self):
+        t = CohereTransport()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        out = t.convert_tools(tools)
+        assert out[0]["function"]["name"] == "search"
+
+    def test_strips_unsupported_fields(self):
+        tools = [
+            {
+                "type": "function",
+                "strict": True,
+                "cache_control": {"type": "ephemeral"},
+                "function": {
+                    "name": "f",
+                    "strict": True,
+                    "cache_control": {"type": "ephemeral"},
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+        out = _strip_tool_fields(tools)
+        assert "strict" not in out[0]
+        assert "cache_control" not in out[0]
+        assert "strict" not in out[0]["function"]
+        assert "cache_control" not in out[0]["function"]
+
+
+# ── build_kwargs ────────────────────────────────────────────────────────
+
+
+class TestBuildKwargs:
+    def test_minimal(self):
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="command-a-03-2025",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert kw["model"] == "command-a-03-2025"
+        assert kw["messages"] == [{"role": "user", "content": "hi"}]
+        assert "tools" not in kw
+
+    def test_tools_included_when_present(self):
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="command-a-03-2025",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "f", "parameters": {"type": "object"}},
+                }
+            ],
+        )
+        assert kw["tools"][0]["function"]["name"] == "f"
+
+    def test_max_tokens_and_temperature(self):
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=512,
+            temperature=0.3,
+            top_p=0.9,
+        )
+        assert kw["max_tokens"] == 512
+        assert kw["temperature"] == pytest.approx(0.3)
+        assert kw["p"] == pytest.approx(0.9)
+
+    def test_native_knobs_direct_params(self):
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            safety_mode="strict",
+            citation_options={"mode": "ACCURATE"},
+            documents=[{"data": "doc one"}],
+            connectors=[{"id": "web-search"}],
+            force_single_step=True,
+        )
+        assert kw["safety_mode"] == "STRICT"
+        assert kw["citation_options"] == {"mode": "ACCURATE"}
+        assert kw["documents"] == [{"data": "doc one"}]
+        assert kw["connectors"] == [{"id": "web-search"}]
+        assert kw["force_single_step"] is True
+
+    def test_empty_collections_are_dropped(self):
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            documents=[],
+            connectors=[],
+            citation_options={},
+        )
+        assert "documents" not in kw
+        assert "connectors" not in kw
+        assert "citation_options" not in kw
+
+    def test_profile_drives_thinking_for_reasoning_model(self):
+        """When a CohereProfile is passed, reasoning_config + reasoning model
+        should produce a Cohere ``thinking`` field with a token budget."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cohere")
+        assert profile is not None, "CohereProfile must be auto-discovered"
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="command-a-reasoning-08-2025",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": True, "effort": "high"},
+            provider_profile=profile,
+        )
+        assert "thinking" in kw
+        assert kw["thinking"]["type"] == "enabled"
+        assert kw["thinking"]["token_budget"] == 16384
+
+    def test_profile_no_thinking_for_non_reasoning_model(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cohere")
+        assert profile is not None
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="command-r-08-2024",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": True, "effort": "high"},
+            provider_profile=profile,
+        )
+        assert "thinking" not in kw
+
+    def test_explicit_thinking_budget_overrides_effort(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cohere")
+        assert profile is not None
+        t = CohereTransport()
+        kw = t.build_kwargs(
+            model="command-a-reasoning-08-2025",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_config={"enabled": True, "effort": "medium"},
+            thinking_token_budget=4096,
+            provider_profile=profile,
+        )
+        assert kw["thinking"]["token_budget"] == 4096
+
+
+# ── normalize_response ──────────────────────────────────────────────────
+
+
+def _make_text_content_block(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_tool_call(id_: str, name: str, args: str):
+    return SimpleNamespace(
+        id=id_,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=args),
+    )
+
+
+class TestNormalizeResponse:
+    def test_text_only(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[_make_text_content_block("hello world")],
+                tool_plan=None,
+                tool_calls=None,
+                citations=None,
+            ),
+            finish_reason="COMPLETE",
+            usage=SimpleNamespace(
+                tokens=SimpleNamespace(input_tokens=12, output_tokens=4)
+            ),
+        )
+        out = t.normalize_response(resp)
+        assert out.content == "hello world"
+        assert out.tool_calls is None
+        assert out.finish_reason == "stop"
+        assert out.usage.prompt_tokens == 12
+        assert out.usage.completion_tokens == 4
+        assert out.usage.total_tokens == 16
+
+    def test_tool_calls_with_tool_plan(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[],
+                tool_plan="I need to check the weather",
+                tool_calls=[_make_tool_call("tc1", "get_weather", '{"city": "Tokyo"}')],
+                citations=None,
+            ),
+            finish_reason="TOOL_CALL",
+            usage=None,
+        )
+        out = t.normalize_response(resp)
+        assert out.content is None
+        assert out.finish_reason == "tool_calls"
+        assert out.reasoning == "I need to check the weather"
+        assert len(out.tool_calls) == 1
+        assert out.tool_calls[0].name == "get_weather"
+        assert out.tool_calls[0].arguments == '{"city": "Tokyo"}'
+
+    def test_max_tokens_finish_reason(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[_make_text_content_block("partial...")],
+                tool_plan=None,
+                tool_calls=None,
+                citations=None,
+            ),
+            finish_reason="MAX_TOKENS",
+            usage=None,
+        )
+        out = t.normalize_response(resp)
+        assert out.finish_reason == "length"
+
+    def test_citations_stashed_in_provider_data(self):
+        t = CohereTransport()
+        citation = {"start": 0, "end": 5, "text": "hello", "sources": ["doc-1"]}
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[_make_text_content_block("hello world")],
+                tool_plan=None,
+                tool_calls=None,
+                citations=[citation],
+            ),
+            finish_reason="COMPLETE",
+            usage=None,
+        )
+        out = t.normalize_response(resp)
+        assert out.provider_data is not None
+        assert out.provider_data["citations"] == [citation]
+
+    def test_tool_call_with_dict_arguments_is_serialized(self):
+        t = CohereTransport()
+        tc = {
+            "id": "tc1",
+            "type": "function",
+            "function": {"name": "f", "arguments": {"k": "v"}},
+        }
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[], tool_plan=None, tool_calls=[tc], citations=None
+            ),
+            finish_reason="TOOL_CALL",
+            usage=None,
+        )
+        out = t.normalize_response(resp)
+        assert out.tool_calls[0].arguments == '{"k": "v"}'
+
+
+# ── validate_response ───────────────────────────────────────────────────
+
+
+class TestValidateResponse:
+    def test_none_invalid(self):
+        t = CohereTransport()
+        assert t.validate_response(None) is False
+
+    def test_no_message_invalid(self):
+        t = CohereTransport()
+        assert t.validate_response(SimpleNamespace()) is False
+
+    def test_text_content_valid(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(content=[_make_text_content_block("hi")]),
+            finish_reason="COMPLETE",
+        )
+        assert t.validate_response(resp) is True
+
+    def test_empty_content_with_tool_call_valid(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(
+                content=[],
+                tool_calls=[_make_tool_call("tc1", "f", "{}")],
+            ),
+            finish_reason="TOOL_CALL",
+        )
+        assert t.validate_response(resp) is True
+
+    def test_empty_content_with_tool_call_finish_reason_valid(self):
+        """Empty content + finish_reason=TOOL_CALL (even without tool_calls
+        populated) is treated as valid — Cohere occasionally yields this
+        shape during streaming."""
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(content=[], tool_calls=None),
+            finish_reason="TOOL_CALL",
+        )
+        assert t.validate_response(resp) is True
+
+    def test_empty_content_no_tool_call_invalid(self):
+        t = CohereTransport()
+        resp = SimpleNamespace(
+            message=SimpleNamespace(content=[], tool_calls=None),
+            finish_reason="COMPLETE",
+        )
+        assert t.validate_response(resp) is False
+
+
+# ── map_finish_reason ───────────────────────────────────────────────────
+
+
+class TestMapFinishReason:
+    def test_complete(self):
+        t = CohereTransport()
+        assert t.map_finish_reason("COMPLETE") == "stop"
+
+    def test_max_tokens(self):
+        t = CohereTransport()
+        assert t.map_finish_reason("MAX_TOKENS") == "length"
+
+    def test_tool_call(self):
+        t = CohereTransport()
+        assert t.map_finish_reason("TOOL_CALL") == "tool_calls"
+
+    def test_error_toxic(self):
+        t = CohereTransport()
+        assert t.map_finish_reason("ERROR_TOXIC") == "content_filter"
+
+    def test_unknown_falls_back_to_stop(self):
+        t = CohereTransport()
+        assert t.map_finish_reason("WHATEVER") == "stop"

--- a/tests/hermes_cli/test_cohere_provider.py
+++ b/tests/hermes_cli/test_cohere_provider.py
@@ -1,0 +1,141 @@
+"""Tests for the Cohere native provider integration.
+
+Covers:
+  - CohereProfile registration via the plugin discovery path
+  - HermesOverlay entry shape (transport, env vars, base URL)
+  - alias resolution: "cohere", "command", "command-r", "command-a"
+  - determine_api_mode() → "cohere_chat" for the provider and the URL
+  - PROVIDER_REGISTRY auto-extension picks up Cohere
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.providers import (
+    HERMES_OVERLAYS,
+    TRANSPORT_TO_API_MODE,
+    ALIASES,
+    _LABEL_OVERRIDES,
+    determine_api_mode,
+    get_label,
+    normalize_provider,
+)
+
+
+# ── Overlay shape ───────────────────────────────────────────────────────
+
+
+class TestCohereOverlay:
+    def test_cohere_in_overlays(self):
+        assert "cohere" in HERMES_OVERLAYS
+
+    def test_cohere_transport_is_cohere_chat(self):
+        assert HERMES_OVERLAYS["cohere"].transport == "cohere_chat"
+
+    def test_cohere_env_vars(self):
+        ev = HERMES_OVERLAYS["cohere"].extra_env_vars
+        assert "COHERE_API_KEY" in ev
+        assert "CO_API_KEY" in ev
+
+    def test_cohere_base_url_override(self):
+        assert HERMES_OVERLAYS["cohere"].base_url_override == "https://api.cohere.com"
+
+    def test_cohere_base_url_env_var(self):
+        assert HERMES_OVERLAYS["cohere"].base_url_env_var == "COHERE_BASE_URL"
+
+    def test_cohere_label(self):
+        assert _LABEL_OVERRIDES.get("cohere") == "Cohere"
+        assert get_label("cohere") == "Cohere"
+
+
+# ── Transport → api_mode wiring ────────────────────────────────────────
+
+
+class TestTransportApiMode:
+    def test_cohere_chat_in_transport_map(self):
+        assert TRANSPORT_TO_API_MODE.get("cohere_chat") == "cohere_chat"
+
+
+# ── Aliases ─────────────────────────────────────────────────────────────
+
+
+class TestCohereAliases:
+    @pytest.mark.parametrize("alias", ["command", "command-r", "command-a", "cohere-ai"])
+    def test_alias_resolves_to_cohere(self, alias):
+        assert ALIASES.get(alias) == "cohere"
+        assert normalize_provider(alias) == "cohere"
+
+    def test_canonical_unchanged(self):
+        assert normalize_provider("cohere") == "cohere"
+
+
+# ── determine_api_mode ──────────────────────────────────────────────────
+
+
+class TestDetermineApiMode:
+    def test_provider_cohere_returns_cohere_chat(self):
+        assert determine_api_mode("cohere") == "cohere_chat"
+
+    def test_provider_command_alias_returns_cohere_chat(self):
+        assert determine_api_mode("command-r") == "cohere_chat"
+
+    def test_url_api_cohere_com_returns_cohere_chat(self):
+        assert determine_api_mode("custom", "https://api.cohere.com/v2") == "cohere_chat"
+
+    def test_url_api_cohere_ai_legacy_host_returns_cohere_chat(self):
+        assert determine_api_mode("custom", "https://api.cohere.ai/v1") == "cohere_chat"
+
+
+# ── Profile registration (via providers/ discovery) ────────────────────
+
+
+class TestCohereProfileRegistered:
+    def test_profile_present(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cohere")
+        assert profile is not None
+        assert profile.name == "cohere"
+        assert profile.api_mode == "cohere_chat"
+        assert profile.base_url == "https://api.cohere.com"
+        assert "COHERE_API_KEY" in profile.env_vars
+
+    def test_profile_aliases_route_back_to_cohere(self):
+        from providers import get_provider_profile
+
+        for alias in ("command", "command-r", "command-a", "cohere-ai"):
+            profile = get_provider_profile(alias)
+            assert profile is not None, f"alias {alias} should resolve"
+            assert profile.name == "cohere"
+
+    def test_profile_fallback_models_contain_chat_capable_entries(self):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("cohere")
+        assert profile is not None
+        models = profile.fallback_models
+        assert isinstance(models, tuple)
+        assert len(models) >= 1
+        # Every fallback model should start with "command-" (chat-capable)
+        assert all(m.startswith("command-") for m in models)
+
+
+# ── PROVIDER_REGISTRY auto-extension ──────────────────────────────────
+
+
+class TestPROVIDER_REGISTRY_AutoExtension:
+    def test_cohere_in_provider_registry(self):
+        # Force discovery first
+        from providers import list_providers
+        list_providers()
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        assert "cohere" in PROVIDER_REGISTRY
+
+    def test_cohere_provider_registry_auth_type(self):
+        from providers import list_providers
+        list_providers()
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pcfg = PROVIDER_REGISTRY["cohere"]
+        assert pcfg.auth_type == "api_key"
+        assert "COHERE_API_KEY" in pcfg.api_key_env_vars

--- a/tests/tools/test_cohere_tools.py
+++ b/tests/tools/test_cohere_tools.py
@@ -1,0 +1,267 @@
+"""Tests for the Cohere embed + rerank built-in tools.
+
+Tests exercise the public handler functions (``cohere_embed`` and
+``cohere_rerank``) with the ``cohere.ClientV2`` mocked at the build-client
+seam (``agent.cohere_adapter.build_cohere_client``) so no network calls
+happen and tests pass in the hermetic environment.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.cohere_embed import (
+    cohere_embed,
+    check_cohere_requirements as check_embed_requirements,
+    _handle_cohere_embed,
+    COHERE_EMBED_SCHEMA,
+)
+from tools.cohere_rerank import (
+    cohere_rerank,
+    check_cohere_requirements as check_rerank_requirements,
+    _handle_cohere_rerank,
+    COHERE_RERANK_SCHEMA,
+)
+
+
+# ── check_fn gating ─────────────────────────────────────────────────────
+
+
+class TestCheckRequirements:
+    def test_unset_key_returns_false(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        monkeypatch.delenv("CO_API_KEY", raising=False)
+        assert check_embed_requirements() is False
+        assert check_rerank_requirements() is False
+
+    def test_cohere_api_key_returns_true(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "test-key")
+        assert check_embed_requirements() is True
+        assert check_rerank_requirements() is True
+
+    def test_co_api_key_fallback(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        monkeypatch.setenv("CO_API_KEY", "test-key")
+        assert check_embed_requirements() is True
+        assert check_rerank_requirements() is True
+
+
+# ── Schema sanity ───────────────────────────────────────────────────────
+
+
+class TestSchemas:
+    def test_embed_schema_required_fields(self):
+        params = COHERE_EMBED_SCHEMA["parameters"]
+        assert set(params["required"]) == {"texts", "input_type"}
+        assert "model" in params["properties"]
+
+    def test_rerank_schema_required_fields(self):
+        params = COHERE_RERANK_SCHEMA["parameters"]
+        assert set(params["required"]) == {"query", "documents"}
+        assert "top_n" in params["properties"]
+        assert "model" in params["properties"]
+
+
+# ── cohere_embed handler ────────────────────────────────────────────────
+
+
+def _make_embed_response(vectors):
+    """Build a SimpleNamespace mimicking a Cohere v2 embed response."""
+    return SimpleNamespace(
+        embeddings=SimpleNamespace(float_=vectors),
+    )
+
+
+class TestCohereEmbed:
+    def test_missing_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        monkeypatch.delenv("CO_API_KEY", raising=False)
+        out = cohere_embed(texts=["hello"], input_type="search_document")
+        data = json.loads(out)
+        assert "error" in data
+        assert "COHERE_API_KEY" in data["error"]
+
+    def test_empty_texts_returns_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        out = cohere_embed(texts=[], input_type="search_document")
+        data = json.loads(out)
+        assert "error" in data
+
+    def test_invalid_input_type_returns_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        out = cohere_embed(texts=["x"], input_type="not_real")
+        data = json.loads(out)
+        assert "error" in data
+
+    def test_happy_path(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.embed.return_value = _make_embed_response(
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        )
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = cohere_embed(
+                texts=["a", "b"], input_type="search_document", model="embed-v4.0"
+            )
+        data = json.loads(out)
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert data["dim"] == 3
+        assert data["embeddings"] == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        assert data["model"] == "embed-v4.0"
+        # Verify the SDK was called with the right keyword shape.
+        fake_client.embed.assert_called_once()
+        kwargs = fake_client.embed.call_args.kwargs
+        assert kwargs["texts"] == ["a", "b"]
+        assert kwargs["model"] == "embed-v4.0"
+        assert kwargs["input_type"] == "search_document"
+        assert kwargs["embedding_types"] == ["float"]
+
+    def test_handler_wraps_cohere_embed(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.embed.return_value = _make_embed_response([[0.0, 0.0]])
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = _handle_cohere_embed(
+                {"texts": ["x"], "input_type": "clustering"}
+            )
+        data = json.loads(out)
+        assert data["success"] is True
+        assert data["dim"] == 2
+
+    def test_sdk_exception_surfaced_as_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.embed.side_effect = RuntimeError("boom")
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = cohere_embed(texts=["x"], input_type="search_document")
+        data = json.loads(out)
+        assert "error" in data
+        assert "boom" in data["error"]
+
+
+# ── cohere_rerank handler ───────────────────────────────────────────────
+
+
+def _make_rerank_response(items):
+    """Build a SimpleNamespace mimicking a Cohere v2 rerank response."""
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(index=i, relevance_score=s) for (i, s) in items
+        ]
+    )
+
+
+class TestCohereRerank:
+    def test_missing_key_returns_error(self, monkeypatch):
+        monkeypatch.delenv("COHERE_API_KEY", raising=False)
+        monkeypatch.delenv("CO_API_KEY", raising=False)
+        out = cohere_rerank(query="q", documents=["a", "b"])
+        data = json.loads(out)
+        assert "error" in data
+
+    def test_empty_query_returns_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        out = cohere_rerank(query="", documents=["a"])
+        data = json.loads(out)
+        assert "error" in data
+
+    def test_empty_documents_returns_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        out = cohere_rerank(query="q", documents=[])
+        data = json.loads(out)
+        assert "error" in data
+
+    def test_happy_path(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        docs = ["the cat sat", "the dog ran", "a fish swam"]
+        fake_client = MagicMock()
+        fake_client.rerank.return_value = _make_rerank_response(
+            [(1, 0.95), (0, 0.42), (2, 0.10)]
+        )
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = cohere_rerank(query="dog?", documents=docs, top_n=3)
+        data = json.loads(out)
+        assert data["success"] is True
+        assert data["model"] == "rerank-v3.5"
+        assert len(data["results"]) == 3
+        assert data["results"][0]["index"] == 1
+        assert data["results"][0]["document"] == "the dog ran"
+        assert data["results"][0]["relevance_score"] == pytest.approx(0.95)
+        # Verify call shape
+        kwargs = fake_client.rerank.call_args.kwargs
+        assert kwargs["query"] == "dog?"
+        assert kwargs["documents"] == docs
+        assert kwargs["top_n"] == 3
+
+    def test_top_n_clamped_to_doc_count(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.rerank.return_value = _make_rerank_response([(0, 0.9)])
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            cohere_rerank(query="q", documents=["only one"], top_n=100)
+        # SDK should have received top_n=1 (clamped to len(documents))
+        kwargs = fake_client.rerank.call_args.kwargs
+        assert kwargs["top_n"] == 1
+
+    def test_invalid_index_dropped(self, monkeypatch):
+        """If Cohere returns an out-of-range index, drop that result."""
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.rerank.return_value = _make_rerank_response(
+            [(0, 0.9), (99, 0.8)]
+        )
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = cohere_rerank(query="q", documents=["a", "b"])
+        data = json.loads(out)
+        assert len(data["results"]) == 1
+        assert data["results"][0]["index"] == 0
+
+    def test_handler_wraps_cohere_rerank(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.rerank.return_value = _make_rerank_response([(0, 0.5)])
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = _handle_cohere_rerank(
+                {"query": "q", "documents": ["one"], "top_n": 1}
+            )
+        data = json.loads(out)
+        assert data["success"] is True
+
+    def test_sdk_exception_surfaced_as_error(self, monkeypatch):
+        monkeypatch.setenv("COHERE_API_KEY", "k")
+        fake_client = MagicMock()
+        fake_client.rerank.side_effect = RuntimeError("nope")
+        with patch(
+            "agent.cohere_adapter.build_cohere_client",
+            return_value=fake_client,
+        ):
+            out = cohere_rerank(query="q", documents=["a"])
+        data = json.loads(out)
+        assert "error" in data
+        assert "nope" in data["error"]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -296,6 +296,8 @@ class TestBuiltinDiscovery:
             "tools.browser_tool",
             "tools.clarify_tool",
             "tools.code_execution_tool",
+            "tools.cohere_embed",
+            "tools.cohere_rerank",
             "tools.computer_use_tool",
             "tools.cronjob_tools",
             "tools.delegate_tool",

--- a/tools/cohere_embed.py
+++ b/tools/cohere_embed.py
@@ -1,0 +1,208 @@
+"""Cohere Embed tool — generate text embeddings via the Cohere v2 API.
+
+Wraps ``cohere.ClientV2.embed`` as a first-class agent tool. The agent can
+call this inside a reasoning loop to vectorize a batch of texts for
+downstream similarity search, clustering, or hybrid retrieval. The tool is
+gated on ``COHERE_API_KEY`` via the registry's ``check_fn`` so it stays
+hidden from the model unless the user has configured Cohere.
+
+Why this lives as a built-in tool rather than an auxiliary surface:
+Hermes does not currently have a generic embedding plumbing layer. The
+agent-facing tool keeps the integration self-contained and lets the model
+opt in only when embedding is genuinely useful for the task at hand.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# Cohere documents the following input_type values for embed-v4.0 and
+# embed-english-v3.0. Rejecting unknown values keeps malformed agent
+# calls from leaking into the Cohere API and confusing debugging.
+_VALID_INPUT_TYPES = {
+    "search_document",
+    "search_query",
+    "classification",
+    "clustering",
+    "image",
+}
+
+
+def check_cohere_requirements() -> bool:
+    """Return True when a Cohere API key is configured.
+
+    Checks ``COHERE_API_KEY`` first, falling back to ``CO_API_KEY`` for
+    parity with the official SDK's lookup order.
+    """
+    return bool(os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY"))
+
+
+def _resolve_api_key() -> str:
+    return (os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or "").strip()
+
+
+COHERE_EMBED_SCHEMA: Dict[str, Any] = {
+    "name": "cohere_embed",
+    "description": (
+        "Generate dense vector embeddings for one or more text passages "
+        "using Cohere's embed API. Returns a list of float vectors and the "
+        "embedding dimension. Use this when the user asks you to compare, "
+        "cluster, or semantically search a batch of texts (for downstream "
+        "cosine similarity, vector store ingestion, or de-duplication). "
+        "Do NOT call this for ordinary question answering — use the model's "
+        "context window instead. Requires the Cohere API key."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "texts": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of text passages to embed. Each entry should be a "
+                    "self-contained chunk (paragraph, document section, or "
+                    "search query). Limit: 96 texts per call."
+                ),
+                "minItems": 1,
+                "maxItems": 96,
+            },
+            "input_type": {
+                "type": "string",
+                "description": (
+                    "Embedding optimisation hint. Use 'search_document' for "
+                    "passages you'll later search over, 'search_query' for "
+                    "the user's query against those passages, 'classification' "
+                    "for labelling tasks, or 'clustering' for grouping tasks."
+                ),
+                "enum": sorted(_VALID_INPUT_TYPES),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Cohere embed model name. Defaults to 'embed-v4.0' "
+                    "(latest, multilingual, 1536-dim). Older alternatives: "
+                    "'embed-english-v3.0', 'embed-multilingual-v3.0'."
+                ),
+                "default": "embed-v4.0",
+            },
+        },
+        "required": ["texts", "input_type"],
+    },
+}
+
+
+def cohere_embed(
+    texts: List[str],
+    input_type: str,
+    model: str = "embed-v4.0",
+    task_id: str | None = None,
+) -> str:
+    """Call ``cohere.ClientV2.embed`` and return the embeddings as JSON."""
+    if not isinstance(texts, list) or not texts:
+        return tool_error("`texts` must be a non-empty list of strings.")
+    if not all(isinstance(t, str) and t for t in texts):
+        return tool_error("Each entry in `texts` must be a non-empty string.")
+    if input_type not in _VALID_INPUT_TYPES:
+        return tool_error(
+            f"`input_type` must be one of: {sorted(_VALID_INPUT_TYPES)}; "
+            f"got {input_type!r}."
+        )
+
+    api_key = _resolve_api_key()
+    if not api_key:
+        return tool_error(
+            "COHERE_API_KEY is not set. Configure it via `hermes setup` or "
+            "export it in your environment to enable cohere_embed."
+        )
+
+    try:
+        from agent.cohere_adapter import build_cohere_client
+        client = build_cohere_client(api_key)
+    except ImportError as exc:
+        return tool_error(
+            f"The 'cohere' package is not installed: {exc}. "
+            "Install it with: pip install cohere>=5.13"
+        )
+    except Exception as exc:
+        logger.exception("Failed to build Cohere client")
+        return tool_error(f"Failed to build Cohere client: {exc}")
+
+    try:
+        response = client.embed(
+            texts=texts,
+            model=model,
+            input_type=input_type,
+            embedding_types=["float"],
+        )
+    except Exception as exc:
+        logger.exception("Cohere embed call failed")
+        return tool_error(f"Cohere embed call failed: {exc}")
+
+    # The SDK returns a typed object whose .embeddings attribute is a
+    # container with a .float_ list (renamed from .float because float
+    # is a Python builtin). Accept dict shapes too for testability.
+    embeddings: List[List[float]] = []
+    embeddings_attr = getattr(response, "embeddings", None)
+    if embeddings_attr is None and isinstance(response, dict):
+        embeddings_attr = response.get("embeddings")
+
+    if embeddings_attr is not None:
+        # New SDK: response.embeddings.float_  (or .float)
+        float_list = (
+            getattr(embeddings_attr, "float_", None)
+            or getattr(embeddings_attr, "float", None)
+        )
+        if float_list is None and isinstance(embeddings_attr, dict):
+            float_list = embeddings_attr.get("float_") or embeddings_attr.get("float")
+        if isinstance(float_list, list):
+            embeddings = [list(vec) for vec in float_list]
+        elif isinstance(embeddings_attr, list):
+            # Legacy SDK shape: response.embeddings is a list of lists.
+            embeddings = [list(vec) for vec in embeddings_attr]
+
+    if not embeddings:
+        return tool_error(
+            "Cohere returned no embeddings — check the model name and "
+            "input_type and try again."
+        )
+
+    dim = len(embeddings[0]) if embeddings else 0
+    return json.dumps(
+        {
+            "success": True,
+            "model": model,
+            "input_type": input_type,
+            "count": len(embeddings),
+            "dim": dim,
+            "embeddings": embeddings,
+        }
+    )
+
+
+def _handle_cohere_embed(args: Dict[str, Any], **kw: Any) -> str:
+    return cohere_embed(
+        texts=args.get("texts") or [],
+        input_type=args.get("input_type", ""),
+        model=(args.get("model") or "embed-v4.0").strip() or "embed-v4.0",
+        task_id=kw.get("task_id"),
+    )
+
+
+registry.register(
+    name="cohere_embed",
+    toolset="cohere",
+    schema=COHERE_EMBED_SCHEMA,
+    handler=_handle_cohere_embed,
+    check_fn=check_cohere_requirements,
+    requires_env=["COHERE_API_KEY"],
+    is_async=False,
+    emoji="🧬",
+)

--- a/tools/cohere_rerank.py
+++ b/tools/cohere_rerank.py
@@ -1,0 +1,206 @@
+"""Cohere Rerank tool — relevance-score a list of documents against a query.
+
+Wraps ``cohere.ClientV2.rerank`` so the agent can ask Cohere to score and
+sort an arbitrary list of candidate passages by how well they match a
+query. This is the canonical "stage 2" reranker that goes after a coarse
+retrieval pass (BM25, embedding search, web search) and before feeding
+the top-k passages into the LLM context.
+
+Gated on ``COHERE_API_KEY`` via the registry's ``check_fn``; stays hidden
+from the model when the user hasn't configured Cohere.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def check_cohere_requirements() -> bool:
+    """Return True when a Cohere API key is configured (env or .env)."""
+    return bool(os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY"))
+
+
+def _resolve_api_key() -> str:
+    return (os.getenv("COHERE_API_KEY") or os.getenv("CO_API_KEY") or "").strip()
+
+
+COHERE_RERANK_SCHEMA: Dict[str, Any] = {
+    "name": "cohere_rerank",
+    "description": (
+        "Rerank a list of candidate documents by their relevance to a "
+        "query, using Cohere's rerank API. Returns the top_n results "
+        "sorted by relevance score with their original indices preserved. "
+        "Use this after a coarse retrieval step (web search, BM25, vector "
+        "search) to pick the best passages before feeding them into the "
+        "model's context. Do NOT use as a general search tool — it scores "
+        "documents the caller provides; it does not retrieve new ones. "
+        "Requires the Cohere API key."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The user's query or information need.",
+            },
+            "documents": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Candidate passages to score. Each entry is treated as "
+                    "a single document. Limit: 1000 documents per call; "
+                    "shorter passages (200-1000 tokens) work best."
+                ),
+                "minItems": 1,
+                "maxItems": 1000,
+            },
+            "top_n": {
+                "type": "integer",
+                "description": (
+                    "Number of top results to return. Defaults to 5. "
+                    "Set to the number of passages you want to feed into "
+                    "the next prompt."
+                ),
+                "default": 5,
+                "minimum": 1,
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Cohere rerank model name. Defaults to 'rerank-v3.5' "
+                    "(latest, multilingual). Older: 'rerank-english-v3.0', "
+                    "'rerank-multilingual-v3.0'."
+                ),
+                "default": "rerank-v3.5",
+            },
+        },
+        "required": ["query", "documents"],
+    },
+}
+
+
+def cohere_rerank(
+    query: str,
+    documents: List[str],
+    top_n: int = 5,
+    model: str = "rerank-v3.5",
+    task_id: str | None = None,
+) -> str:
+    """Call ``cohere.ClientV2.rerank`` and return the ranked results as JSON."""
+    if not isinstance(query, str) or not query.strip():
+        return tool_error("`query` must be a non-empty string.")
+    if not isinstance(documents, list) or not documents:
+        return tool_error("`documents` must be a non-empty list of strings.")
+    if not all(isinstance(d, str) and d for d in documents):
+        return tool_error("Each entry in `documents` must be a non-empty string.")
+    if not isinstance(top_n, int) or top_n < 1:
+        top_n = 5
+    top_n = min(top_n, len(documents))
+
+    api_key = _resolve_api_key()
+    if not api_key:
+        return tool_error(
+            "COHERE_API_KEY is not set. Configure it via `hermes setup` or "
+            "export it in your environment to enable cohere_rerank."
+        )
+
+    try:
+        from agent.cohere_adapter import build_cohere_client
+        client = build_cohere_client(api_key)
+    except ImportError as exc:
+        return tool_error(
+            f"The 'cohere' package is not installed: {exc}. "
+            "Install it with: pip install cohere>=5.13"
+        )
+    except Exception as exc:
+        logger.exception("Failed to build Cohere client")
+        return tool_error(f"Failed to build Cohere client: {exc}")
+
+    try:
+        response = client.rerank(
+            query=query,
+            documents=documents,
+            model=model,
+            top_n=top_n,
+        )
+    except Exception as exc:
+        logger.exception("Cohere rerank call failed")
+        return tool_error(f"Cohere rerank call failed: {exc}")
+
+    # Normalize the SDK's results into a plain list of dicts. Each result
+    # carries an index (into the input documents list) and a relevance
+    # score in [0, 1]. We also echo back the matched document text so the
+    # caller doesn't have to re-correlate by index.
+    raw_results = getattr(response, "results", None)
+    if raw_results is None and isinstance(response, dict):
+        raw_results = response.get("results")
+    if not isinstance(raw_results, list):
+        return tool_error("Cohere returned no results — check the model name.")
+
+    results: List[Dict[str, Any]] = []
+    for item in raw_results:
+        idx = (
+            getattr(item, "index", None)
+            if not isinstance(item, dict)
+            else item.get("index")
+        )
+        score = (
+            getattr(item, "relevance_score", None)
+            if not isinstance(item, dict)
+            else item.get("relevance_score")
+        )
+        if idx is None or score is None:
+            continue
+        try:
+            idx_int = int(idx)
+            score_f = float(score)
+        except (TypeError, ValueError):
+            continue
+        if not (0 <= idx_int < len(documents)):
+            continue
+        results.append(
+            {
+                "index": idx_int,
+                "relevance_score": score_f,
+                "document": documents[idx_int],
+            }
+        )
+
+    return json.dumps(
+        {
+            "success": True,
+            "model": model,
+            "query": query,
+            "top_n": top_n,
+            "results": results,
+        }
+    )
+
+
+def _handle_cohere_rerank(args: Dict[str, Any], **kw: Any) -> str:
+    return cohere_rerank(
+        query=args.get("query", ""),
+        documents=args.get("documents") or [],
+        top_n=int(args.get("top_n") or 5),
+        model=(args.get("model") or "rerank-v3.5").strip() or "rerank-v3.5",
+        task_id=kw.get("task_id"),
+    )
+
+
+registry.register(
+    name="cohere_rerank",
+    toolset="cohere",
+    schema=COHERE_RERANK_SCHEMA,
+    handler=_handle_cohere_rerank,
+    check_fn=check_cohere_requirements,
+    requires_env=["COHERE_API_KEY"],
+    is_async=False,
+    emoji="📊",
+)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -81,6 +81,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "provider.anthropic": ("anthropic==0.86.0",),
     # AWS Bedrock provider
     "provider.bedrock": ("boto3==1.42.89",),
+    # Cohere native provider — chat (ClientV2), embed, rerank
+    "provider.cohere": ("cohere==5.13.0",),
 
     # ─── Web search backends ───────────────────────────────────────────────
     "search.exa": ("exa-py==2.10.2",),

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,9 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # Cohere Embed + Rerank — gated on COHERE_API_KEY via check_fn so they
+    # only appear in the schema for users who have configured Cohere.
+    "cohere_embed", "cohere_rerank",
 ]
 
 
@@ -104,6 +107,15 @@ TOOLSETS = {
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
+        "includes": []
+    },
+
+    "cohere": {
+        "description": (
+            "Cohere Embed + Rerank tools — vectorize batches of text and "
+            "rerank candidate passages against a query. Gated on COHERE_API_KEY."
+        ),
+        "tools": ["cohere_embed", "cohere_rerank"],
         "includes": []
     },
 


### PR DESCRIPTION
Adds a first-class Cohere integration that routes through the official `cohere` Python SDK against the native v2 chat API rather than Cohere's OpenAI-compat shim. This unlocks the Cohere-only request/response surface: tool_plan reasoning, citations, RAG documents, hosted connectors, safety_mode, and Command A Reasoning's thinking token budget.

New surfaces

- `plugins/model-providers/cohere/` — `CohereProfile` with `api_mode="cohere_chat"`, native `fetch_models()`, and a `build_extra_body()` hook that surfaces `safety_mode`, `documents`, `connectors`, `citation_options`, `force_single_step`, and a `thinking` token budget derived from Hermes's generic `reasoning_config`.
- `agent/transports/cohere.py` — `CohereTransport` (registered for `api_mode="cohere_chat"`): converts OpenAI-shape messages to Cohere's v2 shape (tool-result `document` blocks, assistant `tool_plan`), strips Cohere-incompatible tool-schema fields (`strict`, `cache_control`), normalizes responses to `NormalizedResponse` with `tool_plan` → `reasoning` and citations stashed in `provider_data`, and maps Cohere's `finish_reason` enum (`COMPLETE`/`MAX_TOKENS`/`TOOL_CALL`/`ERROR_TOXIC`/...) to the OpenAI vocabulary.
- `agent/cohere_adapter.py` — lazy SDK accessor (`provider.cohere` lazy install), `build_cohere_client()`, `is_cohere_url()`, and a `stream_chat_with_callbacks()` SSE pump that maps Cohere v2 stream events (`content-delta`, `tool-plan-delta`, `tool-call-*`, `citation-start`, `message-end`) into an OpenAI-shaped response so the agent loop is provider-agnostic.
- `tools/cohere_embed.py` + `tools/cohere_rerank.py` — built-in agent tools wrapping `ClientV2.embed` and `ClientV2.rerank`, gated on `COHERE_API_KEY` via the registry `check_fn`.

Wiring

- `run_agent.py`: extends the `api_mode` whitelist, adds auto-detect for `provider=="cohere"` and the `api.cohere.com` host, builds a `cohere.ClientV2` in the client-init dispatcher, adds `_cohere_chat_create()` and dispatch arms in `_interruptible_api_call` and `_run_streaming_api_call`, plumbs a `cohere_chat` arm through `_build_api_kwargs` (provider-profile + runtime config snapshot), and snapshots `cohere_api_key`/`cohere_base_url` on `_primary_runtime`.
- `hermes_cli/providers.py`: `cohere` overlay (transport=`cohere_chat`), `TRANSPORT_TO_API_MODE` entry, `command`/`command-r`/`command-a` aliases, URL heuristic for `api.cohere.com`/`api.cohere.ai`.
- `hermes_cli/config.py`: `COHERE_API_KEY` and `COHERE_BASE_URL` in `OPTIONAL_ENV_VARS`; new `cohere:` section in `DEFAULT_CONFIG` (`safety_mode`, `citation_options`, `force_single_step`, `connectors`, `thinking_token_budget`). No `_config_version` bump required — additive section handled by deep-merge.
- `toolsets.py`: new `cohere` toolset; `cohere_embed`/`cohere_rerank` appended to `_HERMES_CORE_TOOLS` (registry `check_fn` keeps them hidden when `COHERE_API_KEY` is unset).
- `pyproject.toml` + `tools/lazy_deps.py`: `cohere` optional extra pinned to `cohere==5.13.0`; `provider.cohere` lazy-install entry so non-Cohere sessions don't import the SDK.

Tests

- `tests/agent/test_cohere_transport.py` — 35 tests covering registry, message/tool conversion, build_kwargs native-knob plumbing, response normalization, validate_response semantics, finish-reason mapping.
- `tests/agent/test_cohere_adapter.py` — 15 tests covering URL detection, finish-reason map, and the streaming pump (text/tool/reasoning/citation events, interrupt, partial tool call).
- `tests/hermes_cli/test_cohere_provider.py` — 21 tests covering overlay shape, alias resolution, `determine_api_mode()`, profile registration, `PROVIDER_REGISTRY` auto-extension.
- `tests/tools/test_cohere_tools.py` — 19 tests covering embed/rerank handlers with the SDK mocked at the `build_cohere_client` seam.
- `tests/tools/test_registry.py` — extends the built-in tool module snapshot to include the two new tools.

Out of scope

- OAuth flow (Cohere is API-key only).
- Legacy v1 `co.chat` (deprecated; we go straight to v2).
- Embeddings as a first-class auxiliary surface (kept as agent tools since Hermes lacks generic embedding plumbing).
- Bedrock-hosted Cohere routing (already covered by `bedrock_converse`).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- Added Cohere Native V2 Chat Provider/Integration -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

