### PR TITLE
fix(feishu): roll over streaming message before edit limit

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -93,6 +93,7 @@ try:
         CreateImageRequestBody,
         CreateMessageRequest,
         CreateMessageRequestBody,
+        DeleteMessageRequest,
         GetChatRequest,
         GetMessageRequest,
         GetMessageResourceRequest,
@@ -228,6 +229,8 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
 }
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_FEISHU_STREAMING_MAX_SAFE_EDITS = 19
+_FEISHU_EDIT_LIMIT_ERROR_CODES = frozenset({"230072"})
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so
@@ -410,6 +413,14 @@ class FeishuBatchState:
     events: Dict[str, MessageEvent] = field(default_factory=dict)
     tasks: Dict[str, asyncio.Task] = field(default_factory=dict)
     counts: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class FeishuStreamingMessageState:
+    chat_id: str
+    reply_to: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    active_edit_count: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -1418,6 +1429,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._media_batch_state = FeishuBatchState()
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
+        self._streaming_message_state: Dict[str, FeishuStreamingMessageState] = {}
+        self._streaming_message_state_order: List[str] = []
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
@@ -1710,6 +1723,125 @@ class FeishuAdapter(BasePlatformAdapter):
             self._webhook_runner = None
             self._webhook_site = None
 
+    def _remember_streaming_message(
+        self,
+        *,
+        message_id: str,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        active_edit_count: int = 0,
+    ) -> None:
+        if not message_id:
+            return
+        if message_id in self._streaming_message_state_order:
+            self._streaming_message_state_order.remove(message_id)
+        self._streaming_message_state_order.append(message_id)
+        self._streaming_message_state[message_id] = FeishuStreamingMessageState(
+            chat_id=chat_id,
+            reply_to=reply_to,
+            metadata=dict(metadata or {}),
+            active_edit_count=active_edit_count,
+        )
+        while len(self._streaming_message_state_order) > _FEISHU_BOT_MSG_TRACK_SIZE:
+            stale_id = self._streaming_message_state_order.pop(0)
+            self._streaming_message_state.pop(stale_id, None)
+
+    def _pop_streaming_message_state(self, message_id: str) -> Optional[FeishuStreamingMessageState]:
+        if not message_id:
+            return None
+        if message_id in self._streaming_message_state_order:
+            self._streaming_message_state_order.remove(message_id)
+        return self._streaming_message_state.pop(message_id, None)
+
+    def _get_streaming_message_state(
+        self,
+        *,
+        message_id: str,
+        chat_id: str,
+    ) -> FeishuStreamingMessageState:
+        existing = self._streaming_message_state.get(message_id)
+        if existing is not None:
+            return existing
+        state = FeishuStreamingMessageState(chat_id=chat_id)
+        if message_id in self._streaming_message_state_order:
+            self._streaming_message_state_order.remove(message_id)
+        self._streaming_message_state_order.append(message_id)
+        self._streaming_message_state[message_id] = state
+        while len(self._streaming_message_state_order) > _FEISHU_BOT_MSG_TRACK_SIZE:
+            stale_id = self._streaming_message_state_order.pop(0)
+            if stale_id != message_id:
+                self._streaming_message_state.pop(stale_id, None)
+        return state
+
+    @staticmethod
+    def _looks_like_edit_limit_error(error: str) -> bool:
+        if not error:
+            return False
+        normalized = error.lower()
+        return any(
+            signal in normalized
+            for signal in (
+                *tuple(_FEISHU_EDIT_LIMIT_ERROR_CODES),
+                "has reached the number of times it can be edited",
+            )
+        )
+
+    async def _rollover_streaming_message(
+        self,
+        *,
+        previous_message_id: str,
+        state: FeishuStreamingMessageState,
+        content: str,
+    ) -> SendResult:
+        logger.debug(
+            "[Feishu] Streaming rollover triggered for message %s in chat %s "
+            "(edit_count=%d, reply_to=%s)",
+            previous_message_id,
+            state.chat_id,
+            state.active_edit_count,
+            state.reply_to or "",
+        )
+        send_result = await self.send(
+            chat_id=state.chat_id,
+            content=content,
+            reply_to=state.reply_to,
+            metadata=state.metadata,
+        )
+        if not send_result.success or not send_result.message_id:
+            logger.warning(
+                "[Feishu] Streaming rollover send failed for message %s in chat %s: %s",
+                previous_message_id,
+                state.chat_id,
+                send_result.error or "unknown error",
+            )
+            return send_result
+
+        new_message_id = str(send_result.message_id)
+        logger.debug(
+            "[Feishu] Streaming rollover created replacement message %s for retired message %s in chat %s",
+            new_message_id,
+            previous_message_id,
+            state.chat_id,
+        )
+        self._pop_streaming_message_state(previous_message_id)
+        self._remember_streaming_message(
+            message_id=new_message_id,
+            chat_id=state.chat_id,
+            reply_to=state.reply_to,
+            metadata=state.metadata,
+            active_edit_count=0,
+        )
+        if previous_message_id and previous_message_id != new_message_id:
+            deleted = await self.delete_message(state.chat_id, previous_message_id)
+            if not deleted:
+                logger.debug(
+                    "[Feishu] Failed to delete retired streaming message %s after rollover",
+                    previous_message_id,
+                )
+        send_result.continuation_message_ids = (new_message_id,)
+        return send_result
+
     # =========================================================================
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
@@ -1766,7 +1898,16 @@ class FeishuAdapter(BasePlatformAdapter):
                     )
                 last_response = response
 
