### PR TITLE
draft: complete named agents stack

### DIFF
--- a/agent/agent_registry.py
+++ b/agent/agent_registry.py
@@ -1,0 +1,810 @@
+"""Native agent registry for Hermes.
+
+Discovers and validates reusable named agent definitions from:
+- Global: $HERMES_HOME/agents/*.md and $HERMES_HOME/agents/**/AGENT.md
+- Project: <project>/.hermes/agents/*.md and <project>/.hermes/agents/**/AGENT.md
+
+Project-local agents override global agents with the same name.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import typing
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Public exceptions
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class AgentLoadError(ValueError):
+    """Raised when an agent file fails validation."""
+
+    pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Secret-like field detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+SECRET_LIKE_FIELD_NAMES: typing.Final[typing.Set[str]] = {
+    "api_key",
+    "token",
+    "secret",
+    "password",
+    "api_key_base",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "private_key",
+}
+
+_SECRET_LIKE_PATTERN = re.compile(
+    r"^(.*[_-])?(api_key|token|secret|password|key|cred|credential)"
+    r"|(api_key|token|secret|password|key|cred|credential)[_-]?.*$",
+    re.IGNORECASE,
+)
+
+
+def _is_secret_like_field(name: str) -> bool:
+    """Return True if the field name looks like it contains a secret value."""
+    name_lower = name.lower()
+    if name_lower in SECRET_LIKE_FIELD_NAMES:
+        return True
+    if _SECRET_LIKE_PATTERN.match(name_lower):
+        return True
+    return False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dataclasses — internal normalized types
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AgentRouting:
+    mode: Literal["inherit", "hermes", "acp"] = "inherit"
+    provider: str | None = None
+    model: str | None = None
+    base_url: str | None = None
+    api_mode: str | None = None
+    reasoning_effort: str | None = None
+    acp_command: str | None = None
+    acp_args: list[str] | None = None
+    # runner is deferred to a future PR; reserve field for forward-compat
+    runner_mode: str | None = None
+    runner_name: str | None = None
+    runner_continue: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AgentRouting:
+        if data is None:
+            return cls()
+        return cls(
+            mode=data.get("mode", "inherit"),
+            provider=data.get("provider"),
+            model=data.get("model"),
+            base_url=data.get("base_url"),
+            api_mode=data.get("api_mode"),
+            reasoning_effort=data.get("reasoning_effort"),
+            acp_command=data.get("acp_command"),
+            acp_args=data.get("acp_args"),
+            runner_mode=data.get("runner", {}).get("mode") if isinstance(data.get("runner"), dict) else None,
+            runner_name=data.get("runner", {}).get("name") if isinstance(data.get("runner"), dict) else None,
+            runner_continue=data.get("runner", {}).get("continue") if isinstance(data.get("runner"), dict) else None,
+        )
+
+
+@dataclass(frozen=True)
+class AgentTools:
+    mode: Literal["inherit", "restrict", "none"] = "inherit"
+    allow_toolsets: list[str] | None = None
+    deny_toolsets: list[str] | None = None
+    allow_tools: list[str] | None = None
+    deny_tools: list[str] | None = None
+    inherit_mcp_toolsets: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AgentTools:
+        if data is None:
+            return cls()
+        return cls(
+            mode=data.get("mode", "inherit"),
+            allow_toolsets=data.get("allow_toolsets"),
+            deny_toolsets=data.get("deny_toolsets"),
+            allow_tools=data.get("allow_tools"),
+            deny_tools=data.get("deny_tools"),
+            inherit_mcp_toolsets=data.get("inherit_mcp_toolsets", True),
+        )
+
+
+@dataclass(frozen=True)
+class AgentSkills:
+    preload: tuple[str, ...] = ()
+    required: bool = False
+    missing: Literal["warn", "error", "ignore"] = "warn"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AgentSkills:
+        if data is None:
+            return cls()
+        preload_raw = data.get("preload", [])
+        preload: tuple[str, ...] = tuple(preload_raw) if isinstance(preload_raw, list) else ()
+        return cls(
+            preload=preload,
+            required=bool(data.get("required", False)),
+            missing=data.get("missing", "warn"),
+        )
+
+
+@dataclass(frozen=True)
+class AgentLimits:
+    max_iterations: int | None = None
+    timeout_seconds: int | None = None
+    max_context_chars: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AgentLimits:
+        if data is None:
+            return cls()
+        return cls(
+            max_iterations=data.get("max_iterations"),
+            timeout_seconds=data.get("timeout_seconds"),
+            max_context_chars=data.get("max_context_chars"),
+        )
+
+
+@dataclass(frozen=True)
+class AgentSecurity:
+    require_approval: bool = False
+    allow_side_effects: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AgentSecurity:
+        if data is None:
+            return cls()
+        return cls(
+            require_approval=bool(data.get("require_approval", False)),
+            allow_side_effects=bool(data.get("allow_side_effects", False)),
+        )
+
+
+@dataclass(frozen=True)
+class AgentCompatibility:
+    platforms: tuple[str, ...] = ()
+    min_hermes_version: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> AgentCompatibility:
+        if data is None:
+            return cls()
+        platforms_raw = data.get("platforms", [])
+        platforms: tuple[str, ...] = tuple(platforms_raw) if isinstance(platforms_raw, list) else ()
+        return cls(
+            platforms=platforms,
+            min_hermes_version=data.get("min_hermes_version"),
+        )
+
+
+@dataclass(frozen=True)
+class AgentDefinition:
+    """Normalized internal representation of a named agent definition."""
+
+    schema_version: int
+    name: str
+    display_name: str
+    description: str
+    enabled: bool
+    source: Literal["global", "project"]
+    path: Path
+    prompt: str
+
+    tags: list[str] = field(default_factory=list)
+    routing: AgentRouting = field(default_factory=AgentRouting)
+    tools: AgentTools = field(default_factory=AgentTools)
+    skills: AgentSkills = field(default_factory=AgentSkills)
+    limits: AgentLimits = field(default_factory=AgentLimits)
+    delegation_role: Literal["leaf", "orchestrator"] | None = None
+    security: AgentSecurity = field(default_factory=AgentSecurity)
+    compatibility: AgentCompatibility = field(default_factory=AgentCompatibility)
+    extensions: tuple[tuple[str, Any], ...] = field(default_factory=tuple)
+
+    # Metadata
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+    shadowed: bool = False  # True when this is a lower-priority definition hidden by a higher-priority one
+
+    def to_dict(self) -> dict[str, Any]:
+        """Full dict representation including prompt."""
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "enabled": self.enabled,
+            "source": self.source,
+            "path": str(self.path),
+            "prompt": self.prompt,
+            "tags": list(self.tags),
+            "routing": {
+                "mode": self.routing.mode,
+                "provider": self.routing.provider,
+                "model": self.routing.model,
+                "base_url": self.routing.base_url,
+                "api_mode": self.routing.api_mode,
+                "reasoning_effort": self.routing.reasoning_effort,
+                "acp_command": self.routing.acp_command,
+                "acp_args": self.routing.acp_args,
+            },
+            "tools": {
+                "mode": self.tools.mode,
+                "allow_toolsets": self.tools.allow_toolsets,
+                "deny_toolsets": self.tools.deny_toolsets,
+                "allow_tools": self.tools.allow_tools,
+                "deny_tools": self.tools.deny_tools,
+                "inherit_mcp_toolsets": self.tools.inherit_mcp_toolsets,
+            },
+            "skills": {
+                "preload": list(self.skills.preload),
+                "required": self.skills.required,
+                "missing": self.skills.missing,
+            },
+            "limits": {
+                "max_iterations": self.limits.max_iterations,
+                "timeout_seconds": self.limits.timeout_seconds,
+                "max_context_chars": self.limits.max_context_chars,
+            },
+            "delegation_role": self.delegation_role,
+            "security": {
+                "require_approval": self.security.require_approval,
+                "allow_side_effects": self.security.allow_side_effects,
+            },
+            "compatibility": {
+                "platforms": list(self.compatibility.platforms),
+                "min_hermes_version": self.compatibility.min_hermes_version,
+            },
+            "extensions": dict(self.extensions),
+            "warnings": list(self.warnings),
+            "shadowed": self.shadowed,
+        }
+
+    def list_summary(self) -> dict[str, Any]:
+        """Compact metadata suitable for agents_list output — no full prompt."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "tags": list(self.tags),
+            "source": self.source,
+            "path": str(self.path),
+            "enabled": self.enabled,
+            "routing": {
+                "mode": self.routing.mode,
+                "model": self.routing.model,
+                "provider": self.routing.provider,
+            },
+            "toolsets": list(self.tools.allow_toolsets) if self.tools.allow_toolsets else None,
+            "role": self.delegation_role,
+            "shadowed": self.shadowed,
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class AgentDir:
+    """A discovered agent directory with its source classification."""
+    path: Path
+    source: Literal["global", "project"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Name validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+_NAME_RE = re.compile(r"^[a-z][a-z0-9\-]{0,63}$")
+
+# Characters that are never allowed in agent names
+_FORBIDDEN_NAME_CHARS = frozenset("/\\.. \t\n\r")
+
+
+def validate_agent_name(name: str) -> str:
+    """Validate an agent name and return it (normalized) or raise AgentLoadError.
+
+    Rules:
+    - Must match ^[a-z][a-z0-9-]{0,63}$ (1-64 chars, lowercase alphanumeric + hyphens, must start with a letter)
+    - Cannot contain path separators, double-dots, spaces, or control chars
+    - Cannot be empty or start with a dash
+    """
+    if not name:
+        raise AgentLoadError("Agent name cannot be empty.")
+
+    if len(name) > 64:
+        raise AgentLoadError(f"Agent name '{name}' exceeds maximum length of 64 characters.")
+
+    # Check for forbidden characters
+    for char in _FORBIDDEN_NAME_CHARS:
+        if char in name:
+            raise AgentLoadError(
+                f"Agent name '{name}' contains forbidden character '{char}'."
+            )
+
+    # Reject names starting with dash
+    if name.startswith("-"):
+        raise AgentLoadError(f"Agent name '{name}' cannot start with a dash.")
+
+    # Reject hidden names (starting with dot)
+    if name.startswith("."):
+        raise AgentLoadError(f"Agent name '{name}' cannot start with a dot (hidden).")
+
+    if not _NAME_RE.match(name):
+        raise AgentLoadError(
+            f"Agent name '{name}' must be lowercase, start with a letter, "
+            "and may contain only letters, numbers, and hyphens (1-64 chars)."
+        )
+
+    return name
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Project root discovery
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _find_project_root(start: Path) -> Path | None:
+    """Walk upward from start and return the first directory containing .git or .hermes.
+
+    Returns None if no project root is found (filesystem root boundary).
+    Does not treat HERMES_HOME itself as a project root to avoid double-scanning.
+    """
+    hermes_home = get_hermes_home()
+    current: Path | None = start.resolve()
+
+    while current is not None:
+        # Stop at filesystem root
+        if current.parent == current:
+            return None
+
+        # Do not treat HERMES_HOME as a project root
+        if current == hermes_home:
+            return None
+
+        if (current / ".git").is_dir() or (current / ".hermes").is_dir():
+            return current
+
+        current = current.parent
+
+    return None
+
+
+def discover_agent_dirs(workdir: str | None = None) -> list[AgentDir]:
+    """Discover all agent directories.
+
+    Global: $HERMES_HOME/agents/
+    Project: <project>/.hermes/agents/ (when workdir is inside a project)
+
+    Returns a list of AgentDir objects. Global dirs are always included;
+    project dirs are included when workdir resolves inside a project.
+    """
+    dirs: list[AgentDir] = []
+    hermes_home = get_hermes_home()
+
+    # Global agents directory — always include the path if HERMES_HOME itself exists
+    # (the path may not exist yet; callers handle missing dirs gracefully)
+    if hermes_home.exists():
+        dirs.append(AgentDir(path=hermes_home / "agents", source="global"))
+
+    # Project-local agents directory
+    if workdir:
+        project_root = _find_project_root(Path(workdir).resolve())
+        if project_root is not None:
+            project_agents = project_root / ".hermes" / "agents"
+            dirs.append(AgentDir(path=project_agents, source="project"))
+
+    return dirs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Frontmatter and body parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _parse_yaml_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    """Parse YAML frontmatter from markdown content.
+
+    Returns (frontmatter_dict, body_str).
+    Uses the same safe-loading approach as agent.skill_utils.parse_frontmatter.
+    """
+    import yaml
+
+    # Import from agent.skill_utils if available (lazy to avoid circular deps)
+    try:
+        from agent.skill_utils import parse_frontmatter as skill_parse
+        return skill_parse(content)
+    except ImportError:
+        pass
+
+    # Inline fallback — same logic as skill_utils
+    frontmatter: dict[str, Any] = {}
+    body = content
+
+    if not content.startswith("---"):
+        return frontmatter, body
+
+    end_match = re.search(r"\n---\s*\n", content[3:])
+    if not end_match:
+        return frontmatter, body
+
+    yaml_content = content[3 : end_match.start() + 3]
+    body = content[end_match.end() + 3:]
+
+    try:
+        loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+        parsed = yaml.load(yaml_content, Loader=loader)
+        if isinstance(parsed, dict):
+            frontmatter = parsed
+    except Exception:
+        # Fallback: simple key:value parsing
+        for line in yaml_content.strip().split("\n"):
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            frontmatter[key.strip()] = value.strip()
+
+    return frontmatter, body
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agent file loading and validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MAX_FILE_SIZE = 128 * 1024  # 128 KiB
+
+
+def load_agent_file(path: Path, source: Literal["global", "project"]) -> AgentDefinition:
+    """Load and validate a single agent .md file.
+
+    Returns a normalized AgentDefinition or raises AgentLoadError.
+    """
+    # Basic file checks
+    if not path.is_file():
+        raise AgentLoadError(f"Agent file '{path}' is not a regular file.")
+
+    # Skip symlinks
+    if path.is_symlink():
+        raise AgentLoadError(f"Agent file '{path}' is a symlink — skipping.")
+
+    # Bound file size
+    try:
+        size = path.stat().st_size
+        if size > _MAX_FILE_SIZE:
+            raise AgentLoadError(
+                f"Agent file '{path.name}' exceeds maximum size: {size} bytes (max 128 KiB)."
+            )
+    except OSError as e:
+        raise AgentLoadError(f"Cannot stat agent file '{path}': {e}")
+
+    # Read content
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise AgentLoadError(f"Agent file '{path}' must be UTF-8 encoded: {e}.")
+    except OSError as e:
+        raise AgentLoadError(f"Cannot read agent file '{path}': {e}.")
+
+    # Parse frontmatter
+    try:
+        frontmatter, body = _parse_yaml_frontmatter(content)
+    except Exception as e:
+        raise AgentLoadError(f"Failed to parse frontmatter in '{path}': {e}")
+
+    if not isinstance(frontmatter, dict):
+        raise AgentLoadError(
+            f"Frontmatter in '{path.name}' must be a YAML dict, got {type(frontmatter).__name__}."
+        )
+
+    # Check for secret-like fields anywhere in frontmatter
+    _check_no_secret_fields(frontmatter, path.name)
+
+    # Validate required fields
+    schema_version = frontmatter.get("schema_version")
+    if schema_version is None:
+        raise AgentLoadError(f"Missing required field 'schema_version' in '{path.name}'.")
+    if not isinstance(schema_version, int):
+        raise AgentLoadError(
+            f"'schema_version' in '{path.name}' must be an integer, got {type(schema_version).__name__}."
+        )
+    if schema_version != 1:
+        raise AgentLoadError(
+            f"Unsupported schema_version {schema_version} in '{path.name}' — only schema_version: 1 is supported."
+        )
+
+    name = frontmatter.get("name")
+    if name is None:
+        raise AgentLoadError(f"Missing required field 'name' in '{path.name}'.")
+    if not isinstance(name, str):
+        raise AgentLoadError(f"'name' in '{path.name}' must be a string.")
+    name = validate_agent_name(name)
+
+    description = frontmatter.get("description")
+    if description is None:
+        raise AgentLoadError(f"Missing required field 'description' in '{path.name}'.")
+    if not isinstance(description, str):
+        raise AgentLoadError(f"'description' in '{path.name}' must be a string.")
+    if not (1 <= len(description) <= 500):
+        raise AgentLoadError(
+            f"'description' in '{path.name}' must be 1-500 characters, got {len(description)}."
+        )
+
+    # Validate prompt body
+    prompt = body.strip() if body else ""
+    if not prompt:
+        raise AgentLoadError(f"Agent '{name}' has an empty prompt body.")
+
+    # Collect warnings for unknown fields
+    warnings: list[str] = []
+    known_top_fields = {
+        "schema_version", "name", "display_name", "description", "enabled",
+        "tags", "routing", "tools", "skills", "limits",
+        "delegation", "security", "compatibility", "extensions",
+    }
+    for key in frontmatter:
+        if key not in known_top_fields and not key.startswith("x-"):
+            warnings.append(f"Unknown top-level field '{key}' — ignoring.")
+
+    # Normalize optional fields
+    enabled = bool(frontmatter.get("enabled", True))
+    display_name = frontmatter.get("display_name") or name
+
+    tags_raw = frontmatter.get("tags")
+    tags: list[str] = []
+    if isinstance(tags_raw, list):
+        tags = [str(t) for t in tags_raw]
+
+    routing = AgentRouting.from_dict(frontmatter.get("routing"))
+    # Warn about unknown routing fields (non-secret only)
+    routing_raw = frontmatter.get("routing")
+    if isinstance(routing_raw, dict):
+        known_routing_fields = {
+            "mode", "provider", "model", "base_url", "api_mode",
+            "reasoning_effort", "acp_command", "acp_args", "runner",
+        }
+        for key in routing_raw:
+            if key not in known_routing_fields and not key.startswith("x-"):
+                if not _is_secret_like_field(key):
+                    warnings.append(f"Unknown routing field '{key}' — ignoring.")
+    tools = AgentTools.from_dict(frontmatter.get("tools"))
+    skills = AgentSkills.from_dict(frontmatter.get("skills"))
+    limits = AgentLimits.from_dict(frontmatter.get("limits"))
+
+    delegation_raw = frontmatter.get("delegation")
+    delegation_role: Literal["leaf", "orchestrator"] | None = None
+    if isinstance(delegation_raw, dict):
+        delegation_role = delegation_raw.get("role")
+        if delegation_role not in (None, "leaf", "orchestrator"):
+            warnings.append(f"Unknown delegation.role '{delegation_role}' — ignoring.")
+            delegation_role = None
+
+    # Reject project-local ACP commands unconditionally (not gated on delegation block)
+    if source == "project" and routing.acp_command:
+        warnings.append("Project-local agents cannot set routing.acp_command — ignoring.")
+        routing = AgentRouting(
+            mode=routing.mode,
+            provider=routing.provider,
+            model=routing.model,
+            base_url=routing.base_url,
+            api_mode=routing.api_mode,
+            reasoning_effort=routing.reasoning_effort,
+            acp_command=None,
+            acp_args=None,
+        )
+
+    security = AgentSecurity.from_dict(frontmatter.get("security"))
+    # Warn about unknown security fields (non-secret only)
+    security_raw = frontmatter.get("security")
+    if isinstance(security_raw, dict):
+        known_security_fields = {"require_approval", "allow_side_effects"}
+        for key in security_raw:
+            if key not in known_security_fields and not key.startswith("x-"):
+                if not _is_secret_like_field(key):
+                    warnings.append(f"Unknown security field '{key}' — ignoring.")
+    compatibility = AgentCompatibility.from_dict(frontmatter.get("compatibility"))
+
+    extensions_raw = frontmatter.get("extensions")
+    extensions: tuple[tuple[str, Any], ...] = ()
+    if isinstance(extensions_raw, dict):
+        extensions = tuple(extensions_raw.items())
+
+    return AgentDefinition(
+        schema_version=schema_version,
+        name=name,
+        display_name=display_name,
+        description=description,
+        enabled=enabled,
+        source=source,
+        path=path,
+        prompt=prompt,
+        tags=tags,
+        routing=routing,
+        tools=tools,
+        skills=skills,
+        limits=limits,
+        delegation_role=delegation_role,
+        security=security,
+        compatibility=compatibility,
+        extensions=extensions,
+        warnings=tuple(warnings),
+    )
+
+
+def _check_no_secret_fields(data: dict[str, Any], path_name: str) -> None:
+    """Recursively check dict for secret-like field names and raise if found."""
+    for key, value in data.items():
+        if _is_secret_like_field(key):
+            raise AgentLoadError(
+                f"Agent '{path_name}' contains a secret-like field name '{key}' — rejecting load."
+            )
+        if isinstance(value, dict):
+            _check_no_secret_fields(value, path_name)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    _check_no_secret_fields(item, path_name)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agent discovery and listing
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Patterns for finding agent files
+_AGENT_FILE_PATTERNS: typing.Final[list[str]] = [
+    "*.md",
+    "*/AGENT.md",
+    "**/*.md",
+]
+
+
+def _iter_agent_files(dir_path: Path) -> typing.Iterator[Path]:
+    """Walk a directory tree and yield candidate agent file paths.
+
+    Skips symlinks and deduplicates — files matching both *.md and **/*.md
+    are yielded only once.
+    """
+    seen: set[Path] = set()
+
+    for pattern in _AGENT_FILE_PATTERNS:
+        for match in dir_path.glob(pattern):
+            if match in seen:
+                continue
+            if match.is_symlink():
+                continue
+            if not match.is_file():
+                continue
+            seen.add(match)
+            yield match
+
+
+def list_agents(
+    workdir: str | None = None,
+    include_disabled: bool = False,
+    include_shadowed: bool = False,
+) -> list[AgentDefinition]:
+    """List all discovered agents with optional filtering.
+
+    Project-local agents shadow global agents with the same name.
+    By default, shadowed lower-priority entries are hidden and disabled agents are hidden.
+    """
+    dirs = discover_agent_dirs(workdir=workdir)
+
+    # Collect all agents by name, tracking precedence
+    # Higher source priority = later in list (we process global then project)
+    agents_by_name: dict[str, list[AgentDefinition]] = {}
+
+    for dir_info in dirs:
+        try:
+            for file_path in _iter_agent_files(dir_info.path):
+                try:
+                    agent = load_agent_file(file_path, dir_info.source)
+                except AgentLoadError as e:
+                    logger.warning("Skipping agent file '%s': %s", file_path, e)
+                    continue
+
+                name = agent.name
+                if name not in agents_by_name:
+                    agents_by_name[name] = []
+
+                agents_by_name[name].append(agent)
+
+        except Exception as e:
+            logger.warning("Error scanning agent directory '%s': %s", dir_info.path, e)
+
+    # Build result list
+    result: list[AgentDefinition] = []
+    for name, agent_list in agents_by_name.items():
+        if len(agent_list) == 1:
+            agent = agent_list[0]
+            if not agent.enabled and not include_disabled:
+                continue
+            result.append(agent)
+        else:
+            # Multiple entries — determine precedence: project > global
+            # Sort so project comes last (we want effective = last appended)
+            sorted_agents = sorted(agent_list, key=lambda a: 0 if a.source == "global" else 1)
+
+            # Mark all but the effective as shadowed
+            effective = sorted_agents[-1]
+            if not effective.enabled and not include_disabled:
+                continue
+
+            for agent in sorted_agents[:-1]:
+                shadowed_agent = AgentDefinition(
+                    schema_version=agent.schema_version,
+                    name=agent.name,
+                    display_name=agent.display_name,
+                    description=agent.description,
+                    enabled=agent.enabled,
+                    source=agent.source,
+                    path=agent.path,
+                    prompt=agent.prompt,
+                    tags=agent.tags,
+                    routing=agent.routing,
+                    tools=agent.tools,
+                    skills=agent.skills,
+                    limits=agent.limits,
+                    delegation_role=agent.delegation_role,
+                    security=agent.security,
+                    compatibility=agent.compatibility,
+                    extensions=agent.extensions,
+                    warnings=agent.warnings,
+                    shadowed=True,
+                )
+                if include_shadowed:
+                    if shadowed_agent.enabled or include_disabled:
+                        result.append(shadowed_agent)
+
+            if include_shadowed or effective.enabled:
+                if not effective.enabled and not include_disabled:
+                    pass  # skip
+                else:
+                    result.append(effective)
+
+    return result
+
+
+def get_agent(
+    name: str,
+    workdir: str | None = None,
+    source: Literal["global", "project"] | None = None,
+) -> AgentDefinition | None:
+    """Get a single agent by name.
+
+    Returns the agent definition, or None if not found / disabled.
+    When source is specified, returns only agents from that source.
+    When source is specified, returns the agent even if it is shadowed.
+    Default get_agent(name) returns the effective (non-shadowed) agent.
+    """
+    # Validate name first
+    try:
+        validate_agent_name(name)
+    except AgentLoadError:
+        return None
+
+    agents = list_agents(workdir=workdir, include_disabled=True, include_shadowed=True)
+
+    for agent in agents:
+        if agent.name != name:
+            continue
+        if source is not None and agent.source != source:
+            continue
+        # When source is specified, return even shadowed entries (caller asked for that source)
+        if agent.shadowed and source is None:
+            continue
+        # Return disabled agents too — caller checks .enabled if they care
+        return agent
+
+    return None

--- a/agent/agent_registry.py
+++ b/agent/agent_registry.py
@@ -86,9 +86,11 @@ class AgentRouting:
     runner_continue: str | None = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> AgentRouting:
+    def from_dict(cls, data: dict[str, Any] | None, runner: dict[str, Any] | None = None) -> AgentRouting:
         if data is None:
-            return cls()
+            data = {}
+        routing_runner = data.get("runner") if isinstance(data.get("runner"), dict) else None
+        runner_data = runner if isinstance(runner, dict) else routing_runner
         return cls(
             mode=data.get("mode", "inherit"),
             provider=data.get("provider"),
@@ -98,9 +100,9 @@ class AgentRouting:
             reasoning_effort=data.get("reasoning_effort"),
             acp_command=data.get("acp_command"),
             acp_args=data.get("acp_args"),
-            runner_mode=data.get("runner", {}).get("mode") if isinstance(data.get("runner"), dict) else None,
-            runner_name=data.get("runner", {}).get("name") if isinstance(data.get("runner"), dict) else None,
-            runner_continue=data.get("runner", {}).get("continue") if isinstance(data.get("runner"), dict) else None,
+            runner_mode=runner_data.get("mode") if isinstance(runner_data, dict) else None,
+            runner_name=runner_data.get("name") if isinstance(runner_data, dict) else None,
+            runner_continue=runner_data.get("continue") if isinstance(runner_data, dict) else None,
         )
 
 
@@ -243,6 +245,11 @@ class AgentDefinition:
                 "reasoning_effort": self.routing.reasoning_effort,
                 "acp_command": self.routing.acp_command,
                 "acp_args": self.routing.acp_args,
+                "runner": {
+                    "mode": self.routing.runner_mode or "delegate_task",
+                    "name": self.routing.runner_name,
+                    "continue": self.routing.runner_continue or "off",
+                },
             },
             "tools": {
                 "mode": self.tools.mode,
@@ -290,6 +297,11 @@ class AgentDefinition:
                 "mode": self.routing.mode,
                 "model": self.routing.model,
                 "provider": self.routing.provider,
+                "runner": {
+                    "mode": self.routing.runner_mode or "delegate_task",
+                    "name": self.routing.runner_name,
+                    "continue": self.routing.runner_continue or "off",
+                },
             },
             "toolsets": list(self.tools.allow_toolsets) if self.tools.allow_toolsets else None,
             "role": self.delegation_role,
