### PR TITLE
docs: add IT automation lab guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,57 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+## IT Automation Lab Operating Rules
+
+This checkout may also be used as a controlled IT automation laboratory. Keep
+that lab layer compatible with the Hermes Agent codebase instead of replacing
+or bypassing the development workflow documented here.
+
+### Lab workflow
+
+1. Inspect the repository, target host, or target service before acting.
+2. Document repeatable operations as runbooks under `docs/runbooks/`.
+3. Add or update scripts only after the manual procedure and risk level are
+   clear.
+4. Prefer read-only discovery first; use `--dry-run` for state-changing
+   automation whenever practical.
+5. Verify results with commands, tests, logs, or captured output.
+6. Do not commit or push lab changes unless the user has explicitly approved
+   that action.
+
+### Safety and approvals
+
+Ask for explicit scope confirmation before destructive or production-impacting
+work, including file deletion, force pushes, service restarts, package upgrades,
+firewall changes, credential rotation, cloud-resource deletion, or database
+mutation. Before executing risky work, state the target, expected effect,
+rollback or recovery path, and verification command.
+
+Never assume a host, API, account, or branch is non-production. Verify context
+first and treat unknown targets as high risk.
+
+### Script standards
+
+Operational scripts should be safe by default:
+
+- provide `--help` or usage text;
+- support `--dry-run` when they change state;
+- validate required commands and inputs;
+- avoid printing secrets;
+- use deterministic exit codes;
+- be idempotent where practical;
+- reference a related runbook for non-trivial IT operations.
+
+Shell scripts should normally use `set -euo pipefail`. Python scripts should
+use `argparse`, `logging`, `pathlib` where applicable, and a `main()` entry
+point.
+
+### Runbook standards
+
+Runbooks should include purpose, scope, prerequisites, inputs, risk level,
+procedure, verification, rollback or recovery, troubleshooting, and related
+scripts. Use `docs/runbooks/template.md` for new operational procedures.
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+## IT Automation Lab Usage
+
+This checkout can also be used as a controlled IT automation laboratory: document a runbook, prototype a safe script, run it in read-only or dry-run mode first, then verify the result before committing or pushing changes.
+
+Start here:
+
+- [`docs/lab/overview.md`](docs/lab/overview.md) — lab purpose, scope, and operating model
+- [`docs/lab/safety.md`](docs/lab/safety.md) — approval, secrets, production-access, and destructive-action rules
+- [`docs/lab/environment.md`](docs/lab/environment.md) — local environment and validation checklist
+- [`docs/lab/workflow.md`](docs/lab/workflow.md) — add new automation experiments safely
+- [`docs/runbooks/`](docs/runbooks/) — repeatable operational procedures and templates
+- [`scripts/README.md`](scripts/README.md) — script catalog and new-script checklist
+
+Example lab scenarios include system inventory, log triage, service health checks, backup verification, scheduled reports, gateway-driven operations, and GitHub/CI automation. Treat production targets as high-risk until verified and prefer explicit `--dry-run` support for any state-changing script.
+
 ## CLI vs Messaging Quick Reference
 
 Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Documentation Index
+
+This directory contains project-local documentation that complements the public Hermes Agent docs site.
+
+## IT Automation Lab
+
+Use these documents when this checkout is used as a controlled IT automation laboratory:
+
+- `lab/overview.md` — lab purpose, scope, and operating model
+- `lab/safety.md` — safety, approval, secrets, and production-access rules
+- `lab/environment.md` — local environment setup and validation
+- `lab/workflow.md` — how to add new automation experiments, runbooks, and scripts
+
+## Runbooks
+
+Runbooks live under `runbooks/` and describe repeatable operational procedures before scripts automate them.
+
+- `runbooks/README.md` — runbook catalog and authoring rules
+- `runbooks/template.md` — copyable template for new runbooks
+- `runbooks/system-inventory.md` — read-only host inventory collection
+- `runbooks/log-triage.md` — log collection and first-pass triage
+- `runbooks/service-health-check.md` — service health verification
+- `runbooks/backup-verification.md` — backup existence and restore-readiness checks
+
+## Implementation Plans
+
+Implementation plans live under `plans/`. They are task-level design documents for larger code changes.
+
+## Existing Specs
+
+- `hermes-kanban-v1-spec.pdf` — Kanban system specification.

