### PR TITLE
fix: add Xiaomi MiMo to thinking-mode reasoning_content echo-back providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9987,6 +9987,7 @@ class AIAgent:
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()  # new
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10017,7 +10018,22 @@ class AIAgent:
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
-
+        
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+    
+        MiMo thinking mode requires ``reasoning_content`` on every assistant
+        message when replaying conversation history. Omitting it causes HTTP 400
+        ("The reasoning_content in the thinking mode must be passed back to the API").
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "mimo"
+            or "mimo" in model
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
+        )
+    
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Copy provider-facing reasoning fields onto an API replay message."""
         if source_msg.get("role") != "assistant":


### PR DESCRIPTION
Added a new method to check for Xiaomi MiMo thinking mode and updated the reasoning checks.

## What does this PR do?

When Hermes falls back from a non-thinking provider (e.g. Vertex Gemini) to Xiaomi MiMo in thinking mode, all subsequent API calls to MiMo fail with HTTP 400:

```
"The reasoning_content in the thinking mode must be passed back to the API."
```

The conversation is permanently broken until `/reset`.

`_needs_thinking_reasoning_pad()` only recognizes DeepSeek and Kimi/Moonshot as providers that enforce `reasoning_content` echo-back. Xiaomi MiMo (`mimo-v2.5-pro` in thinking mode) has the same requirement but is not listed. This PR adds MiMo detection to fix the issue.

## Related Issue

Fixes # (no issue created yet)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: Added `_needs_mimo_tool_reasoning()` method to detect Xiaomi MiMo thinking mode providers (by provider name, model name, and `xiaomimimo.com` base URL)
- `run_agent.py`: Updated `_needs_thinking_reasoning_pad()` to include `_needs_mimo_tool_reasoning()` in its check

## How to Test

1. Set primary model to Vertex Gemini, fallback to MiMo (`mimo-v2.5-pro` via custom provider with `xiaomimimo.com` base URL)
2. Send a message that triggers rate-limit on Gemini (HTTP 429)
3. Hermes falls back to MiMo — subsequent calls should succeed instead of failing with HTTP 400
4. Verify that conversation history with mixed providers (Gemini + MiMo) replays correctly to MiMo

### Reproduction (before fix)

1. Configure fallback chain: primary = Vertex Gemini, fallback = MiMo (`mimo-v2.5-pro`)
2. Trigger Gemini rate-limit (429)
3. Hermes falls back to MiMo
4. Next call fails with: `HTTP 400: "The reasoning_content in the thinking mode must be passed back to the API."`
5. Conversation is permanently broken until `/reset`

### After fix

Same steps as above — step 4 succeeds, conversation continues normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Linux (GCP Ubuntu)