### PR TITLE
fix: canonicalize Kimi provider alias

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -705,6 +705,17 @@ def switch_model(
             )
 
         target_provider = pdef.id
+        if target_provider == "kimi-for-coding":
+            # models.dev exposes Kimi endpoints as ``kimi-for-coding``.  Hermes
+            # keeps separate runtime/auth ids for global and China Kimi
+            # providers, so preserve the user-requested region while avoiding
+            # persistence of the models.dev alias.
+            _explicit_provider_key = explicit_provider.strip().lower()
+            target_provider = (
+                "kimi-coding-cn"
+                if _explicit_provider_key in {"kimi-coding-cn", "kimi-cn", "moonshot-cn"}
+                else "kimi-coding"
+            )
 
         # If no model specified, try auto-detect from endpoint
         if not new_model:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -250,7 +250,9 @@ ALIASES: Dict[str, str] = {
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
     "kimi-coding-cn": "kimi-for-coding",
+    "kimi-cn": "kimi-for-coding",
     "moonshot": "kimi-for-coding",
+    "moonshot-cn": "kimi-for-coding",
 
     # stepfun
     "step": "stepfun",

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -657,3 +657,10 @@ def test_switch_model_preserves_kimi_cn_when_canonicalizing_models_dev_alias(mon
     assert result.success is True
     assert result.target_provider == "kimi-coding-cn"
     assert captured["requested"] == "kimi-coding-cn"
+
+
+def test_kimi_cn_short_aliases_resolve_before_switch_canonicalization():
+    """Short CN aliases must resolve so switch_model can preserve CN routing."""
+
+    assert resolve_provider_full("kimi-cn").id == "kimi-for-coding"
+    assert resolve_provider_full("moonshot-cn").id == "kimi-for-coding"

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -567,3 +567,93 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
         "gateway-model-c",
     ], "Live models must replace the static subset"
     assert gateway_prov["total_models"] == 3
+
+
+
+def test_switch_model_canonicalizes_models_dev_kimi_provider_alias(monkeypatch):
+    """Regression for #25105: persist Hermes' kimi-coding provider id.
+
+    models.dev names the endpoint family ``kimi-for-coding``. Hermes runtime,
+    auth, and config paths use ``kimi-coding``. Explicit /model switches that
+    resolve through models.dev must not persist the models.dev alias.
+    """
+    from types import SimpleNamespace
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_provider_full",
+        lambda *a, **k: SimpleNamespace(
+            id="kimi-for-coding",
+            name="Kimi / Kimi Coding Plan",
+            base_url="https://api.kimi.com/coding/v1",
+        ),
+    )
+
+    def _runtime(**kwargs):
+        captured.update(kwargs)
+        return {
+            "api_key": "sk-kimi-test",
+            "base_url": "https://api.kimi.com/coding",
+            "api_mode": "anthropic_messages",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime)
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="kimi-k2.6",
+        current_provider="openrouter",
+        current_model="openai/gpt-5.5",
+        explicit_provider="kimi-for-coding",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "kimi-coding"
+    assert captured["requested"] == "kimi-coding"
+
+
+
+def test_switch_model_preserves_kimi_cn_when_canonicalizing_models_dev_alias(monkeypatch):
+    """The kimi-for-coding alias must not collapse China Kimi to global Kimi."""
+    from types import SimpleNamespace
+
+    captured = {}
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_provider_full",
+        lambda *a, **k: SimpleNamespace(
+            id="kimi-for-coding",
+            name="Kimi / Moonshot (China)",
+            base_url="https://api.moonshot.cn/v1",
+        ),
+    )
+
+    def _runtime(**kwargs):
+        captured.update(kwargs)
+        return {
+            "api_key": "sk-cn-test",
+            "base_url": "https://api.moonshot.cn/v1",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime)
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="kimi-k2.6",
+        current_provider="openrouter",
+        current_model="openai/gpt-5.5",
+        explicit_provider="kimi-coding-cn",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "kimi-coding-cn"
+    assert captured["requested"] == "kimi-coding-cn"


### PR DESCRIPTION
## Bug

Hermes uses kimi-coding / kimi-coding-cn for runtime, auth, and config, but models.dev may identify the endpoint family as kimi-for-coding. Persisting the models.dev alias leaves downstream runtime/config paths with an unknown or wrong provider id.

Fixes #25105

## Summary

Canonicalize kimi-for-coding during model switching to the correct Hermes provider id before resolving credentials or persisting config. The fix preserves the China Kimi variant when the user requested kimi-coding-cn / kimi-cn / moonshot-cn.

## TDD / ATDD coverage

- Added a focused regression test that reproduces the reported behavior.
- Implemented the minimal production change needed to satisfy the regression.
- Re-ran the targeted test file to guard nearby behavior.

## Test plan

- /Users/mudrii/src/hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py -q -o 'addopts=' -> 20 passed

## Review notes

- Kept the change scoped to the issue-specific runtime path.
- No secrets are persisted or logged.