--- a/docs/lab/environment.md
+++ b/docs/lab/environment.md
@@ -1,0 +1,72 @@
+# IT Automation Lab Environment
+
+## Base Requirements
+
+Use the repository root as the lab workspace.
+
+Recommended tools:
+
+- Python 3.11
+- project virtual environment: `.venv` or `venv`
+- Node.js 20+ for UI and integration scripts
+- Git
+- ripgrep
+- shellcheck for shell script review, when available
+
+## Python Environment
+
+Prefer the project virtual environment:
+
+```bash
+source .venv/bin/activate
+```
+
+If this checkout uses `venv` instead:
+
+```bash
+source venv/bin/activate
+```
+
+## Test Runner
+
+Use the canonical test wrapper, not direct `pytest`:
+
+```bash
+scripts/run_tests.sh
+```
+
+Targeted examples:
+
+```bash
+scripts/run_tests.sh tests/agent/
+scripts/run_tests.sh tests/path/to/test_file.py::test_name -v
+```
+
+## Node-based Areas
+
+Some subprojects have their own Node dependencies, for example:
+
+- `ui-tui/`
+- `web/`
+- `scripts/whatsapp-bridge/`
+
+Run their package-manager commands from the relevant subdirectory, not blindly from the repository root.
+
+## Local Configuration
+
+- User config: `~/.hermes/config.yaml`
+- Local secrets: `~/.hermes/.env`
+- Example env file: `.env.example`
+
+Do not commit real secrets.
+
+## Lab Validation Checklist
+
+Before running an automation experiment:
+
+- [ ] Confirm the current Git branch and working tree.
+- [ ] Confirm whether the target is local, staging, or production.
+- [ ] Read the related runbook.
+- [ ] Run in read-only or dry-run mode first when available.
+- [ ] Capture verification output.
+- [ ] Update docs if behavior or commands changed.

--- a/docs/lab/overview.md
+++ b/docs/lab/overview.md
@@ -1,0 +1,33 @@
+# IT Automation Lab Overview
+
+## Purpose
+
+This checkout can be used as an IT automation laboratory for designing, documenting, testing, and safely running operational workflows with Hermes Agent.
+
+The lab is intended for controlled experiments such as:
+
+- system inventory collection
+- service health checks
+- log triage
+- backup verification
+- scheduled maintenance reports
+- gateway/bot-driven operations
+- GitHub issue, PR, and CI automation
+- script prototyping before production rollout
+
+## Non-goals
+
+This lab is not a license to run destructive commands without review. It should not be used to modify production hosts, delete data, rotate secrets, restart critical services, or change network/firewall state without explicit human approval and a documented rollback path.
+
+## Operating Model
+
+1. Describe the operational procedure as a runbook in `docs/runbooks/`.
+2. Add or update scripts only after the runbook is clear.
+3. Prefer read-only discovery first.
+4. Add `--dry-run` for actions that change state.
+5. Verify results with commands, tests, or captured output.
+6. Summarize the change and wait for human approval before committing or pushing unless approval has already been granted.
+
+## Repository Relationship
+
+The repository remains the Hermes Agent codebase. The lab documentation and scripts are an additional operating layer that helps agents and humans run IT automation work consistently without disrupting core development workflows.

