### PR TITLE
fix(skills): exclude .bak-*/.backup-* directories from skill discovery (#25113)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -62,6 +62,14 @@ def is_excluded_skill_path(path) -> bool:
     return any(part in EXCLUDED_SKILL_DIRS for part in parts)
 
 
+
+def _is_backup_dir(name: str) -> bool:
+    # ``hermes profile`` and ``hermes update`` rename old skill trees to
+    # ``.bak-<timestamp>`` / ``<skill>.bak-<suffix>`` on upgrade. Those
+    # siblings must not shadow the live skill — alphabetic walk order
+    # would otherwise yield the stale backup's SKILL.md first (#25113).
+    return ".bak-" in name or ".backup-" in name
+
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
 _yaml_load_fn = None
@@ -533,11 +541,17 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
     Excludes Hermes metadata, VCS, virtualenv/dependency, and cache
-    directories so dependencies cannot register nested skills.
+    directories so dependencies cannot register nested skills, and
+    any ``.bak-*``/``.backup-*`` backup directories left behind by
+    ``hermes profile`` / ``hermes update`` so they don't shadow the
+    live skill (#25113).
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        dirs[:] = [
+            d for d in dirs
+            if d not in EXCLUDED_SKILL_DIRS and not _is_backup_dir(d)
+        ]
         if filename in files:
             matches.append(Path(root) / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,5 +1,6 @@
 """Tests for agent/skill_utils.py."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from agent.skill_utils import (
@@ -197,3 +198,64 @@ class TestSkillMatchesPlatformTermux:
             "agent.skill_utils.is_termux", return_value=False
         ):
             assert skill_matches_platform(fm) is True
+
+
+# ── iter_skill_index_files: backup-directory exclusion (#25113) ───────────
+
+
+def _touch(path: Path, content: str = "x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_iter_skill_index_files_skips_bak_sibling_dir(tmp_path):
+    # Live skill alongside a `.bak-<timestamp>` snapshot left over from
+    # `hermes profile`/`hermes update`. The live file must be the only
+    # one yielded — the backup must not shadow it.
+    live = tmp_path / "core" / "my-skill" / "SKILL.md"
+    bak = tmp_path / "core" / ".bak-20260510_233500" / "my-skill" / "SKILL.md"
+    _touch(live, "live")
+    _touch(bak, "stale")
+
+    result = [p.read_text() for p in iter_skill_index_files(tmp_path, "SKILL.md")]
+    assert result == ["live"]
+
+
+def test_iter_skill_index_files_skips_backup_suffix_in_skill_name(tmp_path):
+    # `<skill_name>.bak-<suffix>` pattern that the convergence skill
+    # uses for in-place backups (#25113 lists both forms).
+    live = tmp_path / "profiles" / "hermes-profile-convergence" / "SKILL.md"
+    bak = (
+        tmp_path
+        / "profiles"
+        / "hermes-profile-convergence.bak-skill-refinement-20260510_234206"
+        / "SKILL.md"
+    )
+    _touch(live, "v3")
+    _touch(bak, "v2")
+
+    result = [p.read_text() for p in iter_skill_index_files(tmp_path, "SKILL.md")]
+    assert result == ["v3"]
+
+
+def test_iter_skill_index_files_skips_dot_backup_dir(tmp_path):
+    # ``.backup-*`` is the documented sibling pattern.
+    live = tmp_path / "a-skill" / "SKILL.md"
+    bak = tmp_path / ".backup-20260510" / "a-skill" / "SKILL.md"
+    _touch(live, "live")
+    _touch(bak, "stale")
+
+    result = [p.read_text() for p in iter_skill_index_files(tmp_path, "SKILL.md")]
+    assert result == ["live"]
+
+
+def test_iter_skill_index_files_keeps_legit_names_containing_bak(tmp_path):
+    # The exclusion uses ``.bak-`` / ``.backup-`` (with the trailing
+    # dash) so legitimate names like ``lookback-tool`` or
+    # ``notebook-skill`` are NOT collateral.
+    _touch(tmp_path / "lookback-tool" / "SKILL.md", "ok-1")
+    _touch(tmp_path / "notebook-skill" / "SKILL.md", "ok-2")
+    _touch(tmp_path / "bak-without-dot" / "SKILL.md", "ok-3")
+
+    result = sorted(p.read_text() for p in iter_skill_index_files(tmp_path, "SKILL.md"))
+    assert result == ["ok-1", "ok-2", "ok-3"]


### PR DESCRIPTION
## Summary

`hermes profile` and `hermes update` leave `.bak-<timestamp>` (or `<skill>.bak-<suffix>`) snapshots alongside live skills. The skill loader walks the tree and yields them in alphabetic order, so a backup `SKILL.md` can shadow the live one — reporter saw `hermes-profile-convergence` load its v2.0.0 backup instead of the live v3.1.0.

## The bug

`agent/skill_utils.py:iter_skill_index_files` excludes `.git`, `.github`, `.hub`, `.archive` but not backup directories. The `os.walk` descends into `.bak-20260510_233500`, finds its `SKILL.md`, and yields it before the live skill's. Discovery is centralised here, so every caller (`skills_tool._find_all_skills`, `prompt_builder`, the `skill_commands` platform scan) inherits the bug.

## The fix

Add `_is_backup_dir(name)` — a narrow substring check on `.bak-` and `.backup-` (with the trailing dash, so `notebook` / `lookback-tool` / `bak-without-dot` are NOT collateral) — and apply it alongside `EXCLUDED_SKILL_DIRS` in the dir-pruning step. Two-line change at the walk site; the helper sits next to `EXCLUDED_SKILL_DIRS` with a comment explaining the upgrade-path origin.

## Test plan

- [x] Focused: `tests/agent/test_skill_utils.py` — three concrete patterns from the issue (`.bak-<ts>` sibling, `<skill>.bak-<suffix>` peer, `.backup-<ts>`) all confirm the live skill is the only one yielded.
- [x] Non-regression: `bak-without-dot`, `lookback-tool`, `notebook-skill` are all still picked up.
- [x] Adjacent: `tests/agent/test_skill_utils.py tests/agent/test_external_skills.py tests/agent/test_external_skills_dirs_cache.py tests/test_plugin_skills.py` — 53 passed locally.
- [x] Regression guard: with the fix reverted, the three new tests fail with `result == ['stale', 'live']` (backup shadows live). With the fix, all 8 pass.

## Related / Positioning

- Fixes #25113.
- Competing PR: #25143 (zccyman). Same root cause, different approach. Honest comparison for the maintainer:

  | aspect                    | this PR (#25140)                                                   | #25143                                                                                  |
  |---------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------------|
  | scope                     | `agent/skill_utils.py` only                                        | `agent/skill_utils.py` + `tools/skills_tool.py` (helper duplicated, kept in sync by comment) |
  | match logic               | `.bak-` / `.backup-` substring (trailing dash, conservative)       | `.bak` / `.backup-` / `backup-` case-insensitive substring (broader; `foo.bakery` would be excluded) |
  | also excludes             | (none added)                                                       | `__pycache__`                                                                            |
  | diff size                 | +47 / -2                                                           | +164 / -4                                                                                |

- Why this PR is correct without touching `tools/skills_tool.py`: that file already calls `iter_skill_index_files` for its scan, so fixing the walker covers it. The local `_EXCLUDED_SKILL_DIRS` check in `tools/skills_tool.py:_find_all_skills` is a redundant secondary filter on already-yielded paths — backup dirs are pruned before they reach it.

> Sibling code paths that may need the same fix if the maintainer prefers defense-in-depth: the duplicated `_EXCLUDED_SKILL_DIRS` frozenset in `tools/skills_tool.py` (and `__pycache__` could be added to `EXCLUDED_SKILL_DIRS` in `agent/skill_utils.py` as a separate small change). Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.