### PR TITLE
fix(dashboard): show chat session titles in browser tabs

### DIFF
--- a/tests/tui_gateway/test_session_title_info.py
+++ b/tests/tui_gateway/test_session_title_info.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+
+class FakeSessionDB:
+    def __init__(self, titles=None):
+        self.titles = dict(titles or {})
+
+    def get_session_title(self, session_id):
+        return self.titles.get(session_id, "")
+
+    def set_session_title(self, session_id, title):
+        self.titles[session_id] = title
+        return True
+
+
+def _agent():
+    return SimpleNamespace(
+        model="openrouter/test-model",
+        service_tier="",
+        reasoning_config={},
+        tools=[],
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+    )
+
+
+def test_session_info_includes_current_session_title(monkeypatch):
+    from tui_gateway import server
+
+    db = FakeSessionDB({"durable-session": "Quarterly planning"})
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    info = server._session_info(_agent(), session={"session_key": "durable-session"})
+
+    assert info["title"] == "Quarterly planning"
+
+
+def test_session_title_rpc_emits_updated_session_info(monkeypatch):
+    from tui_gateway import server
+
+    db = FakeSessionDB()
+    agent = _agent()
+    server._sessions["sid-live-title"] = {
+        "agent": agent,
+        "pending_title": None,
+        "session_key": "durable-session",
+    }
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+
+    try:
+        response = server._methods["session.title"](
+            "req-1",
+            {"session_id": "sid-live-title", "title": "Manual title"},
+        )
+    finally:
+        server._sessions.pop("sid-live-title", None)
+
+    assert response["result"] == {"pending": False, "title": "Manual title"}
+    assert emitted
+    event, sid, payload = emitted[-1]
+    assert event == "session.info"
+    assert sid == "sid-live-title"
+    assert payload["title"] == "Manual title"

--- a/tests/web/test_chat_page_document_title.py
+++ b/tests/web/test_chat_page_document_title.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_PAGE = REPO_ROOT / "web" / "src" / "pages" / "ChatPage.tsx"
+
+
+def test_chat_page_forwards_osc_window_titles_to_document_title():
+    source = CHAT_PAGE.read_text(encoding="utf-8")
+
+    assert "registerOscHandler(0" in source
+    assert "registerOscHandler(2" in source
+    assert "document.title" in source

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -581,7 +581,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _wire_callbacks(sid)
             _notify_session_boundary("on_session_reset", key)
 
-            info = _session_info(agent)
+            info = _session_info_for(agent, session=current)
             warn = _probe_credentials(agent)
             if warn:
                 info["credential_warning"] = warn
@@ -1121,7 +1121,7 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
             api_mode=result.api_mode,
         )
         _restart_slash_worker(session)
-        _emit("session.info", sid, _session_info(agent))
+        _emit("session.info", sid, _session_info_for(agent, session=session))
 
     os.environ["HERMES_MODEL"] = result.new_model
     os.environ["HERMES_INFERENCE_MODEL"] = result.new_model
@@ -1362,7 +1362,26 @@ def _probe_config_health(cfg: dict) -> str:
     return " ".join(warnings).strip()
 
 
-def _session_info(agent) -> dict:
+def _session_title(session: dict | None) -> str:
+    if not session:
+        return ""
+    pending = str(session.get("pending_title") or "").strip()
+    key = str(session.get("session_key") or "").strip()
+    if not key:
+        return pending
+    try:
+        db = _get_db()
+    except Exception:
+        db = None
+    if db is None:
+        return pending
+    try:
+        return (db.get_session_title(key) or pending or "").strip()
+    except Exception:
+        return pending
+
+
+def _session_info(agent, session: dict | None = None) -> dict:
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
     if (
@@ -1383,6 +1402,7 @@ def _session_info(agent) -> dict:
         "release_date": "",
         "update_behind": None,
         "update_command": "",
+        "title": _session_title(session),
         "usage": _get_usage(agent),
     }
     try:
@@ -1427,6 +1447,27 @@ def _session_info(agent) -> dict:
     except Exception:
         pass
     return info