--- a/docs/lab/safety.md
+++ b/docs/lab/safety.md
@@ -1,0 +1,83 @@
+# IT Automation Lab Safety Guide
+
+## Safety Levels
+
+### Safe / Read-only
+
+Examples:
+
+- list files, services, processes, disks, or packages
+- inspect logs
+- check Git status or diffs
+- query health endpoints
+- validate configuration syntax
+
+These usually do not require extra confirmation, but results should still be summarized accurately.
+
+### Risky / State-changing
+
+Examples:
+
+- installing packages
+- editing configuration files
+- restarting services
+- changing cron jobs
+- updating firewall rules
+- modifying cloud resources
+- writing to shared directories
+
+These require a clear plan and user approval before execution.
+
+### Destructive
+
+Examples:
+
+- deleting files or databases
+- force-pushing Git history
+- removing cloud resources
+- rotating or revoking credentials
+- changing production networking
+- wiping caches that may contain required state
+
+These require explicit scope confirmation, a rollback or recovery plan, and verification steps.
+
+## Approval Rules
+
+Before a state-changing or destructive action, document:
+
+- target systems or paths
+- command or script to be run
+- expected effect
+- risk level
+- rollback or recovery step
+- verification command
+
+## Secrets
+
+- Do not commit real credentials.
+- Store example variables in `.env.example`; store real values only in approved local secret stores such as `~/.hermes/.env`.
+- Do not print tokens, passwords, private keys, or webhook secrets in logs.
+- Redact secrets in summaries and issue/PR comments.
+
+## Production Access
+
+Never assume a host or API is non-production. Verify environment, account, context, and target before changing state.
+
+Production work should use:
+
+- least-privilege credentials
+- dry-run or preview mode where available
+- explicit maintenance window if relevant
+- backup or rollback plan
+- post-change verification
+
+## Agent Expectations
+
+Agents should:
+
+1. inspect before acting;
+2. prefer read-only commands first;
+3. present a plan for risky work;
+4. stop for approval when scope is unclear or risk is high;
+5. verify after executing approved actions;
+6. avoid committing or pushing unless the user has approved it.

--- a/docs/lab/workflow.md
+++ b/docs/lab/workflow.md
@@ -1,0 +1,52 @@
+# IT Automation Lab Workflow
+
+## Add a New Automation Procedure
+
+1. Define the problem and target environment.
+2. Create a runbook in `docs/runbooks/` using `docs/runbooks/template.md`.
+3. Start with read-only discovery commands.
+4. Identify risk level and required approvals.
+5. Add or update a script only after the manual procedure is clear.
+6. Add `--dry-run` for state-changing scripts.
+7. Add tests or validation commands.
+8. Update `scripts/README.md` if a new script is added.
+9. Review the diff before committing.
+10. Push only after approval.
+
+## Script Design Rules
+
+Scripts should be:
+
+- idempotent when practical
+- explicit about inputs and targets
+- safe by default
+- verbose enough for auditability
+- quiet about secrets
+- easy to run with `--help`
+- testable without production credentials
+
+## Runbook Design Rules
+
+Runbooks should include:
+
+- purpose
+- scope
+- prerequisites
+- inputs
+- risk level
+- step-by-step procedure
+- verification
+- rollback or recovery
+- troubleshooting
+- related scripts
+
+## Commit Guidance
+
+Use conventional commits for lab-only documentation or scripts:
+
+```bash
+git add docs scripts README.md AGENTS.md
+git commit -m "docs: add IT automation lab guide"
+```
+
+Do not mix unrelated code behavior changes with lab documentation unless the plan explicitly calls for it.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,25 @@
+# Runbooks
+
+Runbooks describe repeatable IT operations before those operations are automated in scripts or delegated to an agent.
+
+## Catalog
+
+- `template.md` — copy this for new runbooks
+- `system-inventory.md` — collect read-only host inventory
+- `log-triage.md` — gather and inspect logs
+- `service-health-check.md` — verify a service is healthy
+- `backup-verification.md` — verify backups exist and are restore-ready
+
+## Authoring Rules
+
+Every runbook should document:
+
+- purpose and scope
+- risk level
+- prerequisites
+- exact commands or script references
+- verification steps
+- rollback or recovery steps
+- known failure modes
+
+Prefer read-only checks first. If a procedure changes state, document approval requirements and dry-run behavior.

