### PR TITLE
fix(stt): lazy-install faster-whisper for stt.provider: local

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -74,6 +74,29 @@ _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
 
+
+def _try_lazy_install_faster_whisper() -> bool:
+    """Attempt to lazy-install the ``stt.faster_whisper`` feature.
+
+    The faster-whisper wheel pulls in heavy native deps (ctranslate2,
+    onnxruntime) so the default Docker image and the base pip install
+    intentionally do not ship it.  When a user explicitly opts into local
+    STT via ``stt.provider: local``, install on first use — mirroring the
+    pattern used by gateway/platforms/* and other tools/* modules.
+
+    Returns ``True`` if faster-whisper is importable after the call.
+    """
+    global _HAS_FASTER_WHISPER
+    if _HAS_FASTER_WHISPER:
+        return True
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("stt.faster_whisper", prompt=False)
+    except Exception:
+        return False
+    _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
+    return _HAS_FASTER_WHISPER
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -216,6 +239,13 @@ def _get_provider(stt_config: dict) -> str:
         if provider == "local":
             if _HAS_FASTER_WHISPER:
                 return "local"
+            # Try lazy-install — same pattern as gateway/platforms/* and
+            # other tools/* modules.  Local STT is an opt-in extra, so the
+            # default Docker image doesn't ship faster-whisper; users who
+            # explicitly set `stt.provider: local` have opted in and the
+            # install should "just work" on first use.
+            if _try_lazy_install_faster_whisper():
+                return "local"
             if _has_local_command():
                 return "local_command"
             logger.warning(
@@ -278,6 +308,11 @@ def _get_provider(stt_config: dict) -> str:
     # --- Auto-detect (no explicit provider): local > groq > openai > xai ---
     # mistral is intentionally skipped while `mistralai` is quarantined on
     # PyPI (malicious 2.4.6 release on 2026-05-12).
+    #
+    # Auto-detect deliberately does NOT lazy-install faster-whisper —
+    # that would impose a multi-MB download (ctranslate2 + onnxruntime)
+    # on users who didn't ask for local STT.  Lazy install only triggers
+    # when the user has explicitly set ``stt.provider: local``.
 
     if _HAS_FASTER_WHISPER:
         return "local"


### PR DESCRIPTION
## Summary

``LAZY_DEPS[\"stt.faster_whisper\"]`` is declared in ``tools/lazy_deps.py`` but never referenced from any call site, so when a user sets ``stt.provider: local`` in ``~/.hermes/config.yaml`` (and is running the default Docker image, which deliberately omits the ``[voice]`` extra) they always hit:

> STT provider 'local' configured but unavailable

even though the lazy-install plumbing exists. This PR wires ``tools/transcription_tools.py`` into ``lazy_deps.ensure(\"stt.faster_whisper\")`` using the same pattern as ``gateway/platforms/{telegram,slack,discord,matrix,...}.py``.

## Repro

1. Build & run the default ``hermes-agent`` Docker image (no ``[voice]`` extra; per the policy comment at ``pyproject.toml`` L177-198 this is the documented production image).
2. Set ``stt.provider: local`` in ``~/.hermes/config.yaml``.
3. Send a voice message.
4. **Observed**: gateway logs ``STT provider 'local' configured but unavailable``, no transcription happens.
5. **Expected**: faster-whisper installs on first use, transcription works.

## Root cause

``tools/transcription_tools.py:_get_provider()`` checks the module-level ``_HAS_FASTER_WHISPER`` flag (computed once at import) and falls through if it's False. There is no attempt to install on demand even though ``LAZY_DEPS[\"stt.faster_whisper\"]`` already declares the right pin set.

## Fix

Add a small helper ``_try_lazy_install_faster_whisper()`` modelled on ``gateway/platforms/telegram.py:_lazy_load()``:

- Returns immediately if ``faster-whisper`` is already importable.
- Calls ``tools.lazy_deps.ensure(\"stt.faster_whisper\", prompt=False)``.
- Re-checks ``importlib.util.find_spec`` and refreshes the module-level flag.

Invoke it from the explicit ``provider == \"local\"`` branch _before_ falling through to ``local_command`` / ``\"none\"``.

Auto-detect (no explicit ``stt.provider``) deliberately does **not** trigger lazy install — that would impose a multi-MB native-wheel download (ctranslate2 + onnxruntime) on users who never asked for local STT. Only the explicit ``provider: local`` path triggers it.

## Why not just add ``[voice]`` to the Dockerfile?

The Dockerfile uses ``uv sync --extra all`` and the policy comment in ``pyproject.toml`` (L177-198) is explicit: ``voice`` was deliberately moved out of ``[all]`` on 2026-05-12 in favour of lazy install, because the wheel + native deps inflate image size and break source-build packagers (Homebrew, Nix). This PR honours that policy — the user-visible breakage is in the lazy-install path being incomplete, not in the Dockerfile.

## Testing

- [x] Built Docker image succeeds (``docker compose build gateway``).
- [x] ``docker compose up -d gateway`` — container healthy.
- [x] API server responds normally after restart.
- [x] In-container check: ``faster_whisper`` is **not** present at boot (as designed), but ``_try_lazy_install_faster_whisper`` is callable and ``_get_provider({\"enabled\": True, \"provider\": \"local\"})`` now invokes ``lazy_deps.ensure(\"stt.faster_whisper\", prompt=False)`` before falling through (verified via mock).
- [ ] End-to-end ``stt.provider: local`` voice round-trip not exercised here (would re-trigger the multi-MB install in CI; covered by the unit-level mock test).

## Breaking changes

None. Users without ``stt.provider: local`` see no change. Users with ``stt.provider: local`` who previously got an unavailable warning will now get a working install at first voice message.

---

PR by Claude Code on behalf of @nnnet. Tracks internal bug tracker entry BUG-7.