### PR TITLE
fix(cli): add windows_subprocess_kwargs() to force UTF-8 in subprocess text output

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -38,6 +38,7 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "windows_subprocess_kwargs",
 ]
 
 
@@ -232,3 +233,20 @@ def windows_detach_popen_kwargs() -> dict:
     if IS_WINDOWS:
         return {"creationflags": windows_detach_flags()}
     return {"start_new_session": True}
+
+
+def windows_subprocess_kwargs() -> dict:
+    """Return kwargs that force UTF-8 encoding for subprocess text output on Windows.
+
+    On Windows, subprocess.run(..., text=True) uses the system codepage
+    (cp1252) by default, which cannot decode UTF-8 emoji bytes emitted by
+    Hermes CLI output (e.g. ✓, ✗, 🚀). This causes UnicodeDecodeError in
+    the reader thread even when the process itself started successfully.
+
+    Usage:
+        subprocess.run(cmd, capture_output=True, text=True,
+                       **windows_subprocess_kwargs())
+    """
+    if not IS_WINDOWS:
+        return {}
+    return {"encoding": "utf-8", "errors": "replace"}

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -156,6 +156,7 @@ def _is_official_ssh_remote(url: str | None) -> bool:
 
 
 def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
+    from hermes_cli._subprocess_compat import windows_subprocess_kwargs
     try:
         result = subprocess.run(
             ["git", *args],
@@ -163,6 +164,7 @@ def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str
             text=True,
             timeout=timeout,
             cwd=str(cwd),
+            **windows_subprocess_kwargs(),
         )
     except Exception:
         return None

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -15,6 +15,12 @@ from urllib.parse import urlparse
 from hermes_constants import get_hermes_home
 from typing import TYPE_CHECKING, Dict, List, Optional
 
+# Forces UTF-8 decoding for text-mode subprocess output on Windows (no-op
+# elsewhere). Applied to every text=True git call below so locale codepages
+# (cp1252) can't raise UnicodeDecodeError on UTF-8 output. Lightweight module
+# (shutil/sys only) — safe to import eagerly on the startup path.
+from hermes_cli._subprocess_compat import windows_subprocess_kwargs
+
 # rich and prompt_toolkit are imported lazily (inside the functions that use
 # them) rather than at module level.  Importing this module is on the TUI
 # gateway's critical startup path purely to reach the lightweight update-check
@@ -156,7 +162,6 @@ def _is_official_ssh_remote(url: str | None) -> bool:
 
 
 def _git_stdout(args: list[str], *, cwd: Path, timeout: int = 5) -> Optional[str]:
-    from hermes_cli._subprocess_compat import windows_subprocess_kwargs
     try:
         result = subprocess.run(
             ["git", *args],
@@ -183,6 +188,7 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
         result = subprocess.run(
             ["git", "ls-remote", _UPSTREAM_REPO_URL, "refs/heads/main"],
             capture_output=True, text=True, timeout=10,
+            **windows_subprocess_kwargs(),
         )
     except Exception:
         return None
@@ -243,6 +249,7 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
             ["git", "rev-list", "--count", "HEAD..origin/main"],
             capture_output=True, text=True, timeout=5,
             cwd=str(repo_dir),
+            **windows_subprocess_kwargs(),
         )
         if result.returncode == 0:
             return int(result.stdout.strip())
@@ -392,6 +399,7 @@ def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
             text=True,
             timeout=5,
             cwd=str(repo_dir),
+            **windows_subprocess_kwargs(),
         )
     except Exception:
         return None
@@ -448,6 +456,7 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
             text=True,
             timeout=5,
             cwd=str(repo_dir),
+            **windows_subprocess_kwargs(),
         )
         if result.returncode == 0:
             ahead = int((result.stdout or "0").strip() or "0")
@@ -484,6 +493,7 @@ def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
             text=True,
             timeout=3,
             cwd=str(repo_dir),
+            **windows_subprocess_kwargs(),
         )
     except Exception:
         _latest_release_cache = ()

