### PR TITLE
fix(providers): disable MiMo thinking replay leakage

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -1,9 +1,61 @@
 """Xiaomi MiMo provider profile."""
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-xiaomi = ProviderProfile(
+
+class XiaomiProfile(ProviderProfile):
+    """Xiaomi MiMo OpenAI-compatible provider quirks."""
+
+    def _thinking_disabled(self, reasoning_config: dict | None) -> bool:
+        return isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Normalize MiMo assistant tool-call turns.
+
+        MiMo rejects assistant tool-call messages with an empty-string content
+        field (``content: ""``) after tool execution with the misleading 400:
+        "reasoning_content in the thinking mode must be passed back". OpenAI's
+        tool-call shape permits omitting content entirely when tool_calls are
+        present, and that is the safest representation for MiMo.
+        """
+        changed = False
+        normalized: list[dict[str, Any]] = []
+        for msg in messages:
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content") == ""
+            ):
+                msg = dict(msg)
+                msg.pop("content", None)
+                changed = True
+            normalized.append(msg)
+        return normalized if changed else messages
+
+    def build_extra_body(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Emit MiMo's explicit thinking switch.
+
+        MiMo defaults several models (mimo-v2.5/pro, mimo-v2-pro/omni) to
+        thinking mode. If we only omit reasoning controls when Hermes has
+        `agent.reasoning_effort: none`, MiMo still thinks internally and then
+        rejects multi-turn/tool-call replays unless every assistant message
+        echoes `reasoning_content`.
+
+        MiMo's OpenAI-compatible docs expose `thinking: enabled|disabled`, so
+        send `disabled` explicitly when Hermes reasoning is disabled.
+        """
+        if self._thinking_disabled(reasoning_config):
+            return {"thinking": "disabled"}
+        return {}
+
+
+xiaomi = XiaomiProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),

--- a/run_agent.py
+++ b/run_agent.py
@@ -9850,7 +9850,18 @@ class AIAgent:
             model_extra = getattr(assistant_message, "model_extra", None) or {}
             if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
                 raw_reasoning_content = model_extra["reasoning_content"]
-        if raw_reasoning_content is not None:
+        try:
+            _rc = getattr(self, "reasoning_config", None)
+            _thinking_disabled = isinstance(_rc, dict) and _rc.get("enabled") is False
+            _is_xiaomi = (
+                (getattr(self, "provider", "") or "").strip().lower() in {"xiaomi", "mimo", "xiaomi-mimo"}
+                or base_url_host_matches(getattr(self, "base_url", ""), "xiaomimimo.com")
+            )
+        except Exception:
+            _thinking_disabled = False
+            _is_xiaomi = False
+
+        if raw_reasoning_content is not None and not (_thinking_disabled and _is_xiaomi):
             msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
         elif assistant_tool_calls and self._needs_thinking_reasoning_pad():
             # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
@@ -9888,7 +9899,11 @@ class AIAgent:
         #     so ``_copy_reasoning_content_for_api``'s cross-provider leak
         #     guard (#15748) and ``reasoning``→``reasoning_content``
         #     promotion tiers still apply at replay time.
-        if "reasoning_content" not in msg and reasoning_text:
+        # Xiaomi/MiMo disabled-thinking is intentionally excluded because live
+        # MiMo rejects replay after a tool-call turn if Hermes persists any
+        # ``reasoning_content`` on that assistant message, even though the next
+        # request says ``extra_body.thinking=disabled``.
+        if "reasoning_content" not in msg and reasoning_text and not (_thinking_disabled and _is_xiaomi):
             msg["reasoning_content"] = reasoning_text
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
@@ -10017,6 +10032,27 @@ class AIAgent:
         """Copy provider-facing reasoning fields onto an API replay message."""
         if source_msg.get("role") != "assistant":
             return
+
+        # Xiaomi/MiMo quirk: when thinking is explicitly disabled, do not replay
+        # any stale reasoning fields from a prior provider/session. MiMo appears
+        # to infer thinking-mode continuity from reasoning_content in history; if
+        # only some old assistant turns have it, the API rejects the whole replay
+        # with "reasoning_content in the thinking mode must be passed back" even
+        # though the current request sends thinking=disabled. Keep the API copy
+        # text-only so model switches into MiMo from GLM/Codex/etc. are clean.
+        try:
+            _rc = getattr(self, "reasoning_config", None)
+            _thinking_disabled = isinstance(_rc, dict) and _rc.get("enabled") is False
+            _is_xiaomi = (
+                (getattr(self, "provider", "") or "").strip().lower() in {"xiaomi", "mimo", "xiaomi-mimo"}
+                or base_url_host_matches(getattr(self, "base_url", ""), "xiaomimimo.com")
+            )
+            if _thinking_disabled and _is_xiaomi:
+                api_msg.pop("reasoning_content", None)
+                api_msg.pop("reasoning_details", None)
+                return
+        except Exception:
+            pass
 
         # 1. Explicit reasoning_content already set — preserve it verbatim
         # (includes DeepSeek/Kimi's own space-placeholder written at creation

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -444,6 +444,50 @@ class TestChatCompletionsBuildKwargs:
         assert "temperature" not in kw
 
 
