### PR TITLE
fix: support Linear webhook headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1,7 +1,7 @@
 """Generic webhook platform adapter.
 
 Runs an aiohttp HTTP server that receives webhook POSTs from external
-services (GitHub, GitLab, JIRA, Stripe, etc.), validates HMAC signatures,
+services (GitHub, GitLab, Linear, JIRA, Stripe, etc.), validates HMAC signatures,
 transforms payloads into agent prompts, and routes responses back to the
 source or to another configured platform.
 
@@ -391,6 +391,7 @@ class WebhookAdapter(BasePlatformAdapter):
         event_type = (
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
+            or request.headers.get("Linear-Event", "")
             or payload.get("event_type", "")
             or "unknown"
         )
@@ -442,9 +443,11 @@ class WebhookAdapter(BasePlatformAdapter):
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
         # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+        delivery_id = (
+            request.headers.get("X-GitHub-Delivery", "")
+            or request.headers.get("Linear-Delivery", "")
+            or request.headers.get("X-Request-ID", "")
+            or str(int(time.time() * 1000))
         )
 
         # ── Idempotency ─────────────────────────────────────────
@@ -589,7 +592,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Linear, generic HMAC-SHA256)."""
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
         gh_sig = request.headers.get("X-Hub-Signature-256", "")
         if gh_sig:
@@ -602,6 +605,14 @@ class WebhookAdapter(BasePlatformAdapter):
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
+
+        # Linear: Linear-Signature = <hex HMAC-SHA256>
+        linear_sig = request.headers.get("Linear-Signature", "")
+        if linear_sig:
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_sig, expected)
 
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -100,6 +100,11 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _linear_signature(body: bytes, secret: str) -> str:
+    """Compute Linear-Signature (plain HMAC-SHA256 hex) for *body*."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 # ===================================================================
 # Signature validation
 # ===================================================================
@@ -169,6 +174,22 @@ class TestValidateSignature:
         sig = _generic_signature(body, secret)
         req = _mock_request(headers={"X-Webhook-Signature": sig})
         assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_valid(self):
+        """Valid Linear-Signature (plain HMAC-SHA256 hex) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"type":"AgentSession","action":"created"}'
+        secret = "linear-webhook-secret"
+        sig = _linear_signature(body, secret)
+        req = _mock_request(headers={"Linear-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_invalid(self):
+        """Wrong Linear-Signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"type":"AgentSession","action":"created"}'
+        req = _mock_request(headers={"Linear-Signature": "deadbeef"})
+        assert adapter._validate_signature(req, body, "linear-webhook-secret") is False
 
 
 # ===================================================================
@@ -304,6 +325,30 @@ class TestEventFilter:
             )
             assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_event_filter_uses_linear_event_header(self):
+        """Linear-Event selects the event type for Linear webhooks."""
+        routes = {
+            "linear": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["AgentSession"],
+                "prompt": "Linear event: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/linear",
+                json={"action": "created"},
+                headers={"Linear-Event": "AgentSession"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["event"] == "AgentSession"
+
 
 # ===================================================================
 # HTTP handling
@@ -410,6 +455,27 @@ class TestIdempotency:
             assert resp2.status == 200
             data = await resp2.json()
             assert data["status"] == "duplicate"
+
+    @pytest.mark.asyncio
+    async def test_linear_delivery_header_is_used_for_idempotency(self):
+        """Linear-Delivery is used as the delivery/idempotency key."""
+        routes = {"linear": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"Linear-Delivery": "linear-delivery-123"}
+            resp1 = await cli.post("/webhooks/linear", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+            data1 = await resp1.json()
+            assert data1["delivery_id"] == "linear-delivery-123"
+
+            resp2 = await cli.post("/webhooks/linear", json={"a": 1}, headers=headers)
+            assert resp2.status == 200
+            data2 = await resp2.json()
+            assert data2["status"] == "duplicate"
+            assert data2["delivery_id"] == "linear-delivery-123"
 
     @pytest.mark.asyncio
     async def test_expired_delivery_id_allows_reprocess(self):


### PR DESCRIPTION
## Summary
- accept Linear-Signature for HMAC-SHA256 webhook validation
- use Linear-Event for route event filtering
- use Linear-Delivery as the idempotency/delivery key
- add focused webhook adapter tests for Linear headers

## Test Plan
- python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='
- ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py

## Review
- Independent subagent review: passed
