### PR TITLE
fix(cli): preserve startup banner on terminal resize

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2703,9 +2703,27 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state."""
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
-        _replay_output_history()
+        """Recover a resized classic CLI without desynchronizing cursor state.
+
+        Unlike _force_full_redraw, we do NOT clear the physical screen or
+        scrollback here.  The startup banner and tool summary are printed
+        before prompt_toolkit owns the live chrome, so they live in normal
+        terminal scrollback.  Erasing the screen on SIGWINCH removes that
+        startup UI and ``_replay_output_history`` cannot reconstruct it
+        (the banner was never added to ``_OUTPUT_HISTORY``).
+
+        Instead we just reset prompt_toolkit's renderer cache so the next
+        incremental redraw starts from a clean slate, then let
+        ``original_on_resize`` recalculate layout for the new size.
+        """
+        try:
+            app.renderer.reset(leave_alternate_screen=False)
+        except Exception:
+            pass
+        try:
+            app.invalidate()
+        except Exception:
+            pass
         original_on_resize()
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,32 +71,32 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+    def test_resize_preserves_scrollback_and_resets_renderer(self, bare_cli, monkeypatch):
+        """Resize recovery must NOT erase screen or scrollback.
+
+        The startup banner lives in normal terminal scrollback (printed
+        before prompt_toolkit owns the chrome).  Clearing scrollback on
+        SIGWINCH removes it and ``_replay_output_history`` cannot
+        reconstruct it.  The fix is to only reset the renderer cache and
+        let ``original_on_resize`` recalculate layout.
+        """
         app = MagicMock()
-        out = app.renderer.output
         events = []
-        out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
-        out.erase_screen.side_effect = lambda: events.append("erase")
-        out.write_raw.side_effect = lambda text: events.append(("raw", text))
-        out.cursor_goto.side_effect = lambda *_: events.append("home")
-        out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
-        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        app.invalidate.side_effect = lambda: events.append("invalidate")
         original_on_resize = lambda: events.append("original_resize")
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
-            "reset_attrs",
-            "erase",
-            ("raw", "\x1b[3J"),
-            "home",
-            "flush",
             "renderer_reset",
-            "replay",
+            "invalidate",
             "original_resize",
         ]
-        app.invalidate.assert_not_called()
+        # Must NOT clear the screen or scrollback — those destroy the banner.
+        app.renderer.output.erase_screen.assert_not_called()
+        app.renderer.output.write_raw.assert_not_called()
+        app.renderer.output.cursor_goto.assert_not_called()
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):
         app = MagicMock()


### PR DESCRIPTION
Salvage of #23048 onto current main (219 commits behind at submission). Cherry-picked @vominh1919's commit; authorship preserved.

## Summary
Classic-CLI resize no longer wipes terminal scrollback. The startup banner, tool summary, and earlier output stay reachable via scroll after any `SIGWINCH`.

## Root cause
Commit 76074d9e ("fix(cli): recover classic CLI output after resize") had `_recover_after_resize()` call `_clear_prompt_toolkit_screen(app, rebuild_scrollback=True)`, which emits `ESC[3J` — the ANSI sequence that erases terminal scrollback. The banner is printed before prompt_toolkit owns the chrome, so it lives in regular scrollback and is never in `_OUTPUT_HISTORY`; clearing scrollback destroys it for good.

## Fix
`_recover_after_resize()` now only calls `renderer.reset(leave_alternate_screen=False)` + `app.invalidate()` and defers to `original_on_resize()`. No screen clear, no scrollback wipe, no replay of a buffer that never held the banner.

## Test plan
- `tests/cli/test_cli_force_redraw.py` — 9/9 pass, including new `test_resize_preserves_scrollback_and_resets_renderer` asserting `erase_screen` / `write_raw` / `cursor_goto` are NOT called on resize.

## Credit
Reported by @Dc-j0e in Discord. Fixed by @vominh1919 in #23048.