### PR TITLE
feat(skills): add aegis-dq data quality skill

### DIFF
--- a/skills/data-quality/DESCRIPTION.md
+++ b/skills/data-quality/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Skills for validating, monitoring, and diagnosing data quality issues in warehouses and data pipelines.
+---

--- a/skills/data-quality/aegis-dq/SKILL.md
+++ b/skills/data-quality/aegis-dq/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: aegis-dq
+description: "Agentic data quality validation across warehouses (DuckDB, BigQuery, Athena, Databricks, Postgres) with LLM diagnosis, root cause analysis, and audit trail."
+version: 0.7.0
+author: Aegis Contributors
+license: Apache-2.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [data-quality, sql, warehouse, analytics, audit, duckdb, bigquery, athena, databricks, postgres]
+    category: data-quality
+---
+
+# Aegis DQ
+
+Runs structured data quality rules against your warehouses and uses LLMs to diagnose failures, trace root causes, and propose SQL remediations. Every decision is audit-logged.
+
+## When to Use This Skill
+
+Use Aegis DQ when you need to:
+- Validate data in a warehouse against business rules (nulls, ranges, referential integrity, custom SQL)
+- Understand *why* a data quality check failed, not just *that* it failed
+- Search past diagnoses across runs
+- Run validation on a schedule and get a conversational summary
+
+## Prerequisites
+
+```bash
+pip install aegis-dq
+```
+
+Set warehouse environment variables for any system you want to validate:
+
+| Warehouse | Required env vars |
+|---|---|
+| DuckDB | `DUCKDB_PATH` (default: `:memory:`) |
+| BigQuery | `BQ_PROJECT`, `BQ_DATASET` |
+| Athena | `ATHENA_S3_STAGING_DIR`, `AWS_REGION` |
+| Databricks | `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_TOKEN` |
+| Postgres / Redshift | `POSTGRES_DSN` |
+
+Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) for LLM diagnosis. Omit to run offline.
+
+## Available Tools
+
+The Aegis MCP server exposes these tools:
+
+- **`run_validation`** — Run a rules YAML file against a warehouse. Returns pass/fail per rule, LLM diagnosis, root cause, and remediation SQL.
+- **`list_runs`** — List recent run IDs from the audit trail.
+- **`get_run_report`** — Get the full report for a past run by ID.
+- **`get_trajectory`** — Get the node-by-node LLM decision log for a run.
+- **`search_decisions`** — Full-text search across all past LLM decisions.
+
+## Example Prompts
+
+- "Run my rules.yaml against BigQuery and tell me what failed."
+- "Show me the last 10 validation runs."
+- "What was the root cause in yesterday's run?"
+- "Search the audit trail for anything about null order IDs."
+- "Run rules.yaml against Athena offline — no LLM, just pass/fail."
+
+## Running a Validation
+
+The `run_validation` tool takes:
+- `rules_path` — path to your rules YAML file
+- `warehouse` — one of: `duckdb`, `bigquery`, `athena`, `databricks`, `postgres`
+- `connection_params` — JSON object with connection kwargs (falls back to env vars if omitted)
+- `no_llm` — set `true` to skip LLM diagnosis for fast offline checks
+
+Example: validate against BigQuery using env vars
+
+```
+run_validation(rules_path="/home/user/rules/orders.yaml", warehouse="bigquery")
+```
+
+Example: validate against Postgres with explicit DSN
+
+```
+run_validation(
+  rules_path="/home/user/rules/orders.yaml",
+  warehouse="postgres",
+  connection_params="{\"dsn\": \"postgresql://user:pass@host:5432/db\"}"
+)
+```
+
+## Edge Cases
+
+- If `connection_params` is omitted and required env vars are missing, the tool returns a clear error listing which variables to set.
+- `no_llm: true` skips all LLM calls — useful for fast checks or when no API key is configured.
+- Rules that reference tables not present in the warehouse return a clear SQL error.
+
+## Links
+
+- Docs: https://aegis-dq.dev/integrations/hermes
+- GitHub: https://github.com/aegis-dq/aegis-dq
+- PyPI: https://pypi.org/project/aegis-dq/

