### PR TITLE
fix: label free OpenRouter models in model picker

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -18,6 +18,8 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+from tools.schema_sanitizer import make_openai_strict_tools
+
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
@@ -202,13 +204,20 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
+def _responses_tools(
+    tools: Optional[List[Dict[str, Any]]] = None,
+    *,
+    strict: bool = False,
+) -> Optional[List[Dict[str, Any]]]:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
     if not tools:
         return None
 
+    strict_ready_tools = make_openai_strict_tools(tools) if strict else None
+    source_tools = strict_ready_tools if strict_ready_tools is not None else tools
+
     converted: List[Dict[str, Any]] = []
-    for item in tools:
+    for item in source_tools:
         fn = item.get("function", {}) if isinstance(item, dict) else {}
         name = fn.get("name")
         if not isinstance(name, str) or not name.strip():
@@ -217,7 +226,7 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
             "type": "function",
             "name": name,
             "description": fn.get("description", ""),
-            "strict": False,
+            "strict": bool(fn.get("strict", False)),
             "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
         })
     return converted or None

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -17,6 +17,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from tools.schema_sanitizer import make_openai_strict_tools
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -97,6 +98,16 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     if "generativelanguage.googleapis.com" not in normalized:
         return False
     return normalized.endswith("/openai")
+
+
+def _is_openai_native_strict_route(*, provider_name: Any = None, profile_name: Any = None, base_url: Any = None) -> bool:
+    """Return True when this request targets OpenAI-native chat-completions."""
+    provider = str(provider_name or profile_name or "").strip().lower()
+    if provider in {"openai", "openai-chatgpt"}:
+        return True
+
+    normalized = str(base_url or "").strip().rstrip("/").lower()
+    return "api.openai.com" in normalized
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -249,6 +260,11 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            if _is_openai_native_strict_route(
+                provider_name=params.get("provider_name"),
+                base_url=params.get("base_url"),
+            ):
+                tools = make_openai_strict_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
@@ -437,6 +453,11 @@ class ChatCompletionsTransport(ProviderTransport):
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            if _is_openai_native_strict_route(
+                profile_name=getattr(profile, "name", None),
+                base_url=params.get("base_url"),
+            ):
+                tools = make_openai_strict_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,6 +11,22 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _is_openai_native_responses_route(
+    *,
+    provider: Any = None,
+    base_url: Any = None,
+    is_codex_backend: bool = False,
+) -> bool:
+    """Return True for Hermes' OpenAI-native Responses/Codex routes."""
+    if is_codex_backend:
+        return True
+    provider_name = str(provider or "").strip().lower()
+    if provider_name in {"openai", "openai-codex", "openai-chatgpt"}:
+        return True
+    normalized = str(base_url or "").strip().rstrip("/").lower()
+    return "api.openai.com" in normalized or "chatgpt.com/backend-api/codex" in normalized
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -75,6 +91,11 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses", False)
         is_codex_backend = params.get("is_codex_backend", False)
         is_xai_responses = params.get("is_xai_responses", False)
+        use_openai_strict_tools = _is_openai_native_responses_route(
+            provider=params.get("provider"),
+            base_url=params.get("base_url"),
+            is_codex_backend=is_codex_backend,
+        )
 
         # Resolve reasoning effort
         reasoning_effort = "medium"
@@ -93,7 +114,7 @@ class ResponsesApiTransport(ProviderTransport):
             "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(payload_messages),
-            "tools": _responses_tools(tools),
+            "tools": _responses_tools(tools, strict=use_openai_strict_tools),
             "tool_choice": "auto",
             "parallel_tool_calls": True,
             "store": False,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1245,6 +1245,26 @@ def list_authenticated_providers(
             model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
+        model_entries = [{"id": mid, "description": ""} for mid in top]
+
+        if hermes_id == "openrouter":
+            try:
+                from hermes_cli.models import fetch_openrouter_models
+
+                openrouter_options = fetch_openrouter_models()
+                if openrouter_options:
+                    total = len(openrouter_options)
+                    top = [mid for mid, _ in openrouter_options[:max_models]]
+                    model_entries = [
+                        {"id": mid, "description": desc}
+                        for mid, desc in openrouter_options[:max_models]
+                    ]
+            except Exception:
+                openrouter_desc = dict(OPENROUTER_MODELS)
+                model_entries = [
+                    {"id": mid, "description": openrouter_desc.get(mid, "")}
+                    for mid in top
+                ]
 
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
@@ -1256,6 +1276,7 @@ def list_authenticated_providers(
             "is_current": slug == current_provider or mdev_id == current_provider,
             "is_user_defined": False,
             "models": top,
+            "model_entries": model_entries,
             "total_models": total,
             "source": "built-in",
         })
