### PR TITLE
fix(delegate_task): honor per-task model/provider overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4551,6 +4551,25 @@ class GatewayRunner:
             )
             failure_limit = _kb.DEFAULT_FAILURE_LIMIT
 
+        # D1 Task 4: resolve worker runtime from config (default: local).
+        # `kanban.worker_runtime` selects how dispatch_once spawns workers:
+        # `local` (today's behavior — bare subprocess), `docker` (per-task
+        # isolated container), `modal` / `ssh` (future). Default is local
+        # so existing setups keep working unchanged.
+        runtime_name = (kanban_cfg.get("worker_runtime") or "local").strip().lower()
+        runtime_cfg = kanban_cfg.get(runtime_name) or {}
+        try:
+            from tools.environments.kanban_spawn import load_runtime
+            kanban_runtime = load_runtime(runtime_name, runtime_cfg)
+        except (ImportError, ValueError, RuntimeError) as exc:
+            logger.error(
+                "kanban dispatcher: failed to load worker_runtime=%r: %s. "
+                "Dispatcher disabled until config is fixed.",
+                runtime_name, exc,
+            )
+            return
+        logger.info("kanban dispatcher: worker_runtime=%s", kanban_runtime.name)
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -4584,6 +4603,7 @@ class GatewayRunner:
                 return _kb.dispatch_once(
                     conn,
                     board=slug,
+                    spawn_fn=kanban_runtime.spawn,    # D1 Task 4: route through runtime
                     max_spawn=max_spawn,
                     failure_limit=failure_limit,
                 )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,50 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _load_assignee_map() -> dict:
+    """Load kanban.assignee_to_profile from config.yaml (D1 Task 2).
+
+    Default (when key absent or empty): ``{"*": "worker"}`` — swarm-as-persona,
+    every assignee tag collapses to a single ``worker`` profile.
+
+    Override examples in config.yaml:
+
+        kanban:
+          assignee_to_profile:
+            "*": worker
+            ops: ops-special      # ops tasks still go to dedicated profile
+
+    Returns dict[str, str]. Returns the swarm default on any config error.
+    """
+    try:
+        from hermes_cli.config import load_config as _lc
+        cfg = _lc() or {}
+    except Exception:
+        return {"*": "worker"}
+    raw = (cfg.get("kanban") or {}).get("assignee_to_profile") or {}
+    if not isinstance(raw, dict) or not raw:
+        return {"*": "worker"}
+    # Normalize to str:str
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def _resolve_assignee_to_profile(assignee: str) -> str:
+    """Apply the kanban.assignee_to_profile map (D1 Task 2).
+
+    Lookup order:
+      1. Exact match in the map
+      2. Wildcard '*' fallback
+      3. Identity (return assignee unchanged) — preserves pre-D1 behavior
+         when user explicitly deletes the wildcard from config.
+    """
+    m = _load_assignee_map()
+    if assignee in m:
+        return m[assignee]
+    if "*" in m:
+        return m["*"]
+    return assignee
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3926,7 +3970,10 @@ def _default_spawn(
 
     from hermes_cli.profiles import normalize_profile_name
 
-    profile_arg = normalize_profile_name(task.assignee)
+    # D1 Task 2: swarm-as-persona — collapse assignee tags to runtime profiles.
+    # Default map {"*": "worker"} routes everything through one profile.
+    resolved_assignee = _resolve_assignee_to_profile(task.assignee)
+    profile_arg = normalize_profile_name(resolved_assignee)
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3905,28 +3905,46 @@ def _resolve_hermes_argv() -> list[str]:
 def _load_assignee_map() -> dict:
     """Load kanban.assignee_to_profile from config.yaml (D1 Task 2).
 
-    Default (when key absent or empty): ``{"*": "worker"}`` — swarm-as-persona,
-    every assignee tag collapses to a single ``worker`` profile.
+    Default (when key absent or empty): ``{}`` — identity passthrough,
+    byte-identical to pre-D1 behavior. Operators opt INTO swarm-as-persona
+    by setting the wildcard explicitly:
 
-    Override examples in config.yaml:
+        kanban:
+          assignee_to_profile:
+            "*": worker          # collapse all assignees to 'worker' profile
+
+    Or for partial collapse with overrides:
 
         kanban:
           assignee_to_profile:
             "*": worker
-            ops: ops-special      # ops tasks still go to dedicated profile
+            ops: ops-special    # ops tasks get a dedicated profile
 
-    Returns dict[str, str]. Returns the swarm default on any config error.
+    Phase-8 P0 fix (triple-flagged): the original D1 Task 2 default was
+    {"*": "worker"} which routed every task through a `worker` profile.
+    But this profile doesn't exist by default on existing Hermes installs
+    (which carry persona-fleet profiles like coder/researcher/analyst).
+    Defaulting to identity passthrough makes the upgrade safe; operators
+    set the wildcard explicitly when they've created the worker profile
+    and want swarm collapse.
+
+    Returns dict[str, str]. Returns the safe default ({}) on any config error.
     """
     try:
         from hermes_cli.config import load_config as _lc
         cfg = _lc() or {}
     except Exception:
-        return {"*": "worker"}
+        return {}
     raw = (cfg.get("kanban") or {}).get("assignee_to_profile") or {}
-    if not isinstance(raw, dict) or not raw:
-        return {"*": "worker"}
-    # Normalize to str:str
-    return {str(k): str(v) for k, v in raw.items()}
+    if not isinstance(raw, dict):
+        return {}
+    # Normalize to str:str (drops None values per Phase-8 P1 finding)
+    out = {}
+    for k, v in raw.items():
+        if v is None:
+            continue   # Skip None values — they'd produce 'hermes -p None' argv
+        out[str(k)] = str(v)
+    return out
 
 
 def _resolve_assignee_to_profile(assignee: str) -> str:
@@ -3936,7 +3954,11 @@ def _resolve_assignee_to_profile(assignee: str) -> str:
       1. Exact match in the map
       2. Wildcard '*' fallback
       3. Identity (return assignee unchanged) — preserves pre-D1 behavior
-         when user explicitly deletes the wildcard from config.
+         when no map is configured.
+
+    Phase-8 P0 fix: default behavior with no config is identity passthrough,
+    matching pre-D1 for safe upgrades. Operators opt INTO swarm collapse
+    by setting `kanban.assignee_to_profile.'*': worker` explicitly.
     """
     m = _load_assignee_map()
     if assignee in m:

--- a/tests/hermes_cli/test_kanban_assignee_to_profile.py
+++ b/tests/hermes_cli/test_kanban_assignee_to_profile.py
@@ -1,0 +1,141 @@
+"""Tests for D1 Task 2 — assignee_to_profile resolution (swarm-as-persona)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+import pytest
+
+
+# ============================================================================
+# _load_assignee_map
+# ============================================================================
+
+def test_load_assignee_map_default_is_swarm_worker(monkeypatch):
+    """No config key → default {'*': 'worker'} (swarm-as-persona default)."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {}},
+    )
+    m = kanban_db._load_assignee_map()
+    assert m == {"*": "worker"}
+
+
+def test_load_assignee_map_empty_dict_is_swarm_default(monkeypatch):
+    """Empty assignee_to_profile dict still yields the swarm default."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"assignee_to_profile": {}}},
+    )
+    m = kanban_db._load_assignee_map()
+    assert m == {"*": "worker"}
+
+
+def test_load_assignee_map_honors_user_overrides(monkeypatch):
+    """User-set map is respected verbatim."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "assignee_to_profile": {
+                    "*": "worker",
+                    "ops": "ops-special",
+                    "researcher": "deep-thinker",
+                }
+            }
+        },
+    )
+    m = kanban_db._load_assignee_map()
+    assert m["*"] == "worker"
+    assert m["ops"] == "ops-special"
+    assert m["researcher"] == "deep-thinker"
+
+
+def test_load_assignee_map_normalizes_str_types(monkeypatch):
+    """Non-string keys/values get coerced to str."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"assignee_to_profile": {1: 2, "*": "worker"}}},
+    )
+    m = kanban_db._load_assignee_map()
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in m.items())
+
+
+def test_load_assignee_map_returns_default_on_config_error(monkeypatch):
+    """If load_config raises, return the swarm default — don't crash workers."""
+    from hermes_cli import kanban_db
+
+    def _raise(*a, **kw):
+        raise RuntimeError("config broken")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+    m = kanban_db._load_assignee_map()
+    assert m == {"*": "worker"}
+
+
+def test_load_assignee_map_returns_default_for_invalid_type(monkeypatch):
+    """If kanban.assignee_to_profile is not a dict, fall back to default."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"assignee_to_profile": "not-a-dict"}},
+    )
+    m = kanban_db._load_assignee_map()
+    assert m == {"*": "worker"}
+
+
+# ============================================================================
+# _resolve_assignee_to_profile
+# ============================================================================
+
+def test_resolve_default_collapses_to_worker(monkeypatch):
+    """With default map, every assignee tag → 'worker'."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(kanban_db, "_load_assignee_map", lambda: {"*": "worker"})
+    assert kanban_db._resolve_assignee_to_profile("researcher") == "worker"
+    assert kanban_db._resolve_assignee_to_profile("analyst") == "worker"
+    assert kanban_db._resolve_assignee_to_profile("anything-else") == "worker"
+
+
+def test_resolve_explicit_override_wins(monkeypatch):
+    """Explicit map entry overrides the wildcard."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        kanban_db, "_load_assignee_map",
+        lambda: {"*": "worker", "ops": "ops-special"},
+    )
+    assert kanban_db._resolve_assignee_to_profile("ops") == "ops-special"
+    # Other tags still hit the wildcard
+    assert kanban_db._resolve_assignee_to_profile("coder") == "worker"
+
+
+def test_resolve_no_wildcard_falls_back_to_identity(monkeypatch):
+    """If user removes wildcard, unknown assignees pass through verbatim
+    (preserves pre-D1 behavior for explicit single-profile setups)."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        kanban_db, "_load_assignee_map",
+        lambda: {"ops": "ops-special"},
+    )
+    # 'ops' resolves; 'unknown-tag' falls through unchanged
+    assert kanban_db._resolve_assignee_to_profile("ops") == "ops-special"
+    assert kanban_db._resolve_assignee_to_profile("unknown-tag") == "unknown-tag"
+
+
+def test_resolve_is_deterministic(monkeypatch):
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(kanban_db, "_load_assignee_map", lambda: {"*": "worker"})
+    a = kanban_db._resolve_assignee_to_profile("xyz")
+    b = kanban_db._resolve_assignee_to_profile("xyz")
+    assert a == b == "worker"

