### PR TITLE
chore: update licensing and local memory tooling

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,11 @@
+# Commercial Licensing
+
+Hermes Agent is available for noncommercial use under the PolyForm Noncommercial License 1.0.0 in [LICENSE](LICENSE).
+
+Commercial use requires a separate written commercial license from Nous Research. This includes use by for-profit companies, use in a paid product or service, use to provide paid consulting or managed services, or any other use outside the permitted noncommercial purposes in the PolyForm Noncommercial License.
+
+To request a commercial license, contact Nous Research: https://nousresearch.com
+
+## Prior MIT-licensed copies
+
+Earlier releases of this repository were distributed under the MIT License. If someone already received a copy under MIT, their rights to that earlier copy remain governed by MIT. New copies, new releases, and future contributions are licensed under the current license unless a separate written agreement says otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ name: my-skill
 description: Brief description (shown in skill search results)
 version: 1.0.0
 author: Your Name
-license: MIT
+license: PolyForm Noncommercial License 1.0.0
 platforms: [macos, linux]          # Optional — restrict to specific OS platforms
                                    #   Valid: macos, linux, windows
                                    #   Omit to load on all platforms (default)
@@ -812,4 +812,4 @@ test(tools): add unit tests for file_operations
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the current project license in [LICENSE](LICENSE), unless a separate written agreement with Nous Research says otherwise.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,81 @@
-MIT License
+Required Notice: Copyright 2025 Nous Research
 
-Copyright (c) 2025 Nous Research
+Commercial License Notice
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Hermes Agent is licensed for noncommercial purposes under the PolyForm Noncommercial License 1.0.0 below. Personal, research, evaluation, educational, hobby, and other noncommercial uses are permitted under those terms.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Commercial use is not permitted under this noncommercial license. For commercial licensing, contact Nous Research: https://nousresearch.com
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Important transition note: earlier releases of this repository were distributed under the MIT License. Rights already granted under the MIT License for earlier copies remain governed by those earlier terms. This license applies to new copies and contributions after the license-change commit.
+
+# PolyForm Noncommercial License 1.0.0
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose. However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software. Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else. These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice. Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
+  <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-PolyForm%20Noncommercial-orange?style=for-the-badge" alt="License: PolyForm Noncommercial"></a>
   <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Built by Nous Research"></a>
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
 </p>
