### PR TITLE
fix(gateway): use service restart path in Docker/Podman containers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8705,13 +8705,15 @@ class GatewayRunner:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
         active_agents = self._running_agent_count()
-        # When running under a service manager (systemd/launchd), use the
-        # service restart path: exit with code 75 so the service manager
-        # restarts us.  The detached subprocess approach (setsid + bash)
-        # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
+        # When running under a service manager (systemd/launchd) or inside a
+        # Docker/Podman container, use the service restart path: exit with
+        # code 75 so the service manager / container restart policy restarts
+        # us.  The detached subprocess approach (setsid + bash) doesn't work
+        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
+        # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        if _under_service:
+        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+        if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)


### PR DESCRIPTION
Fixes #25218

The `/restart` slash command used a detached subprocess approach to restart the gateway. In Docker/Podman, when the gateway process exits, tini (PID 1) also exits, causing Docker to stop the container and kill the detached helper before it can restart the gateway. This made `/restart` effectively a `/shutdown` in containerized deployments.

## Changes

Detect Docker (`/.dockerenv`) and Podman (`/run/.containerenv`) containers in `_handle_restart_command` and use the service restart path (exit code 75) instead. This lets the container's restart policy (e.g. `unless-stopped` or `on-failure`) handle the actual restart — the same approach already used for systemd.

## Notes

- Requires the container to have a restart policy that restarts on non-zero exit codes
- Detection is lightweight: just `os.path.exists()` on well-known container sentinel files