@@ -550,7 +562,7 @@ def load_agent_file(path: Path, source: Literal["global", "project"]) -> AgentDe
     warnings: list[str] = []
     known_top_fields = {
         "schema_version", "name", "display_name", "description", "enabled",
-        "tags", "routing", "tools", "skills", "limits",
+        "tags", "routing", "runner", "tools", "skills", "limits",
         "delegation", "security", "compatibility", "extensions",
     }
     for key in frontmatter:
@@ -566,7 +578,7 @@ def load_agent_file(path: Path, source: Literal["global", "project"]) -> AgentDe
     if isinstance(tags_raw, list):
         tags = [str(t) for t in tags_raw]
 
-    routing = AgentRouting.from_dict(frontmatter.get("routing"))
+    routing = AgentRouting.from_dict(frontmatter.get("routing"), frontmatter.get("runner"))
     # Warn about unknown routing fields (non-secret only)
     routing_raw = frontmatter.get("routing")
     if isinstance(routing_raw, dict):
@@ -602,6 +614,9 @@ def load_agent_file(path: Path, source: Literal["global", "project"]) -> AgentDe
             reasoning_effort=routing.reasoning_effort,
             acp_command=None,
             acp_args=None,
+            runner_mode=routing.runner_mode,
+            runner_name=routing.runner_name,
+            runner_continue=routing.runner_continue,
         )
 
     security = AgentSecurity.from_dict(frontmatter.get("security"))