@@ -190,6 +190,10 @@ scripts/run_tests.sh
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+Hermes Agent is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+
+Personal, research, evaluation, educational, hobby, and other noncommercial uses are permitted. Commercial use requires a separate written license from Nous Research. See [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+
+Earlier releases were distributed under the MIT License. Rights already granted under MIT for earlier copies remain governed by those earlier terms. This license applies going forward.
 
 Built by [Nous Research](https://nousresearch.com).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
+  <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-PolyForm%20Noncommercial-orange?style=for-the-badge" alt="License: PolyForm Noncommercial"></a>
   <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Built by Nous Research"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/Lang-English-lightgrey?style=for-the-badge" alt="English"></a>
 </p>
@@ -181,6 +181,10 @@ python -m pytest tests/ -q
 
 ## 许可证
 
-MIT — 详见 [LICENSE](LICENSE)。
+Hermes Agent 采用 [PolyForm Noncommercial License 1.0.0](LICENSE) 授权。
+
+个人、研究、评估、教育、爱好项目以及其他非商业用途可以依照该许可证使用。商业用途需要从 Nous Research 获得单独的书面商业授权。详见 [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)。
+
+早期版本曾采用 MIT License 发布。已经根据 MIT License 获得的早期副本，其权利仍由当时的 MIT 条款管理。新的许可证适用于后续副本、版本和贡献。
 
 由 [Nous Research](https://nousresearch.com) 构建。

--- a/hermes-already-has-routines.md
+++ b/hermes-already-has-routines.md
@@ -62,7 +62,7 @@ Every use case in their blog post — backlog triage, docs drift, deploy verific
 | **Infrastructure** | Anthropic's servers | **Your infrastructure** — VPS, home server, laptop |
 | **Data residency** | Anthropic's cloud | **Your machines** |
 | **Cost** | Pro/Max/Team/Enterprise subscription | Your API key, your rates |
-| **Open source** | No | **Yes** — MIT license |
+| **Source available** | No | **Yes**: free for noncommercial use, commercial license required |
 
 ---
 
@@ -124,7 +124,7 @@ A nightly backlog triage on Sonnet costs roughly $0.02-0.05. A monitoring check 
 
 ## Get Started
 
-Hermes Agent is open source and free. The automation infrastructure — cron scheduler, webhook platform, skill system, multi-platform delivery — is built in.
+Hermes Agent is source available and free for noncommercial use. Commercial use requires a separate license. The automation infrastructure — cron scheduler, webhook platform, skill system, multi-platform delivery — is built in.
 
 ```bash
 pip install hermes-agent

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -341,7 +341,13 @@ def _try_resolve_from_custom_pool(
         if entry is None:
             return None
         pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
-        if not pool_api_key:
+        pool_api_key = str(pool_api_key or "").strip()
+        # Some older custom-provider pool entries stored literal env refs
+        # like "env:GOOGLE_API_KEY" as the credential. That string is not
+        # accepted by upstream APIs and shadows the correctly resolved
+        # key_env value from config.yaml. Ignore it so the caller can fall
+        # back to the config/env key.
+        if not pool_api_key or pool_api_key.startswith("env:"):
             return None
         return {
             "provider": provider_label,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hermes-agent",
       "version": "1.0.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@askjo/camofox-browser": "^1.5.2",
         "agent-browser": "^0.26.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
   },
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/NousResearch/Hermes-Agent/issues"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "The self-improving AI agent — creates skills from experience, i
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Nous Research" }]
-license = { text = "MIT" }
+license = { text = "PolyForm Noncommercial License 1.0.0" }
 dependencies = [
   # Core — every direct dep is exact-pinned to ==X.Y.Z (no ranges).
   # Rationale: ranges allow PyPI to ship a fresh version of a transitive

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -3,7 +3,7 @@ name: hermes-agent
 description: "Configure, extend, or contribute to Hermes Agent."
 version: 2.1.0
 author: Hermes Agent + Teknium
-license: MIT
+license: PolyForm Noncommercial License 1.0.0
 platforms: [linux, macos, windows]
 metadata:
   hermes:
@@ -14,7 +14,7 @@ metadata:
 
 # Hermes Agent
 
-Hermes Agent is an open-source AI agent framework by Nous Research that runs in your terminal, messaging platforms, and IDEs. It belongs to the same category as Claude Code (Anthropic), Codex (OpenAI), and OpenClaw — autonomous coding and task-execution agents that use tool calling to interact with your system. Hermes works with any LLM provider (OpenRouter, Anthropic, OpenAI, DeepSeek, local models, and 15+ others) and runs on Linux, macOS, and WSL.
+Hermes Agent is a source-available AI agent framework by Nous Research that runs in your terminal, messaging platforms, and IDEs. It belongs to the same category as Claude Code (Anthropic), Codex (OpenAI), and OpenClaw — autonomous coding and task-execution agents that use tool calling to interact with your system. Hermes works with any LLM provider (OpenRouter, Anthropic, OpenAI, DeepSeek, local models, and 15+ others) and runs on Linux, macOS, and WSL.
 
 What makes Hermes different:
 

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -96,7 +96,7 @@ class TestManifestParsing:
             "description: Telem monitor\n"
             "hermes_requires: '>=0.12.0'\n"
             "author: Kyle\n"
-            "license: MIT\n"
+            "license: PolyForm Noncommercial License 1.0.0\n"
             "env_requires:\n"
             "  - name: OPENAI_API_KEY\n"
             "    description: OpenAI key\n"
@@ -111,7 +111,7 @@ class TestManifestParsing:
         assert m.name == "telem"
         assert m.version == "1.2.3"
         assert m.author == "Kyle"
-        assert m.license == "MIT"
+        assert m.license == "PolyForm Noncommercial License 1.0.0"
         assert len(m.env_requires) == 2
         assert m.env_requires[0].name == "OPENAI_API_KEY"
         assert m.env_requires[0].required is True

--- a/tools/knowledge_local_source.py
+++ b/tools/knowledge_local_source.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Knowledge Local Source — SkillSource adapter for ~/github/knowledge/skills/
+
+This adapter lets Hermes discover and install skills from the local knowledge
+repo without requiring a GitHub API call. It reads SKILL.md files directly
+from the filesystem.
+
+Trust level: "trusted" (because it's local to this machine)
+"""
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# The local knowledge repo skills directory
+KNOWLEDGE_SKILLS_DIR = Path.home() / "github" / "knowledge" / "skills"
+
+
+# ----------------------------------------------------------------------
+# Minimal SkillSource types (duplicated from skills_hub to avoid circular import)
+# ----------------------------------------------------------------------
+
+@dataclass
+class SkillMeta:
+    """Minimal metadata for a skill."""
+    name: str
+    description: str
+    source: str
+    identifier: str
+    trust_level: str
+    repo: Optional[str] = None
+    path: Optional[str] = None
+    tags: List[str] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SkillBundle:
+    """A skill directory with its file contents."""
+    name: str
+    files: Dict[str, Union[str, bytes]]
+    source: str
+    identifier: str
+    trust_level: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class SkillSource(ABC):
+    """Abstract base for skill registry adapters."""
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        ...
+
+    @abstractmethod
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        ...
+
+    @abstractmethod
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        ...
+
+    @abstractmethod
+    def source_id(self) -> str:
+        ...
+
+
+# ----------------------------------------------------------------------
+# KnowledgeLocalSource implementation
+# ----------------------------------------------------------------------
+
+class KnowledgeLocalSource(SkillSource):
+    """
+    SkillSource that reads skills from the local ~/github/knowledge/skills/ directory.
+
+    This is the primary source for all shared team skills — it's always available
+    (no network required), fast (local filesystem), and trusted.
+    """
+
+    def __init__(self, skills_dir: Path = KNOWLEDGE_SKILLS_DIR):
+        self.skills_dir = skills_dir
+
+    def source_id(self) -> str:
+        return "knowledge-local"
+
+    def trust_level_for(self, identifier: str) -> str:
+        return "trusted"
+
+    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+        """Search skills by name and description in the local knowledge repo."""
+        results: List[SkillMeta] = []
+        query_lower = query.lower()
+
+        if not self.skills_dir.exists():
+            return results
+
+        for skill_path in self.skills_dir.iterdir():
+            if not skill_path.is_dir() or skill_path.name.startswith("."):
+                continue
+
+            skill_md = skill_path / "SKILL.md"
+            if not skill_md.exists():
+                continue
+
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+
+            fm = self._parse_frontmatter(content)
+            name = fm.get("name", skill_path.name)
+            description = fm.get("description", "")
+
+            tags = []
+            meta = fm.get("metadata", {})
+            if isinstance(meta, dict):
+                hermes_meta = meta.get("hermes", {})
+                if isinstance(hermes_meta, dict):
+                    tags = hermes_meta.get("tags", [])
+            if not tags:
+                raw_tags = fm.get("tags", [])
+                tags = raw_tags if isinstance(raw_tags, list) else []
+
+            searchable = f"{name} {description} {' '.join(tags)}".lower()
+            if query_lower in searchable:
+                results.append(SkillMeta(
+                    name=name,
+                    description=str(description)[:200],
+                    source="knowledge-local",
+                    identifier=f"knowledge-local/{skill_path.name}",
+                    trust_level="trusted",
+                    repo=None,
+                    path=str(skill_path.relative_to(self.skills_dir)),
+                    tags=[str(t) for t in tags],
+                ))
+
+            if len(results) >= limit:
+                break
+
+        return results
+
+    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+        """
+        Read a skill from the local knowledge repo.
+
+        identifier format: "knowledge-local/<skill-name>"
+        """
+        if not identifier.startswith("knowledge-local/"):
+            return None
+
+        skill_name = identifier.split("/", 1)[-1]
+        skill_path = self.skills_dir / skill_name
+
+        if not skill_path.exists() or not skill_path.is_dir():
+            return None
+
+        skill_md = skill_path / "SKILL.md"
+        if not skill_md.exists():
+            return None
+
+        files: dict = {}
+        for fpath in skill_path.rglob("*"):
+            if fpath.is_file() and not fpath.name.startswith("."):
+                rel_path = str(fpath.relative_to(skill_path))
+                try:
+                    files[rel_path] = fpath.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    pass
+
+        if not files:
+            return None
+
+        return SkillBundle(
+            name=skill_name,
+            files=files,
+            source="knowledge-local",
+            identifier=identifier,
+            trust_level="trusted",
+        )
+
+    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+        """Get metadata for a skill without downloading all files."""
+        if not identifier.startswith("knowledge-local/"):
+            return None
+
+        skill_name = identifier.split("/", 1)[-1]
+        skill_path = self.skills_dir / skill_name
+
+        if not skill_path.exists():
+            return None
+
+        skill_md = skill_path / "SKILL.md"
+        if not skill_md.exists():
+            return None
+
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+
+        fm = self._parse_frontmatter(content)
+        name = fm.get("name", skill_name)
+        description = fm.get("description", "")
+
+        tags = []
+        meta = fm.get("metadata", {})
+        if isinstance(meta, dict):
+            hermes_meta = meta.get("hermes", {})
+            if isinstance(hermes_meta, dict):
+                tags = hermes_meta.get("tags", [])
+        if not tags:
+            raw_tags = fm.get("tags", [])
+            tags = raw_tags if isinstance(raw_tags, list) else []
+
+        return SkillMeta(
+            name=name,
+            description=str(description)[:200],
+            source="knowledge-local",
+            identifier=identifier,
+            trust_level="trusted",
+            repo=None,
+            path=skill_name,
+            tags=[str(t) for t in tags],
+        )
+
+    @staticmethod
+    def _parse_frontmatter(content: str) -> dict:
+        """Parse YAML frontmatter from SKILL.md content."""
+        if not content.startswith("---"):
+            return {}
+        match = re.search(r"\n---\s*\n", content[3:])
+        if not match:
+            return {}
+        yaml_text = content[3:match.start() + 3]
+        try:
+            parsed = yaml.safe_load(yaml_text)
+            return parsed if isinstance(parsed, dict) else {}
+        except yaml.YAMLError:
+            return {}

--- a/tools/mem0_tool.py
+++ b/tools/mem0_tool.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+Mem0 Tool — Vector Memory Retrieval via HTTP API
+
+Queries the local mem0 HTTP API server (localhost:3201) for persistent,
+semantic memory across sessions. The mem0 server uses Qdrant for vector
+storage backed by SQLite.
+
+This is the same mem0 instance that remote OpenClaw agents (via Tailscale VPN)
+connect to at http://100.68.222.60:3201.
+
+Use when the user asks things like:
+  - "what were we working on before?"
+  - "remember when we discussed X?"
+  - "what did we do about Y last time?"
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+MEM0_API = "http://localhost:3201"
+
+
+def _api_get(path: str, params: dict = None) -> Optional[dict]:
+    """Make a GET request to the mem0 API."""
+    try:
+        resp = httpx.get(f"{MEM0_API}{path}", params=params, timeout=10)
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError as e:
+        logger.debug(f"mem0 API error: {e}")
+    return None
+
+
+def _api_post(path: str, data: dict) -> Optional[dict]:
+    """Make a POST request to the mem0 API."""
+    try:
+        resp = httpx.post(f"{MEM0_API}{path}", json=data, timeout=10)
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError as e:
+        logger.debug(f"mem0 API error: {e}")
+    return None
+
+
+def mem0_recall(query: str, agent_id: str = "hermes", limit: int = 5) -> List[Dict[str, Any]]:
+    """
+    Search mem0 for relevant memories using vector similarity.
+
+    Args:
+        query: Search query
+        agent_id: Which agent's memories to search (default: "hermes")
+        limit: Max results to return
+    """
+    result = _api_get(
+        "/memory/search",
+        params={"q": query, "agent_id": agent_id, "limit": limit}
+    )
+    if not result:
+        return []
+    return result.get("memories", [])
+
+
+def mem0_get_all(agent_id: str = "hermes", limit: int = 50) -> List[Dict[str, Any]]:
+    """Get all memories for an agent."""
+    result = _api_get(
+        "/memory/all",
+        params={"agent_id": agent_id, "limit": limit}
+    )
+    if not result:
+        return []
+    return result.get("memories", [])
+
+
+def mem0_save(text: str, agent_id: str = "hermes", metadata: dict = None) -> bool:
+    """Save a memory to mem0."""
+    result = _api_post("/memory/add", {
+        "text": text,
+        "agent_id": agent_id,
+        "metadata": metadata or {},
+    })
+    return result is not None
+
+
+def mem0_tool(
+    action: str,
+    query: str = None,
+    text: str = None,
+    agent_id: str = "hermes",
+    limit: int = 5,
+) -> str:
+    """
+    Query mem0 vector memory for relevant past conversations and facts.
+
+    Actions:
+      - "recall": Search for memories matching a query
+      - "all": Get all memories for this agent
+      - "save": Save a new memory
+      - "health": Check if mem0 API is available
+    """
+    if action == "health":
+        result = _api_get("/health")
+        if result:
+            return json.dumps({
+                "success": True,
+                "status": result,
+                "message": "mem0 is healthy"
+            }, ensure_ascii=False)
+        return json.dumps({
+            "success": False,
+            "error": "mem0 API is not reachable at http://localhost:3201"
+        }, ensure_ascii=False)
+
+    if action == "recall":
+        if not query:
+            return json.dumps({
+                "success": False,
+                "error": "query is required for 'recall' action"
+            }, ensure_ascii=False)
+
+        memories = mem0_recall(query=query, agent_id=agent_id, limit=limit)
+
+        if not memories:
+            return json.dumps({
+                "success": True,
+                "query": query,
+                "agent_id": agent_id,
+                "memories": [],
+                "message": "No relevant memories found"
+            }, ensure_ascii=False)
+
+        return json.dumps({
+            "success": True,
+            "query": query,
+            "agent_id": agent_id,
+            "memories": memories,
+            "count": len(memories),
+        }, ensure_ascii=False)
+
+    elif action == "all":
+        memories = mem0_get_all(agent_id=agent_id, limit=limit)
+        return json.dumps({
+            "success": True,
+            "agent_id": agent_id,
+            "memories": memories,
+            "count": len(memories),
+        }, ensure_ascii=False)
+
+    elif action == "save":
+        if not text:
+            return json.dumps({
+                "success": False,
+                "error": "text is required for 'save' action"
+            }, ensure_ascii=False)
+
+        success = mem0_save(text=text, agent_id=agent_id)
+        if success:
+            return json.dumps({
+                "success": True,
+                "message": "Memory saved",
+                "agent_id": agent_id,
+            }, ensure_ascii=False)
+        return json.dumps({
+            "success": False,
+            "error": "Failed to save memory"
+        }, ensure_ascii=False)
+
+    else:
+        return json.dumps({
+            "success": False,
+            "error": f"Unknown action '{action}'. Use: recall, all, save, health"
+        }, ensure_ascii=False)
+
+
+def check_mem0_requirements() -> bool:
+    """Check if mem0 API is reachable."""
+    return _api_get("/health") is not None
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+MEM0_SCHEMA = {
+    "name": "mem0",
+    "description": (
+        "Query mem0 vector memory for relevant past conversations and facts. "
+        "Mem0 stores semantic embeddings of conversation history across sessions.\n\n"
+        "This connects to the local mem0 server (localhost:3201), which is the "
+        "same instance that remote OpenClaw agents access via Tailscale VPN.\n\n"
+        "Use when:\n"
+        "- User asks 'what were we working on before?' or 'remember when X?'\n"
+        "- You need to recall context from past sessions\n"
+        "- User references something from a previous conversation\n\n"
+        "Actions:\n"
+        "- 'recall': Search for memories matching a query\n"
+        "- 'all': Get all memories for this agent\n"
+        "- 'save': Save a new memory\n"
+        "- 'health': Check if mem0 is available"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["recall", "all", "save", "health"],
+                "description": "Action to perform"
+            },
+            "query": {
+                "type": "string",
+                "description": "Search query to find relevant memories (for 'recall')"
+            },
+            "text": {
+                "type": "string",
+                "description": "Text to save (for 'save')"
+            },
+            "agent_id": {
+                "type": "string",
+                "description": "Agent ID to filter memories (default: 'hermes')",
+                "default": "hermes"
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum memories to return (default: 5)",
+                "default": 5
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="mem0",
+    toolset="memory",
+    schema=MEM0_SCHEMA,
+    handler=lambda args, **kw: mem0_tool(
+        action=args.get("action", ""),
+        query=args.get("query"),
+        text=args.get("text"),
+        agent_id=args.get("agent_id", "hermes"),
+        limit=args.get("limit", 5),
+    ),
+    check_fn=check_mem0_requirements,
+    emoji="🧠",
+)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -30,7 +30,7 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     name: skill-name              # Required, max 64 chars
     description: Brief description # Required, max 1024 chars
     version: 1.0.0                # Optional
-    license: MIT                  # Optional (agentskills.io)
+    license: PolyForm Noncommercial License 1.0.0  # Optional (agentskills.io)
     platforms: [macos]            # Optional — restrict to specific OS platforms
                                   #   Valid: macos, linux, windows
                                   #   Omit to load on all platforms (default)

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -243,4 +243,4 @@ fix(security): prevent shell injection in sudo password piping
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](https://github.com/NousResearch/hermes-agent/blob/main/LICENSE).
+By contributing, you agree that your contributions will be licensed under the current project license in [LICENSE](https://github.com/NousResearch/hermes-agent/blob/main/LICENSE), unless a separate written agreement with Nous Research says otherwise.

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -49,7 +49,7 @@ name: my-skill
 description: Brief description (shown in skill search results)
 version: 1.0.0
 author: Your Name
-license: MIT
+license: PolyForm Noncommercial License 1.0.0
 platforms: [macos, linux]          # Optional — restrict to specific OS platforms
                                    #   Valid: macos, linux, windows
                                    #   Omit to load on all platforms (default)

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -108,7 +108,7 @@ Hermes auto-detects local endpoints and relaxes streaming timeouts (read timeout
 
 ### How much does it cost?
 
-Hermes Agent itself is **free and open-source** (MIT license). You pay only for the LLM API usage from your chosen provider. Local models are completely free to run.
+Hermes Agent itself is **free for noncommercial use** under the PolyForm Noncommercial License 1.0.0. Commercial use requires a separate written license from Nous Research. You pay separately for LLM API usage from your chosen provider. Local models are free to run on your own hardware.
 
 ### Can multiple people use one instance?
 

--- a/website/docs/user-guide/skills/bundled/mlops/mlops-inference-obliteratus.md
+++ b/website/docs/user-guide/skills/bundled/mlops/mlops-inference-obliteratus.md
@@ -38,7 +38,7 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Remove refusal behaviors (guardrails) from open-weight LLMs without retraining or fine-tuning. Uses mechanistic interpretability techniques — including diff-in-means, SVD, whitened SVD, LEACE concept erasure, SAE decomposition, Bayesian kernel projection, and more — to identify and surgically excise refusal directions from model weights while preserving reasoning capabilities.
 
-**License warning:** OBLITERATUS is AGPL-3.0. NEVER import it as a Python library. Always invoke via CLI (`obliteratus` command) or subprocess. This keeps Hermes Agent's MIT license clean.
+**License warning:** OBLITERATUS is AGPL-3.0. NEVER import it as a Python library. Always invoke via CLI (`obliteratus` command) or subprocess. This keeps Hermes Agent's project license clean.
 
 ## Video Guide
 

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring.md
@@ -63,7 +63,7 @@ name: my-skill-name               # lowercase, hyphens, ≤64 chars (MAX_NAME_LE
 description: Use when <trigger>. <one-line behavior>.
 version: 1.0.0
 author: Hermes Agent
-license: MIT
+license: PolyForm Noncommercial License 1.0.0
 metadata:
   hermes:
     tags: [short, descriptive, tags]

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -162,7 +162,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Built by <a href="https://nousresearch.com">Nous Research</a> · MIT License · ${new Date().getFullYear()}`,
+      copyright: `Built by <a href="https://nousresearch.com">Nous Research</a> · PolyForm Noncommercial License 1.0.0 · ${new Date().getFullYear()}`,
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
## Summary
- Switch project metadata and documentation references from MIT to PolyForm Noncommercial License 1.0.0
- Add commercial licensing notice
- Add local knowledge skill source and mem0 utility tooling
- Ignore literal `env:` credential placeholders in custom provider pool resolution so config/env keys can be used

## Verification
- `python -m py_compile hermes_cli/runtime_provider.py tools/knowledge_local_source.py tools/mem0_tool.py tools/skills_tool.py`
- `python -m pytest tests/hermes_cli/test_profile_distribution.py -q` (63 passed)

## Notes
- Did not include local private/temp untracked files: `download.txt`, `tmp-render-hermes-slide.mjs`