-            return self._finalize_send_result(last_response, "send failed")
+            result = self._finalize_send_result(last_response, "send failed")
+            if result.success and result.message_id:
+                self._remember_streaming_message(
+                    message_id=str(result.message_id),
+                    chat_id=chat_id,
+                    reply_to=reply_to,
+                    metadata=metadata,
+                    active_edit_count=0,
+                )
+            return result
         except Exception as exc:
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
@@ -1785,6 +1926,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
         content = self.format_message(content)
         try:
+            state = self._get_streaming_message_state(message_id=message_id, chat_id=chat_id)
+            if state.active_edit_count >= _FEISHU_STREAMING_MAX_SAFE_EDITS:
+                return await self._rollover_streaming_message(
+                    previous_message_id=message_id,
+                    state=state,
+                    content=content,
+                )
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
@@ -1801,10 +1949,56 @@ class FeishuAdapter(BasePlatformAdapter):
                 result = self._finalize_send_result(fallback_response, "update failed")
             if result.success:
                 result.message_id = message_id
+                state.active_edit_count += 1
+                if finalize:
+                    self._pop_streaming_message_state(message_id)
+                else:
+                    self._streaming_message_state[message_id] = state
+                return result
+            if self._looks_like_edit_limit_error(result.error or ""):
+                return await self._rollover_streaming_message(
+                    previous_message_id=message_id,
+                    state=state,
+                    content=content,
+                )
             return result
         except Exception as exc:
