### PR TITLE
fix(state): use TRUNCATE WAL checkpoint to prevent unbounded WAL growth

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -425,17 +425,27 @@ class SessionDB:
         )
 
     def _try_wal_checkpoint(self) -> None:
-        """Best-effort PASSIVE WAL checkpoint.  Never blocks, never raises.
+        """Best-effort TRUNCATE WAL checkpoint.  Never raises.
 
-        Flushes committed WAL frames back into the main DB file for any
-        frames that no other connection currently needs.  Keeps the WAL
-        from growing unbounded when many processes hold persistent
+        Flushes committed WAL frames back into the main DB file and
+        truncates the WAL file to zero bytes.  Keeps the WAL from
+        growing unbounded when many processes hold persistent
         connections.
+
+        PASSIVE checkpoint was previously used here, but it never
+        truncates the WAL file — the file stays at its high-water
+        mark until an explicit TRUNCATE is called (which only
+        happened inside the infrequent vacuum()).
+
+        TRUNCATE may block writers briefly while checkpointing, but
+        _try_wal_checkpoint is called off the hot path (every 50
+        writes) and already runs under ``self._lock``, so the
+        additional hold time is negligible.
         """
         try:
             with self._lock:
                 result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
+                    "PRAGMA wal_checkpoint(TRUNCATE)"
                 ).fetchone()
                 if result and result[1] > 0:
                     logger.debug(
@@ -448,13 +458,13 @@ class SessionDB:
     def close(self):
         """Close the database connection.
 
-        Attempts a PASSIVE WAL checkpoint first so that exiting processes
-        help keep the WAL file from growing unbounded.
+        Attempts a TRUNCATE WAL checkpoint first so that exiting processes
+        help shrink the WAL file.
         """
         with self._lock:
             if self._conn:
                 try:
-                    self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
                 except Exception:
                     pass
                 self._conn.close()


### PR DESCRIPTION
## Problem

`state.db-wal` grows without bound because `_try_wal_checkpoint()` and `close()` both use `PRAGMA wal_checkpoint(PASSIVE)`, which never shrinks the WAL file.

## Root Cause

PASSIVE checkpoint moves dirty pages to the main DB but never truncates the WAL. The only TRUNCATE call is inside `vacuum()`, which only fires when old sessions are pruned.

## Fix

Changed both `_try_wal_checkpoint()` and `close()` to use `PRAGMA wal_checkpoint(TRUNCATE)`. These calls run under `self._lock` and are off the hot path (every 50 writes).

Fixes #24034