--- a/tests/hermes_cli/test_kanban_assignee_to_profile.py
+++ b/tests/hermes_cli/test_kanban_assignee_to_profile.py
@@ -9,8 +9,14 @@ import pytest
 # _load_assignee_map
 # ============================================================================
 
-def test_load_assignee_map_default_is_swarm_worker(monkeypatch):
-    """No config key → default {'*': 'worker'} (swarm-as-persona default)."""
+def test_load_assignee_map_default_is_empty(monkeypatch):
+    """No config key → default {} (identity passthrough — Phase-8 P0 fix).
+
+    The original D1 Task 2 default was {"*": "worker"}, but that broke
+    existing installs that don't have a 'worker' profile on disk. The
+    safe default is identity passthrough; operators opt-in to swarm
+    collapse by setting the wildcard explicitly.
+    """
     from hermes_cli import kanban_db
 
     monkeypatch.setattr(
@@ -18,11 +24,11 @@ def test_load_assignee_map_default_is_swarm_worker(monkeypatch):
         lambda: {"kanban": {}},
     )
     m = kanban_db._load_assignee_map()
-    assert m == {"*": "worker"}
+    assert m == {}
 
 
-def test_load_assignee_map_empty_dict_is_swarm_default(monkeypatch):
-    """Empty assignee_to_profile dict still yields the swarm default."""
+def test_load_assignee_map_empty_dict_is_empty(monkeypatch):
+    """Empty assignee_to_profile dict → empty map (identity passthrough)."""
     from hermes_cli import kanban_db
 
     monkeypatch.setattr(
@@ -30,7 +36,7 @@ def test_load_assignee_map_empty_dict_is_swarm_default(monkeypatch):
         lambda: {"kanban": {"assignee_to_profile": {}}},
     )
     m = kanban_db._load_assignee_map()
-    assert m == {"*": "worker"}
+    assert m == {}
 
 
 def test_load_assignee_map_honors_user_overrides(monkeypatch):
@@ -68,7 +74,7 @@ def test_load_assignee_map_normalizes_str_types(monkeypatch):
 
 
 def test_load_assignee_map_returns_default_on_config_error(monkeypatch):
-    """If load_config raises, return the swarm default — don't crash workers."""
+    """If load_config raises, return the safe default ({}) — don't crash workers."""
     from hermes_cli import kanban_db
 
     def _raise(*a, **kw):
@@ -76,11 +82,11 @@ def test_load_assignee_map_returns_default_on_config_error(monkeypatch):
 
     monkeypatch.setattr("hermes_cli.config.load_config", _raise)
     m = kanban_db._load_assignee_map()
-    assert m == {"*": "worker"}
+    assert m == {}
 
 
 def test_load_assignee_map_returns_default_for_invalid_type(monkeypatch):
-    """If kanban.assignee_to_profile is not a dict, fall back to default."""
+    """If kanban.assignee_to_profile is not a dict, fall back to {}."""
     from hermes_cli import kanban_db
 
     monkeypatch.setattr(
@@ -88,21 +94,40 @@ def test_load_assignee_map_returns_default_for_invalid_type(monkeypatch):
         lambda: {"kanban": {"assignee_to_profile": "not-a-dict"}},
     )
     m = kanban_db._load_assignee_map()
+    assert m == {}
+
+
+def test_load_assignee_map_drops_none_values(monkeypatch):
+    """Phase-8 P1 fix: None values in map are skipped (would produce
+    'hermes -p None' argv otherwise)."""
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"assignee_to_profile": {"*": "worker", "ops": None}}},
+    )
+    m = kanban_db._load_assignee_map()
     assert m == {"*": "worker"}
+    assert "ops" not in m
 
 
-# ============================================================================
-# _resolve_assignee_to_profile
-# ============================================================================
+def test_resolve_default_is_identity(monkeypatch):
+    """With no config, every assignee passes through unchanged (Phase-8 P0 fix)."""
+    from hermes_cli import kanban_db
 
-def test_resolve_default_collapses_to_worker(monkeypatch):
-    """With default map, every assignee tag → 'worker'."""
+    monkeypatch.setattr(kanban_db, "_load_assignee_map", lambda: {})
+    assert kanban_db._resolve_assignee_to_profile("researcher") == "researcher"
+    assert kanban_db._resolve_assignee_to_profile("analyst") == "analyst"
+    assert kanban_db._resolve_assignee_to_profile("worker") == "worker"
+
+
+def test_resolve_swarm_collapse_when_wildcard_explicitly_set(monkeypatch):
+    """When operator opts in by setting '*': 'worker', all tags collapse."""
     from hermes_cli import kanban_db
 
     monkeypatch.setattr(kanban_db, "_load_assignee_map", lambda: {"*": "worker"})
     assert kanban_db._resolve_assignee_to_profile("researcher") == "worker"
     assert kanban_db._resolve_assignee_to_profile("analyst") == "worker"
-    assert kanban_db._resolve_assignee_to_profile("anything-else") == "worker"
 
 
 def test_resolve_explicit_override_wins(monkeypatch):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2642,16 +2642,10 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     We intercept Popen to capture the argv without actually spawning a
     hermes subprocess (which would hang trying to call an LLM).
 
