### PR TITLE
fix: normalize Kimi runtime base URL

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -176,6 +176,23 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _normalize_kimi_anthropic_base_url(base_url: str, api_mode: str) -> str:
+    """Normalize Kimi Code catalog URLs for Anthropic Messages runtime calls."""
+    base_url = (base_url or "").strip().rstrip("/")
+    if (
+        api_mode == "anthropic_messages"
+        and base_url_host_matches(base_url, "api.kimi.com")
+        and base_url.lower().endswith("/coding/v1")
+    ):
+        # Kimi Code exposes /models on the OpenAI-compatible /coding/v1
+        # surface, but Anthropic SDK clients append /v1/messages to the
+        # configured base_url. Strip the catalog suffix for runtime calls
+        # so requests target /coding/v1/messages rather than
+        # /coding/v1/v1/messages.
+        return base_url[:-3]
+    return base_url
+
+
 def _resolve_runtime_from_pool_entry(
     *,
     provider: str,
@@ -292,6 +309,7 @@ def _resolve_runtime_from_pool_entry(
     # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
     if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
         base_url = re.sub(r"/v1/?$", "", base_url)
+    base_url = _normalize_kimi_anthropic_base_url(base_url, api_mode)
 
     return {
         "provider": provider,
@@ -896,17 +914,7 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
-        if (
-            api_mode == "anthropic_messages"
-            and base_url_host_matches(base_url, "api.kimi.com")
-            and base_url.rstrip("/").lower().endswith("/coding/v1")
-        ):
-            # Kimi Code exposes /models on the OpenAI-compatible /coding/v1
-            # surface, but Anthropic SDK clients append /v1/messages to the
-            # configured base_url.  Strip the catalog suffix for runtime calls
-            # so requests target /coding/v1/messages rather than
-            # /coding/v1/v1/messages.
-            base_url = base_url.rstrip("/")[:-3]
+        base_url = _normalize_kimi_anthropic_base_url(base_url, api_mode)
 
         return {
             "provider": provider,
@@ -1347,6 +1355,7 @@ def resolve_runtime_provider(
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
             base_url = re.sub(r"/v1/?$", "", base_url)
+        base_url = _normalize_kimi_anthropic_base_url(base_url, api_mode)
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -896,6 +896,18 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
+        if (
+            api_mode == "anthropic_messages"
+            and base_url_host_matches(base_url, "api.kimi.com")
+            and base_url.rstrip("/").lower().endswith("/coding/v1")
+        ):
+            # Kimi Code exposes /models on the OpenAI-compatible /coding/v1
+            # surface, but Anthropic SDK clients append /v1/messages to the
+            # configured base_url.  Strip the catalog suffix for runtime calls
+            # so requests target /coding/v1/messages rather than
+            # /coding/v1/v1/messages.
+            base_url = base_url.rstrip("/")[:-3]
+
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2321,3 +2321,29 @@ def test_minimax_oauth_pool_forces_anthropic_messages_despite_stale_config(monke
     assert resolved["provider"] == "minimax-oauth"
     assert resolved["api_mode"] == "anthropic_messages"
     assert resolved["base_url"] == "https://api.minimax.io/anthropic"
+
+
+
+def test_resolve_runtime_provider_strips_kimi_coding_v1_for_anthropic_messages(monkeypatch):
+    """Regression for #25104: Anthropic SDK appends /v1/messages itself.
+
+    A persisted Kimi Code base URL copied from the OpenAI-compatible /models
+    surface (``.../coding/v1``) must be normalized to ``.../coding`` when the
+    runtime transport is Anthropic Messages, otherwise requests go to
+    ``/coding/v1/v1/messages``.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "kimi-coding", "api_mode": "anthropic_messages"},
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="kimi-coding",
+        explicit_api_key="sk-kimi-test",
+        explicit_base_url="https://api.kimi.com/coding/v1",
+    )
+
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2347,3 +2347,64 @@ def test_resolve_runtime_provider_strips_kimi_coding_v1_for_anthropic_messages(m
 
     assert resolved["api_mode"] == "anthropic_messages"
     assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_resolve_runtime_provider_strips_persisted_kimi_coding_v1(monkeypatch):
+    """Persisted model.base_url must get the same Anthropic SDK normalization."""
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "kimi-coding",
+            "default": "kimi-k2.6",
+            "base_url": "https://api.kimi.com/coding/v1",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **k: None)
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "api_key": "sk-kimi-test",
+            "base_url": "https://api.kimi.com/coding/v1",
+            "source": "env",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_pool_entry_strips_kimi_coding_v1_for_anthropic_messages(monkeypatch):
+    """Pool-supplied Kimi catalog URLs must also avoid /coding/v1/v1/messages."""
+
+    class _Entry:
+        runtime_api_key = "sk-kimi-test"
+        runtime_base_url = "https://api.kimi.com/coding/v1"
+        source = "pool:kimi-coding"
+
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "kimi-coding",
+            "default": "kimi-k2.6",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="kimi-coding",
+        entry=_Entry(),
+        requested_provider="kimi-coding",
+    )
+
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"


### PR DESCRIPTION
## Bug

Kimi Code can expose an OpenAI-compatible catalog URL at https://api.kimi.com/coding/v1, but Anthropic Messages clients append /v1/messages internally. Keeping /coding/v1 as the runtime base URL produces /coding/v1/v1/messages and 404s.

Fixes #25104

## Summary

Normalize api.kimi.com/coding/v1 to api.kimi.com/coding only when the resolved runtime transport is anthropic_messages. This preserves /models/catalog compatibility elsewhere while preventing the Anthropic SDK double-/v1 path.

## TDD / ATDD coverage

- Added a focused regression test that reproduces the reported behavior.
- Implemented the minimal production change needed to satisfy the regression.
- Re-ran the targeted test file to guard nearby behavior.

## Test plan

- /Users/mudrii/src/hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -o 'addopts=' -> 111 passed

## Review notes

- Kept the change scoped to the issue-specific runtime path.
- No secrets are persisted or logged.
