### PR TITLE
fix(memory): verify dependencies are importable before configuring memory provider

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -55,28 +55,33 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
-def _install_dependencies(provider_name: str) -> None:
-    """Install pip dependencies declared in plugin.yaml."""
+def _install_dependencies(provider_name: str) -> bool:
+    """Install pip dependencies declared in plugin.yaml.
+
+    Returns True if all dependencies are importable (either already installed
+    or successfully installed).  Returns False if any dependency is still
+    missing after the install attempt.
+    """""
     import subprocess
     from plugins.memory import find_provider_dir
 
     plugin_dir = find_provider_dir(provider_name)
     if not plugin_dir:
-        return
+        return True
     yaml_path = plugin_dir / "plugin.yaml"
     if not yaml_path.exists():
-        return
+        return True
 
     try:
         import yaml
         with open(yaml_path, encoding="utf-8") as f:
             meta = yaml.safe_load(f) or {}
     except Exception:
-        return
+        return True
 
     pip_deps = meta.get("pip_dependencies", [])
     if not pip_deps:
-        return
+        return True
 
     # pip name → import name mapping for packages where they differ
     _IMPORT_NAMES = {
@@ -96,7 +101,7 @@ def _install_dependencies(provider_name: str) -> None:
             missing.append(dep)
 
     if not missing:
-        return
+        return True
 
     print(f"\n  Installing dependencies: {', '.join(missing)}")
 
@@ -106,7 +111,7 @@ def _install_dependencies(provider_name: str) -> None:
         print(f"  ⚠ uv not found — cannot install dependencies")
         print(f"  Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh")
         print(f"  Then re-run: hermes memory setup")
-        return
+        return False
 
     try:
         subprocess.run(
@@ -125,6 +130,18 @@ def _install_dependencies(provider_name: str) -> None:
         print(f"  ⚠ Install failed: {e}")
         print(f"  Run manually: uv pip install --python {sys.executable} {' '.join(missing)}")
 
+    # Verify all dependencies are now importable
+    still_missing = []
+    for dep in pip_deps:
+        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+        try:
+            __import__(import_name)
+        except ImportError:
+            still_missing.append(dep)
+    if still_missing:
+        print(f"  ⚠ Dependencies still missing after install: {', '.join(still_missing)}")
+        return False
+
     # Also show external dependencies (non-pip) if any
     ext_deps = meta.get("external_dependencies", [])
     for dep in ext_deps:
@@ -140,6 +157,8 @@ def _install_dependencies(provider_name: str) -> None:
                 if install_cmd:
                     print(f"\n  ⚠ '{dep_name}' not found. Install with:")
                     print(f"    {install_cmd}")
+
+    return True
 
 
 def _get_available_providers() -> list:
@@ -200,7 +219,10 @@ def cmd_setup_provider(provider_name: str) -> None:
 
     name, _, provider = match
 
-    _install_dependencies(name)
+    if not _install_dependencies(name):
+        print(f"  ⚠ Cannot configure '{name}' — required dependencies are missing.")
+        print(f"  Install manually and re-run: hermes memory setup\n")
+        return
 
     config = load_config()
     if not isinstance(config.get("memory"), dict):
@@ -253,7 +275,10 @@ def cmd_setup(args) -> None:
     name, _, provider = providers[selected]
 
     # Install pip dependencies if declared in plugin.yaml
-    _install_dependencies(name)
+    if not _install_dependencies(name):
+        print(f"  ⚠ Cannot configure '{name}' — required dependencies are missing.")
+        print(f"  Install manually and re-run: hermes memory setup\n")
+        return
 
     # If the provider has a post_setup hook, delegate entirely to it.
     # The hook handles its own config, connection test, and activation.

--- a/tests/hermes_cli/test_memory_setup_dependency_check.py
+++ b/tests/hermes_cli/test_memory_setup_dependency_check.py
@@ -1,0 +1,160 @@
+"""Tests for memory_setup._install_dependencies return value and setup abort behavior.
+
+Regression tests for:
+    https://github.com/NousResearch/hermes-agent/issues/25086
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _install_dependencies return value
+# ---------------------------------------------------------------------------
+
+class TestInstallDependenciesReturn:
+    """Verify _install_dependencies returns True/False correctly."""
+
+    def test_returns_true_when_no_plugin_dir(self, tmp_path: Path) -> None:
+        """No plugin directory -> no deps to check -> True."""
+        from hermes_cli.memory_setup import _install_dependencies
+
+        with patch("plugins.memory.find_provider_dir", return_value=None):
+            assert _install_dependencies("nonexistent") is True
+
+    def test_returns_true_when_no_plugin_yaml(self, tmp_path: Path) -> None:
+        """Plugin dir exists but no plugin.yaml -> True."""
+        from hermes_cli.memory_setup import _install_dependencies
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        with patch("plugins.memory.find_provider_dir", return_value=plugin_dir):
+            assert _install_dependencies("test_plugin") is True
+
+    def test_returns_true_when_no_pip_deps(self, tmp_path: Path) -> None:
+        """plugin.yaml has no pip_dependencies -> True."""
+        from hermes_cli.memory_setup import _install_dependencies
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text("name: test\nversion: 1.0\n")
+        with patch("plugins.memory.find_provider_dir", return_value=plugin_dir):
+            assert _install_dependencies("test_plugin") is True
+
+    def test_returns_true_when_all_deps_importable(self, tmp_path: Path) -> None:
+        """All pip_dependencies already installed -> True without installing."""
+        from hermes_cli.memory_setup import _install_dependencies
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: test\npip_dependencies:\n  - json\n"  # json is always available
+        )
+        with patch("plugins.memory.find_provider_dir", return_value=plugin_dir):
+            assert _install_dependencies("test_plugin") is True
+
+    def test_returns_false_when_uv_not_found(self, tmp_path: Path) -> None:
+        """Missing dep + no uv -> False."""
+        from hermes_cli.memory_setup import _install_dependencies
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: test\npip_dependencies:\n  - nonexistent-fake-pkg-xyz\n"
+        )
+        with (
+            patch("plugins.memory.find_provider_dir", return_value=plugin_dir),
+            patch("shutil.which", return_value=None),
+        ):
+            assert _install_dependencies("test_plugin") is False
+
+    def test_returns_false_when_install_fails(self, tmp_path: Path) -> None:
+        """Missing dep + uv install fails -> False."""
+        import subprocess
+
+        from hermes_cli.memory_setup import _install_dependencies
+
+        plugin_dir = tmp_path / "test_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: test\npip_dependencies:\n  - nonexistent-fake-pkg-xyz\n"
+        )
+        with (
+            patch("plugins.memory.find_provider_dir", return_value=plugin_dir),
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "uv", stderr=b"fail"),
+            ),
+        ):
+            assert _install_dependencies("test_plugin") is False
+
+
+# ---------------------------------------------------------------------------
+# cmd_setup aborts when deps are missing
+# ---------------------------------------------------------------------------
+
+class TestCmdSetupAbortOnMissingDeps:
+    """Verify cmd_setup / cmd_setup_provider abort when deps are missing."""
+
+    def test_cmd_setup_aborts_when_install_fails(self, tmp_path: Path, capsys) -> None:
+        """cmd_setup should abort with message when _install_dependencies returns False."""
+        from hermes_cli.memory_setup import cmd_setup
+
+        mock_provider = MagicMock()
+        mock_provider.get_config_schema.return_value = []
+
+        with (
+            patch("hermes_cli.memory_setup._get_available_providers",
+                  return_value=[("mem0", "requires API key", mock_provider)]),
+            patch("hermes_cli.memory_setup._curses_select", return_value=0),
+            patch("hermes_cli.memory_setup._install_dependencies", return_value=False),
+        ):
+            cmd_setup(None)
+
+        captured = capsys.readouterr()
+        assert "Cannot configure" in captured.out
+        assert "dependencies are missing" in captured.out
+
+    def test_cmd_setup_provider_aborts_when_install_fails(self, tmp_path: Path, capsys) -> None:
+        """cmd_setup_provider should abort when _install_dependencies returns False."""
+        from hermes_cli.memory_setup import cmd_setup_provider
+
+        mock_provider = MagicMock()
+
+        with (
+            patch("hermes_cli.memory_setup._get_available_providers",
+                  return_value=[("mem0", "requires API key", mock_provider)]),
+            patch("hermes_cli.memory_setup._install_dependencies", return_value=False),
+        ):
+            cmd_setup_provider("mem0")
+
+        captured = capsys.readouterr()
+        assert "Cannot configure" in captured.out
+        assert "dependencies are missing" in captured.out
+
+    def test_cmd_setup_proceeds_when_deps_ok(self, tmp_path: Path) -> None:
+        """cmd_setup should proceed normally when _install_dependencies returns True."""
+        from hermes_cli.memory_setup import cmd_setup
+
+        mock_provider = MagicMock()
+        # Mock has auto-created post_setup, so cmd_setup delegates to it
+
+        with (
+            patch("hermes_cli.memory_setup._get_available_providers",
+                  return_value=[("test", "local", mock_provider)]),
+            patch("hermes_cli.memory_setup._curses_select", return_value=0),
+            patch("hermes_cli.memory_setup._install_dependencies", return_value=True),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("hermes_cli.config.save_config"),
+            patch("hermes_constants.get_hermes_home", return_value=tmp_path),
+        ):
+            cmd_setup(None)
+
+        # post_setup should have been called (setup proceeded past dep check)
+        mock_provider.post_setup.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

`hermes memory setup` previously configured providers (e.g. Mem0) without verifying that their pip dependencies were actually importable. If `uv pip install` failed silently (network issues, permission errors, missing `uv`), the wizard reported success but the plugin crashed at runtime with `ModuleNotFoundError`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `_install_dependencies` (callers: 2, callees: 1, flows: 1)
- Blast radius: LOW — both callers (`cmd_setup`, `cmd_setup_provider`) are in the same file
- Related patterns: `find_provider_dir` in `plugins/memory/__init__.py` (read-only dependency)

## Regression coverage

9 new tests in `tests/hermes_cli/test_memory_setup_dependency_check.py`:
- `TestInstallDependenciesReturn` (6 tests): True for no plugin dir, no yaml, no deps, all importable; False for missing uv, failed install
- `TestCmdSetupAbortOnMissingDeps` (3 tests): abort on failed install, abort on missing deps for provider-specific setup, proceed when deps OK

All 18 tests pass (9 new + 9 existing `test_memory_reset.py`).

## Testing

```bash
python -m pytest tests/hermes_cli/test_memory_setup_dependency_check.py tests/hermes_cli/test_memory_reset.py -v
# 18 passed
```

Fixes [Bug]: hermes memory setup does not verify mem0ai is importable before configuring Mem0 #25086