### PR TITLE
fix: use Gemini API key query auth in doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -201,7 +201,7 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
-def _build_models_probe_request(pname: str, url: str, key: str) -> tuple[str, dict]:
+def _build_models_probe_request(url: str, key: str) -> tuple[str, dict]:
     """Build the URL and headers for a provider /models health check.
 
     Most OpenAI-compatible providers accept ``Authorization: Bearer``.
@@ -1462,7 +1462,7 @@ def run_doctor(args):
             if base_url_host_matches(base, "api.kimi.com") and base.rstrip("/").endswith("/coding"):
                 base = base.rstrip("/") + "/v1"
             url = (base.rstrip("/") + "/models") if base else default_url
-            url, headers = _build_models_probe_request(pname, url, key)
+            url, headers = _build_models_probe_request(url, key)
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
             r = httpx.get(url, headers=headers, timeout=10)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -201,6 +201,26 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
+def _build_models_probe_request(pname: str, url: str, key: str) -> tuple[str, dict]:
+    """Build the URL and headers for a provider /models health check.
+
+    Most OpenAI-compatible providers accept ``Authorization: Bearer``.
+    Google's native Generative Language API validates API keys via the ``key``
+    query parameter instead; sending the key as Bearer returns 401 and makes
+    ``hermes doctor`` report false negatives for valid Gemini keys.
+    """
+    headers = {
+        "User-Agent": _HERMES_USER_AGENT,
+    }
+    if base_url_host_matches(url, "generativelanguage.googleapis.com"):
+        from urllib.parse import quote as _url_quote
+
+        sep = "&" if "?" in url else "?"
+        return f"{url}{sep}key={_url_quote(key, safe='')}", headers
+    headers["Authorization"] = f"Bearer {key}"
+    return url, headers
+
+
 def _build_apikey_providers_list() -> list:
     """Build the API-key provider health-check list once and cache it.
 
@@ -1442,10 +1462,7 @@ def run_doctor(args):
             if base_url_host_matches(base, "api.kimi.com") and base.rstrip("/").endswith("/coding"):
                 base = base.rstrip("/") + "/v1"
             url = (base.rstrip("/") + "/models") if base else default_url
-            headers = {
-                "Authorization": f"Bearer {key}",
-                "User-Agent": _HERMES_USER_AGENT,
-            }
+            url, headers = _build_models_probe_request(pname, url, key)
             if base_url_host_matches(base, "api.kimi.com"):
                 headers["User-Agent"] = "claude-code/0.1.0"
             r = httpx.get(url, headers=headers, timeout=10)

--- a/tests/hermes_cli/test_doctor_gemini_auth.py
+++ b/tests/hermes_cli/test_doctor_gemini_auth.py
@@ -1,0 +1,43 @@
+"""Regression tests for Gemini API-key probing in hermes doctor."""
+
+
+def test_gemini_models_probe_uses_key_query_param_not_bearer_header():
+    """Regression for #25108: Google Generative Language /models uses ?key=."""
+    from hermes_cli.doctor import _build_models_probe_request
+
+    url, headers = _build_models_probe_request(
+        "Google Gemini",
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        "AIza-test-key",
+    )
+
+    assert url == "https://generativelanguage.googleapis.com/v1beta/models?key=AIza-test-key"
+    assert "Authorization" not in headers
+    assert headers["User-Agent"]
+
+
+def test_non_gemini_models_probe_keeps_bearer_header():
+    from hermes_cli.doctor import _build_models_probe_request
+
+    url, headers = _build_models_probe_request(
+        "DeepSeek",
+        "https://api.deepseek.com/v1/models",
+        "sk-test",
+    )
+
+    assert url == "https://api.deepseek.com/v1/models"
+    assert headers["Authorization"] == "Bearer sk-test"
+
+
+
+def test_gemini_models_probe_preserves_existing_query_params_and_encodes_key():
+    from hermes_cli.doctor import _build_models_probe_request
+
+    url, headers = _build_models_probe_request(
+        "Google Gemini",
+        "https://generativelanguage.googleapis.com/v1beta/models?alt=json",
+        "AIza-test+key&bad=value",
+    )
+
+    assert url == "https://generativelanguage.googleapis.com/v1beta/models?alt=json&key=AIza-test%2Bkey%26bad%3Dvalue"
+    assert "Authorization" not in headers

--- a/tests/hermes_cli/test_doctor_gemini_auth.py
+++ b/tests/hermes_cli/test_doctor_gemini_auth.py
@@ -6,7 +6,6 @@ def test_gemini_models_probe_uses_key_query_param_not_bearer_header():
     from hermes_cli.doctor import _build_models_probe_request
 
     url, headers = _build_models_probe_request(
-        "Google Gemini",
         "https://generativelanguage.googleapis.com/v1beta/models",
         "AIza-test-key",
     )
@@ -20,7 +19,6 @@ def test_non_gemini_models_probe_keeps_bearer_header():
     from hermes_cli.doctor import _build_models_probe_request
 
     url, headers = _build_models_probe_request(
-        "DeepSeek",
         "https://api.deepseek.com/v1/models",
         "sk-test",
     )
@@ -34,7 +32,6 @@ def test_gemini_models_probe_preserves_existing_query_params_and_encodes_key():
     from hermes_cli.doctor import _build_models_probe_request
 
     url, headers = _build_models_probe_request(
-        "Google Gemini",
         "https://generativelanguage.googleapis.com/v1beta/models?alt=json",
         "AIza-test+key&bad=value",
     )


### PR DESCRIPTION
## Bug

hermes doctor probed Google Generative Language /models with Authorization: Bearer, which returns false 401 invalid-key results for valid Gemini API keys. Google native Gemini API keys are supplied via the key query parameter.

Fixes #25108

## Summary

Extract the generic /models probe request builder and make generativelanguage.googleapis.com use ?key= with URL encoding and no Bearer header. Other OpenAI-compatible providers continue to use Authorization: Bearer.

## TDD / ATDD coverage

- Added a focused regression test that reproduces the reported behavior.
- Implemented the minimal production change needed to satisfy the regression.
- Re-ran the targeted test file to guard nearby behavior.

## Test plan

- /Users/mudrii/src/hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_doctor_gemini_auth.py -q -o 'addopts=' -> 3 passed

## Review notes

- Kept the change scoped to the issue-specific runtime path.
- No secrets are persisted or logged.
