### PR TITLE
feat(feishu): CardKit v2 streaming cards with typewriter effect

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -394,6 +394,10 @@ class FeishuAdapterSettings:
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
     message_format: str = "post"  # "text" | "post" | "card"
+    # CardKit v2 streaming cards — when True, the adapter creates CardKit v2
+    # streaming cards for typewriter-style rendering instead of editing plain
+    # text messages.  Falls back gracefully when CardKit API is unavailable.
+    streaming_card: bool = True
 
 
 @dataclass
@@ -1373,6 +1377,16 @@ class FeishuAdapter(BasePlatformAdapter):
     # the streaming response completes — needed for CardKit v2 card finalization.
     REQUIRES_EDIT_FINALIZE = True
 
+    @property
+    def streaming_cards_enabled(self) -> bool:
+        """Whether CardKit v2 streaming cards are available and enabled.
+
+        Returns True only when:
+        1. The ``streaming_card`` config setting is enabled (default: True)
+        2. The lark_oapi SDK is available (lark is importable)
+        """
+        return self._streaming_card and FEISHU_AVAILABLE
+
     # =========================================================================
     # Lifecycle — init / settings / connect / disconnect
     # =========================================================================
@@ -1536,6 +1550,9 @@ class FeishuAdapter(BasePlatformAdapter):
             message_format=str(
                 extra.get("message_format") or os.getenv("FEISHU_MESSAGE_FORMAT", "post")
             ).strip().lower(),
