### PR TITLE
fix(web): use Node.js for sync-assets instead of Unix rm/cp

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync-assets": "rm -rf public/fonts public/ds-assets && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets",
+    "sync-assets": "node scripts/sync-assets.js",
     "predev": "npm run sync-assets",
     "prebuild": "npm run sync-assets",
     "dev": "vite",

--- a/web/scripts/sync-assets.js
+++ b/web/scripts/sync-assets.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Cross-platform sync-assets: replaces `rm -rf public/fonts public/ds-assets && cp -r ...`
+// Works on Windows (CMD/PowerShell), macOS, and Linux without Unix utilities.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webRoot = path.resolve(__dirname, "..");
+
+const targets = ["fonts", "ds-assets"];
+const destDir = path.join(webRoot, "public");
+
+for (const target of targets) {
+  const dest = path.join(destDir, target);
+  // Remove existing directory (recursive, works cross-platform)
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true, force: true });
+  }
+}
+
+// Copy from node_modules
+const srcPkg = "@nous-research/ui";
+const srcFonts = path.join(webRoot, "node_modules", srcPkg, "dist", "fonts");
+const srcAssets = path.join(webRoot, "node_modules", srcPkg, "dist", "assets");
+const destFonts = path.join(destDir, "fonts");
+const destAssets = path.join(destDir, "ds-assets");
+
+if (fs.existsSync(srcFonts)) {
+  fs.cpSync(srcFonts, destFonts, { recursive: true });
+}
+if (fs.existsSync(srcAssets)) {
+  fs.cpSync(srcAssets, destAssets, { recursive: true });
+}


### PR DESCRIPTION
## Summary

sync-assets used Unix rm which is not available on Windows CMD/PowerShell, causing the web UI build to fail with 'rm is not recognized'.

Replace with a small Node.js script (web/scripts/sync-assets.js) that uses Node.js built-in fs APIs for cross-platform file operations.

## Changes

- web/scripts/sync-assets.js (new): ESM script that replicates the sync-assets logic
- web/package.json: Updated sync-assets script to call node scripts/sync-assets.js

## Closes #25073