@@ -1752,10 +1773,19 @@ def list_picker_providers(
             try:
                 live = fetch_openrouter_models()
                 live_ids = [mid for mid, _ in live]
+                live_entries = [
+                    {"id": mid, "description": desc}
+                    for mid, desc in live[:max_models]
+                ]
             except Exception:
                 live_ids = list(p.get("models", []))
+                live_entries = list(p.get("model_entries", []))
             p = dict(p)
             p["models"] = live_ids[:max_models]
+            p["model_entries"] = live_entries or [
+                {"id": mid, "description": ""}
+                for mid in live_ids[:max_models]
+            ]
             p["total_models"] = len(live_ids)
 
         has_models = bool(p.get("models"))

--- a/run_agent.py
+++ b/run_agent.py
@@ -8935,6 +8935,8 @@ class AIAgent:
                 session_id=getattr(self, "session_id", None),
                 max_tokens=self.max_tokens,
                 request_overrides=self.request_overrides,
+                provider=self.provider,
+                base_url=self.base_url,
                 is_github_responses=is_github_responses,
                 is_codex_backend=is_codex_backend,
                 is_xai_responses=is_xai_responses,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -72,6 +72,62 @@ class TestChatCompletionsBuildKwargs:
         kw = transport.build_kwargs(model="gpt-4o", messages=msgs, tools=tools)
         assert kw["tools"] == tools
 
+    def test_openai_native_tools_enable_strict_mode(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "offset": {"type": "integer"},
+                    },
+                    "required": ["path"],
+                },
+            },
+        }]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            tools=tools,
+            provider_name="openai",
+            base_url="https://api.openai.com/v1",
+        )
+        fn = kw["tools"][0]["function"]
+        assert fn["strict"] is True
+        assert fn["parameters"]["additionalProperties"] is False
+        assert fn["parameters"]["required"] == ["path", "offset"]
+
+    def test_openrouter_tools_do_not_force_openai_strict_mode(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "browser_cdp",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": True,
+                        },
+                    },
+                },
+            },
+        }]
+        kw = transport.build_kwargs(
+            model="openai/gpt-4o",
+            messages=msgs,
+            tools=tools,
+            provider_name="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            is_openrouter=True,
+        )
+        assert "strict" not in kw["tools"][0]["function"]
+
     def test_openrouter_provider_prefs(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("openrouter")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -180,6 +180,56 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low" for xAI as well
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_openai_native_responses_tools_enable_strict_mode(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "offset": {"type": "integer"},
+                    },
+                    "required": ["path"],
+                },
+            },
+        }]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=tools,
+            provider="openai",
+            base_url="https://api.openai.com/v1/responses",
+        )
+        assert kw["tools"][0]["strict"] is True
+        assert kw["tools"][0]["parameters"]["required"] == ["path", "offset"]
+
+    def test_github_responses_tools_remain_non_strict(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                    },
+                },
+            },
+        }]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=tools,
+            provider="copilot",
+            base_url="https://models.github.ai/inference",
+            is_github_responses=True,
+        )
+        assert kw["tools"][0]["strict"] is False
+
 
 class TestCodexValidateResponse:
 

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -54,6 +54,10 @@ def test_openrouter_models_replaced_with_live_catalog(monkeypatch):
     openrouter = result[0]
     assert openrouter["slug"] == "openrouter"
     assert openrouter["models"] == ["openai/gpt-5.4", "moonshotai/kimi-k2.6"]
+    assert openrouter["model_entries"] == [
+        {"id": "openai/gpt-5.4", "description": "recommended"},
+        {"id": "moonshotai/kimi-k2.6", "description": ""},
+    ]
     assert openrouter["total_models"] == 2
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3455,6 +3455,10 @@ def test_model_options_does_not_overwrite_curated_models(monkeypatch):
             "slug": "nous",
             "name": "Nous",
             "models": ["moonshotai/kimi-k2.5", "anthropic/claude-opus-4.7"],