+            streaming_card=_to_boolean(
+                extra.get("streaming_card", os.getenv("FEISHU_STREAMING_CARD", "true"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1569,6 +1586,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
         self._message_format = settings.message_format
+        self._streaming_card = settings.streaming_card
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1994,6 +2012,31 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] CardKit finalize fallback patch also failed: %s", patch_exc)
                 return SendResult(success=False, error=str(patch_exc))
 
+    async def send_streaming_card(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Create and send a CardKit v2 streaming card for typewriter rendering.
+
+        Called by ``GatewayStreamConsumer`` on the first streaming delta when
+        ``adapter.streaming_cards_enabled`` is True.  On failure, returns an
+        unsuccessful SendResult so the consumer falls back to the regular
+        ``send()`` + ``edit_message()`` path.
+
+        This is intentionally separate from ``send()`` so that non-streaming
+        sends (notifications, approvals, media captions, gateway lifecycle
+        messages) never accidentally create streaming cards.
+        """
+        if not self.streaming_cards_enabled:
+            return SendResult(success=False, error="Streaming cards not enabled")
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        formatted = self.format_message(content)
+        return await self._create_streaming_card(chat_id, formatted, reply_to)
+
     # =========================================================================
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
@@ -2023,18 +2066,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return SendResult(success=True)
             self._finalized_card_ids.pop(chat_id, None)
 
-        # Try creating a CardKit v2 streaming card first.
-        # Only attempt when content is a streaming placeholder (short text with
-        # the streaming cursor).  Non-streaming sends (notifications, approvals,
-        # media captions) should go through the regular path.
         formatted = self.format_message(content)
-        _STREAMING_CURSOR = " ▉"
-        if _STREAMING_CURSOR in formatted or len(formatted) < 30:
-            cardkit_result = await self._create_streaming_card(chat_id, formatted, reply_to)
-            if cardkit_result.success:
-                return cardkit_result
-            # CardKit creation failed — fall through to legacy send
-
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2052,14 +2052,12 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        # If there's an active streaming card for this chat, skip —
-        # the card is already displaying the content.
-        if self._active_cards.get(chat_id):
-            state = self._active_cards[chat_id]
-            return SendResult(success=True, message_id=state.message_id)
-
         # If a streaming card was recently finalized for this chat, skip —
-        # the final content is already displayed in the card.
+        # the final content is already displayed in the card.  This prevents
+        # the gateway's final-response send() from creating a duplicate.
+        # Tool progress messages and other non-streaming sends are unaffected
+        # because they arrive while the card is still active (before finalize),
+        # not after it.
         if chat_id in self._finalized_card_ids:
             if time.monotonic() - self._finalized_card_ids[chat_id] < 30:
                 self._finalized_card_ids.pop(chat_id, None)
@@ -2124,9 +2122,17 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        # CardKit v2 streaming card path — only update existing cards
+        # CardKit v2 streaming card path — only route to CardKit when the
+        # edit targets the streaming card's own message.  Tool progress
+        # edits target a different message_id and must go through the
+        # regular im.v1.message.update path.
         active_card = self._active_cards.get(chat_id)
-        if active_card and active_card.is_cardkit and active_card.card_id:
+        if (
+            active_card
+            and active_card.is_cardkit
+            and active_card.card_id
+            and message_id == active_card.message_id
+        ):
             if finalize:
                 return await self._finalize_streaming_card(chat_id, self.format_message(content))
             else:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -393,6 +393,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    message_format: str = "post"  # "text" | "post" | "card"
 
 
 @dataclass
@@ -403,6 +404,18 @@ class FeishuGroupRule:
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
     require_mention: Optional[bool] = None  # None = inherit global
+
+
+@dataclass
+class _StreamingCardState:
+    """Tracks an active CardKit v2 streaming card for a chat."""
+    card_id: str
+    message_id: str
+    sequence: int
+    start_time: float  # time.monotonic()
+    inflight: bool = False
+    dirty: bool = False
+    is_cardkit: bool = True  # False = fell back to legacy edit-based streaming
 
 
 @dataclass
@@ -1356,6 +1369,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # is almost certain.
     _SPLIT_THRESHOLD = 4000
 
+    # Tells GatewayStreamConsumer to call edit_message(finalize=True) when
+    # the streaming response completes — needed for CardKit v2 card finalization.
+    REQUIRES_EDIT_FINALIZE = True
+
     # =========================================================================
     # Lifecycle — init / settings / connect / disconnect
     # =========================================================================
@@ -1411,6 +1428,12 @@ class FeishuAdapter(BasePlatformAdapter):
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
+
+        # CardKit v2 streaming card state
+        self._active_cards: Dict[str, _StreamingCardState] = {}  # chat_id → state
+        self._finalized_card_ids: Dict[str, float] = {}  # chat_id → time.monotonic() (recently finalized)
+        self._tenant_token: Optional[str] = None
+        self._tenant_token_expires: float = 0.0
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1510,6 +1533,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            message_format=str(
+                extra.get("message_format") or os.getenv("FEISHU_MESSAGE_FORMAT", "post")
+            ).strip().lower(),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1542,6 +1568,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._message_format = settings.message_format
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1694,6 +1721,280 @@ class FeishuAdapter(BasePlatformAdapter):
             self._webhook_site = None
 
     # =========================================================================
+    # CardKit v2 — streaming card lifecycle
+    # =========================================================================
+
+    async def _ensure_tenant_token(self) -> Optional[str]:
+        """Return a cached tenant access token, refreshing if needed."""
+        if self._tenant_token and time.time() < self._tenant_token_expires:
+            return self._tenant_token
+
+        domain = self._settings.domain_name or "feishu"
+        base_url = (
+            "https://open.larksuite.com" if domain == "lark"
+            else "https://open.feishu.cn"
+        )
+        url = f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"
+        body = json.dumps({
+            "app_id": self._settings.app_id,
+            "app_secret": self._settings.app_secret,
+        }).encode("utf-8")
+        req = Request(url, data=body, headers={"Content-Type": "application/json"})
+
+        try:
+            response = await asyncio.to_thread(urlopen, req, timeout=10)
+            data = json.loads(response.read())
+            token = data.get("tenant_access_token")
+            if token:
+                self._tenant_token = token
+                expires_in = data.get("expire", 7200)
+                self._tenant_token_expires = time.time() + expires_in - 300
+                return token
+            logger.warning("[Feishu] Tenant token refresh returned no token: %s", data.get("msg"))
+        except Exception as exc:
+            logger.warning("[Feishu] Tenant token refresh failed: %s", exc)
+        return None
+
+    async def _cardkit_fetch(self, path: str, method: str, body: dict) -> dict:
+        """Make an authenticated request to CardKit v2 API."""
+        token = await self._ensure_tenant_token()
+        if not token:
+            raise RuntimeError("No tenant access token available")
+
+        domain = self._settings.domain_name or "feishu"
+        base_url = (
+            "https://open.larksuite.com" if domain == "lark"
+            else "https://open.feishu.cn"
+        )
+        url = f"{base_url}/open-apis{path}"
+        payload = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        req = Request(url, data=payload, method=method, headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        })
+
+        response = await asyncio.to_thread(urlopen, req, timeout=30)
+        data = json.loads(response.read())
+        if data.get("code") != 0:
+            raise RuntimeError(f"CardKit API error {data.get('code')}: {data.get('msg')}")
+        return data
+
+    async def _create_streaming_card(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Create a CardKit v2 streaming card and send it as a message."""
+        card_json = json.dumps({
+            "schema": "2.0",
+            "config": {"wide_screen_mode": True, "streaming_mode": True},
+            "header": {
+                "title": {"tag": "plain_text", "content": "🤖 Hermes"},
+                "template": "blue",
+            },
+            "body": {
+                "elements": [{
+                    "tag": "markdown",
+                    "element_id": "streaming_md",
+                    "content": " ",
+                }],
+            },
+        }, ensure_ascii=False)
+
+        try:
+            # 1. Create card entity
+            create_res = await self._cardkit_fetch("/cardkit/v1/cards", "POST", {
+                "type": "card_json",
+                "data": card_json,
+            })
+            card_id = (create_res.get("data") or {}).get("card_id")
+            if not card_id:
+                logger.warning("[Feishu] CardKit create returned no card_id")
+                return SendResult(success=False, error="No card_id from CardKit")
+
+            # 2. Send card as message
+            msg_payload = json.dumps({
+                "type": "card",
+                "data": {"card_id": card_id},
+            })
+
+            if reply_to:
+                body_obj = self._build_reply_message_body(
+                    content=msg_payload, msg_type="interactive",
+                    reply_in_thread=False, uuid_value=str(uuid.uuid4()),
+                )
+                req_obj = self._build_reply_message_request(
+                    message_id=reply_to, request_body=body_obj
+                )
+                resp = await asyncio.to_thread(self._client.im.v1.message.reply, req_obj)
+            else:
+                receive_id_type = "open_id" if chat_id.startswith("ou_") else "chat_id"
+                body_obj = self._build_create_message_body(
+                    receive_id=chat_id, msg_type="interactive", content=msg_payload,
+                    uuid_value=str(uuid.uuid4()),
+                )
+                req_obj = self._build_create_message_request(
+                    receive_id_type=receive_id_type, request_body=body_obj
+                )
+                resp = await asyncio.to_thread(self._client.im.v1.message.create, req_obj)
+
+            message_id = self._extract_response_field(resp, "message_id")
+            if not message_id:
+                logger.warning("[Feishu] Card message send returned no message_id")
+                return SendResult(success=False, error="No message_id from card send")
+
+            # 3. Store card state
+            self._active_cards[chat_id] = _StreamingCardState(
+                card_id=card_id,
+                message_id=message_id,
+                sequence=0,
+                start_time=time.monotonic(),
+            )
+
+            logger.info("[Feishu] CardKit v2 streaming card created: card_id=%s, msg_id=%s", card_id, message_id)
+            return SendResult(success=True, message_id=message_id)
+
+        except Exception as exc:
+            logger.warning("[Feishu] CardKit v2 card creation failed, falling back to legacy: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def _stream_card_content(self, chat_id: str, content: str) -> bool:
+        """Stream content update to a CardKit v2 card (serialized + throttled)."""
+        state = self._active_cards.get(chat_id)
+        if not state or not state.is_cardkit or not state.card_id:
+            return False
+
+        # Serialize: only one in-flight request at a time
+        if state.inflight:
+            state.dirty = True
+            return True  # optimistically report success
+
+        state.sequence += 1
+        state.inflight = True
+        state.dirty = False
+
+        try:
+            await self._cardkit_fetch(
+                f"/cardkit/v1/cards/{state.card_id}/elements/streaming_md/content",
+                "PUT",
+                {"content": content, "sequence": state.sequence},
+            )
+            return True
+        except Exception as exc:
+            logger.warning("[Feishu] CardKit stream content update failed: %s", exc)
+            return False
+        finally:
+            state.inflight = False
+            if state.dirty:
+                # Re-flush with latest text — schedule via event loop
+                loop = self._loop or asyncio.get_event_loop()
+                loop.call_soon_threadsafe(
+                    lambda: asyncio.ensure_future(
+                        self._stream_card_content(chat_id, content)
+                    )
+                )
+
+    async def _finalize_streaming_card(
+        self,
+        chat_id: str,
+        content: str,
+    ) -> SendResult:
+        """Finalize a CardKit v2 streaming card: flush text, close streaming, update card."""
+        state = self._active_cards.pop(chat_id, None)
+        if state and state.is_cardkit:
+            # Record that this chat just had a card finalized — prevents
+            # the gateway's final send() from delivering a duplicate message.
+            self._finalized_card_ids[chat_id] = time.monotonic()
+        if not state or not state.is_cardkit or not state.card_id:
+            return SendResult(success=False, error="No active CardKit card to finalize")
+
+        elapsed_s = time.monotonic() - state.start_time
+        if elapsed_s < 60:
+            elapsed_str = f"{elapsed_s:.1f}s"
+        else:
+            m, s = divmod(int(elapsed_s), 60)
+            elapsed_str = f"{m}m {s}s"
+
+        try:
+            # 1. Flush last text content
+            state.sequence += 1
+            await self._cardkit_fetch(
+                f"/cardkit/v1/cards/{state.card_id}/elements/streaming_md/content",
+                "PUT",
+                {"content": content, "sequence": state.sequence},
+            )
+
+            # 2. Close streaming mode
+            state.sequence += 1
+            await self._cardkit_fetch(
+                f"/cardkit/v1/cards/{state.card_id}/settings",
+                "PATCH",
+                {
+                    "settings": json.dumps({"config": {"streaming_mode": False}}),
+                    "sequence": state.sequence,
+                },
+            )
+
+            # 3. Final card update with header color + footer
+            state.sequence += 1
+            await self._cardkit_fetch(
+                f"/cardkit/v1/cards/{state.card_id}",
+                "PUT",
+                {
+                    "card": {
+                        "type": "card_json",
+                        "data": json.dumps({
+                            "schema": "2.0",
+                            "config": {"wide_screen_mode": True},
+                            "header": {
+                                "title": {"tag": "plain_text", "content": "🤖 Hermes"},
+                                "template": "green",
+                            },
+                            "body": {
+                                "elements": [
+                                    {"tag": "markdown", "element_id": "streaming_md", "content": content},
+                                    {"tag": "hr"},
+                                    {"tag": "markdown", "content": f"⏱ {elapsed_str}", "text_size": "notation"},
+                                ],
+                            },
+                        }, ensure_ascii=False),
+                    },
+                    "sequence": state.sequence,
+                },
+            )
+
+            logger.info("[Feishu] CardKit v2 card finalized: card_id=%s, elapsed=%s", state.card_id, elapsed_str)
+            return SendResult(success=True, message_id=state.message_id)
+
+        except Exception as exc:
+            logger.warning("[Feishu] CardKit finalize failed, falling back to patch: %s", exc)
+            # Fallback: patch the message via im API
+            try:
+                final_card = json.dumps({
+                    "schema": "2.0",
+                    "config": {"wide_screen_mode": True},
+                    "header": {
+                        "title": {"tag": "plain_text", "content": "🤖 Hermes"},
+                        "template": "green",
+                    },
+                    "body": {
+                        "elements": [
+                            {"tag": "markdown", "content": content},
+                            {"tag": "hr"},
+                            {"tag": "markdown", "content": f"⏱ {elapsed_str}", "text_size": "notation"},
+                        ],
+                    },
+                }, ensure_ascii=False)
+                body_obj = self._build_update_message_body(msg_type="interactive", content=final_card)
+                req_obj = self._build_update_message_request(message_id=state.message_id, request_body=body_obj)
+                await asyncio.to_thread(self._client.im.v1.message.update, req_obj)
+                return SendResult(success=True, message_id=state.message_id)
+            except Exception as patch_exc:
+                logger.warning("[Feishu] CardKit finalize fallback patch also failed: %s", patch_exc)
+                return SendResult(success=False, error=str(patch_exc))
+
+    # =========================================================================
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
@@ -1708,7 +2009,32 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # If there's an active streaming card for this chat, skip —
+        # the card is already displaying the content.
+        if self._active_cards.get(chat_id):
+            state = self._active_cards[chat_id]
+            return SendResult(success=True, message_id=state.message_id)
+
+        # If a streaming card was recently finalized for this chat, skip —
+        # the final content is already displayed in the card.
+        if chat_id in self._finalized_card_ids:
+            if time.monotonic() - self._finalized_card_ids[chat_id] < 30:
+                self._finalized_card_ids.pop(chat_id, None)
+                return SendResult(success=True)
+            self._finalized_card_ids.pop(chat_id, None)
+
+        # Try creating a CardKit v2 streaming card first.
+        # Only attempt when content is a streaming placeholder (short text with
+        # the streaming cursor).  Non-streaming sends (notifications, approvals,
+        # media captions) should go through the regular path.
         formatted = self.format_message(content)
+        _STREAMING_CURSOR = " ▉"
+        if _STREAMING_CURSOR in formatted or len(formatted) < 30:
+            cardkit_result = await self._create_streaming_card(chat_id, formatted, reply_to)
+            if cardkit_result.success:
+                return cardkit_result
+            # CardKit creation failed — fall through to legacy send
+
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
@@ -1765,6 +2091,19 @@ class FeishuAdapter(BasePlatformAdapter):
         """Edit a previously sent Feishu text/post message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        # CardKit v2 streaming card path — only update existing cards
+        active_card = self._active_cards.get(chat_id)
+        if active_card and active_card.is_cardkit and active_card.card_id:
+            if finalize:
+                return await self._finalize_streaming_card(chat_id, self.format_message(content))
+            else:
+                ok = await self._stream_card_content(chat_id, self.format_message(content))
+                if ok:
+                    return SendResult(success=True, message_id=active_card.message_id)
+                # Stream content update failed — fall through to legacy path
+                logger.warning("[Feishu] CardKit stream update failed, falling back to legacy edit")
+                active_card.is_cardkit = False
 
         content = self.format_message(content)
         try:
@@ -4175,6 +4514,14 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        # If content is a JSON string starting with {, treat as interactive card
+        if self._message_format == "card" or (content.strip().startswith("{") and content.strip().endswith("}")):
+            try:
+                parsed = json.loads(content)
+                if isinstance(parsed, dict) and "schema" in parsed:
+                    return "interactive", content
+            except json.JSONDecodeError:
+                pass
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -159,6 +159,15 @@ class GatewayStreamConsumer:
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
 
+        # Streaming card support (e.g. Feishu CardKit v2).  When enabled,
+        # the first send creates a streaming card via
+        # ``adapter.send_streaming_card()`` instead of ``adapter.send()``.
+        # Subsequent edits and finalization still go through the normal
+        # ``edit_message()`` path, which the adapter routes to CardKit APIs.
+        self._uses_streaming_card: bool = (
+            getattr(adapter, "streaming_cards_enabled", False) is True
+        )
+
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
@@ -215,6 +224,11 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # Re-enable streaming card for the new segment if the adapter
+        # supports it — a per-card creation failure in the previous segment
+        # should not prevent the next segment from trying again.
+        if getattr(self.adapter, "streaming_cards_enabled", False) is True:
+            self._uses_streaming_card = True
         # Native draft streaming: bump the draft_id so the next text segment
         # animates as a fresh preview below the tool-progress bubbles, not
         # over the prior segment's already-finalized draft.  This is how
@@ -1230,6 +1244,37 @@ class GatewayStreamConsumer:
             else:
                 # First message — send new, threaded to the original user message
                 # so it lands in the correct topic/thread.
+                #
+                # When the adapter supports streaming cards (e.g. Feishu CardKit
+                # v2), try creating a streaming card first for typewriter-style
+                # rendering.  On failure, fall back to the regular send path.
+                if self._uses_streaming_card:
+                    try:
+                        result = await self.adapter.send_streaming_card(
+                            chat_id=self.chat_id,
+                            content=text,
+                            reply_to=self._initial_reply_to_id,
+                        )
+                        if result.success:
+                            if result.message_id:
+                                self._message_id = result.message_id
+                                self._message_created_ts = time.monotonic()
+                            else:
+                                self._edit_supported = False
+                            self._already_sent = True
+                            self._last_sent_text = text
+                            self._notify_new_message()
+                            return True
+                        # Streaming card creation failed — fall back to regular send
+                        logger.debug(
+                            "Streaming card creation failed (%s), falling back to regular send",
+                            result.error,
+                        )
+                        self._uses_streaming_card = False  # disable for remainder of this run
+                    except Exception as e:
+                        logger.debug("Streaming card error: %s, falling back to regular send", e)
+                        self._uses_streaming_card = False
+
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -512,9 +512,17 @@ class GatewayStreamConsumer:
                     # the next segment (tool progress, next chunk) creates a
                     # new message below it.  got_done has its own finalize
                     # path below so we don't finalize here for it.
+                    #
+                    # Exception: streaming cards (e.g. Feishu CardKit v2) span
+                    # the entire response — segment breaks just send a mid-
+                    # stream update without cursor; the card keeps accumulating
+                    # text and is only finalized on got_done.
+                    _finalize_segment = (
+                        got_segment_break and not self._uses_streaming_card
+                    )
                     current_update_visible = await self._send_or_edit(
                         display_text,
-                        finalize=(got_done or got_segment_break),
+                        finalize=(got_done or _finalize_segment),
                     )
                     self._last_edit_time = time.monotonic()
 
@@ -567,22 +575,26 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
-                    # If the segment-break edit failed to deliver the
-                    # accumulated content (flood control that has not yet
-                    # promoted to fallback mode, or fallback mode itself),
-                    # _accumulated still holds pre-boundary text the user
-                    # never saw. Flush that tail as a continuation message
-                    # before the reset below wipes _accumulated — otherwise
-                    # text generated before the tool boundary is silently
-                    # dropped (issue #8124).
-                    if (
+                    # Streaming cards: keep the same card alive across
+                    # segments.  Tool progress messages from the gateway
+                    # appear as separate platform messages between card
+                    # updates.  The card's streaming_md content keeps
+                    # growing with the full accumulated text.
+                    if self._uses_streaming_card and self._message_id:
+                        # Don't reset — _accumulated keeps growing,
+                        # _message_id stays so edits continue hitting
+                        # the same card.
+                        pass
+                    elif (
                         self._accumulated
                         and not current_update_visible
                         and self._message_id
                         and self._message_id != "__no_edit__"
                     ):
                         await self._flush_segment_tail_on_edit_failure()
-                    self._reset_segment_state(preserve_no_edit=True)
+                        self._reset_segment_state(preserve_no_edit=True)
+                    else:
+                        self._reset_segment_state(preserve_no_edit=True)
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -168,6 +168,14 @@ class GatewayStreamConsumer:
             getattr(adapter, "streaming_cards_enabled", False) is True
         )
 
+        # Defer streaming card creation until after the first segment break.
+        # The first segment (usually "Let me think...") is sent as a regular
+        # message, so tool progress bubbles (🔍/⚙️) appear ABOVE the streaming
+        # card which is created for the final response segment.
+        # Reset to False after the first segment break so subsequent segments
+        # use the streaming card.
+        self._defer_streaming_card: bool = self._uses_streaming_card
+
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
@@ -575,12 +583,19 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
+                    # Deferred streaming card: the first segment was sent as
+                    # a regular message.  Now that tool progress bubbles will
+                    # appear below it, reset and disable defer so the next
+                    # segment creates the actual streaming card.
+                    if self._defer_streaming_card:
+                        self._defer_streaming_card = False
+                        self._reset_segment_state(preserve_no_edit=True)
                     # Streaming cards: keep the same card alive across
                     # segments.  Tool progress messages from the gateway
                     # appear as separate platform messages between card
                     # updates.  The card's streaming_md content keeps
                     # growing with the full accumulated text.
-                    if self._uses_streaming_card and self._message_id:
+                    elif self._uses_streaming_card and self._message_id:
                         # Don't reset — _accumulated keeps growing,
                         # _message_id stays so edits continue hitting
                         # the same card.
@@ -1260,7 +1275,11 @@ class GatewayStreamConsumer:
                 # When the adapter supports streaming cards (e.g. Feishu CardKit
                 # v2), try creating a streaming card first for typewriter-style
                 # rendering.  On failure, fall back to the regular send path.
-                if self._uses_streaming_card:
+                #
+                # Optimization: defer streaming card to the second segment so
+                # tool progress bubbles (🔍/⚙️) appear ABOVE the card.  The
+                # first segment is sent as a regular message.
+                if self._uses_streaming_card and not self._defer_streaming_card:
                     try:
                         result = await self.adapter.send_streaming_card(
                             chat_id=self.chat_id,

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -82,7 +82,8 @@ class TestSendStreamingCard:
             return_value=SimpleNamespace(success=True, message_id="msg_card_1")
         )
 
-        result = await adapter.send_streaming_card("oc_test", "Hello")
+        with patch.object(FeishuAdapter, "streaming_cards_enabled", True):
+            result = await adapter.send_streaming_card("oc_test", "Hello")
         assert result.success is True
         assert result.message_id == "msg_card_1"
         adapter._create_streaming_card.assert_called_once_with("oc_test", "Hello", None)
@@ -95,7 +96,8 @@ class TestSendStreamingCard:
         adapter = object.__new__(FeishuAdapter)
         adapter._streaming_card = False
 
-        result = await adapter.send_streaming_card("oc_test", "Hello")
+        with patch.object(FeishuAdapter, "streaming_cards_enabled", False):
+            result = await adapter.send_streaming_card("oc_test", "Hello")
         assert result.success is False
 
     @pytest.mark.asyncio
@@ -107,7 +109,8 @@ class TestSendStreamingCard:
         adapter._streaming_card = True
         adapter._client = None
 
-        result = await adapter.send_streaming_card("oc_test", "Hello")
+        with patch.object(FeishuAdapter, "streaming_cards_enabled", True):
+            result = await adapter.send_streaming_card("oc_test", "Hello")
         assert result.success is False
 
 
@@ -118,13 +121,26 @@ class TestStreamConsumerStreamingCard:
     """Verify GatewayStreamConsumer routes to send_streaming_card."""
 
     @pytest.mark.asyncio
-    async def test_uses_streaming_card_on_first_send(self):
-        """When adapter has streaming_cards_enabled, first send uses send_streaming_card."""
+    async def test_first_send_defers_to_regular_send(self):
+        """When defer is active (default), first send uses regular send()."""
         adapter = _make_feishu_adapter(streaming_card=True)
         consumer = GatewayStreamConsumer(adapter, "oc_test")
         assert consumer._uses_streaming_card is True
+        assert consumer._defer_streaming_card is True
 
-        # First send should call send_streaming_card
+        # First send with defer active → regular send, not streaming card
+        result = await consumer._send_or_edit("Hello world")
+        assert result is True
+        adapter.send.assert_called_once()
+        adapter.send_streaming_card.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_streaming_card_after_defer_disabled(self):
+        """After defer is disabled, send uses send_streaming_card."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
+
         result = await consumer._send_or_edit("Hello world")
         assert result is True
         adapter.send_streaming_card.assert_called_once()
@@ -139,6 +155,7 @@ class TestStreamConsumerStreamingCard:
         )
 
         consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
         result = await consumer._send_or_edit("Hello world")
         assert result is True
         adapter.send_streaming_card.assert_called_once()
@@ -153,6 +170,7 @@ class TestStreamConsumerStreamingCard:
         adapter.send_streaming_card = AsyncMock(side_effect=RuntimeError("Network error"))
 
         consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
         result = await consumer._send_or_edit("Hello world")
         assert result is True
         adapter.send.assert_called_once()
@@ -176,6 +194,7 @@ class TestStreamConsumerStreamingCard:
         adapter = _make_feishu_adapter(streaming_card=True)
 
         consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
 
         # First send creates the streaming card
         await consumer._send_or_edit("Hello")
@@ -193,6 +212,7 @@ class TestStreamConsumerStreamingCard:
         adapter = _make_feishu_adapter(streaming_card=True)
 
         consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
         await consumer._send_or_edit("Hello")
         adapter.send_streaming_card.assert_called_once()
 
@@ -208,6 +228,7 @@ class TestStreamConsumerStreamingCard:
         adapter = _make_feishu_adapter(streaming_card=True)
 
         consumer = GatewayStreamConsumer(adapter, "oc_test")
+        consumer._defer_streaming_card = False  # simulate after first segment break
         assert consumer._uses_streaming_card is True
 
         # Simulate a failed card creation that disables streaming card

--- a/tests/gateway/test_feishu_streaming_cards.py
+++ b/tests/gateway/test_feishu_streaming_cards.py
@@ -1,0 +1,361 @@
+"""Tests for Feishu CardKit v2 streaming card lifecycle.
+
+Covers:
+- streaming_cards_enabled property
+- send_streaming_card() method
+- stream_consumer integration (_uses_streaming_card flag)
+- Config wiring (streaming_card setting + FEISHU_STREAMING_CARD env var)
+"""
+
+import asyncio
+import json
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_feishu_adapter(*, streaming_card: bool = True):
+    """Create a minimal FeishuAdapter mock with streaming card support."""
+    adapter = MagicMock()
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.streaming_cards_enabled = streaming_card
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.message_len_fn = len
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.send_streaming_card = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="msg_card_1")
+    )
+    adapter.truncate_message = lambda text, limit, **kw: [text]
+    return adapter
+
+
+# ── streaming_cards_enabled property ─────────────────────────────────────
+
+
+class TestStreamingCardsEnabled:
+    """Verify the streaming_cards_enabled property gates CardKit usage."""
+
+    def test_enabled_by_default(self):
+        """streaming_cards_enabled is True when config is enabled and SDK available."""
+        from gateway.platforms.feishu import FeishuAdapter, FEISHU_AVAILABLE
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._streaming_card = True
+        # FEISHU_AVAILABLE is a module-level flag; it's True when lark_oapi is installed
+        # We test the property logic directly
+        assert adapter._streaming_card is True
+
+    def test_disabled_by_config(self):
+        """streaming_cards_enabled is False when streaming_card config is False."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._streaming_card = False
+        assert adapter._streaming_card is False
+
+
+# ── send_streaming_card method ───────────────────────────────────────────
+
+
+class TestSendStreamingCard:
+    """Verify send_streaming_card() creates cards and handles failures."""
+
+    @pytest.mark.asyncio
+    async def test_calls_create_streaming_card(self):
+        """send_streaming_card delegates to _create_streaming_card."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._streaming_card = True
+        adapter._client = MagicMock()
+        adapter.format_message = lambda text: text
+        adapter._create_streaming_card = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_card_1")
+        )
+
+        result = await adapter.send_streaming_card("oc_test", "Hello")
+        assert result.success is True
+        assert result.message_id == "msg_card_1"
+        adapter._create_streaming_card.assert_called_once_with("oc_test", "Hello", None)
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_failure(self):
+        """send_streaming_card returns failure when streaming cards are disabled."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._streaming_card = False
+
+        result = await adapter.send_streaming_card("oc_test", "Hello")
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_not_connected_returns_failure(self):
+        """send_streaming_card returns failure when client is not connected."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = object.__new__(FeishuAdapter)
+        adapter._streaming_card = True
+        adapter._client = None
+
+        result = await adapter.send_streaming_card("oc_test", "Hello")
+        assert result.success is False
+
+
+# ── StreamConsumer integration ───────────────────────────────────────────
+
+
+class TestStreamConsumerStreamingCard:
+    """Verify GatewayStreamConsumer routes to send_streaming_card."""
+
+    @pytest.mark.asyncio
+    async def test_uses_streaming_card_on_first_send(self):
+        """When adapter has streaming_cards_enabled, first send uses send_streaming_card."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        assert consumer._uses_streaming_card is True
+
+        # First send should call send_streaming_card
+        result = await consumer._send_or_edit("Hello world")
+        assert result is True
+        adapter.send_streaming_card.assert_called_once()
+        adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_send_on_card_failure(self):
+        """When send_streaming_card fails, falls back to regular send."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+        adapter.send_streaming_card = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="CardKit unavailable")
+        )
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        result = await consumer._send_or_edit("Hello world")
+        assert result is True
+        adapter.send_streaming_card.assert_called_once()
+        adapter.send.assert_called_once()
+        # _uses_streaming_card should be disabled after failure
+        assert consumer._uses_streaming_card is False
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_card_exception(self):
+        """When send_streaming_card raises, falls back to regular send."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+        adapter.send_streaming_card = AsyncMock(side_effect=RuntimeError("Network error"))
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        result = await consumer._send_or_edit("Hello world")
+        assert result is True
+        adapter.send.assert_called_once()
+        assert consumer._uses_streaming_card is False
+
+    @pytest.mark.asyncio
+    async def test_skips_streaming_card_when_disabled(self):
+        """When streaming_cards_enabled is False, uses regular send."""
+        adapter = _make_feishu_adapter(streaming_card=False)
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        assert consumer._uses_streaming_card is False
+        result = await consumer._send_or_edit("Hello world")
+        assert result is True
+        adapter.send.assert_called_once()
+        adapter.send_streaming_card.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_subsequent_edits_use_edit_message(self):
+        """After streaming card is created, edits go through edit_message."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+
+        # First send creates the streaming card
+        await consumer._send_or_edit("Hello")
+        adapter.send_streaming_card.assert_called_once()
+
+        # Second edit updates the card content
+        result = await consumer._send_or_edit("Hello world more text")
+        assert result is True
+        adapter.edit_message.assert_called_once()
+        adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_finalize_edit_on_stream_end(self):
+        """Final edit (finalize=True) goes through edit_message with finalize flag."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        await consumer._send_or_edit("Hello")
+        adapter.send_streaming_card.assert_called_once()
+
+        # Final edit
+        result = await consumer._send_or_edit("Hello world", finalize=True)
+        assert result is True
+        adapter.edit_message.assert_called_once()
+        assert adapter.edit_message.call_args[1]["finalize"] is True
+
+    @pytest.mark.asyncio
+    async def test_reset_segment_re_enables_streaming_card(self):
+        """After segment break, streaming card is re-enabled for next segment."""
+        adapter = _make_feishu_adapter(streaming_card=True)
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        assert consumer._uses_streaming_card is True
+
+        # Simulate a failed card creation that disables streaming card
+        adapter.send_streaming_card = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="fail")
+        )
+        await consumer._send_or_edit("Hello")
+        assert consumer._uses_streaming_card is False
+
+        # Reset segment state (simulates segment break)
+        consumer._reset_segment_state()
+        # Should be re-enabled because adapter still supports it
+        assert consumer._uses_streaming_card is True
+
+    @pytest.mark.asyncio
+    async def test_reset_segment_does_not_enable_if_adapter_lacks_support(self):
+        """Reset does not re-enable streaming card if adapter doesn't support it."""
+        adapter = _make_feishu_adapter(streaming_card=False)
+
+        consumer = GatewayStreamConsumer(adapter, "oc_test")
+        assert consumer._uses_streaming_card is False
+
+        consumer._reset_segment_state()
+        assert consumer._uses_streaming_card is False
+
+
+# ── Config wiring ────────────────────────────────────────────────────────
+
+
+class TestStreamingCardConfig:
+    """Verify streaming_card config is loaded from settings and env vars."""
+
+    def test_default_is_enabled(self):
+        """streaming_card defaults to True (enabled)."""
+        from gateway.platforms.feishu import FeishuAdapterSettings
+
+        settings = FeishuAdapterSettings(
+            app_id="cli_test", app_secret="secret", domain_name="feishu",
+            connection_mode="websocket", encrypt_key="", verification_token="",
+            group_policy="allowlist", allowed_group_users=frozenset(),
+            bot_open_id="", bot_user_id="", bot_name="",
+            dedup_cache_size=100, text_batch_delay_seconds=0.6,
+            text_batch_split_delay_seconds=2.0, text_batch_max_messages=8,
+            text_batch_max_chars=4000, media_batch_delay_seconds=0.8,
+            webhook_host="127.0.0.1", webhook_port=8645, webhook_path="/webhook",
+        )
+        assert settings.streaming_card is True
+
+    def test_can_be_disabled_via_extra(self):
+        """streaming_card can be disabled via extra config dict."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({
+            "app_id": "cli_test",
+            "app_secret": "secret",
+            "streaming_card": False,
+        })
+        assert settings.streaming_card is False
+
+    @patch.dict(os.environ, {"FEISHU_STREAMING_CARD": "false"})
+    def test_can_be_disabled_via_env(self):
+        """streaming_card can be disabled via FEISHU_STREAMING_CARD env var."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({
+            "app_id": "cli_test",
+            "app_secret": "secret",
+        })
+        assert settings.streaming_card is False
+
+    @patch.dict(os.environ, {"FEISHU_STREAMING_CARD": "false"})
+    def test_apply_settings_stores_config(self):
+        """_apply_settings persists the streaming_card setting."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({
+            "app_id": "cli_test",
+            "app_secret": "secret",
+        })
+        adapter = object.__new__(FeishuAdapter)
+        adapter._apply_settings(settings)
+        assert adapter._streaming_card is False
+
+
+# ── CardKit API sequence numbers ─────────────────────────────────────────
+
+
+class TestCardKitSequence:
+    """Verify sequence numbers are strictly incrementing."""
+
+    @pytest.mark.asyncio
+    async def test_sequence_increments_on_stream_updates(self):
+        """Each stream content update increments the sequence counter."""
+        from gateway.platforms.feishu import _StreamingCardState
+
+        state = _StreamingCardState(
+            card_id="card_1",
+            message_id="msg_1",
+            sequence=0,
+            start_time=time.monotonic(),
+        )
+        assert state.sequence == 0
+
+        # Simulate stream updates
+        state.sequence += 1
+        assert state.sequence == 1
+        state.sequence += 1
+        assert state.sequence == 2
+
+
+# ── _StreamingCardState dataclass ────────────────────────────────────────
+
+
+class TestStreamingCardState:
+    """Verify _StreamingCardState tracks card lifecycle correctly."""
+
+    def test_default_flags(self):
+        """New streaming card state has correct default flags."""
+        from gateway.platforms.feishu import _StreamingCardState
+
+        state = _StreamingCardState(
+            card_id="card_1",
+            message_id="msg_1",
+            sequence=0,
+            start_time=time.monotonic(),
+        )
+        assert state.inflight is False
+        assert state.dirty is False
+        assert state.is_cardkit is True
+
+    def test_inflight_serialization(self):
+        """inflight/dirty flags model request serialization correctly."""
+        from gateway.platforms.feishu import _StreamingCardState
+
+        state = _StreamingCardState(
+            card_id="card_1",
+            message_id="msg_1",
+            sequence=0,
+            start_time=time.monotonic(),
+        )
+        # Start a request
+        state.inflight = True
+        assert state.inflight is True
+
+        # Mark dirty while inflight (another update arrived)
+        state.dirty = True
+        assert state.dirty is True
+
+        # Request completes
+        state.inflight = False
+        assert state.dirty is True  # dirty should remain until re-flush


### PR DESCRIPTION
## Summary

Replace Feishu's edit-based streaming (`im.v1.message.update`) with **CardKit v2 streaming cards**, providing smooth typewriter-effect text rendering, proper card layout with header/footer, and no QPS limit during streaming mode.

## Changes

### New CardKit v2 lifecycle methods on `FeishuAdapter`

| Method | Purpose |
|--------|---------|
| `_ensure_tenant_token()` | Cache and refresh tenant access token for CardKit API |
| `_cardkit_fetch(path, method, body)` | Authenticated HTTP client for CardKit v2 API |
| `_create_streaming_card()` | Create card entity + send as message |
| `_stream_card_content()` | Stream content updates with request serialization (inflight/dirty) |
| `_finalize_streaming_card()` | Close streaming + update final card (3-tier fallback) |

### Modified adapter methods

- **`send()`**: Creates CardKit streaming cards for streaming sessions (detected by streaming cursor `▉` or short content). Falls back to legacy send for non-streaming messages.
- **`edit_message()`**: Routes through CardKit content API when an active streaming card exists.
- **`REQUIRES_EDIT_FINALIZE = True`**: Ensures `GatewayStreamConsumer` calls `edit_message(finalize=True)` for proper card lifecycle closure.

### New state tracking

- `_StreamingCardState` dataclass — per-chat card tracking with sequence numbers, inflight/dirty flags for request serialization
- `_finalized_card_ids` — prevents duplicate message delivery after card finalization

## API Flow

```
send() [first call]:
  1. POST /cardkit/v1/cards          → create card (streaming_mode: true)
  2. POST /im/v1/messages            → send card by card_id

edit_message() [streaming updates]:
  3. PUT /cardkit/v1/cards/{id}/elements/streaming_md/content  → update text

edit_message(finalize=True):
  4. PUT .../content                  → flush final text
  5. PATCH .../settings               → close streaming_mode
  6. PUT /cardkit/v1/cards/{id}       → final card (green header + elapsed footer)
```

## Fallback Chain

```
CardKit v2 streaming → im.message.patch → new message
```

## Required Feishu Permissions

- `cardkit:card` — create and update CardKit cards

## Testing

- Verified end-to-end with Feishu WebSocket connection
- Streaming typewriter effect confirmed working
- Card finalization with header color + elapsed footer confirmed
- Duplicate message prevention via `_finalized_card_ids` confirmed
- Non-streaming messages (approvals, notifications) unaffected