### PR TITLE
ci: harden site deployment with Supabase support

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -9,28 +9,117 @@ on:
       - 'website/**'
       - 'skills/**'
       - 'optional-skills/**'
+      - 'supabase/**'
+      - 'vercel.json'
+      - 'website/vercel.json'
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
 
-permissions:
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  deploy-vercel:
-    if: github.event_name == 'release'
+  supabase-migrations:
+    if: github.repository == 'NousResearch/hermes-agent' && github.ref == 'refs/heads/main' && vars.SUPABASE_MIGRATIONS_ENABLED == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: supabase-production
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Check for committed migrations
+        id: migrations
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          migrations=(supabase/migrations/*.sql)
+          if [ "${#migrations[@]}" -eq 0 ]; then
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Supabase migration SQL files are committed; skipping db push."
+          else
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+            printf 'Found %s migration(s).\n' "${#migrations[@]}"
+          fi
+
+      - name: Validate Supabase deployment secrets
+        if: steps.migrations.outputs.has_migrations == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name secret is not configured"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333  # v2
+        if: steps.migrations.outputs.has_migrations == 'true'
+        with:
+          version: ${{ vars.SUPABASE_CLI_VERSION || 'latest' }}
+
+      - name: Link Supabase project
+        if: steps.migrations.outputs.has_migrations == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push Supabase migrations
+        if: steps.migrations.outputs.has_migrations == 'true'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          supabase db push
+
+  deploy-vercel:
+    needs: supabase-migrations
+    if: >-
+      always() &&
+      github.repository == 'NousResearch/hermes-agent' &&
+      (github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (needs.supabase-migrations.result == 'success' || needs.supabase-migrations.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Trigger Vercel Deploy
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_DEPLOY_HOOK:-}" ]; then
+            echo "::error::VERCEL_DEPLOY_HOOK secret is not configured"
+            exit 1
+          fi
+          curl --fail-with-body --show-error --silent -X POST "$VERCEL_DEPLOY_HOOK"
 
   deploy-docs:
-    if: github.repository == 'NousResearch/hermes-agent'
+    if: github.repository == 'NousResearch/hermes-agent' && github.event_name != 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,11 @@
+# Supabase CLI local state and secrets
+.temp/
+.env
+.env.*
+
+# Keep migrations, seeds, edge functions, and config committed.
+!.gitignore
+!config.toml
+!README.md
+!migrations/
+!migrations/.gitkeep

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,33 @@
+# Supabase backend
+
+This directory is reserved for the Supabase backend that supports hosted Hermes Agent web experiences.
+
+## What belongs here
+
+- `migrations/*.sql` — ordered schema migrations generated with `supabase migration new ...`.
+- `config.toml` — non-secret Supabase CLI project settings.
+- Edge Functions, seed files, or typed schema artifacts can be added here when the product needs them.
+
+## What must stay out of git
+
+- `supabase/.temp/` — created by `supabase link` and local CLI commands.
+- `.env` files and database passwords.
+- Secret API keys (`sb_secret_...`) or legacy `service_role` keys.
+
+## CI behavior
+
+The `supabase-migrations` job in `.github/workflows/deploy-site.yml` is intentionally disabled until the repository variable `SUPABASE_MIGRATIONS_ENABLED` is set to `true`.
+
+When enabled, it applies committed SQL migrations on `main` before the workflow triggers the Vercel deploy hook. This ordering prevents application code from deploying before its required database schema.
+
+Required GitHub secrets for migration deployment:
+
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_PROJECT_ID`
+- `SUPABASE_DB_PASSWORD`
+
+Optional GitHub variable:
+
+- `SUPABASE_CLI_VERSION` — pin a Supabase CLI version; defaults to `latest`.
+
+Vercel application runtime variables such as `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` should be configured in Vercel Project Settings, not committed here.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,9 @@
+# Supabase CLI project metadata for Hermes Agent deployments.
+#
+# The production project reference is intentionally not committed here. CI links
+# to the production project at runtime via the SUPABASE_PROJECT_ID GitHub secret.
+project_id = "hermes-agent"
+
+[db.migrations]
+enabled = true
+schema_paths = []

--- a/website/docs/developer-guide/site-deployment.md
+++ b/website/docs/developer-guide/site-deployment.md
@@ -1,0 +1,104 @@
+---
+title: "Site deployment with Vercel and Supabase"
+description: "How the Hermes Agent docs/site deployment uses Vercel deploy hooks, GitHub Pages, and optional Supabase backend migrations."
+---
+
+# Site deployment with Vercel and Supabase
+
+Hermes Agent uses GitHub Actions to keep the public docs/site deployable from repository events while keeping production credentials out of the repository.
+
+## Deployment paths
+
+### Vercel production deploy hook
+
+`.github/workflows/deploy-site.yml` triggers the existing Vercel Deploy Hook for:
+
+- published releases,
+- pushes to `main` that change the site, skills catalogs, Supabase deployment files, or the deployment workflow, and
+- manual `workflow_dispatch` runs.
+
+The Vercel job does not need GitHub token permissions. It only requires the `VERCEL_DEPLOY_HOOK` repository secret and calls the hook with:
+
+```bash
+curl --fail-with-body --show-error --silent -X POST "$VERCEL_DEPLOY_HOOK"
+```
+
+Deploy hooks are bearer-style URLs. Treat the hook URL like a password: anyone with it can trigger a deployment for the configured Vercel project/branch.
+
+### GitHub Pages docs deployment
+
+The same workflow still publishes the Docusaurus docs artifact to GitHub Pages for push and manual runs. It intentionally skips release events so a release can trigger Vercel without failing because the Pages job runs in the wrong event context.
+
+The Pages job has the only GitHub token permissions it needs:
+
+- `contents: read`
+- `pages: write`
+- `id-token: write`
+
+## Supabase backend support
+
+Supabase support is split into two concerns:
+
+1. **Application runtime variables** live in Vercel Project Settings.
+2. **Database migrations** live under `supabase/` and are applied by the `supabase-migrations` job in `.github/workflows/deploy-site.yml` only after migration deployment is explicitly enabled.
+
+A Vercel deploy hook does not carry a secret payload to the build. Configure Supabase variables directly in Vercel so each new production deployment receives them. When Supabase migrations are enabled, the workflow applies committed migrations on `main` before triggering the Vercel deploy hook so application code does not deploy ahead of its database schema.
+
+### Vercel environment variables
+
+Configure these in Vercel for the project that the deploy hook targets.
+
+Public/client-safe values:
+
+- `SUPABASE_URL` — Supabase project URL.
+- `SUPABASE_PUBLISHABLE_KEY` — current Supabase browser-safe publishable key.
+- `SUPABASE_ANON_KEY` — legacy browser-safe anon key if the app still expects it.
+
+Server-only values, only if a Vercel serverless/edge backend needs elevated access:
+
+- `SUPABASE_SECRET_KEY` — preferred secret key for backend-only access.
+- `SUPABASE_SERVICE_ROLE_KEY` — legacy elevated key; never expose in browser bundles.
+
+Do not prefix elevated keys with a public/client build prefix. Static Docusaurus or Vite bundles should only receive values that are safe to expose to every browser visitor.
+
+### Supabase migration workflow
+
+The migration workflow is disabled by default. Enable it only after the Supabase project and migration review process are ready.
+
+Required GitHub repository variable:
+
+- `SUPABASE_MIGRATIONS_ENABLED=true`
+
+Required GitHub repository secrets:
+
+- `SUPABASE_ACCESS_TOKEN` — Supabase personal access token for the deploying account.
+- `SUPABASE_PROJECT_ID` — project ref from the Supabase dashboard URL.
+- `SUPABASE_DB_PASSWORD` — database password for `supabase link` / `supabase db push`.
+
+Optional GitHub repository variable:
+
+- `SUPABASE_CLI_VERSION` — pin a CLI version; defaults to `latest`.
+
+The workflow is a no-op when there are no committed `supabase/migrations/*.sql` files. Once SQL migrations exist and deployment is enabled, it runs:
+
+```bash
+supabase link --project-ref "$SUPABASE_PROJECT_ID"
+supabase db push
+```
+
+## First-time setup checklist
+
+1. In Vercel, confirm the project is connected to `NousResearch/hermes-agent` and the production branch is `main`.
+2. In Vercel, create or verify a Deploy Hook for `main`.
+3. In GitHub repository secrets, set `VERCEL_DEPLOY_HOOK` to that hook URL.
+4. In Vercel Project Settings, add the Supabase runtime variables for Production and Preview as needed.
+5. In Supabase, create/confirm the project, enable Row Level Security where browser clients access data, and copy the project ref.
+6. In GitHub repository secrets, add `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, and `SUPABASE_DB_PASSWORD`.
+7. After at least one reviewed SQL migration exists under `supabase/migrations/`, set repository variable `SUPABASE_MIGRATIONS_ENABLED=true`.
+8. Run `Deploy Site` manually once from `main` to verify Vercel hook deployment and, if migrations are ready/enabled, the Supabase migration step.
+
+## Rotation and recovery
+
+- If `VERCEL_DEPLOY_HOOK` leaks, revoke it in Vercel and replace the GitHub secret.
+- If a Supabase secret key or service-role key leaks, rotate/delete it in Supabase and update every server-side consumer.
+- Vercel environment-variable changes apply only to new deployments; trigger a fresh deployment after changing Supabase values.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -199,6 +199,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'developer-guide/contributing',
+        'developer-guide/site-deployment',
         {
           type: 'category',
           label: 'Architecture',


### PR DESCRIPTION
## Summary

- Runs the existing Vercel deploy hook on release, qualifying `main` pushes, and manual dispatch with explicit missing-secret and curl failure handling.
- Keeps GitHub Pages deployment for push/manual runs, but skips it on release events so release-triggered Vercel deployments do not fail because of Pages.
- Moves workflow permissions to the jobs that need them.
- Adds an optional Supabase migration step in the deploy workflow, gated by `SUPABASE_MIGRATIONS_ENABLED=true`, guarded to `refs/heads/main`, and ordered before the Vercel hook.
- Adds a Supabase directory skeleton plus deployment documentation for required Vercel/Supabase secrets.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-site.yml")'`
- `python3`/`tomllib` parse of `supabase/config.toml`
- `git diff --cached --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy-site.yml`
- Staged-file secret-pattern scan found no concrete Vercel hook URLs, Supabase keys, JWTs, or project URLs.
- `npm ci --no-audit --prefix website`
- `npm run build --prefix website` succeeded; existing Docusaurus warnings remain for pre-existing docs links/anchors.

## Deployment notes

Secrets/variables still need to be configured after merge before deployment is fully operational:

- GitHub secret: `VERCEL_DEPLOY_HOOK`
- Vercel project env: `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY` or legacy `SUPABASE_ANON_KEY`; server-only `SUPABASE_SECRET_KEY` or legacy `SUPABASE_SERVICE_ROLE_KEY` only if backend code needs elevated server access.
- GitHub secrets for migrations: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`
- GitHub variable to enable migrations after review: `SUPABASE_MIGRATIONS_ENABLED=true`
- Optional GitHub variable: `SUPABASE_CLI_VERSION`