+            "model_entries": [
+                {"id": "moonshotai/kimi-k2.5", "description": "recommended"},
+                {"id": "anthropic/claude-opus-4.7", "description": ""},
+            ],
             "total_models": 30,
             "source": "built-in",
             "is_current": False,
@@ -3485,6 +3489,10 @@ def test_model_options_does_not_overwrite_curated_models(monkeypatch):
     assert nous["models"] == [
         "moonshotai/kimi-k2.5",
         "anthropic/claude-opus-4.7",
+    ]
+    assert nous["model_entries"] == [
+        {"id": "moonshotai/kimi-k2.5", "description": "recommended"},
+        {"id": "anthropic/claude-opus-4.7", "description": ""},
     ]
     assert nous["total_models"] == 30
     # Handler must not consult the live catalog — curated is the truth.

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import copy
 
-from tools.schema_sanitizer import sanitize_tool_schemas, strip_pattern_and_format
+from tools.schema_sanitizer import (
+    make_openai_strict_tools,
+    sanitize_tool_schemas,
+    strip_pattern_and_format,
+)
 
 
 def _tool(name: str, parameters: dict) -> dict:
@@ -203,6 +207,47 @@ def test_empty_tools_list_returns_empty():
 
 def test_none_tools_returns_none():
     assert sanitize_tool_schemas(None) is None
+
+
+def test_make_openai_strict_tools_closes_objects_and_requires_all_fields():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "offset": {"type": "integer"},
+            "meta": {
+                "type": "object",
+                "properties": {
+                    "line": {"type": "integer"},
+                },
+            },
+        },
+        "required": ["path"],
+    })]
+    out = make_openai_strict_tools(tools)
+    params = out[0]["function"]["parameters"]
+    assert out[0]["function"]["strict"] is True
+    assert params["additionalProperties"] is False
+    assert params["required"] == ["path", "offset", "meta"]
+    assert params["properties"]["offset"]["type"] == ["integer", "null"]
+    assert params["properties"]["meta"]["additionalProperties"] is False
+    assert params["properties"]["meta"]["required"] == ["line"]
+
+
+def test_make_openai_strict_tools_opts_out_for_freeform_object_maps():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "params": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": True,
+            },
+        },
+    })]
+    out = make_openai_strict_tools(tools)
+    assert out[0]["function"]["strict"] is False
+    assert out[0]["function"]["parameters"]["properties"]["params"]["additionalProperties"] is True
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -55,6 +55,29 @@ def sanitize_tool_schemas(tools: list[dict]) -> list[dict]:
     return sanitized
 
 
