### PR TITLE
fix(gateway): stop HASS_TOKEN from overriding enabled: false

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1353,7 +1353,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
+            config.platforms[Platform.HOMEASSISTANT].enabled = True
         config.platforms[Platform.HOMEASSISTANT].token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:


### PR DESCRIPTION
## Summary

When HASS_TOKEN is set, it previously unconditionally set platforms.homeassistant.enabled = True, overriding an explicit enabled: false in the user's config.yaml.

Now enabled = True is only set when creating a brand-new PlatformConfig (i.e., when HOMEASSISTANT was not already in config). If the user already configured the platform (even with enabled: false), the env var only sets the token/URL but leaves enabled untouched.

## Closes #25065