### PR TITLE
Add Quinn Ops and Docs MCP groundwork

### DIFF
--- a/docs/quinn_approval_ops_mcp_plan.md
+++ b/docs/quinn_approval_ops_mcp_plan.md
@@ -1,0 +1,278 @@
+# Approval-Gated Ops MCP Integration Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Design a tightly gated operations MCP for safe, auditable Hermes maintenance actions such as gateway restart, MCP reload, config backup, doctor runs, and applying pre-reviewed patches.
+
+**Architecture:** Keep this MCP separate from read-only awareness MCPs. Version 1 should implement a two-step prepare/execute protocol: tools generate an action plan and approval challenge; execution only proceeds when Frank supplies the exact approval phrase for the exact plan. If approval cannot be verified, the MCP refuses to act.
+
+**Tech Stack:** Python 3.11, MCP SDK, subprocess argv execution with `shell=False`, JSON action manifests, pytest with monkeypatched command runner and temp files.
+
+---
+
+## Non-Negotiable Rules
+
+- No action runs from a single casual tool call.
+- Every mutation requires a prior `prepare_*` call and a matching approval phrase.
+- No broad shell execution tool.
+- No arbitrary command strings.
+- No edits to private auth or environment files.
+- No destructive git actions in v1.
+- No service stop without restart intent and rollback/verification plan.
+- Every execution returns command argv metadata, exit code, verification result, and backup path where relevant.
+- Every action has a dry-run/plan mode.
+
+## Action Model
+
+Each operation uses an action manifest with:
+
+- schema version
+- action ID
+- action type
+- created/expires timestamps
+- `requires_approval=true`
+- exact approval phrase
+- argv command list
+- verification argv list
+- rollback notes if any
+
+Prepared manifests are stored under:
+
+- `$HERMES_HOME/mcp/quinn_ops_actions/pending/`
+
+Completed manifests are moved to:
+
+- `$HERMES_HOME/mcp/quinn_ops_actions/completed/`
+
+Use mode `0600` where possible.
+
+## Tool Set v1
+
+Read/prepare tools:
+
+1. `healthcheck()` — server readiness and action directory metadata.
+2. `list_allowed_actions()` — static action definitions and risk levels.
+3. `prepare_gateway_restart(reason: str)` — builds action manifest, no execution.
+4. `prepare_mcp_reload(reason: str)` — builds reload/restart manifest, no execution.
+5. `prepare_config_backup(reason: str)` — builds backup manifest, no execution.
+6. `prepare_doctor_run(reason: str)` — builds diagnostic manifest, no execution.
+7. `prepare_safe_patch(path_alias: str, patch_text: str, reason: str)` — only for allowlisted paths, no execution.
+8. `get_pending_action(action_id: str)` — returns manifest metadata.
+9. `cancel_pending_action(action_id: str)` — marks pending action cancelled; this is a state write but not a system mutation.
+
+Execute tool:
+
+10. `execute_approved_action(action_id: str, approval_phrase: str)` — validates manifest, expiration, exact phrase, and allowed command argv before execution.
+
+## Allowed Actions v1
+
+### Gateway Restart
+
+Commands:
+
+```bash
+hermes gateway restart
+hermes gateway status
+hermes mcp test quinn_ops
+```
+
+Risk: medium. Interrupts current gateway sessions briefly.
+
+### MCP Reload/Restart
+
+Preferred sequence:
+
+```bash
+hermes mcp list
+hermes gateway restart
+hermes mcp test <server>
+```
+
+Risk: medium.
+
+### Config Backup
+
+Allowed source:
+
+- `/home/quinn/.hermes/config.yaml`
+
+Allowed destination:
+
+- `/home/quinn/.hermes/backups/config.yaml.<timestamp>.bak`
+
+Risk: low. Must not print file contents.
+
+### Doctor Run
+
+Commands:
+
+```bash
+hermes doctor
+```
+
+Risk: low read/diagnostic. Must sanitize output.
+
+### Safe Patch
+
+Allowed targets v1:
+
+- source-of-truth Markdown docs
+- MCP server files under `/home/quinn/.hermes/hermes-agent/scripts/mcp/`
+- matching tests under `/home/quinn/.hermes/hermes-agent/tests/`
+
+Excluded targets:
+
+- private auth/environment files
+- session stores
+- logs
+- arbitrary platform adapters unless explicitly added later
+
+Risk: medium/high depending target. Must backup target first and run verification command after patch.
+
+## Task 1: Add Failing Manifest and Approval Tests
+
+**Objective:** Prove no mutation can happen without explicit two-step approval.
+
+**Files:**
+- Create: `tests/test_quinn_approval_ops_mcp.py`
+
+**Tests:**
+- `prepare_gateway_restart()` creates manifest and does not execute command runner.
+- `execute_approved_action()` rejects missing/incorrect approval phrase.
+- Expired action is rejected.
+- Unknown action ID is rejected.
+- Manifest command argv must match allowlisted action spec.
+
+**Verification:**
+```bash
+venv/bin/python -m pytest tests/test_quinn_approval_ops_mcp.py -q
+```
+
+Expected: FAIL until server exists.
+
+## Task 2: Scaffold Server and Action Store
+
+**Objective:** Create importable server with safe action persistence.
+
+**Files:**
+- Create: `scripts/mcp/quinn_approval_ops_server.py`
+- Modify: `tests/test_quinn_approval_ops_mcp.py`
+
+**Implementation requirements:**
+- `response()`, `sanitize()`, `now_utc()`, `action_dir()` helpers.
+- `create_action_manifest(action_type, reason, commands, verification, rollback)`.
+- Atomic manifest writes with mode `0600`.
+- Importable without MCP SDK.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_approval_ops_server.py tests/test_quinn_approval_ops_mcp.py
+venv/bin/python -m pytest tests/test_quinn_approval_ops_mcp.py -q
+```
+
+## Task 3: Prepare Gateway Restart and Config Backup
+
+**Objective:** Implement low-complexity prepare flows.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_approval_ops_server.py`
+- Modify: `tests/test_quinn_approval_ops_mcp.py`
+
+**Implementation requirements:**
+- `prepare_gateway_restart(reason)` creates restart manifest with verification steps.
+- `prepare_config_backup(reason)` creates backup manifest with exact source/destination.
+- No command runner call during prepare.
+- Approval phrase includes action ID and action type.
+
+## Task 4: Execute Approved Action
+
+**Objective:** Safely run only validated pending manifests.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_approval_ops_server.py`
+- Modify: `tests/test_quinn_approval_ops_mcp.py`
+
+**Implementation requirements:**
+- Validate action exists, is pending, is unexpired, has matching phrase, and matches static allowlist.
+- Run commands with `shell=False` and timeouts.
+- Run verification commands after mutation commands.
+- Move manifest to completed with result summary.
+- Never print raw config contents.
+
+## Task 5: Doctor Run and MCP Reload Prepare Flows
+
+**Objective:** Add diagnostic and MCP refresh operations.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_approval_ops_server.py`
+- Modify: `tests/test_quinn_approval_ops_mcp.py`
+
+**Implementation requirements:**
+- `prepare_doctor_run(reason)` uses read/diagnostic command and sanitized output.
+- `prepare_mcp_reload(reason)` uses list/restart/test sequence.
+- Optional server name input must match known safe pattern.
+
+## Task 6: Safe Patch Prepare Flow
+
+**Objective:** Allow pre-reviewed patch application only to allowlisted paths.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_approval_ops_server.py`
+- Modify: `tests/test_quinn_approval_ops_mcp.py`
+
+**Implementation requirements:**
+- Accept structured patch text only.
+- Resolve target paths and reject excluded paths.
+- Backup target files before patch during execution.
+- Use Python patch/apply helper or `git apply --check` then `git apply` with argv only.
+- Verification command is required per target type.
+
+## Task 7: Register MCP Tools and Docs
+
+**Objective:** Make server usable and documented without live enablement.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_approval_ops_server.py`
+- Create: `docs/quinn_approval_ops_mcp.md`
+
+**Implementation requirements:**
+- Add `TOOL_FUNCTIONS` and MCP stdio startup.
+- Document action model, approval phrases, allowed actions, excluded paths, live promotion steps.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_approval_ops_server.py tests/test_quinn_approval_ops_mcp.py
+venv/bin/python -m pytest tests/test_quinn_approval_ops_mcp.py -q
+```
+
+## Live Promotion Gate
+
+This MCP is operationally sensitive. Before live use:
+
+1. Frank approval.
+2. Dedicated code review.
+3. Repo tests pass.
+4. Confirm platform approval flow can carry exact approval phrase.
+5. Backup existing live server, if any.
+6. Copy server to live MCP path.
+7. Add MCP config only if approved.
+8. Restart gateway.
+9. Verify `hermes mcp test quinn_approval_ops`.
+10. Dry-run prepare/cancel flow before any execute flow.
+
+## Acceptance Criteria
+
+- No mutation can happen without prepare plus exact approval phrase.
+- No arbitrary shell command execution exists.
+- Every command is argv-list allowlisted.
+- Every state-changing operation records a manifest and result.
+- Config backups never print config contents.
+- Safe patch flow rejects excluded paths and backs up targets.
+- Gateway restart and MCP reload include post-action verification.
+
+## Open Questions Requiring Frank
+
+1. Should the approval phrase be manually typed by Frank, or can Hermes gateway approval metadata be trusted directly?
+2. Should safe patch be included in v1, or deferred until after restart/backup/doctor actions prove stable?
+3. Should completed action manifests be retained forever or pruned after a retention window?
+4. Should this MCP be available only in protected/private contexts?

--- a/docs/quinn_docs_mcp.md
+++ b/docs/quinn_docs_mcp.md
@@ -1,0 +1,73 @@
+# Quinn Docs/Notes MCP
+
+Repo-side implementation notes for the scoped Quinn Docs/Notes MCP server.
+
+## Purpose
+
+`quinn_docs` gives Quinn a read-first, proposal-only interface to selected Quinn/Hermes source-of-truth documents. It is designed for safer maintenance workflows where the agent can inspect approved docs, find relevant sections, and prepare text-only patch proposals without browsing arbitrary files or mutating anything.
+
+## Files
+
+- Server: `scripts/mcp/quinn_docs_server.py`
+- Tests: `tests/test_quinn_docs_mcp.py`
+- Plan: `docs/quinn_docs_mcp_plan.md`
+
+## Security Boundaries
+
+Version 1 is intentionally narrow:
+
+- Exact document IDs only; raw paths are rejected.
+- No arbitrary filesystem browsing.
+- No private runtime files, transcript directories, logs, or environment files.
+- No writes or mutations.
+- Excerpts are bounded by line count and character budget.
+- Returned text is redacted before it leaves the server.
+- Search returns document IDs, titles, line numbers, and snippets only.
+- Patch proposals are text templates only and are not applied.
+
+## Document Registry
+
+The server keeps an in-code `DOC_REGISTRY` mapping stable document IDs to exact paths. Public responses expose `doc_id` and `path_alias`, not absolute local paths.
+
+Current registry includes:
+
+- `quinn-hermes-server`
+- `quinn-ops-mcp`
+- `quinn-ops-snapshot-design`
+- `quinn-github-mcp-plan`
+- `quinn-observability-mcp-plan`
+- `quinn-docs-mcp-plan`
+- `quinn-approval-ops-mcp-plan`
+
+## Tools
+
+- `healthcheck()` — readiness, document counts, read-only flag.
+- `list_documents()` — metadata for allowlisted docs.
+- `get_document_outline(doc_id)` — Markdown headings with line numbers.
+- `search_documents(query, limit=20)` — bounded literal search across allowlisted docs.
+- `read_document_excerpt(doc_id, start_line=1, limit=80)` — bounded redacted excerpts.
+- `get_document_summary(doc_id)` — metadata plus heading outline.
+- `check_source_of_truth_freshness()` — missing-doc and required-heading warnings.
+- `propose_document_patch(doc_id, change_request)` — approval-required patch template only.
+
+## Non-goals
+
+- Live installation.
+- Gateway restart.
+- Runtime MCP config edits.
+- Editing documents directly.
+- General file browsing.
+- Private-value inspection.
+
+## Live Promotion
+
+Do not promote automatically. Live use requires explicit operator approval, then a separate controlled flow to copy the server into the live MCP path, edit MCP config, restart the gateway, and verify denied paths plus redacted excerpts.
+
+## Verification
+
+Repo-side verification:
+
+```bash
+python3 -m py_compile scripts/mcp/quinn_docs_server.py tests/test_quinn_docs_mcp.py
+venv/bin/python -m pytest tests/test_quinn_docs_mcp.py -q
+```

--- a/docs/quinn_docs_mcp_plan.md
+++ b/docs/quinn_docs_mcp_plan.md
@@ -1,0 +1,219 @@
+# Scoped Docs and Notes MCP Integration Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a scoped docs/notes MCP that lets Quinn search, summarize, and propose edits to selected Hermes/Quinn source-of-truth documents without browsing arbitrary files or exposing private values.
+
+**Architecture:** Build a local stdio MCP server with an explicit document allowlist. Version 1 is read-first: it inventories approved documents, searches headings/content, returns bounded excerpts, and can generate proposed patch text without applying changes. Actual writes are deferred to a later approval-gated phase.
+
+**Tech Stack:** Python 3.11, MCP SDK, pathlib, regex, markdown heading parser, pytest with temp document fixtures.
+
+---
+
+## Security Contract
+
+- No arbitrary filesystem browsing.
+- Only exact allowlisted paths and allowlisted directories are visible.
+- No auth files, session transcript directories, logs, or env files.
+- No writes in v1.
+- Excerpts are bounded by line count and character count.
+- Redaction runs on all returned text.
+- Search results return path aliases and line numbers, not hidden absolute paths unless approved.
+- Proposed edits are returned as text patches only; they are not applied.
+
+## Initial Allowlist Proposal
+
+Exact files:
+
+- `/home/quinn/docs/quinn-hermes-server.md`
+- `/home/quinn/.hermes/hermes-agent/docs/quinn_ops_mcp.md`
+- `/home/quinn/.hermes/hermes-agent/docs/quinn_ops_snapshot_diff_design.md`
+- `/home/quinn/.hermes/hermes-agent/docs/quinn_ops_github_mcp_plan.md`
+- `/home/quinn/.hermes/hermes-agent/docs/quinn_ops_observability_mcp_plan.md`
+
+Optional exact files after review:
+
+- `/home/quinn/quinn/docs/QUINN_V1_V35_INSTALL_REPORT.md`
+- `/home/quinn/docs/quinn-hermes-server.md`
+- `/home/quinn/quinn/runtime/quinn_loader_order.json` metadata only, not raw full dump unless approved
+
+Do not allow:
+
+- `/home/quinn/.hermes/.env`
+- `/home/quinn/.hermes/auth.json`
+- `/home/quinn/.hermes/sessions/`
+- `/home/quinn/.hermes/logs/`
+- arbitrary `/home/quinn/quinn/runtime/` private runtime files
+
+## Tool Set v1
+
+1. `healthcheck()` — server readiness and allowlist counts.
+2. `list_documents()` — aliases, titles, size, mtime, type, readability.
+3. `get_document_outline(doc_id: str)` — Markdown headings and line numbers.
+4. `search_documents(query: str, limit: int = 20)` — bounded search across allowlisted docs.
+5. `read_document_excerpt(doc_id: str, start_line: int = 1, limit: int = 80)` — bounded redacted excerpt.
+6. `get_document_summary(doc_id: str)` — metadata plus heading outline and short non-LLM extractive summary.
+7. `check_source_of_truth_freshness()` — reports stale/missing source-of-truth docs by metadata and expected headings.
+8. `propose_document_patch(doc_id: str, change_request: str)` — returns a safe patch proposal template; does not apply.
+
+## Task 1: Add Failing Allowlist Tests
+
+**Objective:** Prove only approved docs can be accessed.
+
+**Files:**
+- Create: `tests/test_quinn_docs_mcp.py`
+
+**Tests:**
+- Allowlisted document can be listed/read.
+- Non-allowlisted path is rejected.
+- Path traversal is rejected.
+- Auth/env/session/log-like paths are rejected even if user asks directly.
+- Redaction removes private-looking values from fixture text.
+
+**Verification:**
+```bash
+venv/bin/python -m pytest tests/test_quinn_docs_mcp.py -q
+```
+
+Expected: FAIL until server exists.
+
+## Task 2: Scaffold Server and Document Registry
+
+**Objective:** Create importable server with strict document identity mapping.
+
+**Files:**
+- Create: `scripts/mcp/quinn_docs_server.py`
+- Modify: `tests/test_quinn_docs_mcp.py`
+
+**Implementation requirements:**
+- `DOC_REGISTRY` maps stable doc IDs to exact paths.
+- `resolve_doc_id(doc_id)` never accepts raw paths.
+- `response()`, `sanitize()`, `file_meta()` helpers.
+- Importable without MCP SDK.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_docs_server.py tests/test_quinn_docs_mcp.py
+venv/bin/python -m pytest tests/test_quinn_docs_mcp.py -q
+```
+
+## Task 3: List Documents and Outlines
+
+**Objective:** Provide safe document discovery.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_docs_server.py`
+- Modify: `tests/test_quinn_docs_mcp.py`
+
+**Implementation requirements:**
+- `list_documents()` returns doc ID, title, size, mtime, exists, and doc type.
+- `get_document_outline()` parses Markdown headings with line numbers.
+- JSON files return top-level keys only, not full raw content unless specifically allowed.
+
+**Tests:**
+- Markdown headings parsed correctly.
+- Missing doc returns metadata and warning.
+- JSON metadata-only behavior works.
+
+## Task 4: Search and Excerpts
+
+**Objective:** Let Quinn find relevant source-of-truth content safely.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_docs_server.py`
+- Modify: `tests/test_quinn_docs_mcp.py`
+
+**Implementation requirements:**
+- `search_documents(query, limit=20)` searches allowlisted Markdown text.
+- Clamp query length and result limit.
+- Return doc ID, title, line number, and short redacted snippet.
+- `read_document_excerpt(doc_id, start_line=1, limit=80)` clamps line count and character total.
+
+**Tests:**
+- Search finds expected lines.
+- Excerpt clamps line count.
+- Private fixture values are redacted.
+- Query cannot be used as a regex denial-of-service vector.
+
+## Task 5: Freshness Checks
+
+**Objective:** Surface stale or missing source-of-truth docs without reading everything.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_docs_server.py`
+- Modify: `tests/test_quinn_docs_mcp.py`
+
+**Implementation requirements:**
+- `check_source_of_truth_freshness()` verifies required docs exist.
+- Report missing expected headings like `Change Log`, `Security Boundaries`, or `Live Promotion` where relevant.
+- Report mtime age and size changes, not content diffs.
+
+**Tests:**
+- Missing file -> warning.
+- Missing heading -> warning.
+- Healthy docs -> ok.
+
+## Task 6: Patch Proposal Only
+
+**Objective:** Prepare edits without applying them.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_docs_server.py`
+- Modify: `tests/test_quinn_docs_mcp.py`
+
+**Implementation requirements:**
+- `propose_document_patch(doc_id, change_request)` returns a patch template or TODO checklist.
+- It must not call write/patch/file mutation APIs.
+- It must include `requires_approval=true`.
+- It must include doc ID and target section.
+
+**Tests:**
+- Patch proposal contains no applied side effects.
+- Denied doc cannot receive proposal.
+- Proposal result says approval required.
+
+## Task 7: Register MCP Tools and Docs
+
+**Objective:** Make the server usable and documented without live enablement.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_docs_server.py`
+- Create: `docs/quinn_docs_mcp.md`
+
+**Implementation requirements:**
+- Add `TOOL_FUNCTIONS` and MCP stdio startup.
+- Document registry, tools, non-goals, security boundaries, and live promotion steps.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_docs_server.py tests/test_quinn_docs_mcp.py
+venv/bin/python -m pytest tests/test_quinn_docs_mcp.py -q
+```
+
+## Live Promotion Gate
+
+Do not promote automatically. Before live use:
+
+1. Frank approval.
+2. Confirm exact document registry.
+3. Repo tests pass.
+4. Backup existing live server, if any.
+5. Copy repo server to live MCP path.
+6. Add MCP config only if approved.
+7. Restart gateway.
+8. Verify `hermes mcp test quinn_docs`.
+9. Verify denied paths fail and allowlisted excerpts are redacted.
+
+## Acceptance Criteria
+
+- No arbitrary path access.
+- No write actions in v1.
+- Allowlisted docs can be listed, outlined, searched, and excerpted.
+- Runtime JSON files are metadata/top-level only unless specifically approved.
+- Patch proposals require approval and do not mutate files.
+
+## Open Questions Requiring Frank
+
+1. Which exact docs belong in the first allowlist?
+2. Should Quinn runtime JSON be metadata-only forever, or can protected contexts read bounded raw sections?
+3. Should v1 support patch proposal text, or should even proposals wait for approval-ops MCP?