+def make_openai_strict_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Return tools with ``function.strict=true`` where OpenAI strict mode fits.
+
+    OpenAI strict function calling requires a narrower schema subset than the
+    broad compatibility sanitizer above. In particular, each object must be
+    closed with ``additionalProperties: false`` and every declared property must
+    be listed in ``required``. Formerly-optional properties are made nullable so
+    the model can still emit ``null`` where callers previously omitted them.
+
+    Some Hermes tools intentionally accept free-form maps via
+    ``additionalProperties: true`` (for example arbitrary CDP params). Those
+    schemas cannot be converted losslessly, so this helper leaves those tools as
+    ``strict: false`` instead of changing their behavior.
+    """
+    if not tools:
+        return tools
+
+    strictified: list[dict] = []
+    for tool in tools:
+        strictified.append(_strictify_single_tool(tool))
+    return strictified
+
+
 def _sanitize_single_tool(tool: dict) -> dict:
     """Deep-copy and sanitize a single OpenAI-format tool entry."""
     out = copy.deepcopy(tool)
@@ -91,6 +114,144 @@ def _sanitize_single_tool(tool: dict) -> dict:
         fn["parameters"], path=fn.get("name", "<tool>")
     )
     return out
+
+
+def _strictify_single_tool(tool: dict) -> dict:
+    """Deep-copy a tool and enable OpenAI strict mode when compatible."""
+    out = copy.deepcopy(tool)
+    fn = out.get("function") if isinstance(out, dict) else None
+    if not isinstance(fn, dict):
+        return out
+
+    params = fn.get("parameters")
+    if not isinstance(params, dict):
+        fn["parameters"] = {"type": "object", "properties": {}}
+        fn["strict"] = True
+        return out
+
+    if _schema_has_openai_strict_incompatibility(params):
+        fn["strict"] = False
+        return out
+
+    fn["parameters"] = _make_schema_openai_strict(params)
+    fn["strict"] = True
+    return out
+
+
+def _schema_has_openai_strict_incompatibility(node: Any) -> bool:
+    """Return True when a schema node cannot be losslessly strictified."""
+    if isinstance(node, list):
+        return any(_schema_has_openai_strict_incompatibility(item) for item in node)
+    if not isinstance(node, dict):
+        return False
+
+    node_type = node.get("type")
+    has_object_shape = node_type == "object" or isinstance(node.get("properties"), dict)
+    if has_object_shape and "additionalProperties" in node:
+        addl = node.get("additionalProperties")
+        if addl is not False:
+            return True
+
+    for key, value in node.items():
+        if key in {"properties", "$defs", "definitions"} and isinstance(value, dict):
+            if any(_schema_has_openai_strict_incompatibility(v) for v in value.values()):
+                return True
+        elif key in {"items", "additionalProperties"}:
+            if isinstance(value, dict) and _schema_has_openai_strict_incompatibility(value):
+                return True
+        elif key in {"anyOf", "oneOf", "allOf"} and isinstance(value, list):
+            if any(_schema_has_openai_strict_incompatibility(v) for v in value):
+                return True
+    return False
+
+
+def _make_schema_openai_strict(node: Any) -> Any:
+    """Convert a sanitized JSON-Schema fragment to OpenAI's strict subset."""
+    if isinstance(node, list):
+        return [_make_schema_openai_strict(item) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    out = copy.deepcopy(node)
+
+    if isinstance(out.get("properties"), dict):
+        out["properties"] = {
+            key: _make_schema_openai_strict(value)
+            for key, value in out["properties"].items()
+        }
+    for key in ("$defs", "definitions"):
+        if isinstance(out.get(key), dict):
+            out[key] = {
+                sub_key: _make_schema_openai_strict(sub_value)
+                for sub_key, sub_value in out[key].items()
+            }
+    if isinstance(out.get("items"), dict):
+        out["items"] = _make_schema_openai_strict(out["items"])
+    for key in ("anyOf", "oneOf", "allOf"):
+        if isinstance(out.get(key), list):
+            out[key] = [_make_schema_openai_strict(item) for item in out[key]]
+
+    has_object_shape = out.get("type") == "object" or isinstance(out.get("properties"), dict)
+    if has_object_shape:
+        out.setdefault("type", "object")
+        props = out.get("properties")
+        if not isinstance(props, dict):
+            props = {}
+            out["properties"] = props
+
+        original_required = set(out.get("required") or [])
+        strict_props: dict[str, Any] = {}
+        for prop_name, prop_schema in props.items():
+            strict_prop = prop_schema
+            if prop_name not in original_required:
+                strict_prop = _make_nullable_schema(strict_prop)
+            strict_props[prop_name] = strict_prop
+        out["properties"] = strict_props
+        out["required"] = list(strict_props.keys()) if strict_props else []
+        out["additionalProperties"] = False
+
+    return out
+
+
+def _schema_allows_null(schema: Any) -> bool:
+    """Return True when the schema already accepts null."""
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("nullable") is True:
+        return True
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    for key in ("anyOf", "oneOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list):
+            for item in variants:
+                if isinstance(item, dict) and item.get("type") == "null":
+                    return True
+    return False
+
+
+def _make_nullable_schema(schema: Any) -> Any:
+    """Wrap a property schema so null is accepted without discarding metadata."""
+    if not isinstance(schema, dict) or _schema_allows_null(schema):
+        return schema
+
+    out = copy.deepcopy(schema)
+    schema_type = out.get("type")
+    if isinstance(schema_type, str) and schema_type != "null":
+        out["type"] = [schema_type, "null"]
+        out.pop("nullable", None)
+        return out
+
+    for key in ("anyOf", "oneOf"):
+        variants = out.get(key)
+        if isinstance(variants, list):
+            out[key] = list(variants) + [{"type": "null"}]
+            return out
+
+    return {"anyOf": [out, {"type": "null"}]}
 
 
 _TOP_LEVEL_FORBIDDEN_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { providerDisplayNames } from '../domain/providers.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
+import type { ModelOptionEntry, ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -70,6 +70,9 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
   const provider = providers[providerIdx]
   const models = provider?.models ?? []
+  const modelEntries = provider?.model_entries?.length
+    ? provider.model_entries
+    : models.map((id): ModelOptionEntry => ({ id }))
   const names = useMemo(() => providerDisplayNames(providers), [providers])
 
   const back = () => {
@@ -201,7 +204,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       return
     }
 
-    const count = stage === 'provider' ? providers.length : models.length
+    const count = stage === 'provider' ? providers.length : modelEntries.length
     const sel = stage === 'provider' ? providerIdx : modelIdx
     const setSel = stage === 'provider' ? setProviderIdx : setModelIdx
 
@@ -241,10 +244,10 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         return
       }
 
-      const model = models[modelIdx]
+      const model = modelEntries[modelIdx]
 
       if (provider && model) {
-        onSelect(`${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`)
+        onSelect(`${model.id} --provider ${provider.slug}${persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`)
       } else {
         setStage('provider')
       }
@@ -433,7 +436,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   }
 
   // ── Model selection stage ────────────────────────────────────────────
-  const { items, offset } = windowItems(models, modelIdx, VISIBLE)
+  const { items, offset } = windowItems(modelEntries, modelIdx, VISIBLE)
 
   return (
     <Box flexDirection="column" width={width}>
@@ -456,7 +459,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         const idx = offset + i
 
         if (!row) {
-          return !models.length && i === 0 ? (
+          return !modelEntries.length && i === 0 ? (
             <Text color={t.color.muted} key="empty" wrap="truncate-end">
               no models listed for this provider
             </Text>
@@ -467,31 +470,32 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           )
         }
 
-        const prefix = modelIdx === idx ? '▸ ' : row === currentModel ? '* ' : '  '
+        const label = row.description ? `${row.id} · ${row.description}` : row.id
+        const prefix = modelIdx === idx ? '▸ ' : row.id === currentModel ? '* ' : '  '
 
         return (
           <Text
             bold={modelIdx === idx}
             color={modelIdx === idx ? t.color.accent : t.color.muted}
             inverse={modelIdx === idx}
-            key={`${provider?.slug ?? 'prov'}:${idx}:${row}`}
+            key={`${provider?.slug ?? 'prov'}:${idx}:${row.id}`}
             wrap="truncate-end"
           >
             {prefix}
-            {idx + 1}. {row}
+            {idx + 1}. {label}
           </Text>
         )
       })}
 
       <Text color={t.color.muted} wrap="truncate-end">