--- a/skills/data-quality/aegis-dq/SKILL.md
+++ b/skills/data-quality/aegis-dq/SKILL.md
@@ -20,16 +20,42 @@ Runs structured data quality rules against your warehouses and uses LLMs to diag
 Use Aegis DQ when you need to:
 - Validate data in a warehouse against business rules (nulls, ranges, referential integrity, custom SQL)
 - Understand *why* a data quality check failed, not just *that* it failed
+- Load a pipeline manifest and run it with a single prompt
 - Search past diagnoses across runs
+- Compare two validation runs to spot regressions
 - Run validation on a schedule and get a conversational summary
 
 ## Prerequisites
 
+**1. Install Aegis and scaffold a project**
+
 ```bash
 pip install aegis-dq
+aegis init my-project --name my-pipeline
+cd my-project
 ```
 
-Set warehouse environment variables for any system you want to validate:
+This creates `aegis.yaml` (project-wide LLM + warehouse config), a starter `pipelines/my-pipeline/pipeline.yaml`, and `rules.yaml`.
+
+**2. Configure Hermes**
+
+Add Aegis to `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  default: claude-haiku-4-5-20251001
+  provider: anthropic
+
+mcp_servers:
+  aegis:
+    command: aegis
+    args: [mcp]
+    env:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+      DUCKDB_PATH: /data/prod.duckdb
+```
+
+**3. Set warehouse env vars**
 
 | Warehouse | Required env vars |
 |---|---|
@@ -39,25 +65,57 @@ Set warehouse environment variables for any system you want to validate:
 | Databricks | `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_TOKEN` |
 | Postgres / Redshift | `POSTGRES_DSN` |
 
-Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) for LLM diagnosis. Omit to run offline.
+Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`, or `AWS_DEFAULT_REGION` for Bedrock) for LLM diagnosis. Omit to run offline with `no_llm: true`.
 
 ## Available Tools
 
-The Aegis MCP server exposes these tools:
+The Aegis MCP server exposes 9 tools:
 
+- **`load_pipeline`** — Load a `pipeline.yaml` manifest and return its config, connection params, and goal as context. Use before `run_validation` so Hermes understands the pipeline without re-explanation.
 - **`run_validation`** — Run a rules YAML file against a warehouse. Returns pass/fail per rule, LLM diagnosis, root cause, and remediation SQL.
-- **`list_runs`** — List recent run IDs from the audit trail.
+- **`list_runs`** — List recent run IDs from the audit trail, newest first.
 - **`get_run_report`** — Get the full report for a past run by ID.
-- **`get_trajectory`** — Get the node-by-node LLM decision log for a run.
+- **`get_trajectory`** — Get the node-by-node LLM decision log for a run — every prompt, response, cost, and latency.
 - **`search_decisions`** — Full-text search across all past LLM decisions.
+- **`compare_reports`** — Diff two runs side by side — regressions, fixes, pass-rate delta.
+- **`summarize_reports`** — Compact summary of one or more runs — pass rate, top failures, cost.
+- **`check_consistency`** — Detect flapping rules and rule-set drift between two runs.
+
+## Pipeline Manifests
+
+The best way to use Aegis with Hermes is a **pipeline manifest** — a single YAML file that captures your rules, warehouse, and goal. Define it once; invoke it with two words.
+
+```yaml
+# pipelines/orders-dq/pipeline.yaml
+name: orders-dq
+description: Daily order data quality checks
+rules: ./rules.yaml
+goal: |
+  For every failure explain the business impact, the likely root
+  cause, and a concrete remediation step. Group by severity.
+```
+
+Hermes calls `load_pipeline` → reads the manifest → calls `run_validation` with the right params. You never re-explain the context.
 
 ## Example Prompts
 
-- "Run my rules.yaml against BigQuery and tell me what failed."
-- "Show me the last 10 validation runs."
-- "What was the root cause in yesterday's run?"
-- "Search the audit trail for anything about null order IDs."
+**Pipeline manifest (recommended)**
+- "Load the pipeline at my-project/pipelines/orders-dq/pipeline.yaml and run it."
+- "Load the fraud pipeline and run it, then send me a severity summary."
+
+**Direct validation**
+- "Run /home/user/rules/orders.yaml against BigQuery and tell me what failed."
 - "Run rules.yaml against Athena offline — no LLM, just pass/fail."
+
+**Audit trail**
+- "Show me the last 10 validation runs."
+- "What was the root cause of the CTR filing failures in yesterday's run?"
+- "Search the audit trail for anything about null order IDs."
+- "Compare today's run with yesterday's — what newly failed?"
+- "Have we ever seen OFAC sanction hits before?"
+
+**Scheduling**
+- "Run the fraud-aml pipeline every morning at 8am and alert me in Slack if anything is CRITICAL."
 
 ## Running a Validation
 
@@ -88,6 +146,7 @@ run_validation(
 - If `connection_params` is omitted and required env vars are missing, the tool returns a clear error listing which variables to set.
 - `no_llm: true` skips all LLM calls — useful for fast checks or when no API key is configured.
 - Rules that reference tables not present in the warehouse return a clear SQL error.
+- `load_pipeline` resolves all paths relative to the manifest file, so manifests are portable across machines.
 
 ## Links
 

--- a/skills/data-quality/aegis-dq/SKILL.md
+++ b/skills/data-quality/aegis-dq/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: aegis-dq
+description: "Validate warehouse data with LLM diagnosis and audit log."
+version: 0.7.0
+author: "Shiva Koreddi (@koreddi) with Hermes Agent"
+license: Apache-2.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [data-quality, sql, warehouse, analytics, audit, duckdb, bigquery, athena, databricks, postgres]
+    category: data-quality
+---
+
+# Aegis DQ Skill
+
+Runs structured data quality rules against warehouses and uses LLMs to diagnose failures, trace root causes, and propose SQL remediations. Every LLM decision is audit-logged. Does not replace your warehouse's native constraints — it validates business rules on top of them.
+
+## When to Use
+
+Use Aegis DQ when you need to:
+- Validate data against business rules (nulls, ranges, referential integrity, custom SQL)
+- Understand *why* a check failed, not just *that* it failed
+- Search past LLM diagnoses across runs
+- Compare two validation runs to spot regressions
+
+## Prerequisites
+
+**1. Install Aegis with MCP support**
+
+```bash
+pip install aegis-dq[mcp]
+```
+
+**2. Add the MCP server to Hermes**
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  aegis:
+    command: aegis
+    args: [mcp]
+    env:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+```
+
+**3. Set warehouse env vars**
+
+| Warehouse | Required env vars |
+|---|---|
+| DuckDB | `DUCKDB_PATH` (default: `:memory:`) |
+| BigQuery | `BQ_PROJECT`, `BQ_DATASET` |
+| Athena | `ATHENA_S3_STAGING_DIR`, `AWS_REGION` |
+| Databricks | `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_TOKEN` |
+| Postgres / Redshift | `POSTGRES_DSN` |
+
+Set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`, or `AWS_DEFAULT_REGION` for Bedrock) for LLM diagnosis. Omit to run offline with `no_llm: true`.
+
+## How to Run
+
+Ask Hermes to run a rules file against your warehouse:
+
+- "Run `rules/orders.yaml` against BigQuery and tell me what failed."
+- "Run rules.yaml against Athena offline — no LLM, just pass/fail."
+- "Show me the last 10 validation runs."
+- "What was the root cause in yesterday's run?"
+- "Search the audit trail for anything about null order IDs."
+- "Compare today's run with yesterday's — what newly failed?"
+
+## Quick Reference
+
+All tools are prefixed `mcp__aegis__`:
+
+| Tool | What it does |
+|---|---|
+| `mcp__aegis__run_validation` | Run a rules YAML against a warehouse; returns pass/fail, diagnosis, remediation SQL |
+| `mcp__aegis__list_runs` | List recent run IDs from the audit trail, newest first |
+| `mcp__aegis__get_run_report` | Full report for a past run by ID |
+| `mcp__aegis__get_trajectory` | Node-by-node LLM decision log for a run |
+| `mcp__aegis__search_decisions` | Full-text search across all past LLM decisions |
+| `mcp__aegis__compare_reports` | Diff two runs — regressions, fixes, pass-rate delta |
+| `mcp__aegis__summarize_reports` | Compact summary of one or more runs |
+| `mcp__aegis__check_consistency` | Detect flapping rules and rule-set drift between two runs |
+| `mcp__aegis__load_pipeline` | Load a `pipeline.yaml` manifest and return its config as context |
+
+## Procedure
+
+**Run a validation**
+
+`mcp__aegis__run_validation` takes:
+- `rules_path` — path to your rules YAML file
+- `warehouse` — one of: `duckdb`, `bigquery`, `athena`, `databricks`, `postgres`
+- `connection_params` — JSON with connection kwargs (falls back to env vars if omitted)
+- `no_llm` — set `true` to skip LLM diagnosis for fast offline checks
+
+**Use a pipeline manifest**
+
+A `pipeline.yaml` captures rules, warehouse, and goal in one file. Call `mcp__aegis__load_pipeline` first — Hermes reads the manifest and calls `mcp__aegis__run_validation` with the right params automatically.
+
+## Pitfalls
+
+- If `connection_params` is omitted and required env vars are missing, the tool returns a clear error listing which variables to set.
+- `no_llm: true` skips all LLM calls — useful when no API key is configured.
+- Rules referencing tables not present in the warehouse return a SQL error, not a pass.
+
+## Verification
+
+After a run, confirm Hermes used the MCP tools:
+- Check that `mcp__aegis__run_validation` appears in the tool call log.
+- `mcp__aegis__get_run_report` on the returned run ID should show per-rule pass/fail with diagnosis.
+
+## Links
+
+- Docs: https://aegis-dq.dev/integrations/hermes
+- GitHub: https://github.com/aegis-dq/aegis-dq
+- PyPI: https://pypi.org/project/aegis-dq/

--- a/tests/skills/test_aegis_dq_skill.py
+++ b/tests/skills/test_aegis_dq_skill.py
@@ -1,0 +1,112 @@
+"""Offline metadata and contract tests for the aegis-dq data quality skill."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "data-quality" / "aegis-dq"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+MCP_PREFIX = "mcp__aegis__"
+EXPECTED_TOOLS = [
+    "run_validation",
+    "list_runs",
+    "get_run_report",
+    "get_trajectory",
+    "search_decisions",
+    "compare_reports",
+    "summarize_reports",
+    "check_consistency",
+    "load_pipeline",
+]
+
+
+def _parse_frontmatter(content: str) -> dict:
+    from agent.skill_utils import parse_frontmatter
+
+    frontmatter, _ = parse_frontmatter(content)
+    return frontmatter
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict:
+    return _parse_frontmatter(skill_text)
+
+
+def test_skill_file_exists():
+    assert SKILL_MD.is_file(), f"SKILL.md not found at {SKILL_MD}"
+
+
+def test_description_length(frontmatter: dict):
+    description = frontmatter.get("description", "")
+    assert isinstance(description, str) and description.strip()
+    assert len(description) <= 60, (
+        f"description is {len(description)} chars (max 60): {description!r}"
+    )
+    assert description.endswith("."), "description must end with a period"
+
+
+def test_author_credits_contributor_first(frontmatter: dict):
+    author = str(frontmatter.get("author", ""))
+    assert "koreddi" in author.lower() or "shiva" in author.lower(), (
+        f"author field must credit the human contributor first, got: {author!r}"
+    )
+
+
+def test_license(frontmatter: dict):
+    assert frontmatter.get("license") == "Apache-2.0"
+
+
+def test_platforms(frontmatter: dict):
+    platforms = frontmatter.get("platforms", [])
+    assert isinstance(platforms, list)
+    assert set(platforms) == {"linux", "macos", "windows"}
+
+
+def test_install_command_includes_mcp_extra(skill_text: str):
+    assert "aegis-dq[mcp]" in skill_text, (
+        "Prerequisites must install aegis-dq[mcp] — bare aegis-dq omits the MCP dependency"
+    )
+
+
+def test_all_tools_use_mcp_prefix(skill_text: str):
+    for tool in EXPECTED_TOOLS:
+        prefixed = f"{MCP_PREFIX}{tool}"
+        assert prefixed in skill_text, (
+            f"Tool {tool!r} must be referenced as {prefixed!r} in SKILL.md"
+        )
+
+
+def test_no_bare_tool_names_in_tool_table(skill_text: str):
+    for tool in EXPECTED_TOOLS:
+        # bare name inside backticks but NOT preceded by mcp__aegis__
+        bare = re.compile(rf"(?<!mcp__aegis__)`{re.escape(tool)}`")
+        assert not bare.search(skill_text), (
+            f"Bare tool name `{tool}` found — use `{MCP_PREFIX}{tool}` instead"
+        )
+
+
+def test_modern_section_order(skill_text: str):
+    sections = re.findall(r"^##\s+(.+)$", skill_text, re.MULTILINE)
+    required = [
+        "When to Use",
+        "Prerequisites",
+        "How to Run",
+        "Quick Reference",
+        "Procedure",
+        "Pitfalls",
+        "Verification",
+    ]
+    for section in required:
+        assert any(section.lower() in s.lower() for s in sections), (
+            f"Required section '## {section}' missing from SKILL.md"
+        )


### PR DESCRIPTION
## Summary

Adds \`aegis-dq\` to a new \`data-quality\` skill category.

**Aegis DQ** is an open-source agentic data quality framework (Apache 2.0) that runs structured rules against warehouses and uses LLMs to diagnose failures, trace root causes, and propose SQL remediations. Every LLM decision is audit-logged.

- GitHub: https://github.com/aegis-dq/aegis-dq
- Docs: https://aegis-dq.dev/integrations/hermes
- PyPI: https://pypi.org/project/aegis-dq/

## What this adds

**New category**: \`skills/data-quality/\` with \`DESCRIPTION.md\`
**New skill**: \`skills/data-quality/aegis-dq/SKILL.md\`

9 MCP tools via \`aegis mcp\`:

| Tool | What it does |
|---|---|
| \`load_pipeline\` | Load a \`pipeline.yaml\` manifest — returns connection params and goal as context |
| \`run_validation\` | Run a rules YAML file against any supported warehouse |
| \`list_runs\` | List recent run IDs from the audit trail |
| \`get_run_report\` | Get the full report for a past run |
| \`get_trajectory\` | Get the node-by-node LLM decision log for a run |
| \`search_decisions\` | Full-text search across all past LLM decisions |
| \`compare_reports\` | Diff two runs — regressions, fixes, pass-rate delta |
| \`summarize_reports\` | Compact summary of one or more runs |
| \`check_consistency\` | Detect flapping rules and rule-set drift between two runs |

Supported warehouses: DuckDB, BigQuery, Athena, Databricks, Postgres/Redshift

## Checklist

- [x] \`name\` matches directory (\`aegis-dq\`)
- [x] Frontmatter includes all required fields
- [x] Category \`DESCRIPTION.md\` included
- [x] Apache 2.0 licensed
- [x] Format follows \`data-science/jupyter-live-kernel\`