### PR TITLE
fix(skills): exclude .bak-* and backup directories from skill discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -24,7 +24,30 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
+EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive", "__pycache__"))
+
+# Directory-name prefixes that indicate backups / non-skill artifacts.
+# Any directory whose name starts with one of these prefixes is skipped
+# during skill discovery (e.g. "my-skill.bak-20260510" or
+# "my-skill.backup-v2").
+_EXCLUDED_DIR_PREFIXES = (".bak", ".backup-", "backup-")
+
+
+def _is_excluded_skill_dir(dirname: str) -> bool:
+    """Return True if *dirname* should be skipped during skill discovery.
+
+    Checks both the explicit ``EXCLUDED_SKILL_DIRS`` set and the
+    backup-prefix patterns in ``_EXCLUDED_DIR_PREFIXES``.
+    """
+    if dirname in EXCLUDED_SKILL_DIRS:
+        return True
+    # Match ".bak" anywhere in the name (covers "skill.bak-20260510")
+    # and prefix patterns (covers ".backup-v2", "backup-20260510").
+    lower = dirname.lower()
+    for prefix in _EXCLUDED_DIR_PREFIXES:
+        if prefix in lower:
+            return True
+    return False
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
@@ -482,7 +505,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        dirs[:] = [d for d in dirs if not _is_excluded_skill_dir(d)]
         if filename in files:
             matches.append(Path(root) / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):

