### PR TITLE
fix(bedrock): call lazy_deps.ensure before importing boto3

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -48,7 +48,11 @@ _bedrock_control_client_cache: Dict[str, Any] = {}
 def _require_boto3():
     """Import boto3, raising a clear error if not installed."""
     try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("provider.bedrock")
         import boto3
+
         return boto3
     except ImportError:
         raise ImportError(


### PR DESCRIPTION
## Summary

.require_boto3() now calls lazy_deps.ensure('provider.bedrock') before attempting to import boto3. Without this, a fresh install that has boto3 as a lazy dep would produce a cryptic ImportError instead of triggering the lazy installation flow.

## Fix

agent/bedrock_adapter.py: Call lazy_deps.ensure('provider.bedrock') inside _require_boto3() before the import boto3 line. This matches the pattern used by other lazy-dep providers.

## Closes #24967