### PR TITLE
ci: support Vercel hook deploys with Supabase config

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -7,14 +7,13 @@ on:
     branches: [main]
     paths:
       - 'website/**'
+      - 'web/**'
       - 'skills/**'
       - 'optional-skills/**'
       - '.github/workflows/deploy-site.yml'
   workflow_dispatch:
 
-permissions:
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -22,15 +21,35 @@ concurrency:
 
 jobs:
   deploy-vercel:
-    if: github.event_name == 'release'
+    if: >-
+      github.repository == 'NousResearch/hermes-agent' &&
+      (github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
     steps:
       - name: Trigger Vercel Deploy
-        run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_DEPLOY_HOOK:-}" ]; then
+            echo "::error::VERCEL_DEPLOY_HOOK secret is not configured"
+            exit 1
+          fi
+          curl --fail-with-body --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 60 \
+            --retry 3 \
+            --retry-delay 5 \
+            -X POST "$VERCEL_DEPLOY_HOOK"
 
   deploy-docs:
-    if: github.repository == 'NousResearch/hermes-agent'
+    if: github.repository == 'NousResearch/hermes-agent' && github.event_name != 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,11 @@
+# Hermes dashboard / Vite frontend optional Supabase backend configuration.
+# These VITE_* values are embedded in the browser bundle, so only use
+# public Supabase values here. Never put service-role keys behind VITE_*.
+
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-public-anon-key
+
+# Server-only Supabase values belong in the deployment platform's secret store
+# or backend runtime environment, not in browser-exposed Vite variables.
+# SUPABASE_SERVICE_ROLE_KEY=
+# SUPABASE_DB_URL=

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@nous-research/ui": "^0.10.0",
         "@observablehq/plot": "^0.6.17",
         "@react-three/fiber": "^9.6.0",
+        "@supabase/supabase-js": "^2.105.4",
         "@tailwindcss/vite": "^4.2.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
@@ -2160,6 +2161,90 @@
         "react": ">= 16.3.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -4288,6 +4373,15 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "entities": "^7.0.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "@nous-research/ui": "^0.10.0",
     "@observablehq/plot": "^0.6.17",
     "@react-three/fiber": "^9.6.0",
+    "@supabase/supabase-js": "^2.105.4",
     "@tailwindcss/vite": "^4.2.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,0 +1,38 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? "";
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? "";
+
+export const supabaseConfig = {
+  url: SUPABASE_URL,
+  anonKey: SUPABASE_ANON_KEY,
+  isConfigured: Boolean(SUPABASE_URL && SUPABASE_ANON_KEY),
+} as const;
+
+let client: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (!supabaseConfig.isConfigured) {
+    return null;
+  }
+
+  client ??= createClient(supabaseConfig.url, supabaseConfig.anonKey, {
+    auth: {
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      persistSession: true,
+    },
+  });
+
+  return client;
+}
+
+export function requireSupabaseClient(): SupabaseClient {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error(
+      "Supabase is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.",
+    );
+  }
+  return supabase;
+}