--- a/docs/runbooks/backup-verification.md
+++ b/docs/runbooks/backup-verification.md
@@ -1,0 +1,65 @@
+# Runbook: Backup Verification
+
+## Purpose
+
+Verify that backups exist, are recent, and have enough metadata to support a restore test.
+
+## Scope
+
+Approved backup directories, object storage buckets, database dumps, or backup service metadata. This runbook does not delete or overwrite backups.
+
+## Risk Level
+
+Low for metadata checks. Medium if accessing sensitive backup contents. High if performing restore tests against shared environments.
+
+## Prerequisites
+
+- Backup location or service name
+- Expected backup frequency and retention policy
+- Read-only access to backup metadata
+- Approved restore target for any restore test
+
+## Inputs
+
+| Input | Description | Example |
+| --- | --- | --- |
+| backup_location | Path, bucket, or service | `/backups/app` |
+| expected_rpo | Maximum acceptable age | `24h` |
+
+## Procedure
+
+1. Confirm backup location and expected recovery point objective.
+2. List recent backup artifacts or metadata.
+3. Confirm timestamps, sizes, and checksums where available.
+4. Confirm at least one backup is within the expected age window.
+5. If restore testing is requested, use an isolated target and get explicit approval first.
+6. Summarize gaps, missing backups, or stale artifacts.
+
+## Example Commands
+
+```bash
+find <backup_location> -maxdepth 2 -type f -printf '%TY-%Tm-%Td %TH:%TM %s %p
+' | sort | tail -20
+sha256sum <backup_file>
+du -sh <backup_location>
+```
+
+## Verification
+
+The backup check is complete when the summary identifies the newest backup, its size, its age, and whether it satisfies the expected policy.
+
+## Rollback / Recovery
+
+Metadata checks require no rollback. Restore tests must be isolated and documented separately before execution.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| No recent backup | Scheduler failure or wrong location | Check backup job status and logs |
+| Backup size is zero | Failed job or incomplete upload | Inspect backup logs and retry policy |
+| Permission denied | Missing read access | Request least-privilege backup metadata access |
+
+## Related Scripts
+
+- Future lab scripts may automate backup metadata checks under `scripts/lab/`.

--- a/docs/runbooks/log-triage.md
+++ b/docs/runbooks/log-triage.md
@@ -1,0 +1,64 @@
+# Runbook: Log Triage
+
+## Purpose
+
+Collect and inspect logs to identify recent errors, warnings, crashes, or suspicious behavior.
+
+## Scope
+
+Local logs, service logs, or approved application logs. Do not upload logs externally unless approved.
+
+## Risk Level
+
+Low to Medium. Reading logs is usually safe, but logs may contain secrets, tokens, email addresses, IP addresses, or customer data.
+
+## Prerequisites
+
+- Permission to read the relevant logs
+- Time window for analysis
+- Service or application name
+
+## Inputs
+
+| Input | Description | Example |
+| --- | --- | --- |
+| service | Service or app to inspect | `nginx` |
+| since | Start of time window | `1 hour ago` |
+| log_path | Optional file path | `/var/log/syslog` |
+
+## Procedure
+
+1. Confirm the service, host, and time window.
+2. Prefer service-specific log tools when available.
+3. Search for errors, warnings, tracebacks, crashes, refused connections, and permission failures.
+4. Extract representative examples, not entire sensitive logs.
+5. Redact secrets and personal data before sharing.
+6. Summarize likely root causes and next checks.
+
+## Example Commands
+
+```bash
+journalctl -u <service> --since "1 hour ago" --no-pager
+journalctl --since "1 hour ago" --priority warning --no-pager
+tail -n 200 /var/log/syslog
+```
+
+## Verification
+
+The triage is complete when the summary includes time window, log sources, key error patterns, and recommended next action.
+
+## Rollback / Recovery
+
+No rollback is required for read-only log inspection. Remove temporary excerpts if they contain sensitive data.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| No logs returned | Wrong service or time window | Re-check service name and broaden the time window |
+| Permission denied | Restricted log access | Request appropriate read-only access |
+| Too much output | Broad query | Narrow by service, priority, or time window |
+
+## Related Scripts
+
+- Future lab scripts may automate filtered log collection under `scripts/lab/`.