+
+
+def _session_info_for(agent, session: dict | None = None) -> dict:
+    try:
+        info = _session_info(agent, session=session)
+    except TypeError:
+        # Some tests monkeypatch _session_info(agent) directly.  Keep those
+        # call sites compatible while still enriching real payloads below.
+        info = _session_info(agent)
+    if session is not None and "title" not in info:
+        info["title"] = _session_title(session)
+    return info
+
+
+def _emit_session_info(sid: str, session: dict | None) -> None:
+    if not sid or not session:
+        return
+    current = _sessions.get(sid)
+    if current is not None and current is not session:
+        return
+    _emit("session.info", sid, _session_info_for(session.get("agent"), session=session))
 
 
 def _tool_ctx(name: str, args: dict) -> str:
@@ -1762,7 +1803,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
-        info = _session_info(agent)
+        info = _session_info_for(agent, session=session)
         _emit("session.info", sid, info)
         return False, info
     return False, None
@@ -1848,7 +1889,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
-    info = _session_info(new_agent)
+    info = _session_info_for(new_agent, session=session)
     _emit("session.info", sid, info)
     _restart_slash_worker(session)
     return info
@@ -1956,7 +1997,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         pass
     _wire_callbacks(sid)
     _notify_session_boundary("on_session_reset", key)
-    _emit("session.info", sid, _session_info(agent))
+    _emit("session.info", sid, _session_info_for(agent, session=_sessions.get(sid)))
 
 
 def _new_session_key() -> str:
@@ -2274,7 +2315,7 @@ def _(rid, params: dict) -> dict:
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,
-            "info": _session_info(agent),
+            "info": _session_info_for(agent, session=_sessions.get(sid)),
         },
     )
 
@@ -2329,6 +2370,7 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _db_unavailable_error(rid, code=5007)
     key = session["session_key"]
+    sid = str(params.get("session_id") or "")
     if "title" not in params:
         fallback = session.get("pending_title") or ""
         try:
@@ -2349,6 +2391,7 @@ def _(rid, params: dict) -> dict:
                 session["pending_title"] = None
         except Exception:
             resolved_title = fallback
