### PR TITLE
docs: add validation contract wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -909,6 +909,24 @@ scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
 ```
 
+### PR validation wrapper
+
+For PR handoff, start with the repo-local validation wrapper:
+
+```bash
+scripts/validate_pr.sh --dry-run
+scripts/validate_pr.sh --scope docs      # docs-only changes
+scripts/validate_pr.sh --scope scripts   # validation wrapper / script changes
+scripts/validate_pr.sh --scope tests     # wrapper contract tests
+scripts/validate_pr.sh --scope full      # runtime or uncertain changes
+```
+
+`scripts/validate_pr.sh` is intentionally thin. It selects the smallest useful
+scope and delegates any pytest execution to `scripts/run_tests.sh`, which remains
+the source of truth for virtualenv selection, credential scrubbing, timezone and
+locale pins, and worker count. Record the exact wrapper command and result in
+the PR body or handoff note.
+
 ### Why the wrapper (and why the old "just call pytest" doesn't work)
 
 Five real sources of local-vs-CI drift the script closes:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -27,7 +27,24 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Prefer a .venv in the current tree, fall back to the main checkout's venv
 # (useful for worktrees where we don't always duplicate the venv).
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
+MAIN_CHECKOUT=""
+if GIT_COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)"; then
+  case "$GIT_COMMON_DIR" in
+    /*) GIT_COMMON_DIR_ABS="$GIT_COMMON_DIR" ;;
+    *) GIT_COMMON_DIR_ABS="$(cd "$REPO_ROOT/$GIT_COMMON_DIR" && pwd)" ;;
+  esac
+  if [ "$(basename "$GIT_COMMON_DIR_ABS")" = ".git" ]; then
+    MAIN_CHECKOUT="$(dirname "$GIT_COMMON_DIR_ABS")"
+  fi
+fi
+
+VENV_CANDIDATES=("$REPO_ROOT/.venv" "$REPO_ROOT/venv")
+if [ -n "$MAIN_CHECKOUT" ] && [ "$MAIN_CHECKOUT" != "$REPO_ROOT" ]; then
+  VENV_CANDIDATES+=("$MAIN_CHECKOUT/.venv" "$MAIN_CHECKOUT/venv")
+fi
+VENV_CANDIDATES+=("$HOME/.hermes/hermes-agent/venv")
+
+for candidate in "${VENV_CANDIDATES[@]}"; do
   if [ -f "$candidate/bin/activate" ]; then
     VENV="$candidate"
     break
@@ -35,7 +52,8 @@ for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agen
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  echo "error: no virtualenv found in:" >&2
+  printf '  %s\n' "${VENV_CANDIDATES[@]}" >&2
   exit 1
 fi
 

--- a/scripts/validate_pr.sh
+++ b/scripts/validate_pr.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Thin PR validation wrapper. It selects a repo-local validation command and
+# delegates all pytest execution to scripts/run_tests.sh.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/validate_pr.sh [--scope auto|docs|scripts|tests|full] [--base REF] [--dry-run]
+
+Scopes:
+  auto     Infer the smallest validation scope from files changed against REF.
+  docs     Syntax-check this wrapper for docs-only changes.
+  scripts  Syntax-check this wrapper and run its contract tests.
+  tests    Run this wrapper's contract tests.
+  full     Run the full hermetic pytest suite through scripts/run_tests.sh.
+
+Options:
+  --base REF   Ref used for auto scope detection. Default: origin/main.
+  --dry-run    Print commands without executing them.
+  -h, --help   Show this help.
+
+This wrapper is intentionally small. scripts/run_tests.sh owns virtualenv
+selection, credential scrubbing, timezone/locale pins, and xdist worker count.
+EOF
+}
+
+BASE_REF="origin/main"
+SCOPE="auto"
+DRY_RUN=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --base requires a ref" >&2
+        exit 2
+      fi
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --scope)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --scope requires a value" >&2
+        exit 2
+      fi
+      SCOPE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+is_docs_file() {
+  case "$1" in
+    AGENTS.md|README.md|README.*.md|CONTRIBUTING.md|SECURITY.md|LICENSE|RELEASE*.md|docs/*|website/docs/*|website/sidebars.ts)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+infer_scope() {
+  local base="$1"
+  local merge_base
+  local inferred="docs"
+  if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
+    echo "full"
+    return
+  fi
+
+  merge_base="$(git merge-base HEAD "$base")"
+  changed=()
+  while IFS= read -r file; do
+    [ -n "$file" ] && changed+=("$file")
+  done < <(git diff --name-only "$merge_base"...HEAD)
+  while IFS= read -r file; do
+    [ -n "$file" ] && changed+=("$file")
+  done < <(git diff --name-only)
+  while IFS= read -r file; do
+    [ -n "$file" ] && changed+=("$file")
+  done < <(git diff --name-only --cached)
+  while IFS= read -r file; do
+    [ -n "$file" ] && changed+=("$file")
+  done < <(git ls-files --others --exclude-standard)
+
+  if [ "${#changed[@]}" -eq 0 ]; then
+    echo "docs"
+    return
+  fi
+
+  local file
+  for file in "${changed[@]}"; do
+    case "$file" in
+      scripts/validate_pr.sh|scripts/run_tests.sh)
+        if [ "$inferred" != "full" ]; then
+          inferred="scripts"
+        fi
+        ;;
+      tests/test_validation_contract.py)
+        if [ "$inferred" = "docs" ]; then
+          inferred="tests"
+        fi
+        ;;
+      *.py)
+        inferred="full"
+        ;;
+      *)
+        if ! is_docs_file "$file"; then
+          inferred="full"
+        fi
+        ;;
+    esac
+  done
+
+  echo "$inferred"
+}
+
+if [ "$SCOPE" = "auto" ]; then
+  SCOPE="$(infer_scope "$BASE_REF")"
+fi
+
+case "$SCOPE" in
+  docs)
+    COMMANDS=("bash -n scripts/validate_pr.sh")
+    ;;
+  scripts)
+    COMMANDS=(
+      "bash -n scripts/validate_pr.sh"
+      "bash -n scripts/run_tests.sh"
+      "scripts/run_tests.sh tests/test_validation_contract.py"
+    )
+    ;;
+  tests)
+    COMMANDS=("scripts/run_tests.sh tests/test_validation_contract.py")
+    ;;
+  full)
+    COMMANDS=("scripts/run_tests.sh")
+    ;;
+  *)
+    echo "error: unknown scope: $SCOPE" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+echo "Validation scope: $SCOPE"
+for command in "${COMMANDS[@]}"; do
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "+ $command"
+  else
+    echo "+ $command"
+    bash -c "$command"
+  fi
+done

--- a/tests/test_validation_contract.py
+++ b/tests/test_validation_contract.py
@@ -1,0 +1,130 @@
+import subprocess
+from pathlib import Path
+from shutil import copy2
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_validate(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/validate_pr.sh", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def make_temp_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    copy2(REPO_ROOT / "scripts" / "validate_pr.sh", scripts / "validate_pr.sh")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def run_temp_validate(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "scripts/validate_pr.sh", "--scope", "auto", "--base", "HEAD", "--dry-run"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_docs_scope_is_shell_syntax_only():
+    result = run_validate("--scope", "docs", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: docs" in result.stdout
+    assert "+ bash -n scripts/validate_pr.sh" in result.stdout
+    assert "scripts/run_tests.sh" not in result.stdout
+
+
+def test_scripts_scope_delegates_pytest_to_canonical_runner():
+    result = run_validate("--scope", "scripts", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: scripts" in result.stdout
+    assert "+ bash -n scripts/validate_pr.sh" in result.stdout
+    assert "+ bash -n scripts/run_tests.sh" in result.stdout
+    assert "+ scripts/run_tests.sh tests/test_validation_contract.py" in result.stdout
+
+
+def test_full_scope_uses_canonical_runner_without_direct_pytest():
+    result = run_validate("--scope", "full", "--dry-run")
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: full" in result.stdout
+    assert "+ scripts/run_tests.sh" in result.stdout
+    assert "python -m pytest" not in result.stdout
+
+
+def test_unknown_scope_fails_with_usage():
+    result = run_validate("--scope", "unknown", "--dry-run")
+
+    assert result.returncode == 2
+    assert "error: unknown scope: unknown" in result.stderr
+    assert "Usage: scripts/validate_pr.sh" in result.stderr
+
+
+def test_auto_scope_escalates_mixed_runtime_and_script_changes(tmp_path):
+    repo = make_temp_repo(tmp_path)
+    (repo / "scripts" / "validate_pr.sh").write_text(
+        (repo / "scripts" / "validate_pr.sh").read_text(encoding="utf-8") + "\n# local edit\n",
+        encoding="utf-8",
+    )
+    (repo / "runtime.py").write_text("print('runtime')\n", encoding="utf-8")
+
+    result = run_temp_validate(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: full" in result.stdout
+    assert "+ scripts/run_tests.sh" in result.stdout
+
+
+def test_auto_scope_does_not_treat_all_tests_as_contract_tests(tmp_path):
+    repo = make_temp_repo(tmp_path)
+    test_dir = repo / "tests" / "agent"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_runtime_behavior.py").write_text("def test_example(): pass\n", encoding="utf-8")
+
+    result = run_temp_validate(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: full" in result.stdout
+
+
+def test_auto_scope_contract_test_only_uses_tests_scope(tmp_path):
+    repo = make_temp_repo(tmp_path)
+    test_dir = repo / "tests"
+    test_dir.mkdir()
+    (test_dir / "test_validation_contract.py").write_text("def test_example(): pass\n", encoding="utf-8")
+
+    result = run_temp_validate(repo)
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation scope: tests" in result.stdout
+    assert "+ scripts/run_tests.sh tests/test_validation_contract.py" in result.stdout

--- a/website/docs/developer-guide/validation-contract.md
+++ b/website/docs/developer-guide/validation-contract.md
@@ -1,0 +1,55 @@
+---
+title: Validation Contract
+---
+
+# Validation Contract
+
+Hermes uses a small wrapper around the canonical pytest runner so contributors
+and agents have one local entry point before opening a PR:
+
+```bash
+scripts/validate_pr.sh
+```
+
+The wrapper chooses the smallest useful scope from the files changed against
+`origin/main`. It does not own pytest setup. Any scope that runs tests delegates
+to `scripts/run_tests.sh`, which is the source of truth for virtualenv selection,
+credential scrubbing, timezone and locale pins, and pytest worker count.
+
+## Scopes
+
+```bash
+scripts/validate_pr.sh --scope docs
+scripts/validate_pr.sh --scope scripts
+scripts/validate_pr.sh --scope tests
+scripts/validate_pr.sh --scope full
+```
+
+Use `--dry-run` to see the selected commands without executing them:
+
+```bash
+scripts/validate_pr.sh --scope auto --dry-run
+```
+
+| Scope | Intended change | Command contract |
+| --- | --- | --- |
+| `docs` | Markdown, docs site pages, sidebar entries, `AGENTS.md`, `README.md`, `CONTRIBUTING.md` | Shell syntax-check the wrapper. |
+| `scripts` | Validation wrapper or adjacent scripts | Syntax-check the wrapper and canonical test runner, then run `tests/test_validation_contract.py` through `scripts/run_tests.sh`. |
+| `tests` | Contract tests for the wrapper | Run `tests/test_validation_contract.py` through `scripts/run_tests.sh`. |
+| `full` | Python runtime behavior, packaging, gateway, CLI, providers, plugins, or uncertain scope | Run the full suite through `scripts/run_tests.sh`. |
+
+Before pushing a runtime PR, prefer `scripts/validate_pr.sh --scope full`.
+For narrow docs/scripts/tests work, record the exact wrapper command you ran in
+the PR body.
+
+## Agent Expectations
+
+Agents working in this repository should:
+
+- Start from a clean branch or worktree based on `origin/main`.
+- Avoid reverting unrelated user or contributor edits.
+- Keep validation changes in docs, scripts, and tests unless the task explicitly
+  asks for runtime behavior.
+- Use `scripts/validate_pr.sh --dry-run` when deciding the smallest validation
+  scope, then run the selected command.
+- Report the command, result, branch, and commit SHA in the PR or handoff.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -199,6 +199,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'developer-guide/contributing',
+        'developer-guide/validation-contract',
         {
           type: 'category',
           label: 'Architecture',


### PR DESCRIPTION
## Summary
- add scripts/validate_pr.sh as a thin PR validation wrapper around scripts/run_tests.sh
- document the validation contract in AGENTS.md and the developer docs sidebar
- add contract tests for explicit scopes and auto-scope escalation
- make scripts/run_tests.sh find the main checkout venv from isolated worktrees

## Validation
- scripts/validate_pr.sh --scope scripts -> 7 passed
- git diff --check -> passed
- Gemini CLI secondary review -> No findings

## Residual risk
- Full suite not run; this slice is limited to docs/scripts/tests and validated through the new wrapper contract test.