--- a/docs/runbooks/service-health-check.md
+++ b/docs/runbooks/service-health-check.md
@@ -1,0 +1,64 @@
+# Runbook: Service Health Check
+
+## Purpose
+
+Verify whether a service is running, reachable, and behaving as expected.
+
+## Scope
+
+A local or approved remote service. This runbook is read-only unless a restart or remediation step is explicitly approved.
+
+## Risk Level
+
+Low for checks only. Medium or High if remediation such as restart, config edit, or failover is added.
+
+## Prerequisites
+
+- Service name or endpoint
+- Access to host or network path
+- Expected healthy response
+
+## Inputs
+
+| Input | Description | Example |
+| --- | --- | --- |
+| service | System service name | `ssh` |
+| endpoint | HTTP/TCP endpoint | `http://localhost:8080/health` |
+
+## Procedure
+
+1. Confirm service name and target environment.
+2. Check process or service manager status.
+3. Check listening ports if relevant.
+4. Check application health endpoint if available.
+5. Review recent warnings/errors if health is degraded.
+6. Do not restart or modify the service without explicit approval.
+
+## Example Commands
+
+```bash
+systemctl status <service> --no-pager
+ss -tulpn
+curl -fsS <endpoint>
+journalctl -u <service> --since "30 minutes ago" --no-pager
+```
+
+## Verification
+
+The service is healthy when status, port checks, and application-level health checks match the expected state.
+
+## Rollback / Recovery
+
+Read-only checks require no rollback. If remediation is approved later, document the exact command and rollback path before executing it.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| Service inactive | Crash, disabled service, failed dependency | Inspect logs before restart |
+| Port closed | Service not listening or firewall issue | Check config and listener state |
+| Health endpoint fails | App dependency or internal error | Inspect app logs and dependency status |
+
+## Related Scripts
+
+- Future lab scripts may automate health checks under `scripts/lab/`.

--- a/docs/runbooks/system-inventory.md
+++ b/docs/runbooks/system-inventory.md
@@ -1,0 +1,62 @@
+# Runbook: System Inventory
+
+## Purpose
+
+Collect a read-only snapshot of a host for troubleshooting, baseline documentation, or automation planning.
+
+## Scope
+
+Local host or explicitly approved remote host. This runbook should not change system state.
+
+## Risk Level
+
+Low. Commands are read-only, but output may contain hostnames, usernames, IP addresses, mount paths, or package names.
+
+## Prerequisites
+
+- Shell access to the target host
+- Permission to inspect system information
+- A secure place to store collected output if it is saved
+
+## Inputs
+
+| Input | Description | Example |
+| --- | --- | --- |
+| target | Host being inspected | `localhost` |
+
+## Procedure
+
+1. Confirm the target host and user context.
+2. Collect OS and kernel information.
+3. Collect CPU, memory, and disk information.
+4. Collect running service/process summary if approved.
+5. Summarize findings and redact sensitive values before sharing.
+
+## Example Commands
+
+```bash
+uname -a
+python --version || true
+df -h
+free -h || true
+ps aux | head -20
+```
+
+## Verification
+
+The inventory is complete when it includes OS, kernel, disk, memory, and relevant runtime information for the approved target.
+
+## Rollback / Recovery
+
+No rollback is required for read-only collection. Delete saved reports if they contain sensitive data and are no longer needed.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| Command missing | Minimal OS image | Use an equivalent tool or document that the field is unavailable |
+| Permission denied | Insufficient privileges | Request read-only access or skip privileged fields |
+
+## Related Scripts
+
+- Future lab scripts may automate this runbook under `scripts/lab/`.

