### PR TITLE
fix(gateway): drop hardcoded English STT-failure send

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6799,34 +6799,16 @@ class GatewayRunner:
                     message_text,
                     audio_paths,
                 )
-                _stt_fail_markers = (
-                    "No STT provider",
-                    "STT is disabled",
-                    "can't listen",
-                    "VOICE_TOOLS_OPENAI_KEY",
-                )
-                if any(marker in message_text for marker in _stt_fail_markers):
-                    _stt_adapter = self.adapters.get(source.platform)
-                    _stt_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _stt_adapter:
-                        try:
-                            _stt_msg = (
-                                "🎤 I received your voice message but can't transcribe it — "
-                                "no speech-to-text provider is configured.\n\n"
-                                "To enable voice: install faster-whisper "
-                                "(`pip install faster-whisper` in the Hermes venv) "
-                                "and set `stt.enabled: true` in config.yaml, "
-                                "then /restart the gateway."
-                            )
-                            if self._has_setup_skill():
-                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
-                            await _stt_adapter.send(
-                                source.chat_id,
-                                _stt_msg,
-                                metadata=_stt_meta,
-                            )
-                        except Exception:
-                            pass
+                # NOTE: Previously, when transcription failed (e.g. no STT
+                # provider configured), the gateway also emitted a hardcoded
+                # English notice via `_stt_adapter.send()`. That bypassed the
+                # LLM and produced two replies — one pre-canned English clip
+                # (TTS spoke it aloud!) and one correct, localized LLM reply
+                # from the enriched message text. The enrichment step above
+                # already appends a localized failure note to the prompt, so
+                # the LLM produces a single coherent reply in the user's
+                # language. The hardcoded send has therefore been removed.
+                # See BUG-3 in the deployment bug tracker for details.
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes


### PR DESCRIPTION
## Summary

When speech-to-text fails, the gateway sends an English pre-canned notice via `_stt_adapter.send()` _in addition to_ letting the LLM reply. Result: two messages, the canned one in English (also read aloud by TTS), the LLM one correctly localized.

This PR removes the standalone hardcoded send. The enrichment step (`_enrich_message_with_transcription`) already appends a transcription-failure note to the prompt, so the LLM produces a single coherent reply in the user's language.

## Repro

1. Configure a non-English locale (e.g. Russian).
2. Misconfigure or disable STT so `_enrich_message_with_transcription` falls through to the "no STT provider" branch.
3. Send a voice message via Telegram.
4. **Observed**: TTS speaks a long English explanation, then a separate Russian text reply arrives from the LLM.
5. **Expected**: A single reply in the user's language.

## Root cause

`gateway/run.py:6797-6829`. Immediately after enrichment, the code re-scans the enriched text for STT-failure markers and, if found, sends a hardcoded English message that bypasses the LLM. The LLM still gets the same enriched text and replies independently in the user's language, yielding two replies.

## Fix

Delete the standalone hardcoded send. The enrichment step already informs the LLM about the failure.

## Testing

- [x] Built Docker image succeeds (`docker compose build gateway`)
- [x] `docker compose up -d gateway` — container healthy
- [x] API server (`/v1/models`, `/v1/responses`) responds normally after restart
- [x] Source verification inside running container: `grep -c "no speech-to-text provider is configured" /opt/hermes/gateway/run.py` returns 0
- [ ] Manual end-to-end voice-message test (requires a misconfigured-STT setup; LLM side already covered)

## Breaking changes

None. The error-path observable behavior changes from "two messages" to "one localized message".

---

PR by Claude Code on behalf of @nnnet (Hermes deployment integrator).
Tracks internal bug tracker entry BUG-3.