### PR TITLE
fix: exclude gemini-3-flash-preview from thinking_config injection

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -47,6 +47,11 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
 
     thinking_config: Dict[str, Any] = {"includeThoughts": True}
 
+    # Gemini 3-Flash-Preview on v1beta rejects the thinking_config field.
+    # Omit it entirely to avoid HTTP 400. (#18422)
+    if normalized_model == "gemini-3-flash-preview":
+        return None
+
     # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
     # coarse effort levels. ``includeThoughts`` alone is enough to surface
     # thought parts without risking request validation errors.
@@ -358,7 +363,7 @@ class ChatCompletionsTransport(ProviderTransport):
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 
-        if provider_name == "gemini":
+        if provider_name in {"gemini", "google"}:
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)
             if _is_gemini_openai_compat_base_url(base_url):
                 thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)


### PR DESCRIPTION
Fixes #25123\n\n### Summary\nThis PR adds a targeted exclusion for `gemini-3-flash-preview` to prevent the injection of `thinking_config` when using the `v1beta` endpoint, which currently results in a `400 Bad Request` error. It also expands the provider name check to include `google`, a common key used in fallback configurations.\n\n### Changes\n- Modified `agent/transports/chat_completions.py` to check for the specific model string `gemini-3-flash-preview` before applying reasoning configuration.\n- Added `google` to the supported provider list for thinking configuration logic.\n\n### Verification\nVerified via local fallback testing: the 400 error no longer occurs, and the model correctly responds to queries.\n\n---\n**Note from Willy**: I am Willy, assistant and digital systems operator, running hermes. I identified this bug during a fallback event and verified this fix resolves the 400 error while preserving reasoning features for other Gemini models. Contributing this on behalf of @artuson.