### PR TITLE
fix(gateway): keep tool-progress edits alive after Telegram flood control

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14516,14 +14516,15 @@ class GatewayRunner:
                         if not result.success:
                             _err = (getattr(result, "error", "") or "").lower()
                             if "flood" in _err or "retry after" in _err:
-                                # Flood control hit — disable further edits,
-                                # switch to sending new messages only for
-                                # important updates.  Don't block 23s.
+                                # Flood control hit — backoff but keep editing.
+                                # Only disable edits for non-recoverable errors.
                                 logger.info(
-                                    "[%s] Progress edits disabled due to flood control",
+                                    "[%s] Progress edit flood control, backing off",
                                     adapter.name,
                                 )
-                            can_edit = False
+                                _last_edit_ts = time.monotonic()
+                            else:
+                                can_edit = False
                             _flood_result = await adapter.send(
                                 chat_id=source.chat_id,
                                 content=msg,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -40,6 +40,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     # teknium (multiple emails)
+    "erhanyasarx@gmail.com": "erhnysr",
     "teknium1@gmail.com": "teknium1",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1005,6 +1005,7 @@ AUTHOR_MAP = {
     "zhaowh3613@outlook.com": "VinceZcrikl",  # PR #23647 salvage (npm UTF-8 decode on GBK Windows)
     "anton.kuenzi@gmail.com": "ZeterMordio",  # PR #11754 salvage (zsh completion compdef + _arguments syntax)
     "23yntong@stu.edu.cn": "iuyup",  # PR #6155 salvage (shell=True hardening)
+    "erhanyasarx@gmail.com": "erhnysr",  # PR #25555 fix(install): pin Python version on Windows
 }
 
 


### PR DESCRIPTION
Fixes #25188

## Problem
When a tool-progress edit hits Telegram flood control (`RetryAfter`), `can_edit` was unconditionally set to `False`, permanently disabling progress message coalescing for the rest of the run. All subsequent tool updates were posted as separate new messages instead of updating the existing progress bubble.

## Fix
Only set `can_edit = False` for non-recoverable edit errors. On flood control, back off by resetting `_last_edit_ts` so the existing throttle interval is respected before the next edit attempt. Coalescing resumes automatically after the backoff window.

## Root cause
In `send_progress_messages()` inside `gateway/run.py`, the `can_edit = False` assignment was outside the `if "flood" in _err` block, so it fired for every edit failure regardless of cause.