### PR TITLE
fix(qqbot): check ws.closed in _read_events to prevent idle loop on reconnect failure

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -628,7 +628,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _read_events(self) -> None:
         """Read WebSocket frames until connection closes."""
-        if not self._ws:
+        if not self._ws or self._ws.closed:
             raise RuntimeError("WebSocket not connected")
 
         while self._running and self._ws and not self._ws.closed:


### PR DESCRIPTION
## Bug

QQ Bot WebSocket reconnect enters an infinite idle loop after a failed reconnection.

## Root Cause

When a WebSocket reconnect fails (e.g. transient network error getting the gateway URL), the old `_ws` object remains but is closed. `_read_events()` at line 631 only checked `if not self._ws:`, so a closed-but-not-None WebSocket passed the guard. The `while` loop condition `not self._ws.closed` evaluated to False immediately, causing `_read_events()` to return successfully. The event loop then reset the backoff counter (`backoff_idx = 0`), entering an infinite idle loop with no further reconnection attempts and no log output.

## Fix

Add `self._ws.closed` check in the guard:

```python
# Before:
if not self._ws:

# After:
if not self._ws or self._ws.closed:
```

This causes `_read_events()` to raise `RuntimeError("WebSocket not connected")` when the WS is closed, properly triggering the reconnect logic in the event loop.

## Observed Behavior

- WebSocket disconnects with code 4009 (session timeout) — normal, reconnects fine
- Non-normal WebSocket close (no close code) at 17:17:53
- Reconnect attempt at 17:18:00 fails: `Reconnect failed: Failed to get QQ Bot gateway URL:` (empty error, transient)
- After that: **complete silence** — no more logs, no more reconnect attempts, bot stays offline indefinitely

## After Fix

The closed WebSocket triggers `RuntimeError`, the event loop catches it and uses the existing backoff logic to retry reconnection.