-        {offset + VISIBLE < models.length ? ` ↓ ${models.length - offset - VISIBLE} more` : ' '}
+        {offset + VISIBLE < modelEntries.length ? ` ↓ ${modelEntries.length - offset - VISIBLE} more` : ' '}
       </Text>
 
       <Text color={t.color.muted} wrap="truncate-end">
         persist: {persistGlobal ? 'global' : 'session'} · g toggle
       </Text>
       <OverlayHint t={t}>
-        {models.length ? '↑/↓ select · Enter switch · Esc back · q close' : 'Enter/Esc back · q close'}
+        {modelEntries.length ? '↑/↓ select · Enter switch · Esc back · q close' : 'Enter/Esc back · q close'}
       </OverlayHint>
     </Box>
   )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -312,11 +312,17 @@ export interface ToolsConfigureResponse {
 
 // ── Model picker ─────────────────────────────────────────────────────
 
+export interface ModelOptionEntry {
+  description?: string
+  id: string
+}
+
 export interface ModelOptionProvider {
   auth_type?: string
   authenticated?: boolean
   is_current?: boolean
   key_env?: string
+  model_entries?: ModelOptionEntry[]
   models?: string[]
   name: string
   slug: string

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -27,9 +27,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
  *    requiring an open chat PTY.
  */
 
+interface ModelOptionEntry {
+  id: string;
+  description?: string;
+}
+
 interface ModelOptionProvider {
   name: string;
   slug: string;
+  model_entries?: ModelOptionEntry[];
   models?: string[];
   total_models?: number;
   is_current?: boolean;
@@ -145,6 +151,13 @@ export function ModelPickerDialog(props: Props) {
     () => selectedProvider?.models ?? [],
     [selectedProvider],
   );
+  const modelEntries = useMemo(
+    () =>
+      selectedProvider?.model_entries?.length
+        ? selectedProvider.model_entries
+        : models.map((id): ModelOptionEntry => ({ id })),
+    [models, selectedProvider],
+  );
 
   const needle = query.trim().toLowerCase();
 
@@ -156,15 +169,26 @@ export function ModelPickerDialog(props: Props) {
             (p) =>
               p.name.toLowerCase().includes(needle) ||
               p.slug.toLowerCase().includes(needle) ||
-              (p.models ?? []).some((m) => m.toLowerCase().includes(needle)),
+              (p.models ?? []).some((m) => m.toLowerCase().includes(needle)) ||
+              (p.model_entries ?? []).some(
+                (entry) =>
+                  entry.id.toLowerCase().includes(needle) ||
+                  entry.description?.toLowerCase().includes(needle),
+              ),
           ),
     [providers, needle],
   );
 
   const filteredModels = useMemo(
     () =>
-      !needle ? models : models.filter((m) => m.toLowerCase().includes(needle)),
-    [models, needle],
+      !needle
+        ? modelEntries
+        : modelEntries.filter(
+            (entry) =>
+              entry.id.toLowerCase().includes(needle) ||
+              entry.description?.toLowerCase().includes(needle),
+          ),
+    [modelEntries, needle],
   );
 
   const canConfirm = !!selectedProvider && !!selectedModel && !applying;
@@ -256,7 +280,7 @@ export function ModelPickerDialog(props: Props) {
           <ModelColumn
             provider={selectedProvider}
             models={filteredModels}
-            allModels={models}
+            allModels={modelEntries}
             selectedModel={selectedModel}
             currentModel={currentModel}
             currentProviderSlug={currentProviderSlug}
@@ -383,8 +407,8 @@ function ModelColumn({
   onConfirm,
 }: {
   provider: ModelOptionProvider | null;
-  models: string[];
-  allModels: string[];
+  models: ModelOptionEntry[];
+  allModels: ModelOptionEntry[];
   selectedModel: string;
   currentModel: string;
   currentProviderSlug: string;
@@ -416,23 +440,26 @@ function ModelColumn({
             : "no models listed for this provider"}
         </div>
       ) : (
-        models.map((m) => {
-          const active = m === selectedModel;
+        models.map((entry) => {
+          const active = entry.id === selectedModel;
           const isCurrent =
-            m === currentModel && provider.slug === currentProviderSlug;
+            entry.id === currentModel && provider.slug === currentProviderSlug;
+          const label = entry.description
+            ? `${entry.id} · ${entry.description}`
+            : entry.id;
 
           return (
             <ListItem
-              key={m}
+              key={entry.id}
               active={active}
-              onClick={() => onSelect(m)}
-              onDoubleClick={() => onConfirm(m)}
+              onClick={() => onSelect(entry.id)}
+              onDoubleClick={() => onConfirm(entry.id)}
               className="px-3 py-1.5 text-xs font-mono"
             >
               <Check
                 className={`h-3 w-3 shrink-0 ${active ? "text-primary" : "text-transparent"}`}
               />
-              <span className="flex-1 truncate">{m}</span>
+              <span className="flex-1 truncate">{label}</span>
               {isCurrent && <CurrentTag />}
             </ListItem>
           );


### PR DESCRIPTION
## Summary
- add `model_entries` metadata to model picker provider payloads
- surface OpenRouter model descriptions like `free`/`recommended` in both TUI and web pickers
- preserve raw model IDs for submission and add regression coverage

## Testing
- python3 -m pytest tests/hermes_cli/test_list_picker_providers.py -q -k 'openrouter_models_replaced_with_live_catalog or max_models_caps_openrouter_live_output'
- python3 -m pytest tests/test_tui_gateway_server.py -q -k 'model_options_does_not_overwrite_curated_models'
- npm run type-check --prefix ui-tui
- npm run build --prefix ui-tui
- npm run build --prefix web