--- a/tests/agent/test_skill_discovery_excludes.py
+++ b/tests/agent/test_skill_discovery_excludes.py
@@ -1,0 +1,123 @@
+"""Test skill discovery excludes .bak-* and backup directories.
+
+Covers: https://github.com/NousResearch/hermes-agent/issues/25113
+
+The skill loader must not discover SKILL.md files inside directories
+whose names contain backup markers (.bak, .backup, backup-).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _is_excluded_skill_dir unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsExcludedSkillDir:
+    """Verify backup-directory detection logic."""
+
+    def test_exact_excluded_dirs(self):
+        """Well-known excluded directory names."""
+        from agent.skill_utils import _is_excluded_skill_dir
+        for name in (".git", ".github", ".hub", ".archive", "__pycache__"):
+            assert _is_excluded_skill_dir(name) is True, f"{name} should be excluded"
+
+    def test_normal_skill_dirs_not_excluded(self):
+        """Regular skill directory names must not be excluded."""
+        from agent.skill_utils import _is_excluded_skill_dir
+        for name in ("my-skill", "hermes-profile-convergence", "daily-stock-report", "devops"):
+            assert _is_excluded_skill_dir(name) is False, f"{name} should NOT be excluded"
+
+    def test_bak_suffix_excluded(self):
+        """Directories with .bak-<timestamp> pattern are excluded."""
+        from agent.skill_utils import _is_excluded_skill_dir
+        for name in (
+            "hermes-profile-convergence.bak-20260510_234206",
+            "hermes-agent.bak-20260510_233500",
+            "my-skill.bak-v2",
+            "something.bak",
+        ):
+            assert _is_excluded_skill_dir(name) is True, f"{name} should be excluded"
+
+    def test_backup_prefix_excluded(self):
+        """Directories starting with .backup- or backup- are excluded."""
+        from agent.skill_utils import _is_excluded_skill_dir
+        for name in (
+            "my-skill.backup-v2",
+            ".backup-20260510",
+            "backup-old-skill",
+        ):
+            assert _is_excluded_skill_dir(name) is True, f"{name} should be excluded"
+
+    def test_case_insensitive(self):
+        """Backup detection is case-insensitive."""
+        from agent.skill_utils import _is_excluded_skill_dir
+        assert _is_excluded_skill_dir("skill.BAK-timestamp") is True
+        assert _is_excluded_skill_dir("skill.Backup-v2") is True
+
+
+# ---------------------------------------------------------------------------
+# iter_skill_index_files integration tests
+# ---------------------------------------------------------------------------
+
+class TestIterSkillIndexFiles:
+    """Verify iter_skill_index_files skips backup directories."""
+
+    def test_skips_bak_directories(self, tmp_path):
+        """.bak-* directories are not yielded."""
+        from agent.skill_utils import iter_skill_index_files
+
+        # Create a live skill
+        live = tmp_path / "my-skill"
+        live.mkdir()
+        (live / "SKILL.md").write_text("---\nname: my-skill\n---\nLive content")
+
+        # Create a backup skill (should be skipped)
+        bak = tmp_path / "my-skill.bak-20260510"
+        bak.mkdir()
+        (bak / "SKILL.md").write_text("---\nname: my-skill\n---\nStale content")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert "my-skill.bak" not in str(results[0])
+
+    def test_skips_pycache(self, tmp_path):
+        """__pycache__ directories are not yielded."""
+        from agent.skill_utils import iter_skill_index_files
+
+        cache = tmp_path / "__pycache__"
+        cache.mkdir()
+        (cache / "SKILL.md").write_text("---\nname: bad\n---\n")
+
+        live = tmp_path / "good-skill"
+        live.mkdir()
+        (live / "SKILL.md").write_text("---\nname: good\n---\n")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert results[0].parent.name == "good-skill"
+
+    def test_nested_bak_excluded(self, tmp_path):
+        """Nested .bak-* directories are excluded even under valid category dirs."""
+        from agent.skill_utils import iter_skill_index_files
+
+        cat = tmp_path / "devops"
+        cat.mkdir()
+
+        live = cat / "hermes-backup"
+        live.mkdir()
+        (live / "SKILL.md").write_text("---\nname: hermes-backup\n---\nLive")
+
+        bak = cat / "hermes-backup.bak-20260510"
+        bak.mkdir()
+        (bak / "SKILL.md").write_text("---\nname: hermes-backup\n---\nStale")
+
+        results = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        assert len(results) == 1
+        assert "bak-" not in str(results[0])

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -100,7 +100,21 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
+_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive", "__pycache__"))
+
+# Backup-directory prefixes — kept in sync with skill_utils._EXCLUDED_DIR_PREFIXES.
+_EXCLUDED_DIR_PREFIXES = (".bak", ".backup-", "backup-")
+
+
+def _is_excluded_skill_dir(dirname: str) -> bool:
+    """Return True if *dirname* should be skipped during skill discovery."""
+    if dirname in _EXCLUDED_SKILL_DIRS:
+        return True
+    lower = dirname.lower()
+    for prefix in _EXCLUDED_DIR_PREFIXES:
+        if prefix in lower:
+            return True
+    return False
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )
@@ -573,7 +587,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-            if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+            if any(_is_excluded_skill_dir(part) for part in skill_md.parts):
                 continue
 
             skill_dir = skill_md.parent


### PR DESCRIPTION
## Summary

The skill loader's `EXCLUDED_SKILL_DIRS` only excluded `.git`, `.github`, `.hub`, and `.archive`. Backup directories matching patterns like `my-skill.bak-20260510` were **not excluded**, causing the stale backup version to be discovered and loaded instead of (or alongside) the live skill.

### Before

```python
EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
```

A directory like `hermes-profile-convergence.bak-20260510_234206` would pass the filter and its `SKILL.md` would be discovered as a valid skill.

### After

Two-layer exclusion:

1. **Static set** — added `__pycache__` to the existing frozenset
2. **Pattern matching** — new `_is_excluded_skill_dir()` checks for `.bak`, `.backup-`, and `backup-` anywhere in the directory name (case-insensitive)

```python
EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive", "__pycache__"))
_EXCLUDED_DIR_PREFIXES = (".bak", ".backup-", "backup-")
```

Applied to both discovery paths:
- `agent/skill_utils.py` — `iter_skill_index_files()`
- `tools/skills_tool.py` — inline scan in skill listing

### Impact

| Scenario | Before | After |
|----------|--------|-------|
| `my-skill.bak-20260510/SKILL.md` | Discovered and loaded | **Skipped** |
| `my-skill.backup-v2/SKILL.md` | Discovered and loaded | **Skipped** |
| `__pycache__/SKILL.md` (unlikely but defensive) | Discovered | **Skipped** |
| `my-skill/SKILL.md` (live) | Discovered | Discovered ✓ |

## Testing

- 8 new tests:
  - 5 unit tests for `_is_excluded_skill_dir()` (exact, normal, .bak, .backup, case-insensitive)
  - 3 integration tests for `iter_skill_index_files()` (bak dirs, pycache, nested)
- 2827 existing agent tests (7 pre-existing env failures unrelated to this change)
- 0 regressions

## Files changed

| File | Change |
|------|--------|
| `agent/skill_utils.py` | Add pattern exclusion + update filter |
| `tools/skills_tool.py` | Sync exclusion logic + update filter |
| `tests/agent/test_skill_discovery_excludes.py` | New: 8 tests |

Closes #25113