### PR TITLE
fix(tui): persist api_mode in _persist_model_switch()

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1684,6 +1684,69 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
     assert saved["model"]["provider"] == "anthropic"
     assert saved["model"]["base_url"] == "https://api.anthropic.com"
+    assert saved["model"]["api_mode"] == "anthropic_messages"
+
+
+def test_config_set_model_global_clears_stale_api_mode(monkeypatch):
+    """Regression: switching away from a provider with api_mode must remove
+    the stale value rather than leaving it in config.yaml."""
+
+    class _Agent:
+        provider = "opencode"
+        model = "old/model"
+        base_url = "https://opencode.example/v1"
+        api_key = "sk-old"
+
+        def switch_model(self, **kwargs):
+            return None
+
+    result = types.SimpleNamespace(
+        success=True,
+        new_model="gpt-5.4",
+        target_provider="openai",
+        api_key="sk-new",
+        base_url="",
+        api_mode="",
+        warning_message="",
+    )
+    saved = {}
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "model": {
+                "default": "old/model",
+                "provider": "opencode",
+                "base_url": "https://opencode.example/v1",
+                "api_mode": "codex_responses",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "gpt-5.4 --global",
+            },
+        }
+    )
+
+    assert saved["model"]["default"] == "gpt-5.4"
+    assert saved["model"]["provider"] == "openai"
+    assert "api_mode" not in saved["model"]
+    assert "base_url" not in saved["model"]
 
 
 def test_config_set_model_syncs_inference_provider_env(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1061,6 +1061,10 @@ def _persist_model_switch(result) -> None:
         model_cfg["base_url"] = result.base_url
     else:
         model_cfg.pop("base_url", None)
+    if result.api_mode:
+        model_cfg["api_mode"] = result.api_mode
+    else:
+        model_cfg.pop("api_mode", None)
     save_config(cfg)
 
 


### PR DESCRIPTION
## What does this PR do?

Root cause: `_persist_model_switch()` in `tui_gateway/server.py` writes
`model.default`, `model.provider`, and `model.base_url` to config.yaml on a
`--global` `/model` switch but never writes `model.api_mode`. When a user
switches away from a provider that requires a non-default `api_mode`
(e.g. OpenCode → `codex_responses`, Kimi Coding → custom mode), the stale
value survives in config.yaml. The next TUI session restores the old
api_mode and routes the new model through the wrong protocol/endpoint.

Fix: mirror the existing `base_url` pop-or-write pattern for `api_mode` —
write when truthy, pop when empty. No other behavior changes.
`gateway/run.py` and `cli.py` already received the equivalent fix via
PRs #25131 / #25138; this closes the third persist path that both missed.

## Related Issue

Fixes #25107

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tui_gateway/server.py`: add 4-line api_mode persist block in `_persist_model_switch()` (+4 lines)
- `tests/test_tui_gateway_server.py`: add `api_mode` assertion to existing `test_config_set_model_global_persists`; add new `test_config_set_model_global_clears_stale_api_mode` (+67 lines)

## How to Test

```
python3.11 -m pytest tests/test_tui_gateway_server.py::test_config_set_model_global_persists tests/test_tui_gateway_server.py::test_config_set_model_global_clears_stale_api_mode -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide okundu | Conventional Commits | Duplicate PR yok
- [x] Sadece bu fix | Tests eklendi | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A