+class TestChatCompletionsXiaomi:
+    """Regression tests for Xiaomi MiMo request-shape quirks."""
+
+    def test_xiaomi_thinking_disabled_extra_body(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("xiaomi")
+        kw = transport.build_kwargs(
+            model="mimo-v2.5",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=profile,
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["thinking"] == "disabled"
+
+    def test_xiaomi_omits_empty_assistant_content_on_tool_call_replay(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("xiaomi")
+        messages = [
+            {"role": "user", "content": "Use a tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+        ]
+        kw = transport.build_kwargs(
+            model="mimo-v2.5",
+            messages=messages,
+            provider_profile=profile,
+            reasoning_config={"enabled": False},
+        )
+        assert "content" not in kw["messages"][1]
+        assert kw["messages"][1]["tool_calls"] == messages[1]["tool_calls"]
+        # Avoid mutating caller-owned history.
+        assert messages[1]["content"] == ""
+
+
 class TestChatCompletionsKimi:
     """Regression tests for the Kimi/Moonshot quirks migrated into the transport."""
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1527,6 +1527,28 @@ class TestBuildAssistantMessage:
         assert len(result["tool_calls"]) == 1
         assert result["tool_calls"][0]["function"]["name"] == "web_search"
 
+    def test_xiaomi_disabled_thinking_does_not_persist_reasoning_content_on_tool_call(self, agent):
+        """MiMo rejects the next tool replay if disabled-thinking turns persist
+        ``reasoning_content`` despite sending ``extra_body.thinking=disabled``.
+        """
+        agent.provider = "xiaomi"
+        agent.base_url = "https://token-plan-sgp.xiaomimimo.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": False, "effort": "none"}
+        tc = _mock_tool_call(name="skill_view", arguments='{"name":"foxtech-client"}', call_id="c4")
+        msg = _mock_assistant_msg(
+            content="",
+            tool_calls=[tc],
+            reasoning_content="MiMo scratchpad",
+        )
+
+        result = agent._build_assistant_message(msg, "tool_calls")
+
+        assert result["tool_calls"]
+        assert result["reasoning"] == "MiMo scratchpad"
+        assert "reasoning_content" not in result
+        assert "reasoning_details" not in result
+
     def test_with_reasoning_details(self, agent):
         details = [{"type": "reasoning.summary", "text": "step1", "signature": "sig1"}]
         msg = _mock_assistant_msg(content="ans", reasoning_details=details)

--- a/tests/run_agent/test_xiaomi_reasoning_replay.py
+++ b/tests/run_agent/test_xiaomi_reasoning_replay.py
@@ -1,0 +1,63 @@
+from run_agent import AIAgent
+
+
+def _agent(*, provider="xiaomi", base_url="https://api.xiaomimimo.com/v1", reasoning_config=None):
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.model = "mimo-v2.5"
+    agent.reasoning_config = reasoning_config if reasoning_config is not None else {"enabled": False}
+    return agent
+
+
+def test_xiaomi_disabled_thinking_strips_reasoning_fields_from_api_copy():
+    agent = _agent(reasoning_config={"enabled": False})
+    source_msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "x", "arguments": "{}"}}],
+        "reasoning_content": "stale chain from another provider",
+        "reasoning_details": [{"type": "reasoning.text", "text": "stale"}],
+    }
+    api_msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": source_msg["tool_calls"],
+        "reasoning_content": source_msg["reasoning_content"],
+        "reasoning_details": source_msg["reasoning_details"],
+    }
+
+    agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+    assert "reasoning_content" not in api_msg
+    assert "reasoning_details" not in api_msg
+
+
+def test_xiaomi_disabled_thinking_detects_xiaomimimo_base_url():
+    agent = _agent(provider="custom", base_url="https://api.xiaomimimo.com/v1", reasoning_config={"enabled": False})
+    source_msg = {"role": "assistant", "reasoning_content": "stale"}
+    api_msg = {"role": "assistant", "reasoning_content": "stale"}
+
+    agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+    assert "reasoning_content" not in api_msg
+
+
+def test_xiaomi_thinking_enabled_preserves_reasoning_content():
+    agent = _agent(reasoning_config={"enabled": True})
+    source_msg = {"role": "assistant", "reasoning_content": "valid mimo reasoning"}
+    api_msg = {"role": "assistant"}
+
+    agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+    assert api_msg["reasoning_content"] == "valid mimo reasoning"
+
+
+def test_non_xiaomi_disabled_thinking_preserves_existing_reasoning_content():
+    agent = _agent(provider="openrouter", base_url="https://openrouter.ai/api/v1", reasoning_config={"enabled": False})
+    source_msg = {"role": "assistant", "reasoning_content": "provider reasoning"}
+    api_msg = {"role": "assistant"}
+
+    agent._copy_reasoning_content_for_api(source_msg, api_msg)
+
+    assert api_msg["reasoning_content"] == "provider reasoning"


### PR DESCRIPTION
## Summary
- explicitly send Xiaomi MiMo `thinking: disabled` when Hermes reasoning is disabled
- normalize MiMo assistant tool-call replay messages by omitting empty `content`
- prevent stale `reasoning_content` / `reasoning_details` from leaking into disabled-thinking MiMo replays
- add regression coverage for request kwargs, assistant-message persistence, and replay copy behavior

## Test Plan
- `venv/bin/python -m pytest tests/agent/transports/test_chat_completions.py::TestChatCompletionsXiaomi tests/run_agent/test_run_agent.py::TestBuildAssistantMessage::test_xiaomi_disabled_thinking_does_not_persist_reasoning_content_on_tool_call tests/run_agent/test_xiaomi_reasoning_replay.py -q`