--- a/agent/agent_runner.py
+++ b/agent/agent_runner.py
@@ -1,0 +1,279 @@
+"""Trusted CLI runner execution for named Hermes agents."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+@dataclass(frozen=True)
+class CliRunnerResult:
+    success: bool
+    output: str
+    stderr: str
+    returncode: int
+    runner_name: str
+    command: list[str]
+    resumed: bool = False
+    external_session_id: str | None = None
+    error: str | None = None
+    warning: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {
+            "success": self.success,
+            "output": self.output,
+            "stderr": self.stderr,
+            "returncode": self.returncode,
+            "runner": {"mode": "cli", "name": self.runner_name, "resumed": self.resumed},
+            "external_session_id": self.external_session_id,
+            "error": self.error,
+        }
+        if self.warning:
+            result["warning"] = self.warning
+        return result
+
+
+class CliSessionStore:
+    """JSON-backed mapping from Hermes session + agent + runner to CLI session id."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or (get_hermes_home() / "agent-runner-sessions.json")
+
+    @staticmethod
+    def _make_key(*, parent_session_id: str, agent_name: str, runner_name: str, workdir: str | None) -> str:
+        return json.dumps(
+            {
+                "parent_session_id": parent_session_id or "default",
+                "agent_name": agent_name,
+                "runner_name": runner_name,
+                "workdir": str(Path(workdir).resolve()) if workdir else "",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @contextmanager
+    def _locked(self):
+        """Serialize updates across Hermes processes using an advisory lock."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        with lock_path.open("a+") as lock_file:
+            try:
+                import fcntl
+
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            except (ImportError, OSError):
+                # Best-effort fallback for non-POSIX platforms; writes remain atomic
+                # via replace(), but concurrent read-modify-write may still race.
+                pass
+            try:
+                yield
+            finally:
+                try:
+                    import fcntl
+
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except (ImportError, OSError):
+                    pass
+
+    def _read(self) -> dict[str, str]:
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write(self, data: dict[str, str]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def get(self, *, parent_session_id: str, agent_name: str, runner_name: str, workdir: str | None) -> str | None:
+        value = self._read().get(self._make_key(
+            parent_session_id=parent_session_id,
+            agent_name=agent_name,
+            runner_name=runner_name,
+            workdir=workdir,
+        ))
+        return value if isinstance(value, str) and value else None
+
+    def set(self, *, parent_session_id: str, agent_name: str, runner_name: str, workdir: str | None, external_session_id: str) -> None:
+        if not external_session_id:
+            return
+        with self._locked():
+            data = self._read()
+            data[self._make_key(
+                parent_session_id=parent_session_id,
+                agent_name=agent_name,
+                runner_name=runner_name,
+                workdir=workdir,
+            )] = external_session_id
+            self._write(data)
+
+
+def _load_agent_runners_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        cfg = {}
+    runners = cfg.get("agent_runners") or {}
+    return runners if isinstance(runners, dict) else {}
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("runner args must be a list of strings")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError("runner args must be a list of strings")
+    return list(value)
+
+
+def _extract_external_session_id(stdout: str) -> str | None:
+    for line in stdout.splitlines():
+        try:
+            obj = json.loads(line.strip())
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        for key in ("session_id", "sessionId", "sessionID", "id"):
+            value = obj.get(key)
+            if isinstance(value, str) and value:
+                return value
+        session = obj.get("session")
+        if isinstance(session, dict):
+            for key in ("id", "session_id", "sessionId"):
+                value = session.get(key)
+                if isinstance(value, str) and value:
+                    return value
+    match = re.search(r"(?:session[_ -]?id|Session ID)[:=]\s*([A-Za-z0-9_.:-]{6,})", stdout)
+    return match.group(1) if match else None
+
+
+def build_cli_prompt(*, agent_name: str, agent_prompt: str, task: str, context: str | None, source: str, path: str) -> str:
+    parts = [
+        f"## Named agent: {agent_name}",
+        f"Source: {source} — {path}",
+        "",
+        "## Agent instructions",
+        agent_prompt,
+        "",
+        "## Assignment task",
+        task,
+    ]
+    if context and context.strip():
+        parts.extend(["", "## Assignment context", context.strip()])
+    return "\n".join(parts)
+
+
+def run_cli_agent(*, agent: Any, task: str, context: str | None, workdir: str | None, parent_session_id: str) -> CliRunnerResult:
+    runner_name = getattr(agent.routing, "runner_name", None)
+    if not runner_name:
+        return CliRunnerResult(False, "", "", 0, "", [], error="CLI runner requires runner.name.")
+
+    runner_cfg = _load_agent_runners_config().get(runner_name)
+    if not isinstance(runner_cfg, dict):
+        return CliRunnerResult(False, "", "", 0, runner_name, [], error=f"Agent runner '{runner_name}' is not configured.")
+    if runner_cfg.get("type") != "cli":
+        return CliRunnerResult(False, "", "", 0, runner_name, [], error=f"Agent runner '{runner_name}' is not a cli runner.")
+    if getattr(agent, "source", None) == "project" and not bool(runner_cfg.get("allowed_from_project_agents", False)):
+        return CliRunnerResult(False, "", "", 0, runner_name, [], error=f"Agent runner '{runner_name}' is not allowed for project-local agents.")
+
+    command = runner_cfg.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return CliRunnerResult(False, "", "", 0, runner_name, [], error=f"Agent runner '{runner_name}' has no command.")
+    try:
+        cmd = [command, *_as_str_list(runner_cfg.get("args", []))]
+    except ValueError as exc:
+        return CliRunnerResult(False, "", "", 0, runner_name, [], error=str(exc))
+
+    continue_mode = getattr(agent.routing, "runner_continue", None) or "off"
+    if continue_mode not in ("off", "auto", "require"):
+        return CliRunnerResult(False, "", "", 0, runner_name, cmd, error=f"Unsupported runner.continue='{continue_mode}'.")
+
+    store = CliSessionStore()
+    external_session_id = None
+    resumed = False
+    if continue_mode in ("auto", "require"):
+        external_session_id = store.get(
+            parent_session_id=parent_session_id,
+            agent_name=agent.name,
+            runner_name=runner_name,
+            workdir=workdir,
+        )
+        if external_session_id:
+            resume_arg = runner_cfg.get("resume_arg")
+            if not isinstance(resume_arg, str) or not resume_arg:
+                return CliRunnerResult(False, "", "", 0, runner_name, cmd, error=f"Agent runner '{runner_name}' has no resume_arg configured.")
+            cmd.extend([resume_arg, external_session_id])
+            resumed = True
+        elif continue_mode == "require":
+            return CliRunnerResult(False, "", "", 0, runner_name, cmd, error=f"Agent '{agent.name}' requires an existing CLI session for runner '{runner_name}'.")
+
+    prompt = build_cli_prompt(
+        agent_name=agent.name,
+        agent_prompt=agent.prompt,
+        task=task,
+        context=context,
+        source=agent.source,
+        path=str(agent.path),
+    )
+    timeout = getattr(agent.limits, "timeout_seconds", None) or runner_cfg.get("timeout_seconds") or 600
+    try:
+        completed = subprocess.run(
+            cmd,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            cwd=workdir or None,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return CliRunnerResult(False, "", "", 127, runner_name, cmd, resumed=resumed, error=f"Runner command not found: {command}")
+    except subprocess.TimeoutExpired as exc:
+        return CliRunnerResult(False, exc.stdout or "", exc.stderr or "", 124, runner_name, cmd, resumed=resumed, external_session_id=external_session_id, error=f"Runner '{runner_name}' timed out after {timeout} seconds.")
+
+    stdout = completed.stdout or ""
+    stderr = completed.stderr or ""
+    new_session_id = _extract_external_session_id(stdout) or external_session_id
+    warning = None
+    if new_session_id:
+        try:
+            store.set(
+                parent_session_id=parent_session_id,
+                agent_name=agent.name,
+                runner_name=runner_name,
+                workdir=workdir,
+                external_session_id=new_session_id,
+            )
+        except OSError as exc:
+            warning = f"Failed to persist CLI session id for runner '{runner_name}': {exc}"
+
+    return CliRunnerResult(
+        completed.returncode == 0,
+        stdout,
+        stderr,
+        completed.returncode,
+        runner_name,
+        cmd,
+        resumed=resumed,
+        external_session_id=new_session_id,
+        error=None if completed.returncode == 0 else f"Runner '{runner_name}' exited with {completed.returncode}.",
+        warning=warning,
+    )

--- a/agent/runtime_trace.py
+++ b/agent/runtime_trace.py
@@ -1,0 +1,134 @@
+"""Safe runtime trace logging for Hermes agent routing decisions.
+
+This module is intentionally tiny and best-effort: observability must never
+change whether an agent run succeeds.  Events are JSONL so they can be tailed,
+filtered, and exposed through tools without a database migration.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_TRACE_FILE_NAME = "runtime-trace.jsonl"
+_REDACTED = "[REDACTED]"
+_SECRET_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "auth_token",
+    "password",
+    "secret",
+    "token",
+)
+
+
+def _trace_path() -> Path:
+    return get_hermes_home() / "logs" / _TRACE_FILE_NAME
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _is_secret_key(key: str) -> bool:
+    lowered = key.lower().replace("-", "_")
+    return any(part in lowered for part in _SECRET_KEY_PARTS)
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for key, item in value.items():
+            key_str = str(key)
+            sanitized[key_str] = _REDACTED if _is_secret_key(key_str) else _sanitize(item)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def emit_runtime_event(
+    event: str,
+    *,
+    session_id: str | None = None,
+    task_id: str | None = None,
+    **data: Any,
+) -> None:
+    """Append a runtime trace event.
+
+    This function is best-effort by design.  It catches all exceptions so
+    debug logging cannot break the production runtime path.
+    """
+    try:
+        payload = {
+            "ts": _utc_now_iso(),
+            "session_id": session_id or "default",
+            "task_id": task_id or "",
+            "event": str(event),
+            "data": _sanitize(data),
+        }
+        path = _trace_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        return
+
+
+def _agent_name_from_event(event: dict[str, Any]) -> str | None:
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return None
+    agent = data.get("agent")
+    if isinstance(agent, dict) and isinstance(agent.get("name"), str):
+        return agent["name"]
+    if isinstance(data.get("agent_name"), str):
+        return data["agent_name"]
+    return None
+
+
+def read_runtime_events(
+    *,
+    session_id: str | None = None,
+    limit: int = 50,
+    agent_name: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read recent runtime trace events, newest last in the returned list."""
+    try:
+        max_events = max(1, min(int(limit), 500))
+    except (TypeError, ValueError):
+        max_events = 50
+
+    path = _trace_path()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+    except Exception:
+        return []
+
+    matched: list[dict[str, Any]] = []
+    for line in reversed(lines):
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if session_id and event.get("session_id") != session_id:
+            continue
+        if agent_name and _agent_name_from_event(event) != agent_name:
+            continue
+        matched.append(event)
+        if len(matched) >= max_events:
+            break
+    return list(reversed(matched))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1082,6 +1082,18 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
+    # Trusted named-agent runners. Agent files may request runner.name, but
+    # executable command, args, env, and resume flag live here in user-owned
+    # config. Example:
+    # agent_runners:
+    #   gemini-cli:
+    #     type: cli
+    #     command: gemini
+    #     args: ["--output-format", "stream-json"]
+    #     resume_arg: "--resume"
+    #     allowed_from_project_agents: true
+    "agent_runners": {},
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all

--- a/model_tools.py
+++ b/model_tools.py
@@ -703,6 +703,7 @@ def handle_function_call(
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
+    parent_agent: Any = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -716,6 +717,8 @@ def handle_function_call(
                        execute_code uses this list to determine which sandbox
                        tools to generate.  Falls back to the process-global
                        ``_last_resolved_tool_names`` for backward compat.
+        parent_agent: Optional calling AIAgent instance for tools that need
+                      runtime context (for example assign_agent -> delegate_task).
 
     Returns:
         Function result as a JSON string.
@@ -785,6 +788,7 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                parent_agent=parent_agent,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9441,6 +9441,43 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    def _emit_model_request_trace(self, *, api_kwargs: dict | None, effective_task_id: str | None, api_call_count: int) -> None:
+        """Emit safe metadata proving which model/provider path is about to run.
+
+        Never include prompts, messages, API keys, auth headers, or the full
+        base URL.  Runtime observability must be best-effort and must not alter
+        the model-call path.
+        """
+        try:
+            from agent.runtime_trace import emit_runtime_event
+
+            tools = []
+            if isinstance(api_kwargs, dict) and isinstance(api_kwargs.get("tools"), list):
+                tools = api_kwargs.get("tools") or []
+            elif isinstance(getattr(self, "tools", None), list):
+                tools = self.tools or []
+
+            base_url_host = getattr(self, "_base_url_hostname", "") or ""
+            if not base_url_host and getattr(self, "base_url", None):
+                try:
+                    base_url_host = urlparse(str(self.base_url)).hostname or ""
+                except Exception:
+                    base_url_host = ""
+
+            emit_runtime_event(
+                "model.request",
+                session_id=self.session_id or "default",
+                task_id=effective_task_id or "",
+                provider=self.provider,
+                model=self.model,
+                api_mode=self.api_mode,
+                base_url_host=base_url_host,
+                tool_count=len(tools),
+                api_call_count=api_call_count,
+            )
+        except Exception:
+            pass
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         tools_for_api = self.tools
@@ -12503,6 +12540,12 @@ class AIAgent:
                         _sanitize_structure_non_ascii(api_kwargs)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+
+                    self._emit_model_request_trace(
+                        api_kwargs=api_kwargs,
+                        effective_task_id=effective_task_id,
+                        api_call_count=api_call_count,
+                    )
 
                     try:
                         from hermes_cli.plugins import invoke_hook as _invoke_hook

--- a/run_agent.py
+++ b/run_agent.py
@@ -11335,6 +11335,7 @@ class AIAgent:
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         skip_pre_tool_call_hook=True,
+                        parent_agent=self,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -11355,6 +11356,7 @@ class AIAgent:
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         skip_pre_tool_call_hook=True,
+                        parent_agent=self,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/tests/agent/test_agent_registry.py
+++ b/tests/agent/test_agent_registry.py
@@ -1,0 +1,908 @@
+"""Tests for agent/agent_registry.py — native agent registry discovery and validation."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Import the module under test
+from agent.agent_registry import (
+    AgentDefinition,
+    AgentRouting,
+    AgentTools,
+    AgentSkills,
+    AgentLimits,
+    AgentSecurity,
+    AgentCompatibility,
+    discover_agent_dirs,
+    get_agent,
+    list_agents,
+    load_agent_file,
+    validate_agent_name,
+    AgentLoadError,
+    SECRET_LIKE_FIELD_NAMES,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME for the duration of a test."""
+    hh = tmp_path / ".hermes"
+    hh.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hh))
+    return hh
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """A fake git-backed project root."""
+    pr = tmp_path / "my-project"
+    pr.mkdir()
+    (pr / ".git").mkdir()
+    return pr
+
+
+@pytest.fixture
+def global_agents_dir(hermes_home):
+    """Global agents directory."""
+    d = hermes_home / "agents"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def project_agents_dir(project_root):
+    """Project-local agents directory."""
+    d = project_root / ".hermes" / "agents"
+    d.mkdir(parents=True)
+    return d
+
+
+def make_agent(path: Path, name: str, description: str = "A test agent", **frontmatter):
+    """Write a minimal valid agent file."""
+    fm = {"schema_version": 1, "name": name, "description": description}
+    fm.update(frontmatter)
+    lines = ["---", *[f"{k}: {v}" for k, v in fm.items()], "---", "", "This is the agent prompt."]
+    path.write_text("\n".join(lines))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Name validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestValidateAgentName:
+    def test_valid_simple(self):
+        assert validate_agent_name("qa-engineer") == "qa-engineer"
+
+    def test_valid_with_numbers(self):
+        assert validate_agent_name("code-explorer-2") == "code-explorer-2"
+
+    def test_valid_min_length(self):
+        assert validate_agent_name("a") == "a"
+
+    def test_valid_max_length_64(self):
+        assert validate_agent_name("a" * 64) == "a" * 64
+
+    def test_rejects_empty(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("")
+
+    def test_rejects_uppercase(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("BadName")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("has space")
+
+    def test_rejects_path_separator(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("foo/bar")
+
+    def test_rejects_double_dot(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("..evil")
+
+    def test_rejects_hidden(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name(".hidden")
+
+    def test_rejects_slashes(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("foo\\bar")
+
+    def test_rejects_too_long(self):
+        with pytest.raises(AgentLoadError):
+            validate_agent_name("a" * 65)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Secret-like fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSecretLikeFields:
+    def test_rejects_api_key(self):
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: secret-agent\n"
+            "description: test\n"
+            "routing:\n"
+            "  api_key: sk-123456\n"
+            "---\n"
+            "prompt\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+
+        try:
+            with pytest.raises(AgentLoadError, match="secret"):
+                load_agent_file(path, "global")
+        finally:
+            path.unlink()
+
+    def test_rejects_token_field(self):
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: token-agent\n"
+            "description: test\n"
+            "token: mytoken123\n"
+            "---\n"
+            "prompt\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+
+        try:
+            with pytest.raises(AgentLoadError, match="secret"):
+                load_agent_file(path, "global")
+        finally:
+            path.unlink()
+
+    def test_rejects_password_field(self):
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: pw-agent\n"
+            "description: test\n"
+            "password: hunter2\n"
+            "---\n"
+            "prompt\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+
+        try:
+            with pytest.raises(AgentLoadError, match="secret"):
+                load_agent_file(path, "global")
+        finally:
+            path.unlink()
+
+    def test_rejects_suffixed_key(self):
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: suffix-agent\n"
+            "description: test\n"
+            "routing:\n"
+            "  anthropic_key: sk-ant-123\n"
+            "---\n"
+            "prompt\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+
+        try:
+            with pytest.raises(AgentLoadError, match="secret"):
+                load_agent_file(path, "global")
+        finally:
+            path.unlink()
+
+    def test_rejects_suffixed_token(self):
+        content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: sfx-token-agent\n"
+            "description: test\n"
+            "github_token: ghp_xxx\n"
+            "---\n"
+            "prompt\n"
+        )
+        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+
+        try:
+            with pytest.raises(AgentLoadError, match="secret"):
+                load_agent_file(path, "global")
+        finally:
+            path.unlink()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Empty directories
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEmptyDirs:
+    def test_empty_global_agents_returns_empty(self, hermes_home, monkeypatch):
+        """list_agents on a HERMES_HOME with no agents dir returns [] without crash."""
+        # Ensure no agents dir exists
+        agents_dir = hermes_home / "agents"
+        # Don't create it
+        result = list_agents()
+        assert result == []
+
+    def test_no_global_dir_no_crash(self, tmp_path, monkeypatch):
+        """When HERMES_HOME has no agents/ subdirectory at all, list_agents returns []. """
+        hh = tmp_path / ".hermes"
+        hh.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hh))
+        result = list_agents()
+        assert result == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Valid global agent loading
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGlobalAgentLoading:
+    def test_loads_valid_global_agent(self, global_agents_dir):
+        """A valid global agent loads and fields normalize correctly."""
+        path = global_agents_dir / "qa-engineer.md"
+        make_agent(path, "qa-engineer", "Reviews code changes for correctness.")
+
+        agents = list_agents()
+        assert len(agents) == 1
+        agent = agents[0]
+        assert agent.name == "qa-engineer"
+        assert agent.source == "global"
+        assert agent.path == path
+        assert agent.description == "Reviews code changes for correctness."
+        assert agent.enabled is True
+        assert agent.prompt == "This is the agent prompt."
+
+    def test_get_agent_by_name(self, global_agents_dir):
+        """get_agent returns the correct agent."""
+        path = global_agents_dir / "code-analyst.md"
+        make_agent(path, "code-analyst", "Analyzes code structure.")
+
+        agent = get_agent("code-analyst")
+        assert agent is not None
+        assert agent.name == "code-analyst"
+        assert agent.description == "Analyzes code structure."
+
+    def test_nonexistent_agent_returns_none(self, global_agents_dir):
+        """get_agent returns None for unknown name."""
+        assert get_agent("does-not-exist") is None
+
+    def test_display_name_defaults_to_name(self, global_agents_dir):
+        """display_name falls back to name when not provided."""
+        path = global_agents_dir / "simple.md"
+        make_agent(path, "simple-agent", "A simple agent.")
+        agent = get_agent("simple-agent")
+        assert agent is not None
+        assert agent.display_name == "simple-agent"
+
+    def test_display_name_from_frontmatter(self, global_agents_dir):
+        """display_name is used when provided."""
+        path = global_agents_dir / "display-test.md"
+        make_agent(path, "display-test", "A test agent.", display_name="My Custom Name")
+        agent = get_agent("display-test")
+        assert agent is not None
+        assert agent.display_name == "My Custom Name"
+
+    def test_tags_normalized(self, global_agents_dir):
+        """tags are loaded as a list."""
+        path = global_agents_dir / "tagged-agent.md"
+        make_agent(path, "tagged-agent", "An agent with tags.", tags=["coding", "review"])
+        agent = get_agent("tagged-agent")
+        assert agent is not None
+        assert agent.tags == ["coding", "review"]
+
+    def test_routing_defaults_inherit(self, global_agents_dir):
+        """routing defaults to mode=inherit when not specified."""
+        path = global_agents_dir / "no-routing.md"
+        make_agent(path, "no-routing", "No routing specified.")
+        agent = get_agent("no-routing")
+        assert agent is not None
+        assert agent.routing.mode == "inherit"
+
+    def test_tools_defaults_inherit(self, global_agents_dir):
+        """tools defaults to mode=inherit when not specified."""
+        path = global_agents_dir / "no-tools.md"
+        make_agent(path, "no-tools", "No tools specified.")
+        agent = get_agent("no-tools")
+        assert agent is not None
+        assert agent.tools.mode == "inherit"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Prompt body required
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPromptBodyRequired:
+    def test_rejects_empty_body(self, global_agents_dir):
+        """Agent with no body after frontmatter is rejected."""
+        path = global_agents_dir / "empty-body.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: empty-body\n"
+            "description: no body\n"
+            "---\n"
+            "\n"
+        )
+        with pytest.raises(AgentLoadError, match="prompt"):
+            load_agent_file(path, "global")
+
+    def test_rejects_whitespace_only_body(self, global_agents_dir):
+        """Agent with only whitespace body is rejected."""
+        path = global_agents_dir / "ws-body.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: ws-body\n"
+            "description: ws only\n"
+            "---\n"
+            "   \n"
+        )
+        with pytest.raises(AgentLoadError, match="prompt"):
+            load_agent_file(path, "global")
+
+    def test_accepts_minimal_body(self, global_agents_dir):
+        """Agent with single-line body is accepted."""
+        path = global_agents_dir / "tiny-body.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: tiny-body\n"
+            "description: tiny\n"
+            "---\n"
+            "x\n"
+        )
+        agent = load_agent_file(path, "global")
+        assert agent.prompt.strip() == "x"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Symlink handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSymlinksSkipped:
+    def test_symlink_in_agents_dir_skipped(self, global_agents_dir):
+        """A symlink inside the agents dir is not loaded."""
+        real = global_agents_dir / "real-agent.md"
+        make_agent(real, "real-agent", "Real agent.")
+
+        link = global_agents_dir / "link-agent.md"
+        link.symlink_to(real)
+
+        agents = list_agents()
+        names = [a.name for a in agents]
+        assert "real-agent" in names
+        # Symlink should be skipped (not crash)
+        assert "link-agent" not in names
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Malformed frontmatter
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestMalformedFrontmatter:
+    def test_bad_yaml_is_warning_not_crash(self, global_agents_dir):
+        """Bad YAML frontmatter produces a warning but doesn't crash list_agents."""
+        path = global_agents_dir / "bad-yaml.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: bad-yaml\n"
+            "description: bad yaml\n"
+            "  - this is not valid yaml list\n"
+            "---\n"
+            "prompt\n"
+        )
+        # Should not raise — warning is logged, agent skipped
+        agents = list_agents()
+        names = [a.name for a in agents]
+        # bad-yaml may or may not load depending on fallback; at minimum no crash
+        assert True  # reached here = no crash
+
+    def test_missing_required_name_field(self, global_agents_dir):
+        """Missing name field in frontmatter is rejected."""
+        path = global_agents_dir / "no-name.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "description: no name\n"
+            "---\n"
+            "prompt\n"
+        )
+        with pytest.raises(AgentLoadError, match="name"):
+            load_agent_file(path, "global")
+
+    def test_missing_required_description_field(self, global_agents_dir):
+        """Missing description field in frontmatter is rejected."""
+        path = global_agents_dir / "no-desc.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: no-desc\n"
+            "---\n"
+            "prompt\n"
+        )
+        with pytest.raises(AgentLoadError, match="description"):
+            load_agent_file(path, "global")
+
+    def test_wrong_schema_version(self, global_agents_dir):
+        """Wrong schema version is rejected."""
+        path = global_agents_dir / "bad-schema.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 99\n"
+            "name: bad-schema\n"
+            "description: wrong schema\n"
+            "---\n"
+            "prompt\n"
+        )
+        with pytest.raises(AgentLoadError, match="schema"):
+            load_agent_file(path, "global")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Disabled agents
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDisabledAgents:
+    def test_disabled_hidden_by_default(self, global_agents_dir):
+        """enabled: false agents are hidden from default list_agents."""
+        path = global_agents_dir / "disabled-agent.md"
+        make_agent(path, "disabled-agent", "Should be hidden.", enabled=False)
+
+        agents = list_agents()
+        names = [a.name for a in agents]
+        assert "disabled-agent" not in names
+
+    def test_disabled_visible_with_include_disabled(self, global_agents_dir):
+        """enabled: false agents appear when include_disabled=True."""
+        path = global_agents_dir / "disabled-agent.md"
+        make_agent(path, "disabled-agent", "Should be visible.", enabled=False)
+
+        agents = list_agents(include_disabled=True)
+        names = [a.name for a in agents]
+        assert "disabled-agent" in names
+
+    def test_disabled_agent_not_gettable(self, global_agents_dir):
+        """get_agent still returns disabled agents (caller can check .enabled)."""
+        path = global_agents_dir / "disabled-agent.md"
+        make_agent(path, "disabled-agent", "A disabled agent.", enabled=False)
+
+        agent = get_agent("disabled-agent")
+        assert agent is not None
+        assert agent.enabled is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Project overrides global
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestProjectOverridesGlobal:
+    def test_project_agent_overrides_global(self, global_agents_dir, project_agents_dir, project_root):
+        """A project-local agent with the same name shadows the global one."""
+        # Global agent
+        gpath = global_agents_dir / "qa-engineer.md"
+        make_agent(gpath, "qa-engineer", "Global QA Engineer")
+
+        # Project agent with same name
+        ppath = project_agents_dir / "qa-engineer.md"
+        make_agent(ppath, "qa-engineer", "Project QA Engineer")
+
+        # get_agent should return project source
+        agent = get_agent("qa-engineer", workdir=str(project_root))
+        assert agent is not None
+        assert agent.source == "project"
+        assert agent.description == "Project QA Engineer"
+        assert agent.path == ppath
+
+    def test_global_still_accessible_when_not_shadowed(self, global_agents_dir, project_agents_dir):
+        """Agents that exist only globally are still found."""
+        gpath = global_agents_dir / "code-analyst.md"
+        make_agent(gpath, "code-analyst", "Global Code Analyst")
+
+        agent = get_agent("code-analyst", workdir=str(project_root))
+        assert agent is not None
+        assert agent.source == "global"
+        assert agent.description == "Global Code Analyst"
+
+    def test_include_shadowed_shows_both(self, global_agents_dir, project_agents_dir, project_root):
+        """include_shadowed=True shows both project-effective and global-shadowed."""
+        gpath = global_agents_dir / "qa-engineer.md"
+        make_agent(gpath, "qa-engineer", "Global QA Engineer")
+
+        ppath = project_agents_dir / "qa-engineer.md"
+        make_agent(ppath, "qa-engineer", "Project QA Engineer")
+
+        agents = list_agents(workdir=str(project_root), include_shadowed=True)
+        names = [a.name for a in agents]
+        assert "qa-engineer" in names
+
+        # Find the shadowed entry
+        shadowed = [a for a in agents if a.shadowed]
+        effective = [a for a in agents if not a.shadowed]
+
+        assert len(shadowed) == 1
+        assert shadowed[0].source == "global"
+        assert shadowed[0].name == "qa-engineer"
+
+        assert len(effective) == 1
+        assert effective[0].source == "project"
+        assert effective[0].description == "Project QA Engineer"
+
+    def test_hermes_home_not_treated_as_project_duplicate(self, hermes_home, monkeypatch):
+        """$HERMES_HOME agents dir should not be scanned as a project-local duplicate."""
+        # Create agents in HERMES_HOME
+        agents_dir = hermes_home / "agents"
+        agents_dir.mkdir()
+        make_agent(agents_dir / "global-only.md", "global-only", "Global only.")
+
+        # Do not create .hermes in hermes_home (would make it look like a project root)
+        # list_agents should return the global agent
+        result = list_agents()
+        names = [a.name for a in result]
+        assert "global-only" in names
+
+    def test_get_agent_source_global_returns_shadowed(self, global_agents_dir, project_agents_dir, project_root):
+        """get_agent(name, source="global") returns the global agent even when shadowed."""
+        gpath = global_agents_dir / "qa-engineer.md"
+        make_agent(gpath, "qa-engineer", "Global QA Engineer")
+
+        ppath = project_agents_dir / "qa-engineer.md"
+        make_agent(ppath, "qa-engineer", "Project QA Engineer")
+
+        # Default get_agent returns project (effective)
+        agent = get_agent("qa-engineer", workdir=str(project_root))
+        assert agent is not None
+        assert agent.source == "project"
+        assert agent.shadowed is False
+
+        # get_agent with source="global" returns the shadowed global agent
+        agent = get_agent("qa-engineer", workdir=str(project_root), source="global")
+        assert agent is not None
+        assert agent.source == "global"
+        assert agent.shadowed is True
+        assert agent.description == "Global QA Engineer"
+
+    def test_get_agent_source_project_returns_project(self, global_agents_dir, project_agents_dir, project_root):
+        """get_agent(name, source="project") returns the project agent."""
+        gpath = global_agents_dir / "qa-engineer.md"
+        make_agent(gpath, "qa-engineer", "Global QA Engineer")
+
+        ppath = project_agents_dir / "qa-engineer.md"
+        make_agent(ppath, "qa-engineer", "Project QA Engineer")
+
+        agent = get_agent("qa-engineer", workdir=str(project_root), source="project")
+        assert agent is not None
+        assert agent.source == "project"
+        assert agent.description == "Project QA Engineer"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Project-local agents — acp_command stripped without delegation block
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestProjectLocalAcpCommand:
+    def test_project_agent_acp_command_stripped_no_delegation(self, project_agents_dir, project_root):
+        """Project-local agents with routing.acp_command and no delegation block get acp_command=None and a warning."""
+        path = project_agents_dir / "acp-test.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: acp-test\n"
+            "description: tests acp_command without delegation\n"
+            "routing:\n"
+            "  acp_command: my-cmd\n"
+            "  acp_args:\n"
+            "    - arg1\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        agent = get_agent("acp-test", workdir=str(project_root))
+        assert agent is not None
+        assert agent.source == "project"
+        assert agent.routing.acp_command is None
+        assert agent.routing.acp_args is None
+        warning_text = " ".join(agent.warnings)
+        assert "routing.acp_command" in warning_text or "acp_command" in warning_text
+
+    def test_project_agent_acp_command_allowed_in_delegation(self, project_agents_dir, project_root):
+        """Project-local agents with delegation block can still have acp_command stripped with warning."""
+        path = project_agents_dir / "acp-delegated.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: acp-delegated\n"
+            "description: tests acp_command with delegation\n"
+            "routing:\n"
+            "  acp_command: my-cmd\n"
+            "delegation:\n"
+            "  role: leaf\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        agent = get_agent("acp-delegated", workdir=str(project_root))
+        assert agent is not None
+        assert agent.source == "project"
+        assert agent.routing.acp_command is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unknown fields inside routing and security
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestUnknownRoutingSecurityFields:
+    def test_unknown_routing_field_produces_warning(self, global_agents_dir):
+        """Unknown routing fields produce a warning but don't fail loading."""
+        path = global_agents_dir / "unknown-routing.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: unknown-routing\n"
+            "description: test unknown routing field\n"
+            "routing:\n"
+            "  mode: hermes\n"
+            "  unknown_knob: some-value\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        agent = get_agent("unknown-routing")
+        assert agent is not None
+        warning_text = " ".join(agent.warnings)
+        assert "unknown_knob" in warning_text
+
+    def test_unknown_security_field_produces_warning(self, global_agents_dir):
+        """Unknown security fields produce a warning but don't fail loading."""
+        path = global_agents_dir / "unknown-security.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: unknown-security\n"
+            "description: test unknown security field\n"
+            "security:\n"
+            "  require_approval: true\n"
+            "  unknown_knob: some-value\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        agent = get_agent("unknown-security")
+        assert agent is not None
+        warning_text = " ".join(agent.warnings)
+        assert "unknown_knob" in warning_text
+
+    def test_secret_like_routing_field_still_rejected(self, global_agents_dir):
+        """Secret-like routing fields (e.g. api_key) are still rejected, not warned."""
+        path = global_agents_dir / "secret-routing.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: secret-routing\n"
+            "description: test secret routing field\n"
+            "routing:\n"
+            "  api_key: sk-secret\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        with pytest.raises(AgentLoadError, match="secret"):
+            load_agent_file(path, "global")
+
+    def test_secret_like_security_field_still_rejected(self, global_agents_dir):
+        """Secret-like security fields are still rejected, not warned."""
+        path = global_agents_dir / "secret-security.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: secret-security\n"
+            "description: test secret security field\n"
+            "security:\n"
+            "  api_key: sk-secret\n"
+            "---\n"
+            "prompt\n"
+        )
+
+        with pytest.raises(AgentLoadError, match="secret"):
+            load_agent_file(path, "global")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentDefinition helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAgentDefinitionHelpers:
+    def test_to_dict_returns_dict(self, global_agents_dir):
+        """AgentDefinition.to_dict() returns a plain dict."""
+        path = global_agents_dir / "to-dict-agent.md"
+        make_agent(path, "to-dict-agent", "Testing to_dict.")
+
+        agent = get_agent("to-dict-agent")
+        d = agent.to_dict()
+        assert isinstance(d, dict)
+        assert d["name"] == "to-dict-agent"
+        assert d["source"] == "global"
+
+    def test_list_summary_returns_compact(self, global_agents_dir):
+        """AgentDefinition.list_summary() returns compact metadata without full prompt."""
+        path = global_agents_dir / "summary-agent.md"
+        make_agent(path, "summary-agent", "Testing summary.")
+
+        agent = get_agent("summary-agent")
+        s = agent.list_summary()
+        assert isinstance(s, dict)
+        assert s["name"] == "summary-agent"
+        assert "prompt" not in s  # no full prompt
+        assert "description" in s  # description is included in list summary
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Discovery helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDiscoverAgentDirs:
+    def test_global_dir_discovered(self, hermes_home):
+        """discover_agent_dirs finds $HERMES_HOME/agents."""
+        dirs = discover_agent_dirs()
+        global_paths = [d.path for d in dirs if d.source == "global"]
+        assert any("agents" in str(p) for p in global_paths)
+
+    def test_no_crash_without_agents_subdir(self, tmp_path, monkeypatch):
+        """discover_agent_dirs handles missing agents subdirectory gracefully."""
+        hh = tmp_path / ".hermes"
+        hh.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hh))
+
+        dirs = discover_agent_dirs()
+        # Should return list (may be empty for global-only when dir absent)
+        assert isinstance(dirs, list)
+
+    def test_project_dir_discovered(self, project_root):
+        """discover_agent_dirs finds <project>/.hermes/agents when project root exists."""
+        dirs = discover_agent_dirs(workdir=str(project_root))
+        project_paths = [d.path for d in dirs if d.source == "project"]
+        assert any(".hermes/agents" in str(p) for p in project_paths)
+
+    def test_no_project_root_no_project_dirs(self, tmp_path):
+        """When no project root found, only global dirs returned."""
+        # tmp_path has no .git or .hermes
+        dirs = discover_agent_dirs(workdir=str(tmp_path))
+        project_dirs = [d for d in dirs if d.source == "project"]
+        assert project_dirs == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unknown fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestUnknownFields:
+    def test_unknown_top_level_field_produces_warning(self, global_agents_dir):
+        """Unknown top-level frontmatter fields produce a warning, not an error."""
+        path = global_agents_dir / "unknown-top.md"
+        path.write_text(
+            "---\n"
+            "schema_version: 1\n"
+            "name: unknown-top\n"
+            "description: tests unknown field\n"
+            "foobar: something\n"
+            "---\n"
+            "prompt\n"
+        )
+        agents = list_agents()
+        names = [a.name for a in agents]
+        assert "unknown-top" in names
+        # Warning should be in the agent's warnings list
+        agent = get_agent("unknown-top")
+        assert any("unknown" in w.lower() or "foobar" in w.lower() for w in agent.warnings)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# File size bound
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestFileSizeBound:
+    def test_oversized_file_rejected(self, global_agents_dir):
+        """Agent files over ~128 KiB are rejected."""
+        path = global_agents_dir / "large-agent.md"
+        large_content = (
+            "---\n"
+            "schema_version: 1\n"
+            "name: large-agent\n"
+            "description: too large\n"
+            "---\n"
+            + ("x" * (129 * 1024))  # 129 KiB
+        )
+        path.write_text(large_content)
+        with pytest.raises(AgentLoadError, match="size"):
+            load_agent_file(path, "global")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentDefinition dataclass fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAgentDefinitionFields:
+    def test_all_expected_fields_present(self, global_agents_dir):
+        """AgentDefinition has all expected dataclass fields."""
+        path = global_agents_dir / "full-agent.md"
+        make_agent(
+            path,
+            "full-agent",
+            "Full agent.",
+            tags=["test"],
+            enabled=True,
+            display_name="Full Agent",
+        )
+
+        agent = get_agent("full-agent")
+        assert hasattr(agent, "schema_version")
+        assert hasattr(agent, "name")
+        assert hasattr(agent, "display_name")
+        assert hasattr(agent, "description")
+        assert hasattr(agent, "enabled")
+        assert hasattr(agent, "source")
+        assert hasattr(agent, "path")
+        assert hasattr(agent, "prompt")
+        assert hasattr(agent, "tags")
+        assert hasattr(agent, "routing")
+        assert hasattr(agent, "tools")
+        assert hasattr(agent, "skills")
+        assert hasattr(agent, "limits")
+        assert hasattr(agent, "delegation_role")
+        assert hasattr(agent, "security")
+        assert hasattr(agent, "compatibility")
+        assert hasattr(agent, "extensions")
+        assert hasattr(agent, "warnings")
+        assert hasattr(agent, "shadowed")
+        assert hasattr(agent, "to_dict")
+        assert hasattr(agent, "list_summary")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# No duplicate loads
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNoDuplicateLoads:
+    def test_agented_md_pattern_not_duplicate(self, global_agents_dir):
+        """An agent file at agents/foo/AGENT.md should not be loaded twice."""
+        # Create agents/foo/AGENT.md
+        subdir = global_agents_dir / "subcategory"
+        subdir.mkdir()
+        path = subdir / "AGENT.md"
+        make_agent(path, "sub-agent", "A subdir agent.")
+
+        agents = list_agents()
+        names = [a.name for a in agents]
+        assert "sub-agent" in names
+        # Should appear exactly once
+        assert names.count("sub-agent") == 1
+
+    def test_nested_md_files_found(self, global_agents_dir):
+        """agents/category/nested.md is discovered."""
+        subdir = global_agents_dir / "category"
+        subdir.mkdir()
+        path = subdir / "nested.md"
+        make_agent(path, "nested-agent", "A nested agent.")
+
+        agents = list_agents()
+        names = [a.name for a in agents]
+        assert "nested-agent" in names