--- a/docs/runbooks/template.md
+++ b/docs/runbooks/template.md
@@ -1,0 +1,54 @@
+# Runbook: <Title>
+
+## Purpose
+
+Describe what this runbook accomplishes.
+
+## Scope
+
+Define systems, files, services, or accounts affected by this procedure.
+
+## Risk Level
+
+Choose one: Low / Medium / High / Destructive
+
+Explain why.
+
+## Prerequisites
+
+- Required access
+- Required tools
+- Required environment variables or config files
+- Required maintenance window, if any
+
+## Inputs
+
+| Input | Description | Example |
+| --- | --- | --- |
+| `<target>` | Target host, service, path, or identifier | `localhost` |
+
+## Procedure
+
+1. Confirm target and environment.
+2. Run read-only discovery.
+3. Run dry-run, if this procedure changes state.
+4. Execute the approved action.
+5. Capture verification output.
+
+## Verification
+
+List commands or checks that prove the procedure succeeded.
+
+## Rollback / Recovery
+
+Describe how to undo the change or recover safely.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+| --- | --- | --- |
+| Example failure | Example cause | Example fix |
+
+## Related Scripts
+
+- `scripts/...`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,71 @@
+# Scripts
+
+This directory contains repository maintenance scripts, install helpers, diagnostics, and integration utilities.
+
+## Safety Rules
+
+Before running a script:
+
+- read the script or its documentation;
+- confirm the target environment;
+- prefer `--help` and `--dry-run` when available;
+- avoid running state-changing scripts against production without approval;
+- do not paste secrets into command lines that may be logged;
+- capture verification output after the script completes.
+
+## Categories
+
+### Test and Quality
+
+- `run_tests.sh` — canonical pytest wrapper with CI-like hermetic settings.
+- `lint_diff.py` — lint changed files.
+
+### Install and Setup
+
+- `install.sh` — Linux/macOS/WSL/Termux installer.
+- `install.ps1` — native Windows PowerShell installer.
+- `install.cmd` — Windows command wrapper.
+- `setup_open_webui.sh` — Open WebUI setup helper.
+- `install_psutil_android.py` — Android/Termux psutil helper.
+
+### Release and Build
+
+- `release.py` — release automation.
+- `build_model_catalog.py` — model catalog generation.
+- `build_skills_index.py` — skills index generation.
+
+### Diagnostics and Profiling
+
+- `check-windows-footguns.py` — Windows compatibility checks.
+- `discord-voice-doctor.py` — Discord voice diagnostics.
+- `keystroke_diagnostic.py` — terminal keystroke diagnostics.
+- `profile-tui.py` — TUI profiling helper.
+- `benchmark_browser_eval.py` — browser evaluation benchmark helper.
+
+### Utilities
+
+- `hermes-gateway` — gateway launcher/helper.
+- `kill_modal.sh` — Modal cleanup helper.
+- `sample_and_compress.py` — trajectory/sample compression helper.
+- `contributor_audit.py` — contributor audit helper.
+
+### Integrations
+
+- `whatsapp-bridge/` — WhatsApp bridge Node project.
+- `lib/node-bootstrap.sh` — shared Node bootstrap helper.
+
+### Lab Area
+
+- `lab/` — reserved for IT automation lab scripts.
+- `templates/` — safe starter templates for new scripts.
+
+## New Script Checklist
+
+- [ ] Has a clear purpose and owner.
+- [ ] Has `--help` or usage text.
+- [ ] Supports `--dry-run` if it changes state.
+- [ ] Validates required commands and inputs.
+- [ ] Avoids printing secrets.
+- [ ] Uses deterministic exit codes.
+- [ ] Has a related runbook in `docs/runbooks/` when operational.
+- [ ] Documents verification and rollback steps.

--- a/scripts/lab/README.md
+++ b/scripts/lab/README.md
@@ -1,0 +1,13 @@
+# IT Automation Lab Scripts
+
+This directory is reserved for lab-specific IT automation scripts.
+
+Before adding a script here:
+
+1. Create or update a runbook in `docs/runbooks/`.
+2. Confirm whether the script is read-only or state-changing.
+3. Add `--dry-run` for state-changing behavior.
+4. Include validation and verification output.
+5. Update `scripts/README.md` with the new script.
+
+Use the templates in `scripts/templates/` as safe starting points.

