### PR TITLE
fix: block sensitive credential reads

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import re
+import shlex
 from pathlib import Path
 from typing import Optional
 
@@ -90,22 +92,611 @@ def is_write_denied(path: str) -> bool:
     return False
 
 
+_SAFE_ENV_EXAMPLE_SUFFIXES = (
+    ".example",
+    ".sample",
+    ".template",
+    ".tmpl",
+    ".dist",
+    ".default",
+    ".defaults",
+    ".mock",
+)
+
+_SENSITIVE_HOME_FILES = (
+    ".xurl",
+    ".netrc",
+    ".pgpass",
+    ".npmrc",
+    ".pypirc",
+)
+
+_SENSITIVE_HOME_DIRS = (
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".kube",
+    ".docker",
+    ".azure",
+    os.path.join(".config", "gh"),
+    os.path.join(".config", "gcloud"),
+)
+
+_TERMINAL_SECRET_READ_VERBS = frozenset({
+    "awk",
+    "base64",
+    "bat",
+    "cat",
+    "cp",
+    "curl",
+    "dd",
+    "grep",
+    "head",
+    "hexdump",
+    "jq",
+    "less",
+    "more",
+    "node",
+    "openssl",
+    "perl",
+    "php",
+    "python",
+    "python3",
+    "rg",
+    "rsync",
+    "ruby",
+    "scp",
+    "sed",
+    "strings",
+    "tail",
+    "tac",
+    "wget",
+    "xxd",
+    "yq",
+})
+
+_ENV_DUMP_RE = re.compile(r"(?:^|[;&|]\s*)(?:(?:/usr/bin|/bin)/)?(?:env|printenv)(?:\s+(?:-[A-Za-z0-9-]+))*\s*(?:$|[;&|])")
+
+_SEARCH_SCAN_SKIP_DIRS = frozenset({
+    ".git",
+    ".hg",
+    ".svn",
+    "node_modules",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+})
+_SENSITIVE_SEARCH_DIR_NAMES = frozenset({".ssh", ".aws", ".gnupg", ".kube", ".docker", ".azure"})
+_SHELL_EVAL_VERBS = frozenset({"bash", "dash", "fish", "ksh", "sh", "zsh"})
+_COMMAND_WRAPPER_VERBS = frozenset({"command", "env", "nice", "timeout"})
+_VERSIONED_READ_VERB_RE = re.compile(r"^(?:python(?:\d+(?:\.\d+)*)?|pypy\d*|nodejs)$")
+
+
+def _resolve_path(path: str | os.PathLike[str]) -> Path:
+    """Resolve a path for safety checks without requiring it to exist."""
+    return Path(path).expanduser().resolve()
+
+
+def _home_path() -> Path:
+    return _resolve_path(os.path.expanduser("~"))
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_secret_env_filename(name: str) -> bool:
+    """Return True for real env files, while allowing examples/templates."""
+    lower = name.lower()
+    if lower.endswith(_SAFE_ENV_EXAMPLE_SUFFIXES):
+        return False
+    return lower == ".env" or lower.startswith(".env.")
+
+
+def _directory_contains_sensitive_read_target(root: Path, max_entries: int = 20_000) -> bool:
+    """Return True when a directory tree contains obvious secret filenames.
+
+    This only inspects path names, never file contents. It is intentionally
+    bounded so ordinary searches do not become expensive on huge trees; known
+    credential roots are handled by exact descendant checks before this scan.
+    """
+    if not root.is_dir():
+        return False
+
+    seen = 0
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            if any(name in _SENSITIVE_SEARCH_DIR_NAMES for name in dirnames):
+                return True
+
+            path = Path(dirpath)
+            if path.name == ".config" and any(name in {"gh", "gcloud"} for name in dirnames):
+                return True
+
+            dirnames[:] = [name for name in dirnames if name not in _SEARCH_SCAN_SKIP_DIRS]
+            if any(_is_secret_env_filename(name) for name in filenames):
+                return True
+
+            seen += len(dirnames) + len(filenames)
+            if seen > max_entries:
+                return True
+    except OSError:
+        return True
+
+    return False
+
+
+def _sensitive_exact_read_paths(home: Path, hermes_home: Path) -> set[Path]:
+    return {
+        hermes_home / ".env",
+        hermes_home / "auth.json",
+        hermes_home / "config.yaml",
+        *(home / name for name in _SENSITIVE_HOME_FILES),
+    }
+
+
+def _sensitive_dir_read_paths(home: Path, hermes_home: Path) -> list[Path]:
+    return [
+        hermes_home / "secrets",
+        *(home / rel for rel in _SENSITIVE_HOME_DIRS),
+    ]
+
+
+def _sensitive_read_block_error(path: str) -> Optional[str]:
+    """Return an error when a read targets local credential material."""
+    resolved = _resolve_path(path)
+    home = _home_path()
+    hermes_home = _hermes_home_path().resolve()
+
+    if resolved in _sensitive_exact_read_paths(home, hermes_home):
+        return (
+            f"Access denied: {path} is a sensitive credential/configuration "
+            "file and cannot be read directly. Use a purpose-built helper that "
+            "prints only redacted, task-specific metadata."
+        )
+
+    for sensitive_dir in _sensitive_dir_read_paths(home, hermes_home):
+        if _is_relative_to(resolved, sensitive_dir):
+            return (
+                f"Access denied: {path} is inside a sensitive credential "
+                "directory and cannot be read directly. Use a redacted, "
+                "purpose-built helper instead."
+            )
+
+    if _is_secret_env_filename(resolved.name):
+        return (
+            f"Access denied: {path} looks like a sensitive credential .env "
+            "file and cannot be read directly. Example/template env files are "
+            "allowed; real env files require a redacted helper."
+        )
+
+    return None
+
+
+def get_search_block_error(path: str) -> Optional[str]:
+    """Return an error when a recursive/content search targets credential roots."""
+    direct_error = get_read_block_error(path)
+    if direct_error:
+        return direct_error
+
+    resolved = _resolve_path(path)
+    home = _home_path()
+    hermes_home = _hermes_home_path().resolve()
+    sensitive_descendants = [
+        *_sensitive_exact_read_paths(home, hermes_home),
+        *_sensitive_dir_read_paths(home, hermes_home),
+    ]
+    for sensitive_path in sensitive_descendants:
+        if _is_relative_to(sensitive_path, resolved):
+            return (
+                f"Access denied: {path} contains sensitive credential stores "
+                "and cannot be searched recursively. Search a narrower "
+                "non-sensitive subdirectory or use a redacted helper."
+            )
+
+    if _directory_contains_sensitive_read_target(resolved):
+        return (
+            f"Access denied: {path} contains sensitive credential-like files "
+            "and cannot be searched recursively. Search a narrower "
+            "non-sensitive subdirectory or use a redacted helper."
+        )
+
+    return None
+
+
 def get_read_block_error(path: str) -> Optional[str]:
-    """Return an error message when a read targets internal Hermes cache files."""
-    resolved = Path(path).expanduser().resolve()
+    """Return an error message when a read targets unsafe local files."""
+    sensitive_error = _sensitive_read_block_error(path)
+    if sensitive_error:
+        return sensitive_error
+
+    resolved = _resolve_path(path)
     hermes_home = _hermes_home_path().resolve()
     blocked_dirs = [
         hermes_home / "skills" / ".hub" / "index-cache",
         hermes_home / "skills" / ".hub",
     ]
     for blocked in blocked_dirs:
-        try:
-            resolved.relative_to(blocked)
-        except ValueError:
+        if _is_relative_to(resolved, blocked):
+            return (
+                f"Access denied: {path} is an internal Hermes cache file "
+                "and cannot be read directly to prevent prompt injection. "
+                "Use the skills_list or skill_view tools instead."
+            )
+    return None
+
+
+def _command_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return re.split(r"\s+", command)
+
+
+def _normalize_shell_path_token(token: str) -> str:
+    """Expand shell-ish home variables in a token without consulting secrets."""
+    home = str(_home_path())
+    hermes_home = str(_hermes_home_path().resolve())
+    normalized = (
+        token.replace("${HERMES_HOME}", hermes_home)
+        .replace("$HERMES_HOME", hermes_home)
+        .replace("${HOME}", home)
+        .replace("$HOME", home)
+    )
+    if normalized.startswith("~"):
+        normalized = normalized.replace("~", home, 1)
+    compact = normalized.strip("'\"` ,;()[]{}<>")
+    if compact.startswith("@"):
+        compact = compact[1:]
+    return compact
+
+
+def _resolve_shell_path_token(token: str, cwd: str | os.PathLike[str] | None = None) -> Path | None:
+    """Resolve a possible shell path token relative to cwd, if it looks usable."""
+    compact = _normalize_shell_path_token(token)
+    if not compact or compact.startswith("-"):
+        return None
+    # Skip common assignment tokens (`FOO=bar command`) and option payloads.
+    if "=" in compact and not compact.startswith(("/", ".", "~")):
+        return None
+    try:
+        candidate = Path(compact).expanduser()
+        if not candidate.is_absolute():
+            base = _resolve_path(cwd) if cwd else Path.cwd().resolve()
+            candidate = base / candidate
+        return candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _token_mentions_sensitive_path(token: str, cwd: str | os.PathLike[str] | None = None) -> bool:
+    """Best-effort detection of credential path references in shell tokens."""
+    if not token:
+        return False
+
+    home = str(_home_path())
+    hermes_home = str(_hermes_home_path().resolve())
+    compact = _normalize_shell_path_token(token)
+
+    if "=" in compact:
+        value = compact.split("=", 1)[1]
+        if value and _token_mentions_sensitive_path(value, cwd=cwd):
+            return True
+
+    sensitive_fragments = [
+        f"{hermes_home}/.env",
+        f"{hermes_home}/auth.json",
+        f"{hermes_home}/config.yaml",
+        f"{hermes_home}/secrets/",
+        f"{home}/.xurl",
+        f"{home}/.netrc",
+        f"{home}/.pgpass",
+        f"{home}/.npmrc",
+        f"{home}/.pypirc",
+        f"{home}/.ssh/",
+        f"{home}/.aws/",
+        f"{home}/.gnupg/",
+        f"{home}/.kube/",
+        f"{home}/.docker/",
+        f"{home}/.azure/",
+        f"{home}/.config/gh/",
+        f"{home}/.config/gcloud/",
+    ]
+    if any(fragment in compact for fragment in sensitive_fragments):
+        return True
+
+    resolved = _resolve_shell_path_token(compact, cwd=cwd)
+    if resolved is not None and get_search_block_error(str(resolved)):
+        return True
+
+    # Bare project env-file reads such as `cat .env` or code strings like
+    # `open('.env.local')` are common prompt-injection targets.
+    for match in re.finditer(r"(?<![\w.-])\.env(?:\.[A-Za-z0-9_-]+)*(?![\w.-])", compact):
+        if _is_secret_env_filename(match.group(0)):
+            return True
+
+    return False
+
+
+def _command_uses_secret_read_verb(tokens: list[str]) -> bool:
+    for token in tokens:
+        base = os.path.basename(token)
+        if base in _TERMINAL_SECRET_READ_VERBS or _VERSIONED_READ_VERB_RE.match(base):
+            return True
+    return False
+
+
+def _split_shell_segments(command: str) -> list[str]:
+    """Split simple shell command chains while preserving quoted separators."""
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    i = 0
+    while i < len(command):
+        ch = command[i]
+        if quote:
+            current.append(ch)
+            if ch == quote:
+                quote = None
+            elif ch == "\\" and i + 1 < len(command):
+                i += 1
+                current.append(command[i])
+            i += 1
             continue