+            if self._looks_like_edit_limit_error(str(exc)):
+                state = self._get_streaming_message_state(message_id=message_id, chat_id=chat_id)
+                return await self._rollover_streaming_message(
+                    previous_message_id=message_id,
+                    state=state,
+                    content=content,
+                )
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Feishu message."""
+        if not self._client or not message_id:
+            return False
+        try:
+            request = self._build_delete_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.delete, request)
+            success = self._response_succeeded(response)
+            if success:
+                self._pop_streaming_message_state(message_id)
+                logger.debug(
+                    "[Feishu] Deleted message %s in chat %s",
+                    message_id,
+                    chat_id,
+                )
+            else:
+                logger.debug(
+                    "[Feishu] Delete message %s failed: [%s] %s",
+                    message_id,
+                    getattr(response, "code", "unknown"),
+                    getattr(response, "msg", "delete failed"),
+                )
+            return success
+        except Exception as exc:
+            logger.debug("[Feishu] Failed to delete message %s: %s", message_id, exc)
+            return False
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
@@ -4598,6 +4792,12 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_delete_message_request(message_id: str) -> Any:
+        if "DeleteMessageRequest" in globals():
+            return DeleteMessageRequest.builder().message_id(message_id).build()
+        return SimpleNamespace(message_id=message_id)
 
     @staticmethod
     def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -415,6 +415,129 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_rolls_over_before_feishu_edit_cap(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import (
+            FeishuAdapter,
+            _FEISHU_STREAMING_MAX_SAFE_EDITS,
+        )
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace())))
+        adapter._remember_streaming_message(
+            message_id="om_progress",
+            chat_id="oc_chat",
+            reply_to="om_parent",
+            metadata={"thread_id": "omt_thread"},
+            active_edit_count=_FEISHU_STREAMING_MAX_SAFE_EDITS,
+        )
+
+        with (
+            patch.object(
+                adapter,
+                "send",
+                new=AsyncMock(return_value=SimpleNamespace(
+                    success=True,
+                    message_id="om_replacement",
+                    continuation_message_ids=(),
+                )),
+            ) as mock_send,
+            patch.object(adapter, "delete_message", new=AsyncMock(return_value=True)) as mock_delete,
+        ):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content="stream update",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_replacement")
+        self.assertEqual(result.continuation_message_ids, ("om_replacement",))
+        mock_send.assert_awaited_once_with(
+            chat_id="oc_chat",
+            content="stream update",
+            reply_to="om_parent",
+            metadata={"thread_id": "omt_thread"},
+        )
+        mock_delete.assert_awaited_once_with("oc_chat", "om_progress")
+        self.assertNotIn("om_progress", adapter._streaming_message_state)
+        self.assertIn("om_replacement", adapter._streaming_message_state)
+        self.assertEqual(
+            adapter._streaming_message_state["om_replacement"].active_edit_count,
+            0,
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_message_rolls_over_on_feishu_edit_cap_error(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def update(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=230072,
+                    msg="The message has reached the number of times it can be edited.",
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+        adapter._remember_streaming_message(
+            message_id="om_progress",
+            chat_id="oc_chat",
+            reply_to="om_parent",
+            metadata={"thread_id": "omt_thread"},
+            active_edit_count=3,
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+            patch.object(
+                adapter,
+                "send",
+                new=AsyncMock(return_value=SimpleNamespace(
+                    success=True,
+                    message_id="om_replacement",
+                    continuation_message_ids=(),
+                )),
+            ) as mock_send,
+            patch.object(adapter, "delete_message", new=AsyncMock(return_value=True)) as mock_delete,
+        ):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                    content="stream update",
+                )
+            )
+
+        self.assertFalse(getattr(captured["request"].request_body, "msg_type", "") == "")
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_replacement")
+        self.assertEqual(result.continuation_message_ids, ("om_replacement",))
+        mock_send.assert_awaited_once_with(
+            chat_id="oc_chat",
+            content="stream update",
+            reply_to="om_parent",
+            metadata={"thread_id": "omt_thread"},
+        )
+        mock_delete.assert_awaited_once_with("oc_chat", "om_progress")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu streaming replies hitting the platform’s per-message edit cap.

Previously, Hermes could keep editing the same Feishu message until the API returned `[230072] The message has reached the number of times it can be edited.` At that point streaming could stall and fail to the non-streaming fallback. 

This change adds Feishu-only rollover logic: before a message reaches the hard cap, Hermes creates a replacement message, switches streaming to the new message, and deletes the old one so users do not see multiple partial streaming messages left behind.

This approach keeps the fix isolated to `gateway/platforms/feishu.py`, reuses the existing `continuation_message_ids` contract with `stream_consumer`, and avoids broader gateway changes.

## Related Issue

Fixes #16889 with minimal changes and without modifying `stream_consumer.py`, in order to minimize the impact surface and make merging easier.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Feishu streaming message rollover state in `gateway/platforms/feishu.py`
- Stop editing a Feishu streaming message after 19 successful edits, leaving 1 edit of safety margin before the platform cap
- On rollover, create a replacement message, return the new `message_id` via `continuation_message_ids`, and let the existing stream consumer continue on the new message
- Immediately delete the retired Feishu streaming message after the replacement message is created, to avoid multiple visible partial messages
- Added Feishu `delete_message()` support for message cleanup
- Narrowed edit-cap detection to Feishu’s specific error signal: code `230072` and the matching API message text
- Added debug-level logs for rollover and delete events

## How to Test

1. Enable gateway streaming on Feishu and trigger a long enough response to cause many incremental edits.
2. Confirm the streamed reply rolls over to a new Feishu message before hitting the hard edit cap, and the old partial message is deleted.
3. Verify logs show the rollover/delete debug entries and that streaming continues instead of stopping on `[230072] The message has reached the number of times it can be edited.` and triggers non-streaming fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Example Feishu error addressed by this fix:

```text
[Feishu] edit_message result: success=False error=[230072] The message has reached the number of times it can be edited.
```