-    D1 Task 2 note: the test pins the assignee_to_profile map to identity
-    (empty dict → fallback) so the assertion against 'some-profile' still
-    holds. Without this pin, the swarm-as-persona default {"*": "worker"}
-    would rewrite the assignee, which is correct behavior but unrelated
-    to this test's intent (skill auto-loading).
+    D1 Task 2 + Phase-8 P0 note: default assignee_to_profile is now {}
+    (identity passthrough), so 'some-profile' passes through unchanged.
+    No monkeypatch needed.
     """
-    # Pin assignee map to identity (no rewrite) — this test is about skill
-    # loading, not about swarm-as-persona.
-    monkeypatch.setattr(kb, "_load_assignee_map", lambda: {})
-
     captured = {}
 
     class FakeProc:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2641,7 +2641,17 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
 
     We intercept Popen to capture the argv without actually spawning a
     hermes subprocess (which would hang trying to call an LLM).
+
+    D1 Task 2 note: the test pins the assignee_to_profile map to identity
+    (empty dict → fallback) so the assertion against 'some-profile' still
+    holds. Without this pin, the swarm-as-persona default {"*": "worker"}
+    would rewrite the assignee, which is correct behavior but unrelated
+    to this test's intent (skill auto-loading).
     """
+    # Pin assignee map to identity (no rewrite) — this test is about skill
+    # loading, not about swarm-as-persona.
+    monkeypatch.setattr(kb, "_load_assignee_map", lambda: {})
+
     captured = {}
 
     class FakeProc:

--- a/tests/tools/environments/test_kanban_spawn.py
+++ b/tests/tools/environments/test_kanban_spawn.py
@@ -1,0 +1,184 @@
+"""Tests for the WorkerRuntime protocol + builtin runtimes (D1 Task 1)."""
+from __future__ import annotations
+
+import os
+import signal
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments.kanban_spawn import (
+    LocalRuntime,
+    WorkerRuntime,
+    load_runtime,
+    register_runtime,
+)
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+def test_load_runtime_default_returns_local():
+    rt = load_runtime("local", {})
+    assert isinstance(rt, LocalRuntime)
+    assert rt.name == "local"
+
+
+def test_load_runtime_unknown_raises():
+    with pytest.raises(ValueError, match="unknown worker_runtime"):
+        load_runtime("does-not-exist", {})
+
+
+def test_load_runtime_passes_cfg():
+    """Config dict reaches the runtime constructor."""
+    rt = load_runtime("local", {"future_key": "future_value"})
+    # LocalRuntime stashes config for future use; just verify no crash
+    assert rt._cfg == {"future_key": "future_value"}
+
+
+def test_load_runtime_none_cfg_is_safe():
+    rt = load_runtime("local", None)
+    assert rt._cfg == {}
+
+
+def test_register_runtime_blocks_duplicates():
+    """Re-registering a name is a bug; raise loudly."""
+    class _Stub:
+        name = "stub-test-dup"
+        def __init__(self, cfg): pass
+        def spawn(self, *a, **kw): return None
+        def is_alive(self, h): return False
+        def terminate(self, h, reason=""): pass
+
+    register_runtime("__test_register_dup__", _Stub)
+    with pytest.raises(ValueError, match="already registered"):
+        register_runtime("__test_register_dup__", _Stub)
+    # Cleanup
+    from tools.environments.kanban_spawn import _RUNTIMES
+    _RUNTIMES.pop("__test_register_dup__", None)
+
+
+# ---------------------------------------------------------------------------
+# LocalRuntime delegation
+# ---------------------------------------------------------------------------
+
+def test_local_runtime_delegates_to_default_spawn(monkeypatch):
+    """LocalRuntime.spawn must call kanban_db._default_spawn unchanged.
+
+    This is the regression-safety guarantee — `worker_runtime: local` is
+    byte-identical to pre-D1 behavior.
+    """
+    rt = LocalRuntime({})
+
+    fake_pid = 4242
+    captured = {}
+
+    def fake_default_spawn(task, workspace, *, board=None):
+        captured["task"] = task
+        captured["workspace"] = workspace
+        captured["board"] = board
+        return fake_pid
+
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db._default_spawn", fake_default_spawn
+    )
+
+    fake_task = MagicMock()
+    fake_task.id = "t_test001"
+    pid = rt.spawn(fake_task, workspace="/tmp/ws", board="main")
+
+    assert pid == fake_pid
+    assert captured["task"] is fake_task
+    assert captured["workspace"] == "/tmp/ws"
+    assert captured["board"] == "main"
+
+
+def test_local_runtime_passes_through_none_board(monkeypatch):
+    """When board=None is passed, default_spawn receives board=None."""
+    rt = LocalRuntime({})
+    captured = {}
+
+    def fake_default_spawn(task, workspace, *, board=None):
+        captured["board"] = board
+        return 1
+
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db._default_spawn", fake_default_spawn
+    )
+    rt.spawn(MagicMock(id="t_x"), workspace="/tmp")
+    assert captured["board"] is None
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+def test_worker_runtime_protocol_methods(monkeypatch):
+    """LocalRuntime exposes the WorkerRuntime contract."""
+    rt = LocalRuntime({})
+    assert hasattr(rt, "name")
+    assert hasattr(rt, "spawn")
+    assert hasattr(rt, "is_alive")
+    assert hasattr(rt, "terminate")
+    # is_alive on an obviously-dead PID returns False without raising.
+    # Mock os.kill to avoid the test-suite's live-system guard on
+    # out-of-subtree PIDs.
+    monkeypatch.setattr(os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
+    assert rt.is_alive(handle=999999999) is False
+
+
+def test_local_runtime_is_alive_handles_bad_input():
+    """is_alive is robust against non-integer / negative input."""
+    rt = LocalRuntime({})
+    assert rt.is_alive(0) is False
+    assert rt.is_alive(-1) is False
+    assert rt.is_alive("not-a-pid") is False
+    assert rt.is_alive(None) is False  # type: ignore[arg-type]
+
+
+def test_local_runtime_is_alive_returns_true_for_self():
+    """The current Python process is alive."""
+    rt = LocalRuntime({})
+    assert rt.is_alive(os.getpid()) is True
+
+
+def test_local_runtime_terminate_handles_dead_pid_silently(monkeypatch):
+    """terminate() on an already-dead PID does not raise.
+
+    Mocks os.kill to raise ProcessLookupError, which terminate() must swallow.
+    Test-suite's live-system guard would otherwise block os.kill on out-of-subtree PIDs.
+    """
+    rt = LocalRuntime({})
+
+    def _raise_dead(pid, sig):
+        raise ProcessLookupError()
+    monkeypatch.setattr(os, "kill", _raise_dead)
+    rt.terminate(999999999, reason="test")
+    # No exception raised → pass.
+
+
+def test_local_runtime_terminate_handles_bad_input():
+    """terminate() on non-integer / negative input is a no-op."""
+    rt = LocalRuntime({})
+    rt.terminate(0, reason="zero")
+    rt.terminate(-1, reason="neg")
+    rt.terminate("not-a-pid", reason="str")
+    rt.terminate(None, reason="none")  # type: ignore[arg-type]
+    # No exceptions → pass.
+
+
+def test_local_runtime_terminate_actually_signals(monkeypatch):
+    """terminate() calls os.kill(pid, SIGTERM) for a valid PID."""
+    rt = LocalRuntime({})
+    captured = {}
+
+    def fake_kill(pid, sig):
+        captured["pid"] = pid
+        captured["sig"] = sig
+
+    monkeypatch.setattr(os, "kill", fake_kill)
+    rt.terminate(12345, reason="test")
+    assert captured["pid"] == 12345
+    assert captured["sig"] == signal.SIGTERM

--- a/tests/tools/environments/test_kanban_spawn.py
+++ b/tests/tools/environments/test_kanban_spawn.py
@@ -501,3 +501,48 @@ def test_load_runtime_docker_now_in_registry(monkeypatch):
     })
     assert isinstance(rt, DockerRuntime)
     assert rt.name == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 P0 fix #1 — HERMES_HOME injection (triple-flag intersection)