--- a/tests/hermes_cli/test_windows_subprocess_kwargs.py
+++ b/tests/hermes_cli/test_windows_subprocess_kwargs.py
@@ -1,0 +1,155 @@
+"""Coverage for windows_subprocess_kwargs() and its wiring into banner git calls.
+
+The helper forces UTF-8 decoding for text-mode subprocess output on Windows
+(where the default cp1252 codepage raises UnicodeDecodeError on UTF-8 bytes)
+and is a no-op elsewhere. These tests assert both helper branches and that
+every text=True git subprocess in banner.py forwards the encoding kwargs,
+while the binary-mode ``git fetch`` does not.
+"""
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import _subprocess_compat
+
+
+# --------------------------------------------------------------------------
+# Helper result: Windows vs POSIX
+# --------------------------------------------------------------------------
+def test_windows_subprocess_kwargs_on_windows():
+    with patch.object(_subprocess_compat, "IS_WINDOWS", True):
+        assert _subprocess_compat.windows_subprocess_kwargs() == {
+            "encoding": "utf-8",
+            "errors": "replace",
+        }
+
+
+def test_windows_subprocess_kwargs_on_posix():
+    with patch.object(_subprocess_compat, "IS_WINDOWS", False):
+        assert _subprocess_compat.windows_subprocess_kwargs() == {}
+
+
+# --------------------------------------------------------------------------
+# Banner git calls forward the encoding kwargs on Windows
+# --------------------------------------------------------------------------
+def _has_utf8_kwargs(kwargs):
+    return kwargs.get("encoding") == "utf-8" and kwargs.get("errors") == "replace"
+
+
+def test_banner_git_state_calls_pass_encoding_kwargs_on_windows(tmp_path):
+    """Every text-mode git call in get_git_banner_state() gets UTF-8 kwargs."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
+        ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="3\n"),
+    }
+    seen = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append((tuple(cmd), kwargs))
+        return results[tuple(cmd)]
+
+    with patch.object(_subprocess_compat, "IS_WINDOWS", True), \
+         patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        state = banner.get_git_banner_state(repo_dir)
+
+    assert state == {"upstream": "b2f477a3", "local": "af8aad31", "ahead": 3}
+    assert len(seen) == 3
+    for cmd, kwargs in seen:
+        assert _has_utf8_kwargs(kwargs), f"missing UTF-8 kwargs on {cmd}"
+
+
+def test_banner_git_state_calls_omit_encoding_kwargs_on_posix(tmp_path):
+    """On POSIX the helper is a no-op — no encoding kwargs are injected."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    results = {
+        ("git", "rev-parse", "--short=8", "origin/main"): MagicMock(returncode=0, stdout="b2f477a3\n"),
+        ("git", "rev-parse", "--short=8", "HEAD"): MagicMock(returncode=0, stdout="af8aad31\n"),
+        ("git", "rev-list", "--count", "origin/main..HEAD"): MagicMock(returncode=0, stdout="3\n"),
+    }
+    seen = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append((tuple(cmd), kwargs))
+        return results[tuple(cmd)]
+
+    with patch.object(_subprocess_compat, "IS_WINDOWS", False), \
+         patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        banner.get_git_banner_state(repo_dir)
+
+    assert len(seen) == 3
+    for cmd, kwargs in seen:
+        assert "encoding" not in kwargs and "errors" not in kwargs, f"unexpected kwargs on {cmd}"
+
+
+def test_local_git_check_text_calls_get_kwargs_but_binary_fetch_does_not(tmp_path):
+    """_check_via_local_git: text-mode git calls get UTF-8 kwargs; the binary
+    ``git fetch`` (no text=True) must NOT receive them."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/someone/fork.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="4\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    seen = []
+
+    def recording_run(cmd, **kwargs):
+        seen.append((tuple(cmd), kwargs))
+        return fake_run(cmd, **kwargs)
+
+    with patch.object(_subprocess_compat, "IS_WINDOWS", True), \
+         patch("hermes_cli.banner.subprocess.run", side_effect=recording_run):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 4
+    for cmd, kwargs in seen:
+        if cmd[:2] == ("git", "fetch"):
+            assert not _has_utf8_kwargs(kwargs), "binary git fetch must not force text decoding"
+        else:
+            assert _has_utf8_kwargs(kwargs), f"missing UTF-8 kwargs on {cmd}"
+
+
+def test_check_via_rev_and_release_tag_get_kwargs_on_windows(tmp_path):
+    """_check_via_rev (ls-remote) and get_latest_release_tag (describe) both
+    forward the encoding kwargs on Windows."""
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    seen = []
+
+    def recording_run(cmd, **kwargs):
+        seen.append((tuple(cmd), kwargs))
+        if cmd[:2] == ["git", "ls-remote"]:
+            return MagicMock(returncode=0, stdout="local-sha\trefs/heads/main\n")
+        if cmd[:2] == ["git", "describe"]:
+            return MagicMock(returncode=0, stdout="v0.13.0\n")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    banner._latest_release_cache = None
+    with patch.object(_subprocess_compat, "IS_WINDOWS", True), \
+         patch("hermes_cli.banner.subprocess.run", side_effect=recording_run):
+        banner._check_via_rev("local-sha")
+        banner.get_latest_release_tag(repo_dir)
+
+    assert len(seen) == 2
+    for cmd, kwargs in seen:
+        assert _has_utf8_kwargs(kwargs), f"missing UTF-8 kwargs on {cmd}"


### PR DESCRIPTION
Fixes #25191

## Problem
On Windows, `subprocess.run(..., text=True)` defaults to the system codepage (cp1252), which cannot decode UTF-8 emoji bytes (✓, ✗, 🚀) emitted by Hermes CLI output. This causes `UnicodeDecodeError` in the reader thread even when the process itself started successfully.

`hermes_cli/__init__.py` already has `_ensure_utf8()` that reconfigures `sys.stdout`/`sys.stderr`, but this doesn't affect subprocess pipe readers which use their own encoding.

## Fix
Adds `windows_subprocess_kwargs()` helper to `_subprocess_compat.py` that returns `encoding='utf-8', errors='replace'` on Windows and an empty dict on POSIX. Callers can spread this into `subprocess.run()` calls alongside `capture_output=True, text=True`.

## Root cause
`subprocess.run(cmd, capture_output=True, text=True)` without explicit `encoding` uses the Windows system codepage (cp1252) to decode stdout/stderr, which fails on UTF-8 multi-byte characters.