### PR TITLE
fix(kanban): notify tool-created tasks

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -109,6 +109,7 @@ AUTHOR_MAP = {
     "20nik.nosov21@gmail.com": "nik1t7n",
     "thunderggnn@gmail.com": "ggnnggez",
     "haozhe4547@gmail.com": "ehz0ah",
+    "eloklam2002@gmail.com": "eloklam",
     "kevyan1998@gmail.com": "kyan12",
     "rylen.anil@gmail.com": "rylena",
     "godnanijatin@gmail.com": "jatingodnani",

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -715,6 +715,113 @@ def test_create_rejects_non_list_skills(worker_env):
     assert json.loads(out).get("error")
 
 
+def test_create_auto_subscribes_origin_in_gateway_session(monkeypatch, tmp_path):
+    """When gateway session context is present, tool-created tasks auto-subscribe
+    the origin platform/chat so the user hears back on completion/block."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    # Simulate gateway session env fallback (contextvars are unset in test process)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "-100123")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "456")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "789")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    out = kt._handle_create({"title": "origin-sub", "assignee": "worker"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    with kb.connect() as conn:
+        subs = kb.list_notify_subs(conn, d["task_id"])
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "-100123"
+    assert subs[0]["thread_id"] == "456"
+    assert subs[0]["user_id"] == "789"
+    assert subs[0]["notifier_profile"] == "test-orchestrator"
+
+
+def test_create_child_inherits_parent_notify_subscriptions(monkeypatch, tmp_path):
+    """Tool-created children copy their parents' notify subscriptions so the
+    original requester stays subscribed through fan-out chains."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="orchestrator")
+        kb.add_notify_sub(
+            conn,
+            task_id=parent,
+            platform="discord",
+            chat_id="#engineering",
+            thread_id="111",
+            user_id="u1",
+            notifier_profile="default",
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+    out = kt._handle_create({
+        "title": "child",
+        "assignee": "fixer",
+        "parents": [parent],
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    with kb.connect() as conn:
+        subs = kb.list_notify_subs(conn, d["task_id"])
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "#engineering"
+    assert subs[0]["thread_id"] == "111"
+    assert subs[0]["user_id"] == "u1"
+    assert subs[0]["notifier_profile"] == "default"
+
+
+def test_create_no_subscription_without_parent_or_session(monkeypatch, tmp_path):
+    """Without parent subscriptions and without gateway session context,
+    tool-created tasks must not get phantom notify subscriptions."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    # Intentionally leave HERMES_SESSION_* unset
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    out = kt._handle_create({"title": "no-sub", "assignee": "worker"})
+    d = json.loads(out)
+    assert d["ok"] is True
+    with kb.connect() as conn:
+        subs = kb.list_notify_subs(conn, d["task_id"])
+    assert subs == []
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     conn = kb.connect()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -551,6 +551,57 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _ensure_notify_subscriptions(conn, kb, new_tid: str, parents) -> None:
+    """Copy parent notify subscriptions or auto-subscribe the origin session.
+
+    If any parent task has gateway notification subscriptions, copy them
+    to the new child so the original requester stays subscribed when
+    workers fan out follow-up cards.
+
+    If no parent subscription was copied, look up the active gateway
+    session and subscribe the origin (platform + chat + thread) so the
+    user hears back when this worker completes / blocks.
+
+    CLI / no-session contexts silently skip subscription when no session
+    context is available.
+    """
+    copied = False
+    for parent_id in parents:
+        for sub in kb.list_notify_subs(conn, parent_id):
+            kb.add_notify_sub(
+                conn,
+                task_id=new_tid,
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                thread_id=(sub.get("thread_id") or None) or None,
+                user_id=sub.get("user_id"),
+                notifier_profile=(
+                    sub.get("notifier_profile")
+                    or os.environ.get("HERMES_PROFILE")
+                    or "default"
+                ),
+            )
+            copied = True
+    if copied:
+        return
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    if platform and chat_id:
+        kb.add_notify_sub(
+            conn,
+            task_id=new_tid,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=get_session_env("HERMES_SESSION_THREAD_ID", "") or None,
+            user_id=get_session_env("HERMES_SESSION_USER_ID", "") or None,
+            notifier_profile=os.environ.get("HERMES_PROFILE") or "default",
+        )
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -613,6 +664,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
+            _ensure_notify_subscriptions(conn, kb, new_tid, parents)
             new_task = kb.get_task(conn, new_tid)
             return _ok(
                 task_id=new_tid,


### PR DESCRIPTION
## Summary
Kanban tasks created through the tool path could finish or block silently because they never received gateway notification subscriptions.

Slash-command-created tasks already call `add_notify_sub(...)`, but orchestrator/worker fan-out goes through `tools/kanban_tools.py::_handle_create`, which previously only created the task row. That left `kanban_notify_subs` empty, so the gateway notifier had no destination when the task reached a terminal state.

This PR adds notification setup to tool-created tasks and preserves subscriptions across child-task fan-out.

## Changes
- Add `_ensure_notify_subscriptions(...)` in `tools/kanban_tools.py`.
- Copy existing parent `kanban_notify_subs` rows onto newly created child tasks.
- If no parent subscription exists, read the active gateway session via `gateway.session_context.get_session_env(...)` and subscribe the origin platform/chat/thread.
- Lazy-import gateway session context so normal CLI/test imports stay safe.
- Preserve CLI/no-session behavior: if no gateway session is present, no subscription is created.
- Add regression tests for origin chat auto-subscription, child task inheritance, and no phantom subscriptions without parent/session context.
- Add `AUTHOR_MAP` entry for contributor attribution check (`scripts/release.py`).

## Validation
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py::test_create_auto_subscribes_origin_in_gateway_session tests/tools/test_kanban_tools.py::test_create_child_inherits_parent_notify_subscriptions tests/tools/test_kanban_tools.py::test_create_no_subscription_without_parent_or_session tests/hermes_cli/test_kanban_notify.py -q`
  - `13 passed in 12.56s`

## Notes
- No linked issue.
- No schema migration; this reuses the existing `kanban_notify_subs` table and notifier flow.
