### PR TITLE
fix(model): strip vendor prefix when aggregator route hits native vendor

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1319,6 +1319,35 @@ class AIAgent:
 
             if self.provider not in _AGGREGATOR_PROVIDERS:
                 self.model = normalize_model_for_provider(self.model, self.provider)
+            else:
+                # When provider routing resolved to an aggregator
+                # (openrouter / nous) but the live ``base_url`` points
+                # directly at a native vendor endpoint (the user set
+                # model.base_url to api.openai.com/v1, etc.), the request
+                # bypasses the aggregator entirely.  The aggregator-style
+                # ``vendor/model`` prefix is invalid at the native vendor's
+                # API and is rejected with HTTP 400 "model does not exist".
+                # Strip the matching prefix in that case so e.g.
+                # ``openai/gpt-4o-mini`` becomes ``gpt-4o-mini`` before the
+                # outgoing request body is built.  See BUG-1.
+                _native_route_map = (
+                    ("api.openai.com",    "openai"),
+                    ("api.anthropic.com", "anthropic"),
+                    ("api.x.ai",          "xai"),
+                    ("api.deepseek.com",  "deepseek"),
+                    ("api.mistral.ai",    "mistral"),
+                    ("api.groq.com",      "groq"),
+                )
+                _hits_native = False
+                for _domain, _vendor_prefix in _native_route_map:
+                    if base_url_host_matches(self.base_url, _domain):
+                        if self.model.startswith(_vendor_prefix + "/"):
+                            self.model = self.model.split("/", 1)[1]
+                        _hits_native = True
+                        break
+                # Mark intentionally unused for static checkers — kept
+                # readable by leaving the loop's terminal state.
+                del _hits_native
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

With ``provider: auto`` + ``base_url: https://api.openai.com/v1`` + ``model: openai/gpt-4o-mini``, the request reaches OpenAI verbatim and is rejected:

    HTTP 400: The requested model 'openai/gpt-4o-mini' does not exist

The aggregator-style ``vendor/model`` slug is OpenRouter convention, not native OpenAI. ``hermes_cli.auth.resolve_provider()`` returns ``"openrouter"`` for any OpenAI-key-only config (its documented fallback), so the constructor's existing prefix-stripping branch (``run_agent.py:1320``) is skipped and the slug survives to the wire.

## Repro

1. ``~/.hermes/.env``: ``OPENAI_API_KEY=sk-...``
2. ``~/.hermes/config.yaml``:
   ```yaml
   model:
     default: openai/gpt-4o-mini
     provider: auto
     base_url: https://api.openai.com/v1
   ```
3. Send any message.
4. **Observed**: ``HTTP 400: The requested model 'openai/gpt-4o-mini' does not exist``.
5. **Expected**: ``gpt-4o-mini`` is sent and the request succeeds.

## Root cause

``run_agent.HermesAgent`` only invokes ``normalize_model_for_provider()`` when ``self.provider`` is not in ``_AGGREGATOR_PROVIDERS``. For OpenAI-key + ``auto``, the provider is resolved to ``"openrouter"`` (correct for credential routing), so the prefix-strip path is skipped and the model id passes through verbatim.

## Fix

Extend the existing branch in the constructor: when the provider is an aggregator AND the live ``self.base_url`` matches a known native vendor host (``api.openai.com``, ``api.anthropic.com``, ``api.x.ai``, ``api.deepseek.com``, ``api.mistral.ai``, ``api.groq.com``), strip the matching ``<vendor>/`` prefix from ``self.model`` so the outgoing kwargs carry the form the vendor's API expects.

Uses ``base_url_host_matches`` (exact-hostname match) so subdomain-spoof URLs like ``api.openai.com.attacker.com`` cannot bypass the guard. Only the prefix is touched — model ids that don't carry a matching prefix flow through unchanged.

## Testing

- [x] Docker image rebuilds (``docker compose build gateway``).
- [x] ``docker compose up -d gateway`` — container healthy.
- [x] API server (``/v1/models``, ``/v1/responses``) works end-to-end after restart with ``gpt-5-nano`` (the founder's current main model — pre-existing config keeps working).
- [x] Source-level integration check: ``_native_route_map`` table is present in the running container.

## Breaking changes

None. The change only triggers when (a) the provider routing returned an aggregator AND (b) the live ``base_url`` points at a native vendor host AND (c) the model id starts with the matching ``<vendor>/`` prefix. All three conditions failing leaves behavior unchanged.

---

PR by Claude Code on behalf of @nnnet. Tracks internal bug tracker entry BUG-1.