### PR TITLE
fix(auxiliary): prefer fallback_providers model for OpenRouter aux tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1411,14 +1411,38 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
         return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+                       default_headers=build_or_headers()), _resolve_openrouter_aux_model()
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=build_or_headers()), _OPENROUTER_MODEL
+                   default_headers=build_or_headers()), _resolve_openrouter_aux_model()
+
+
+def _resolve_openrouter_aux_model() -> str:
+    """Return the user's preferred OpenRouter aux model from fallback_providers, or the hardcoded default.
+
+    When the user has configured fallback_providers with an OpenRouter entry
+    that specifies a model (especially :free variants), use that model for
+    auxiliary tasks instead of the hardcoded paid default.  This prevents
+    unexpected billing for free-tier users.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        fallbacks = cfg.get("fallback_providers", [])
+        if isinstance(fallbacks, list):
+            for entry in fallbacks:
+                if isinstance(entry, dict):
+                    prov = (entry.get("provider") or "").strip().lower()
+                    model = (entry.get("model") or "").strip()
+                    if prov == "openrouter" and model:
+                        return model
+    except Exception:
+        pass
+    return _OPENROUTER_MODEL
 
 
 def _describe_openrouter_unavailable() -> str:


### PR DESCRIPTION
## Problem

Users who configure only OpenRouter `:free` models in `fallback_providers` still get billed because auxiliary tasks (title_generation, compression, vision) hardcode `google/gemini-3-flash-preview` (a paid model).

## Root Cause

`_try_openrouter()` always returns `_OPENROUTER_MODEL` regardless of the user's `fallback_providers` configuration.

## Fix

Added `_resolve_openrouter_aux_model()` which checks the user's `fallback_providers` for an OpenRouter entry with an explicit model. If found, that model is used for auxiliary tasks. Otherwise falls back to the hardcoded default.

Fixes #24029