### PR TITLE
fix(gateway): stop poisoning the LLM prompt with STT-mode chatter

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6799,34 +6799,16 @@ class GatewayRunner:
                     message_text,
                     audio_paths,
                 )
-                _stt_fail_markers = (
-                    "No STT provider",
-                    "STT is disabled",
-                    "can't listen",
-                    "VOICE_TOOLS_OPENAI_KEY",
-                )
-                if any(marker in message_text for marker in _stt_fail_markers):
-                    _stt_adapter = self.adapters.get(source.platform)
-                    _stt_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _stt_adapter:
-                        try:
-                            _stt_msg = (
-                                "🎤 I received your voice message but can't transcribe it — "
-                                "no speech-to-text provider is configured.\n\n"
-                                "To enable voice: install faster-whisper "
-                                "(`pip install faster-whisper` in the Hermes venv) "
-                                "and set `stt.enabled: true` in config.yaml, "
-                                "then /restart the gateway."
-                            )
-                            if self._has_setup_skill():
-                                _stt_msg += "\n\nFor full setup instructions, type: `/skill hermes-agent-setup`"
-                            await _stt_adapter.send(
-                                source.chat_id,
-                                _stt_msg,
-                                metadata=_stt_meta,
-                            )
-                        except Exception:
-                            pass
+                # NOTE: Previously, when transcription failed (e.g. no STT
+                # provider configured), the gateway also emitted a hardcoded
+                # English notice via `_stt_adapter.send()`. That bypassed the
+                # LLM and produced two replies — one pre-canned English clip
+                # (TTS spoke it aloud!) and one correct, localized LLM reply
+                # from the enriched message text. The enrichment step above
+                # already appends a localized failure note to the prompt, so
+                # the LLM produces a single coherent reply in the user's
+                # language. The hardcoded send has therefore been removed.
+                # See BUG-3 in the deployment bug tracker for details.
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -13060,40 +13042,36 @@ class GatewayRunner:
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
-                    )
+                    # Pass the transcript through as a plain quoted line.
+                    # Earlier wording ("The user sent a voice message~
+                    # Here's what they said: ...") was being treated by
+                    # the LLM as a meta-instruction to *talk about* the
+                    # voice mode rather than reply to its content — and,
+                    # combined with old failure templates that mentioned
+                    # "no STT provider", contaminated future turns so
+                    # the model kept volunteering STT-setup advice even
+                    # after STT started working.
+                    enriched_parts.append(f'"{transcript}"')
                 else:
                     error = result.get("error", "unknown error")
-                    if (
-                        "No STT provider" in error
-                        or error.startswith("Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set")
-                    ):
-                        _no_stt_note = (
-                            "[The user sent a voice message but I can't listen "
-                            "to it right now — no STT provider is configured. "
-                            "A direct message has already been sent to the user "
-                            "with setup instructions."
-                        )
-                        if self._has_setup_skill():
-                            _no_stt_note += (
-                                " You have a skill called hermes-agent-setup "
-                                "that can help users configure Hermes features "
-                                "including voice, tools, and more."
-                            )
-                        _no_stt_note += "]"
-                        enriched_parts.append(_no_stt_note)
-                    else:
-                        enriched_parts.append(
-                            "[The user sent a voice message but I had trouble "
-                            f"transcribing it~ ({error})]"
-                        )
+                    # All failure branches: a single, minimal, neutral
+                    # note. Do NOT mention "no STT provider configured",
+                    # "setup instructions", or "hermes-agent-setup skill"
+                    # — those phrases poisoned future turns. Do NOT
+                    # claim a direct message was sent: the gateway no
+                    # longer sends one (see commit history for BUG-3).
+                    # Cause is logged for operator diagnosis but kept out
+                    # of the LLM-visible prompt.
+                    logger.info(
+                        "Voice transcription failed for %s: %s", path, error
+                    )
+                    enriched_parts.append(
+                        "[voice message could not be transcribed]"
+                    )
             except Exception as e:
                 logger.error("Transcription error: %s", e)
                 enriched_parts.append(
-                    "[The user sent a voice message but something went wrong "
-                    "when I tried to listen to it~ Let them know!]"
+                    "[voice message could not be transcribed]"
                 )
 
         if enriched_parts:


### PR DESCRIPTION
## Summary

Two related issues in the gateway voice-input path made every voice message provoke wrong-language pre-canned chatter about STT setup — even after STT started working:

1. **Hardcoded English send.** After `_enrich_message_with_transcription`, the gateway also called `_stt_adapter.send()` with a hardcoded English notice. TTS would read it aloud while the LLM produced its own (correctly localized) reply from the enriched prompt — two messages, wrong language.

2. **Self-poisoning enrichment templates.** The failure branches of `_enrich_message_with_transcription` injected long, detailed instructions about STT providers, setup, and a `hermes-agent-setup` skill into the LLM-visible prompt — and falsely claimed *"a direct message has already been sent to the user with setup instructions."* That text gets persisted in conversation history. Once it appears in any past turn, the LLM keeps the topic alive: every subsequent voice message — even one transcribed successfully — provokes a reply about *"configuring STT"* instead of an answer to what the user actually said. Observed in production with `gpt-5-nano`: after a single STT failure the assistant volunteered Whisper / Vosk setup instructions on every voice turn for the rest of the session.

## Repro

1. Misconfigure STT or send a voice message before STT is set up.
2. Note that two messages arrive (one English pre-canned, one localized LLM reply) and that TTS reads the English one aloud.
3. Fix STT, send several more voice messages in the same session.
4. **Observed**: LLM keeps replying about *"setting up Whisper / Vosk / STT providers"* even though transcription is now succeeding and the user is asking about other topics.

## Root cause

`gateway/run.py:6797-6829` (hardcoded send) plus `gateway/run.py:13042-13079` (enrichment templates with `"no STT provider is configured"`, `"A direct message has already been sent"`, `"hermes-agent-setup skill"` phrases that survive in conversation history).

## Fix

- Drop the standalone hardcoded send.
- Rewrite the four enrichment templates to be minimal and neutral:
  - **Success**: a plain quoted line carrying the transcript only — `"<transcript>"`. The previous wording (`[The user sent a voice message~ Here's what they said: "..."]`) read as a meta-instruction and made the LLM volunteer commentary about voice mode.
  - **All failure branches** (no STT provider / other error / exception): a single `[voice message could not be transcribed]` marker. No mentions of providers, setup, skills, or "a message has been sent" (the gateway no longer sends one).
- Move the operator-facing failure cause to a `logger.info` line — it stays diagnosable in container logs without leaking into the LLM-visible prompt.

## Testing

- [x] Docker image rebuilds (`docker compose build gateway`).
- [x] `docker compose up -d gateway` — container healthy; API server responds normally.
- [x] In-container grep: `"no speech-to-text provider is configured"` no longer present in `/opt/hermes/gateway/run.py`.
- [x] End-to-end: Russian voice message → transcript reaches LLM as a plain quoted line → LLM replies on topic in Russian. No STT-setup pre-canned messages, no double-message effect.

A follow-up TTS-pipeline issue (TTS reading only a fragment of multi-paragraph replies and auto-detecting language per fragment) is being tracked separately — it became visible only after this fix unblocked normal LLM replies from reaching TTS.

## Breaking changes

None. The error-path observable behavior changes from "two messages, one English pre-canned" to "one message, generated by the LLM in the user's language". The success-path prompt to the LLM is shorter and quoted instead of bracketed.

---

PR by Claude Code on behalf of @nnnet. Tracks internal bug tracker entry BUG-3.