### PR TITLE
fix(label): use native vendor in compression warning when base_url is direct

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3287,6 +3287,29 @@ class AIAgent:
                 # fall back to the client's base_url hostname.
                 _main_model = getattr(self, "model", "") or "?"
                 _main_provider = getattr(self, "provider", "") or ""
+                # When provider was resolved to "openrouter" but the
+                # actual base_url points at a native vendor host (the
+                # user set model.base_url to api.openai.com/v1, etc.),
+                # the "openrouter" label is misleading. Prefer a label
+                # derived from the live base_url's hostname so the user
+                # can tell at a glance which vendor is actually being
+                # hit. Cosmetic only — routing is unchanged.
+                _main_base_url = getattr(self, "base_url", "") or ""
+                if _main_base_url:
+                    _hostname_label_map = (
+                        ("api.openai.com",    "openai"),
+                        ("api.anthropic.com", "anthropic"),
+                        ("api.x.ai",          "xai"),
+                        ("api.deepseek.com",  "deepseek"),
+                        ("api.mistral.ai",    "mistral"),
+                        ("api.groq.com",      "groq"),
+                        ("api.cohere.com",    "cohere"),
+                        ("api.cohere.ai",     "cohere"),
+                    )
+                    for _domain, _label in _hostname_label_map:
+                        if base_url_host_matches(_main_base_url, _domain):
+                            _main_provider = _label
+                            break
                 _aux_provider_label = (
                     _aux_cfg_provider
                     if _aux_cfg_provider and _aux_cfg_provider != "auto"


### PR DESCRIPTION
## Summary

When the user sets ``model.base_url: https://api.openai.com/v1`` and leaves ``model.provider: auto``, the context-compression auto-adjust warning shows ``"main model gpt-5-nano (openrouter)"`` even though the request goes straight to OpenAI. The mislabel is purely cosmetic but actively confuses anyone debugging which provider is being hit.

## Repro

1. ``~/.hermes/config.yaml``:
   ```yaml
   model:
     default: gpt-5-nano
     provider: auto
     base_url: https://api.openai.com/v1
   ```
2. Configure a compression model with a smaller context window than the main model so the auto-adjust path fires.
3. Trigger compression on a long session.
4. **Observed**: ``Compression model openai/gpt-oss-20b context is 131,072 tokens, but the main model gpt-5-nano (openrouter)'s compression threshold was 200,000 tokens.``
5. **Expected**: ``... main model gpt-5-nano (openai)'s compression threshold ...`` — the request never touches OpenRouter.

## Root cause

``hermes_cli/auth.py:resolve_provider()`` returns ``"openrouter"`` when an explicit ``OPENAI_API_KEY`` is present (its catch-all default for credential routing). That value is then stored on ``HermesAgent.provider`` and reused as a user-visible label at ``run_agent.py:3303``, which is where the cosmetic disagreement surfaces.

## Fix

At the **display** site only (``run_agent.py:3303``), prefer a label derived from the live ``self.base_url`` hostname when it matches a known native vendor host. ``resolve_provider``'s return value (and the credential routing it drives) is unchanged.

Uses ``utils.base_url_host_matches`` (already imported by ``run_agent.py``) for exact-hostname matching, so subdomain-spoof URLs like ``api.openai.com.attacker.com`` are not mislabelled as openai.

Why not patch ``resolve_provider``? Changing the return value cascades through ``hermes_cli/runtime_provider.py``, credential pool selection, ``PROVIDER_REGISTRY`` lookups, and ~30 tests that assert ``resolve_provider(...) == \"openrouter\"`` for OpenAI-key-only configs. The cosmetic-only fix at the display site is the smallest change that actually addresses the user-facing complaint.

## Testing

- [x] Docker image rebuilds (``docker compose build gateway``).
- [x] ``docker compose up -d gateway`` — container healthy.
- [x] API server (``/v1/models``, ``/v1/responses``) responds normally after restart.
- [x] In-container unit-style check: the label-selection helper returns ``"openai"`` for ``https://api.openai.com/v1``, ``"anthropic"`` for ``https://api.anthropic.com``, ``"openrouter"`` for empty/unknown, and refuses subdomain-spoof URLs.

## Breaking changes

None. Routing semantics are unchanged. The only user-visible difference is the label inside the auto-adjust warning, which now accurately names the vendor when ``base_url`` points at one.

---

PR by Claude Code on behalf of @nnnet. Tracks internal bug tracker entry BUG-6.