### PR TITLE
fix: add Xiaomi MiMo to reasoning_content echo-back check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9980,13 +9980,14 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
-        of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and Xiaomi MiMo
+        thinking all reject replays of assistant tool-call messages that
+        omit ``reasoning_content`` (refs #15250, #17400, xiaomi).
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_xiaomi_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10016,6 +10017,20 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_xiaomi_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        Xiaomi MiMo thinking mode requires ``reasoning_content`` on every
+        assistant tool-call message; omitting it causes the next replay to
+        fail with HTTP 400 ("The reasoning_content in the thinking mode
+        must be passed back to the API").
+        """
+        provider = (self.provider or "").lower()
+        return (
+            provider == "xiaomi"
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:


### PR DESCRIPTION
## Summary

Xiaomi MiMo thinking mode requires `reasoning_content` on every assistant message when replaying conversation history. Without it, the API returns HTTP 400:

```
"The reasoning_content in the thinking mode must be passed back to the API."
```

This is the same requirement as DeepSeek V4 thinking (#15250) and Kimi/Moonshot thinking (#17400), but Xiaomi MiMo was not included in the `_needs_thinking_reasoning_pad()` check.

## Changes

- Add `_needs_xiaomi_tool_reasoning()` method that checks for `provider == "xiaomi"` or `xiaomimimo.com` base URL
- Include Xiaomi in `_needs_thinking_reasoning_pad()` alongside DeepSeek and Kimi

## Test Plan

- [x] Verified fix resolves HTTP 400 on Xiaomi MiMo gateway with conversation history containing reasoning_content
- [x] Gateway successfully processes messages after restart with patched code

## Reproduction

1. Use Xiaomi MiMo (`mimo-v2.5-pro`) as the provider
2. Have a conversation where the model returns reasoning_content (thinking mode)
3. On the next turn, the API call fails with HTTP 400 because reasoning_content is stripped during message serialization