### PR TITLE
fix: use worker profile git identity for kanban spawns

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3902,6 +3902,28 @@ def _resolve_hermes_argv() -> list[str]:
     return [sys.executable, "-m", "hermes_cli.main"]
 
 
+def _kanban_worker_git_identity(profile: str) -> tuple[str, str]:
+    """Return the Git author/committer identity for a spawned worker.
+
+    Kanban workers are autonomous agents, so commits they create should be
+    attributable to the profile that did the work rather than to a shared host
+    account, a human operator, or a generic ``Hermes Agent`` identity.  Use a
+    deterministic, non-secret noreply-style address so the mapping covers all
+    current and future profiles without per-profile bootstrap config.
+    """
+    safe_profile = profile.strip() or "hermes-worker"
+    return safe_profile, f"{safe_profile}@users.noreply.github.com"
+
+
+def _inject_kanban_worker_git_identity(env: dict[str, str], profile: str) -> None:
+    """Force Git commits in a spawned worker to use that worker profile."""
+    git_name, git_email = _kanban_worker_git_identity(profile)
+    env["GIT_AUTHOR_NAME"] = git_name
+    env["GIT_AUTHOR_EMAIL"] = git_email
+    env["GIT_COMMITTER_NAME"] = git_name
+    env["GIT_COMMITTER_EMAIL"] = git_email
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3975,6 +3997,11 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+    # Git reads these environment variables before repository/global config.
+    # Setting them at dispatcher spawn time makes commit author/committer
+    # metadata match the worker profile in every workspace, without touching
+    # per-profile secrets or relying on mutable ~/.gitconfig bootstrap state.
+    _inject_kanban_worker_git_identity(env, profile_arg)
 
     cmd = [
         *_resolve_hermes_argv(),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1084,6 +1084,57 @@ class TestSharedBoardPaths:
             default_home / "kanban" / "workspaces"
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_PROFILE"] == "coder"
+        assert env["GIT_AUTHOR_NAME"] == "coder"
+        assert env["GIT_AUTHOR_EMAIL"] == "coder@users.noreply.github.com"
+        assert env["GIT_COMMITTER_NAME"] == "coder"
+        assert env["GIT_COMMITTER_EMAIL"] == "coder@users.noreply.github.com"
+
+    def test_dispatcher_spawn_overrides_parent_git_identity_with_worker_profile(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Hermes Agent")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "hermes-agent@users.noreply.github.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "flees")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "flees@example.com")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4343
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_dispatch_git_identity",
+            title="x",
+            body=None,
+            assignee="PixelPanda",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        assert env["HERMES_PROFILE"] == "pixelpanda"
+        assert env["GIT_AUTHOR_NAME"] == "pixelpanda"
+        assert env["GIT_AUTHOR_EMAIL"] == "pixelpanda@users.noreply.github.com"
+        assert env["GIT_COMMITTER_NAME"] == "pixelpanda"
+        assert env["GIT_COMMITTER_EMAIL"] == "pixelpanda@users.noreply.github.com"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Force dispatcher-spawned kanban workers to inherit Git author and committer identity from the worker profile name.
- Use deterministic non-secret noreply-style email mapping: `<profile>@users.noreply.github.com`.
- Add regression coverage that parent identities like `Hermes Agent` or `flees` are overridden at spawn time.

## Test plan
- `/opt/hermes/.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='`

## Verification
Representative `git var` checks with the injected worker env now resolve to profile-specific author/committer identities for ottobytebeaver, pixelpanda, inspectorbadger, cloudymcsquirrel, drferretfacts, and captaincollie.
