### PR TITLE
fix(models): prioritize Ollama Cloud models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3031,6 +3031,10 @@ def fetch_api_models(
 
 
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
+_OLLAMA_CLOUD_PREFERRED_PREFIXES = (
+    "qwen3.5",
+    "gemma4",
+)
 
 
 def _strip_ollama_cloud_suffix(model_id: str) -> str:
@@ -3044,6 +3048,36 @@ def _strip_ollama_cloud_suffix(model_id: str) -> str:
         if model_id.endswith(suffix):
             return model_id[: -len(suffix)]
     return model_id
+
+
+def _prioritize_ollama_cloud_models(models: list[str]) -> list[str]:
+    """Keep owner-preferred Ollama Cloud families at the top when present.
+
+    The catalog itself remains live/dynamic; this only reorders IDs already
+    returned by Ollama Cloud/models.dev so every available model remains shown.
+    """
+    preferred: list[str] = []
+    remainder: list[str] = []
+    seen: set[str] = set()
+
+    for prefix in _OLLAMA_CLOUD_PREFERRED_PREFIXES:
+        prefix_l = prefix.lower()
+        for model_id in models:
+            mid = str(model_id or "").strip()
+            if not mid or mid in seen:
+                continue
+            if mid.lower().startswith(prefix_l):
+                seen.add(mid)
+                preferred.append(mid)
+
+    for model_id in models:
+        mid = str(model_id or "").strip()
+        if not mid or mid in seen:
+            continue
+        seen.add(mid)
+        remainder.append(mid)
+
+    return preferred + remainder
 
 
 def _ollama_cloud_cache_path() -> Path:
@@ -3146,6 +3180,7 @@ def fetch_ollama_cloud_models(
                 seen.add(normalized)
                 merged.append(normalized)
         if merged:
+            merged = _prioritize_ollama_cloud_models(merged)
             _save_ollama_cloud_cache(merged)
             return merged
 

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -197,12 +197,29 @@ class TestOllamaCloudMergedDiscovery:
              patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
             result = fetch_ollama_cloud_models(force_refresh=True)
 
-        # Live models first, then models.dev additions (deduped)
+        # Preferred Ollama Cloud families are pinned first, then live/models.dev
+        # ordering is preserved for the rest.
         assert result[0] == "qwen3.5:397b"  # from live API
         assert result[1] == "glm-5"          # from live API (also in models.dev)
         assert "kimi-k2.5" in result         # from models.dev only
         assert "nemotron-3-super" in result  # from models.dev only
         assert result.count("glm-5") == 1    # no duplicates
+
+    def test_prioritizes_owner_quick_access_models(self, tmp_path, monkeypatch):
+        """Qwen 3.5 and Gemma 4 stay at the top when present."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["glm-5", "gemma4:31b", "qwen3.5:397b", "kimi-k2.6"],
+        ), patch("agent.models_dev.fetch_models_dev", return_value={}):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+
+        assert result[:2] == ["qwen3.5:397b", "gemma4:31b"]
+        assert result[2:] == ["glm-5", "kimi-k2.6"]
 
     def test_falls_back_to_models_dev_without_api_key(self, tmp_path, monkeypatch):
         """Without API key, only models.dev results are returned."""


### PR DESCRIPTION
## Summary
- Prioritizes Ollama Cloud models in model listing/selection behavior.
- Updates focused tests for Ollama Cloud provider ordering.

## Files changed
- `hermes_cli/models.py`
- `tests/hermes_cli/test_ollama_cloud_provider.py`

## Test commands/results
```bash
python3 -m py_compile hermes_cli/models.py tests/hermes_cli/test_ollama_cloud_provider.py
venv/bin/python -m pytest tests/hermes_cli/test_ollama_cloud_provider.py -q
```

Result:
```text
46 passed
```

## Live impact
- Affects Hermes CLI/runtime model listing and selection paths when running updated code.
- No gateway platform behavior changed.
- No running service was restarted or modified.

## Restart/reload needed
- CLI use picks this up when run from the updated checkout/install.
- Existing long-running processes need restart/relaunch only if they rely on this model-listing code path.
- No gateway restart is specifically required unless the gateway process itself must refresh this code.

## Known caveats
- Targeted Ollama Cloud tests passed.
- Optional broader sweep before merge:
```bash
venv/bin/python -m pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_ollama_cloud_provider.py -q
```
