### PR TITLE
fix(tui): collapse long composer input

### DIFF
--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import { offsetFromPosition } from '../components/textInput.js'
-import { composerPromptWidth, cursorLayout, inputVisualHeight, stableComposerColumns } from '../lib/inputMetrics.js'
+import {
+  COMPOSER_COLLAPSE_MARKER,
+  composerPromptWidth,
+  cursorLayout,
+  inputVisualHeight,
+  projectComposerInput,
+  projectedInputVisualHeight,
+  stableComposerColumns
+} from '../lib/inputMetrics.js'
 
 describe('cursorLayout — word-wrap parity with wrap-ansi', () => {
   it('places cursor mid-line at its column', () => {
@@ -61,6 +69,45 @@ describe('input metrics helpers', () => {
     expect(stableComposerColumns(100, 5)).toBe(91)
     expect(stableComposerColumns(10, 3)).toBe(5)
     expect(stableComposerColumns(6, 3)).toBe(1)
+  })
+})
+
+describe('projectComposerInput', () => {
+  it('leaves inputs at or below the visual-line limit untouched', () => {
+    const value = 'one two three'
+
+    expect(projectComposerInput(value, value.length, 20, 3)).toMatchObject({
+      collapsed: false,
+      cursor: value.length,
+      value
+    })
+    expect(projectedInputVisualHeight(value, 20, 3)).toBe(inputVisualHeight(value, 20))
+  })
+
+  it('collapses long tail input to a marker plus the final two visual lines', () => {
+    const value = 'aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk'
+    const projected = projectComposerInput(value, value.length, 8, 3)
+
+    expect(inputVisualHeight(value, 8)).toBeGreaterThan(3)
+    expect(projected.collapsed).toBe(true)
+    expect(projected.value.split('\n')[0]).toBe(COMPOSER_COLLAPSE_MARKER)
+    expect(inputVisualHeight(projected.value, 8)).toBeLessThanOrEqual(3)
+    expect(projected.cursor).toBe(projected.value.length)
+    expect(projected.sourceOffsetFromDisplayOffset(projected.cursor)).toBe(value.length)
+    expect(projectedInputVisualHeight(value, 8, 3)).toBeLessThanOrEqual(3)
+  })
+
+  it('keeps the cursor line visible when the cursor is in the hidden middle', () => {
+    const value = 'aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk'
+    const cursor = value.indexOf('fff') + 1
+    const projected = projectComposerInput(value, cursor, 8, 3)
+
+    expect(projected.collapsed).toBe(true)
+    expect(projected.value.split('\n')).toHaveLength(3)
+    expect(projected.value.startsWith(`${COMPOSER_COLLAPSE_MARKER}\n`)).toBe(true)
+    expect(projected.value.endsWith(`\n${COMPOSER_COLLAPSE_MARKER}`)).toBe(true)
+    expect(projected.sourceOffsetFromDisplayOffset(projected.cursor)).toBe(cursor)
+    expect(projected.value[projected.cursor]).toBe(value[cursor])
   })
 })
 

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -17,7 +17,7 @@ import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
 import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
-import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
+import { normalizeComposerPasteText, pasteTokenLabel } from '../lib/text.js'
 
 import type { MaybePromise, PasteSnippet, UseComposerStateOptions, UseComposerStateResult } from './interfaces.js'
 import { $isBlocked } from './overlayStore.js'
@@ -142,7 +142,7 @@ export function useComposerState({
       text,
       value
     }: Omit<PasteEvent, 'hotkey'>): Promise<null | { cursor: number; value: string }> => {
-      const cleanedText = stripTrailingPasteNewlines(text)
+      const cleanedText = normalizeComposerPasteText(text)
 
       if (!cleanedText || !/[^\n]/.test(cleanedText)) {
         if (bracketed) {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -10,9 +10,10 @@ import { INLINE_MODE, SHOW_FPS } from '../config/env.js'
 import { FULL_RENDER_TAIL_ITEMS } from '../config/limits.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import {
+  COMPOSER_INPUT_MAX_VISUAL_LINES,
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
-  inputVisualHeight,
+  projectedInputVisualHeight,
   stableComposerColumns
 } from '../lib/inputMetrics.js'
 import { PerfPane } from '../lib/perfPane.js'
@@ -174,7 +175,7 @@ const ComposerPane = memo(function ComposerPane({
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth)
-  const inputHeight = inputVisualHeight(composer.input, inputColumns)
+  const inputHeight = projectedInputVisualHeight(composer.input, inputColumns, COMPOSER_INPUT_MAX_VISUAL_LINES)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
   const captureInputDrag = (e: GutterMouseEvent) => {
@@ -297,6 +298,7 @@ const ComposerPane = memo(function ComposerPane({
                 {/* Reserve the transcript scrollbar gutter too so typing never rewraps when the scrollbar column repaints. */}
                 <TextInput
                   columns={inputColumns}
+                  maxVisualLines={COMPOSER_INPUT_MAX_VISUAL_LINES}
                   mouseApiRef={inputMouseRef}
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,7 +4,7 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
-import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
+import { cursorLayout, offsetFromPosition, projectComposerInput } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
@@ -245,6 +245,7 @@ export function TextInput({
   onPaste,
   onSubmit,
   mask,
+  maxVisualLines,
   mouseApiRef,
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
   placeholder = '',
@@ -282,7 +283,13 @@ export function TextInput({
   cbPaste.current = onPaste
 
   const raw = self.current ? vRef.current : value
-  const display = mask ? raw.replace(/[^\n]/g, mask[0] ?? '*') : raw
+  const sourceDisplay = mask ? raw.replace(/[^\n]/g, mask[0] ?? '*') : raw
+  const projection = useMemo(
+    () => projectComposerInput(sourceDisplay, cur, columns, maxVisualLines),
+    [columns, cur, maxVisualLines, sourceDisplay]
+  )
+  const display = projection.value
+  const displayCursor = projection.cursor
 
   const selected = useMemo(
     () =>
@@ -290,19 +297,21 @@ export function TextInput({
     [sel]
   )
 
-  const layout = useMemo(() => cursorLayout(display, cur, columns), [columns, cur, display])
+  const visualSelected = projection.collapsed ? null : selected
+
+  const layout = useMemo(() => cursorLayout(display, displayCursor, columns), [columns, display, displayCursor])
 
   const boxRef = useDeclaredCursor({
     line: layout.line,
     column: layout.column,
-    active: focus && termFocus && !selected
+    active: focus && termFocus && !visualSelected
   })
 
   // Hide the hardware cursor while a selection is active (prevents
   // auto-wrap onto the next row when inverted text fills the column
   // exactly) or when the terminal loses focus (suppresses the hollow-rect
   // ghost most terminals draw at the parked position).
-  const hideHardwareCursor = focus && !!stdout?.isTTY && (!!selected || !termFocus)
+  const hideHardwareCursor = focus && !!stdout?.isTTY && (!!visualSelected || !termFocus)
 
   useEffect(() => {
     if (!hideHardwareCursor || !stdout) {
@@ -316,7 +325,7 @@ export function TextInput({
     }
   }, [hideHardwareCursor, stdout])
 
-  const nativeCursor = focus && termFocus && !selected && !!stdout?.isTTY
+  const nativeCursor = focus && termFocus && !visualSelected && !!stdout?.isTTY
 
   // Placeholder text is just a hint, not a selection — render it dim
   // without inverse styling. In a TTY the hardware cursor parks at column
@@ -331,12 +340,12 @@ export function TextInput({
       return nativeCursor ? dim(placeholder) : invert(placeholder[0] ?? ' ') + dim(placeholder.slice(1))
     }
 
-    if (selected) {
-      return renderWithSelection(display, selected.start, selected.end)
+    if (visualSelected) {
+      return renderWithSelection(display, visualSelected.start, visualSelected.end)
     }
 
-    return nativeCursor ? display || ' ' : renderWithCursor(display, cur)
-  }, [cur, display, focus, nativeCursor, placeholder, selected])
+    return nativeCursor ? display || ' ' : renderWithCursor(display, displayCursor)
+  }, [display, displayCursor, focus, nativeCursor, placeholder, visualSelected])
 
   useEffect(() => {
     if (self.current) {
@@ -685,7 +694,7 @@ export function TextInput({
   }
 
   const offsetAt = (e: { localCol?: number; localRow?: number }) =>
-    offsetFromPosition(display, e.localRow ?? 0, e.localCol ?? 0, columns)
+    projection.sourceOffsetFromDisplayOffset(offsetFromPosition(display, e.localRow ?? 0, e.localCol ?? 0, columns))
 
   const isMultiClickAt = (offset: number) => {
     const now = Date.now()
@@ -697,7 +706,7 @@ export function TextInput({
 
   if (mouseApiRef) {
     mouseApiRef.current = {
-      dragAt: (row, col) => dragMouseSelection(offsetFromPosition(display, row, col, columns)),
+      dragAt: (row, col) => dragMouseSelection(offsetAt({ localRow: row, localCol: col })),
       end: endMouseSelection,
       startAtBeginning: () => startMouseSelection(0)
     }
@@ -1039,6 +1048,7 @@ interface TextInputProps {
   columns?: number
   focus?: boolean
   mask?: string
+  maxVisualLines?: number
   mouseApiRef?: MutableRefObject<null | TextInputMouseApi>
   onChange: (v: string) => void
   onPaste?: (

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -3,6 +3,8 @@ import { stringWidth } from '@hermes/ink'
 import type { Role } from '../types.js'
 
 export const COMPOSER_PROMPT_GAP_WIDTH = 1
+export const COMPOSER_INPUT_MAX_VISUAL_LINES = 3
+export const COMPOSER_COLLAPSE_MARKER = '[[...]]'
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))
@@ -12,7 +14,23 @@ interface VisualLine {
   start: number
 }
 
+interface ProjectedSegment {
+  displayEnd: number
+  displayStart: number
+  sourceEnd: number
+  sourceStart: number
+}
+
+export interface ProjectedComposerInput {
+  collapsed: boolean
+  cursor: number
+  height: number
+  sourceOffsetFromDisplayOffset: (offset: number) => number
+  value: string
+}
+
 const isWhitespace = (value: string) => /\s/.test(value)
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value))
 
 const graphemes = (value: string) =>
   [...seg().segment(value)].map(({ segment, index }) => ({
@@ -93,6 +111,162 @@ function visualLines(value: string, cols: number): VisualLine[] {
   }
 
   return lines.length ? lines : [{ start: 0, end: 0 }]
+}
+
+function identityProjection(value: string, cursor: number, cols: number): ProjectedComposerInput {
+  const pos = clamp(cursor, 0, value.length)
+
+  return {
+    collapsed: false,
+    cursor: pos,
+    height: inputVisualHeight(value, cols),
+    sourceOffsetFromDisplayOffset: offset => clamp(offset, 0, value.length),
+    value
+  }
+}
+
+function projectionSourceMapper(segments: ProjectedSegment[], sourceLength: number, displayLength: number) {
+  return (offset: number) => {
+    const pos = clamp(offset, 0, displayLength)
+    let previous: ProjectedSegment | null = null
+
+    for (const segment of segments) {
+      if (pos < segment.displayStart) {
+        return clamp(segment.sourceStart, 0, sourceLength)
+      }
+
+      if (pos <= segment.displayEnd) {
+        const sourceSpan = segment.sourceEnd - segment.sourceStart
+        const displayDelta = clamp(pos - segment.displayStart, 0, sourceSpan)
+
+        return clamp(segment.sourceStart + displayDelta, 0, sourceLength)
+      }
+
+      previous = segment
+    }
+
+    return clamp(previous?.sourceEnd ?? 0, 0, sourceLength)
+  }
+}
+
+function linesWithTrailingCursorRow(value: string, cols: number): VisualLine[] {
+  const lines = [...visualLines(value, cols)]
+  const height = inputVisualHeight(value, cols)
+
+  while (lines.length < height) {
+    lines.push({ start: value.length, end: value.length })
+  }
+
+  return lines
+}
+
+export function projectComposerInput(
+  value: string,
+  cursor: number,
+  cols: number,
+  maxVisualLines = Number.POSITIVE_INFINITY
+): ProjectedComposerInput {
+  const width = Math.max(1, cols)
+  const limit = Math.floor(maxVisualLines)
+  const pos = clamp(cursor, 0, value.length)
+
+  if (!Number.isFinite(limit) || limit < 1 || inputVisualHeight(value, width) <= limit) {
+    return identityProjection(value, pos, width)
+  }
+
+  const lines = linesWithTrailingCursorRow(value, width)
+  const totalLines = lines.length
+  const cursorLine = clamp(cursorLayout(value, pos, width).line, 0, totalLines - 1)
+  const marker = stringWidth(COMPOSER_COLLAPSE_MARKER) <= width ? COMPOSER_COLLAPSE_MARKER : '…'
+
+  let contentStart = 0
+  let contentEnd = totalLines
+  let markerBefore = false
+  let markerAfter = false
+
+  if (limit === 1) {
+    contentStart = cursorLine
+    contentEnd = cursorLine + 1
+  } else if (cursorLine < limit - 1) {
+    contentStart = 0
+    contentEnd = Math.min(totalLines, limit - 1)
+    markerAfter = contentEnd < totalLines
+  } else if (cursorLine >= totalLines - (limit - 1)) {
+    contentEnd = totalLines
+    contentStart = Math.max(0, totalLines - (limit - 1))
+    markerBefore = contentStart > 0
+  } else {
+    const contentSlots = Math.max(1, limit - 2)
+    const beforeCursor = Math.floor((contentSlots - 1) / 2)
+
+    contentStart = clamp(cursorLine - beforeCursor, 1, totalLines - contentSlots - 1)
+    contentEnd = contentStart + contentSlots
+    markerBefore = true
+    markerAfter = true
+  }
+
+  const renderedLines: { isMarker?: boolean; sourceEnd: number; sourceStart: number; text: string }[] = []
+
+  if (markerBefore) {
+    const sourceStart = lines[contentStart]?.start ?? 0
+    renderedLines.push({ isMarker: true, sourceStart, sourceEnd: sourceStart, text: marker })
+  }
+
+  for (let i = contentStart; i < contentEnd; i += 1) {
+    const line = lines[i]!
+    renderedLines.push({ sourceStart: line.start, sourceEnd: line.end, text: value.slice(line.start, line.end) })
+  }
+
+  if (markerAfter) {
+    const sourceEnd = lines[contentEnd - 1]?.end ?? value.length
+    renderedLines.push({ isMarker: true, sourceStart: sourceEnd, sourceEnd, text: marker })
+  }
+
+  let projectedValue = ''
+  let projectedCursor: number | null = null
+  const segments: ProjectedSegment[] = []
+  let sourceLineIndex = contentStart
+
+  for (let index = 0; index < renderedLines.length; index += 1) {
+    const line = renderedLines[index]!
+    if (index > 0) {
+      projectedValue += '\n'
+    }
+
+    const displayStart = projectedValue.length
+    projectedValue += line.text
+    const displayEnd = projectedValue.length
+
+    segments.push({ displayStart, displayEnd, sourceStart: line.sourceStart, sourceEnd: line.sourceEnd })
+
+    if (!line.isMarker) {
+      if (sourceLineIndex === cursorLine && projectedCursor === null) {
+        projectedCursor = displayStart + clamp(pos - line.sourceStart, 0, line.text.length)
+      }
+
+      sourceLineIndex += 1
+    }
+  }
+
+  const mapSource = projectionSourceMapper(segments, value.length, projectedValue.length)
+
+  if (projectedCursor === null) {
+    projectedCursor = projectedValue.length
+  }
+
+  const projectedHeight = inputVisualHeight(projectedValue, width)
+
+  return {
+    collapsed: true,
+    cursor: clamp(projectedCursor, 0, projectedValue.length),
+    height: Math.min(limit, projectedHeight),
+    sourceOffsetFromDisplayOffset: mapSource,
+    value: projectedValue
+  }
+}
+
+export function projectedInputVisualHeight(value: string, columns: number, maxVisualLines: number) {
+  return projectComposerInput(value, value.length, columns, maxVisualLines).height
 }
 
 function widthBetween(value: string, start: number, end: number) {

--- a/ui-tui/src/lib/text.test.ts
+++ b/ui-tui/src/lib/text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { stripTrailingPasteNewlines } from './text.js'
+import { normalizeComposerPasteText, stripTrailingPasteNewlines } from './text.js'
 
 describe('stripTrailingPasteNewlines', () => {
   it('removes trailing newline runs from pasted text', () => {
@@ -14,5 +14,17 @@ describe('stripTrailingPasteNewlines', () => {
 
   it('preserves newline-only pastes', () => {
     expect(stripTrailingPasteNewlines('\n\n')).toBe('\n\n')
+  })
+})
+
+describe('normalizeComposerPasteText', () => {
+  it('leaves pasted text at or below three content lines multiline', () => {
+    expect(normalizeComposerPasteText('alpha\nbeta\ngamma')).toBe('alpha\nbeta\ngamma')
+    expect(normalizeComposerPasteText('alpha\nbeta\ngamma\n')).toBe('alpha\nbeta\ngamma')
+  })
+
+  it('flattens pasted text with more than three content lines into one readable line', () => {
+    expect(normalizeComposerPasteText('alpha\n  beta\n\ngamma\ndelta')).toBe('alpha beta gamma delta')
+    expect(normalizeComposerPasteText('alpha\r\nbeta\r\ngamma\r\ndelta')).toBe('alpha beta gamma delta')
   })
 })

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -164,6 +164,18 @@ const countNewlines = (text: string, end: number) => {
 
 export const stripTrailingPasteNewlines = (text: string) => (/[^\n]/.test(text) ? text.replace(/\n+$/, '') : text)
 
+const COMPOSER_PASTE_MULTILINE_LIMIT = 3
+
+export const normalizeComposerPasteText = (text: string, multilineLimit = COMPOSER_PASTE_MULTILINE_LIMIT) => {
+  const normalized = stripTrailingPasteNewlines(text.replace(/\r\n/g, '\n').replace(/\r/g, '\n'))
+
+  if (!/[^\n]/.test(normalized) || normalized.split('\n').length <= multilineLimit) {
+    return normalized
+  }
+
+  return normalized.replace(/[ \t]*\n+[ \t]*/g, ' ').replace(/[ \t]{2,}/g, ' ').trim()
+}
+
 export const toolTrailLabel = (name: string) =>
   name
     .split('_')


### PR DESCRIPTION
## Summary
- Add a composer input projection layer that visually collapses long input to a maximum of 3 visual lines using `[[...]]` markers.
- Keep the active cursor line visible by projecting the display cursor into the visible slice.
- Use projected height accounting in the TUI layout and map mouse display offsets back to source offsets for editing.
- Flatten pasted text with more than 3 content lines into one readable composer line before insertion.
- Add focused regression coverage for unchanged short input, long-tail collapse, cursor-in-hidden-middle behavior, and >3-line paste normalization.

## Test Plan
- [x] `npm run build --prefix packages/hermes-ink`
- [x] `npm run test -- src/lib/text.test.ts src/__tests__/textInputWrap.test.ts src/__tests__/useComposerState.test.ts src/__tests__/text.test.ts`
- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm run test` (703 passed, 3 skipped)
- [x] `git diff --check`

## Notes
- `npm run test` exits successfully; the existing skipped `slashParity` tests print a Python `ModuleNotFoundError: No module named 'yaml'` while being skipped in this local environment.