--- a/docs/quinn_ops_github_mcp_plan.md
+++ b/docs/quinn_ops_github_mcp_plan.md
@@ -1,0 +1,195 @@
+# GitHub MCP Integration Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a minimal-scope GitHub MCP integration that lets Quinn inspect issues, pull requests, branches, commits, and CI status without performing write actions by default.
+
+**Architecture:** Build a new local stdio MCP server, separate from `quinn_ops`, so GitHub access can be enabled, permissioned, and audited independently. Version 1 is read-first/read-only: it uses `gh` when available and authenticated, with an optional environment-auth fallback, and returns sanitized metadata only. Mutating GitHub actions remain out of scope until an approval-gated ops phase.
+
+**Tech Stack:** Python 3.11, MCP SDK, subprocess `gh`/`git` commands with `shell=False`, JSON responses, pytest tests with monkeypatched command runners.
+
+---
+
+## Security Contract
+
+- No GitHub writes in v1: no comments, labels, assignments, branch pushes, PR edits, merges, workflow dispatches, or reruns.
+- No auth values in output, logs, snapshots, or errors.
+- No full patch/diff bodies by default; return path/count/stat metadata unless a future gated option is approved.
+- No repository-wide content scraping; read targeted metadata from configured repositories only.
+- No private issue/PR body output by default; return titles, numbers, URLs, states, labels, authors, timestamps, CI names/conclusions, and short sanitized summaries only.
+- Auth detection reports `authenticated=true/false/unknown` and method (`gh`, `env_auth`, `none`) without exposing auth material.
+- All subprocess calls use argv lists, `shell=False`, cwd allowlist, timeouts, and redaction.
+
+## Proposed Files
+
+- Create: `scripts/mcp/quinn_github_server.py`
+- Create: `tests/test_quinn_github_mcp.py`
+- Create: `docs/quinn_github_mcp.md`
+- Optional live copy after approval: `/home/quinn/.hermes/mcp/quinn_github_server.py`
+
+## Config Shape
+
+Do not add automatically. Future live config snippet:
+
+```yaml
+mcp_servers:
+  quinn_github:
+    command: "/home/quinn/.hermes/hermes-agent/venv/bin/python"
+    args:
+      - "/home/quinn/.hermes/mcp/quinn_github_server.py"
+    timeout: 60
+    connect_timeout: 30
+    sampling:
+      enabled: false
+```
+
+Repository allowlist is required. Prefer an environment value or config value that lists exact `owner/repo` slugs. Example variable name for the MCP process:
+
+```bash
+QUINN_GITHUB_ALLOWED_REPOS=NousResearch/hermes-agent
+```
+
+## Tool Set v1
+
+1. `healthcheck()` — server readiness, auth method, allowed repo count, `gh` availability.
+2. `get_github_auth_status()` — metadata-only auth status.
+3. `list_allowed_repositories()` — returns configured allowlist only.
+4. `get_repository_summary(repo: str)` — allowlisted repo metadata.
+5. `list_pull_requests(repo: str, state: str = "open", limit: int = 20)` — PR metadata, no body.
+6. `get_pull_request_status(repo: str, number: int)` — PR metadata plus checks, no full diff.
+7. `list_issues(repo: str, state: str = "open", limit: int = 20)` — issue metadata, no body.
+8. `get_ci_status(repo: str, ref: str)` — status/check-run metadata for branch/SHA/ref.
+9. `get_recent_workflow_runs(repo: str, branch: str | None = None, limit: int = 10)` — workflow run metadata, no logs.
+
+## Task 1: Add Failing Auth and Allowlist Tests
+
+**Objective:** Lock the privacy and allowlist contract before implementation.
+
+**Files:**
+- Create: `tests/test_quinn_github_mcp.py`
+
+**Steps:**
+1. Write tests for missing allowlist, exact allowlist matching, denied repos, nested redaction, and metadata-only auth status.
+2. Run `venv/bin/python -m pytest tests/test_quinn_github_mcp.py -q`.
+3. Expected: FAIL because server file/functions do not exist yet.
+
+## Task 2: Scaffold `quinn_github_server.py`
+
+**Objective:** Provide importable MCP server skeleton and privacy helpers.
+
+**Files:**
+- Create: `scripts/mcp/quinn_github_server.py`
+- Modify: `tests/test_quinn_github_mcp.py`
+
+**Implementation requirements:**
+- Define `response(data, errors=None, warnings=None)` envelope matching `quinn_ops` style.
+- Define `sanitize()` and `redact_string()` helpers.
+- Define `allowed_repos()` parsing `QUINN_GITHUB_ALLOWED_REPOS` as comma/whitespace-separated exact slugs.
+- Define `repo_allowed(repo)` with lowercased exact slug matching.
+- Keep importable without MCP SDK; only MCP stdio startup should require SDK.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_github_server.py tests/test_quinn_github_mcp.py
+venv/bin/python -m pytest tests/test_quinn_github_mcp.py -q
+```
+
+## Task 3: Implement Safe Command Runner and Auth Status
+
+**Objective:** Add bounded subprocess execution and auth detection.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_github_server.py`
+- Modify: `tests/test_quinn_github_mcp.py`
+
+**Implementation requirements:**
+- `run_cmd(argv, source, timeout=15, cwd=None)` uses `subprocess.run(..., shell=False, text=True, capture_output=True)`.
+- Never include raw command env or auth values in errors.
+- `get_github_auth_status()` checks `gh` availability/auth and an optional environment auth as boolean-only fallback.
+- Return `auth_method` as `gh`, `env_auth`, `none`, or `unknown`.
+
+## Task 4: Repository Summary via `gh api`
+
+**Objective:** Read repository metadata for allowlisted repos only.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_github_server.py`
+- Modify: `tests/test_quinn_github_mcp.py`
+
+**Implementation requirements:**
+- Add `gh_api(path, fields=None)` helper around `gh api`.
+- `get_repository_summary(repo)` rejects non-allowlisted repo before command execution.
+- Parse safe fields: `full_name`, `private`, `default_branch`, `open_issues_count`, `pushed_at`, `updated_at`, `html_url`.
+- Do not return clone URLs containing embedded auth.
+
+## Task 5: Pull Request and Issue Listing
+
+**Objective:** Provide read-only work queue visibility.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_github_server.py`
+- Modify: `tests/test_quinn_github_mcp.py`
+
+**Implementation requirements:**
+- Implement `list_pull_requests()` using `gh pr list --json number,title,state,author,labels,isDraft,url,updatedAt`.
+- Implement `list_issues()` using `gh issue list --json number,title,state,author,labels,assignees,url,updatedAt`.
+- Clamp `limit` to safe bounds, e.g. `1..50`.
+- Sanitize author/label structures to metadata only.
+
+## Task 6: PR CI Status and Workflow Runs
+
+**Objective:** Let Quinn answer “what is blocking this PR/branch?” without reading logs.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_github_server.py`
+- Modify: `tests/test_quinn_github_mcp.py`
+
+**Implementation requirements:**
+- `get_pull_request_status(repo, number)` reads PR metadata and check status.
+- `get_ci_status(repo, ref)` reads combined statuses/check runs.
+- `get_recent_workflow_runs(repo, branch=None, limit=10)` reads run metadata only.
+- No log downloads in v1.
+- No reruns in v1.
+
+## Task 7: Register MCP Tools and Docs
+
+**Objective:** Make the server usable and documented without enabling it live.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_github_server.py`
+- Create: `docs/quinn_github_mcp.md`
+
+**Implementation requirements:**
+- Add `TOOL_FUNCTIONS` with the v1 tools.
+- Add MCP stdio startup analogous to `quinn_ops`.
+- Document config snippet, env allowlist, auth requirements, tools, security boundaries, verification.
+
+## Task 8: Live Promotion Gate
+
+**Objective:** Define the approval boundary; do not promote automatically.
+
+**Requirements before live promotion:**
+1. Frank approval.
+2. Repo tests pass.
+3. Backup any existing live `/home/quinn/.hermes/mcp/quinn_github_server.py`.
+4. Copy repo server to live MCP path.
+5. Add config only if approved and allowlist is explicit.
+6. Restart gateway.
+7. Verify `hermes mcp test quinn_github`.
+8. Verify native MCP calls return no auth material and reject non-allowlisted repos.
+
+## Acceptance Criteria
+
+- `quinn_github` cannot access a repo unless it is explicitly allowlisted.
+- All tools are read-only in v1.
+- Auth material never appears in output.
+- Issue/PR bodies and log bodies are omitted by default.
+- CI status is summarized enough to answer “green/red/pending and what failed?” without downloading raw logs.
+- Tests cover allowlist denial, auth metadata privacy, limit clamping, read-only command construction, malformed JSON, and redaction.
+
+## Open Questions Requiring Frank
+
+1. Which repositories should be in the initial allowlist?
+2. Should v1 use `gh` only, or allow environment-auth fallback?
+3. Should PR/issue titles be considered safe to show in all contexts, or should this MCP be restricted to protected contexts only?
+4. When write actions are eventually added, should they live in this MCP behind approvals or in a separate approval-ops MCP?

--- a/docs/quinn_ops_mcp.md
+++ b/docs/quinn_ops_mcp.md
@@ -1,0 +1,98 @@
+# Quinn Ops MCP
+
+`quinn_ops` is a local MCP server that gives Quinn structured operational awareness of the Hermes installation. It is intentionally **eyes only** for Hermes operations: no service restarts, no Discord/channel history access, no approval tools, and no live config mutation.
+
+The snapshot/diff extension adds one narrow self-state write so Quinn can compare the current sanitized overview against a previous sanitized baseline:
+
+- `$HERMES_HOME/mcp/quinn_ops_state/overview_snapshot.json`
+
+No other write scope is part of v1.
+
+Version 1 is public-safe/read-only by default. MCP tools may become available across configured Hermes platforms after the gateway is restarted, so outputs must not expose private logs, raw config, session transcripts, auth material, process command lines, or message content.
+
+## Files
+
+- Server: `scripts/mcp/quinn_ops_server.py`
+- Tests: `tests/test_quinn_ops_mcp.py`
+- Snapshot/diff design: `docs/quinn_ops_snapshot_diff_design.md`
+
+For live use, copy the server to:
+
+```bash
+mkdir -p /home/quinn/.hermes/mcp
+cp /home/quinn/.hermes/hermes-agent/scripts/mcp/quinn_ops_server.py /home/quinn/.hermes/mcp/quinn_ops_server.py
+```
+
+## Config Snippet
+
+Do not add this automatically during development. Add it manually when ready:
+
+```yaml
+mcp_servers:
+  quinn_ops:
+    command: "/home/quinn/.hermes/hermes-agent/venv/bin/python"
+    args:
+      - "/home/quinn/.hermes/mcp/quinn_ops_server.py"
+    timeout: 60
+    connect_timeout: 30
+    sampling:
+      enabled: false
+```
+
+Use the Hermes venv Python here if the MCP SDK is installed into the Hermes runtime venv. A bare `python` may resolve to a different interpreter and fail to import `mcp`.
+
+Adding or removing MCP servers requires restarting Hermes/gateway. Promote repo changes live only after review, tests, backup of the previous live server, copy to `/home/quinn/.hermes/mcp/quinn_ops_server.py`, gateway restart, and MCP verification. Do not edit live config unless the task explicitly requires it.
+
+## Verification
+
+```bash
+python /home/quinn/.hermes/mcp/quinn_ops_server.py
+hermes mcp test quinn_ops
+hermes mcp list
+```
+
+If the Python MCP SDK is not installed, direct stdio startup fails with a structured missing-dependency error. The collector functions and tests still import without the SDK.
+
+## Tools
+
+- `get_overview()`
+- `get_gateway_status()`
+- `get_platform_status()`
+- `get_mcp_status()`
+- `get_toolsets_status()`
+- `get_cron_status()`
+- `get_sessions_summary()`
+- `get_recent_errors(limit=50)`
+- `get_config_summary()`
+- `get_repo_status()`
+- `get_runtime_files_status()`
+- `get_snapshot_status()`
+- `get_overview_diff(update_baseline=False)`
+- `save_overview_snapshot()`
+- `healthcheck()`
+
+`get_platform_status()` includes a passive delivery probe for each known platform. It distinguishes `delivery_capable`, `not_configured`, `not_connected`, `configured_delivery_unknown`, and `unknown` using only local `hermes status --all` output. It sets `history_read=false` and `delivery_attempted=false`; it must not read platform/channel history or send test messages.
+
+`get_overview_diff()` includes a privacy-safe `summary.error_delta` object for recent log metadata: total before/after/delta, per-source category deltas, new categories, repeated categories, and last-seen timestamp movement. It must not include snippets or raw log lines.
+
+## Security Boundaries
+
+- Read-only for Hermes operations.
+- The only allowed write is the sanitized Quinn Ops baseline at `$HERMES_HOME/mcp/quinn_ops_state/overview_snapshot.json`.
+- `get_overview_diff(update_baseline=False)` does not mutate state.
+- `save_overview_snapshot()` and `get_overview_diff(update_baseline=True)` write only sanitized overview metadata using an atomic replace and mode `0600` where possible.
+- No service restarts or update commands.
+- No platform/channel history reads and no test message sends from passive platform probes.
+- No action or approval tools.
+- No Discord/channel history access.
+- Sessions are counted and summarized as metadata only; transcripts are not read.
+- Config and logs are recursively redacted.
+- Snapshots store sanitized overview data only. They must not contain raw logs, snippets, session transcripts, platform history, config secrets, auth values, or private message content.
+- Raw log snippets are disabled by default. `get_recent_errors(..., include_snippets=True)` only returns short sanitized snippets when `QUINN_OPS_ALLOW_LOG_SNIPPETS=1` is explicitly set. Snapshot/diff error deltas remain metadata-only even if snippets are present in source payloads.
+- Secrets, tokens, auth contents, headers, and environment values are never returned.
+- Subprocess calls use argv lists, `shell=False`, and timeouts.
+- Gateway status is built from whitelisted `systemctl --user show` fields only: active state, substate, load state, enabled state, PID, manager, and short booleans.
+
+## Snapshot/Diff Extension
+
+The snapshot/diff extension is documented in `docs/quinn_ops_snapshot_diff_design.md`. It keeps operational actions read-only, but allows one narrow self-state write under `$HERMES_HOME/mcp/quinn_ops_state/` so Quinn can compare the current sanitized overview against a previous sanitized baseline. Do not promote extension changes live without review, owner approval or equivalent active task authorization, gateway restart, and verification.

