### PR TITLE
fix: persist gateway model runtime state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9146,10 +9146,19 @@ class GatewayRunner:
                 else:
                     cfg = {}
                 model_cfg = cfg.setdefault("model", {})
+                if not isinstance(model_cfg, dict):
+                    model_cfg = {"default": str(model_cfg)} if model_cfg else {}
+                    cfg["model"] = model_cfg
                 model_cfg["default"] = result.new_model
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url
+                else:
+                    model_cfg.pop("base_url", None)
+                if result.api_mode:
+                    model_cfg["api_mode"] = result.api_mode
+                else:
+                    model_cfg.pop("api_mode", None)
                 from hermes_cli.config import save_config
                 save_config(cfg)
             except Exception as e:

--- a/tests/gateway/test_model_command_persistence.py
+++ b/tests/gateway/test_model_command_persistence.py
@@ -1,0 +1,122 @@
+"""Regression tests for gateway /model --global persistence."""
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+@pytest.mark.asyncio
+async def test_gateway_model_global_persists_complete_runtime_state(monkeypatch, tmp_path):
+    """Regression for #25107: gateway /model --global persists api_mode too."""
+    from gateway import run as gateway_run
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "model": {
+            "default": "old-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+    }))
+    saved = {}
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._session_key_for_source = lambda source: "telegram:u1:c1"
+    runner._evict_cached_agent = lambda session_key: None
+
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="c1"),
+        get_command_args=lambda: "kimi-k2.6 --global --provider kimi-coding",
+    )
+    result = ModelSwitchResult(
+        success=True,
+        new_model="kimi-k2.6",
+        target_provider="kimi-coding",
+        provider_changed=True,
+        api_key="sk-kimi-test",
+        base_url="https://api.kimi.com/coding",
+        api_mode="anthropic_messages",
+        warning_message="",
+        provider_label="Kimi Coding",
+        capabilities=None,
+        model_info=None,
+        is_global=True,
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kwargs: result)
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_display_context_length", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
+
+    response = await runner._handle_model_command(event)
+
+    assert "Saved" in response or "saved" in response
+    assert saved["model"]["default"] == "kimi-k2.6"
+    assert saved["model"]["provider"] == "kimi-coding"
+    assert saved["model"]["base_url"] == "https://api.kimi.com/coding"
+    assert saved["model"]["api_mode"] == "anthropic_messages"
+
+
+@pytest.mark.asyncio
+async def test_gateway_model_global_clears_stale_runtime_fields(monkeypatch, tmp_path):
+    """Regression for #25107: stale base_url/api_mode must not survive switches."""
+    from gateway import run as gateway_run
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "model": {
+            "default": "old-model",
+            "provider": "custom",
+            "base_url": "https://stale.example/v1",
+            "api_mode": "anthropic_messages",
+        }
+    }))
+    saved = {}
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache_lock = None
+    runner._agent_cache = {}
+    runner._session_key_for_source = lambda source: "telegram:u1:c1"
+    runner._evict_cached_agent = lambda session_key: None
+
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="c1"),
+        get_command_args=lambda: "gpt-5.5 --global --provider openai-codex",
+    )
+    result = ModelSwitchResult(
+        success=True,
+        new_model="gpt-5.5",
+        target_provider="openai-codex",
+        provider_changed=True,
+        api_key="",
+        base_url="",
+        api_mode="",
+        warning_message="",
+        provider_label="Codex",
+        capabilities=None,
+        model_info=None,
+        is_global=True,
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kwargs: result)
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_display_context_length", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
+
+    await runner._handle_model_command(event)
+
+    assert saved["model"]["default"] == "gpt-5.5"
+    assert saved["model"]["provider"] == "openai-codex"
+    assert "base_url" not in saved["model"]
+    assert "api_mode" not in saved["model"]


### PR DESCRIPTION
## Bug

Gateway /model --global persisted model.default/provider and sometimes base_url, but omitted api_mode and left stale base_url/api_mode values in config.yaml when switching providers.

Fixes #25107

## Summary

Update gateway /model --global persistence to write default/provider/base_url/api_mode and remove stale base_url/api_mode when the resolved switch has empty runtime fields. This keeps gateway config aligned with the actual session override.

## TDD / ATDD coverage

- Added a focused regression test that reproduces the reported behavior.
- Implemented the minimal production change needed to satisfy the regression.
- Re-ran the targeted test file to guard nearby behavior.

## Test plan

- /Users/mudrii/src/hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_model_command_persistence.py tests/gateway/test_session_model_reset.py -q -o 'addopts=' -> 5 passed

## Review notes

- Kept the change scoped to the issue-specific runtime path.
- No secrets are persisted or logged.