-        return (
-            f"Access denied: {path} is an internal Hermes cache file "
-            "and cannot be read directly to prevent prompt injection. "
-            "Use the skills_list or skill_view tools instead."
+        if ch in ("'", '"'):
+            quote = ch
+            current.append(ch)
+            i += 1
+            continue
+        if command.startswith("&&", i) or command.startswith("||", i):
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            i += 2
+            continue
+        if ch == ";" or ch in "\n\r":
+            segment = "".join(current).strip()
+            if segment:
+                segments.append(segment)
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    segment = "".join(current).strip()
+    if segment:
+        segments.append(segment)
+    return segments or [command]
+
+
+def _update_cwd_from_cd(tokens: list[str], cwd: Path) -> Path:
+    if not tokens or tokens[0] != "cd":
+        return cwd
+    # `cd` with no operand returns home; ignore flags/complex expansions.
+    target = tokens[1] if len(tokens) > 1 else str(_home_path())
+    resolved = _resolve_shell_path_token(target, cwd=cwd)
+    return resolved if resolved is not None else cwd
+
+
+def _iter_embedded_shell_commands(command: str) -> list[str]:
+    """Extract command substitution payloads for recursive scanning."""
+    embedded: list[str] = []
+    i = 0
+    while i < len(command):
+        if command.startswith("$(", i):
+            start = i + 2
+            depth = 1
+            quote: str | None = None
+            j = start
+            while j < len(command):
+                ch = command[j]
+                if quote:
+                    if ch == quote:
+                        quote = None
+                    elif ch == "\\" and j + 1 < len(command):
+                        j += 1
+                    j += 1
+                    continue
+                if ch in ("'", '"'):
+                    quote = ch
+                elif command.startswith("$(", j):
+                    depth += 1
+                    j += 1
+                elif ch == ")":
+                    depth -= 1
+                    if depth == 0:
+                        embedded.append(command[start:j])
+                        i = j
+                        break
+                j += 1
+        elif command[i] == "`":
+            j = i + 1
+            while j < len(command):
+                if command[j] == "`":
+                    embedded.append(command[i + 1:j])
+                    i = j
+                    break
+                if command[j] == "\\" and j + 1 < len(command):
+                    j += 1
+                j += 1
+        i += 1
+    return embedded
+
+
+def _extract_shell_c_payload(tokens: list[str]) -> str | None:
+    if not tokens or os.path.basename(tokens[0]) not in _SHELL_EVAL_VERBS:
+        return None
+    for idx, token in enumerate(tokens[1:], start=1):
+        if token == "--":
+            break
+        if token == "-c" or (token.startswith("-") and "c" in token and not token.startswith("--")):
+            if idx + 1 < len(tokens):
+                return tokens[idx + 1]
+            return None
+    return None
+
+
+def _unwrap_command_wrappers(tokens: list[str]) -> list[str] | None:
+    """Return the real command after common benign launcher wrappers."""
+    if not tokens:
+        return None
+    base = os.path.basename(tokens[0])
+    if base not in _COMMAND_WRAPPER_VERBS:
+        return None
+
+    if base == "command":
+        idx = 1
+        while idx < len(tokens) and tokens[idx].startswith("-"):
+            idx += 1
+        return tokens[idx:] or None
+
+    if base == "env":
+        idx = 1
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token == "--":
+                idx += 1
+                break
+            if token == "-S" and idx + 1 < len(tokens):
+                return _command_tokens(tokens[idx + 1]) + tokens[idx + 2:]
+            if token.startswith("-"):
+                idx += 1
+                continue
+            if "=" in token and not token.startswith(("/", ".", "~")):
+                idx += 1
+                continue
+            break
+        return tokens[idx:] or None
+
+    if base == "nice":
+        idx = 1
+        while idx < len(tokens):
+            token = tokens[idx]
+            if token == "-n" and idx + 1 < len(tokens):
+                idx += 2
+                continue
+            if token.startswith("-"):
+                idx += 1
+                continue
+            break
+        return tokens[idx:] or None
+
+    if base == "timeout":
+        idx = 1
+        while idx < len(tokens) and tokens[idx].startswith("-"):
+            # Options may have a following value. This is conservative; if we
+            # skip too little, the recursive scan just sees a harmless token.
+            idx += 1
+        if idx < len(tokens):
+            idx += 1  # duration
+        return tokens[idx:] or None
+
+    return None
+
+
+def _command_recursively_searches_cwd(tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    base = os.path.basename(tokens[0])
+    if base == "grep":
+        return any(
+            token in {"-R", "-r", "--recursive", "--dereference-recursive"}
+            or (token.startswith("-") and not token.startswith("--") and any(ch in token for ch in "Rr"))
+            for token in tokens[1:]
         )
+    if base == "rg":
+        return any(
+            token in {"--hidden", "--unrestricted", "-u", "-uu", "-uuu"}
+            for token in tokens[1:]
+        )
+    return False
+
+
+def get_terminal_read_block_error(
+    command: str,
+    cwd: str | os.PathLike[str] | None = None,
+    _depth: int = 0,
+) -> Optional[str]:
+    """Return an error when a shell command appears to read local secrets.
+
+    This is a guardrail for obvious prompt-injection/exfiltration attempts. It
+    is intentionally conservative and complements, rather than replaces,
+    running untrusted web/X automations with restricted toolsets.
+    """
+    if not isinstance(command, str):
+        return None
+
+    stripped = command.strip()
+    if not stripped:
+        return None
+
+    if _ENV_DUMP_RE.search(stripped):
+        return (
+            "Access denied: this command would dump process environment "
+            "variables, which may include sensitive credentials. Request only "
+            "specific non-secret variables or use a redacted helper."
+        )
+
+    current_cwd = _resolve_path(cwd) if cwd else Path.cwd().resolve()
+
+    if _depth < 4:
+        for embedded in _iter_embedded_shell_commands(stripped):
+            embedded_error = get_terminal_read_block_error(embedded, cwd=current_cwd, _depth=_depth + 1)
+            if embedded_error:
+                return embedded_error
+
+    whole_tokens = _command_tokens(stripped)
+    if _command_uses_secret_read_verb(whole_tokens) and any(
+        _token_mentions_sensitive_path(token, cwd=current_cwd) for token in whole_tokens
+    ):
+        return (
+            "Access denied: this command appears to read or exfiltrate a "
+            "sensitive credential file. Use a redacted, purpose-built helper "
+            "instead of reading credential stores directly."
+        )
+
+    for segment in _split_shell_segments(stripped):
+        tokens = _command_tokens(segment)
+        if not tokens:
+            continue
+        unwrapped = _unwrap_command_wrappers(tokens)
+        if unwrapped is not None and _depth < 4:
+            wrapper_error = get_terminal_read_block_error(shlex.join(unwrapped), cwd=current_cwd, _depth=_depth + 1)
+            if wrapper_error:
+                return wrapper_error
+            tokens = unwrapped
+        shell_payload = _extract_shell_c_payload(tokens)
+        if shell_payload is not None and _depth < 4:
+            shell_error = get_terminal_read_block_error(shell_payload, cwd=current_cwd, _depth=_depth + 1)
+            if shell_error:
+                return shell_error
+        if tokens[0] == "cd":
+            current_cwd = _update_cwd_from_cd(tokens, current_cwd)
+            continue
+        if _command_recursively_searches_cwd(tokens) and get_search_block_error(str(current_cwd)):
+            return (
+                "Access denied: this recursive search command would scan a "
+                "directory containing sensitive credential files. Search a "
+                "narrower non-sensitive path or use a redacted helper."
+            )
+        if not _command_uses_secret_read_verb(tokens):
+            continue
+        if any(_token_mentions_sensitive_path(token, cwd=current_cwd) for token in tokens):
+            return (
+                "Access denied: this command appears to read or exfiltrate a "
+                "sensitive credential file. Use a redacted, purpose-built helper "
+                "instead of reading credential stores directly."
+            )
+
     return None

--- a/tests/agent/test_sensitive_read_blocks.py
+++ b/tests/agent/test_sensitive_read_blocks.py
@@ -1,0 +1,291 @@
+"""Hard blocks for local credential reads.
+
+These tests cover the prompt-injection threat model where untrusted web/X content
+tries to make Hermes read local credential stores through file or terminal tools.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import agent.file_safety as file_safety
+from tools.file_tools import read_file_tool, search_tool
+from tools.terminal_tool import terminal_tool
+
+
+@pytest.fixture()
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(file_safety, "_hermes_home_path", lambda: hermes_home)
+    return home, hermes_home
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        ".hermes/.env",
+        ".hermes/auth.json",
+        ".hermes/config.yaml",
+        ".hermes/secrets/gcp-service-account.json",
+        ".xurl",
+        ".ssh/id_ed25519",
+        ".aws/credentials",
+        ".azure/accessTokens.json",
+        ".config/gh/hosts.yml",
+        ".netrc",
+        ".npmrc",
+        "projects/example/.env",
+        "projects/example/.env.local",
+        "projects/example/.env.production",
+    ],
+)
+def test_sensitive_read_paths_are_hard_blocked(isolated_home, relative_path):
+    home, _hermes_home = isolated_home
+    err = file_safety.get_read_block_error(str(home / relative_path))
+
+    assert err is not None
+    assert "Access denied" in err
+    assert "sensitive credential" in err.lower()
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "projects/example/.env.example",
+        "projects/example/.env.sample",
+        "projects/example/.env.template",
+        "projects/example/README.md",
+    ],
+)
+def test_non_secret_example_files_are_not_hard_blocked(isolated_home, relative_path):
+    home, _hermes_home = isolated_home
+
+    assert file_safety.get_read_block_error(str(home / relative_path)) is None
+
+
+def test_read_file_tool_blocks_sensitive_paths_before_io(isolated_home):
+    _home, hermes_home = isolated_home
+
+    with patch("tools.file_tools._get_file_ops") as mock_ops:
+        result = json.loads(read_file_tool(str(hermes_home / ".env"), task_id="secret-read"))
+
+    assert "error" in result
+    assert "sensitive credential" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+def test_search_files_tool_blocks_sensitive_roots_before_io(isolated_home):
+    _home, hermes_home = isolated_home
+
+    with patch("tools.file_tools._get_file_ops") as mock_ops:
+        result = json.loads(search_tool(".*", path=str(hermes_home / ".env"), task_id="secret-search"))
+
+    assert "error" in result
+    assert "sensitive credential" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+@pytest.mark.parametrize("root_selector", ["hermes_home", "home", "config"])
+def test_search_files_tool_blocks_sensitive_parent_roots_before_io(isolated_home, root_selector):
+    home, hermes_home = isolated_home
+    root = {
+        "hermes_home": hermes_home,
+        "home": home,
+        "config": home / ".config",
+    }[root_selector]
+
+    with patch("tools.file_tools._get_file_ops") as mock_ops:
+        result = json.loads(search_tool(".*", path=str(root), task_id=f"secret-search-{root_selector}"))
+
+    assert "error" in result
+    assert "sensitive" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+def test_read_file_tool_blocks_relative_sensitive_paths_against_live_cwd(isolated_home):
+    home, _hermes_home = isolated_home
+
+    with (
+        patch("tools.file_tools._get_live_tracking_cwd", return_value=str(home)),
+        patch("tools.file_tools._get_file_ops") as mock_ops,
+    ):
+        result = json.loads(read_file_tool(".ssh/id_ed25519", task_id="relative-secret-read"))
+
+    assert "error" in result
+    assert "sensitive credential" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+def test_search_files_tool_blocks_relative_sensitive_paths_against_live_cwd(isolated_home):
+    home, _hermes_home = isolated_home
+
+    with (
+        patch("tools.file_tools._get_live_tracking_cwd", return_value=str(home)),
+        patch("tools.file_tools._get_file_ops") as mock_ops,
+    ):
+        result = json.loads(search_tool(".*", path=".aws/credentials", task_id="relative-secret-search"))
+
+    assert "error" in result
+    assert "sensitive credential" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+def test_search_files_tool_blocks_project_roots_with_real_env_before_io(isolated_home):
+    home, _hermes_home = isolated_home
+    project = home / "projects" / "example"
+    project.mkdir(parents=True)
+    (project / ".env").write_text("FAKE_SECRET=do-not-read\n", encoding="utf-8")
+
+    with patch("tools.file_tools._get_file_ops") as mock_ops:
+        result = json.loads(search_tool("FAKE_SECRET", path=str(project), task_id="project-env-search"))
+
+    assert "error" in result
+    assert "sensitive" in result["error"].lower()
+    mock_ops.assert_not_called()
+
+
+def test_search_files_tool_allows_project_roots_with_env_examples(isolated_home):
+    home, _hermes_home = isolated_home
+    project = home / "projects" / "example-template"
+    project.mkdir(parents=True)
+    (project / ".env.example").write_text("EXAMPLE=value\n", encoding="utf-8")
+
+    assert file_safety.get_search_block_error(str(project)) is None
+
+
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        "cat {hermes_env}",
+        "cat $HERMES_HOME/.env",
+        "cat ${{HERMES_HOME}}/auth.json",
+        "sed -n '1,20p' {hermes_auth}",
+        "python3 -c \"print(open('{xurl}').read())\"",
+        "cd ~/.hermes && cat auth.json",
+        "cd ~/.ssh && cat id_ed25519",
+        "cd ~/.hermes\ncat auth.json",
+        "cd ~/.ssh\ncat id_ed25519",
+        "cat ~/.azure/accessTokens.json",
+        "grep -R token ~/.hermes",
+        "rg token ~/.config",
+        "bash -lc 'cat ~/.hermes/.env'",
+        "sh -c 'cat ~/.ssh/id_ed25519'",
+        "/usr/bin/env bash -lc 'cat ~/.hermes/.env'",
+        "echo $(cat ~/.hermes/.env)",
+        "echo $(python3 -c \"print(open('~/.hermes/.env').read())\")",
+        "echo `cat ~/.hermes/.env`",
+        "python3 <<'PY'\nprint(open('~/.hermes/.env').read())\nPY",
+        "python3.11 -c \"print(open('~/.hermes/.env').read())\"",
+        "nodejs -e \"require('fs').readFileSync('~/.hermes/.env','utf8')\"",
+        "dd if=~/.ssh/id_ed25519 of=/tmp/out",
+        "/usr/bin/env | sort",
+        "/usr/bin/env -0 | tr '\\0' '\\n'",
+        "printenv -0",
+        "cat .env",
+        "cat .env.local",
+        "cat .env.production.local",
+        "env | sort",
+        "printenv",
+    ],
+)
+def test_terminal_secret_read_commands_are_hard_blocked(isolated_home, command_template):
+    home, hermes_home = isolated_home
+    command = command_template.format(
+        hermes_env=hermes_home / ".env",
+        hermes_auth=hermes_home / "auth.json",
+        xurl=home / ".xurl",
+    )
+
+    err = file_safety.get_terminal_read_block_error(command)
+
+    assert err is not None
+    assert "Access denied" in err
+    assert "sensitive" in err.lower()
+
+
+@pytest.mark.parametrize(
+    "command,cwd",
+    [
+        ("cat .ssh/id_ed25519", "home"),
+        ("cat .aws/credentials", "home"),
+        ("cat auth.json", "hermes_home"),
+    ],
+)
+def test_terminal_secret_read_commands_resolve_relative_to_cwd(isolated_home, command, cwd):
+    home, hermes_home = isolated_home
+    cwd_path = home if cwd == "home" else hermes_home
+
+    err = file_safety.get_terminal_read_block_error(command, cwd=str(cwd_path))
+
+    assert err is not None
+    assert "Access denied" in err
+    assert "sensitive" in err.lower()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cat .env.example",
+        "python3 -m pytest tests/tools/test_file_read_guards.py",
+        "env FOO=bar python3 scripts/build.py",
+        "/usr/bin/env FOO=bar python3 scripts/build.py",
+        "bash -lc 'python3 -m pytest tests/tools/test_file_read_guards.py'",
+        "printenv PATH",
+    ],
+)
+def test_terminal_guard_allows_common_non_secret_commands(isolated_home, command):
+    assert file_safety.get_terminal_read_block_error(command) is None
+
+
+def test_terminal_tool_blocks_sensitive_reads_before_execution(isolated_home):
+    _home, hermes_home = isolated_home
+
+    result = json.loads(terminal_tool(f"cat {hermes_home / '.env'}"))
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "sensitive" in result["error"].lower()
+
+
+def test_terminal_tool_blocks_relative_sensitive_reads_with_workdir(isolated_home):
+    _home, hermes_home = isolated_home
+
+    result = json.loads(terminal_tool("cat auth.json", workdir=str(hermes_home)))
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "sensitive" in result["error"].lower()
+
+
+def test_terminal_tool_blocks_recursive_project_env_grep_before_execution(isolated_home):
+    home, _hermes_home = isolated_home
+    project = home / "projects" / "grep-target"
+    project.mkdir(parents=True)
+    (project / ".env").write_text("FAKE_GREP_SECRET=do-not-read\n", encoding="utf-8")
+
+    result = json.loads(terminal_tool("grep -R FAKE_GREP_SECRET .", workdir=str(project)))
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "sensitive" in result["error"].lower()
+
+
+@pytest.mark.parametrize("command", ["grep -R FAKE_GREP_SECRET", "rg --hidden FAKE_GREP_SECRET"])
+def test_terminal_guard_blocks_implicit_cwd_recursive_searches(isolated_home, command):
+    home, _hermes_home = isolated_home
+    project = home / "projects" / "implicit-grep-target"
+    project.mkdir(parents=True)
+    (project / ".env").write_text("FAKE_GREP_SECRET=do-not-read\n", encoding="utf-8")
+
+    err = file_safety.get_terminal_read_block_error(command, cwd=str(project))
+
+    assert err is not None
+    assert "sensitive" in err.lower()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,7 +8,26 @@ import os
 import threading
 from pathlib import Path
 
-from agent.file_safety import get_read_block_error
+try:
+    from agent.file_safety import get_read_block_error, get_search_block_error
+except ImportError:
+    # Some tests intentionally replace the agent package while loading this file
+    # directly from a worktree. Fall back to the sibling source file so safety
+    # guards still run against the code being tested instead of a stale editable
+    # install from another checkout.
+    import importlib.util as _importlib_util
+
+    _file_safety_path = Path(__file__).resolve().parents[1] / "agent" / "file_safety.py"
+    _file_safety_spec = _importlib_util.spec_from_file_location(
+        "_hermes_file_safety_fallback",
+        _file_safety_path,
+    )
+    if _file_safety_spec is None or _file_safety_spec.loader is None:
+        raise
+    _file_safety_module = _importlib_util.module_from_spec(_file_safety_spec)
+    _file_safety_spec.loader.exec_module(_file_safety_module)
+    get_read_block_error = _file_safety_module.get_read_block_error
+    get_search_block_error = _file_safety_module.get_search_block_error
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -473,9 +492,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        # ── Hermes internal path guard ────────────────────────────────
-        # Prevent prompt injection via catalog or hub metadata files.
-        block_error = get_read_block_error(path)
+        # ── Sensitive read guard ──────────────────────────────────────
+        # Prevent prompt injection from reading credential stores. Check the
+        # same task-resolved path that the eventual file I/O will use.
+        block_error = get_read_block_error(str(_resolved))
         if block_error:
             return json.dumps({"error": block_error})
 
@@ -950,6 +970,14 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+
+        # Block explicit attempts to search credential stores. Content search can
+        # expose the same secrets as read_file, so apply the shared read guard to
+        # the same task-resolved root that the eventual search will use.
+        _resolved = _resolve_path_for_task(path, task_id)
+        block_error = get_search_block_error(str(_resolved))
+        if block_error:
+            return json.dumps({"error": block_error})
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -56,6 +56,23 @@ logger = logging.getLogger(__name__)
 # long-running subprocesses immediately instead of blocking until timeout.
 # ---------------------------------------------------------------------------
 from tools.interrupt import is_interrupted, _interrupt_event  # noqa: F401 — re-exported
+try:
+    from agent.file_safety import get_terminal_read_block_error
+except ImportError:
+    # Some tests intentionally replace the agent package while loading this file
+    # directly from a worktree. Fall back to the sibling source file so safety
+    # guards still run against the code being tested instead of a stale editable
+    # install from another checkout.
+    _file_safety_path = Path(__file__).resolve().parents[1] / "agent" / "file_safety.py"
+    _file_safety_spec = importlib.util.spec_from_file_location(
+        "_hermes_file_safety_fallback",
+        _file_safety_path,
+    )
+    if _file_safety_spec is None or _file_safety_spec.loader is None:
+        raise
+    _file_safety_module = importlib.util.module_from_spec(_file_safety_spec)
+    _file_safety_spec.loader.exec_module(_file_safety_module)
+    get_terminal_read_block_error = _file_safety_module.get_terminal_read_block_error
 # display_hermes_home imported lazily at call site (stale-module safety during hermes update)
 
 
@@ -1713,6 +1730,20 @@ def terminal_tool(
         cwd = overrides.get("cwd") or config["cwd"]
         default_timeout = config["timeout"]
         effective_timeout = timeout or default_timeout
+
+        with _env_lock:
+            existing_env = _active_environments.get(effective_task_id)
+        secret_read_error = get_terminal_read_block_error(
+            command,
+            cwd=workdir or getattr(existing_env, "cwd", None) or cwd,
+        )
+        if secret_read_error:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": secret_read_error,
+                "status": "error",
+            }, ensure_ascii=False)
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.


### PR DESCRIPTION
## Summary
- add shared hard blocks for direct reads/searches of local credential stores such as Hermes env/auth files, SSH/AWS/Azure/GitHub/GCloud credential paths, and real `.env*` files
- wire the guard into `read_file`, `search_files`, and terminal command execution before I/O happens
- add regression coverage for direct file reads, recursive search roots, shell wrappers, command substitution/backticks, heredoc/interpreter reads, env dumps, and recursive grep/rg of project roots containing `.env`

## Verification
- `scripts/run_tests.sh tests/agent/test_sensitive_read_blocks.py tests/tools/test_file_read_guards.py tests/tools/test_terminal_tool.py tests/tools/test_managed_browserbase_and_modal.py -q` -> 129 passed
- `venv/bin/python -m py_compile agent/file_safety.py tools/file_tools.py tools/terminal_tool.py tests/agent/test_sensitive_read_blocks.py`
- full-suite check on this branch: `scripts/run_tests.sh -q` -> 8 failures, 22538 passed, 61 skipped; failures are pre-existing/order-related and outside this diff
- baseline `origin/main` full-suite comparison: `scripts/run_tests.sh -q` -> 29 failures, 22446 passed, 61 skipped

Security note: this is a focused recovery/packaging of the sensitive-read hardening that was previously stranded in an autostash, with additional bypass tests/fixes added before commit.
