### PR TITLE
fix(responses): HERMES_DISABLE_REASONING_INCLUDE env-var escape hatch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -683,11 +683,19 @@ class _CodexCompletionsAdapter:
                     # match the main-agent Codex transport behavior.
                     if effort == "minimal":
                         effort = "low"
-                    resp_kwargs["reasoning"] = {
-                        "effort": effort,
-                        "summary": "auto",
-                    }
-                    resp_kwargs["include"] = ["reasoning.encrypted_content"]
+                    # Env-var escape hatch (see agent/transports/codex.py
+                    # _reasoning_include_disabled): for non-reasoning OpenAI
+                    # models at api.openai.com, the Responses API rejects
+                    # include=["reasoning.encrypted_content"] with HTTP 400.
+                    _disable_include = (
+                        os.getenv("HERMES_DISABLE_REASONING_INCLUDE", "") or ""
+                    ).strip().lower() in {"1", "true", "yes", "on"}
+                    if not _disable_include:
+                        resp_kwargs["reasoning"] = {
+                            "effort": effort,
+                            "summary": "auto",
+                        }
+                        resp_kwargs["include"] = ["reasoning.encrypted_content"]
 
         # Tools support for auxiliary callers (e.g. skills_hub) that pass function schemas
         tools = kwargs.get("tools")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,10 +5,30 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import os
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
+
+
+def _reasoning_include_disabled() -> bool:
+    """Return True if the user has opted out of ``reasoning.encrypted_content``.
+
+    ``include: ["reasoning.encrypted_content"]`` is only accepted by the
+    Responses API on reasoning-capable models (o-series, gpt-5*).  For
+    non-reasoning models the API returns:
+
+        HTTP 400: Encrypted content is not supported with this model.
+
+    Users targeting a non-reasoning OpenAI model (e.g. gpt-4o-mini) via
+    ``base_url: https://api.openai.com/v1`` can set
+    ``HERMES_DISABLE_REASONING_INCLUDE=true`` in ``~/.hermes/.env`` to
+    suppress the include parameter on every Responses-API request.
+    """
+    return (os.getenv("HERMES_DISABLE_REASONING_INCLUDE", "") or "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
 
 
 class ResponsesApiTransport(ProviderTransport):
@@ -103,10 +123,18 @@ class ResponsesApiTransport(ProviderTransport):
         if not is_github_responses and session_id:
             kwargs["prompt_cache_key"] = session_id
 
+        # Env-var escape hatch: when targeting a non-reasoning OpenAI model
+        # via the Responses API (e.g. gpt-4o-mini at api.openai.com), the
+        # API rejects ``include: ["reasoning.encrypted_content"]`` with
+        # HTTP 400.  Allow users to opt out so all encrypted-content
+        # additions below are suppressed.
+        _include_reasoning = not _reasoning_include_disabled()
+
         if reasoning_enabled and is_xai_responses:
             from agent.model_metadata import grok_supports_reasoning_effort
 
-            kwargs["include"] = ["reasoning.encrypted_content"]
+            if _include_reasoning:
+                kwargs["include"] = ["reasoning.encrypted_content"]
             # xAI rejects `reasoning.effort` on grok-4 / grok-4-fast / grok-3
             # / grok-code-fast / grok-4.20-0309-* with HTTP 400 even though
             # those models reason natively. Only send the effort dial when
@@ -120,8 +148,9 @@ class ResponsesApiTransport(ProviderTransport):
                 if github_reasoning is not None:
                     kwargs["reasoning"] = github_reasoning
             else:
-                kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
-                kwargs["include"] = ["reasoning.encrypted_content"]
+                if _include_reasoning:
+                    kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+                    kwargs["include"] = ["reasoning.encrypted_content"]
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 


### PR DESCRIPTION
## Summary

The Responses API rejects ``include: [\"reasoning.encrypted_content\"]`` on non-reasoning models with:

    HTTP 400: Encrypted content is not supported with this model.
    param='include', code='model_not_found'

Users running Hermes against ``api.openai.com`` with a non-reasoning model (e.g. ``gpt-4o-mini``) have no way to opt out — every request fails. This PR adds an env-var escape hatch.

## Repro

1. ``~/.hermes/.env``: ``OPENAI_API_KEY=sk-...``
2. ``~/.hermes/config.yaml``:
   ```yaml
   model:
     default: gpt-4o-mini
     provider: auto
     base_url: https://api.openai.com/v1
   ```
3. Send any message via Telegram / API.
4. **Observed**: HTTP 400 on every call.
5. **Workaround until this PR**: switch to a reasoning model (``gpt-5-nano`` etc.).

## Root cause

``agent/transports/codex.py:109,124`` and ``agent/auxiliary_client.py:690`` unconditionally set ``include=[\"reasoning.encrypted_content\"]`` whenever ``reasoning_enabled`` is true (the default). The parameter is only accepted by reasoning-capable models (o-series, gpt-5*); the Responses API returns 400 on every other model.

## Fix

Add a single env var, ``HERMES_DISABLE_REASONING_INCLUDE``, that suppresses both the ``include`` parameter and the ``reasoning`` block in the outgoing Responses-API kwargs. Default behavior (always send ``include``) is preserved when the env var is unset or falsy.

Why an env var and not model-family detection?
1. ~30 tests assert ``include == [\"reasoning.encrypted_content\"]`` on every Responses-API path; teaching the transport about reasoning-capable model families would require revising every one of those test expectations. That's a larger refactor and a riskier PR.
2. The env var is opt-in and 100% backward compatible — nothing changes for existing users.
3. A follow-up PR can introduce ``agent.model_metadata.is_reasoning_model()`` to make this automatic; this PR unblocks users today.

## Testing

- [x] Docker image rebuilds (``docker compose build gateway``).
- [x] ``docker compose up -d gateway`` — container healthy.
- [x] API server (``/v1/models``, ``/v1/responses``) responds normally after restart with the founder's ``gpt-5-nano`` default config (env var unset).
- [x] In-container integration check:
  - ``_reasoning_include_disabled()`` returns ``False`` by default, ``True`` for ``HERMES_DISABLE_REASONING_INCLUDE`` in ``{1, true, yes, on}``.
  - With env var unset: ``build_kwargs(\"gpt-4o-mini\", ...)`` includes ``[\"reasoning.encrypted_content\"]`` and ``reasoning={\"effort\":\"medium\",\"summary\":\"auto\"}`` (default behavior preserved).
  - With env var ``\"true\"``: same call returns kwargs with no ``include`` and no ``reasoning`` block.

## Breaking changes

None. Default behavior is unchanged. The env var is opt-in.

## Follow-up

A follow-up PR can introduce ``agent.model_metadata.is_reasoning_model(model_id) -> bool`` and switch the transport to use it automatically — at which point the env var can be deprecated in favour of automatic detection.

---

PR by Claude Code on behalf of @nnnet. Tracks internal bug tracker entry BUG-2.