+# ---------------------------------------------------------------------------
+
+def test_docker_runtime_injects_hermes_home(monkeypatch):
+    """Phase-8 P0 fix: the in-container HERMES_HOME must be /hermes so
+    the worker reads /hermes/profiles/<profile>/config.yaml not the
+    host's path. _default_spawn (Local) sets a host-resolved profile path;
+    Docker sets /hermes because the Dockerfile establishes that root.
+
+    Without this fix, the container falls back to Path.home()/.hermes
+    inside the image, silently ignoring profile-specific config (the
+    same bug `_default_spawn` was patched to fix at kanban_db.py:3981).
+    """
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    _stub_kanban_db_helpers(monkeypatch)
+    monkeypatch.setattr("hermes_cli.profiles.normalize_profile_name", lambda n: n)
+
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+        "network": "hermes-net",
+    })
+
+    captured = {}
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        out = MagicMock()
+        out.stdout = b"cid_xyz\n"
+        out.returncode = 0
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    rt.spawn(_make_fake_task(), workspace="/tmp", board="main")
+
+    cmd = captured["cmd"]
+    env_idxs = [i for i, x in enumerate(cmd) if x == "-e"]
+    env_pairs = [cmd[i + 1] for i in env_idxs]
+    # Critical assertion: HERMES_HOME=/hermes is injected
+    assert any(e == "HERMES_HOME=/hermes" for e in env_pairs), (
+        f"HERMES_HOME=/hermes missing from env args. Got pairs: {env_pairs}"
+    )

--- a/tests/tools/environments/test_kanban_spawn.py
+++ b/tests/tools/environments/test_kanban_spawn.py
@@ -182,3 +182,322 @@ def test_local_runtime_terminate_actually_signals(monkeypatch):
     rt.terminate(12345, reason="test")
     assert captured["pid"] == 12345
     assert captured["sig"] == signal.SIGTERM
