### PR TITLE
fix(dashboard): allow WebSocket connections on non-loopback binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -101,7 +101,7 @@ _REVEAL_WINDOW_SECONDS = 30
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0|100\.\d+\.\d+\.\d+)(:\d+)?$",
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -119,6 +119,12 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    # WebSocket routes validate the session token themselves via query
+    # params (browsers cannot set custom headers on WebSocket upgrades).
+    "/api/events",
+    "/api/pub",
+    "/api/pty",
+    "/api/ws",
 })
 
 
@@ -3194,9 +3200,17 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
     Allows loopback always; allows any IP when bound to all-interfaces
-    (--insecure mode, guarded by session token auth).
+    (--insecure mode, guarded by session token auth); also allows any IP
+    when bound to a specific non-loopback address (e.g. Tailscale IP with
+    --insecure), since that also implies an intentional non-loopback bind.
     """
     if _is_public_bind():
+        return True
+    # When bound to a specific non-loopback address (Tailscale IP, etc.)
+    # with --insecure, allow any client — the operator explicitly chose
+    # a non-loopback bind.
+    bound_host = getattr(app.state, "bound_host", "")
+    if bound_host and bound_host not in _LOOPBACK_HOSTS:
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:


### PR DESCRIPTION
## Problem

The dashboard chat tab fails to connect when the web UI is bound to a non-loopback address (e.g. a Tailscale IP with `--insecure`). The button shows "reconnect" but the WebSocket never establishes. Three distinct bugs contribute to this:

### 1. HTTP auth middleware blocks WebSocket upgrades
The `auth_middleware` enforces `X-Hermes-Session-Token` or `Authorization: Bearer` headers on all `/api/*` routes **except** a hardcoded allowlist. WebSocket endpoints use query params (`?token=...`) because browsers cannot set custom headers during the WS upgrade. `/api/pty`, `/api/ws`, `/api/events`, and `/api/pub` were not on the allowlist, so the middleware returned 401 before the WS handler could validate the token.

### 2. CORS blocks non-loopback origins
The `allow_origin_regex` only accepted `localhost` and `127.0.0.1`. Accessing the dashboard from a Tailscale IP (or any other non-loopback bind) failed CORS preflight checks.

### 3. `_ws_client_is_allowed` rejects non-localhost clients
This function only checked for `0.0.0.0`/`::` binds (`_is_public_bind`) when deciding whether to accept non-loopback WebSocket clients. An explicit non-loopback bind (like a specific Tailscale IP with `--insecure`) fell through to the localhost-only check, rejecting the connection.

## Fixes

- **web_server.py lines 114-128**: Add WebSocket paths to `_PUBLIC_API_PATHS` so the HTTP auth middleware doesnt intercept them (they validate tokens themselves via query params).
- **web_server.py line 104**: Extend CORS regex to include `0.0.0.0` and Tailscale IP range (`100.x.x.x`).
- **web_server.py lines 3200-3218**: Extend `_ws_client_is_allowed` to allow any client when `bound_host` is a specific non-loopback address.