--- a/scripts/templates/bash-script-template.sh
+++ b/scripts/templates/bash-script-template.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Safe starter template for IT automation lab shell scripts.
+
+set -euo pipefail
+
+DRY_RUN=0
+TARGET=""
+
+usage() {
+  cat <<'USAGE'
+Usage: bash-script-template.sh [--dry-run] --target <target>
+
+Options:
+  --dry-run          Print actions without changing state.
+  --target <target>  Target host, path, service, or identifier.
+  -h, --help         Show this help text.
+USAGE
+}
+
+log() {
+  printf '[%s] %s
+' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+fail() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+run_cmd() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: $*"
+  else
+    log "RUN: $*"
+    "$@"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --target)
+      TARGET="${2:-}"
+      [ -n "$TARGET" ] || fail "--target requires a value"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$TARGET" ] || fail "--target is required"
+
+main() {
+  require_command date
+  log "Starting automation for target: $TARGET"
+  log "Replace this template action with a safe, idempotent operation."
+  run_cmd true
+  log "Completed. Add verification commands before using this in production."
+}
+
+main "$@"

--- a/scripts/templates/python-script-template.py
+++ b/scripts/templates/python-script-template.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Safe starter template for IT automation lab Python scripts."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Config:
+    target: str
+    dry_run: bool
+
+
+def parse_args(argv: list[str]) -> Config:
+    parser = argparse.ArgumentParser(description="IT automation lab script template")
+    parser.add_argument("--target", required=True, help="Target host, path, service, or identifier")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without changing state")
+    args = parser.parse_args(argv)
+    return Config(target=args.target, dry_run=args.dry_run)
+
+
+def require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        raise SystemExit(f"required command not found: {name}")
+
+
+def run_command(command: list[str], *, dry_run: bool) -> subprocess.CompletedProcess[str] | None:
+    if dry_run:
+        logging.info("DRY-RUN: %s", " ".join(command))
+        return None
+    logging.info("RUN: %s", " ".join(command))
+    return subprocess.run(command, check=True, text=True, capture_output=True)
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)sZ %(levelname)s %(message)s")
+    config = parse_args(argv)
+    require_command("python3")
+
+    logging.info("Starting automation for target: %s", config.target)
+    logging.info("Replace this template action with a safe, idempotent operation.")
+    run_command(["python3", "--version"], dry_run=config.dry_run)
+    logging.info("Completed. Add verification commands before using this in production.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/whatsapp-bridge/README.md
+++ b/scripts/whatsapp-bridge/README.md
@@ -1,0 +1,28 @@
+# WhatsApp Bridge Scripts
+
+This directory contains the Node-based WhatsApp bridge helper.
+
+## Files
+
+- `bridge.js` — bridge runtime.
+- `allowlist.js` — allowlist logic.
+- `allowlist.test.mjs` — allowlist tests.
+- `package.json` / `package-lock.json` — Node dependencies.
+
+## Basic Workflow
+
+Run commands from this directory:
+
+```bash
+npm install
+npm test
+```
+
+Review configuration and secrets before starting the bridge. Do not commit real tokens, session material, QR codes, or exported credentials.
+
+## Safety Notes
+
+- Treat bridge sessions as sensitive account access.
+- Keep allowlists restrictive.
+- Redact phone numbers and tokens in logs before sharing.
+- Stop the bridge before changing authentication/session files.


### PR DESCRIPTION
## Summary
- Add IT automation lab usage notes to README and AGENTS
- Add lab documentation for overview, safety, environment, and workflow
- Add runbook catalog, template, and example runbooks
- Add scripts README plus safe Bash/Python templates

## Verification
- python3 -m py_compile scripts/templates/python-script-template.py
- bash -n scripts/templates/bash-script-template.sh
- git diff --check