--- a/tests/agent/test_runtime_trace.py
+++ b/tests/agent/test_runtime_trace.py
@@ -1,0 +1,84 @@
+"""Tests for agent/runtime_trace.py — safe runtime observability JSONL."""
+
+import json
+from pathlib import Path
+
+
+def test_emit_runtime_event_writes_jsonl_with_required_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event
+
+    emit_runtime_event(
+        "assign_agent.resolved",
+        session_id="session-1",
+        task_id="task-1",
+        agent={"name": "smoke-cli"},
+    )
+
+    trace_path = tmp_path / ".hermes" / "logs" / "runtime-trace.jsonl"
+    assert trace_path.exists()
+    lines = trace_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    event = json.loads(lines[0])
+    assert event["event"] == "assign_agent.resolved"
+    assert event["session_id"] == "session-1"
+    assert event["task_id"] == "task-1"
+    assert event["data"]["agent"]["name"] == "smoke-cli"
+    assert event["ts"].endswith("Z")
+
+
+def test_emit_runtime_event_redacts_secret_like_keys_recursively(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event, read_runtime_events
+
+    emit_runtime_event(
+        "model.request",
+        session_id="session-1",
+        api_key="sk-secret",
+        nested={
+            "Authorization": "Bearer secret",
+            "safe": "visible",
+            "items": [{"password": "p4ss", "token_value": "tok"}],
+        },
+    )
+
+    [event] = read_runtime_events(session_id="session-1")
+    assert event["data"]["api_key"] == "[REDACTED]"
+    assert event["data"]["nested"]["Authorization"] == "[REDACTED]"
+    assert event["data"]["nested"]["safe"] == "visible"
+    assert event["data"]["nested"]["items"][0]["password"] == "[REDACTED]"
+    assert event["data"]["nested"]["items"][0]["token_value"] == "[REDACTED]"
+
+
+def test_read_runtime_events_filters_by_session_agent_and_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event, read_runtime_events
+
+    emit_runtime_event("assign_agent.completed", session_id="s1", agent={"name": "a"}, seq=1)
+    emit_runtime_event("assign_agent.completed", session_id="s1", agent={"name": "b"}, seq=2)
+    emit_runtime_event("assign_agent.completed", session_id="s1", agent={"name": "a"}, seq=3)
+    emit_runtime_event("assign_agent.completed", session_id="s2", agent={"name": "a"}, seq=4)
+
+    events = read_runtime_events(session_id="s1", agent_name="a", limit=1)
+
+    assert len(events) == 1
+    assert events[0]["session_id"] == "s1"
+    assert events[0]["data"]["agent"]["name"] == "a"
+    assert events[0]["data"]["seq"] == 3
+
+
+def test_emit_runtime_event_is_best_effort_when_log_path_unwritable(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    logs_path = hermes_home / "logs"
+    logs_path.parent.mkdir(parents=True)
+    logs_path.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent.runtime_trace import emit_runtime_event
+
+    # Must not raise even though $HERMES_HOME/logs is a file.
+    emit_runtime_event("assign_agent.requested", session_id="s1")

--- a/tests/run_agent/test_model_request_trace.py
+++ b/tests/run_agent/test_model_request_trace.py
@@ -1,0 +1,72 @@
+"""Tests for low-level model.request runtime trace events."""
+
+import json
+
+from run_agent import AIAgent
+
+
+def _make_agent() -> AIAgent:
+    return AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1?secret=do-not-log",
+        provider="openrouter",
+        model="openai/gpt-4o-mini",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id="model-trace-session",
+    )
+
+
+def test_emit_model_request_trace_logs_safe_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    agent = _make_agent()
+
+    agent._emit_model_request_trace(
+        api_kwargs={
+            "model": "openai/gpt-4o-mini",
+            "messages": [{"role": "user", "content": "secret prompt"}],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+            "api_key": "sk-secret",
+            "base_url": "https://openrouter.ai/api/v1?secret=do-not-log",
+        },
+        effective_task_id="task-123",
+        api_call_count=2,
+    )
+
+    from agent.runtime_trace import read_runtime_events
+
+    [event] = read_runtime_events(session_id="model-trace-session")
+    assert event["event"] == "model.request"
+    assert event["task_id"] == "task-123"
+    assert event["data"] == {
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini",
+        "api_mode": agent.api_mode,
+        "base_url_host": "openrouter.ai",
+        "tool_count": 1,
+        "api_call_count": 2,
+    }
+
+    raw_trace = (tmp_path / ".hermes" / "logs" / "runtime-trace.jsonl").read_text(encoding="utf-8")
+    assert "secret prompt" not in raw_trace
+    assert "sk-secret" not in raw_trace
+    assert "do-not-log" not in raw_trace
+    assert "messages" not in raw_trace
+    assert '"base_url"' not in raw_trace
+
+
+def test_emit_model_request_trace_is_best_effort(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    logs_path = hermes_home / "logs"
+    logs_path.parent.mkdir(parents=True)
+    logs_path.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    agent = _make_agent()
+
+    # Must not raise even when trace storage is unavailable.
+    agent._emit_model_request_trace(
+        api_kwargs={"messages": [{"role": "user", "content": "hello"}]},
+        effective_task_id="task-123",
+        api_call_count=0,
+    )

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -112,6 +112,23 @@ class TestHandleFunctionCall:
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
 
+    def test_parent_agent_forwarded_to_registry_dispatch(self):
+        """Tools like assign_agent need the live AIAgent instance from the loop."""
+        parent = object()
+        with (
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}') as mock_dispatch,
+            patch("hermes_cli.plugins.invoke_hook"),
+        ):
+            result = handle_function_call(
+                "assign_agent",
+                {"agent_name": "code-explorer", "task": "smoke"},
+                task_id="task-1",
+                parent_agent=parent,
+            )
+
+        assert result == '{"ok":true}'
+        assert mock_dispatch.call_args.kwargs["parent_agent"] is parent
+
 
 # =========================================================================
 # Agent loop tools

--- a/tests/tools/test_agents_tool.py
+++ b/tests/tools/test_agents_tool.py
@@ -1,0 +1,890 @@
+"""Tests for tools/agents_tool.py — native agent registry tools."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test
+from tools.agents_tool import agents_list, agent_view, assign_agent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME for the duration of a test."""
+    hh = tmp_path / ".hermes"
+    hh.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hh))
+    return hh
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """A fake git-backed project root."""
+    pr = tmp_path / "my-project"
+    pr.mkdir()
+    (pr / ".git").mkdir()
+    return pr
+
+
+@pytest.fixture
+def global_agents_dir(hermes_home):
+    """Global agents directory."""
+    d = hermes_home / "agents"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def project_agents_dir(project_root):
+    """Project-local agents directory."""
+    d = project_root / ".hermes" / "agents"
+    d.mkdir(parents=True)
+    return d
+
+
+def make_agent(path: Path, name: str, description: str = "A test agent", **frontmatter):
+    """Write a minimal valid agent file."""
+    fm = {"schema_version": 1, "name": name, "description": description}
+    fm.update(frontmatter)
+    lines = ["---", *[f"{k}: {v}" for k, v in fm.items()], "---", "", "This is the agent prompt."]
+    path.write_text("\n".join(lines))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tool registration checks
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAgentsToolRegistration:
+    """Verify tools register with correct toolset membership."""
+
+    def test_agents_list_registered_in_agents_toolset(self):
+        """agents_list must be registered in the 'agents' toolset."""
+        from tools.registry import registry
+        entry = registry.get_entry("agents_list")
+        assert entry is not None, "agents_list not found in registry"
+        assert entry.toolset == "agents", f"agents_list toolset is {entry.toolset}, expected 'agents'"
+
+    def test_agent_view_registered_in_agents_toolset(self):
+        """agent_view must be registered in the 'agents' toolset."""
+        from tools.registry import registry
+        entry = registry.get_entry("agent_view")
+        assert entry is not None, "agent_view not found in registry"
+        assert entry.toolset == "agents", f"agent_view toolset is {entry.toolset}, expected 'agents'"
+
+    def test_assign_agent_registered_in_delegation_toolset(self):
+        """assign_agent must be registered in the 'delegation' toolset."""
+        from tools.registry import registry
+        entry = registry.get_entry("assign_agent")
+        assert entry is not None, "assign_agent not found in registry"
+        assert entry.toolset == "delegation", f"assign_agent toolset is {entry.toolset}, expected 'delegation'"
+
+
+class TestAgentsToolsetIntegration:
+    """Verify toolset resolution includes the correct agents tools."""
+
+    def test_resolve_toolset_agents_contains_list_and_view(self):
+        """resolve_toolset('agents') must contain agents_list and agent_view."""
+        from toolsets import resolve_toolset
+        tools = resolve_toolset("agents")
+        assert "agents_list" in tools, "agents_list missing from agents toolset"
+        assert "agent_view" in tools, "agent_view missing from agents toolset"
+        # assign_agent belongs to delegation, not agents
+        assert "assign_agent" not in tools, "assign_agent should NOT be in agents toolset"
+
+    def test_resolve_toolset_delegation_contains_assign_agent(self):
+        """resolve_toolset('delegation') must contain assign_agent."""
+        from toolsets import resolve_toolset
+        tools = resolve_toolset("delegation")
+        assert "assign_agent" in tools, "assign_agent missing from delegation toolset"
+
+    def test_agents_toolset_does_not_contain_assign_agent(self):
+        """The 'agents' toolset must be read-only — no delegation."""
+        from toolsets import resolve_toolset
+        tools = resolve_toolset("agents")
+        assert "assign_agent" not in tools
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# agents_list
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAgentsList:
+    """Tests for agents_list()."""
+
+    def test_returns_json_with_success(self, global_agents_dir):
+        """agents_list must return JSON with success=True."""
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+
+    def test_output_shape_excludes_prompt(self, global_agents_dir):
+        """agents_list must NOT include full prompt bodies."""
+        make_agent(global_agents_dir / "test-agent.md", "test-agent", description="A test agent")
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        agents = parsed.get("agents", [])
+        assert len(agents) >= 1
+        for agent in agents:
+            assert "prompt" not in agent, "agents_list must not include prompt bodies"
+            assert "prompt" not in agent.get("description", "")
+
+    def test_count_field_present(self, global_agents_dir):
+        """agents_list must include a count field."""
+        make_agent(global_agents_dir / "agent-a.md", "agent-a", description="Agent A")
+        make_agent(global_agents_dir / "agent-b.md", "agent-b", description="Agent B")
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert "count" in parsed
+        assert parsed["count"] >= 2
+
+    def test_empty_dir_returns_empty_list(self, global_agents_dir):
+        """No agents in dir → empty list, not an error."""
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+        assert parsed.get("count", 0) == 0
+        assert parsed.get("agents", []) == []
+
+    def test_category_filter_no_match(self, global_agents_dir):
+        """category filter with no matching agents returns empty list."""
+        make_agent(global_agents_dir / "web-agent.md", "web-agent", description="Web agent",
+                   tags=["web", "research"])
+        result = agents_list(category="nonexistent-tag", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("count", 0) == 0
+
+    def test_category_filter_matches(self, global_agents_dir):
+        """category filter returns only matching agents."""
+        make_agent(global_agents_dir / "web-agent.md", "web-agent", description="Web agent",
+                   tags=["web"])
+        make_agent(global_agents_dir / "code-agent.md", "code-agent", description="Code agent",
+                   tags=["code"])
+        result = agents_list(category="web", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        names = [a["name"] for a in parsed.get("agents", [])]
+        assert "web-agent" in names
+        assert "code-agent" not in names
+
+    def test_disabled_agents_excluded_by_default(self, global_agents_dir):
+        """Disabled agents are excluded from default output."""
+        make_agent(global_agents_dir / "enabled-agent.md", "enabled-agent",
+                   description="Enabled agent", enabled=True)
+        make_agent(global_agents_dir / "disabled-agent.md", "disabled-agent",
+                   description="Disabled agent", enabled=False)
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        names = [a["name"] for a in parsed.get("agents", [])]
+        assert "enabled-agent" in names
+        assert "disabled-agent" not in names
+
+    def test_disabled_agents_included_when_requested(self, global_agents_dir):
+        """include_disabled=True includes disabled agents."""
+        make_agent(global_agents_dir / "disabled-agent.md", "disabled-agent",
+                   description="Disabled agent", enabled=False)
+        result = agents_list(include_disabled=True, workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        names = [a["name"] for a in parsed.get("agents", [])]
+        assert "disabled-agent" in names
+
+    def test_list_summary_fields(self, global_agents_dir):
+        """Each agent in list must have expected summary fields."""
+        make_agent(global_agents_dir / "review-agent.md", "review-agent",
+                   description="A code review agent", tags=["review"],
+                   routing={"mode": "inherit", "model": "claude-3-5"})
+        result = agents_list(workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        agent = parsed["agents"][0]
+        # Must have these fields
+        assert agent["name"] == "review-agent"
+        assert agent["description"] == "A code review agent"
+        assert agent["tags"] == ["review"]
+        assert agent["source"] == "global"
+        assert agent["enabled"] is True
+        # Routing summary
+        assert "routing" in agent
+        assert agent["routing"]["mode"] == "inherit"
+        # Must NOT have prompt
+        assert "prompt" not in agent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# agent_view
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAgentView:
+    """Tests for agent_view()."""
+
+    def test_returns_json_with_success(self, global_agents_dir):
+        """agent_view must return JSON with success=True for a valid agent."""
+        make_agent(global_agents_dir / "my-agent.md", "my-agent", description="My agent")
+        result = agent_view(name="my-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+
+    def test_output_includes_prompt(self, global_agents_dir):
+        """agent_view must include the full prompt."""
+        make_agent(global_agents_dir / "prompt-agent.md", "prompt-agent",
+                   description="Has a prompt",
+                   tags=["test"])
+        result = agent_view(name="prompt-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert "prompt" in parsed.get("agent", {}), "agent_view must include prompt"
+        assert "This is the agent prompt." in parsed["agent"]["prompt"]
+
+    def test_output_includes_path_and_source(self, global_agents_dir):
+        """agent_view must include path and source."""
+        make_agent(global_agents_dir / "source-agent.md", "source-agent",
+                   description="Source agent")
+        result = agent_view(name="source-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        agent = parsed.get("agent", {})
+        assert "path" in agent
+        assert "source" in agent
+        assert agent["source"] == "global"
+
+    def test_invalid_name_returns_error(self, global_agents_dir):
+        """Non-existent agent name returns success=False."""
+        result = agent_view(name="nonexistent-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("success") is False, "agent_view should return success=False for unknown agent"
+        assert "error" in parsed or "agent" in parsed
+
+    def test_path_traversal_rejected(self, global_agents_dir):
+        """agent_view must not allow path traversal via name."""
+        # validate_agent_name should reject names with slashes/dots
+        result = agent_view(name="../etc/passwd", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        # Should be rejected as invalid name (returns success=False)
+        assert parsed.get("success") is False
+
+    def test_disabled_agent_can_be_viewed(self, global_agents_dir):
+        """Disabled agents can still be viewed (view is read-only)."""
+        make_agent(global_agents_dir / "disabled-agent.md", "disabled-agent",
+                   description="A disabled agent", enabled=False)
+        result = agent_view(name="disabled-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+        assert parsed.get("agent", {}).get("enabled") is False
+
+    def test_to_dict_includes_all_expected_fields(self, global_agents_dir):
+        """agent_view returns full to_dict output."""
+        make_agent(global_agents_dir / "full-agent.md", "full-agent",
+                   description="Full agent",
+                   tags=["test", "demo"],
+                   routing={"mode": "hermes", "provider": "openai"},
+                   tools={"mode": "restrict", "allow_toolsets": ["web"]},
+                   delegation={"role": "orchestrator"})
+        result = agent_view(name="full-agent", workdir=str(global_agents_dir))
+        parsed = json.loads(result)
+        agent = parsed.get("agent", {})
+        assert agent["name"] == "full-agent"
+        assert agent["description"] == "Full agent"
+        assert agent["tags"] == ["test", "demo"]
+        assert agent["routing"]["mode"] == "hermes"
+        assert agent["routing"]["provider"] == "openai"
+        assert agent["tools"]["mode"] == "restrict"
+        assert agent["tools"]["allow_toolsets"] == ["web"]
+        assert agent["delegation_role"] == "orchestrator"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assign_agent
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgent:
+    """Tests for assign_agent()."""
+
+    def test_without_parent_agent_returns_error(self, global_agents_dir):
+        """assign_agent without parent_agent must return error JSON."""
+        make_agent(global_agents_dir / "some-agent.md", "some-agent", description="Some agent")
+        result = assign_agent(
+            agent_name="some-agent",
+            task="Do something",
+            parent_agent=None,
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False, "assign_agent without parent_agent should fail"
+        assert "error" in parsed
+
+    def test_disabled_agent_returns_error(self, global_agents_dir):
+        """assign_agent with a disabled agent must return error."""
+        make_agent(global_agents_dir / "disabled-delegation.md", "disabled-delegation",
+                   description="Disabled agent", enabled=False)
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="disabled-delegation",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "error" in parsed
+
+    def test_unknown_agent_returns_error(self, global_agents_dir):
+        """assign_agent with unknown agent must return error."""
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="does-not-exist",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+
+    def test_assign_agent_calls_delegate_task_with_goal(self, global_agents_dir, monkeypatch):
+        """assign_agent must call delegate_task with goal=task."""
+        make_agent(global_agents_dir / "delegate-agent.md", "delegate-agent",
+                   description="Delegatable agent")
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": [{"goal": kwargs.get("goal"), "output": "done"}]})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        result = assign_agent(
+            agent_name="delegate-agent",
+            task="Review the code",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["goal"] == "Review the code"
+
+    def test_assign_agent_compiles_context_with_prompt(self, global_agents_dir, monkeypatch):
+        """assign_agent context must include agent name, path, prompt, and user context."""
+        make_agent(global_agents_dir / "context-agent.md", "context-agent",
+                   description="Context test agent")
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="context-agent",
+            task="Test task",
+            context="User context here",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        compiled = recorded_calls[0]["context"]
+        assert "Named agent: context-agent" in compiled
+        assert "Agent instructions" in compiled
+        assert "This is the agent prompt." in compiled
+        assert "User context here" in compiled
+
+    def test_assign_agent_toolsets_from_agent_allow_toolsets(self, global_agents_dir, monkeypatch):
+        """When tools.mode==restrict, effective toolsets come from agent.tools.allow_toolsets."""
+        make_agent(global_agents_dir / "restrict-agent.md", "restrict-agent",
+                   description="Restricted agent",
+                   tools={"mode": "restrict", "allow_toolsets": ["web", "terminal"]})
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="restrict-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["toolsets"] == ["web", "terminal"]
+
+    def test_assign_agent_toolsets_none_when_no_restrict(self, global_agents_dir, monkeypatch):
+        """When tools.mode != restrict, toolsets is None (not restricted)."""
+        make_agent(global_agents_dir / "open-agent.md", "open-agent",
+                   description="Open agent",
+                   tools={"mode": "inherit"})  # inherit = no restriction
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="open-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        # When mode is not restrict, toolsets is None
+        assert recorded_calls[0]["toolsets"] is None
+
+    def test_assign_agent_role_leaf_by_default(self, global_agents_dir, monkeypatch):
+        """Default role is 'leaf'."""
+        make_agent(global_agents_dir / "role-agent.md", "role-agent",
+                   description="Role test agent")
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="role-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["role"] == "leaf"
+
+    def test_assign_agent_role_from_delegation_role(self, global_agents_dir, monkeypatch):
+        """When agent has delegation_role, it is used."""
+        make_agent(global_agents_dir / "orch-agent.md", "orch-agent",
+                   description="Orchestrator agent",
+                   delegation={"role": "orchestrator"})
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="orch-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["role"] == "orchestrator"
+
+    def test_assign_agent_runtime_toolsets_override(self, global_agents_dir, monkeypatch):
+        """Runtime toolsets override agent defaults."""
+        make_agent(global_agents_dir / "runtime-agent.md", "runtime-agent",
+                   description="Runtime override agent",
+                   tools={"mode": "restrict", "allow_toolsets": ["web"]})
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="runtime-agent",
+            task="Task",
+            toolsets=["terminal", "file"],
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["toolsets"] == ["terminal", "file"]
+
+    def test_assign_agent_runtime_role_override(self, global_agents_dir, monkeypatch):
+        """Runtime role overrides agent delegation_role."""
+        make_agent(global_agents_dir / "override-role.md", "override-role",
+                   description="Override role agent",
+                   delegation={"role": "leaf"})
+        mock_parent = MagicMock()
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="override-role",
+            task="Task",
+            role="orchestrator",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["role"] == "orchestrator"
+
+    def test_assign_agent_returns_success_with_metadata(self, global_agents_dir, monkeypatch):
+        """assign_agent returns success=True with agent metadata and parsed result."""
+        make_agent(global_agents_dir / "result-agent.md", "result-agent",
+                   description="Result agent")
+        mock_parent = MagicMock()
+
+        def mock_delegate_task(**kwargs):
+            return json.dumps({
+                "success": True,
+                "results": [{"goal": kwargs["goal"], "output": "Fixed the bug"}]
+            })
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        result = assign_agent(
+            agent_name="result-agent",
+            task="Fix the bug",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+        assert "agent" in parsed
+        assert parsed["agent"]["name"] == "result-agent"
+        assert "result" in parsed
+        assert "Fixed the bug" in str(parsed["result"])
+
+    def test_assign_agent_returns_raw_when_not_json(self, global_agents_dir, monkeypatch):
+        """Non-JSON delegate_task return is passed through as-is."""
+        make_agent(global_agents_dir / "raw-agent.md", "raw-agent",
+                   description="Raw agent")
+        mock_parent = MagicMock()
+
+        def mock_delegate_task(**kwargs):
+            return "raw string result"
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        result = assign_agent(
+            agent_name="raw-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+        assert parsed.get("result") == "raw string result"
+
+    def test_assign_agent_passes_parent_agent(self, global_agents_dir, monkeypatch):
+        """assign_agent must pass parent_agent to delegate_task."""
+        make_agent(global_agents_dir / "parent-agent.md", "parent-agent",
+                   description="Parent test agent")
+        mock_parent = MagicMock()
+        mock_parent._subagent_id = "parent-123"
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="parent-agent",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["parent_agent"] is mock_parent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assign_agent — routing mode rejection (PR1 constraints)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgentRoutingRejection:
+    """Tests for routing mode / runner metadata rejection in PR1."""
+
+    def test_rejects_hermes_routing_mode(self, global_agents_dir):
+        """Agents with routing.mode='hermes' must be rejected."""
+        make_agent(global_agents_dir / "hermes-agent.md", "hermes-agent",
+                   description="Hermes routing agent",
+                   routing={"mode": "hermes", "provider": "openai"})
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="hermes-agent",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "routing.mode='hermes'" in parsed["error"]
+        assert "PR1" in parsed["error"]
+
+    def test_rejects_acp_routing_mode(self, global_agents_dir):
+        """Agents with routing.mode='acp' must be rejected."""
+        make_agent(global_agents_dir / "acp-agent.md", "acp-agent",
+                   description="ACP routing agent",
+                   routing={"mode": "acp"})
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="acp-agent",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "routing.mode='acp'" in parsed["error"]
+        assert "PR1" in parsed["error"]
+
+    def test_accepts_inherit_routing_mode(self, global_agents_dir, monkeypatch):
+        """Agents with routing.mode='inherit' (default) must be accepted."""
+        make_agent(global_agents_dir / "inherit-agent.md", "inherit-agent",
+                   description="Inherit routing agent",
+                   routing={"mode": "inherit"})
+
+        def mock_delegate_task(**kwargs):
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="inherit-agent",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is True
+
+    def test_rejects_acp_command(self, global_agents_dir):
+        """Agents with routing.acp_command must be rejected even with mode=inherit."""
+        make_agent(global_agents_dir / "acpcmd-agent.md", "acpcmd-agent",
+                   description="ACP command agent",
+                   routing={"mode": "inherit", "acp_command": "some-cmd"})
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="acpcmd-agent",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "acp_command" in parsed["error"]
+        assert "PR1" in parsed["error"]
+
+    def test_rejects_runner_mode_inline(self, global_agents_dir):
+        """Agents with runner.mode set to a non-delegate_task value must be rejected."""
+        make_agent(global_agents_dir / "runner-agent.md", "runner-agent",
+                   description="Inline runner agent",
+                   routing={"mode": "inherit", "runner": {"mode": "subprocess"}})
+        mock_parent = MagicMock()
+        result = assign_agent(
+            agent_name="runner-agent",
+            task="Do something",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert "runner.mode='subprocess'" in parsed["error"]
+        assert "PR1" in parsed["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assign_agent — workdir resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgentWorkdirResolution:
+    """Tests for workdir resolution from parent_agent attributes."""
+
+    def test_explicit_workdir_takes_precedence(self, global_agents_dir, monkeypatch):
+        """Explicit workdir is used even when parent_agent has cwd attributes."""
+        make_agent(global_agents_dir / "wd-test.md", "wd-test",
+                   description="Workdir test agent")
+        mock_parent = MagicMock()
+        mock_parent.terminal_cwd = "/should/not/be/used"
+        mock_parent.cwd = "/also/not/used"
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="wd-test",
+            task="Task",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+
+        # The agent should be found — explicit workdir was used
+        assert len(recorded_calls) == 1
+
+    def test_resolves_workdir_from_terminal_cwd_env(self, global_agents_dir, monkeypatch):
+        """TERMINAL_CWD env var is used when no explicit workdir is given."""
+        make_agent(global_agents_dir / "env-wd.md", "env-wd",
+                   description="Env workdir agent")
+        mock_parent = MagicMock()
+
+        # Remove cwd attributes so only env var could help
+        mock_parent._subdirectory_hints = None
+        mock_parent.terminal_cwd = None
+        mock_parent.cwd = None
+
+        monkeypatch.setenv("TERMINAL_CWD", str(global_agents_dir))
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="env-wd",
+            task="Task",
+            parent_agent=mock_parent,
+            # no explicit workdir
+        )
+
+        # Should succeed because TERMINAL_CWD pointed to global_agents_dir
+        assert len(recorded_calls) == 1
+
+    def test_resolves_workdir_from_parent_subdirectory_hints(self, global_agents_dir, monkeypatch):
+        """parent_agent._subdirectory_hints.working_dir is used as fallback."""
+        make_agent(global_agents_dir / "hint-wd.md", "hint-wd",
+                   description="Hint workdir agent")
+
+        # Create a mock subdirectory_hints object
+        mock_hints = MagicMock()
+        mock_hints.working_dir = str(global_agents_dir)
+
+        mock_parent = MagicMock()
+        mock_parent._subdirectory_hints = mock_hints
+        mock_parent.terminal_cwd = None
+        mock_parent.cwd = None
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="hint-wd",
+            task="Task",
+            parent_agent=mock_parent,
+            # no explicit workdir, TERMINAL_CWD unset
+        )
+
+        assert len(recorded_calls) == 1
+
+    def test_resolves_workdir_from_parent_terminal_cwd(self, global_agents_dir, monkeypatch):
+        """parent_agent.terminal_cwd is used when no other hint available."""
+        make_agent(global_agents_dir / "term-cwd.md", "term-cwd",
+                   description="Terminal cwd agent")
+        mock_parent = MagicMock()
+        mock_parent._subdirectory_hints = None
+        mock_parent.terminal_cwd = str(global_agents_dir)
+        mock_parent.cwd = None
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="term-cwd",
+            task="Task",
+            parent_agent=mock_parent,
+        )
+
+        assert len(recorded_calls) == 1
+
+    def test_resolves_workdir_from_parent_cwd(self, global_agents_dir, monkeypatch):
+        """parent_agent.cwd is used as final fallback."""
+        make_agent(global_agents_dir / "plain-cwd.md", "plain-cwd",
+                   description="Plain cwd agent")
+        mock_parent = MagicMock()
+        mock_parent._subdirectory_hints = None
+        mock_parent.terminal_cwd = None
+        mock_parent.cwd = str(global_agents_dir)
+
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+
+        assign_agent(
+            agent_name="plain-cwd",
+            task="Task",
+            parent_agent=mock_parent,
+        )
+
+        assert len(recorded_calls) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgentSchema:
+    """Tests for ASSIGN_AGENT_SCHEMA structure."""
+
+    def test_schema_required_is_agent_name_and_task_only(self):
+        """Schema required fields must be exactly agent_name and task (no parent_agent)."""
+        from tools.agents_tool import ASSIGN_AGENT_SCHEMA
+        required = ASSIGN_AGENT_SCHEMA["parameters"]["required"]
+        assert "agent_name" in required
+        assert "task" in required
+        assert "parent_agent" not in required
+
+    def test_schema_does_not_have_parent_agent_property(self):
+        """Schema must not include parent_agent as a model-facing parameter."""
+        from tools.agents_tool import ASSIGN_AGENT_SCHEMA
+        properties = ASSIGN_AGENT_SCHEMA["parameters"]["properties"]
+        assert "parent_agent" not in properties

--- a/tests/tools/test_agents_tool.py
+++ b/tests/tools/test_agents_tool.py
@@ -626,12 +626,19 @@ class TestAssignAgent:
 class TestAssignAgentRoutingRejection:
     """Tests for routing mode / runner metadata rejection in PR1."""
 
-    def test_rejects_hermes_routing_mode(self, global_agents_dir):
-        """Agents with routing.mode='hermes' must be rejected."""
+    def test_hermes_routing_mode_passes_native_provider_model_to_delegate_task(self, global_agents_dir, monkeypatch):
+        """Agents with routing.mode='hermes' must route children to their configured provider/model."""
         make_agent(global_agents_dir / "hermes-agent.md", "hermes-agent",
                    description="Hermes routing agent",
-                   routing={"mode": "hermes", "provider": "openai"})
+                   routing={"mode": "hermes", "provider": "kimi-coding", "model": "kimi-k2.6"})
         mock_parent = MagicMock()
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
         result = assign_agent(
             agent_name="hermes-agent",
             task="Do something",
@@ -639,9 +646,41 @@ class TestAssignAgentRoutingRejection:
             workdir=str(global_agents_dir),
         )
         parsed = json.loads(result)
-        assert parsed.get("success") is False
-        assert "routing.mode='hermes'" in parsed["error"]
-        assert "PR1" in parsed["error"]
+        assert parsed.get("success") is True
+        assert len(recorded_calls) == 1
+        assert recorded_calls[0]["provider"] == "kimi-coding"
+        assert recorded_calls[0]["model"] == "kimi-k2.6"
+
+    def test_assign_agent_passes_all_native_provider_routes(self, global_agents_dir, monkeypatch):
+        """Kimi, MiniMax, and GLM/Z.AI agent routes are forwarded exactly to delegation."""
+        routes = {
+            "kimi-agent": ("kimi-coding", "kimi-k2.6"),
+            "minimax-agent": ("minimax", "MiniMax-M2.7-highspeed"),
+            "glm-agent": ("zai", "glm-5.1"),
+        }
+        for name, (provider, model) in routes.items():
+            make_agent(global_agents_dir / f"{name}.md", name,
+                       description=f"{provider} route",
+                       routing={"mode": "hermes", "provider": provider, "model": model})
+
+        recorded_calls = []
+
+        def mock_delegate_task(**kwargs):
+            recorded_calls.append(kwargs)
+            return json.dumps({"success": True, "results": []})
+
+        monkeypatch.setattr("tools.delegate_tool.delegate_task", mock_delegate_task)
+        mock_parent = MagicMock()
+        for name in routes:
+            result = assign_agent(
+                agent_name=name,
+                task="Do something",
+                parent_agent=mock_parent,
+                workdir=str(global_agents_dir),
+            )
+            assert json.loads(result).get("success") is True
+
+        assert [(c["provider"], c["model"]) for c in recorded_calls] == list(routes.values())
 
     def test_rejects_acp_routing_mode(self, global_agents_dir):
         """Agents with routing.mode='acp' must be rejected."""
@@ -658,7 +697,7 @@ class TestAssignAgentRoutingRejection:
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert "routing.mode='acp'" in parsed["error"]
-        assert "PR1" in parsed["error"]
+        assert "Supported routing modes: inherit, hermes" in parsed["error"]
 
     def test_accepts_inherit_routing_mode(self, global_agents_dir, monkeypatch):
         """Agents with routing.mode='inherit' (default) must be accepted."""

--- a/tests/tools/test_agents_tool.py
+++ b/tests/tools/test_agents_tool.py
@@ -698,8 +698,8 @@ class TestAssignAgentRoutingRejection:
         assert "acp_command" in parsed["error"]
         assert "PR1" in parsed["error"]
 
-    def test_rejects_runner_mode_inline(self, global_agents_dir):
-        """Agents with runner.mode set to a non-delegate_task value must be rejected."""
+    def test_rejects_unknown_runner_mode_inline(self, global_agents_dir):
+        """Agents with unsupported runner.mode values must be rejected."""
         make_agent(global_agents_dir / "runner-agent.md", "runner-agent",
                    description="Inline runner agent",
                    routing={"mode": "inherit", "runner": {"mode": "subprocess"}})
@@ -713,7 +713,250 @@ class TestAssignAgentRoutingRejection:
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert "runner.mode='subprocess'" in parsed["error"]
-        assert "PR1" in parsed["error"]
+        assert "delegate_task, cli" in parsed["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assign_agent — CLI runner execution
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgentCliRunner:
+    """Tests for trusted CLI-backed named agents."""
+
+    def test_cli_runner_invokes_trusted_configured_command(self, global_agents_dir, monkeypatch):
+        (global_agents_dir / "cli-agent.md").write_text("""---
+schema_version: 1
+name: cli-agent
+description: CLI-backed agent
+runner:
+  mode: cli
+  name: claude-cli
+  continue: off
+---
+
+You are a CLI agent.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "parent-session"
+        recorded = {}
+
+        class Completed:
+            returncode = 0
+            stdout = '{"session_id":"external-123","result":"ok"}\n'
+            stderr = ""
+
+        def fake_run(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            recorded["kwargs"] = kwargs
+            return Completed()
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "claude-cli": {
+                    "type": "cli",
+                    "command": "claude",
+                    "args": ["-p", "--output-format", "stream-json"],
+                    "resume_arg": "--resume",
+                    "allowed_from_project_agents": True,
+                }
+            }
+        })
+
+        result = assign_agent(
+            agent_name="cli-agent",
+            task="Review the diff",
+            context="Only inspect files.",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["runner"]["mode"] == "cli"
+        assert parsed["runner"]["name"] == "claude-cli"
+        assert recorded["cmd"] == ["claude", "-p", "--output-format", "stream-json"]
+        assert "Review the diff" in recorded["kwargs"]["input"]
+        assert "You are a CLI agent." in recorded["kwargs"]["input"]
+        assert parsed["external_session_id"] == "external-123"
+        assert "command" not in parsed
+
+    def test_cli_runner_auto_resume_uses_stored_external_session(self, global_agents_dir, monkeypatch):
+        (global_agents_dir / "resume-agent.md").write_text("""---
+schema_version: 1
+name: resume-agent
+description: Resume CLI agent
+runner:
+  mode: cli
+  name: gemini-cli
+  continue: auto
+---
+
+You resume external CLI sessions.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "parent-session"
+        recorded = {}
+
+        class Completed:
+            returncode = 0
+            stdout = "done"
+            stderr = ""
+
+        def fake_run(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            return Completed()
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "gemini-cli": {
+                    "type": "cli",
+                    "command": "gemini",
+                    "args": ["--output-format", "stream-json"],
+                    "resume_arg": "--resume",
+                    "allowed_from_project_agents": True,
+                }
+            }
+        })
+        from agent import agent_runner
+        monkeypatch.setattr(agent_runner.CliSessionStore, "get", lambda self, **kw: "gemini-session-777")
+
+        result = assign_agent(
+            agent_name="resume-agent",
+            task="Continue",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["runner"]["resumed"] is True
+        assert recorded["cmd"] == ["gemini", "--output-format", "stream-json", "--resume", "gemini-session-777"]
+
+    def test_cli_runner_require_continuation_fails_without_stored_session(self, global_agents_dir, monkeypatch):
+        (global_agents_dir / "require-agent.md").write_text("""---
+schema_version: 1
+name: require-agent
+description: Require resume CLI agent
+runner:
+  mode: cli
+  name: claude-cli
+  continue: require
+---
+
+You require an existing external session.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "parent-session"
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "claude-cli": {
+                    "type": "cli",
+                    "command": "claude",
+                    "args": ["-p"],
+                    "resume_arg": "--resume",
+                    "allowed_from_project_agents": True,
+                }
+            }
+        })
+
+        result = assign_agent(
+            agent_name="require-agent",
+            task="Continue",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "requires an existing CLI session" in parsed["error"]
+
+    def test_cli_runner_session_persistence_failure_is_nonfatal(self, global_agents_dir, monkeypatch):
+        """A successful CLI run still succeeds if persisting external session id fails."""
+        (global_agents_dir / "store-fail-agent.md").write_text("""---
+schema_version: 1
+name: store-fail-agent
+description: Store failure CLI agent
+runner:
+  mode: cli
+  name: claude-cli
+  continue: off
+---
+
+You are a CLI agent.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "parent-session"
+
+        class Completed:
+            returncode = 0
+            stdout = '{"session_id":"external-123","result":"ok"}\n'
+            stderr = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Completed())
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "claude-cli": {
+                    "type": "cli",
+                    "command": "claude",
+                    "args": ["-p"],
+                    "allowed_from_project_agents": True,
+                }
+            }
+        })
+        from agent import agent_runner
+        monkeypatch.setattr(agent_runner.CliSessionStore, "set", lambda self, **kw: (_ for _ in ()).throw(OSError("disk full")))
+
+        result = assign_agent(
+            agent_name="store-fail-agent",
+            task="Review",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["external_session_id"] == "external-123"
+        assert "warning" in parsed
+        assert "Failed to persist CLI session" in parsed["warning"]
+
+    def test_project_cli_runner_must_be_allowed_by_trusted_config(self, project_agents_dir, project_root, monkeypatch):
+        (project_agents_dir / "project-cli.md").write_text("""---
+schema_version: 1
+name: project-cli
+description: Project CLI agent
+runner:
+  mode: cli
+  name: locked-cli
+  continue: off
+---
+
+Project agent prompt.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "parent-session"
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "locked-cli": {
+                    "type": "cli",
+                    "command": "locked",
+                    "args": [],
+                    "allowed_from_project_agents": False,
+                }
+            }
+        })
+
+        result = assign_agent(
+            agent_name="project-cli",
+            task="Run",
+            parent_agent=mock_parent,
+            workdir=str(project_root),
+        )
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "not allowed for project-local agents" in parsed["error"]
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tools/test_agents_tool.py
+++ b/tests/tools/test_agents_tool.py
@@ -960,6 +960,117 @@ Project agent prompt.
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# assign_agent — runtime trace
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAssignAgentRuntimeTrace:
+    """Tests for runtime observability events emitted by assign_agent()."""
+
+    def test_cli_runner_emits_runtime_trace_without_command_argv(self, global_agents_dir, monkeypatch):
+        (global_agents_dir / "trace-cli.md").write_text("""---
+schema_version: 1
+name: trace-cli
+description: Traceable CLI agent
+runner:
+  mode: cli
+  name: trace-runner
+  continue: off
+---
+
+You are a traceable CLI agent.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "trace-parent-session"
+
+        class Completed:
+            returncode = 0
+            stdout = '{"session_id":"external-trace-123","result":"ok"}\n'
+            stderr = ""
+
+        monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: Completed())
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "agent_runners": {
+                "trace-runner": {
+                    "type": "cli",
+                    "command": "trace-secret-command",
+                    "args": ["--api-key", "should-not-appear"],
+                    "allowed_from_project_agents": True,
+                }
+            }
+        })
+
+        result = assign_agent(
+            agent_name="trace-cli",
+            task="Trace this",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+
+        from agent.runtime_trace import read_runtime_events
+        events = read_runtime_events(session_id="trace-parent-session")
+        event_names = [event["event"] for event in events]
+        assert "assign_agent.requested" in event_names
+        assert "assign_agent.resolved" in event_names
+        assert "assign_agent.dispatched" in event_names
+        assert "assign_agent.completed" in event_names
+
+        resolved = next(event for event in events if event["event"] == "assign_agent.resolved")
+        assert resolved["data"]["agent"]["name"] == "trace-cli"
+        assert resolved["data"]["routing"]["runner_mode"] == "cli"
+        assert resolved["data"]["routing"]["runner_name"] == "trace-runner"
+
+        completed = next(event for event in events if event["event"] == "assign_agent.completed")
+        assert completed["data"]["success"] is True
+        assert completed["data"]["runner"]["name"] == "trace-runner"
+        assert completed["data"]["external_session_id"] == "external-trace-123"
+
+        trace_text = (global_agents_dir.parent / "logs" / "runtime-trace.jsonl").read_text(encoding="utf-8")
+        assert "trace-secret-command" not in trace_text
+        assert "should-not-appear" not in trace_text
+
+    def test_delegate_agent_emits_runtime_trace_with_effective_toolsets(self, global_agents_dir, monkeypatch):
+        (global_agents_dir / "trace-delegate.md").write_text("""---
+schema_version: 1
+name: trace-delegate
+description: Traceable delegate agent
+tools:
+  mode: restrict
+  allow_toolsets: [file]
+---
+
+You are a traceable delegate agent.
+""")
+        mock_parent = MagicMock()
+        mock_parent.session_id = "delegate-parent-session"
+
+        monkeypatch.setattr(
+            "tools.delegate_tool.delegate_task",
+            lambda **kwargs: json.dumps({"success": True, "results": [{"summary": "ok"}]}),
+        )
+
+        result = assign_agent(
+            agent_name="trace-delegate",
+            task="Trace delegate",
+            parent_agent=mock_parent,
+            workdir=str(global_agents_dir),
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+
+        from agent.runtime_trace import read_runtime_events
+        events = read_runtime_events(session_id="delegate-parent-session", agent_name="trace-delegate")
+        resolved = next(event for event in events if event["event"] == "assign_agent.resolved")
+        assert resolved["data"]["routing"]["runner_mode"] == "delegate_task"
+        assert resolved["data"]["toolsets_effective"] == ["file"]
+
+        completed = next(event for event in events if event["event"] == "assign_agent.completed")
+        assert completed["data"]["dispatch"] == "delegate_task"
+        assert completed["data"]["success"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # assign_agent — workdir resolution
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -73,6 +73,11 @@ class TestDelegateRequirements(unittest.TestCase):
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
         self.assertNotIn("max_iterations", props)
+        self.assertNotIn("model", props)
+        self.assertNotIn("provider", props)
+        self.assertNotIn("base_url", props)
+        self.assertNotIn("api_key", props)
+        self.assertNotIn("api_mode", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
     def test_schema_description_advertises_runtime_limits(self):
@@ -107,6 +112,30 @@ class TestDelegateRequirements(unittest.TestCase):
         for surface in (desc, tasks_desc, role_desc):
             self.assertNotIn("default 3", surface)
             self.assertNotIn("default 2", surface)
+
+    def test_internal_provider_model_override_resolves_runtime_credentials(self):
+        """assign_agent-only routing overrides must use runtime provider resolution."""
+        parent = _make_mock_parent()
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "model": "ignored-runtime-model",
+                "provider": "zai",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "api_key": "test-key",
+                "api_mode": "chat_completions",
+            }
+            creds = _resolve_delegation_credentials(
+                {},
+                parent,
+                model_override="glm-5.1",
+                provider_override="zai",
+            )
+
+        mock_resolve.assert_called_once_with(requested="zai", target_model="glm-5.1")
+        self.assertEqual(creds["provider"], "zai")
+        self.assertEqual(creds["model"], "glm-5.1")
+        self.assertEqual(creds["base_url"], "https://api.z.ai/api/coding/paas/v4")
+        self.assertEqual(creds["api_key"], "test-key")
 
     def test_schema_overrides_applied_via_get_definitions(self):
         """Registry.get_definitions() must apply dynamic_schema_overrides so

--- a/tests/tools/test_runtime_tool.py
+++ b/tests/tools/test_runtime_tool.py
@@ -1,0 +1,67 @@
+"""Tests for tools/runtime_tool.py — runtime trace inspection tool."""
+
+import json
+
+
+def test_runtime_inspect_registered_in_debugging_toolset():
+    import tools.runtime_tool  # noqa: F401 - registers tool
+    from tools.registry import registry
+    from toolsets import resolve_toolset
+
+    entry = registry.get_entry("runtime_inspect")
+    assert entry is not None
+    assert entry.toolset == "debugging"
+    assert "runtime_inspect" in resolve_toolset("debugging")
+
+
+def test_runtime_inspect_returns_recent_events(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event
+    from tools.runtime_tool import runtime_inspect
+
+    emit_runtime_event("assign_agent.resolved", session_id="inspect-session", agent={"name": "a"})
+    emit_runtime_event("assign_agent.completed", session_id="inspect-session", agent={"name": "a"}, success=True)
+    emit_runtime_event("assign_agent.completed", session_id="other-session", agent={"name": "a"}, success=True)
+
+    parsed = json.loads(runtime_inspect(session_id="inspect-session", limit=10))
+
+    assert parsed["success"] is True
+    assert parsed["session_id"] == "inspect-session"
+    assert parsed["count"] == 2
+    assert [event["event"] for event in parsed["events"]] == [
+        "assign_agent.resolved",
+        "assign_agent.completed",
+    ]
+
+
+def test_runtime_inspect_filters_by_agent_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event
+    from tools.runtime_tool import runtime_inspect
+
+    emit_runtime_event("assign_agent.completed", session_id="inspect-session", agent={"name": "a"})
+    emit_runtime_event("assign_agent.completed", session_id="inspect-session", agent={"name": "b"})
+
+    parsed = json.loads(runtime_inspect(session_id="inspect-session", agent_name="b"))
+
+    assert parsed["success"] is True
+    assert parsed["count"] == 1
+    assert parsed["events"][0]["data"]["agent"]["name"] == "b"
+
+
+def test_runtime_inspect_clamps_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from agent.runtime_trace import emit_runtime_event
+    from tools.runtime_tool import runtime_inspect
+
+    for idx in range(3):
+        emit_runtime_event("assign_agent.completed", session_id="inspect-session", seq=idx)
+
+    parsed = json.loads(runtime_inspect(session_id="inspect-session", limit=1))
+
+    assert parsed["success"] is True
+    assert parsed["count"] == 1
+    assert parsed["events"][0]["data"]["seq"] == 2

--- a/tools/agents_tool.py
+++ b/tools/agents_tool.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""
+Agents Tool Module — Native Agent Registry Tools
+
+Provides tools for discovering and delegating to named agents:
+  - agents_list: discover available named agents (read-only)
+  - agent_view: inspect a single agent's full definition including prompt
+  - assign_agent: delegate a task to a named agent via delegate_task
+
+Named agents are defined in:
+  - Global: $HERMES_HOME/agents/*.md and $HERMES_HOME/agents/**/AGENT.md
+  - Project: <project>/.hermes/agents/*.md and <project>/.hermes/agents/**/AGENT.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, List, Literal, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# Lazy imports to avoid circular dependency at module level
+_AgentDefinition = None
+
+
+def _get_agent_definition():
+    global _AgentDefinition
+    if _AgentDefinition is None:
+        from agent.agent_registry import AgentDefinition
+        _AgentDefinition = AgentDefinition
+    return _AgentDefinition
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# agents_list
+# ─────────────────────────────────────────────────────────────────────────────
+
+def agents_list(
+    category: Optional[str] = None,
+    include_disabled: bool = False,
+    include_shadowed: bool = False,
+    workdir: Optional[str] = None,
+) -> str:
+    """
+    List all discovered named agents with compact metadata (no prompts).
+
+    Agents are discovered from:
+      - Global: $HERMES_HOME/agents/
+      - Project: <project>/.hermes/agents/ (when workdir is inside a project)
+
+    Args:
+        category: Optional tag to filter agents by (e.g. "web", "code").
+                  If provided, only agents with this tag are returned.
+                  If no agent matches, an empty list is returned.
+        include_disabled: Include agents with enabled=False (default: False).
+        include_shadowed: Include shadowed agents hidden by higher-priority
+                          entries of the same name (default: False).
+        workdir: Optional working directory used to resolve the project root
+                 for project-local agent discovery.
+
+    Returns:
+        JSON string with success, count, agents (list_summary), and hint.
+    """
+    try:
+        from agent.agent_registry import list_agents
+
+        agents = list_agents(
+            workdir=workdir,
+            include_disabled=include_disabled,
+            include_shadowed=include_shadowed,
+        )
+
+        # Filter by category tag if provided
+        if category:
+            agents = [a for a in agents if category in a.tags]
+
+        summaries = [a.list_summary() for a in agents]
+
+        return json.dumps(
+            {
+                "success": True,
+                "count": len(summaries),
+                "agents": summaries,
+                "hint": "Use agent_view(name='...') to see full details including the prompt.",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.warning("agents_list failed: %s", exc)
+        return json.dumps({"success": False, "error": str(exc), "count": 0, "agents": []})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# agent_view
+# ─────────────────────────────────────────────────────────────────────────────
+
+def agent_view(
+    name: str,
+    source: Optional[Literal["global", "project"]] = None,
+    workdir: Optional[str] = None,
+) -> str:
+    """
+    Get the full definition of a single named agent, including its prompt.
+
+    Args:
+        name: The agent's unique name (lowercase alphanumeric + hyphens).
+        source: Optional source filter — "global" or "project".
+                If omitted, returns the effective (non-shadowed) agent.
+        workdir: Optional working directory for project-local agent discovery.
+
+    Returns:
+        JSON string with success and full agent.to_dict() on success,
+        or success=False with error on failure.
+    """
+    try:
+        from agent.agent_registry import get_agent
+
+        agent = get_agent(name=name, workdir=workdir, source=source)
+        if agent is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Agent '{name}' not found.",
+                },
+                ensure_ascii=False,
+            )
+
+        return json.dumps(
+            {
+                "success": True,
+                "agent": agent.to_dict(),
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.warning("agent_view(%s) failed: %s", name, exc)
+        return json.dumps({"success": False, "error": str(exc)})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Workdir helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_workdir(workdir: str | None, parent_agent: Any | None) -> str | None:
+    """Resolve effective workdir: explicit > TERMINAL_CWD > parent_agent hints."""
+    if workdir:
+        return workdir
+
+    # Check TERMINAL_CWD env var
+    import os
+    env_cwd = os.environ.get("TERMINAL_CWD")
+    if env_cwd:
+        return env_cwd
+
+    # Best-effort from parent_agent attributes
+    if parent_agent is not None:
+        # _subdirectory_hints is a common pattern in AIAgent
+        hints = getattr(parent_agent, "_subdirectory_hints", None)
+        if hints is not None:
+            wd = getattr(hints, "working_dir", None)
+            if wd:
+                return wd
+        # terminal_cwd attribute
+        wd = getattr(parent_agent, "terminal_cwd", None)
+        if wd:
+            return wd
+        # plain cwd attribute
+        wd = getattr(parent_agent, "cwd", None)
+        if wd:
+            return wd
+
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# assign_agent
+# ─────────────────────────────────────────────────────────────────────────────
+
+def assign_agent(
+    agent_name: str,
+    task: str,
+    context: Optional[str] = None,
+    toolsets: Optional[List[str]] = None,
+    role: Optional[str] = None,
+    workdir: Optional[str] = None,
+    parent_agent: Optional[Any] = None,
+) -> str:
+    """
+    Delegate a task to a named agent, compiling its prompt as the child context.
+
+    The named agent's prompt is embedded in a structured context block that
+    informs the child agent of its identity and instructions.  The child's
+    toolsets and role are derived from the agent definition (respecting
+    tools.mode == "restrict" for allow_toolsets) and can be overridden at
+    call time.
+
+    Args:
+        agent_name: Name of the agent to assign the task to.
+        task: The user's task/goal for the named agent.
+        context: Optional additional user context to include in the child's context.
+        toolsets: Runtime override for the agent's effective toolsets.
+                  If provided, overrides agent.tools.allow_toolsets.
+        role: Runtime override for the agent's delegation role.
+              If provided, overrides agent.delegation_role.
+        workdir: Optional working directory for agent discovery.
+                 If not provided, falls back to TERMINAL_CWD env var or
+                 parent_agent terminal_cwd/cwd attributes.
+        parent_agent: Optional. The calling agent instance (dispatcher injects this).
+
+    Returns:
+        JSON string with success, agent metadata, and the delegate_task result
+        (parsed if JSON, raw string otherwise).
+    """
+    # ── Require parent_agent ──────────────────────────────────────────────
+    if parent_agent is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "assign_agent requires a parent_agent context. "
+                         "Omitting parent_agent is not allowed.",
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Resolve effective workdir ──────────────────────────────────────────
+    effective_workdir = _resolve_workdir(workdir, parent_agent)
+
+    # ── Resolve the agent ─────────────────────────────────────────────────
+    try:
+        from agent.agent_registry import get_agent
+
+        agent = get_agent(name=agent_name, workdir=effective_workdir)
+        if agent is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Agent '{agent_name}' not found.",
+                },
+                ensure_ascii=False,
+            )
+
+        if not agent.enabled:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Agent '{agent_name}' is disabled.",
+                },
+                ensure_ascii=False,
+            )
+    except Exception as exc:
+        logger.warning("assign_agent resolution failed for '%s': %s", agent_name, exc)
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Failed to load agent '{agent_name}': {exc}",
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Reject unsupported routing modes in PR1 ────────────────────────────
+    # PR1 native registry only supports routing.mode == "inherit" or None.
+    # All other modes require delegate_task's full routing machinery.
+    routing_mode = agent.routing.mode
+    if routing_mode not in (None, "inherit"):
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Agent '{agent_name}' has routing.mode='{routing_mode}' which is "
+                    "not supported in the PR1 native registry. "
+                    "Use delegate_task for non-inherit routing modes."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Reject routing.acp_command defensively ─────────────────────────────
+    if agent.routing.acp_command:
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Agent '{agent_name}' has routing.acp_command set, which is "
+                    "not supported in the PR1 native registry. "
+                    "Use delegate_task for ACP-based routing."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Reject unsupported runner metadata in PR1 ─────────────────────────
+    # runner_mode != None/"delegate_task" requires the full runner infrastructure.
+    runner_mode = agent.routing.runner_mode
+    if runner_mode is not None and runner_mode not in ("delegate_task",):
+        return json.dumps(
+            {
+                "success": False,
+                "error": (
+                    f"Agent '{agent_name}' has runner.mode='{runner_mode}' which is "
+                    "not supported in the PR1 native registry. "
+                    "Use delegate_task for custom runner modes."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Compute effective toolsets ─────────────────────────────────────────
+    # Runtime toolsets override agent defaults; otherwise derive from
+    # agent.tools.allow_toolsets when mode == "restrict".
+    if toolsets is not None:
+        effective_toolsets: Optional[List[str]] = list(toolsets)
+    elif agent.tools.mode == "restrict" and agent.tools.allow_toolsets:
+        effective_toolsets = list(agent.tools.allow_toolsets)
+    else:
+        effective_toolsets = None
+
+    # ── Compute effective role ─────────────────────────────────────────────
+    # Runtime role overrides agent delegation_role.
+    effective_role: str = role if role else (agent.delegation_role or "leaf")
+
+    # ── Compile context block ──────────────────────────────────────────────
+    # Build a structured context string from the agent definition:
+    #   ## Named agent: <name>
+    #   Source/path
+    #   ## Agent instructions
+    #   <prompt>
+    #   ## Assignment context
+    #   <user context>
+    context_parts: List[str] = [
+        f"## Named agent: {agent.name}",
+        f"Source: {agent.source} — {agent.path}",
+        "",
+        "## Agent instructions",
+        agent.prompt,
+    ]
+    if context and context.strip():
+        context_parts.extend(["", "## Assignment context", context.strip()])
+
+    compiled_context = "\n".join(context_parts)
+
+    # ── Delegate via delegate_task ─────────────────────────────────────────
+    try:
+        from tools.delegate_tool import delegate_task
+
+        raw_result = delegate_task(
+            goal=task,
+            context=compiled_context,
+            toolsets=effective_toolsets,
+            role=effective_role,
+            parent_agent=parent_agent,
+        )
+    except Exception as exc:
+        logger.warning("assign_agent delegate_task failed: %s", exc)
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Delegation failed: {exc}",
+                "agent": agent.list_summary(),
+            },
+            ensure_ascii=False,
+        )
+
+    # ── Parse and wrap the result ─────────────────────────────────────────
+    try:
+        parsed_result = json.loads(raw_result)
+        return json.dumps(
+            {
+                "success": parsed_result.get("success", True),
+                "agent": agent.list_summary(),
+                "result": parsed_result,
+            },
+            ensure_ascii=False,
+        )
+    except (json.JSONDecodeError, TypeError):
+        return json.dumps(
+            {
+                "success": True,
+                "agent": agent.list_summary(),
+                "result": raw_result,
+            },
+            ensure_ascii=False,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema definitions
+# ─────────────────────────────────────────────────────────────────────────────
+
+AGENTS_LIST_SCHEMA = {
+    "name": "agents_list",
+    "description": (
+        "List all discovered named agents with compact metadata (no prompts). "
+        "Agents are defined in $HERMES_HOME/agents/ (global) or "
+        "<project>/.hermes/agents/ (project-local). "
+        "Use this to discover available named agents before calling agent_view "
+        "or assign_agent."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "description": (
+                    "Optional tag to filter agents by (e.g. 'web', 'code'). "
+                    "If provided, only agents with this tag are returned. "
+                    "If no agent matches, an empty list is returned."
+                ),
+            },
+            "include_disabled": {
+                "type": "boolean",
+                "description": "Include disabled agents in the listing (default: false).",
+                "default": False,
+            },
+            "include_shadowed": {
+                "type": "boolean",
+                "description": (
+                    "Include agents shadowed by higher-priority entries of the same name "
+                    "(default: false)."
+                ),
+                "default": False,
+            },
+            "workdir": {
+                "type": "string",
+                "description": (
+                    "Optional working directory used to resolve the project root "
+                    "for project-local agent discovery."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+AGENT_VIEW_SCHEMA = {
+    "name": "agent_view",
+    "description": (
+        "Get the full definition of a single named agent, including its prompt. "
+        "Returns all metadata (routing, tools, skills, limits, delegation role, etc.). "
+        "Use this before assign_agent to inspect an agent's instructions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": (
+                    "The agent's unique name (lowercase alphanumeric + hyphens, "
+                    "1-64 chars, must start with a letter). "
+                    "Path traversal attempts are rejected."
+                ),
+            },
+            "source": {
+                "type": "string",
+                "enum": ["global", "project"],
+                "description": (
+                    "Optional source filter. "
+                    "If omitted, returns the effective (non-shadowed) agent."
+                ),
+            },
+            "workdir": {
+                "type": "string",
+                "description": (
+                    "Optional working directory for project-local agent discovery."
+                ),
+            },
+        },
+        "required": ["name"],
+    },
+}
+
+ASSIGN_AGENT_SCHEMA = {
+    "name": "assign_agent",
+    "description": (
+        "Delegate a task to a named agent by composing its prompt into the child's "
+        "context.  The named agent's instructions become the child's system prompt "
+        "fragment, allowing reusable agent definitions to be invoked by name. "
+        "The child inherits toolsets and delegation role from the agent definition "
+        "(or runtime overrides), and the parent's context is compiled as a structured "
+        "block."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "agent_name": {
+                "type": "string",
+                "description": (
+                    "Name of the agent to assign the task to. "
+                    "Must be a valid agent definition in "
+                    "$HERMES_HOME/agents/ or <project>/.hermes/agents/."
+                ),
+            },
+            "task": {
+                "type": "string",
+                "description": (
+                    "The user's task or goal to delegate to the named agent. "
+                    "This is passed as the child's 'goal' parameter."
+                ),
+            },
+            "context": {
+                "type": "string",
+                "description": (
+                    "Optional additional context from the parent to include "
+                    "in the child's context block (e.g. relevant files, user preferences)."
+                ),
+            },
+            "toolsets": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Runtime override for the agent's effective toolsets. "
+                    "If provided, overrides agent.tools.allow_toolsets. "
+                    "Example: ['web', 'terminal']"
+                ),
+            },
+            "role": {
+                "type": "string",
+                "enum": ["leaf", "orchestrator"],
+                "description": (
+                    "Runtime override for the agent's delegation role. "
+                    "'leaf' (default): cannot delegate further. "
+                    "'orchestrator': retains the delegation toolset and can spawn workers."
+                ),
+            },
+            "workdir": {
+                "type": "string",
+                "description": (
+                    "Optional working directory for agent discovery. "
+                    "Used to resolve the project root for project-local agents."
+                ),
+            },
+        },
+        "required": ["agent_name", "task"],
+    },
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Registry
+# ─────────────────────────────────────────────────────────────────────────────
+
+registry.register(
+    name="agents_list",
+    toolset="agents",
+    schema=AGENTS_LIST_SCHEMA,
+    handler=lambda args, **kw: agents_list(
+        category=args.get("category"),
+        include_disabled=args.get("include_disabled", False),
+        include_shadowed=args.get("include_shadowed", False),
+        workdir=args.get("workdir"),
+    ),
+    description="List all discovered named agents with compact metadata",
+    emoji="🤖",
+)
+
+registry.register(
+    name="agent_view",
+    toolset="agents",
+    schema=AGENT_VIEW_SCHEMA,
+    handler=lambda args, **kw: agent_view(
+        name=args.get("name"),
+        source=args.get("source"),
+        workdir=args.get("workdir"),
+    ),
+    description="Get the full definition of a single named agent including its prompt",
+    emoji="🔍",
+)
+
+registry.register(
+    name="assign_agent",
+    toolset="delegation",
+    schema=ASSIGN_AGENT_SCHEMA,
+    handler=lambda args, **kw: assign_agent(
+        agent_name=args.get("agent_name"),
+        task=args.get("task"),
+        context=args.get("context"),
+        toolsets=args.get("toolsets"),
+        role=args.get("role"),
+        workdir=args.get("workdir"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    description="Delegate a task to a named agent by composing its prompt into child context",
+    emoji="📋",
+)

--- a/tools/agents_tool.py
+++ b/tools/agents_tool.py
@@ -301,18 +301,19 @@ def assign_agent(
             ensure_ascii=False,
         )
 
-    # ── Reject unsupported routing modes in PR1 ────────────────────────────
-    # PR1 native registry only supports routing.mode == "inherit" or None.
-    # All other modes require delegate_task's full routing machinery.
+    # ── Validate routing mode ───────────────────────────────────────────────
+    # assign_agent supports inherited routing and native Hermes provider/model
+    # overrides.  ACP transport remains unsupported here; it belongs either in
+    # delegate_task's explicit ACP override path or trusted CLI runners.
     routing_mode = agent.routing.mode
-    if routing_mode not in (None, "inherit"):
+    if routing_mode not in (None, "inherit", "hermes"):
         return json.dumps(
             {
                 "success": False,
                 "error": (
                     f"Agent '{agent_name}' has routing.mode='{routing_mode}' which is "
-                    "not supported in the PR1 native registry. "
-                    "Use delegate_task for non-inherit routing modes."
+                    "not supported. Supported routing modes: inherit, hermes. "
+                    "Use trusted CLI runners for external transports."
                 ),
             },
             ensure_ascii=False,
@@ -476,6 +477,10 @@ def assign_agent(
             toolsets=effective_toolsets,
             role=effective_role,
             parent_agent=parent_agent,
+            model=agent.routing.model if routing_mode == "hermes" else None,
+            provider=agent.routing.provider if routing_mode == "hermes" else None,
+            base_url=agent.routing.base_url if routing_mode == "hermes" else None,
+            api_mode=agent.routing.api_mode if routing_mode == "hermes" else None,
         )
     except Exception as exc:
         logger.warning("assign_agent delegate_task failed: %s", exc)

--- a/tools/agents_tool.py
+++ b/tools/agents_tool.py
@@ -292,17 +292,51 @@ def assign_agent(
             ensure_ascii=False,
         )
 
-    # ── Reject unsupported runner metadata in PR1 ─────────────────────────
-    # runner_mode != None/"delegate_task" requires the full runner infrastructure.
-    runner_mode = agent.routing.runner_mode
-    if runner_mode is not None and runner_mode not in ("delegate_task",):
+    # ── Handle runner execution modes ─────────────────────────────────────
+    # delegate_task remains the default in-process runner.  CLI-backed agents
+    # are executed via trusted agent_runners config; agent files only name the
+    # runner and continuity preference.
+    runner_mode = agent.routing.runner_mode or "delegate_task"
+    if runner_mode == "cli":
+        try:
+            from agent.agent_runner import run_cli_agent
+
+            parent_session_id = (
+                str(getattr(parent_agent, "session_id", "") or "")
+                or str(getattr(parent_agent, "task_id", "") or "")
+            )
+            if not parent_session_id:
+                import os
+
+                parent_session_id = os.environ.get("HERMES_SESSION_ID") or "default"
+            cli_result = run_cli_agent(
+                agent=agent,
+                task=task,
+                context=context,
+                workdir=effective_workdir,
+                parent_session_id=parent_session_id,
+            )
+            payload = cli_result.to_dict()
+            payload["agent"] = agent.list_summary()
+            return json.dumps(payload, ensure_ascii=False)
+        except Exception as exc:
+            logger.warning("assign_agent cli runner failed: %s", exc)
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"CLI runner failed: {exc}",
+                    "agent": agent.list_summary(),
+                },
+                ensure_ascii=False,
+            )
+
+    if runner_mode != "delegate_task":
         return json.dumps(
             {
                 "success": False,
                 "error": (
                     f"Agent '{agent_name}' has runner.mode='{runner_mode}' which is "
-                    "not supported in the PR1 native registry. "
-                    "Use delegate_task for custom runner modes."
+                    "not supported. Supported runner modes: delegate_task, cli."
                 ),
             },
             ensure_ascii=False,

--- a/tools/agents_tool.py
+++ b/tools/agents_tool.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import time
 from pathlib import Path
 from typing import Any, List, Literal, Optional
 
@@ -151,7 +153,6 @@ def _resolve_workdir(workdir: str | None, parent_agent: Any | None) -> str | Non
         return workdir
 
     # Check TERMINAL_CWD env var
-    import os
     env_cwd = os.environ.get("TERMINAL_CWD")
     if env_cwd:
         return env_cwd
@@ -174,6 +175,34 @@ def _resolve_workdir(workdir: str | None, parent_agent: Any | None) -> str | Non
             return wd
 
     return None
+
+
+def _parent_session_id(parent_agent: Any | None) -> str:
+    """Best-effort stable session id for runtime trace correlation."""
+    if parent_agent is not None:
+        for attr in ("session_id", "task_id"):
+            value = getattr(parent_agent, attr, None)
+            if isinstance(value, str) and value:
+                return value
+    return os.environ.get("HERMES_SESSION_ID") or "default"
+
+
+def _emit_runtime_trace(event: str, *, parent_session_id: str, task_id: str = "", **data: Any) -> None:
+    try:
+        from agent.runtime_trace import emit_runtime_event
+
+        emit_runtime_event(event, session_id=parent_session_id, task_id=task_id, **data)
+    except Exception:
+        pass
+
+
+def _agent_trace_payload(agent: Any) -> dict[str, Any]:
+    return {
+        "name": agent.name,
+        "source": agent.source,
+        "path": str(agent.path),
+        "enabled": agent.enabled,
+    }
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -226,8 +255,19 @@ def assign_agent(
             ensure_ascii=False,
         )
 
+    started_at = time.monotonic()
+    parent_session_id = _parent_session_id(parent_agent)
+
     # ── Resolve effective workdir ──────────────────────────────────────────
     effective_workdir = _resolve_workdir(workdir, parent_agent)
+    _emit_runtime_trace(
+        "assign_agent.requested",
+        parent_session_id=parent_session_id,
+        agent_name=agent_name,
+        task_preview=(task or "")[:120],
+        workdir_requested=workdir,
+        workdir_effective=effective_workdir,
+    )
 
     # ── Resolve the agent ─────────────────────────────────────────────────
     try:
@@ -292,23 +332,52 @@ def assign_agent(
             ensure_ascii=False,
         )
 
+    # ── Compute effective toolsets ─────────────────────────────────────────
+    # Runtime toolsets override agent defaults; otherwise derive from
+    # agent.tools.allow_toolsets when mode == "restrict".
+    if toolsets is not None:
+        effective_toolsets: Optional[List[str]] = list(toolsets)
+    elif agent.tools.mode == "restrict" and agent.tools.allow_toolsets:
+        effective_toolsets = list(agent.tools.allow_toolsets)
+    else:
+        effective_toolsets = None
+
+    # ── Compute effective role ─────────────────────────────────────────────
+    # Runtime role overrides agent delegation_role.
+    effective_role: str = role if role else (agent.delegation_role or "leaf")
+
     # ── Handle runner execution modes ─────────────────────────────────────
     # delegate_task remains the default in-process runner.  CLI-backed agents
     # are executed via trusted agent_runners config; agent files only name the
     # runner and continuity preference.
     runner_mode = agent.routing.runner_mode or "delegate_task"
+    _emit_runtime_trace(
+        "assign_agent.resolved",
+        parent_session_id=parent_session_id,
+        agent=_agent_trace_payload(agent),
+        routing={
+            "mode": agent.routing.mode,
+            "provider": agent.routing.provider,
+            "model": agent.routing.model,
+            "runner_mode": runner_mode,
+            "runner_name": agent.routing.runner_name,
+            "runner_continue": agent.routing.runner_continue,
+        },
+        toolsets_effective=effective_toolsets,
+        role_effective=effective_role,
+        workdir_effective=effective_workdir,
+    )
     if runner_mode == "cli":
         try:
             from agent.agent_runner import run_cli_agent
 
-            parent_session_id = (
-                str(getattr(parent_agent, "session_id", "") or "")
-                or str(getattr(parent_agent, "task_id", "") or "")
+            _emit_runtime_trace(
+                "assign_agent.dispatched",
+                parent_session_id=parent_session_id,
+                agent=_agent_trace_payload(agent),
+                dispatch="cli_runner",
+                routing={"runner_mode": runner_mode, "runner_name": agent.routing.runner_name},
             )
-            if not parent_session_id:
-                import os
-
-                parent_session_id = os.environ.get("HERMES_SESSION_ID") or "default"
             cli_result = run_cli_agent(
                 agent=agent,
                 task=task,
@@ -318,9 +387,35 @@ def assign_agent(
             )
             payload = cli_result.to_dict()
             payload["agent"] = agent.list_summary()
+            _emit_runtime_trace(
+                "assign_agent.completed",
+                parent_session_id=parent_session_id,
+                agent=_agent_trace_payload(agent),
+                dispatch="cli_runner",
+                success=cli_result.success,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                runner={
+                    "mode": "cli",
+                    "name": cli_result.runner_name,
+                    "resumed": cli_result.resumed,
+                },
+                external_session_id=cli_result.external_session_id,
+                returncode=cli_result.returncode,
+                error=cli_result.error,
+                warning=cli_result.warning,
+            )
             return json.dumps(payload, ensure_ascii=False)
         except Exception as exc:
             logger.warning("assign_agent cli runner failed: %s", exc)
+            _emit_runtime_trace(
+                "assign_agent.completed",
+                parent_session_id=parent_session_id,
+                agent=_agent_trace_payload(agent),
+                dispatch="cli_runner",
+                success=False,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                error=str(exc),
+            )
             return json.dumps(
                 {
                     "success": False,
@@ -341,20 +436,6 @@ def assign_agent(
             },
             ensure_ascii=False,
         )
-
-    # ── Compute effective toolsets ─────────────────────────────────────────
-    # Runtime toolsets override agent defaults; otherwise derive from
-    # agent.tools.allow_toolsets when mode == "restrict".
-    if toolsets is not None:
-        effective_toolsets: Optional[List[str]] = list(toolsets)
-    elif agent.tools.mode == "restrict" and agent.tools.allow_toolsets:
-        effective_toolsets = list(agent.tools.allow_toolsets)
-    else:
-        effective_toolsets = None
-
-    # ── Compute effective role ─────────────────────────────────────────────
-    # Runtime role overrides agent delegation_role.
-    effective_role: str = role if role else (agent.delegation_role or "leaf")
 
     # ── Compile context block ──────────────────────────────────────────────
     # Build a structured context string from the agent definition:
@@ -380,6 +461,15 @@ def assign_agent(
     try:
         from tools.delegate_tool import delegate_task
 
+        _emit_runtime_trace(
+            "assign_agent.dispatched",
+            parent_session_id=parent_session_id,
+            agent=_agent_trace_payload(agent),
+            dispatch="delegate_task",
+            routing={"runner_mode": runner_mode},
+            toolsets_effective=effective_toolsets,
+            role_effective=effective_role,
+        )
         raw_result = delegate_task(
             goal=task,
             context=compiled_context,
@@ -389,6 +479,15 @@ def assign_agent(
         )
     except Exception as exc:
         logger.warning("assign_agent delegate_task failed: %s", exc)
+        _emit_runtime_trace(
+            "assign_agent.completed",
+            parent_session_id=parent_session_id,
+            agent=_agent_trace_payload(agent),
+            dispatch="delegate_task",
+            success=False,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+            error=str(exc),
+        )
         return json.dumps(
             {
                 "success": False,
@@ -401,15 +500,32 @@ def assign_agent(
     # ── Parse and wrap the result ─────────────────────────────────────────
     try:
         parsed_result = json.loads(raw_result)
+        success = parsed_result.get("success", True)
+        _emit_runtime_trace(
+            "assign_agent.completed",
+            parent_session_id=parent_session_id,
+            agent=_agent_trace_payload(agent),
+            dispatch="delegate_task",
+            success=success,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+        )
         return json.dumps(
             {
-                "success": parsed_result.get("success", True),
+                "success": success,
                 "agent": agent.list_summary(),
                 "result": parsed_result,
             },
             ensure_ascii=False,
         )
     except (json.JSONDecodeError, TypeError):
+        _emit_runtime_trace(
+            "assign_agent.completed",
+            parent_session_id=parent_session_id,
+            agent=_agent_trace_payload(agent),
+            dispatch="delegate_task",
+            success=True,
+            duration_ms=int((time.monotonic() - started_at) * 1000),
+        )
         return json.dumps(
             {
                 "success": True,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1906,6 +1906,14 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     parent_agent=None,
+    # Internal per-call routing overrides used by assign_agent. These are not
+    # exposed in the public tool schema, so models cannot smuggle secrets or
+    # arbitrary transports through delegate_task.
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -1974,7 +1982,15 @@ def delegate_task(
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = _resolve_delegation_credentials(
+            cfg,
+            parent_agent,
+            model_override=model,
+            provider_override=provider,
+            base_url_override=base_url,
+            api_key_override=api_key,
+            api_mode_override=api_mode,
+        )
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2323,7 +2339,16 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _resolve_delegation_credentials(
+    cfg: dict,
+    parent_agent,
+    *,
+    model_override: Optional[str] = None,
+    provider_override: Optional[str] = None,
+    base_url_override: Optional[str] = None,
+    api_key_override: Optional[str] = None,
+    api_mode_override: Optional[str] = None,
+) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
@@ -2344,10 +2369,11 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     Raises ValueError with a user-friendly message on credential failure.
     """
-    configured_model = str(cfg.get("model") or "").strip() or None
-    configured_provider = str(cfg.get("provider") or "").strip() or None
-    configured_base_url = str(cfg.get("base_url") or "").strip() or None
-    configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_model = model_override or str(cfg.get("model") or "").strip() or None
+    configured_provider = provider_override or str(cfg.get("provider") or "").strip() or None
+    configured_base_url = base_url_override or str(cfg.get("base_url") or "").strip() or None
+    configured_api_key = api_key_override or str(cfg.get("api_key") or "").strip() or None
+    configured_api_mode = api_mode_override or None
 
     if configured_base_url:
         # When delegation.api_key is not set, return None so _build_child_agent
@@ -2373,6 +2399,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"
+        if configured_api_mode:
+            api_mode = configured_api_mode
 
         return {
             "model": configured_model,
@@ -2417,7 +2445,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "provider": runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
-        "api_mode": runtime.get("api_mode"),
+        "api_mode": configured_api_mode or runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -40,6 +40,7 @@ from utils import base_url_hostname, is_truthy_value
 DELEGATE_BLOCKED_TOOLS = frozenset(
     [
         "delegate_task",  # no recursive delegation
+        "assign_agent",   # named-agent delegation is also blocked for leaves
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects

--- a/tools/runtime_tool.py
+++ b/tools/runtime_tool.py
@@ -1,0 +1,88 @@
+"""Runtime inspection tools.
+
+Read-only access to structured runtime trace events emitted by Hermes routing
+and execution paths.  This is intended for debugging whether named agents,
+runners, model/provider selection, and continuity behaved as expected.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from tools.registry import registry
+
+
+def runtime_inspect(
+    session_id: Optional[str] = None,
+    limit: int = 20,
+    agent_name: Optional[str] = None,
+) -> str:
+    """Return recent runtime trace events as JSON."""
+    try:
+        from agent.runtime_trace import read_runtime_events
+
+        try:
+            bounded_limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            bounded_limit = 20
+        events = read_runtime_events(
+            session_id=session_id,
+            limit=bounded_limit,
+            agent_name=agent_name,
+        )
+        return json.dumps(
+            {
+                "success": True,
+                "session_id": session_id,
+                "agent_name": agent_name,
+                "count": len(events),
+                "events": events,
+                "hint": "Runtime trace is best-effort and redacts secret-like fields; CLI command argv and prompts are intentionally not logged.",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        return json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False)
+
+
+RUNTIME_INSPECT_SCHEMA = {
+    "name": "runtime_inspect",
+    "description": (
+        "Inspect recent runtime trace events for debugging named-agent routing, "
+        "runner selection, session continuity, and execution results. Read-only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Optional Hermes session id to filter events by.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of recent events to return (default 20, max 100).",
+                "default": 20,
+            },
+            "agent_name": {
+                "type": "string",
+                "description": "Optional named-agent filter, e.g. 'code-architect'.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+registry.register(
+    name="runtime_inspect",
+    toolset="debugging",
+    schema=RUNTIME_INSPECT_SCHEMA,
+    handler=lambda args, **kw: runtime_inspect(
+        session_id=args.get("session_id"),
+        limit=args.get("limit", 20),
+        agent_name=args.get("agent_name"),
+    ),
+    description="Inspect recent runtime trace events for agent/model routing debugging",
+    emoji="🧭",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -309,7 +309,7 @@ TOOLSETS = {
     
     "debugging": {
         "description": "Debugging and troubleshooting toolkit",
-        "tools": ["terminal", "process"],
+        "tools": ["terminal", "process", "runtime_inspect"],
         "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
     },
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Agent registry (named agent discovery and delegation)
+    "agents_list", "agent_view", "assign_agent",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -215,12 +217,19 @@ TOOLSETS = {
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "tools": ["delegate_task", "assign_agent"],
         "includes": []
     },
 
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
+
+    "agents": {
+        "description": "Native agent registry — discover and inspect named agents (read-only). "
+                       "Use assign_agent to delegate tasks to a named agent.",
+        "tools": ["agents_list", "agent_view"],
+        "includes": [],
+    },
 
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
@@ -332,6 +341,7 @@ TOOLSETS = {
             "todo", "memory",
             "session_search",
             "execute_code", "delegate_task",
+            "agents_list", "agent_view", "assign_agent",
         ],
         "includes": []
     },
@@ -360,6 +370,7 @@ TOOLSETS = {
             "session_search",
             # Code execution + delegation
             "execute_code", "delegate_task",
+            "agents_list", "agent_view", "assign_agent",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -60,7 +60,15 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `delegate_task` | Spawn one or more subagents to work on tasks in isolated contexts. Each subagent gets its own conversation, terminal session, and toolset. Only the final summary is returned -- intermediate tool results never enter your context window. TWO… | — |
+| `assign_agent` | Run a named agent (defined in `$HERMES_HOME/agents/` or `<project>/.hermes/agents/`) with a task prompt. The agent runs synchronously through `delegate_task`; only the final result is returned. Pass `toolsets`, `role`, or `context` to constrain the subagent's environment. | — |
+| `delegate_task` | Spawn one or more subagents to work on tasks in isolated contexts. Each subagent gets its own conversation, terminal session, and toolset. Only the final summary is returned -- intermediate tool results never enter your context window. | — |
+
+## `agents` toolset (read-only)
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `agents_list` | List all registered named agents with compact metadata (name, description, source path, shadowing status). Does not include prompt bodies. Accepts `category`, `include_disabled`, `include_shadowed`, and `workdir` filters. | — |
+| `agent_view` | Return the full definition of a named agent including its prompt body. Accepts `name`, `source` (`global` \| `project`), and `workdir`. Use to inspect or verify an agent before delegating to it. | — |
 
 ## `feishu_doc` toolset
 

--- a/website/docs/user-guide/features/agents.md
+++ b/website/docs/user-guide/features/agents.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 11
+title: "Named Agents"
+description: "Define reusable agent workers with Markdown files — stored globally in HERMES_HOME or per-project — and run them by name via assign_agent"
+---
+
+# Named Agents
+
+Named agents are reusable worker definitions stored as Markdown files. Each agent has its own identity, instructions, and optional tool constraints. Instead of copy-pasting a system prompt into every conversation, you define it once and invoke it by name.
+
+## Agents vs Skills
+
+Skills are **procedures** — reusable playbooks that get loaded into your *current* agent session. Agents are **workers** — independent agent instances with their own context that you delegate tasks to.
+
+| | Agents | Skills |
+|--|--------|--------|
+| Execution | Spawned as isolated subagents via `assign_agent` | Inlined into current session via `/skill` or skill tools |
+| State | Stateless (no memory between calls) | Stateless |
+| Storage | Markdown files on disk | Markdown files on disk |
+| Use case | Dedicated specialists (code reviewer, tester, writer) | Reusable workflows (refactor, release, debug) |
+
+## Storage and Override Rules
+
+Agents are discovered from two locations:
+
+| Scope | Location |
+|-------|----------|
+| **Global** | `$HERMES_HOME/agents/*.md`, `$HERMES_HOME/agents/**/*.md`, `$HERMES_HOME/agents/AGENT.md` |
+| **Project-local** | `<project>/.hermes/agents/*.md`, `<project>/.hermes/agents/**/*.md`, `<project>/.hermes/agents/AGENT.md` |
+
+A project-local agent with the same `name` as a global one **shadows** the global definition. This lets projects override or specialize shared agents without editing global files.
+
+Discovery is non-recursive at the top level — `agents/*.md` is scanned flat; subdirectories are traversed recursively. Project-local agents are found by walking from the current working directory toward the filesystem root.
+
+## Agent File Format
+
+Agent files are Markdown with YAML frontmatter. Required fields: `schema_version`, `name`, `description`, and a non-empty body prompt.
+
+```markdown
+---
+schema_version: 1
+name: code-reviewer
+description: "Thorough code reviewer for pull requests — checks logic, style, and test coverage"
+tags: [coding, review]
+tools:
+  mode: restrict
+  allow_toolsets: [terminal, file]
+delegation:
+  role: leaf
+---
+
+You are a senior code reviewer. Your job:
+
+- Read the changed files carefully
+- Focus on logic errors, edge cases, and potential bugs
+- Flag style violations and suggest improvements
+- Check that tests cover the changes
+- Be specific and constructive in your feedback
+
+When done, summarize your findings in a concise report.
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `schema_version` | Yes | Must be `1`. Reserved for future schema changes. |
+| `name` | Yes | Unique identifier. Lowercase, hyphens allowed. Used by `assign_agent`. |
+| `description` | Yes | Human-readable summary shown in `agents_list` output. |
+| `tags` | No | Labels used by the `agents_list(category=...)` filter. |
+| `tools.mode` / `tools.allow_toolsets` | No | Optional toolset restriction for the delegated worker. |
+| `delegation.role` | No | Optional child role (`leaf` or `orchestrator`) passed to the delegation layer. |
+
+:::warning No secrets in frontmatter
+Do not put API keys, tokens, or other secrets in agent frontmatter. Secrets belong in `~/.hermes/.env` or your environment, not in files that may be checked into version control.
+:::
+
+## Running Agents with `assign_agent`
+
+Use the `assign_agent` tool to delegate a task synchronously to a named agent:
+
+```
+assign_agent(agent_name="code-reviewer", task="Review PR #42 in /home/nuuair/myproject")
+```
+
+The agent runs with its own isolated context. Only the final result is returned — intermediate tool calls and thoughts stay private to the subagent.
+
+### Delegation Toolset
+
+`assign_agent` lives in the `delegation` toolset alongside `delegate_task`. Enable it with:
+
+```
+enabled_toolsets: [delegation]
+```
+
+## Listing and Inspecting Agents
+
+Two read-only tools are available in the `agents` toolset:
+
+### `agents_list`
+
+Returns compact metadata for all registered agents — names, descriptions, source paths, and enabled/disabled/shadowed status. Does not include prompt bodies.
+
+```
+agents_list()                          # all agents
+agents_list(category="review")          # filter by tag
+agents_list(include_shadowed=true)     # include shadowed globals
+agents_list(workdir="/path/to/project") # include project-local agents for that project
+```
+
+### `agent_view`
+
+Returns the full agent definition including the prompt body, for inspection or verification.
+
+```
+agent_view(name="code-reviewer")       # from default search paths
+agent_view(name="code-reviewer", source="global")   # global only
+agent_view(name="code-reviewer", source="project") # project-local only
+agent_view(name="code-reviewer", workdir="/path/to/project")
+```
+
+## Security Notes
+
+- **Agents toolset is read-only.** You can list and view agents, but cannot create, edit, or delete them via tools.
+- **`assign_agent` is in the delegation toolset**, not the agents toolset. It requires explicit enablement.
+- **Project-local agents cannot set arbitrary CLI or ACP command execution.** They are scoped to the toolsets they declare.
+- **Secrets in frontmatter are rejected** at load time. Never put credentials in agent files.
+
+## PR1 Limitations
+
+Named agents are a new capability (PR1). Current limitations:
+
+- **No `spawn_agent` / background execution.** Agents run synchronously via `assign_agent` and return when complete.
+- **No marketplace or install wizard.** Agent files are created and managed by hand.
+- **No edit or update tools.** To change an agent, edit its Markdown file directly.
+- **PR1 routing only.** Explicit routing to specific models or CLI runner modes is rejected. Agents use inherited delegation routing via `delegate_task`.
+- **No agent-to-agent chaining.** You cannot currently have one agent spawn another as a subagent.
+
+These limitations will be addressed in future releases.

--- a/website/docs/user-guide/features/agents.md
+++ b/website/docs/user-guide/features/agents.md
@@ -70,6 +70,7 @@ When done, summarize your findings in a concise report.
 | `tags` | No | Labels used by the `agents_list(category=...)` filter. |
 | `tools.mode` / `tools.allow_toolsets` | No | Optional toolset restriction for the delegated worker. |
 | `delegation.role` | No | Optional child role (`leaf` or `orchestrator`) passed to the delegation layer. |
+| `routing.mode` / `routing.provider` / `routing.model` | No | Optional native Hermes provider routing. `routing.mode: hermes` runs the child with the named provider/model through Hermes' normal credential resolver. |
 | `runner.mode` / `runner.name` / `runner.continue` | No | Optional execution runner. Defaults to `delegate_task`; `cli` uses a trusted runner from `agent_runners` config. |
 
 :::warning No secrets in frontmatter
@@ -85,6 +86,31 @@ assign_agent(agent_name="code-reviewer", task="Review PR #42 in /home/nuuair/myp
 ```
 
 The agent runs with its own isolated context. Only the final result is returned — intermediate tool calls and thoughts stay private to the subagent.
+
+### Native provider routing
+
+By default, a named agent inherits the normal delegation model/provider. To pin a named agent to a specific Hermes-supported provider and model, use `routing.mode: hermes`:
+
+```markdown
+---
+schema_version: 1
+name: fast-code-explorer
+description: "Repository exploration specialist backed by Kimi"
+routing:
+  mode: hermes
+  provider: kimi-coding
+  model: kimi-k2.6
+tools:
+  mode: restrict
+  allow_toolsets: [file]
+---
+
+You explore repositories and report concise findings.
+```
+
+When `assign_agent` runs this agent, the child uses the configured provider/model while the parent session keeps its own model. Credentials, base URLs, API modes, OAuth state, and credential pools are resolved by Hermes' normal provider machinery. Do not put API keys in agent files.
+
+`routing.mode: hermes` is intended for native Hermes providers such as OpenRouter, Anthropic, Kimi, MiniMax, Z.AI/GLM, and other configured provider integrations. External command-backed agents should use trusted CLI runners instead.
 
 ### CLI-backed agents
 
@@ -191,6 +217,7 @@ agent_view(name="code-reviewer", workdir="/path/to/project")
 
 - **Agents toolset is read-only.** You can list and view agents, but cannot create, edit, or delete them via tools.
 - **`assign_agent` is in the delegation toolset**, not the agents toolset. It requires explicit enablement.
+- **Native provider routing is trusted metadata.** Agent files may request a provider/model with `routing.mode: hermes`, but API keys and credential lookup stay outside the file. Internal provider/model overrides are not exposed on the public `delegate_task` tool schema.
 - **Project-local agents cannot define arbitrary CLI or ACP commands.** CLI commands, args, resume flags, and executable paths must come from trusted `agent_runners` config. Project-local agents can only request a configured runner by name, and only when that runner sets `allowed_from_project_agents: true`.
 - **Secrets in frontmatter are rejected** at load time. Never put credentials in agent files.
 
@@ -201,7 +228,7 @@ Named agents are a new capability. Current limitations:
 - **No `spawn_agent` / background execution.** Agents run synchronously via `assign_agent` and return when complete.
 - **No marketplace or install wizard.** Agent files are created and managed by hand.
 - **No edit or update tools.** To change an agent, edit its Markdown file directly.
-- **Limited routing.** `delegate_task` agents inherit delegation routing; `cli` agents can use trusted external runners from `agent_runners`; arbitrary per-agent provider/model routing is not implemented yet.
+- **Limited routing.** `delegate_task` agents can inherit delegation routing or use `routing.mode: hermes` for native provider/model routing; `cli` agents can use trusted external runners from `agent_runners`. Arbitrary ACP commands from agent files are not supported.
 - **No agent-to-agent chaining.** You cannot currently have one agent spawn another as a subagent.
 
 These limitations will be addressed in future releases.

--- a/website/docs/user-guide/features/agents.md
+++ b/website/docs/user-guide/features/agents.md
@@ -145,6 +145,7 @@ runtime_inspect(session_id="20260513_...", agent_name="code-architect", limit=20
 
 Typical events include:
 
+- `model.request` — ordinary LLM call metadata: provider, model, API mode, base URL host, tool count, and API call count. It does not include prompts, messages, API keys, auth headers, or the full base URL.
 - `assign_agent.requested` — the parent session requested a named agent.
 - `assign_agent.resolved` — registry lookup chose a global or project-local agent and resolved runner/model/provider metadata.
 - `assign_agent.dispatched` — Hermes selected `delegate_task` or `cli_runner` execution.

--- a/website/docs/user-guide/features/agents.md
+++ b/website/docs/user-guide/features/agents.md
@@ -70,6 +70,7 @@ When done, summarize your findings in a concise report.
 | `tags` | No | Labels used by the `agents_list(category=...)` filter. |
 | `tools.mode` / `tools.allow_toolsets` | No | Optional toolset restriction for the delegated worker. |
 | `delegation.role` | No | Optional child role (`leaf` or `orchestrator`) passed to the delegation layer. |
+| `runner.mode` / `runner.name` / `runner.continue` | No | Optional execution runner. Defaults to `delegate_task`; `cli` uses a trusted runner from `agent_runners` config. |
 
 :::warning No secrets in frontmatter
 Do not put API keys, tokens, or other secrets in agent frontmatter. Secrets belong in `~/.hermes/.env` or your environment, not in files that may be checked into version control.
@@ -85,6 +86,46 @@ assign_agent(agent_name="code-reviewer", task="Review PR #42 in /home/nuuair/myp
 
 The agent runs with its own isolated context. Only the final result is returned — intermediate tool calls and thoughts stay private to the subagent.
 
+### CLI-backed agents
+
+By default, `assign_agent` uses the in-process `delegate_task` runner. Advanced users can route a named agent to a trusted external CLI runner by adding `runner` frontmatter:
+
+```markdown
+---
+schema_version: 1
+name: code-architect
+description: "Architecture planner backed by an external CLI"
+runner:
+  mode: cli
+  name: gemini-cli
+  continue: auto   # off | auto | require
+---
+
+You are a careful software architect.
+```
+
+The executable command is **not** read from the agent file. It must come from trusted user-owned config:
+
+```yaml
+agent_runners:
+  gemini-cli:
+    type: cli
+    command: gemini
+    args: ["--output-format", "stream-json"]
+    resume_arg: "--resume"
+    allowed_from_project_agents: true
+```
+
+Continuation modes:
+
+| Mode | Behavior |
+|------|----------|
+| `off` | Always start a fresh external CLI session. |
+| `auto` | Resume when Hermes has a stored external session id for this parent session, agent, runner, and workdir; otherwise start fresh. |
+| `require` | Fail closed unless a stored external CLI session exists. |
+
+External CLI session ids are stored under `$HERMES_HOME/agent-runner-sessions.json`. Project-local agents may request a runner by name, but they cannot define commands, args, env vars, or executable paths.
+ 
 ### Delegation Toolset
 
 `assign_agent` lives in the `delegation` toolset alongside `delegate_task`. Enable it with:
@@ -123,17 +164,17 @@ agent_view(name="code-reviewer", workdir="/path/to/project")
 
 - **Agents toolset is read-only.** You can list and view agents, but cannot create, edit, or delete them via tools.
 - **`assign_agent` is in the delegation toolset**, not the agents toolset. It requires explicit enablement.
-- **Project-local agents cannot set arbitrary CLI or ACP command execution.** They are scoped to the toolsets they declare.
+- **Project-local agents cannot define arbitrary CLI or ACP commands.** CLI commands, args, resume flags, and executable paths must come from trusted `agent_runners` config. Project-local agents can only request a configured runner by name, and only when that runner sets `allowed_from_project_agents: true`.
 - **Secrets in frontmatter are rejected** at load time. Never put credentials in agent files.
 
-## PR1 Limitations
+## Current Limitations
 
-Named agents are a new capability (PR1). Current limitations:
+Named agents are a new capability. Current limitations:
 
 - **No `spawn_agent` / background execution.** Agents run synchronously via `assign_agent` and return when complete.
 - **No marketplace or install wizard.** Agent files are created and managed by hand.
 - **No edit or update tools.** To change an agent, edit its Markdown file directly.
-- **PR1 routing only.** Explicit routing to specific models or CLI runner modes is rejected. Agents use inherited delegation routing via `delegate_task`.
+- **Limited routing.** `delegate_task` agents inherit delegation routing; `cli` agents can use trusted external runners from `agent_runners`; arbitrary per-agent provider/model routing is not implemented yet.
 - **No agent-to-agent chaining.** You cannot currently have one agent spawn another as a subagent.
 
 These limitations will be addressed in future releases.

--- a/website/docs/user-guide/features/agents.md
+++ b/website/docs/user-guide/features/agents.md
@@ -125,6 +125,32 @@ Continuation modes:
 | `require` | Fail closed unless a stored external CLI session exists. |
 
 External CLI session ids are stored under `$HERMES_HOME/agent-runner-sessions.json`. Project-local agents may request a runner by name, but they cannot define commands, args, env vars, or executable paths.
+
+### Inspecting runtime routing
+
+Hermes writes a small, best-effort runtime trace when `assign_agent` resolves and runs a named agent. This lets you verify which agent file won discovery, which runner mode was used, and whether CLI session continuity resumed.
+
+The trace is stored as JSONL:
+
+```text
+$HERMES_HOME/logs/runtime-trace.jsonl
+```
+
+Use the read-only `runtime_inspect` tool from the `debugging` toolset:
+
+```python
+runtime_inspect(session_id="20260513_...")
+runtime_inspect(session_id="20260513_...", agent_name="code-architect", limit=20)
+```
+
+Typical events include:
+
+- `assign_agent.requested` — the parent session requested a named agent.
+- `assign_agent.resolved` — registry lookup chose a global or project-local agent and resolved runner/model/provider metadata.
+- `assign_agent.dispatched` — Hermes selected `delegate_task` or `cli_runner` execution.
+- `assign_agent.completed` — execution finished, including success, duration, runner name, resume status, return code, and external CLI session id when available.
+
+Runtime trace payloads redact secret-looking fields and intentionally omit full prompts and configured CLI command argv.
  
 ### Delegation Toolset
 


### PR DESCRIPTION
## Summary
This draft PR shows the complete end-to-end named agents stack for review and testing.

It includes:
- native named agent registry and project/global discovery
- `agents_list`, `agent_view`, and `assign_agent`
- trusted CLI runners for named agents
- runtime trace / runtime inspection metadata
- native provider/model routing for named agents via `routing.mode: hermes`
- parent-agent dispatch context so `assign_agent` works from normal CLI/gateway sessions
- docs and tests

## Preferred merge path
The preferred merge path is the smaller incremental series, starting with #25036.

This draft exists so maintainers can see and test the full working design before deciding whether to merge the sliced stack or request one complete PR.

Suggested review order:
1. #25036 — native named agent registry foundation
2. CLI runners
3. runtime trace / inspection
4. native provider routing

If maintainers prefer one complete patch instead, this draft can be converted to ready-for-review.

## Test plan
Focused verification run locally:

```bash
/home/nuuair/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/agent/test_agent_registry.py \
  tests/tools/test_agents_tool.py \
  tests/tools/test_delegate.py \
  tests/test_model_tools.py \
  -q -o 'addopts='
```

Result:

```text
270 passed in 15.17s
```

Plain CLI smoke also passed using the normal `hermes` wrapper:

```text
CLI_ASSIGN_SMOKE_OK agent=code-explorer provider=kimi-coding model=kimi-k2.6
```

Runtime trace confirmed the child actually used:

```text
provider=kimi-coding
model=kimi-k2.6
api_mode=anthropic_messages
host=api.kimi.com
```