+        _emit_session_info(sid, session)
         return _ok(
             rid,
             {
@@ -2362,12 +2405,14 @@ def _(rid, params: dict) -> dict:
     try:
         if db.set_session_title(key, title):
             session["pending_title"] = None
+            _emit_session_info(sid, session)
             return _ok(rid, {"pending": False, "title": title})
         # rowcount == 0 can mean "same value" as well as "missing row".
         # Queue only when the session row truly does not exist yet.
         existing_row = db.get_session(key)
         if existing_row:
             session["pending_title"] = None
+            _emit_session_info(sid, session)
             return _ok(
                 rid,
                 {
@@ -2376,6 +2421,7 @@ def _(rid, params: dict) -> dict:
                 },
             )
         session["pending_title"] = title
+        _emit_session_info(sid, session)
         return _ok(rid, {"pending": True, "title": title})
     except ValueError as e:
         return _err(rid, 4022, str(e))
@@ -2577,7 +2623,7 @@ def _(rid, params: dict) -> dict:
             summary = summarize_manual_compression(
                 before_messages, messages, before_tokens, after_tokens
             )
-            info = _session_info(agent)
+            info = _session_info_for(agent, session=session)
             _emit("session.info", sid, info)
             return _ok(
                 rid,
@@ -3279,6 +3325,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     try:
                         if _pdb.set_session_title(_session_key, _pending):
                             session["pending_title"] = None
+                            _emit_session_info(sid, session)
                     except ValueError as exc:
                         # Invalid/duplicate title — non-retryable, drop it.
                         # Auto-title will take over. Fix for #19029.
@@ -3301,12 +3348,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 try:
                     from agent.title_generator import maybe_auto_title
 
+                    def _on_auto_title(_title: str) -> None:
+                        _emit_session_info(sid, session)
+
                     maybe_auto_title(
                         _get_db(),
                         session.get("session_key") or sid,
                         text,
                         raw,
                         session.get("history", []),
+                        title_callback=_on_auto_title,
                     )
                 except Exception:
                     pass
@@ -3710,7 +3761,7 @@ def _(rid, params: dict) -> dict:
             _emit(
                 "session.info",
                 params.get("session_id", ""),
-                _session_info(agent),
+                _session_info_for(agent, session=session),
             )
         return _ok(rid, {"key": key, "value": nv})
 
@@ -4198,7 +4249,7 @@ def _(rid, params: dict) -> dict:
             agent = session["agent"]
             if hasattr(agent, "refresh_tools"):
                 agent.refresh_tools()
-            _emit("session.info", params.get("session_id", ""), _session_info(agent))
+            _emit("session.info", params.get("session_id", ""), _session_info_for(agent, session=session))
 
         # Honor `always=true` by persisting the opt-out to config.
         if bool(params.get("always", False)):
@@ -5423,14 +5474,14 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "compress" and agent:
             _compress_session_history(session, arg)
             _sync_session_key_after_compress(sid, session)
-            _emit("session.info", sid, _session_info(agent))
+            _emit("session.info", sid, _session_info_for(agent, session=session))
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
-            _emit("session.info", sid, _session_info(agent))
+            _emit("session.info", sid, _session_info_for(agent, session=session))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
         elif name == "stop":

--- a/ui-tui/src/__tests__/terminalTitle.test.ts
+++ b/ui-tui/src/__tests__/terminalTitle.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { buildTerminalTitle } from '../domain/terminalTitle.js'
+
+describe('buildTerminalTitle', () => {
+  const origHome = process.env.HOME
+
+  beforeEach(() => {
+    process.env.HOME = '/Users/bb'
+  })
+
+  afterEach(() => {
+    process.env.HOME = origHome
+  })
+
+  it('prefers the session title before model and cwd', () => {
+    expect(
+      buildTerminalTitle({
+        cwd: '/Users/bb/projects/hermes-agent',
+        marker: '✓',
+        model: 'openrouter/deepseek-v4-pro',
+        sessionTitle: 'Quarterly planning'
+      })
+    ).toBe('✓ Quarterly planning · deepseek-v4-pro · ~/projects/hermes-agent')
+  })
+
+  it('preserves the previous model and cwd title when there is no session title', () => {
+    expect(
+      buildTerminalTitle({
+        cwd: '/Users/bb/projects/hermes-agent',
+        marker: '⏳',
+        model: 'anthropic/claude-sonnet-4'
+      })
+    ).toBe('⏳ claude-sonnet-4 · ~/projects/hermes-agent')
+  })
+
+  it('sanitizes blank and control-character titles', () => {
+    expect(
+      buildTerminalTitle({
+        marker: '✓',
+        model: 'openai/gpt-5.5',
+        sessionTitle: '  Release\nplanning\u001b[31m  '
+      })
+    ).toBe('✓ Release planning · gpt-5.5')
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -6,7 +6,8 @@ import { STARTUP_RESUME_ID } from '../config/env.js'
 import { FULL_RENDER_TAIL_ITEMS, MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
-import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
+import { fmtCwdBranch } from '../domain/paths.js'
+import { buildTerminalTitle } from '../domain/terminalTitle.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
@@ -404,13 +405,16 @@ export function useMainApp(gw: GatewayClient) {
   useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid: ui.sid })
 
   // Tab title: `⚠` waiting on approval/sudo/secret/clarify, `⏳` busy, `✓` idle.
-  const model = ui.info?.model?.replace(/^.*\//, '') ?? ''
-
   const marker = overlay.approval || overlay.sudo || overlay.secret || overlay.clarify ? '⚠' : ui.busy ? '⏳' : '✓'
 
-  const tabCwd = ui.info?.cwd
-
-  useTerminalTitle(model ? `${marker} ${model}${tabCwd ? ` · ${shortCwd(tabCwd, 24)}` : ''}` : 'Hermes')
+  useTerminalTitle(
+    buildTerminalTitle({
+      cwd: ui.info?.cwd,
+      marker,
+      model: ui.info?.model,
+      sessionTitle: ui.info?.title
+    })
+  )
 
   useEffect(() => {
     if (!ui.sid || !stdout) {

--- a/ui-tui/src/domain/terminalTitle.ts
+++ b/ui-tui/src/domain/terminalTitle.ts
@@ -1,0 +1,30 @@
+import { shortCwd } from './paths.js'
+
+const ANSI_CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g
+const CONTROL_RE = /[\x00-\x1f\x7f]/g
+
+export interface TerminalTitleParts {
+  cwd?: string | null
+  marker: string
+  model?: string | null
+  sessionTitle?: string | null
+}
+
+const cleanSegment = (value: null | string | undefined, max = 80) => {
+  const cleaned = (value ?? '')
+    .replace(ANSI_CSI_RE, '')
+    .replace(CONTROL_RE, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return cleaned.length <= max ? cleaned : `${cleaned.slice(0, Math.max(0, max - 1))}…`
+}
+
+export const buildTerminalTitle = ({ cwd, marker, model, sessionTitle }: TerminalTitleParts) => {
+  const title = cleanSegment(sessionTitle, 48)
+  const shortModel = cleanSegment(model?.replace(/^.*\//, ''), 80)
+  const shortPath = cwd ? shortCwd(cwd, 24) : ''
+  const parts = [title || shortModel, title && shortModel ? shortModel : '', shortPath].filter(Boolean)
+
+  return parts.length ? `${marker} ${parts.join(' · ')}` : 'Hermes'
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -143,6 +143,7 @@ export interface McpServerStatus {
 export interface SessionInfo {
   cwd?: string
   fast?: boolean
+  title?: string
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -70,6 +70,15 @@ const TERMINAL_THEME = {
   selectionBackground: "#f0e6d244",
 };
 
+function applyOscWindowTitle(data: string): boolean {
+  const title = data
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  document.title = title || "Hermes Agent - Dashboard";
+  return true;
+}
+
 /**
  * CSS width for xterm font tiers.
  *
@@ -317,6 +326,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // OSC 52 reads (terminal asking to read the clipboard) are not
     // supported — that would let any content the TUI renders exfiltrate
     // the user's clipboard.
+    // The embedded Ink TUI emits OSC 0/2 terminal-window titles.  Mirror
+    // those into the browser tab so multiple Dashboard Chat tabs can be
+    // distinguished by session title/status, just like native terminal tabs.
+    term.parser.registerOscHandler(0, applyOscWindowTitle);
+    term.parser.registerOscHandler(2, applyOscWindowTitle);
+
     term.parser.registerOscHandler(52, (data) => {
       // Format: "<targets>;<base64 | '?'>"
       const semi = data.indexOf(";");


### PR DESCRIPTION
## Summary

Fixes #21072 by letting Dashboard `/chat` browser tabs follow the embedded TUI's real session title instead of staying stuck on the static dashboard title.

This wires the existing terminal-title path through all three layers:

- `tui_gateway/server.py` includes the current session title in `session.info` and re-emits `session.info` when `/title`, pending-title flushes, or auto-title generation update the title.
- `ui-tui` builds the terminal title from status marker + session title + model + cwd, preserving the previous model/cwd fallback when no title is available.
- `web/src/pages/ChatPage.tsx` registers xterm OSC 0/2 handlers and mirrors the embedded TUI terminal title into `document.title`.

Related: #23376 also improves real chat identity display, but in the dashboard sidebar. This PR targets the browser tab title specifically.

## Tests

- `scripts/run_tests.sh tests/tui_gateway/test_session_title_info.py tests/web/test_chat_page_document_title.py tests/tui_gateway/test_protocol.py -q`
  - `56 passed`
- `npm --prefix ui-tui run test -- src/__tests__/terminalTitle.test.ts`
  - `3 passed`
- `npm --prefix ui-tui run type-check`
- `npm --prefix ui-tui run build`
- `npm --prefix web run build`
  - passes with the existing Vite chunk-size warning
- `git diff --check upstream/main..HEAD`

## Notes

I created this as a Draft PR because the browser-facing manual smoke test should confirm the end-to-end title behavior in a running dashboard:

1. Open multiple `/chat` tabs.
2. Start or resume different sessions.
3. Use `/title ...` and/or wait for auto-title generation.
4. Confirm each browser tab updates to the corresponding chat/session identity and still falls back cleanly before a title exists.

Fixes #21072
