### PR TITLE
fix(gateway): route conflict-retry start_polling failure to reconnect ladder

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -903,8 +903,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
             except Exception as retry_err:
                 logger.warning("[%s] Telegram polling retry failed: %s", self.name, retry_err)
-                # Don't fall through to fatal yet — wait for the next conflict
-                # to trigger another retry attempt (up to MAX_CONFLICT_RETRIES).
+                # start_polling failed — polling is dead and no further error
+                # callbacks will fire, so route into the network-error reconnect
+                # ladder which handles retries with back-off and eventual
+                # escalation to retryable-fatal.
+                if not self.has_fatal_error:
+                    task = asyncio.ensure_future(
+                        self._handle_polling_network_error(retry_err)
+                    )
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
                 return
 
         # Exhausted retries — fatal

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -288,6 +288,48 @@ async def test_conflict_retry_also_drains_polling_connections():
 
 
 @pytest.mark.asyncio
+async def test_conflict_retry_routes_to_reconnect_on_start_polling_failure():
+    """
+    When start_polling() raises during a conflict retry, the adapter must
+    schedule a _handle_polling_network_error task so that the reconnect
+    ladder can recover.  Otherwise polling stays dead with no further
+    error callbacks.
+
+    Regression test for #25221: gateway alive but deaf after conflict retry
+    start_polling failure.
+    """
+    adapter = _make_adapter()
+    adapter._polling_conflict_count = 0
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock(side_effect=Exception("Timed out"))
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_conflict(Exception("Conflict: terminated by other getUpdates"))
+
+    # A reconnect task must have been added to _background_tasks
+    pending = [t for t in adapter._background_tasks if not t.done()]
+    assert len(pending) >= 1, (
+        "Expected at least one reconnect task in _background_tasks "
+        f"after conflict-retry start_polling failure, got {len(pending)}"
+    )
+
+    # Clean up
+    for t in pending:
+        t.cancel()
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_drain_helper_noop_without_app():
     """_drain_polling_connections must be a no-op when _app is None."""
     adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

When `start_polling()` raises during a conflict retry in `_handle_polling_conflict`, the exception was logged and swallowed. Polling stayed dead with no further error callbacks, leaving the gateway "alive but deaf" until manual restart.


### Root Cause

In `gateway/platforms/telegram.py`, `_handle_polling_conflict` retries `start_polling()` after a 409 Conflict. If that retry call itself fails (timeout, network error), the `except` block logged the error and returned — without routing the failure into the existing reconnect ladder.

The `_handle_polling_network_error` handler already has the correct pattern: when `start_polling()` fails in its retry path, it self-schedules a new `_handle_polling_network_error` task via `asyncio.ensure_future` (lines 814-823). The conflict-retry path was missing this.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- Analyzed: `_handle_polling_conflict` (callers: 2, callees: 3, flows: 0)
- Blast radius: LOW — change is inside an exception handler on a rarely-triggered retry path
- Related patterns: `_handle_polling_network_error` already uses the same `asyncio.ensure_future` self-scheduling pattern (lines 814-823)

## Regression Coverage

New test `test_conflict_retry_routes_to_reconnect_on_start_polling_failure` in `tests/gateway/test_telegram_network_reconnect.py`:
- Mocks `start_polling` to raise during conflict retry
- Asserts that a reconnect task is scheduled in `_background_tasks`
- Mirrors the existing `test_reconnect_self_schedules_on_start_polling_failure` which covers the network-error path

## Testing

```
tests/gateway/test_telegram_network_reconnect.py — 16 passed
tests/gateway/test_telegram_conflict.py — 6 passed
```

Fixes Telegram gateway can stay alive with dead polling after conflict retry start_polling failure #25221