### PR TITLE
fix(security): reduce unnecessary shell=True in subprocess calls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7600,6 +7600,8 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # shell=True is intentional: quick_commands are user-defined
+                            # shell snippets from config.yaml — not agent/LLM controlled.
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
                                 text=True, timeout=30

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import getpass
 import os
 import sys
+import shlex
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -134,7 +135,7 @@ def _install_dependencies(provider_name: str) -> None:
         if check_cmd:
             try:
                 subprocess.run(
-                    check_cmd, shell=True, capture_output=True, timeout=5
+                    shlex.split(check_cmd), check=True, capture_output=True, timeout=5
                 )
             except Exception:
                 if install_cmd:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1004,6 +1004,7 @@ AUTHOR_MAP = {
     "freedemon@gmail.com": "fr33d3m0n",  # PR #21128 salvage (sudo stdin/askpass DANGEROUS, #17873 cat 4)
     "zhaowh3613@outlook.com": "VinceZcrikl",  # PR #23647 salvage (npm UTF-8 decode on GBK Windows)
     "anton.kuenzi@gmail.com": "ZeterMordio",  # PR #11754 salvage (zsh completion compdef + _arguments syntax)
+    "23yntong@stu.edu.cn": "iuyup",  # PR #6155 salvage (shell=True hardening)
 }
 
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1363,3 +1363,45 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# Shell safety — shlex.split on auto-detected templates
+# ============================================================================
+class TestShellSafety:
+    def test_auto_detected_template_is_shlex_safe(self, monkeypatch):
+        """Auto-detected whisper command should be safely splittable."""
+        import shlex
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_whisper_binary",
+            lambda: "/usr/bin/whisper",
+        )
+        from tools.transcription_tools import _get_local_command_template
+        template = _get_local_command_template()
+        assert template is not None
+        cmd = template.format(
+            input_path=shlex.quote("/tmp/test.wav"),
+            output_dir=shlex.quote("/tmp/out"),
+            language=shlex.quote("en"),
+            model=shlex.quote("base"),
+        )
+        parts = shlex.split(cmd)
+        assert parts[0] == "/usr/bin/whisper"
+        assert "/tmp/test.wav" in parts
+
+    def test_env_var_template_uses_shell_path(self, monkeypatch):
+        """When HERMES_LOCAL_STT_COMMAND is set, use_shell should be True."""
+        import os
+        from tools.transcription_tools import LOCAL_STT_COMMAND_ENV
+        monkeypatch.setenv(LOCAL_STT_COMMAND_ENV, "whisper {input_path} | tee log.txt")
+        use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+        assert use_shell is True
+
+    def test_no_env_var_uses_list_mode(self, monkeypatch):
+        """When no env var is set, use_shell should be False."""
+        import os
+        from tools.transcription_tools import LOCAL_STT_COMMAND_ENV
+        monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
+        use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+        assert use_shell is False

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -505,7 +505,13 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
+            use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+            if use_shell:
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+            else:
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+            
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:


### PR DESCRIPTION
Salvage of #6155 (@iuyup) onto current main.

Drops `shell=True` from two subprocess sites where the input isn't a user-authored shell snippet:
- Auto-detected whisper STT command (`tools/transcription_tools.py`) — args are already `shlex.quote`'d, so list mode is strictly safer. User templates via `HERMES_LOCAL_STT_COMMAND` still use shell mode (may contain pipes/redirects).
- Memory-plugin `external_dependencies.check` field (`hermes_cli/memory_setup.py`) — also adds `check=True` so the install hint actually fires (was previously dead code).

`cli.py` quick_commands keeps `shell=True` with a clarifying comment — that path is user-defined config, not agent-controlled.

## Changes
- `tools/transcription_tools.py`: shell/list branching on env var presence
- `hermes_cli/memory_setup.py`: `shlex.split` + `check=True`
- `cli.py`: intent comment on quick_commands
- `tests/tools/test_transcription_tools.py`: new `TestShellSafety` class (3 tests)
- `scripts/release.py`: AUTHOR_MAP entry for contributor

## Validation
| Suite | Before | After |
|---|---|---|
| `tests/tools/test_transcription_tools.py` | 92/92 | 95/95 |
| `tests/agent/test_memory_provider.py` + `test_hindsight_provider.py` | 158/158 | 158/158 |

Closes #6155.

Co-authored-by: iuyup <23yntong@stu.edu.cn>