### PR TITLE
fix(dashboard): allow reverse proxy hosts

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -176,6 +176,19 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
 
+    # Operator-configured reverse-proxy hostnames. This is intentionally
+    # narrow and explicit so localhost binds can be safely published through
+    # a trusted private proxy such as Tailscale Serve without switching the
+    # dashboard to all-interface/insecure mode.
+    extra_hosts_raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    extra_hosts = {
+        item.strip().lower().rsplit(":", 1)[0]
+        for item in extra_hosts_raw.split(",")
+        if item.strip()
+    }
+    if host_only in extra_hosts:
+        return True
+
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
     # defence can protect that mode; rely on operator network controls.

--- a/tests/hermes_cli/test_dashboard_allowed_hosts.py
+++ b/tests/hermes_cli/test_dashboard_allowed_hosts.py
@@ -1,0 +1,39 @@
+"""Tests for dashboard reverse-proxy Host allowlisting."""
+
+from hermes_cli.web_server import _is_accepted_host
+
+
+def test_dashboard_allowed_hosts_accepts_explicit_host(monkeypatch):
+    monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "dashboard.tailnet.example")
+
+    assert _is_accepted_host("dashboard.tailnet.example", "127.0.0.1") is True
+    assert _is_accepted_host("dashboard.tailnet.example:443", "127.0.0.1") is True
+
+
+def test_dashboard_allowed_hosts_keeps_unlisted_host_blocked(monkeypatch):
+    monkeypatch.setenv("HERMES_DASHBOARD_ALLOWED_HOSTS", "dashboard.tailnet.example")
+
+    assert _is_accepted_host("evil.example", "127.0.0.1") is False
+
+
+def test_dashboard_allowed_hosts_does_not_enable_wildcards(monkeypatch):
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_ALLOWED_HOSTS",
+        "*, *.example.test, .example.org",
+    )
+
+    assert _is_accepted_host("evil.example", "127.0.0.1") is False
+    assert _is_accepted_host("dashboard.example.test", "127.0.0.1") is False
+    assert _is_accepted_host("sub.example.org", "127.0.0.1") is False
+
+
+def test_dashboard_allowed_hosts_trims_comma_separated_hosts(monkeypatch):
+    monkeypatch.setenv(
+        "HERMES_DASHBOARD_ALLOWED_HOSTS",
+        " dashboard.tailnet.example , alt.example:8443,\tMIXED.Example ",
+    )
+
+    assert _is_accepted_host("dashboard.tailnet.example", "127.0.0.1") is True
+    assert _is_accepted_host("alt.example:443", "127.0.0.1") is True
+    assert _is_accepted_host("mixed.example", "127.0.0.1") is True
+    assert _is_accepted_host("missing.example", "127.0.0.1") is False


### PR DESCRIPTION
## Summary
- Adds explicit dashboard reverse-proxy host allowlisting via `HERMES_DASHBOARD_ALLOWED_HOSTS`.
- Keeps unlisted hosts blocked and avoids wildcard-style bypass behavior.
- Adds focused tests for allowed proxy host parsing and matching.

## Files changed
- `hermes_cli/web_server.py`
- `tests/hermes_cli/test_dashboard_allowed_hosts.py`

## Test commands/results
```bash
python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_dashboard_allowed_hosts.py
venv/bin/python -m pytest tests/hermes_cli/test_dashboard_allowed_hosts.py -q
```

Result:
```text
4 passed in 3.02s
```

## Live impact
- Enables operator-approved reverse proxy hostnames for the dashboard.
- Does not set any live environment variables.
- Does not restart or modify any running service.

## Restart/reload needed
- If the dashboard/web server is already running, restart that dashboard/web process after merge/deploy.
- If the dashboard is served through a long-running Hermes process, restart that process after approval.

## Known caveats
- Security-sensitive Host header behavior; reviewers should verify allowlist semantics carefully.
- No live env var was set and no live dashboard process was restarted.