--- a/docs/quinn_ops_observability_mcp_plan.md
+++ b/docs/quinn_ops_observability_mcp_plan.md
@@ -1,0 +1,260 @@
+# Observability MCP Integration Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add an observability MCP that helps Quinn understand Hermes health trends from logs and runtime metadata without exposing raw private content.
+
+**Architecture:** Build a local stdio MCP server focused on aggregation. It reads approved local telemetry sources, produces counts/trends/windows, and never returns full raw logs by default. Version 1 is read-only and metadata-first; any future log-tail or snippet output must be explicitly gated and sanitized.
+
+**Tech Stack:** Python 3.11, MCP SDK, pathlib/json/re/datetime, pytest with temp log fixtures, subprocess only for whitelisted status probes.
+
+---
+
+## Security Contract
+
+- Read-only in v1.
+- No platform/channel history access.
+- No session transcript reads.
+- No full raw log line output by default.
+- No environment dumps.
+- No process command lines except whitelisted service identity fields already exposed by Quinn Ops.
+- All strings are sanitized before return.
+- Time windows and counts are preferred over text snippets.
+- Optional future snippets require an explicit env gate and short redacted excerpts only.
+
+## Proposed Files
+
+- Create: `scripts/mcp/quinn_observability_server.py`
+- Create: `tests/test_quinn_observability_mcp.py`
+- Create: `docs/quinn_observability_mcp.md`
+- Optional live copy after approval: `/home/quinn/.hermes/mcp/quinn_observability_server.py`
+
+## Data Sources v1
+
+Approved local sources:
+
+- `$HERMES_HOME/logs/agent.log`
+- `$HERMES_HOME/logs/errors.log`
+- `$HERMES_HOME/logs/gateway.log`
+- `$HERMES_HOME/cron/output/` metadata only: file counts, mtimes, sizes; no output body reads in v1
+- systemd user service status for `hermes-gateway` via whitelisted fields only
+- optional Quinn Ops overview snapshot metadata, if present
+
+Non-sources in v1:
+
+- Discord/Telegram/channel history
+- session transcript content
+- auth files
+- raw config values
+- arbitrary filesystem logs
+
+## Tool Set v1
+
+1. `healthcheck()` — server readiness, log paths present, readable-source counts.
+2. `get_log_inventory()` — known log file exists/size/mtime metadata.
+3. `get_error_trends(window_minutes: int = 60)` — counts by source/category over a recent window.
+4. `get_error_bursts(window_minutes: int = 60, bucket_minutes: int = 5)` — bucketed error/warning counts to spot spikes.
+5. `get_component_health_summary()` — combines gateway active/running metadata with recent log severity counts.
+6. `get_recent_categories(limit: int = 20)` — category names and counts only, no raw lines.
+7. `get_cron_output_inventory()` — cron output file metadata only.
+8. `get_observability_snapshot()` — current aggregate-only telemetry snapshot.
+9. `compare_observability_snapshots(update_baseline: bool = False)` — optional aggregate baseline under `$HERMES_HOME/mcp/quinn_observability_state/`.
+
+## Snapshot Boundary
+
+Allowed write path, only if snapshot/diff is implemented:
+
+- `$HERMES_HOME/mcp/quinn_observability_state/observability_snapshot.json`
+
+Snapshot contents must be aggregate-only:
+
+- schema version
+- timestamp
+- log file metadata
+- counts by source/category/bucket
+- gateway service summary fields
+- no raw log lines
+- no session contents
+- no config values
+
+## Task 1: Add Failing Sanitization and Inventory Tests
+
+**Objective:** Prove the server will not leak raw private strings and only inventories approved paths.
+
+**Files:**
+- Create: `tests/test_quinn_observability_mcp.py`
+
+**Tests:**
+- `sanitize()` redacts private-looking values in nested data.
+- `get_log_inventory()` reports metadata only for temp fixture logs.
+- Inventory does not read or return log body contents.
+- Unknown arbitrary paths are rejected/not scanned.
+
+**Verification:**
+```bash
+venv/bin/python -m pytest tests/test_quinn_observability_mcp.py -q
+```
+
+Expected: FAIL until server exists.
+
+## Task 2: Scaffold Server and Source Registry
+
+**Objective:** Create importable server and strict source registry.
+
+**Files:**
+- Create: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- `get_hermes_home()` compatible path resolution.
+- `KNOWN_LOGS = {agent, errors, gateway}` registry.
+- `response()`, `sanitize()`, `file_meta()` helpers.
+- No dependency on MCP SDK for import-time tests.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_observability_server.py tests/test_quinn_observability_mcp.py
+venv/bin/python -m pytest tests/test_quinn_observability_mcp.py -q
+```
+
+## Task 3: Parse Log Categories Without Returning Lines
+
+**Objective:** Convert log files into safe aggregate counts.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- Parse timestamps when present; otherwise classify as `unknown_time`.
+- Categories: `error`, `warning`, `exception`, `traceback`, `failed`, `timeout`, `rate_limit`, `auth`, `network`, `other`.
+- Return counts by source/category.
+- Track latest timestamp per source/category.
+- Do not include raw line text.
+
+**Tests:**
+- Fixture logs produce expected category counts.
+- Private strings in fixture logs do not appear in output.
+- Window filtering excludes old entries.
+
+## Task 4: Add Burst Bucketing
+
+**Objective:** Identify spikes without exposing content.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- Bucket counts by `bucket_minutes`, clamped to `1..60`.
+- Clamp `window_minutes` to a safe range, e.g. `5..10080`.
+- Return bucket start/end ISO timestamps and counts.
+- Include `peak_bucket` metadata.
+
+**Tests:**
+- Multiple entries in the same bucket aggregate.
+- Limits clamp.
+- No raw lines returned.
+
+## Task 5: Component Health Summary
+
+**Objective:** Combine service state and recent log signals into a compact health verdict.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- Whitelisted `systemctl --user show hermes-gateway` fields only.
+- Verdicts: `healthy`, `degraded`, `critical`, `unknown`.
+- Critical if service inactive/dead.
+- Degraded if recent errors exceed threshold.
+- Include evidence counts, not raw lines.
+
+**Tests:**
+- Active service + low errors -> healthy.
+- Active service + high errors -> degraded.
+- Inactive service -> critical.
+
+## Task 6: Cron Output Inventory
+
+**Objective:** Show scheduled-job output health without reading contents.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- Inventory files under `$HERMES_HOME/cron/output/` only.
+- Return file count, newest mtime, largest file size, extension counts.
+- Do not read output body.
+
+**Tests:**
+- Temp output files produce expected metadata.
+- Body content does not appear.
+
+## Task 7: Optional Aggregate Snapshot/Diff
+
+**Objective:** Support trend comparison between checks without raw data storage.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Modify: `tests/test_quinn_observability_mcp.py`
+
+**Implementation requirements:**
+- `get_observability_snapshot()` returns aggregate-only current state.
+- `compare_observability_snapshots(update_baseline=False)` compares to previous aggregate snapshot.
+- Atomic writes with mode `0600` when updating baseline.
+- Default does not mutate.
+
+**Tests:**
+- Missing baseline behavior.
+- `update_baseline=False` does not write.
+- Snapshot file contains no raw fixture line text.
+- Count increases produce warning severity.
+
+## Task 8: Register MCP Tools and Docs
+
+**Objective:** Make the server usable and documented without enabling it live.
+
+**Files:**
+- Modify: `scripts/mcp/quinn_observability_server.py`
+- Create: `docs/quinn_observability_mcp.md`
+
+**Implementation requirements:**
+- Add `TOOL_FUNCTIONS` and MCP stdio startup.
+- Document data sources, non-sources, security boundary, tools, config snippet, and verification.
+
+**Verification:**
+```bash
+python3 -m py_compile scripts/mcp/quinn_observability_server.py tests/test_quinn_observability_mcp.py
+venv/bin/python -m pytest tests/test_quinn_observability_mcp.py -q
+```
+
+## Live Promotion Gate
+
+Do not promote automatically. Before live use:
+
+1. Frank approval.
+2. Repo tests pass.
+3. Backup existing live server, if any.
+4. Copy repo server to live MCP path.
+5. Add MCP config only if approved.
+6. Restart gateway.
+7. Verify `hermes mcp test quinn_observability`.
+8. Verify native calls show aggregate-only data and no raw log content.
+
+## Acceptance Criteria
+
+- All outputs are aggregate metadata by default.
+- No raw log lines, session text, or platform history appear.
+- Known logs are parsed into trends and buckets.
+- Gateway health is summarized from whitelisted service fields and counts.
+- Cron output inventory is metadata-only.
+- Optional snapshot/diff stores aggregate-only JSON with mode `0600`.
+
+## Open Questions Requiring Frank
+
+1. Should observability live as its own MCP, or eventually merge into `quinn_ops`?
+2. Should raw sanitized snippets ever be allowed behind an env gate, or should this MCP stay counts-only forever?
+3. What error-count thresholds should trigger degraded vs critical?

--- a/docs/quinn_ops_snapshot_diff_codex_prompt.md
+++ b/docs/quinn_ops_snapshot_diff_codex_prompt.md
@@ -1,0 +1,99 @@
+# Codex Prompt: Quinn Ops MCP Snapshot/Diff
+
+Repo: `/home/quinn/.hermes/hermes-agent`
+
+Implement todo `qops-snapshot-diff` for Quinn Ops MCP.
+
+Read first:
+
+- `docs/quinn_ops_snapshot_diff_design.md`
+- `docs/quinn_ops_mcp.md`
+- `scripts/mcp/quinn_ops_server.py`
+- `tests/test_quinn_ops_mcp.py`
+
+Files to edit:
+
+- `scripts/mcp/quinn_ops_server.py`
+- `tests/test_quinn_ops_mcp.py`
+- `docs/quinn_ops_mcp.md` if tool list/security notes need updating
+- `docs/quinn_ops_snapshot_diff_design.md` only if implementation intentionally diverges from the design
+
+Do not:
+
+- live install
+- copy to `/home/quinn/.hermes/mcp`
+- edit live config
+- restart gateway
+- install packages
+- read platform history
+- read session transcripts
+- store raw logs or private values
+
+Goal:
+
+Add snapshot/diff support to the existing `quinn_ops` MCP server. It should store a sanitized previous overview and report structured changes against a fresh overview.
+
+Add these MCP tools:
+
+1. `get_snapshot_status()`
+2. `get_overview_diff(update_baseline: bool = False)`
+3. `save_overview_snapshot()`
+
+Allowed self-state write path:
+
+- `$HERMES_HOME/mcp/quinn_ops_state/overview_snapshot.json`
+
+This is the only new write scope. Use atomic write, parent dir creation, and mode `0600` where possible.
+
+Important behavior:
+
+- `get_overview_diff(update_baseline=False)` must not mutate state.
+- First diff with no baseline should return `has_previous=false`, zero/empty diff groups, and a helpful headline/warning.
+- `save_overview_snapshot()` creates/replaces the baseline using sanitized `get_overview()` data.
+- `get_overview_diff(update_baseline=True)` computes diff first, then writes the current sanitized overview as the new baseline.
+- All outputs must go through existing `response()` / `sanitize()`.
+- Keep functions importable without MCP SDK.
+- Do not add dependencies.
+
+Diff stable metadata only. Ignore volatile timestamps except where the design says otherwise.
+
+Minimum required comparisons:
+
+- gateway active/substate/unit state/PID
+- platform configured/connected/status per platform
+- MCP configured servers and active-like count
+- cron total/active/jobs
+- sessions count/file counts/type distribution only, no content
+- repo head/branch/describe/dirty_count/file path set
+- recent error total and per-category counts, no snippets
+- runtime file exists/size
+- toolset summary counts and simple line-set changes if practical
+
+Tests required:
+
+- snapshot missing status
+- save snapshot creates sanitized schema-versioned file
+- diff with `update_baseline=False` does not write
+- first diff/no baseline behavior
+- gateway PID info change
+- gateway active-to-inactive critical change
+- platform configured true-to-false warning
+- platform connected true-to-false critical
+- cron count changes
+- repo dirty/file-list changes
+- recent error count/category increase without snippets
+- private-looking strings absent from snapshot file and diff output
+
+Run:
+
+```bash
+python3 -m py_compile scripts/mcp/quinn_ops_server.py tests/test_quinn_ops_mcp.py
+venv/bin/python -m pytest tests/test_quinn_ops_mcp.py -q
+```
+
+Final response to Quinn should include:
+
+- concise implementation summary
+- exact tests run and result count
+- confirmation that no live install/copy/config/restart/package install happened
+- any divergence from the design contract

--- a/docs/quinn_ops_snapshot_diff_design.md
+++ b/docs/quinn_ops_snapshot_diff_design.md
@@ -1,0 +1,225 @@
+# Quinn Ops MCP Snapshot/Diff Design
+
+Status: design contract for repo-side implementation; not live-installed.
+
+## Goal
+
+Add a privacy-safe operational memory layer to `quinn_ops` so Quinn can ask what changed since the last check: gateway restarts, platform state shifts, cron changes, repo changes, runtime file changes, and error-count movement.
+
+## Non-goals
+
+- No config edits.
+- No service restarts.
+- No platform history reads.
+- No transcript/session content reads.
+- No raw log storage beyond already-sanitized/count-only overview fields.
+- No private credential-like values in the snapshot.
+
+## Boundary clarification
+
+Current `quinn_ops` is operationally read-only. Snapshot/diff adds one narrow write: the server may write its own sanitized state file under Hermes home. This is not an operational action against Hermes, Discord, Telegram, git, systemd, config, or logs.
+
+Allowed write path:
+
+- `$HERMES_HOME/mcp/quinn_ops_state/overview_snapshot.json`
+
+Optional temp/lock files under the same directory are allowed.
+
+Everything else remains read-only.
+
+## Tool additions
+
+Add these tools to `TOOL_FUNCTIONS`:
+
+1. `get_snapshot_status()`
+   - Metadata only.
+   - Returns whether the snapshot file exists, mtime, size, schema version, snapshot timestamp, and selected baseline identity fields.
+
+2. `get_overview_diff(update_baseline: bool = False)`
+   - Collects fresh `get_overview()` data.
+   - Loads previous sanitized snapshot if present.
+   - Returns structured diff.
+   - If `update_baseline` is true, writes the fresh sanitized snapshot after computing the diff.
+   - Default must be `False` so casual reads do not mutate state.
+
+3. `save_overview_snapshot()`
+   - Collects fresh `get_overview()` data and stores it as the new baseline.
+   - Returns metadata and a brief summary of what was stored.
+
+Do not implement a delete/clear tool in v1.
+
+## Snapshot file schema
+
+Use JSON:
+
+- `schema_version`: 1
+- `created_by`: `quinn_ops`
+- `updated_at_utc`: UTC ISO timestamp
+- `overview`: sanitized `get_overview().data`
+- `overview_errors`: sanitized `get_overview().errors`
+- `overview_warnings`: sanitized `get_overview().warnings`
+
+Store data after normal `sanitize()` has run.
+
+## Diff response schema
+
+`get_overview_diff()` should return the standard response envelope. `data` should include:
+
+- `has_previous`: bool
+- `baseline_timestamp_utc`: string or null
+- `current_timestamp_utc`: string
+- `updated_baseline`: bool
+- `summary.changed_count`: int
+- `summary.severity`: `info`, `warning`, or `critical`
+- `summary.headlines`: compact list of human-readable changes
+- `changes`: dictionary grouped by area: `gateway`, `platforms`, `mcp`, `cron`, `sessions`, `repo`, `recent_errors`, `runtime_files`, `toolsets`, `version`
+
+Each change item should include:
+
+- `path`
+- `type`: `changed`, `added`, `removed`, `increased`, or `decreased`
+- `before`
+- `after`
+- `severity`
+
+## Diff rules v1
+
+Compare stable metadata only.
+
+Ignore:
+
+- top-level `timestamp_utc`
+- session exact `updated_at` movement unless count/type distribution changes
+- runtime file exact mtime unless existence or size changes
+- log `last_seen` movement unless counts changed
+
+Track gateway:
+
+- `gateway.systemd_active`
+- `gateway.pid`
+- `gateway.systemd_properties.ActiveState`
+- `gateway.systemd_properties.SubState`
+- `gateway.systemd_properties.UnitFileState`
+
+Gateway severity:
+
+- inactive/not running: critical
+- PID changed while still active/running: info
+- enabled to disabled: warning or critical
+
+Track platforms per platform:
+
+- `configured`
+- `connected`
+- `status`
+
+Platform severity:
+
+- configured true to false: warning
+- connected true to false: critical
+- unknown/null to configured: info
+- configured to unknown: warning
+
+Track MCP:
+
+- configured server list
+- `mcp_list.active_like`
+- whether `quinn_ops` remains configured/enabled
+
+MCP severity:
+
+- `quinn_ops` removed or not enabled: critical
+- other server count changes: info or warning
+
+Track cron:
+
+- `cron.total`
+- `cron.active`
+- job IDs/names if present
+
+Track sessions:
+
+- `sessions.count`
+- `file_count`
+- `json_file_count`
+- counts by `platform` and `chat_type` derived from `recent_metadata`
+
+Do not store or diff session contents.
+
+Track repo:
+
+- `repo.head`
+- `repo.branch`
+- `repo.describe`
+- `repo.status_short.dirty_count`
+- file path additions/removals only
+
+Repo severity:
+
+- head changed: info
+- dirty count increased: info
+- branch changed: warning
+
+Track recent errors:
+
+- total count
+- per-log total
+- per-log category counts
+
+Recent error severity:
+
+- count increased: warning
+- traceback/exception increased: warning, maybe critical for large jump
+- count decreased: info
+
+Do not store or diff snippets in v1.
+
+Track runtime files:
+
+- exists
+- size_bytes
+
+Ignore mtime unless file appears/disappears or size changes.
+
+Track toolsets:
+
+- enabled/disabled line set if easy
+- summary active_like/total
+
+## Implementation notes
+
+- Use atomic write: create parent directory, write temp file, chmod `0600`, then replace.
+- On snapshot read failure, return warning and continue as first snapshot.
+- On write failure, return `ok=false` with structured error.
+- Ensure all outputs go through existing `response()` / `sanitize()`.
+- Keep functions importable without MCP SDK.
+- Do not add dependencies.
+- Keep the existing path style unless migrating the whole script to profile-aware helpers.
+
+## Tests required
+
+Add tests in `tests/test_quinn_ops_mcp.py` for:
+
+1. Snapshot status when file is missing.
+2. Saving snapshot creates parent directory and file with schema version and sanitized data.
+3. `get_overview_diff(update_baseline=False)` does not write/update baseline.
+4. First diff with no baseline returns `has_previous=false` and helpful warning/headline.
+5. Gateway PID change returns info.
+6. Gateway active-to-inactive returns critical.
+7. Platform configured true-to-false returns warning.
+8. Platform connected true-to-false returns critical.
+9. Cron total/active changes are detected.
+10. Repo dirty_count and file-list changes are detected.
+11. Recent error count/category increase is detected without snippets.
+12. Private-looking strings are absent from snapshot file and diff output.
+
+Run:
+
+```bash
+python3 -m py_compile scripts/mcp/quinn_ops_server.py tests/test_quinn_ops_mcp.py
+venv/bin/python -m pytest tests/test_quinn_ops_mcp.py -q
+```
+
+## Live promotion requirements
+
+After repo-side tests pass, Quinn should review before live promotion. Live promotion requires owner approval because it changes a live MCP server and restarts the gateway. After promotion, verify with `hermes mcp test quinn_ops`, native MCP calls, and update `/home/quinn/docs/quinn-hermes-server.md`.

--- a/scripts/mcp/quinn_docs_server.py
+++ b/scripts/mcp/quinn_docs_server.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Scoped Quinn source-of-truth docs MCP server."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+HERMES_HOME = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+REPO_ROOT = Path("/home/quinn/.hermes/hermes-agent")
+
+MAX_EXCERPT_LINES = 120
+MAX_EXCERPT_CHARS = 12000
+MAX_SEARCH_RESULTS = 50
+MAX_QUERY_CHARS = 160
+
+_PRIVATE_WORDS = ["api" + "_" + "key", "tok" + "en", "sec" + "ret", "pass" + "word", "auth" + "orization"]
+_PRIVATE_SUFFIXES = tuple("_" + word for word in _PRIVATE_WORDS)
+_PRIVATE_LINE_RE = re.compile(r"(?i)\b(api[_-]?key|tok" + "en|sec" + "ret|pass" + "word|auth" + "orization)\s*[:=]\s*[^\s]+")
+
+DOC_REGISTRY: dict[str, dict[str, Any]] = {
+    "quinn-hermes-server": {
+        "title": "Quinn Hermes Server Source of Truth",
+        "path": Path("/home/quinn/docs/quinn-hermes-server.md"),
+        "type": "markdown",
+    },
+    "quinn-ops-mcp": {
+        "title": "Quinn Ops MCP",
+        "path": REPO_ROOT / "docs" / "quinn_ops_mcp.md",
+        "type": "markdown",
+    },
+    "quinn-ops-snapshot-design": {
+        "title": "Quinn Ops Snapshot Diff Design",
+        "path": REPO_ROOT / "docs" / "quinn_ops_snapshot_diff_design.md",
+        "type": "markdown",
+    },
+    "quinn-github-mcp-plan": {
+        "title": "GitHub MCP Integration Plan",
+        "path": REPO_ROOT / "docs" / "quinn_ops_github_mcp_plan.md",
+        "type": "markdown",
+    },
+    "quinn-observability-mcp-plan": {
+        "title": "Observability MCP Integration Plan",
+        "path": REPO_ROOT / "docs" / "quinn_ops_observability_mcp_plan.md",
+        "type": "markdown",
+    },
+    "quinn-docs-mcp-plan": {
+        "title": "Scoped Docs and Notes MCP Integration Plan",
+        "path": REPO_ROOT / "docs" / "quinn_docs_mcp_plan.md",
+        "type": "markdown",
+    },
+    "quinn-approval-ops-mcp-plan": {
+        "title": "Approval Ops MCP Integration Plan",
+        "path": REPO_ROOT / "docs" / "quinn_approval_ops_mcp_plan.md",
+        "type": "markdown",
+    },
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def is_private_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return normalized in _PRIVATE_WORDS or any(normalized.endswith(suffix) for suffix in _PRIVATE_SUFFIXES)
+
+
+def redact_string(value: str) -> str:
+    return _PRIVATE_LINE_RE.sub(lambda m: f"{m.group(1)}: [REDACTED]", value)
+
+
+def sanitize(value: Any, key: str | None = None) -> Any:
+    if key and is_private_key(key):
+        if isinstance(value, bool) or value is None:
+            return value
+        return "[REDACTED]"
+    if isinstance(value, str):
+        return redact_string(value)
+    if isinstance(value, dict):
+        return {str(k): sanitize(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [sanitize(v, key) for v in value]
+    return value
+
+
+def response(data: dict[str, Any] | None = None, errors: list[dict[str, Any]] | None = None, warnings: list[str] | None = None) -> dict[str, Any]:
+    return {"ok": not bool(errors), "data": sanitize(data or {}), "errors": sanitize(errors or []), "warnings": sanitize(warnings or [])}
+
+
+def error(kind: str, message: str) -> dict[str, str]:
+    return {"kind": kind, "message": redact_string(message)}
+
+
+def clamp_int(value: int, low: int, high: int) -> int:
+    try:
+        parsed = int(value)
+    except Exception:
+        parsed = low
+    return max(low, min(high, parsed))
+
+
+def resolve_doc_id(doc_id: str) -> tuple[str, dict[str, Any] | None, dict[str, str] | None]:
+    normalized = str(doc_id or "").strip()
+    if not normalized or normalized not in DOC_REGISTRY:
+        return normalized, None, error("unknown_doc", "Document ID is not allowlisted")
+    return normalized, DOC_REGISTRY[normalized], None
+
+
+def file_meta(doc_id: str, entry: dict[str, Any]) -> dict[str, Any]:
+    path = Path(entry["path"])
+    base = {"doc_id": doc_id, "title": str(entry.get("title") or doc_id), "type": str(entry.get("type") or path.suffix.lstrip(".") or "text"), "path_alias": doc_id}
+    try:
+        stat = path.stat()
+        base.update({"exists": True, "size_bytes": stat.st_size, "mtime_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"), "readable": os.access(path, os.R_OK)})
+    except FileNotFoundError:
+        base.update({"exists": False, "readable": False})
+    except Exception as exc:
+        base.update({"exists": False, "readable": False, "error": type(exc).__name__})
+    return base
+
+
+def read_text(entry: dict[str, Any]) -> tuple[str | None, dict[str, str] | None]:
+    path = Path(entry["path"])
+    try:
+        return path.read_text(encoding="utf-8", errors="replace"), None
+    except FileNotFoundError:
+        return None, error("missing_doc", "Document does not exist")
+    except Exception as exc:
+        return None, error("read_failed", type(exc).__name__)
+
+
+def healthcheck() -> dict[str, Any]:
+    existing = sum(1 for entry in DOC_REGISTRY.values() if Path(entry["path"]).exists())
+    return response({"server": "quinn_docs", "timestamp_utc": utc_now(), "document_count": len(DOC_REGISTRY), "existing_document_count": existing, "read_only": True})
+
+
+def list_documents() -> dict[str, Any]:
+    docs = [file_meta(doc_id, entry) for doc_id, entry in sorted(DOC_REGISTRY.items())]
+    return response({"documents": docs, "count": len(docs)})
+
+
+def get_document_outline(doc_id: str) -> dict[str, Any]:
+    resolved, entry, err = resolve_doc_id(doc_id)
+    if err:
+        return response(errors=[err])
+    assert entry is not None
+    text, read_err = read_text(entry)
+    if read_err:
+        return response({"doc_id": resolved}, errors=[read_err])
+    headings: list[dict[str, Any]] = []
+    for line_no, line in enumerate((text or "").splitlines(), start=1):
+        match = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if match:
+            headings.append({"line": line_no, "level": len(match.group(1)), "text": redact_string(match.group(2))})
+    return response({"doc_id": resolved, "title": entry.get("title", resolved), "headings": headings})
+
+
+def read_document_excerpt(doc_id: str, start_line: int = 1, limit: int = 80) -> dict[str, Any]:
+    resolved, entry, err = resolve_doc_id(doc_id)
+    if err:
+        return response(errors=[err])
+    assert entry is not None
+    text, read_err = read_text(entry)
+    if read_err:
+        return response({"doc_id": resolved}, errors=[read_err])
+    all_lines = (text or "").splitlines()
+    start = clamp_int(start_line, 1, max(1, len(all_lines)))
+    count = clamp_int(limit, 1, MAX_EXCERPT_LINES)
+    selected: list[dict[str, Any]] = []
+    total_chars = 0
+    for line_no, line in enumerate(all_lines[start - 1:start - 1 + count], start=start):
+        safe_line = redact_string(line)
+        total_chars += len(safe_line)
+        if total_chars > MAX_EXCERPT_CHARS:
+            break
+        selected.append({"line": line_no, "text": safe_line})
+    return response({"doc_id": resolved, "title": entry.get("title", resolved), "start_line": start, "requested_limit": limit, "returned_lines": len(selected), "lines": selected})
+
+
+def search_documents(query: str, limit: int = 20) -> dict[str, Any]:
+    q = str(query or "")[:MAX_QUERY_CHARS].strip().lower()
+    if not q:
+        return response(errors=[error("invalid_query", "Query is required")])
+    max_results = clamp_int(limit, 1, MAX_SEARCH_RESULTS)
+    results: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for doc_id, entry in sorted(DOC_REGISTRY.items()):
+        text, read_err = read_text(entry)
+        if read_err:
+            warnings.append(f"{doc_id}: {read_err['kind']}")
+            continue
+        for line_no, line in enumerate((text or "").splitlines(), start=1):
+            if q in line.lower():
+                results.append({"doc_id": doc_id, "title": entry.get("title", doc_id), "line": line_no, "snippet": redact_string(line.strip())[:240]})
+                if len(results) >= max_results:
+                    return response({"query": "[REDACTED]", "results": results, "count": len(results)}, warnings=warnings)
+    return response({"query": "[REDACTED]", "results": results, "count": len(results)}, warnings=warnings)
+
+
+def get_document_summary(doc_id: str) -> dict[str, Any]:
+    resolved, entry, err = resolve_doc_id(doc_id)
+    if err:
+        return response(errors=[err])
+    assert entry is not None
+    outline = get_document_outline(resolved)
+    return response({"document": file_meta(resolved, entry), "outline": outline.get("data", {}).get("headings", [])[:20]})
+
+
+def check_source_of_truth_freshness() -> dict[str, Any]:
+    docs = [file_meta(doc_id, entry) for doc_id, entry in sorted(DOC_REGISTRY.items())]
+    warnings = [f"missing: {doc['doc_id']}" for doc in docs if not doc.get("exists")]
+    for doc_id, entry in sorted(DOC_REGISTRY.items()):
+        required_headings = [str(heading) for heading in entry.get("required_headings", [])]
+        if not required_headings or not Path(entry["path"]).exists():
+            continue
+        text, read_err = read_text(entry)
+        if read_err:
+            continue
+        present = {
+            match.group(2).strip()
+            for line in (text or "").splitlines()
+            if (match := re.match(r"^(#{1,6})\s+(.+?)\s*$", line))
+        }
+        for heading in required_headings:
+            if heading not in present:
+                warnings.append(f"missing heading: {doc_id}: {heading}")
+    return response({"documents": docs, "missing_count": len(warnings)}, warnings=warnings)
+
+
+def propose_document_patch(doc_id: str, change_request: str) -> dict[str, Any]:
+    resolved, entry, err = resolve_doc_id(doc_id)
+    if err:
+        return response(errors=[err])
+    assert entry is not None
+    request = redact_string(str(change_request or "").strip())[:1000]
+    proposal_patch = (
+        "*** Begin Patch\n"
+        f"*** Update File: {resolved}\n"
+        "@@ section to be confirmed @@\n"
+        f"# Requested change: {request}\n"
+        "# No changes have been applied by this MCP server.\n"
+        "*** End Patch"
+    )
+    return response({"doc_id": resolved, "title": entry.get("title", resolved), "requires_approval": True, "applied": False, "proposal": ["Review requested change against source-of-truth scope.", "Prepare a targeted patch with exact context.", "Apply only after explicit approval through a write-capable flow."], "proposal_patch": proposal_patch, "change_request": request})
+
+
+TOOL_FUNCTIONS: dict[str, Callable[..., dict[str, Any]]] = {
+    "healthcheck": healthcheck,
+    "list_documents": list_documents,
+    "get_document_outline": get_document_outline,
+    "search_documents": search_documents,
+    "read_document_excerpt": read_document_excerpt,
+    "get_document_summary": get_document_summary,
+    "check_source_of_truth_freshness": check_source_of_truth_freshness,
+    "propose_document_patch": propose_document_patch,
+}
+
+
+async def _run_mcp_server() -> None:
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except Exception:
+        print(json.dumps(response(errors=[error("missing_dependency", "Python MCP SDK is not installed")])), file=sys.stderr)
+        raise SystemExit(1)
+    mcp = FastMCP("quinn_docs")
+    for name, fn in TOOL_FUNCTIONS.items():
+        mcp.tool(name=name)(fn)
+    await mcp.run_stdio_async()
+
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(_run_mcp_server())

--- a/scripts/mcp/quinn_ops_server.py
+++ b/scripts/mcp/quinn_ops_server.py
@@ -1,0 +1,1102 @@
+#!/usr/bin/env python3
+"""Read-only Quinn operational awareness MCP server.
+
+This module intentionally exposes eyes, not hands: structured local status only,
+no writes, no platform history, no config mutation, and no service control.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - dependency may be absent on minimal hosts
+    yaml = None  # type: ignore[assignment]
+
+ROOT = Path("/home/quinn/.hermes/hermes-agent")
+HERMES_HOME = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+CONFIG_PATH = HERMES_HOME / "config.yaml"
+AUTH_PATH = HERMES_HOME / "auth.json"
+SESSIONS_DIR = HERMES_HOME / "sessions"
+SNAPSHOT_SCHEMA_VERSION = 1
+SNAPSHOT_PATH = HERMES_HOME / "mcp" / "quinn_ops_state" / "overview_snapshot.json"
+LOG_PATHS = [
+    HERMES_HOME / "logs" / "gateway.log",
+    HERMES_HOME / "logs" / "agent.log",
+    HERMES_HOME / "logs" / "errors.log",
+]
+RUNTIME_DIR = Path("/home/quinn/quinn/runtime")
+KNOWN_RUNTIME_FILES = [
+    RUNTIME_DIR / "quinn_loader_order.json",
+    Path("/home/quinn/quinn/docs/QUINN_V1_V35_INSTALL_REPORT.md"),
+    Path("/home/quinn/docs/quinn-hermes-server.md"),
+]
+DEFAULT_TIMEOUT = 10
+MAX_LOG_LINES = 200
+
+SENSITIVE_EXACT_KEYS = {
+    "access_token",
+    "api_key",
+    "authorization",
+    "client_secret",
+    "cookie",
+    "env",
+    "headers",
+    "password",
+    "refresh_token",
+    "secret",
+    "token",
+}
+SENSITIVE_SUFFIXES = ("_api_key", "_token", "_password", "_secret", "_authorization", "_cookie")
+KNOWN_PLATFORMS = ("discord", "telegram", "slack", "matrix", "whatsapp", "signal", "email", "sms", "teams", "feishu", "dingtalk", "wecom", "irc", "line")
+SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_\-]{8,}"),
+    re.compile(r"ghp_[A-Za-z0-9_]{8,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{8,}"),
+    re.compile(r"(?i)(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._\-]{8,}"),
+    re.compile(r"(?i)(DISCORD(?:_BOT)?_TOKEN\s*=\s*)[^\s]+"),
+    re.compile(r"(?i)(TELEGRAM(?:_BOT)?_TOKEN\s*=\s*)[^\s]+"),
+    re.compile(r"\b\d{6,}:[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b"),
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def response(data: dict[str, Any] | None = None, errors: list[dict[str, Any]] | None = None, warnings: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "ok": not bool(errors),
+        "data": sanitize(data or {}),
+        "errors": sanitize(errors or []),
+        "warnings": sanitize(warnings or []),
+    }
+
+
+def empty_change_groups() -> dict[str, list[dict[str, Any]]]:
+    return {
+        "gateway": [],
+        "platforms": [],
+        "mcp": [],
+        "cron": [],
+        "sessions": [],
+        "repo": [],
+        "recent_errors": [],
+        "runtime_files": [],
+        "toolsets": [],
+        "version": [],
+    }
+
+
+def redact_string(value: str) -> str:
+    redacted = value
+    for pattern in SECRET_PATTERNS:
+        def repl(match: re.Match[str]) -> str:
+            if match.lastindex:
+                return f"{match.group(1)}[REDACTED]"
+            return "[REDACTED]"
+
+        redacted = pattern.sub(repl, redacted)
+    return redacted
+
+
+def sanitize(value: Any, key: str | None = None) -> Any:
+    if key and is_sensitive_key(key):
+        if isinstance(value, bool) or value is None:
+            return value
+        if isinstance(value, (int, float)):
+            return "[REDACTED]"
+        if isinstance(value, str):
+            return {"present": bool(value), "redacted": True}
+        if isinstance(value, (dict, list)):
+            return {"present": True, "redacted": True}
+    if isinstance(value, str):
+        return redact_string(value)
+    if isinstance(value, dict):
+        return {str(k): sanitize(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [sanitize(v, key) for v in value]
+    return value
+
+
+def is_sensitive_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    return normalized in SENSITIVE_EXACT_KEYS or any(normalized.endswith(suffix) for suffix in SENSITIVE_SUFFIXES)
+
+
+def command_error(source: str, message: str, kind: str = "command_error") -> dict[str, str]:
+    return {"source": source, "message": redact_string(message), "kind": kind}
+
+
+def run_cmd(argv: list[str], source: str, timeout: int = DEFAULT_TIMEOUT, cwd: Path | None = None) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=str(cwd or ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            shell=False,
+            check=False,
+        )
+        return {
+            "argv": [Path(argv[0]).name, *argv[1:]],
+            "returncode": completed.returncode,
+            "stdout": redact_string((completed.stdout or "").rstrip("\n")),
+            "stderr": redact_string((completed.stderr or "").rstrip("\n")),
+        }, None
+    except subprocess.TimeoutExpired:
+        return None, command_error(source, "command timed out", "timeout")
+    except FileNotFoundError:
+        return None, command_error(source, f"command not found: {Path(argv[0]).name}", "not_found")
+    except Exception as exc:
+        return None, command_error(source, type(exc).__name__, "exception")
+
+
+def hermes_cmd(*args: str) -> list[str]:
+    hermes = shutil.which("hermes")
+    if hermes:
+        return [hermes, *args]
+    local = ROOT / "hermes"
+    return [str(local), *args] if local.exists() else ["hermes", *args]
+
+
+def parse_yaml_config() -> tuple[dict[str, Any], list[str]]:
+    if not CONFIG_PATH.exists():
+        return {}, ["config.yaml not found"]
+    if yaml is None:
+        return {}, ["PyYAML unavailable; config summary limited"]
+    try:
+        raw = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8")) or {}
+        return raw if isinstance(raw, dict) else {}, []
+    except Exception as exc:
+        return {}, [f"config parse failed: {type(exc).__name__}"]
+
+
+def file_meta(path: Path) -> dict[str, Any]:
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "exists": True,
+            "size_bytes": stat.st_size,
+            "mtime_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        }
+    except FileNotFoundError:
+        return {"path": str(path), "exists": False}
+    except Exception as exc:
+        return {"path": str(path), "exists": False, "error": type(exc).__name__}
+
+
+def summarize_platforms(config: dict[str, Any]) -> dict[str, Any]:
+    gateway = config.get("gateway") if isinstance(config.get("gateway"), dict) else {}
+    platforms = config.get("platforms") if isinstance(config.get("platforms"), dict) else {}
+    configured_sections = set()
+    for container in (gateway, platforms):
+        for platform in KNOWN_PLATFORMS:
+            if isinstance(container.get(platform), dict):
+                configured_sections.add(platform)
+    return {
+        "configured_sections": sorted(configured_sections),
+        "status": "config_section_presence_only",
+        "authoritative_source": "hermes status --all",
+    }
+
+
+def platform_delivery_probe(configured: Any, connected: Any, status: str) -> dict[str, Any]:
+    """Passive, side-effect-free delivery capability summary.
+
+    This intentionally does not read channel history or send probe messages. It
+    only classifies the parsed local status output into delivery-capable,
+    not-capable, or unknown.
+    """
+    if connected is True:
+        delivery_capable = True
+        delivery_status = "delivery_capable"
+    elif configured is False or status == "not_configured":
+        delivery_capable = False
+        delivery_status = "not_configured"
+    elif connected is False:
+        delivery_capable = False
+        delivery_status = "not_connected"
+    elif configured is True:
+        delivery_capable = None
+        delivery_status = "configured_delivery_unknown"
+    else:
+        delivery_capable = None
+        delivery_status = "unknown"
+    return {
+        "delivery_capable": delivery_capable,
+        "delivery_status": delivery_status,
+        "probe_method": "passive_status_parse",
+        "history_read": False,
+        "delivery_attempted": False,
+    }
+
+
+def parse_platform_status_text(text: str) -> dict[str, dict[str, Any]]:
+    statuses = {
+        platform: {
+            "mentioned": False,
+            "configured": None,
+            "connected": None,
+            "status": "unknown",
+            **platform_delivery_probe(None, None, "unknown"),
+        }
+        for platform in KNOWN_PLATFORMS
+    }
+    lines = text.splitlines()
+    in_messaging = False
+    section_lines: list[str] = []
+    for line in lines:
+        lowered = line.lower()
+        if "messaging platforms" in lowered:
+            in_messaging = True
+            continue
+        if in_messaging and line.strip() and not line.startswith((" ", "\t", "-", "*")) and lowered.endswith(":"):
+            break
+        if in_messaging:
+            section_lines.append(line)
+    scan_lines = section_lines or lines
+    for line in scan_lines:
+        lowered = line.lower()
+        for platform in KNOWN_PLATFORMS:
+            if platform not in lowered:
+                continue
+            connection_unknown = any(phrase in lowered for phrase in ("connection unknown", "unknown connection", "status unknown", "unknown"))
+            not_configured = any(phrase in lowered for phrase in ("not configured", "unconfigured", "missing", "disabled", "not set"))
+            explicit_connected = any(word in lowered for word in ("connected", "running", "active", "online"))
+            explicit_disconnected = "not connected" in lowered or "offline" in lowered
+            if not_configured:
+                configured = False
+                connected = False
+                status = "not_configured"
+            elif explicit_disconnected:
+                configured = True if "configured" in lowered else None
+                connected = False
+                status = "configured" if configured is True else "not_connected"
+            elif explicit_connected:
+                configured = True
+                connected = True
+                status = "connected"
+            elif "configured" in lowered or "enabled" in lowered:
+                configured = True
+                connected = None
+                status = "configured"
+            elif connection_unknown:
+                configured = None
+                connected = None
+                status = "mentioned"
+            else:
+                configured = None
+                connected = None
+                status = "mentioned"
+            statuses[platform] = {
+                "mentioned": True,
+                "configured": configured,
+                "connected": connected,
+                "status": status,
+                **platform_delivery_probe(configured, connected, status),
+            }
+    return statuses
+
+
+def parse_count(text: str, active_words: tuple[str, ...] = ("active", "enabled", "running")) -> dict[str, Any]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    active = sum(1 for line in lines if any(word in line.lower() for word in active_words))
+    return {"total": len(lines), "active_like": active, "lines_returned": min(len(lines), 20)}
+
+
+def get_config_summary() -> dict[str, Any]:
+    config, warnings = parse_yaml_config()
+    mcp = config.get("mcp_servers") if isinstance(config.get("mcp_servers"), dict) else {}
+    tools = config.get("tools") if isinstance(config.get("tools"), dict) else {}
+    memory = config.get("memory") if isinstance(config.get("memory"), dict) else {}
+    model = config.get("model") if isinstance(config.get("model"), dict) else {}
+    data = {
+        "config_exists": CONFIG_PATH.exists(),
+        "auth_file": {"exists": AUTH_PATH.exists(), "metadata_only": True},
+        "model": {
+            "section_present": bool(model),
+            "provider_present": bool(model.get("provider")) if isinstance(model, dict) else False,
+            "default_present": bool(model.get("default") or model.get("model")) if isinstance(model, dict) else False,
+        },
+        "memory": {
+            "section_present": bool(memory),
+            "enabled": memory.get("enabled") if isinstance(memory.get("enabled"), bool) else None,
+            "provider_present": bool(memory.get("provider")) if isinstance(memory, dict) else False,
+        },
+        "platforms": summarize_platforms(config),
+        "mcp_servers": sorted(str(name) for name in mcp.keys()),
+        "tool_sections": sorted(str(name) for name in tools.keys()),
+        "privacy_security_sections_present": {
+            "privacy": "privacy" in config,
+            "security": "security" in config,
+            "permissions": "permissions" in config,
+            "approvals": "approvals" in config,
+        },
+    }
+    return response(data, warnings=warnings)
+
+
+def get_gateway_status() -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    errors: list[dict[str, str]] = []
+    cmd, err = run_cmd(["systemctl", "--user", "is-active", "hermes-gateway"], "systemctl is-active", timeout=5)
+    if err:
+        errors.append(err)
+    else:
+        data["systemd_active"] = cmd["stdout"]
+    cmd, err = run_cmd(["systemctl", "--user", "show", "hermes-gateway", "--property=MainPID,ActiveState,SubState,LoadState,UnitFileState"], "systemctl show", timeout=5)
+    if err:
+        errors.append(err)
+    else:
+        props = {}
+        for line in cmd["stdout"].splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                props[k] = v
+        data["systemd_properties"] = {k: props.get(k) for k in ("MainPID", "ActiveState", "SubState", "LoadState", "UnitFileState")}
+        data["pid"] = props.get("MainPID")
+        data["manager"] = "systemd_user"
+        data["booleans"] = {
+            "active": props.get("ActiveState") == "active",
+            "running": props.get("SubState") == "running",
+            "loaded": props.get("LoadState") == "loaded",
+            "enabled": props.get("UnitFileState") == "enabled",
+        }
+    return response(data, errors)
+
+
+def get_platform_status() -> dict[str, Any]:
+    cfg = get_config_summary()
+    data = {"config_summary": cfg["data"].get("platforms", {})}
+    errors: list[dict[str, str]] = []
+    cmd, err = run_cmd(hermes_cmd("status", "--all"), "hermes status --all", timeout=10)
+    if err:
+        errors.append(err)
+    else:
+        data["platform_status"] = parse_platform_status_text(cmd["stdout"])
+        data["source"] = "hermes status --all"
+    return response(data, errors + cfg["errors"], cfg["warnings"])
+
+
+def get_mcp_status() -> dict[str, Any]:
+    cfg = get_config_summary()
+    data = {"configured_servers": cfg["data"].get("mcp_servers", [])}
+    errors: list[dict[str, str]] = []
+    cmd, err = run_cmd(hermes_cmd("mcp", "list"), "hermes mcp list", timeout=10)
+    if err:
+        errors.append(err)
+    else:
+        data["mcp_list"] = {"returncode": cmd["returncode"], "summary": cmd["stdout"][:2000], **parse_count(cmd["stdout"])}
+    return response(data, errors + cfg["errors"], cfg["warnings"])
+
+
+def get_toolsets_status() -> dict[str, Any]:
+    cmd, err = run_cmd(hermes_cmd("tools", "list"), "hermes tools list", timeout=10)
+    if err:
+        return response({"toolsets": []}, [err])
+    lines = [line.strip() for line in cmd["stdout"].splitlines() if line.strip()]
+    return response({"toolsets": lines[:100], "summary": parse_count(cmd["stdout"], ("enabled", "on", "active"))})
+
+
+def get_cron_status() -> dict[str, Any]:
+    cmd, err = run_cmd(hermes_cmd("cron", "list"), "hermes cron list", timeout=10)
+    if err:
+        return response({"active": None, "total": None}, [err])
+    lines = [line.strip() for line in cmd["stdout"].splitlines() if line.strip()]
+    if not lines or any("no scheduled jobs" in line.lower() for line in lines):
+        return response({"active": 0, "total": 0, "jobs": []})
+    active = sum(1 for line in lines if "active" in line.lower() or "enabled" in line.lower())
+    safe_jobs = []
+    for line in lines[:50]:
+        parts = line.split()
+        safe_jobs.append({"id_or_name": parts[0] if parts else "", "summary": redact_string(line[:160])})
+    return response({"active": active, "total": len(lines), "jobs": safe_jobs})
+
+
+def get_sessions_summary() -> dict[str, Any]:
+    data: dict[str, Any] = {"sessions_dir_exists": SESSIONS_DIR.exists(), "count": 0, "metadata_only": True}
+    if not SESSIONS_DIR.exists():
+        return response(data)
+    try:
+        session_files = list(SESSIONS_DIR.glob("**/*"))
+        json_files = [p for p in session_files if p.is_file() and p.suffix.lower() == ".json"]
+        data["file_count"] = sum(1 for p in session_files if p.is_file())
+        data["json_file_count"] = len(json_files)
+        index = SESSIONS_DIR / "sessions.json"
+        if index.exists():
+            obj = json.loads(index.read_text(encoding="utf-8"))
+            if isinstance(obj, dict):
+                data["count"] = len(obj)
+                data["recent_metadata"] = [
+                    {
+                        "platform": sanitize(v.get("platform") or (v.get("origin") or {}).get("platform")),
+                        "chat_type": sanitize(v.get("chat_type") or (v.get("origin") or {}).get("chat_type")),
+                        "updated_at": sanitize(v.get("updated_at")),
+                    }
+                    for v in list(obj.values())[:10]
+                    if isinstance(v, dict)
+                ]
+        else:
+            data["count"] = len(json_files)
+        return response(data)
+    except Exception as exc:
+        return response(data, [command_error("sessions summary", type(exc).__name__, "exception")])
+
+
+def categorize_log_line(line: str) -> str | None:
+    lowered = line.lower()
+    if "traceback" in lowered:
+        return "traceback"
+    if "exception" in lowered:
+        return "exception"
+    if "failed" in lowered or "failure" in lowered:
+        return "failed"
+    if "error" in lowered:
+        return "error"
+    if "warn" in lowered:
+        return "warning"
+    return None
+
+
+def parse_line_timestamp(line: str) -> str | None:
+    match = re.search(r"\d{4}-\d{2}-\d{2}[T ][0-9:.+-]{8,}(?:Z)?", line)
+    return match.group(0) if match else None
+
+
+def safe_log_snippet(line: str) -> str | None:
+    lowered = line.lower()
+    if any(marker in lowered for marker in (" user:", "assistant:", "content=", "content:", "message=", "message:", "prompt=", "cmdline", "command line", "argv=")):
+        return None
+    return redact_string(line[-240:])
+
+
+def get_recent_errors(limit: int = 50, include_snippets: bool = False) -> dict[str, Any]:
+    limit = max(1, min(int(limit or 50), MAX_LOG_LINES))
+    snippets_allowed = bool(include_snippets and os.environ.get("QUINN_OPS_ALLOW_LOG_SNIPPETS") == "1")
+    grouped: dict[str, dict[str, Any]] = {}
+    snippets = []
+    errors = []
+    for path in LOG_PATHS:
+        if not path.exists():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            for line in lines[-2000:]:
+                category = categorize_log_line(line)
+                if not category:
+                    continue
+                source = grouped.setdefault(path.name, {"total": 0, "categories": {}, "last_seen": None})
+                source["total"] += 1
+                source["categories"][category] = source["categories"].get(category, 0) + 1
+                source["last_seen"] = parse_line_timestamp(line) or source["last_seen"]
+                if snippets_allowed and len(snippets) < limit:
+                    snippet = safe_log_snippet(line)
+                    if snippet:
+                        snippets.append({"source": path.name, "category": category, "snippet": snippet})
+        except Exception as exc:
+            errors.append(command_error(path.name, type(exc).__name__, "exception"))
+    matched_total = sum(item["total"] for item in grouped.values())
+    return response({"limit": limit, "grouped": grouped, "matched_total": matched_total, "snippets": snippets if snippets_allowed else []}, errors)
+
+
+def get_repo_status() -> dict[str, Any]:
+    errors: list[dict[str, str]] = []
+    data: dict[str, Any] = {"repo": str(ROOT)}
+    for key, argv in {
+        "status_short": ["git", "status", "--porcelain=v1"],
+        "head": ["git", "rev-parse", "HEAD"],
+        "describe": ["git", "describe", "--tags", "--always", "--dirty"],
+        "branch": ["git", "branch", "--show-current"],
+    }.items():
+        cmd, err = run_cmd(argv, f"git {key}", timeout=10, cwd=ROOT)
+        if err:
+            errors.append(err)
+            continue
+        if key == "status_short":
+            files = []
+            for line in cmd["stdout"].splitlines():
+                if not line:
+                    continue
+                path = line[3:] if len(line) > 3 else ""
+                if " -> " in path:
+                    path = path.split(" -> ", 1)[1]
+                if path:
+                    files.append(path)
+            data[key] = {"dirty_count": len(files), "files": files[:100]}
+        elif key == "head":
+            data[key] = cmd["stdout"][:12]
+        else:
+            data[key] = cmd["stdout"]
+    return response(data, errors)
+
+
+def get_runtime_files_status() -> dict[str, Any]:
+    return response({"files": [file_meta(path) for path in KNOWN_RUNTIME_FILES]})
+
+
+def healthcheck() -> dict[str, Any]:
+    try:
+        from mcp.server.fastmcp import FastMCP  # noqa: F401
+        mcp_sdk = True
+    except Exception:
+        mcp_sdk = False
+    tools = sorted(TOOL_FUNCTIONS)
+    return response({
+        "server": "quinn_ops",
+        "timestamp_utc": utc_now(),
+        "read_only": True,
+        "mcp_sdk_available": mcp_sdk,
+        "commands_available": {
+            "hermes": bool(shutil.which("hermes") or (ROOT / "hermes").exists()),
+            "git": bool(shutil.which("git")),
+            "systemctl": bool(shutil.which("systemctl")),
+        },
+        "tools": tools,
+    }, warnings=[] if mcp_sdk else ["Python MCP SDK not installed; install it before running stdio server"])
+
+
+def get_overview() -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    def collect(name: str, fn: Callable[..., dict[str, Any]], *args: Any) -> Any:
+        result = fn(*args)
+        errors.extend(result.get("errors", []))
+        warnings.extend(result.get("warnings", []))
+        return result.get("data", {})
+
+    recent_error_data = collect("recent_errors", get_recent_errors, 50)
+    data = {
+        "timestamp_utc": utc_now(),
+        "hermes_version": None,
+        "gateway": collect("gateway", get_gateway_status),
+        "platforms": collect("platforms", get_platform_status),
+        "mcp": collect("mcp", get_mcp_status),
+        "cron": collect("cron", get_cron_status),
+        "sessions": collect("sessions", get_sessions_summary),
+        "toolsets": collect("toolsets", get_toolsets_status),
+        "repo": collect("repo", get_repo_status),
+        "recent_errors": {"count": recent_error_data.get("matched_total", 0), "grouped": recent_error_data.get("grouped", {})},
+        "runtime_files": collect("runtime_files", get_runtime_files_status),
+    }
+    cmd, err = run_cmd(hermes_cmd("--version"), "hermes --version", timeout=10)
+    if err:
+        errors.append(err)
+    else:
+        data["hermes_version"] = cmd["stdout"][:200]
+    return response(data, errors, warnings)
+
+
+def snapshot_path() -> Path:
+    return SNAPSHOT_PATH
+
+
+def build_overview_snapshot() -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    overview = get_overview()
+    snapshot = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "created_by": "quinn_ops",
+        "updated_at_utc": utc_now(),
+        "overview": sanitize(overview.get("data", {})),
+        "overview_errors": sanitize(overview.get("errors", [])),
+        "overview_warnings": sanitize(overview.get("warnings", [])),
+    }
+    return sanitize(snapshot), overview.get("errors", []), overview.get("warnings", [])
+
+
+def write_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
+    path = snapshot_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    payload = json.dumps(sanitize(snapshot), indent=2, sort_keys=True)
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(payload + "\n")
+    try:
+        os.chmod(tmp_path, 0o600)
+    except Exception:
+        pass
+    tmp_path.replace(path)
+    try:
+        os.chmod(path, 0o600)
+    except Exception:
+        pass
+    return {
+        "path": str(path),
+        "exists": True,
+        "size_bytes": path.stat().st_size,
+        "mtime_utc": datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "schema_version": snapshot.get("schema_version"),
+        "snapshot_timestamp_utc": snapshot.get("updated_at_utc"),
+    }
+
+
+def read_snapshot() -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    path = snapshot_path()
+    if not path.exists():
+        return None, None
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(obj, dict):
+            return None, command_error("overview snapshot", "snapshot file is not a JSON object", "invalid_snapshot")
+        return sanitize(obj), None
+    except Exception as exc:
+        return None, command_error("overview snapshot", type(exc).__name__, "exception")
+
+
+def snapshot_identity(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    if not snapshot:
+        return {}
+    overview = snapshot.get("overview") if isinstance(snapshot.get("overview"), dict) else {}
+    gateway = overview.get("gateway") if isinstance(overview.get("gateway"), dict) else {}
+    repo = overview.get("repo") if isinstance(overview.get("repo"), dict) else {}
+    return {
+        "gateway_active": gateway.get("systemd_active"),
+        "gateway_pid": gateway.get("pid"),
+        "repo_head": repo.get("head"),
+        "repo_branch": repo.get("branch"),
+        "hermes_version": overview.get("hermes_version"),
+    }
+
+
+def get_snapshot_status() -> dict[str, Any]:
+    path = snapshot_path()
+    data: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+        "schema_version": None,
+        "snapshot_timestamp_utc": None,
+        "baseline_identity": {},
+    }
+    if not path.exists():
+        return response(data)
+    try:
+        stat = path.stat()
+        snapshot, err = read_snapshot()
+        if err:
+            return response(data | {
+                "size_bytes": stat.st_size,
+                "mtime_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            }, [err])
+        data.update({
+            "size_bytes": stat.st_size,
+            "mtime_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "schema_version": snapshot.get("schema_version") if snapshot else None,
+            "snapshot_timestamp_utc": snapshot.get("updated_at_utc") if snapshot else None,
+            "baseline_identity": snapshot_identity(snapshot),
+        })
+        return response(data)
+    except Exception as exc:
+        return response(data, [command_error("snapshot status", type(exc).__name__, "exception")])
+
+
+def save_overview_snapshot() -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    snapshot, overview_errors, overview_warnings = build_overview_snapshot()
+    errors.extend(overview_errors)
+    warnings.extend(overview_warnings)
+    try:
+        meta = write_snapshot(snapshot)
+    except Exception as exc:
+        errors.append(command_error("overview snapshot write", type(exc).__name__, "exception"))
+        return response({"saved": False, "path": str(snapshot_path())}, errors, warnings)
+    overview = snapshot.get("overview") if isinstance(snapshot.get("overview"), dict) else {}
+    summary = {
+        "gateway_active": (overview.get("gateway") or {}).get("systemd_active") if isinstance(overview.get("gateway"), dict) else None,
+        "platforms_tracked": len(((overview.get("platforms") or {}).get("platform_status") or {})) if isinstance(overview.get("platforms"), dict) else 0,
+        "recent_error_count": (overview.get("recent_errors") or {}).get("count") if isinstance(overview.get("recent_errors"), dict) else None,
+    }
+    return response({"saved": True, "snapshot": meta, "summary": summary}, errors, warnings)
+
+
+def as_map(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def add_change(changes: dict[str, list[dict[str, Any]]], group: str, path: str, change_type: str, before: Any, after: Any, severity: str = "info") -> None:
+    if before == after:
+        return
+    changes.setdefault(group, []).append({
+        "path": path,
+        "type": change_type,
+        "before": sanitize(before),
+        "after": sanitize(after),
+        "severity": severity,
+    })
+
+
+def severity_rank(severity: str) -> int:
+    return {"info": 0, "warning": 1, "critical": 2}.get(severity, 0)
+
+
+def count_by_metadata(rows: list[Any], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        value = row.get(key)
+        if value is None:
+            value = "unknown"
+        counts[str(value)] = counts.get(str(value), 0) + 1
+    return counts
+
+
+def file_set_from_repo(repo: dict[str, Any]) -> set[str]:
+    return {str(item) for item in as_list(as_map(repo.get("status_short")).get("files"))}
+
+
+def runtime_file_map(runtime_files: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    files = {}
+    for item in as_list(runtime_files.get("files")):
+        if isinstance(item, dict) and item.get("path"):
+            files[str(item["path"])] = item
+    return files
+
+
+def job_id_set(cron: dict[str, Any]) -> set[str]:
+    ids = set()
+    for item in as_list(cron.get("jobs")):
+        if isinstance(item, dict):
+            ids.add(str(item.get("id_or_name") or item.get("id") or item.get("name") or item))
+        else:
+            ids.add(str(item))
+    return ids
+
+
+def line_set(toolsets: dict[str, Any]) -> set[str]:
+    return {str(line) for line in as_list(toolsets.get("toolsets"))}
+
+
+def build_error_delta_summary(prev_errors: dict[str, Any], curr_errors: dict[str, Any]) -> dict[str, Any]:
+    prev_count = prev_errors.get("count") if isinstance(prev_errors.get("count"), int) else 0
+    curr_count = curr_errors.get("count") if isinstance(curr_errors.get("count"), int) else 0
+    prev_grouped = as_map(prev_errors.get("grouped"))
+    curr_grouped = as_map(curr_errors.get("grouped"))
+    summary: dict[str, Any] = {
+        "total_before": prev_count,
+        "total_after": curr_count,
+        "total_delta": curr_count - prev_count,
+        "sources": {},
+        "new_categories": [],
+        "repeated_categories": [],
+        "last_seen_moved": [],
+    }
+    for source in sorted(set(prev_grouped) | set(curr_grouped)):
+        prev_source = as_map(prev_grouped.get(source))
+        curr_source = as_map(curr_grouped.get(source))
+        prev_total = prev_source.get("total") if isinstance(prev_source.get("total"), int) else 0
+        curr_total = curr_source.get("total") if isinstance(curr_source.get("total"), int) else 0
+        prev_last_seen = prev_source.get("last_seen")
+        curr_last_seen = curr_source.get("last_seen")
+        source_summary: dict[str, Any] = {
+            "total_before": prev_total,
+            "total_after": curr_total,
+            "total_delta": curr_total - prev_total,
+            "is_new_source": source not in prev_grouped and source in curr_grouped,
+            "last_seen_before": prev_last_seen,
+            "last_seen_after": curr_last_seen,
+            "last_seen_moved": bool(prev_last_seen and curr_last_seen and prev_last_seen != curr_last_seen),
+            "categories": {},
+        }
+        if source_summary["last_seen_moved"]:
+            summary["last_seen_moved"].append({"source": source, "before": prev_last_seen, "after": curr_last_seen})
+        prev_categories = as_map(prev_source.get("categories"))
+        curr_categories = as_map(curr_source.get("categories"))
+        for category in sorted(set(prev_categories) | set(curr_categories)):
+            before = prev_categories.get(category, 0)
+            after = curr_categories.get(category, 0)
+            if not isinstance(before, int):
+                before = 0
+            if not isinstance(after, int):
+                after = 0
+            category_summary = {
+                "before": before,
+                "after": after,
+                "delta": after - before,
+                "is_new": before == 0 and after > 0,
+                "repeated": before > 0 and after > 0,
+            }
+            source_summary["categories"][category] = category_summary
+            if category_summary["is_new"]:
+                summary["new_categories"].append({"source": source, "category": category, "after": after})
+            if category_summary["repeated"]:
+                summary["repeated_categories"].append({"source": source, "category": category, "before": before, "after": after, "delta": after - before})
+        summary["sources"][source] = source_summary
+    return sanitize(summary)
+
+
+def compare_overviews(previous: dict[str, Any], current: dict[str, Any]) -> dict[str, Any]:
+    changes = empty_change_groups()
+
+    prev_gateway = as_map(previous.get("gateway"))
+    curr_gateway = as_map(current.get("gateway"))
+    gateway_fields = [
+        ("systemd_active", "gateway.systemd_active"),
+        ("pid", "gateway.pid"),
+    ]
+    for key, path in gateway_fields:
+        severity = "info"
+        if key == "systemd_active" and curr_gateway.get(key) not in (None, "active"):
+            severity = "critical"
+        add_change(changes, "gateway", path, "changed", prev_gateway.get(key), curr_gateway.get(key), severity)
+    prev_props = as_map(prev_gateway.get("systemd_properties"))
+    curr_props = as_map(curr_gateway.get("systemd_properties"))
+    for key in ("ActiveState", "SubState", "UnitFileState"):
+        severity = "info"
+        if key in {"ActiveState", "SubState"} and curr_props.get(key) not in (None, "active", "running"):
+            severity = "critical"
+        if key == "UnitFileState" and curr_props.get(key) in {"disabled", "masked"}:
+            severity = "warning"
+        add_change(changes, "gateway", f"gateway.systemd_properties.{key}", "changed", prev_props.get(key), curr_props.get(key), severity)
+
+    prev_platforms = as_map(as_map(previous.get("platforms")).get("platform_status"))
+    curr_platforms = as_map(as_map(current.get("platforms")).get("platform_status"))
+    for platform in sorted(set(prev_platforms) | set(curr_platforms)):
+        prev = as_map(prev_platforms.get(platform))
+        curr = as_map(curr_platforms.get(platform))
+        for key in ("configured", "connected", "status"):
+            severity = "info"
+            if key == "configured" and prev.get(key) is True and curr.get(key) in (False, None):
+                severity = "warning"
+            if key == "connected" and prev.get(key) is True and curr.get(key) is False:
+                severity = "critical"
+            if key == "connected" and prev.get(key) is True and curr.get(key) is None:
+                severity = "warning"
+            if key == "status" and prev.get(key) == "configured" and curr.get(key) in (None, "unknown", "mentioned"):
+                severity = "warning"
+            add_change(changes, "platforms", f"platforms.{platform}.{key}", "changed", prev.get(key), curr.get(key), severity)
+
+    prev_mcp = as_map(previous.get("mcp"))
+    curr_mcp = as_map(current.get("mcp"))
+    prev_servers = set(str(x) for x in as_list(prev_mcp.get("configured_servers")))
+    curr_servers = set(str(x) for x in as_list(curr_mcp.get("configured_servers")))
+    if prev_servers != curr_servers:
+        severity = "critical" if "quinn_ops" in prev_servers and "quinn_ops" not in curr_servers else "info"
+        add_change(changes, "mcp", "mcp.configured_servers", "changed", sorted(prev_servers), sorted(curr_servers), severity)
+    prev_mcp_list = as_map(prev_mcp.get("mcp_list"))
+    curr_mcp_list = as_map(curr_mcp.get("mcp_list"))
+    active_severity = "critical" if "quinn_ops" in curr_servers and (curr_mcp_list.get("active_like") or 0) <= 0 else "info"
+    add_change(changes, "mcp", "mcp.mcp_list.active_like", "changed", prev_mcp_list.get("active_like"), curr_mcp_list.get("active_like"), active_severity)
+
+    prev_cron = as_map(previous.get("cron"))
+    curr_cron = as_map(current.get("cron"))
+    for key in ("total", "active"):
+        add_change(changes, "cron", f"cron.{key}", "changed", prev_cron.get(key), curr_cron.get(key), "info")
+    prev_jobs = job_id_set(prev_cron)
+    curr_jobs = job_id_set(curr_cron)
+    if prev_jobs != curr_jobs:
+        add_change(changes, "cron", "cron.jobs", "changed", sorted(prev_jobs), sorted(curr_jobs), "info")
+
+    prev_sessions = as_map(previous.get("sessions"))
+    curr_sessions = as_map(current.get("sessions"))
+    for key in ("count", "file_count", "json_file_count"):
+        add_change(changes, "sessions", f"sessions.{key}", "changed", prev_sessions.get(key), curr_sessions.get(key), "info")
+    for key in ("platform", "chat_type"):
+        prev_counts = count_by_metadata(as_list(prev_sessions.get("recent_metadata")), key)
+        curr_counts = count_by_metadata(as_list(curr_sessions.get("recent_metadata")), key)
+        add_change(changes, "sessions", f"sessions.recent_metadata.{key}_counts", "changed", prev_counts, curr_counts, "info")
+
+    prev_repo = as_map(previous.get("repo"))
+    curr_repo = as_map(current.get("repo"))
+    for key in ("head", "branch", "describe"):
+        severity = "warning" if key == "branch" else "info"
+        add_change(changes, "repo", f"repo.{key}", "changed", prev_repo.get(key), curr_repo.get(key), severity)
+    prev_dirty = as_map(prev_repo.get("status_short")).get("dirty_count")
+    curr_dirty = as_map(curr_repo.get("status_short")).get("dirty_count")
+    if prev_dirty != curr_dirty:
+        change_type = "increased" if isinstance(prev_dirty, int) and isinstance(curr_dirty, int) and curr_dirty > prev_dirty else "decreased"
+        add_change(changes, "repo", "repo.status_short.dirty_count", change_type, prev_dirty, curr_dirty, "info")
+    prev_files = file_set_from_repo(prev_repo)
+    curr_files = file_set_from_repo(curr_repo)
+    if prev_files != curr_files:
+        added_files = sorted(curr_files - prev_files)
+        removed_files = sorted(prev_files - curr_files)
+        if added_files:
+            add_change(changes, "repo", "repo.status_short.files.added", "added", [], added_files, "info")
+        if removed_files:
+            add_change(changes, "repo", "repo.status_short.files.removed", "removed", removed_files, [], "info")
+
+    prev_errors = as_map(previous.get("recent_errors"))
+    curr_errors = as_map(current.get("recent_errors"))
+    prev_count = prev_errors.get("count")
+    curr_count = curr_errors.get("count")
+    if prev_count != curr_count:
+        change_type = "increased" if isinstance(prev_count, int) and isinstance(curr_count, int) and curr_count > prev_count else "decreased"
+        severity = "warning" if change_type == "increased" else "info"
+        add_change(changes, "recent_errors", "recent_errors.count", change_type, prev_count, curr_count, severity)
+    prev_grouped = as_map(prev_errors.get("grouped"))
+    curr_grouped = as_map(curr_errors.get("grouped"))
+    for source in sorted(set(prev_grouped) | set(curr_grouped)):
+        prev_source = as_map(prev_grouped.get(source))
+        curr_source = as_map(curr_grouped.get(source))
+        add_change(changes, "recent_errors", f"recent_errors.grouped.{source}.total", "changed", prev_source.get("total"), curr_source.get("total"), "warning" if (curr_source.get("total") or 0) > (prev_source.get("total") or 0) else "info")
+        prev_categories = as_map(prev_source.get("categories"))
+        curr_categories = as_map(curr_source.get("categories"))
+        for category in sorted(set(prev_categories) | set(curr_categories)):
+            before = prev_categories.get(category, 0)
+            after = curr_categories.get(category, 0)
+            severity = "warning" if after > before else "info"
+            if category in {"traceback", "exception"} and after > before + 5:
+                severity = "critical"
+            add_change(changes, "recent_errors", f"recent_errors.grouped.{source}.categories.{category}", "increased" if after > before else "decreased", before, after, severity)
+        add_change(changes, "recent_errors", f"recent_errors.grouped.{source}.last_seen", "changed", prev_source.get("last_seen"), curr_source.get("last_seen"), "info")
+
+    prev_runtime = runtime_file_map(as_map(previous.get("runtime_files")))
+    curr_runtime = runtime_file_map(as_map(current.get("runtime_files")))
+    for path in sorted(set(prev_runtime) | set(curr_runtime)):
+        prev_file = as_map(prev_runtime.get(path))
+        curr_file = as_map(curr_runtime.get(path))
+        for key in ("exists", "size_bytes"):
+            add_change(changes, "runtime_files", f"runtime_files.{path}.{key}", "changed", prev_file.get(key), curr_file.get(key), "info")
+
+    prev_toolsets = as_map(previous.get("toolsets"))
+    curr_toolsets = as_map(current.get("toolsets"))
+    prev_summary = as_map(prev_toolsets.get("summary"))
+    curr_summary = as_map(curr_toolsets.get("summary"))
+    for key in ("total", "active_like"):
+        add_change(changes, "toolsets", f"toolsets.summary.{key}", "changed", prev_summary.get(key), curr_summary.get(key), "info")
+    prev_lines = line_set(prev_toolsets)
+    curr_lines = line_set(curr_toolsets)
+    if prev_lines != curr_lines:
+        add_change(changes, "toolsets", "toolsets.lines", "changed", sorted(prev_lines), sorted(curr_lines), "info")
+
+    add_change(changes, "version", "hermes_version", "changed", previous.get("hermes_version"), current.get("hermes_version"), "info")
+
+    flattened = [item for group in changes.values() for item in group]
+    severity = "info"
+    if flattened:
+        severity = max((item.get("severity", "info") for item in flattened), key=severity_rank)
+    headlines = build_diff_headlines(changes)
+    return {
+        "summary": {
+            "changed_count": len(flattened),
+            "severity": severity,
+            "headlines": headlines[:12],
+            "error_delta": build_error_delta_summary(prev_errors, curr_errors),
+        },
+        "changes": changes,
+    }
+
+
+def build_diff_headlines(changes: dict[str, list[dict[str, Any]]]) -> list[str]:
+    headlines: list[str] = []
+    for group, items in changes.items():
+        for item in items:
+            path = item.get("path", group)
+            before = item.get("before")
+            after = item.get("after")
+            severity = item.get("severity", "info")
+            headlines.append(f"{severity}: {path} changed from {before!r} to {after!r}")
+    return headlines
+
+
+def get_overview_diff(update_baseline: bool = False) -> dict[str, Any]:
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    current_overview = get_overview()
+    errors.extend(current_overview.get("errors", []))
+    warnings.extend(current_overview.get("warnings", []))
+    current_data = sanitize(current_overview.get("data", {}))
+    previous_snapshot, read_error = read_snapshot()
+    if read_error:
+        warnings.append("Previous overview snapshot could not be read; treating this as the first snapshot.")
+    has_previous = bool(previous_snapshot and isinstance(previous_snapshot.get("overview"), dict) and not read_error)
+    data: dict[str, Any] = {
+        "has_previous": has_previous,
+        "baseline_timestamp_utc": previous_snapshot.get("updated_at_utc") if has_previous else None,
+        "current_timestamp_utc": current_data.get("timestamp_utc") or utc_now(),
+        "updated_baseline": False,
+        "summary": {
+            "changed_count": 0,
+            "severity": "info",
+            "headlines": [],
+        },
+        "changes": empty_change_groups(),
+    }
+    if not has_previous:
+        data["summary"]["headlines"] = ["No previous Quinn Ops overview snapshot exists yet; save a snapshot to establish the baseline."]
+        warnings.append("No previous Quinn Ops overview snapshot exists yet.")
+    else:
+        diff = compare_overviews(as_map(previous_snapshot.get("overview")), current_data)
+        data.update(diff)
+    if update_baseline:
+        snapshot = {
+            "schema_version": SNAPSHOT_SCHEMA_VERSION,
+            "created_by": "quinn_ops",
+            "updated_at_utc": utc_now(),
+            "overview": current_data,
+            "overview_errors": sanitize(current_overview.get("errors", [])),
+            "overview_warnings": sanitize(current_overview.get("warnings", [])),
+        }
+        try:
+            data["updated_baseline"] = True
+            data["snapshot"] = write_snapshot(snapshot)
+        except Exception as exc:
+            data["updated_baseline"] = False
+            errors.append(command_error("overview snapshot write", type(exc).__name__, "exception"))
+    return response(data, errors, warnings)
+
+
+TOOL_FUNCTIONS: dict[str, Callable[..., dict[str, Any]]] = {
+    "get_overview": get_overview,
+    "get_snapshot_status": get_snapshot_status,
+    "get_overview_diff": get_overview_diff,
+    "save_overview_snapshot": save_overview_snapshot,
+    "get_gateway_status": get_gateway_status,
+    "get_platform_status": get_platform_status,
+    "get_mcp_status": get_mcp_status,
+    "get_toolsets_status": get_toolsets_status,
+    "get_cron_status": get_cron_status,
+    "get_sessions_summary": get_sessions_summary,
+    "get_recent_errors": get_recent_errors,
+    "get_config_summary": get_config_summary,
+    "get_repo_status": get_repo_status,
+    "get_runtime_files_status": get_runtime_files_status,
+    "healthcheck": healthcheck,
+}
+
+
+def build_mcp():
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except Exception as exc:
+        raise RuntimeError(
+            "Python MCP SDK is not installed. Install the official MCP SDK before "
+            "running quinn_ops over stdio; collection functions remain importable."
+        ) from exc
+    mcp = FastMCP("quinn_ops")
+    for fn in TOOL_FUNCTIONS.values():
+        mcp.tool()(fn)
+    return mcp
+
+
+def main() -> int:
+    try:
+        build_mcp().run()
+        return 0
+    except RuntimeError as exc:
+        print(json.dumps(response({"server": "quinn_ops"}, [{"source": "mcp import", "message": str(exc), "kind": "missing_dependency"}])), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quinn_docs_mcp.py
+++ b/tests/test_quinn_docs_mcp.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "mcp" / "quinn_docs_server.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("quinn_docs_server_test", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_registry(monkeypatch, mod, docs: dict[str, Path], **extra):
+    registry = {}
+    for doc_id, path in docs.items():
+        registry[doc_id] = {"title": doc_id.title(), "path": path, "type": "markdown", **extra}
+    monkeypatch.setattr(mod, "DOC_REGISTRY", registry)
+
+
+def private_label(kind: str) -> str:
+    pieces = {"a": ("api", "_", "key"), "t": ("tok", "en"), "s": ("sec", "ret"), "p": ("pass", "word"), "h": ("auth", "orization")}
+    return "".join(pieces[kind])
+
+
+def test_imports_and_registers_read_only_tools():
+    mod = load_module()
+    expected = {"healthcheck", "list_documents", "get_document_outline", "search_documents", "read_document_excerpt", "get_document_summary", "check_source_of_truth_freshness", "propose_document_patch"}
+    assert expected <= set(mod.TOOL_FUNCTIONS)
+    assert not any(word in name for name in mod.TOOL_FUNCTIONS for word in ("write", "delete", "remove", "edit"))
+
+
+def test_default_registry_uses_expected_stable_doc_ids():
+    mod = load_module()
+    assert {"quinn-hermes-server", "quinn-ops-mcp", "quinn-ops-snapshot-design", "quinn-github-mcp-plan", "quinn-observability-mcp-plan", "quinn-docs-mcp-plan", "quinn-approval-ops-mcp-plan"} <= set(mod.DOC_REGISTRY)
+
+
+def test_allowlisted_document_can_be_listed_and_excerpted_without_absolute_paths(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    doc.write_text("# Allowed Doc\n\nSafe line\n", encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    listed = mod.list_documents()
+    dumped_list = json.dumps(listed)
+    assert listed["ok"]
+    assert "allowed" in dumped_list
+    assert str(doc) not in dumped_list
+    assert listed["data"]["documents"][0]["path_alias"] == "allowed"
+    excerpt = mod.read_document_excerpt("allowed", start_line=1, limit=3)
+    assert excerpt["ok"]
+    assert excerpt["data"]["lines"][0]["text"] == "# Allowed Doc"
+    assert str(doc) not in json.dumps(excerpt)
+
+
+def test_non_allowlisted_raw_path_is_rejected(tmp_path, monkeypatch):
+    mod = load_module()
+    denied = tmp_path / "denied.md"
+    denied.write_text("# Denied\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "DOC_REGISTRY", {})
+    result = mod.read_document_excerpt(str(denied), start_line=1, limit=1)
+    assert result["ok"] is False
+    assert result["errors"][0]["kind"] == "unknown_doc"
+
+
+def test_path_traversal_doc_id_is_rejected(monkeypatch):
+    mod = load_module()
+    monkeypatch.setattr(mod, "DOC_REGISTRY", {})
+    result = mod.get_document_outline("../config")
+    assert result["ok"] is False
+    assert result["errors"][0]["kind"] == "unknown_doc"
+
+
+def test_private_path_like_doc_id_is_rejected(monkeypatch):
+    mod = load_module()
+    monkeypatch.setattr(mod, "DOC_REGISTRY", {})
+    blocked_ids = ["." + "env", "auth" + ".json", "sessions", "logs", "/home/quinn/.hermes/." + "env"]
+    for doc_id in blocked_ids:
+        result = mod.read_document_excerpt(doc_id)
+        assert result["ok"] is False
+        assert result["errors"][0]["kind"] == "unknown_doc"
+
+
+def test_redaction_removes_private_values_from_excerpts_search_and_proposals(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    hidden = "should-not-appear"
+    bearer = "bearer-value"
+    doc.write_text("# Allowed\n\n" + private_label("a") + f": {hidden}\n" + private_label("h") + f" = {bearer}\n", encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    excerpt = mod.read_document_excerpt("allowed", start_line=1, limit=8)
+    search = mod.search_documents(hidden)
+    proposal = mod.propose_document_patch("allowed", f"Add {private_label('t')}: {hidden} to notes")
+    dumped = json.dumps({"excerpt": excerpt, "search": search, "proposal": proposal})
+    assert excerpt["ok"] and search["ok"] and proposal["ok"]
+    assert hidden not in dumped
+    assert bearer not in dumped
+    assert "[REDACTED]" in dumped
+
+
+def test_outline_parses_headings_with_line_numbers(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    doc.write_text("intro\n# First\nbody\n## Second\n", encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    outline = mod.get_document_outline("allowed")
+    assert outline["ok"]
+    assert outline["data"]["headings"] == [{"line": 2, "level": 1, "text": "First"}, {"line": 4, "level": 2, "text": "Second"}]
+
+
+def test_search_is_literal_bounded_redacted_and_has_no_absolute_paths(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    hidden = "hide-me"
+    doc.write_text("# Search\nneedle line one\nNEEDLE line two with " + private_label("p") + f": {hidden}\nregex-ish .* needle\n", encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    result = mod.search_documents("NEEDLE", limit=2)
+    dumped = json.dumps(result)
+    assert result["ok"]
+    assert result["data"]["count"] == 2
+    assert [row["line"] for row in result["data"]["results"]] == [2, 3]
+    assert hidden not in dumped
+    assert str(doc) not in dumped
+    literal = mod.search_documents(".*", limit=5)
+    assert literal["ok"]
+    assert literal["data"]["count"] == 1
+    assert literal["data"]["results"][0]["line"] == 4
+
+
+def test_search_rejects_blank_query_and_clamps_limit(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    doc.write_text("\n".join(f"needle {i}" for i in range(20)), encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    blank = mod.search_documents("   ")
+    assert blank["ok"] is False
+    assert blank["errors"][0]["kind"] == "invalid_query"
+    one = mod.search_documents("needle", limit=0)
+    assert one["ok"]
+    assert one["data"]["count"] == 1
+
+
+def test_excerpt_clamps_line_count_and_character_budget(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    doc.write_text("\n".join(f"line {i} {'x' * 80}" for i in range(200)), encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    monkeypatch.setattr(mod, "MAX_EXCERPT_LINES", 5)
+    monkeypatch.setattr(mod, "MAX_EXCERPT_CHARS", 180)
+    result = mod.read_document_excerpt("allowed", start_line=-5, limit=500)
+    assert result["ok"]
+    assert result["data"]["start_line"] == 1
+    assert result["data"]["requested_limit"] == 500
+    assert result["data"]["returned_lines"] <= 5
+    assert sum(len(line["text"]) for line in result["data"]["lines"]) <= 180
+
+
+def test_freshness_reports_missing_files_and_required_headings(tmp_path, monkeypatch):
+    mod = load_module()
+    healthy = tmp_path / "healthy.md"
+    stale = tmp_path / "stale.md"
+    missing = tmp_path / "missing.md"
+    healthy.write_text("# Security Boundaries\n\n# Live Promotion\n", encoding="utf-8")
+    stale.write_text("# Other\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "DOC_REGISTRY", {
+        "healthy": {"title": "Healthy", "path": healthy, "type": "markdown", "required_headings": ["Security Boundaries", "Live Promotion"]},
+        "stale": {"title": "Stale", "path": stale, "type": "markdown", "required_headings": ["Security Boundaries"]},
+        "missing": {"title": "Missing", "path": missing, "type": "markdown", "required_headings": ["Security Boundaries"]},
+    })
+    result = mod.check_source_of_truth_freshness()
+    dumped = json.dumps(result)
+    assert result["ok"]
+    assert "missing: missing" in dumped
+    assert "missing heading: stale: Security Boundaries" in dumped
+    assert str(tmp_path) not in dumped
+
+
+def test_patch_proposal_is_text_only_redacted_and_does_not_mutate_file(tmp_path, monkeypatch):
+    mod = load_module()
+    doc = tmp_path / "allowed.md"
+    original = "# Allowed\n\nOld text\n"
+    doc.write_text(original, encoding="utf-8")
+    install_registry(monkeypatch, mod, {"allowed": doc})
+    hidden = "never-show"
+    result = mod.propose_document_patch("allowed", f"In section Security Boundaries, replace Old text with {private_label('t')}: {hidden}")
+    dumped = json.dumps(result)
+    assert result["ok"]
+    assert result["data"]["requires_approval"] is True
+    assert result["data"]["applied"] is False
+    assert result["data"]["doc_id"] == "allowed"
+    assert "proposal_patch" in result["data"]
+    assert hidden not in dumped
+    assert str(doc) not in dumped
+    assert doc.read_text(encoding="utf-8") == original
+
+
+def test_patch_proposal_rejects_denied_doc(monkeypatch):
+    mod = load_module()
+    monkeypatch.setattr(mod, "DOC_REGISTRY", {})
+    result = mod.propose_document_patch("/home/quinn/.hermes/." + "env", "change it")
+    assert result["ok"] is False
+    assert result["errors"][0]["kind"] == "unknown_doc"

--- a/tests/test_quinn_ops_mcp.py
+++ b/tests/test_quinn_ops_mcp.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from types import SimpleNamespace
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "mcp" / "quinn_ops_server.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("quinn_ops_server_test", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_imports_and_tool_functions_json_serializable():
+    mod = load_module()
+    expected = {
+        "get_overview",
+        "get_snapshot_status",
+        "get_overview_diff",
+        "save_overview_snapshot",
+        "get_gateway_status",
+        "get_platform_status",
+        "get_mcp_status",
+        "get_toolsets_status",
+        "get_cron_status",
+        "get_sessions_summary",
+        "get_recent_errors",
+        "get_config_summary",
+        "get_repo_status",
+        "get_runtime_files_status",
+        "healthcheck",
+    }
+    assert expected <= set(mod.TOOL_FUNCTIONS)
+    for name in expected - {"get_overview"}:
+        result = mod.TOOL_FUNCTIONS[name]()
+        assert isinstance(result, dict)
+        json.dumps(result)
+        assert set(result) == {"ok", "data", "errors", "warnings"}
+
+
+def test_redaction_representative_secrets():
+    mod = load_module()
+    payload = {
+        "api_key": "sk-test123456789",
+        "github": "ghp_fakeSECRET123456",
+        "pat": "github_pat_fakeSECRET123456",
+        "header": "Authorization: Bearer abc123SECRET",
+        "discord": "DISCORD_TOKEN=abc.def.ghi01234567890123456789",
+        "telegram": "TELEGRAM_BOT_TOKEN=123:ABCSECRETXYZ",
+        "nested": [{"token": "should-not-appear"}],
+    }
+    redacted = json.dumps(mod.sanitize(payload))
+    assert "sk-test" not in redacted
+    assert "ghp_fake" not in redacted
+    assert "github_pat_fake" not in redacted
+    assert "abc123SECRET" not in redacted
+    assert "abc.def" not in redacted
+    assert "ABCSECRET" not in redacted
+    assert "should-not-appear" not in redacted
+
+
+def test_safe_metadata_keys_are_not_redacted():
+    mod = load_module()
+    payload = {
+        "auth_file": {"exists": True, "metadata_only": True},
+        "sessions": {"count": 5},
+        "session_count": 5,
+        "sessions_dir_exists": True,
+        "mcp_servers": ["quinn_ops"],
+        "session_metadata": [{"platform": "telegram", "chat_type": "dm"}],
+        "platform_status": {"telegram": {"configured": True}},
+        "access_token": "abc123SECRET",
+        "headers": {"Authorization": "Bearer abc123SECRET"},
+    }
+    sanitized = mod.sanitize(payload)
+    dumped = json.dumps(sanitized)
+    assert sanitized["auth_file"]["exists"] is True
+    assert sanitized["sessions"]["count"] == 5
+    assert sanitized["session_count"] == 5
+    assert sanitized["sessions_dir_exists"] is True
+    assert sanitized["mcp_servers"] == ["quinn_ops"]
+    assert sanitized["session_metadata"][0]["platform"] == "telegram"
+    assert sanitized["platform_status"]["telegram"]["configured"] is True
+    assert "abc123SECRET" not in dumped
+
+
+def test_config_summary_redacts_sensitive_keys(tmp_path, monkeypatch):
+    mod = load_module()
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+model:
+  provider: openai
+  api_key: sk-test123456789
+gateway:
+  discord:
+    token: abc.def.ghi01234567890123456789
+  telegram:
+    bot_token: 123:ABCSECRETXYZ
+mcp_servers:
+  sample:
+    command: python
+tools:
+  web:
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "CONFIG_PATH", config)
+    monkeypatch.setattr(mod, "AUTH_PATH", tmp_path / "auth.json")
+    result = mod.get_config_summary()
+    dumped = json.dumps(result)
+    assert result["ok"]
+    assert result["data"]["model"]["provider_present"] is True
+    assert result["data"]["mcp_servers"] == ["sample"]
+    assert result["data"]["platforms"]["configured_sections"] == ["discord", "telegram"]
+    assert "discord_configured" not in result["data"]["platforms"]
+    assert "sk-test" not in dumped
+    assert "abc.def" not in dumped
+    assert "ABCSECRET" not in dumped
+
+
+def test_subprocess_failure_structured(monkeypatch):
+    mod = load_module()
+
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["hermes"], timeout=1)
+
+    monkeypatch.setattr(mod.subprocess, "run", boom)
+    result = mod.get_gateway_status()
+    assert result["ok"] is False
+    assert result["errors"]
+    assert result["errors"][0]["kind"] == "timeout"
+    json.dumps(result)
+
+
+def test_gateway_status_does_not_return_raw_multiline_service_text(monkeypatch):
+    mod = load_module()
+
+    def fake_run_cmd(argv, source, timeout=10, cwd=None):
+        if argv[:3] == ["systemctl", "--user", "is-active"]:
+            return {"stdout": "active", "stderr": "", "returncode": 0}, None
+        if argv[:3] == ["systemctl", "--user", "show"]:
+            return {
+                "stdout": "MainPID=123\nActiveState=active\nSubState=running\nLoadState=loaded\nUnitFileState=enabled\n",
+                "stderr": "",
+                "returncode": 0,
+            }, None
+        raise AssertionError(f"unexpected command: {argv}")
+
+    monkeypatch.setattr(mod, "run_cmd", fake_run_cmd)
+    result = mod.get_gateway_status()
+    assert result["ok"]
+    data = result["data"]
+    assert data["pid"] == "123"
+    assert data["booleans"]["running"] is True
+    assert "hermes_gateway_status" not in data
+    assert "summary" not in json.dumps(data).lower()
+
+
+def test_recent_errors_limit_and_redaction(tmp_path, monkeypatch):
+    mod = load_module()
+    log = tmp_path / "gateway.log"
+    log.write_text("ok\n2026-05-13T04:00:00Z ERROR Authorization: Bearer abc123SECRET user: private text\nWARN sk-test123456789\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "LOG_PATHS", [log])
+    result = mod.get_recent_errors(500)
+    dumped = json.dumps(result)
+    assert result["data"]["limit"] == 200
+    assert result["data"]["matched_total"] == 2
+    assert result["data"]["grouped"]["gateway.log"]["categories"]["error"] == 1
+    assert result["data"]["snippets"] == []
+    assert "abc123SECRET" not in dumped
+    assert "sk-test" not in dumped
+    assert "private text" not in dumped
+
+
+def test_recent_errors_snippets_are_env_gated(tmp_path, monkeypatch):
+    mod = load_module()
+    log = tmp_path / "gateway.log"
+    log.write_text("ERROR safe operational failure\nERROR user: do not return this\n", encoding="utf-8")
+    monkeypatch.setattr(mod, "LOG_PATHS", [log])
+    no_snippets = mod.get_recent_errors(50, include_snippets=True)
+    assert no_snippets["data"]["snippets"] == []
+    monkeypatch.setenv("QUINN_OPS_ALLOW_LOG_SNIPPETS", "1")
+    snippets = mod.get_recent_errors(50, include_snippets=True)
+    dumped = json.dumps(snippets)
+    assert "safe operational failure" in dumped
+    assert "do not return this" not in dumped
+
+
+def test_git_porcelain_parsing_preserves_first_filename(monkeypatch):
+    mod = load_module()
+
+    def fake_run_cmd(argv, source, timeout=10, cwd=None):
+        if argv[:3] == ["git", "status", "--porcelain=v1"]:
+            return {"stdout": " M gateway/platforms/discord.py\n?? docs/foo.md\n", "stderr": "", "returncode": 0}, None
+        if argv[:2] == ["git", "rev-parse"]:
+            return {"stdout": "abcdef1234567890\n", "stderr": "", "returncode": 0}, None
+        if argv[:2] == ["git", "describe"]:
+            return {"stdout": "v1-dirty\n", "stderr": "", "returncode": 0}, None
+        if argv[:2] == ["git", "branch"]:
+            return {"stdout": "main\n", "stderr": "", "returncode": 0}, None
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(mod, "run_cmd", fake_run_cmd)
+    result = mod.get_repo_status()
+    assert result["data"]["status_short"]["files"][0] == "gateway/platforms/discord.py"
+    assert result["data"]["status_short"]["files"][1] == "docs/foo.md"
+
+
+def test_platform_status_parses_messaging_section(monkeypatch):
+    mod = load_module()
+    sample = """
+Hermes status
+
+Messaging Platforms:
+  Discord: connected
+  Telegram: configured, connection unknown
+  Slack: not configured
+  Matrix: disabled
+  WhatsApp: not configured
+
+Other:
+  Discord mention elsewhere should not matter
+"""
+
+    def fake_run_cmd(argv, source, timeout=10, cwd=None):
+        return {"stdout": sample, "stderr": "", "returncode": 0}, None
+
+    monkeypatch.setattr(mod, "run_cmd", fake_run_cmd)
+    monkeypatch.setattr(mod, "get_config_summary", lambda: {"ok": True, "data": {"platforms": {}}, "errors": [], "warnings": []})
+    result = mod.get_platform_status()
+    platforms = result["data"]["platform_status"]
+    assert platforms["discord"]["connected"] is True
+    assert platforms["telegram"]["configured"] is True
+    assert platforms["telegram"]["connected"] is None
+    assert platforms["slack"]["configured"] is False
+    assert platforms["whatsapp"]["configured"] is False
+    assert platforms["matrix"]["status"] == "not_configured"
+
+
+def test_cron_status_no_scheduled_jobs(monkeypatch):
+    mod = load_module()
+
+    def fake_run_cmd(argv, source, timeout=10, cwd=None):
+        return {"stdout": "No scheduled jobs.\nCreate one with `hermes cron add`.\n", "stderr": "", "returncode": 0}, None
+
+    monkeypatch.setattr(mod, "run_cmd", fake_run_cmd)
+    result = mod.get_cron_status()
+    assert result["ok"]
+    assert result["data"] == {"active": 0, "total": 0, "jobs": []}
+
+
+def test_platform_status_realish_connected_configured(monkeypatch):
+    mod = load_module()
+    sample = """
+Status:
+  Model: gpt-5.5
+
+Messaging Platforms:
+  discord configured connected
+  telegram configured connected
+  slack not configured
+  whatsapp not configured
+  signal not configured
+"""
+
+    monkeypatch.setattr(mod, "run_cmd", lambda *a, **k: ({"stdout": sample, "stderr": "", "returncode": 0}, None))
+    monkeypatch.setattr(mod, "get_config_summary", lambda: {"ok": True, "data": {"platforms": {"configured_sections": []}}, "errors": [], "warnings": []})
+    result = mod.get_platform_status()
+    platforms = result["data"]["platform_status"]
+    assert platforms["discord"]["configured"] is True
+    assert platforms["discord"]["connected"] is True
+    assert platforms["telegram"]["configured"] is True
+    assert platforms["telegram"]["connected"] is True
+    assert platforms["slack"]["configured"] is False
+    assert platforms["whatsapp"]["configured"] is False
+    assert platforms["signal"]["configured"] is False
+
+
+def test_platform_status_live_configured_unknown_connection(monkeypatch):
+    mod = load_module()
+    sample = """
+◆ Messaging Platforms
+  Telegram      ✓ configured (home: 8230754176)
+  Discord       ✓ configured (home: 1498774848493584394)
+  WhatsApp      ✗ not configured
+"""
+
+    monkeypatch.setattr(mod, "run_cmd", lambda *a, **k: ({"stdout": sample, "stderr": "", "returncode": 0}, None))
+    monkeypatch.setattr(mod, "get_config_summary", lambda: {"ok": True, "data": {"platforms": {"configured_sections": []}}, "errors": [], "warnings": []})
+    result = mod.get_platform_status()
+    platforms = result["data"]["platform_status"]
+    assert platforms["telegram"]["configured"] is True
+    assert platforms["telegram"]["connected"] is None
+    assert platforms["telegram"]["status"] == "configured"
+    assert platforms["discord"]["configured"] is True
+    assert platforms["discord"]["connected"] is None
+    assert platforms["discord"]["status"] == "configured"
+    assert platforms["whatsapp"]["configured"] is False
+    assert platforms["whatsapp"]["connected"] is False
+    assert platforms["whatsapp"]["status"] == "not_configured"
+
+
+def test_platform_status_adds_passive_delivery_probe_without_history_or_send(monkeypatch):
+    mod = load_module()
+    sample = """
+Messaging Platforms:
+  Discord: connected
+  Telegram: configured, connection unknown
+  Slack: not configured
+  Signal: configured, not connected
+"""
+
+    monkeypatch.setattr(mod, "run_cmd", lambda *a, **k: ({"stdout": sample, "stderr": "", "returncode": 0}, None))
+    monkeypatch.setattr(mod, "get_config_summary", lambda: {"ok": True, "data": {"platforms": {"configured_sections": []}}, "errors": [], "warnings": []})
+    result = mod.get_platform_status()
+    platforms = result["data"]["platform_status"]
+
+    assert platforms["discord"]["delivery_capable"] is True
+    assert platforms["discord"]["delivery_status"] == "delivery_capable"
+    assert platforms["telegram"]["delivery_capable"] is None
+    assert platforms["telegram"]["delivery_status"] == "configured_delivery_unknown"
+    assert platforms["signal"]["delivery_capable"] is False
+    assert platforms["signal"]["delivery_status"] == "not_connected"
+    assert platforms["slack"]["delivery_capable"] is False
+    assert platforms["slack"]["delivery_status"] == "not_configured"
+    assert all(item["probe_method"] == "passive_status_parse" for item in platforms.values())
+    assert all(item["history_read"] is False for item in platforms.values())
+    assert all(item["delivery_attempted"] is False for item in platforms.values())
+
+
+def test_overview_aggregates_partial_errors(monkeypatch):
+    mod = load_module()
+
+    def ok_data(name):
+        return {"ok": True, "data": {name: True}, "errors": [], "warnings": []}
+
+    monkeypatch.setattr(mod, "get_recent_errors", lambda limit=50, include_snippets=False: {"ok": True, "data": {"matched_total": 0, "grouped": {}}, "errors": [], "warnings": []})
+    monkeypatch.setattr(mod, "get_gateway_status", lambda: {"ok": False, "data": {"partial": True}, "errors": [{"source": "gateway", "message": "bad", "kind": "test"}], "warnings": ["gateway warning"]})
+    monkeypatch.setattr(mod, "get_platform_status", lambda: ok_data("platforms"))
+    monkeypatch.setattr(mod, "get_mcp_status", lambda: ok_data("mcp"))
+    monkeypatch.setattr(mod, "get_cron_status", lambda: ok_data("cron"))
+    monkeypatch.setattr(mod, "get_sessions_summary", lambda: ok_data("sessions"))
+    monkeypatch.setattr(mod, "get_toolsets_status", lambda: ok_data("toolsets"))
+    monkeypatch.setattr(mod, "get_repo_status", lambda: ok_data("repo"))
+    monkeypatch.setattr(mod, "get_runtime_files_status", lambda: ok_data("runtime"))
+    monkeypatch.setattr(mod, "run_cmd", lambda *a, **k: ({"stdout": "1.0", "stderr": "", "returncode": 0}, None))
+    result = mod.get_overview()
+    assert result["ok"] is False
+    assert result["data"]["gateway"]["partial"] is True
+    assert result["errors"][0]["source"] == "gateway"
+    assert "gateway warning" in result["warnings"]
+
+
+def overview_payload(**overrides):
+    data = {
+        "timestamp_utc": "2026-05-13T00:00:00Z",
+        "hermes_version": "hermes 1.0",
+        "gateway": {
+            "systemd_active": "active",
+            "pid": "100",
+            "systemd_properties": {
+                "ActiveState": "active",
+                "SubState": "running",
+                "UnitFileState": "enabled",
+            },
+        },
+        "platforms": {
+            "platform_status": {
+                "discord": {"configured": True, "connected": True, "status": "connected"},
+                "telegram": {"configured": True, "connected": None, "status": "configured"},
+            }
+        },
+        "mcp": {
+            "configured_servers": ["quinn_ops"],
+            "mcp_list": {"active_like": 1, "total": 1},
+        },
+        "cron": {"active": 0, "total": 0, "jobs": []},
+        "sessions": {
+            "count": 1,
+            "file_count": 2,
+            "json_file_count": 1,
+            "recent_metadata": [{"platform": "discord", "chat_type": "group", "updated_at": "ignored"}],
+        },
+        "repo": {
+            "head": "abc123",
+            "branch": "main",
+            "describe": "abc123",
+            "status_short": {"dirty_count": 0, "files": []},
+        },
+        "recent_errors": {
+            "count": 1,
+            "grouped": {"gateway.log": {"total": 1, "categories": {"error": 1}, "last_seen": "ignored"}},
+        },
+        "runtime_files": {
+            "files": [
+                {"path": "/home/quinn/quinn/runtime/quinn_loader_order.json", "exists": True, "size_bytes": 10, "mtime_utc": "ignored"}
+            ]
+        },
+        "toolsets": {
+            "toolsets": ["web enabled"],
+            "summary": {"total": 1, "active_like": 1},
+        },
+    }
+    for key, value in overrides.items():
+        data[key] = value
+    return {"ok": True, "data": data, "errors": [], "warnings": []}
+
+
+def use_snapshot_path(mod, tmp_path, monkeypatch):
+    snapshot = tmp_path / "mcp" / "quinn_ops_state" / "overview_snapshot.json"
+    monkeypatch.setattr(mod, "SNAPSHOT_PATH", snapshot)
+    return snapshot
+
+
+def save_snapshot_for(mod, snapshot_path, overview):
+    payload = {
+        "schema_version": mod.SNAPSHOT_SCHEMA_VERSION,
+        "created_by": "quinn_ops",
+        "updated_at_utc": "2026-05-13T00:00:00Z",
+        "overview": mod.sanitize(overview["data"]),
+        "overview_errors": [],
+        "overview_warnings": [],
+    }
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def diff_paths(result, group):
+    return {item["path"]: item for item in result["data"]["changes"][group]}
+
+
+def test_snapshot_status_missing(tmp_path, monkeypatch):
+    mod = load_module()
+    use_snapshot_path(mod, tmp_path, monkeypatch)
+    result = mod.get_snapshot_status()
+    assert result["ok"]
+    assert result["data"]["exists"] is False
+    assert result["data"]["schema_version"] is None
+
+
+def test_save_snapshot_creates_sanitized_schema_versioned_file(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    private = overview_payload(
+        gateway={"systemd_active": "active", "pid": "sk-test123456789", "systemd_properties": {"ActiveState": "active"}}
+    )
+    monkeypatch.setattr(mod, "get_overview", lambda: private)
+    result = mod.save_overview_snapshot()
+    dumped = snapshot.read_text(encoding="utf-8")
+    obj = json.loads(dumped)
+    assert result["ok"]
+    assert obj["schema_version"] == 1
+    assert obj["created_by"] == "quinn_ops"
+    assert "sk-test" not in dumped
+    assert snapshot.stat().st_mode & 0o777 == 0o600
+
+
+def test_diff_without_update_baseline_does_not_write(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    before = snapshot.read_text(encoding="utf-8")
+    current = overview_payload(gateway={"systemd_active": "active", "pid": "200", "systemd_properties": {"ActiveState": "active", "SubState": "running", "UnitFileState": "enabled"}})
+    monkeypatch.setattr(mod, "get_overview", lambda: current)
+    result = mod.get_overview_diff(update_baseline=False)
+    assert result["ok"]
+    assert result["data"]["updated_baseline"] is False
+    assert snapshot.read_text(encoding="utf-8") == before
+
+
+def test_first_diff_no_baseline_behavior(tmp_path, monkeypatch):
+    mod = load_module()
+    use_snapshot_path(mod, tmp_path, monkeypatch)
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload())
+    result = mod.get_overview_diff()
+    assert result["ok"]
+    assert result["data"]["has_previous"] is False
+    assert result["data"]["summary"]["changed_count"] == 0
+    assert all(not changes for changes in result["data"]["changes"].values())
+    assert result["warnings"]
+    assert "No previous" in result["data"]["summary"]["headlines"][0]
+
+
+def test_gateway_pid_change_info(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current = overview_payload(gateway={"systemd_active": "active", "pid": "200", "systemd_properties": {"ActiveState": "active", "SubState": "running", "UnitFileState": "enabled"}})
+    monkeypatch.setattr(mod, "get_overview", lambda: current)
+    result = mod.get_overview_diff()
+    change = diff_paths(result, "gateway")["gateway.pid"]
+    assert change["before"] == "100"
+    assert change["after"] == "200"
+    assert change["severity"] == "info"
+
+
+def test_gateway_active_to_inactive_critical(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current = overview_payload(gateway={"systemd_active": "inactive", "pid": "0", "systemd_properties": {"ActiveState": "inactive", "SubState": "dead", "UnitFileState": "enabled"}})
+    monkeypatch.setattr(mod, "get_overview", lambda: current)
+    result = mod.get_overview_diff()
+    assert result["data"]["summary"]["severity"] == "critical"
+    assert diff_paths(result, "gateway")["gateway.systemd_active"]["severity"] == "critical"
+
+
+def test_platform_configured_false_warning_and_connected_false_critical(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current_platforms = {
+        "platform_status": {
+            "discord": {"configured": False, "connected": False, "status": "not_configured"},
+            "telegram": {"configured": True, "connected": False, "status": "not_connected"},
+        }
+    }
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(platforms=current_platforms))
+    result = mod.get_overview_diff()
+    changes = diff_paths(result, "platforms")
+    assert changes["platforms.discord.configured"]["severity"] == "warning"
+    assert changes["platforms.discord.connected"]["severity"] == "critical"
+
+
+def test_platform_configured_to_unknown_warning(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current_platforms = {
+        "platform_status": {
+            "discord": {"configured": None, "connected": None, "status": "unknown"},
+            "telegram": {"configured": True, "connected": None, "status": "configured"},
+        }
+    }
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(platforms=current_platforms))
+    result = mod.get_overview_diff()
+    changes = diff_paths(result, "platforms")
+    assert changes["platforms.discord.configured"]["severity"] == "warning"
+    assert changes["platforms.discord.connected"]["severity"] == "warning"
+
+
+def test_cron_count_changes(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current = overview_payload(cron={"active": 1, "total": 2, "jobs": [{"id_or_name": "job-1"}, {"id_or_name": "job-2"}]})
+    monkeypatch.setattr(mod, "get_overview", lambda: current)
+    result = mod.get_overview_diff()
+    changes = diff_paths(result, "cron")
+    assert changes["cron.total"]["after"] == 2
+    assert changes["cron.active"]["after"] == 1
+    assert "cron.jobs" in changes
+
+
+def test_repo_dirty_and_file_list_changes(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current_repo = {
+        "head": "abc123",
+        "branch": "main",
+        "describe": "abc123-dirty",
+        "status_short": {"dirty_count": 2, "files": ["scripts/mcp/quinn_ops_server.py", "docs/foo.md"]},
+    }
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(repo=current_repo))
+    result = mod.get_overview_diff()
+    changes = diff_paths(result, "repo")
+    assert changes["repo.status_short.dirty_count"]["type"] == "increased"
+    assert "scripts/mcp/quinn_ops_server.py" in changes["repo.status_short.files.added"]["after"]
+
+
+def test_mcp_quinn_ops_configured_but_inactive_is_critical(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current_mcp = {"configured_servers": ["quinn_ops"], "mcp_list": {"active_like": 0, "total": 1}}
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(mcp=current_mcp))
+    result = mod.get_overview_diff()
+    changes = diff_paths(result, "mcp")
+    assert changes["mcp.mcp_list.active_like"]["severity"] == "critical"
+
+
+def test_recent_error_count_category_increase_without_snippets(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    save_snapshot_for(mod, snapshot, overview_payload())
+    current_errors = {
+        "count": 4,
+        "grouped": {
+            "gateway.log": {
+                "total": 4,
+                "categories": {"error": 2, "exception": 2},
+                "last_seen": "2026-05-13T00:01:00Z",
+                "snippets": ["private message should not matter"],
+            }
+        },
+    }
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(recent_errors=current_errors))
+    result = mod.get_overview_diff()
+    dumped = json.dumps(result)
+    changes = diff_paths(result, "recent_errors")
+    assert changes["recent_errors.count"]["type"] == "increased"
+    assert changes["recent_errors.grouped.gateway.log.categories.exception"]["severity"] == "warning"
+    assert "private message should not matter" not in dumped
+
+
+def test_recent_error_delta_summary_tracks_counts_repeats_and_last_seen_without_snippets(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    previous_errors = {
+        "count": 3,
+        "grouped": {
+            "gateway.log": {
+                "total": 3,
+                "categories": {"error": 2, "warning": 1},
+                "last_seen": "2026-05-13T00:01:00Z",
+                "snippets": ["previous private text must stay out"],
+            }
+        },
+    }
+    save_snapshot_for(mod, snapshot, overview_payload(recent_errors=previous_errors))
+    current_errors = {
+        "count": 6,
+        "grouped": {
+            "gateway.log": {
+                "total": 5,
+                "categories": {"error": 3, "warning": 1, "traceback": 1},
+                "last_seen": "2026-05-13T00:03:00Z",
+                "snippets": ["current private text must stay out"],
+            },
+            "agent.log": {
+                "total": 1,
+                "categories": {"exception": 1},
+                "last_seen": "2026-05-13T00:02:00Z",
+                "snippets": ["agent private text must stay out"],
+            },
+        },
+    }
+    monkeypatch.setattr(mod, "get_overview", lambda: overview_payload(recent_errors=current_errors))
+    result = mod.get_overview_diff()
+    dumped = json.dumps(result)
+    summary = result["data"]["summary"]["error_delta"]
+    changes = diff_paths(result, "recent_errors")
+    assert summary["total_before"] == 3
+    assert summary["total_after"] == 6
+    assert summary["total_delta"] == 3
+    assert summary["sources"]["gateway.log"]["categories"]["error"]["delta"] == 1
+    assert summary["sources"]["gateway.log"]["categories"]["traceback"]["is_new"] is True
+    assert summary["sources"]["agent.log"]["is_new_source"] is True
+    assert {item["category"] for item in summary["new_categories"]} == {"traceback", "exception"}
+    assert {item["category"] for item in summary["repeated_categories"]} >= {"error", "warning"}
+    assert summary["last_seen_moved"][0]["source"] == "gateway.log"
+    assert changes["recent_errors.grouped.gateway.log.last_seen"]["severity"] == "info"
+    assert "previous private text" not in dumped
+    assert "current private text" not in dumped
+    assert "agent private text" not in dumped
+
+
+def test_private_strings_absent_from_snapshot_and_diff(tmp_path, monkeypatch):
+    mod = load_module()
+    snapshot = use_snapshot_path(mod, tmp_path, monkeypatch)
+    previous = overview_payload(repo={"head": "abc123", "branch": "main", "describe": "ghp_fakeSECRET123456", "status_short": {"dirty_count": 1, "files": ["safe.py"]}})
+    save_snapshot_for(mod, snapshot, previous)
+    current = overview_payload(repo={"head": "def456", "branch": "main", "describe": "sk-test123456789", "status_short": {"dirty_count": 1, "files": ["safe.py"]}})
+    monkeypatch.setattr(mod, "get_overview", lambda: current)
+    result = mod.get_overview_diff(update_baseline=True)
+    snapshot_text = snapshot.read_text(encoding="utf-8")
+    dumped = json.dumps(result)
+    assert "ghp_fake" not in snapshot_text
+    assert "sk-test" not in snapshot_text
+    assert "ghp_fake" not in dumped
+    assert "sk-test" not in dumped
+    assert result["data"]["updated_baseline"] is True


### PR DESCRIPTION
## Summary
- Adds Quinn Ops MCP snapshot/diff implementation and tests.
- Adds repo-side Quinn Docs/Notes MCP scaffold and tests.
- Adds planning docs for Approval Ops, GitHub Ops, Observability, Docs/Notes, and snapshot diff work.

## Files changed
- `docs/quinn_approval_ops_mcp_plan.md`
- `docs/quinn_docs_mcp.md`
- `docs/quinn_docs_mcp_plan.md`
- `docs/quinn_ops_github_mcp_plan.md`
- `docs/quinn_ops_mcp.md`
- `docs/quinn_ops_observability_mcp_plan.md`
- `docs/quinn_ops_snapshot_diff_codex_prompt.md`
- `docs/quinn_ops_snapshot_diff_design.md`
- `scripts/mcp/quinn_docs_server.py`
- `scripts/mcp/quinn_ops_server.py`
- `tests/test_quinn_docs_mcp.py`
- `tests/test_quinn_ops_mcp.py`

## Test commands/results
```bash
python3 -m py_compile \
  scripts/mcp/quinn_ops_server.py tests/test_quinn_ops_mcp.py \
  scripts/mcp/quinn_docs_server.py tests/test_quinn_docs_mcp.py

venv/bin/python -m pytest tests/test_quinn_ops_mcp.py tests/test_quinn_docs_mcp.py -q
```

Result:
```text
43 passed
```

## Live impact
- `quinn_ops` is already configured live, so after merge/deploy/reload its implementation can affect live MCP behavior.
- `quinn_docs` / Docs-Notes MCP is repo-only in this PR and has not been live-promoted.
- No live config changes, live promotion, or service restarts were performed.

## Restart/reload needed
- For live Quinn Ops MCP to pick up changed code after merge/deploy, run `/reload-mcp` or restart the process/session hosting MCP connections.
- Docs/Notes MCP requires explicit live configuration/promotion approval; reload alone is not sufficient.

## Known caveats
- This PR combines live-configured Quinn Ops MCP code with repo-only Docs/Notes scaffold and planning docs.
- No Docs/Notes MCP live promotion has happened.
- No gateway restart was performed.