--- a/website/docs/guides/vercel-supabase-deployments.md
+++ b/website/docs/guides/vercel-supabase-deployments.md
@@ -1,0 +1,92 @@
+---
+title: "Deploy with Vercel and Supabase"
+description: "How to wire the Hermes site/dashboard deployment to Vercel with a Supabase backend."
+---
+
+# Deploy with Vercel and Supabase
+
+Hermes can use two separate deployment paths:
+
+1. **The docs site** (`website/`) builds as a static Docusaurus site and is published to GitHub Pages.
+2. **The Vercel deployment** is triggered by the `Deploy Site` GitHub Actions workflow through `VERCEL_DEPLOY_HOOK`. Vercel owns the build command, output directory, and runtime environment for the connected project.
+
+When you add Supabase, keep the responsibility split clear:
+
+- GitHub Actions only needs the Vercel deploy hook URL when using the deploy-hook path.
+- Vercel needs the Supabase environment variables because Vercel runs the production build and any serverless functions.
+- Browser-exposed variables must use the `VITE_` prefix and must only contain public Supabase values.
+- Service-role credentials must stay server-side. Never expose them through `VITE_*`, `NEXT_PUBLIC_*`, static files, or client code.
+
+## Required GitHub secret
+
+Set this in **GitHub → Settings → Secrets and variables → Actions** for `NousResearch/hermes-agent`:
+
+```bash
+VERCEL_DEPLOY_HOOK=https://api.vercel.com/v1/integrations/deploy/...
+```
+
+The workflow checks this value explicitly. If it is missing, the Vercel deploy job fails with a clear `VERCEL_DEPLOY_HOOK secret is not configured` error instead of silently posting an empty URL.
+
+## Vercel environment variables
+
+Set these in **Vercel → Project → Settings → Environment Variables**.
+
+Current required public browser variables for the Vite dashboard Supabase client:
+
+```bash
+VITE_SUPABASE_URL=https://<project-ref>.supabase.co
+VITE_SUPABASE_ANON_KEY=<public-anon-key>
+```
+
+Optional server-only variables for future API routes, serverless functions, or backend jobs:
+
+```bash
+SUPABASE_SERVICE_ROLE_KEY=<server-only-service-role-key>
+SUPABASE_DB_URL=postgresql://...
+```
+
+Only add `SUPABASE_SERVICE_ROLE_KEY` when there is server-side code that needs elevated Supabase access. Keep it server-side only. Do not set it as `VITE_SUPABASE_SERVICE_ROLE_KEY`; that would publish it to every browser that loads the app.
+
+## Local dashboard development
+
+Copy the Vite example env file and fill only public values:
+
+```bash
+cd web
+cp .env.example .env.local
+```
+
+The dashboard exposes a small helper at `web/src/lib/supabase.ts`:
+
+```ts
+import { getSupabaseClient, requireSupabaseClient } from "@/lib/supabase";
+
+const supabase = getSupabaseClient();
+if (supabase) {
+  const { data, error } = await supabase.from("example_table").select("*");
+}
+```
+
+Use `getSupabaseClient()` when Supabase is optional and `requireSupabaseClient()` when the feature cannot run without Supabase configuration.
+
+## Deploy-hook behavior
+
+The GitHub workflow triggers the Vercel deploy hook for:
+
+- published releases,
+- qualifying pushes to `main`, and
+- manual `workflow_dispatch` runs.
+
+It also skips the GitHub Pages job on release events so release workflows do not fail because the Pages deployment path ran when only the Vercel hook was needed.
+
+## Moving to Vercel-native PR previews later
+
+Deploy hooks trigger production deployments but do not provide Vercel GitHub App PR previews/checks/comments by themselves. For full Vercel-native preview behavior, connect the repository in the Vercel dashboard or add a Vercel CLI workflow with:
+
+```bash
+VERCEL_TOKEN=
+VERCEL_ORG_ID=
+VERCEL_PROJECT_ID=
+```
+
+The Supabase variables above still belong in Vercel project environment variables unless a GitHub Action is doing the build directly.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -186,6 +186,7 @@ const sidebars: SidebarsConfig = {
         'guides/delegation-patterns',
         'guides/github-pr-review-agent',
         'guides/webhook-github-pr-review',
+        'guides/vercel-supabase-deployments',
         'guides/migrate-from-openclaw',
         'guides/aws-bedrock',
         'guides/azure-foundry',


### PR DESCRIPTION
## Summary
- Harden the existing `deploy-site.yml` Vercel deploy-hook job so releases, qualifying `main` pushes, and manual dispatches can trigger Vercel with explicit missing-secret and curl failure handling.
- Skip the GitHub Pages deploy job on release events so release workflows do not fail through the Pages path when the Vercel hook is the intended release deployment.
- Move broad workflow permissions down to the jobs that need them.
- Add foundational Supabase support for the Vite dashboard through `@supabase/supabase-js`, a small optional client helper, and a browser-safe `web/.env.example`.
- Document Vercel + Supabase deployment setup and required secrets/environment variables.

## Validation
- `python3` YAML parse for `.github/workflows/deploy-site.yml`
- `actionlint .github/workflows/deploy-site.yml` via temporary `go install` binary
- `git diff --check` and `git diff --cached --check`
- `npm ci --ignore-scripts --no-audit` in `web/`
- `npm run build` in `web/`
- `npx eslint src/lib/supabase.ts` in `web/`
- `npm ci --ignore-scripts --no-audit` in `website/`
- `npm run build` in `website/` (passes with existing Docusaurus broken-link/anchor warnings)
- `env_auditor` on repo with changed-file filtering: 0 findings in changed files
- Independent read-only review completed; docs were adjusted so server-only Supabase secrets are optional/future-only, not required for the current client helper.

## Deployment notes
After merge, `VERCEL_DEPLOY_HOOK` must be configured as a GitHub Actions secret for `NousResearch/hermes-agent` or the Vercel job will fail clearly on qualifying deploy events.

For the Supabase-backed dashboard path, set public browser variables in Vercel project env vars:
- `VITE_SUPABASE_URL`
- `VITE_SUPABASE_ANON_KEY`

Only add server-only Supabase values such as `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_DB_URL` when server-side Vercel code actually needs them; never expose those as `VITE_*` variables.