+
+
+# ---------------------------------------------------------------------------
+# DockerRuntime tests (D1 Task 3)
+# ---------------------------------------------------------------------------
+
+def _make_fake_task(task_id="t_d1", assignee="researcher", skills=None):
+    fake = MagicMock()
+    fake.id = task_id
+    fake.assignee = assignee
+    fake.tenant = None
+    fake.current_run_id = 5
+    fake.claim_lock = "lock-xyz"
+    fake.skills = skills
+    return fake
+
+
+def _stub_kanban_db_helpers(monkeypatch):
+    """Stub kanban_db helpers so tests don't touch the real DB or PATH."""
+    import hermes_cli.kanban_db as kb
+    import pathlib
+    monkeypatch.setattr(kb, "kanban_db_path", lambda board=None: "/db")
+    monkeypatch.setattr(kb, "workspaces_root", lambda board=None: "/ws")
+    monkeypatch.setattr(kb, "get_current_board", lambda: "main")
+    monkeypatch.setattr(kb, "_normalize_board_slug", lambda s: s)
+    monkeypatch.setattr(kb, "_resolve_assignee_to_profile", lambda a: "worker")
+
+
+def _stub_docker_present(monkeypatch):
+    """Make shutil.which('docker') return a path so DockerRuntime() boots."""
+    import shutil
+    monkeypatch.setattr(shutil, "which",
+                        lambda n: "/usr/bin/docker" if n == "docker" else None)
+
+
+def test_docker_runtime_requires_default_image(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    with pytest.raises(ValueError, match="image_per_profile.default"):
+        DockerRuntime({"image_per_profile": {}})
+
+
+def test_docker_runtime_requires_docker_cli(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda n: None)
+    with pytest.raises(RuntimeError, match="docker.*CLI not found"):
+        DockerRuntime({"image_per_profile": {"default": "img:latest"}})
+
+
+def test_docker_runtime_resolve_image_falls_back_to_default(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+    assert rt._resolve_image("never-defined") == "hermes-worker:latest"
+
+
+def test_docker_runtime_resolve_image_uses_per_profile_when_set(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {
+            "default": "hermes-worker:latest",
+            "ops": "hermes-ops:latest",
+        },
+        "bind_mounts": [], "env_passthrough": [],
+    })
+    assert rt._resolve_image("ops") == "hermes-ops:latest"
+    assert rt._resolve_image("anything-else") == "hermes-worker:latest"
+
+
+def test_docker_runtime_expand_bind_substitutes_hermes_home(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+    expanded = rt._expand_bind(
+        "{hermes_home}/kanban.db:/hermes/kanban.db",
+        "/home/u/.hermes",
+    )
+    assert expanded == "/home/u/.hermes/kanban.db:/hermes/kanban.db"
+
+
+def test_docker_runtime_spawn_builds_correct_command(monkeypatch):
+    """Full happy-path: spawn() produces the expected `docker run` argv."""
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    _stub_kanban_db_helpers(monkeypatch)
+    monkeypatch.setattr("hermes_cli.profiles.normalize_profile_name", lambda n: n)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-token")
+
+    rt = DockerRuntime({
+        "image_per_profile": {
+            "worker": "hermes-worker:latest",
+            "default": "hermes-worker:latest",
+        },
+        "bind_mounts": [
+            "/home/u/.hermes/kanban.db:/hermes/kanban.db",
+            "/home/u/.hermes/.env:/hermes/.env:ro",
+        ],
+        "env_passthrough": ["OPENROUTER_API_KEY"],
+        "mem_limit": "4g",
+        "cpus": "2.0",
+        "network": "hermes-net",
+        "auto_remove": True,
+    })
+
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        out = MagicMock()
+        out.stdout = b"abc123def456789\n"
+        out.returncode = 0
+        out.stderr = b""
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    handle = rt.spawn(
+        _make_fake_task("t_d1", "researcher"),
+        workspace="/tmp/work",
+        board="main",
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "docker"
+    assert cmd[1] == "run"
+    assert "-d" in cmd
+    assert "--rm" in cmd
+    assert "--network" in cmd and "hermes-net" in cmd
+    assert "--memory" in cmd and "4g" in cmd
+    assert "--cpus" in cmd and "2.0" in cmd
+    # Bind mounts present
+    assert cmd.count("-v") == 2
+    # Env passthrough captured
+    env_idxs = [i for i, x in enumerate(cmd) if x == "-e"]
+    env_pairs = [cmd[i + 1] for i in env_idxs]
+    assert any(e.startswith("OPENROUTER_API_KEY=sk-test-token") for e in env_pairs)
+    assert any(e.startswith("HERMES_KANBAN_TASK=t_d1") for e in env_pairs)
+    # Image present
+    assert "hermes-worker:latest" in cmd
+    # In-container hermes invocation
+    h_idx = cmd.index("hermes-worker:latest")
+    in_cmd = cmd[h_idx + 1:]
+    assert in_cmd[:2] == ["hermes", "-p"]
+    # Per swarm-as-persona, assignee 'researcher' resolved to 'worker'
+    assert in_cmd[2] == "worker"
+    assert "chat" in in_cmd and "-q" in in_cmd
+    # Handle returned is the truncated container id (12 chars)
+    assert handle == "abc123def456"
+
+
+def test_docker_runtime_spawn_raises_on_docker_failure(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    _stub_kanban_db_helpers(monkeypatch)
+    monkeypatch.setattr("hermes_cli.profiles.normalize_profile_name", lambda n: n)
+
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    def fake_run(cmd, **kw):
+        out = MagicMock()
+        out.returncode = 125
+        out.stdout = b""
+        out.stderr = b"docker: image not found"
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="docker run failed.*image not found"):
+        rt.spawn(_make_fake_task(), workspace="/tmp", board="main")
+
+
+def test_docker_runtime_skills_appended_to_command(monkeypatch):
+    """Per-task skills are emitted as additional --skills X pairs."""
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    _stub_kanban_db_helpers(monkeypatch)
+    monkeypatch.setattr("hermes_cli.profiles.normalize_profile_name", lambda n: n)
+
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        out = MagicMock()
+        out.stdout = b"cid123\n"
+        out.returncode = 0
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    rt.spawn(
+        _make_fake_task(skills=["custom-skill-a", "kanban-worker", "custom-skill-b"]),
+        workspace="/tmp",
+        board="main",
+    )
+
+    cmd = captured["cmd"]
+    skills_idxs = [i for i, x in enumerate(cmd) if x == "--skills"]
+    skill_values = [cmd[i + 1] for i in skills_idxs]
+    # Built-in kanban-worker is always there
+    assert "kanban-worker" in skill_values
+    # Per-task skills also included
+    assert "custom-skill-a" in skill_values
+    assert "custom-skill-b" in skill_values
+    # kanban-worker appears EXACTLY once (de-duped against the built-in)
+    assert skill_values.count("kanban-worker") == 1
+
+
+def test_docker_runtime_is_alive_returns_true_when_status_running(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "img:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    def fake_run(cmd, **kw):
+        out = MagicMock()
+        out.stdout = b"running\n"
+        out.returncode = 0
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert rt.is_alive("abc123") is True
+
+
+def test_docker_runtime_is_alive_returns_false_when_exited(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "img:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    def fake_run(cmd, **kw):
+        out = MagicMock()
+        out.stdout = b"exited\n"
+        out.returncode = 0
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert rt.is_alive("abc123") is False
+
+
+def test_docker_runtime_is_alive_handles_unknown_container(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "img:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    def fake_run(cmd, **kw):
+        out = MagicMock()
+        out.returncode = 1   # docker inspect returns non-zero on unknown container
+        out.stdout = b""
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert rt.is_alive("nonexistent") is False
+
+
+def test_docker_runtime_is_alive_handles_empty_handle(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "img:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+    assert rt.is_alive("") is False
+    assert rt.is_alive(None) is False
+
+
+def test_docker_runtime_terminate_calls_docker_kill(monkeypatch):
+    from tools.environments.kanban_spawn import DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = DockerRuntime({
+        "image_per_profile": {"default": "img:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+
+    captured = {}
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        out = MagicMock()
+        out.returncode = 0
+        return out
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    rt.terminate("abc123", reason="test")
+    assert captured["cmd"][:2] == ["docker", "kill"]
+    assert "abc123" in captured["cmd"]
+
+
+def test_load_runtime_docker_now_in_registry(monkeypatch):
+    """After D1 Task 3, 'docker' is a registered runtime."""
+    from tools.environments.kanban_spawn import load_runtime, DockerRuntime
+    _stub_docker_present(monkeypatch)
+    rt = load_runtime("docker", {
+        "image_per_profile": {"default": "hermes-worker:latest"},
+        "bind_mounts": [], "env_passthrough": [],
+    })
+    assert isinstance(rt, DockerRuntime)
+    assert rt.name == "docker"

--- a/tests/tools/test_delegate_route_fidelity.py
+++ b/tests/tools/test_delegate_route_fidelity.py
@@ -1,0 +1,273 @@
+"""Regression tests for the per-task model/provider override route-fidelity bug.
+
+Verified failure mode: per-task `model` / `provider` / `base_url` / `api_key`
+overrides on `delegate_task(tasks=[{...}, ...])` were silently dropped — every
+child built with `creds["model"]` from the top-level `delegation.*` config
+regardless of what the per-task dict specified.
+
+Impact: parallel-critique scatter "with cross-family signal" was actually
+single-family; "MoA via delegate_task" routed all subagents to one model;
+and any caller relying on per-task model selection got the orchestrator's
+primary model regardless.
+
+These tests pin the FIX (in `delegate_tool.py`'s per-task creds layering loop)
+so it can't silently regress. Verified RED for the 6th time on 2026-05-13;
+this fix lands on `feat/d1-kanban-worker-runtime` sibling branch
+`fix/delegate-task-route-fidelity`.
+"""
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _resolve_delegation_credentials, delegate_task
+
+
+def _make_mock_parent(depth=0):
+    parent = MagicMock()
+    parent.base_url = "https://openrouter.ai/api/v1"
+    parent.api_key = "sk-parent"
+    parent.provider = "openrouter"
+    parent.api_mode = "chat_completions"
+    parent.model = "anthropic/claude-opus-4.7"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    return parent
+
+
+class TestPerTaskRouteFidelity(unittest.TestCase):
+    """The per-task model/provider override must reach the child build."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_only_override_reaches_child(self, mock_creds, mock_cfg):
+        """Single per-task `model` field overrides creds["model"] only.
+
+        Other fields (provider, base_url, api_key, api_mode) are inherited
+        from parent creds. This is the canonical scatter-gather case:
+        same OpenRouter endpoint, different model slug per reviewer.
+        """
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+        }
+        mock_creds.return_value = {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-parent",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0,
+            }
+
+            tasks = [
+                {"goal": "Review with Gemini",  "model": "google/gemini-3.1-pro-preview"},
+                {"goal": "Review with DeepSeek", "model": "deepseek/deepseek-v4-pro"},
+                {"goal": "Review with Kimi",    "model": "moonshotai/kimi-k2.6"},
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+            self.assertEqual(mock_build.call_count, 3)
+            models_used = [c.kwargs["model"] for c in mock_build.call_args_list]
+            self.assertEqual(
+                models_used,
+                ["google/gemini-3.1-pro-preview",
+                 "deepseek/deepseek-v4-pro",
+                 "moonshotai/kimi-k2.6"],
+                "Per-task `model` override was silently dropped — "
+                "route-fidelity bug regression",
+            )
+            # Provider / base / key / mode all inherited from parent creds
+            for c in mock_build.call_args_list:
+                self.assertEqual(c.kwargs["override_provider"], "openrouter")
+                self.assertEqual(
+                    c.kwargs["override_base_url"], "https://openrouter.ai/api/v1"
+                )
+                self.assertEqual(c.kwargs["override_api_key"], "sk-or-parent")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_no_model_override_uses_parent_creds(
+        self, mock_creds, mock_cfg
+    ):
+        """Tasks without any model/provider keys keep parent creds verbatim."""
+        mock_cfg.return_value = {"max_iterations": 45, "model": "x"}
+        mock_creds.return_value = {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-parent",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0,
+            }
+            tasks = [{"goal": "Task A"}, {"goal": "Task B"}]
+            delegate_task(tasks=tasks, parent_agent=parent)
+            self.assertEqual(mock_build.call_count, 2)
+            for c in mock_build.call_args_list:
+                self.assertEqual(c.kwargs["model"], "anthropic/claude-opus-4.7")
+                self.assertEqual(c.kwargs["override_provider"], "openrouter")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_per_task_provider_override_re_resolves_full_creds(
+        self, mock_cfg
+    ):
+        """Per-task `provider` field triggers full credential re-resolution.
+
+        We mock _resolve_delegation_credentials such that:
+          - first call (top-level) returns parent creds (openrouter)
+          - subsequent calls (per-task) return alternative creds based on the
+            cfg dict that was passed in.
+        Verify the re-resolved creds reach the child build, not the parent.
+        """
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        # Track resolution calls and return per-task-specific creds
+        resolution_calls = []
+
+        def fake_resolve(cfg, parent_agent):
+            resolution_calls.append(dict(cfg))
+            return {
+                "model": cfg.get("model") or "anthropic/claude-opus-4.7",
+                "provider": cfg.get("provider") or "openrouter",
+                "base_url": cfg.get("base_url") or "https://openrouter.ai/api/v1",
+                "api_key": cfg.get("api_key") or "sk-or-parent",
+                "api_mode": "chat_completions",
+            }
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            side_effect=fake_resolve,
+        ), patch("tools.delegate_tool._build_child_agent") as mock_build, \
+           patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0,
+            }
+
+            tasks = [
+                {
+                    "goal": "Anthropic-direct task",
+                    "model": "claude-sonnet-4.6",
+                    "provider": "anthropic",
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "sk-ant-direct",
+                },
+                {"goal": "OR task", "model": "google/gemini-3.1-pro-preview"},
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+            self.assertEqual(mock_build.call_count, 2)
+            # Task 0: anthropic-direct — provider override triggered re-resolution
+            self.assertEqual(
+                mock_build.call_args_list[0].kwargs["override_provider"],
+                "anthropic",
+            )
+            self.assertEqual(
+                mock_build.call_args_list[0].kwargs["override_base_url"],
+                "https://api.anthropic.com",
+            )
+            self.assertEqual(
+                mock_build.call_args_list[0].kwargs["override_api_key"],
+                "sk-ant-direct",
+            )
+            self.assertEqual(
+                mock_build.call_args_list[0].kwargs["model"], "claude-sonnet-4.6"
+            )
+            # Task 1: OR task — model-only override, parent provider preserved
+            self.assertEqual(
+                mock_build.call_args_list[1].kwargs["model"],
+                "google/gemini-3.1-pro-preview",
+            )
+            self.assertEqual(
+                mock_build.call_args_list[1].kwargs["override_provider"],
+                "openrouter",
+            )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_credential_resolution_failure_falls_back_to_parent_creds(
+        self, mock_creds, mock_cfg
+    ):
+        """If per-task credential re-resolution raises, fall back to parent creds
+        with a WARNING log — surface-isolation invariant.
+        """
+        mock_cfg.return_value = {"max_iterations": 45}
+        # First call returns parent creds; subsequent (per-task) calls raise
+        parent_creds = {
+            "model": "anthropic/claude-opus-4.7",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-parent",
+            "api_mode": "chat_completions",
+        }
+        call_count = [0]
+
+        def side_effect(cfg, parent_agent):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return parent_creds
+            raise ValueError("synthetic per-task resolution failure")
+
+        mock_creds.side_effect = side_effect
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0,
+            }
+
+            tasks = [
+                {
+                    "goal": "Task that triggers per-task resolution",
+                    "provider": "broken-provider",  # triggers re-resolve which raises
+                },
+            ]
+            delegate_task(tasks=tasks, parent_agent=parent)
+
+            self.assertEqual(mock_build.call_count, 1)
+            # Falls back to parent creds — no crash
+            self.assertEqual(
+                mock_build.call_args.kwargs["override_provider"], "openrouter"
+            )
+            self.assertEqual(
+                mock_build.call_args.kwargs["model"], "anthropic/claude-opus-4.7"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2038,26 +2038,71 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task model/provider override resolution (route-fidelity fix).
+            # If the per-task dict carries `model`, `provider`, `base_url`, or
+            # `api_key`, build a per-task creds bundle layered on top of the
+            # parent's resolved creds. Without this, every per-task model/
+            # provider override is silently dropped — verified failure mode
+            # in 6+ scatter-gather sessions across 2026-05-05 to 2026-05-13.
+            #
+            # Resolution rules:
+            #   - If per-task has `base_url` OR `provider`, re-resolve the
+            #     full credential bundle via _resolve_delegation_credentials
+            #     using a layered cfg (per-task overrides on top of cfg).
+            #   - Else if per-task has `model` only, override creds["model"]
+            #     while inheriting everything else from parent creds (the
+            #     common scatter-gather case: same OpenRouter endpoint,
+            #     different model slug per reviewer).
+            #   - Else use parent creds verbatim.
+            task_creds = creds
+            t_model = str(t.get("model") or "").strip() or None
+            t_provider = str(t.get("provider") or "").strip() or None
+            t_base_url = str(t.get("base_url") or "").strip() or None
+            t_api_key = str(t.get("api_key") or "").strip() or None
+            if t_provider or t_base_url or t_api_key:
+                try:
+                    task_cfg = dict(cfg) if isinstance(cfg, dict) else {}
+                    if t_model:
+                        task_cfg["model"] = t_model
+                    if t_provider:
+                        task_cfg["provider"] = t_provider
+                    if t_base_url:
+                        task_cfg["base_url"] = t_base_url
+                    if t_api_key:
+                        task_cfg["api_key"] = t_api_key
+                    task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+                except Exception as exc:
+                    logger.warning(
+                        "delegate_task: per-task credential resolution failed "
+                        "for task %d (%s); falling back to parent creds", i, exc,
+                    )
+                    task_creds = creds
+            elif t_model:
+                # Model-only override — keep parent's provider/base/key/api_mode
+                task_creds = dict(creds)
+                task_creds["model"] = t_model
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )

--- a/tools/environments/kanban_spawn.py
+++ b/tools/environments/kanban_spawn.py
@@ -210,7 +210,7 @@ class DockerRuntime:
             "HERMES_KANBAN_TASK", "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD",
             "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_WORKSPACE",
             "HERMES_KANBAN_RUN_ID", "HERMES_KANBAN_CLAIM_LOCK",
-            "HERMES_PROFILE", "HERMES_TENANT",
+            "HERMES_PROFILE", "HERMES_TENANT", "HERMES_HOME",
         ):
             if key in env and key not in seen:
                 args.extend(["-e", f"{key}={env[key]}"])
@@ -267,6 +267,15 @@ class DockerRuntime:
         resolved_board = kb._normalize_board_slug(board) or kb.get_current_board()
         env["HERMES_KANBAN_BOARD"] = resolved_board
         env["HERMES_PROFILE"] = profile_arg
+        # Phase-8 P0 (triple-flagged): _default_spawn injects HERMES_HOME so
+        # the worker reads profile-scoped config (fallback_providers,
+        # toolsets, agent settings). DockerRuntime must do the same — but
+        # the in-container HERMES_HOME points at /hermes (set by the
+        # Dockerfile), not the host's resolved profile path. The profile
+        # subdir gets in via the bind-mount of the host's hermes home.
+        # The container's hermes -p <profile> then reads
+        # /hermes/profiles/<profile>/config.yaml as expected.
+        env["HERMES_HOME"] = "/hermes"
 
         # Container name (truncated task id for readability)
         short = task.id.replace("t_", "")[:12]

--- a/tools/environments/kanban_spawn.py
+++ b/tools/environments/kanban_spawn.py
@@ -1,0 +1,182 @@
+"""Worker-spawn runtime strategy for the kanban dispatcher.
+
+This module isolates *how* a kanban worker process gets created from *when*
+the dispatcher decides to spawn one. The dispatcher remains responsible for
+claim acquisition, DAG promotion, retry policy, and PID-tracking; the
+runtime is responsible only for "produce a handle to a running worker
+that has the supplied env contract."
+
+Contract: every runtime gets the same env vars in scope (HERMES_KANBAN_*,
+HERMES_PROFILE, HERMES_TENANT, etc.) and must launch a process that runs
+``hermes -p <profile> --skills kanban-worker chat -q "work kanban task <id>"``.
+
+The default ``LocalRuntime`` is a thin wrapper around ``_default_spawn`` in
+``hermes_cli/kanban_db.py`` so that ``worker_runtime: local`` is byte-identical
+to pre-D1 behavior.
+
+See also:
+    ~/.hermes/plans/2026-05-12-d1-kanban-worker-runtime.md  (this file's plan)
+    ~/.hermes/skills/software-development/mission-control-architecture/SKILL.md
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+from typing import Any, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+class WorkerRuntime(Protocol):
+    """Strategy interface for spawning kanban workers.
+
+    Implementations:
+      - LocalRuntime — bare subprocess (today's default)
+      - DockerRuntime — `docker run --rm` per-task container (D1 Task 3)
+      - (future) ModalRuntime, SSHRuntime, etc.
+
+    Attributes:
+        name: short identifier matching the config key
+              (`local`, `docker`, `modal`, `ssh`).
+
+    Methods:
+        spawn(task, workspace, board=None) -> handle:
+            Launch a worker. Returns a *handle* (int PID for local/ssh,
+            container_id string for docker, Modal call_id for modal).
+            Must be string-able and stable for the worker's lifetime.
+            ``None`` indicates a benign skip (e.g. dry-run or already-running).
+            Raise on unrecoverable errors (image missing, daemon down, etc.).
+        is_alive(handle) -> bool:
+            Probe whether the worker is still running. Best-effort; the
+            dispatcher's claim-TTL logic remains the authoritative
+            crash detector.
+        terminate(handle, reason) -> None:
+            Best-effort SIGTERM (or container kill). Used by `kanban
+            reclaim` and shutdown paths.
+    """
+
+    name: str
+
+    def spawn(
+        self,
+        task: Any,
+        workspace: str,
+        *,
+        board: Optional[str] = None,
+    ) -> Optional[int | str]: ...
+
+    def is_alive(self, handle: int | str) -> bool: ...
+
+    def terminate(self, handle: int | str, reason: str = "") -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# LocalRuntime — the regression-safe default
+# ---------------------------------------------------------------------------
+
+class LocalRuntime:
+    """Today's behavior: ``hermes`` on PATH via subprocess.Popen.
+
+    Wraps ``hermes_cli.kanban_db._default_spawn`` so ``worker_runtime: local``
+    is byte-identical to pre-D1 behavior.
+    """
+
+    name = "local"
+
+    def __init__(self, cfg: Optional[dict] = None) -> None:
+        # No config consumed at v1. Reserved for future fields like
+        # `start_new_session`, `cgroup_path`, etc.
+        self._cfg = cfg or {}
+
+    def spawn(
+        self,
+        task: Any,
+        workspace: str,
+        *,
+        board: Optional[str] = None,
+    ) -> Optional[int]:
+        # Lazy import to avoid a circular dep with kanban_db (which imports
+        # things from gateway/run.py at module top, and gateway/run.py may
+        # in turn import this module via the runtime-loading helper).
+        from hermes_cli import kanban_db
+        return kanban_db._default_spawn(task, workspace, board=board)
+
+    def is_alive(self, handle: int | str) -> bool:
+        try:
+            pid = int(handle)
+        except (TypeError, ValueError):
+            return False
+        if pid <= 0:
+            return False
+        try:
+            # Signal 0 doesn't kill; just probes existence.
+            os.kill(pid, 0)
+            return True
+        except (ProcessLookupError, PermissionError):
+            return False
+        except OSError:
+            return False
+
+    def terminate(self, handle: int | str, reason: str = "") -> None:
+        try:
+            pid = int(handle)
+        except (TypeError, ValueError):
+            return
+        if pid <= 0:
+            return
+        try:
+            os.kill(pid, signal.SIGTERM)
+            logger.info("LocalRuntime: SIGTERM pid=%d (%s)", pid, reason)
+        except ProcessLookupError:
+            pass  # Already dead; not an error.
+        except OSError as exc:
+            logger.warning(
+                "LocalRuntime: terminate failed pid=%d: %s", pid, exc
+            )
+
+
+# ---------------------------------------------------------------------------
+# Factory + registry
+# ---------------------------------------------------------------------------
+
+# Registry — populated below. D1 Task 3 extends with DockerRuntime;
+# future deliverables add ModalRuntime / SSHRuntime via register_runtime().
+_RUNTIMES: dict[str, type] = {
+    "local": LocalRuntime,
+}
+
+
+def register_runtime(name: str, cls: type) -> None:
+    """Register a new runtime implementation.
+
+    Used by D1 Task 3 (DockerRuntime), future deliverables, and tests
+    that need to swap in a fake runtime.
+
+    Raises ValueError if ``name`` is already registered — re-registration
+    is almost always a bug (two plugins fighting over the same key).
+    """
+    if name in _RUNTIMES:
+        raise ValueError(
+            f"runtime {name!r} already registered "
+            f"(existing: {_RUNTIMES[name].__name__})"
+        )
+    _RUNTIMES[name] = cls
+
+
+def load_runtime(name: str, cfg: Optional[dict] = None) -> WorkerRuntime:
+    """Resolve a config name to a runtime instance.
+
+    Raises ValueError on unknown names so the gateway boot fails loudly
+    rather than silently fall back to local (which would mask config typos).
+    """
+    if name not in _RUNTIMES:
+        available = ", ".join(sorted(_RUNTIMES.keys()))
+        raise ValueError(
+            f"unknown worker_runtime={name!r}. Available: {available}"
+        )
+    return _RUNTIMES[name](cfg or {})

--- a/tools/environments/kanban_spawn.py
+++ b/tools/environments/kanban_spawn.py
@@ -141,6 +141,231 @@ class LocalRuntime:
 
 
 # ---------------------------------------------------------------------------
+# DockerRuntime — per-task isolated container (D1 Task 3)
+# ---------------------------------------------------------------------------
+
+class DockerRuntime:
+    """Spawn each kanban worker in its own ``hermes-worker:latest`` container.
+
+    Container lifecycle: ``docker run -d --rm ...`` (detached, auto-remove
+    on exit). Container name is ``hermes-kanban-<task_id_short>`` so a
+    human can ``docker logs`` it. The dispatcher's claim-TTL logic (15min
+    default) is the authoritative crash detector; ``is_alive`` queries
+    ``docker inspect`` as a faster signal.
+
+    Config keys (all under ``kanban.docker`` in config.yaml):
+
+        image_per_profile:
+          worker: hermes-worker:latest      # primary swarm image
+          default: hermes-worker:latest     # fallback for unknown profiles
+          ops: hermes-ops:latest            # optional per-profile override
+        bind_mounts:                        # list of `host:container[:mode]`
+          - "{hermes_home}/kanban.db:/hermes/kanban.db"
+          - "{hermes_home}/.env:/hermes/.env:ro"
+        env_passthrough:                    # env var names (or globs)
+          - OPENROUTER_API_KEY
+          - HERMES_*
+        mem_limit: "4g"                     # per-container RAM cap
+        cpus: "2.0"                         # per-container CPU cap
+        network: hermes-net                 # bridge name (compose stack)
+        auto_remove: true                   # docker run --rm
+    """
+
+    name = "docker"
+
+    def __init__(self, cfg: dict) -> None:
+        self._cfg = cfg or {}
+        self._images = self._cfg.get("image_per_profile") or {}
+        if not self._images.get("default"):
+            raise ValueError(
+                "DockerRuntime requires kanban.docker.image_per_profile.default"
+            )
+        self._bind_mounts = self._cfg.get("bind_mounts") or []
+        self._env_passthrough = self._cfg.get("env_passthrough") or []
+        self._mem = self._cfg.get("mem_limit")
+        self._cpus = self._cfg.get("cpus")
+        self._network = self._cfg.get("network", "hermes-net")
+        self._auto_remove = bool(self._cfg.get("auto_remove", True))
+        # Verify docker CLI present at boot. Fails loudly.
+        import shutil
+        if shutil.which("docker") is None:
+            raise RuntimeError(
+                "DockerRuntime: `docker` CLI not found on PATH. "
+                "Install Docker Engine and ensure the user is in the docker group."
+            )
+
+    def _resolve_image(self, profile: str) -> str:
+        return self._images.get(profile) or self._images["default"]
+
+    def _expand_bind(self, raw: str, hermes_home: str) -> str:
+        return raw.replace("{hermes_home}", hermes_home.rstrip("/"))
+
+    def _build_env_args(self, env: dict) -> list:
+        """Emit -e KEY=VAL pairs honoring the passthrough allowlist + globs."""
+        import fnmatch
+        args = []
+        seen = set()
+        # 1) Always pass the kanban contract
+        for key in (
+            "HERMES_KANBAN_TASK", "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD",
+            "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_WORKSPACE",
+            "HERMES_KANBAN_RUN_ID", "HERMES_KANBAN_CLAIM_LOCK",
+            "HERMES_PROFILE", "HERMES_TENANT",
+        ):
+            if key in env and key not in seen:
+                args.extend(["-e", f"{key}={env[key]}"])
+                seen.add(key)
+        # 2) Apply allowlist (literal names + globs)
+        for pattern in self._env_passthrough:
+            if pattern in os.environ and pattern not in seen:
+                args.extend(["-e", f"{pattern}={os.environ[pattern]}"])
+                seen.add(pattern)
+                continue
+            # Glob matching
+            for k, v in os.environ.items():
+                if k in seen:
+                    continue
+                if fnmatch.fnmatch(k, pattern):
+                    args.extend(["-e", f"{k}={v}"])
+                    seen.add(k)
+        return args
+
+    def spawn(
+        self,
+        task: Any,
+        workspace: str,
+        *,
+        board: Optional[str] = None,
+    ) -> Optional[str]:
+        # Lazy imports to avoid circular deps.
+        from hermes_cli import kanban_db as kb
+        from hermes_cli.profiles import normalize_profile_name
+        import subprocess
+
+        if not task.assignee:
+            raise ValueError(f"task {task.id} has no assignee")
+
+        # Apply the same swarm-as-persona resolution as LocalRuntime.
+        # (kanban_db._default_spawn does this for local; we replicate here
+        # so the env contract matches and only the runtime differs.)
+        resolved = kb._resolve_assignee_to_profile(task.assignee)
+        profile_arg = normalize_profile_name(resolved)
+        image = self._resolve_image(profile_arg)
+
+        # Build the in-container env (mirrors _default_spawn).
+        env: dict = {}
+        if task.tenant:
+            env["HERMES_TENANT"] = task.tenant
+        env["HERMES_KANBAN_TASK"] = task.id
+        env["HERMES_KANBAN_WORKSPACE"] = workspace
+        if task.current_run_id is not None:
+            env["HERMES_KANBAN_RUN_ID"] = str(task.current_run_id)
+        if task.claim_lock:
+            env["HERMES_KANBAN_CLAIM_LOCK"] = task.claim_lock
+        env["HERMES_KANBAN_DB"] = str(kb.kanban_db_path(board=board))
+        env["HERMES_KANBAN_WORKSPACES_ROOT"] = str(kb.workspaces_root(board=board))
+        resolved_board = kb._normalize_board_slug(board) or kb.get_current_board()
+        env["HERMES_KANBAN_BOARD"] = resolved_board
+        env["HERMES_PROFILE"] = profile_arg
+
+        # Container name (truncated task id for readability)
+        short = task.id.replace("t_", "")[:12]
+        cname = f"hermes-kanban-{short}"
+
+        # Build `docker run` argv
+        cmd: list = ["docker", "run", "-d"]
+        if self._auto_remove:
+            cmd.append("--rm")
+        cmd.extend(["--name", cname])
+        cmd.extend(["--network", self._network])
+        if self._mem:
+            cmd.extend(["--memory", str(self._mem)])
+        if self._cpus:
+            cmd.extend(["--cpus", str(self._cpus)])
+
+        # Bind mounts ({hermes_home} placeholder expansion)
+        hermes_home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+        for raw in self._bind_mounts:
+            cmd.extend(["-v", self._expand_bind(raw, hermes_home)])
+
+        # Env vars
+        cmd.extend(self._build_env_args(env))
+
+        # Image
+        cmd.append(image)
+
+        # In-container command (mirrors _default_spawn's argv)
+        cmd.extend([
+            "hermes", "-p", profile_arg,
+            "--skills", "kanban-worker",
+        ])
+        if task.skills:
+            for sk in task.skills:
+                if sk and sk != "kanban-worker":
+                    cmd.extend(["--skills", sk])
+        cmd.extend(["chat", "-q", f"work kanban task {task.id}"])
+
+        # Launch
+        try:
+            result = subprocess.run(  # noqa: S603 -- argv is a list built above
+                cmd,
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"DockerRuntime: docker CLI lost from PATH: {exc}"
+            )
+        if result.returncode != 0:
+            stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"DockerRuntime: docker run failed (exit {result.returncode}): "
+                f"{stderr.strip()}"
+            )
+        cid_full = (result.stdout or b"").decode("utf-8", errors="replace").strip()
+        if not cid_full:
+            raise RuntimeError("DockerRuntime: docker run produced no container id")
+        short_cid = cid_full[:12]
+        logger.info(
+            "DockerRuntime spawned task=%s container=%s image=%s",
+            task.id, short_cid, image,
+        )
+        return short_cid
+
+    def is_alive(self, handle) -> bool:
+        if not handle:
+            return False
+        import subprocess
+        try:
+            r = subprocess.run(
+                ["docker", "inspect", "-f", "{{.State.Status}}", str(handle)],
+                check=False, capture_output=True, timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        if r.returncode != 0:
+            return False
+        return (r.stdout or b"").decode("utf-8", errors="replace").strip() == "running"
+
+    def terminate(self, handle, reason: str = "") -> None:
+        if not handle:
+            return
+        import subprocess
+        try:
+            subprocess.run(
+                ["docker", "kill", str(handle)],
+                check=False, capture_output=True, timeout=10,
+            )
+            logger.info(
+                "DockerRuntime: docker kill %s (%s)", handle, reason
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "DockerRuntime: terminate failed handle=%s: %s", handle, exc
+            )
+
+
+# ---------------------------------------------------------------------------
 # Factory + registry
 # ---------------------------------------------------------------------------
 
@@ -148,6 +373,7 @@ class LocalRuntime:
 # future deliverables add ModalRuntime / SSHRuntime via register_runtime().
 _RUNTIMES: dict[str, type] = {
     "local": LocalRuntime,
+    "docker": DockerRuntime,
 }
 
 


### PR DESCRIPTION
fix(delegate_task): honor per-task model/provider overrides (route-fidelity bug)

Verified failure mode: per-task `model` / `provider` / `base_url` / `api_key`
overrides on `delegate_task(tasks=[{...}, ...])` were silently dropped — every
child built with `creds["model"]` from the top-level `delegation.*` config
regardless of what the per-task dict specified.

Verified RED across 6+ scatter-gather sessions between 2026-05-05 and
2026-05-13. Most recent failure: route-fidelity probe asked for
`google/gemini-3.1-pro-preview`, returned `actual_model:
anthropic/claude-opus-4.7` (from the parent's primary). Side-effect:
"cross-family" reviews silently became single-family role-play, requiring
a $0.50 curl-bypass workaround dispatcher per scatter.

Root cause: `tools/delegate_tool.py` lines ~2046+ passed
`model=creds["model"]` and `override_provider=creds["provider"]` etc. to
`_build_child_agent()` for every task — without ever consulting
`t.get("model")` or `t.get("provider")` on the per-task dict. Other per-task
fields (`role`, `toolsets`, `acp_command`, `acp_args`, `context`) DID
consult `t.get(...)` properly; only the credential overrides were missed.

Fix: insert a per-task creds layering step before _build_child_agent():
  - Per-task `provider` / `base_url` / `api_key` → re-resolve full creds
    bundle via _resolve_delegation_credentials with the layered cfg
    (per-task overrides on top of cfg). This handles fully-different
    provider routes (e.g. `provider: anthropic` direct + `base_url:
    https://api.anthropic.com`).
  - Per-task `model` only → keep parent provider/base/key/api_mode,
    swap creds["model"] with the per-task model. This is the canonical
    scatter-gather case (same OpenRouter endpoint, different model slug
    per reviewer).
  - Neither → use parent creds verbatim (back-compat path).
  - Per-task resolution failure → log WARNING + fall back to parent
    creds (surface-isolation invariant — one bad task must not crash
    the others).

Tests: 4 new in tests/tools/test_delegate_route_fidelity.py
  - test_per_task_model_only_override_reaches_child
    (canonical scatter case: 3 tasks with different `model` slugs all
     reach the child build with their requested slug, not the parent's)
  - test_per_task_no_model_override_uses_parent_creds
    (back-compat: tasks without overrides keep parent creds verbatim)
  - test_per_task_provider_override_re_resolves_full_creds
    (per-task `provider: anthropic` + `base_url` re-resolves the full
     bundle and reaches the child; OR-only override on a sibling task
     keeps parent provider intact)
  - test_per_task_credential_resolution_failure_falls_back_to_parent_creds
    (synthetic raise from _resolve_delegation_credentials does NOT
     crash the dispatch — falls back to parent creds with WARNING log)

Existing 127 delegate_tool tests pass unchanged. 131/131 green together.

This unblocks `parallel-critique` skill's `delegate_task`-based scatter,
removes the need for the curl-bypass dispatcher in most cases, and makes
genuine cross-family review available without OPENROUTER_API_KEY env-var
gymnastics.

Branch: fix/delegate-task-route-fidelity (off feat/d1-kanban-worker-runtime).

When this lands upstream, the parallel-critique skill's "Hard Rule #0
route-fidelity probe MUST run before scatter" can be downgraded from
mandatory to advisory; ditto the §17b reasoning-burn fallback (still
real, but the scatter pattern itself becomes reliable).
