### PR TITLE
feat(gateway): echo voice transcripts back to user before agent reply

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6795,10 +6795,21 @@ class GatewayRunner:
                     )
 
             if audio_paths:
+                self._pending_voice_transcripts = []
                 message_text = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
                 )
+                if self._pending_voice_transcripts:
+                    _echo_adapter = self.adapters.get(source.platform)
+                    _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                    if _echo_adapter:
+                        try:
+                            _echo_text = "\n".join(f'🎤 "{t}"' for t in self._pending_voice_transcripts)
+                            await _echo_adapter.send(source.chat_id, _echo_text, metadata=_echo_meta)
+                        except Exception:
+                            pass
+                    self._pending_voice_transcripts = []
                 _stt_fail_markers = (
                     "No STT provider",
                     "STT is disabled",
@@ -13060,6 +13071,9 @@ class GatewayRunner:
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
+                    if not hasattr(self, "_pending_voice_transcripts"):
+                        self._pending_voice_transcripts = []
+                    self._pending_voice_transcripts.append(transcript)
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
                         f'Here\'s what they said: "{transcript}"]'


### PR DESCRIPTION
## Summary

- When STT transcription succeeds, immediately sends the transcribed text back to the user as a `🎤 "..."` message before the agent processes it
- Lets users confirm what was heard without waiting for the full agent response
- Matches the `echoTranscript: true` behaviour familiar from other agent frameworks

## Implementation

Stores successful transcripts on `_pending_voice_transcripts` during `_enrich_message_with_transcription`, then flushes them via the platform adapter at the call site before the agent turn begins. Failures are silently swallowed so a send error never blocks the agent response.

## Test plan

- [ ] Send a voice message via Telegram — should see `🎤 "transcribed text"` echoed back immediately, followed by the agent reply
- [ ] Send a voice message when STT is misconfigured — echo should not fire, existing error message still sent
- [ ] Send a text message — no change in behaviour

🤖 Generated with [Claude Code](https://claude.ai/claude-code)