### PR TITLE
feat: harden Hermes operational paths

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -22,7 +22,7 @@ from typing import Optional, Dict, List, Any, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, normalize_attribution
 
 try:
     from croniter import croniter
@@ -69,6 +69,23 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     skills = _normalize_skill_list(normalized.get("skill"), normalized.get("skills"))
     normalized["skills"] = skills
     normalized["skill"] = skills[0] if skills else None
+
+    attribution_source = normalized.get("attribution") or normalized.get("origin") or normalized
+    attribution = normalize_attribution(
+        attribution_source,
+        run_type=normalized.get("run_type") or "cron",
+        actor=normalized.get("actor") or "cron",
+    )
+    existing_attribution = normalized.get("attribution") if isinstance(normalized.get("attribution"), dict) else {}
+    normalized["attribution"] = {
+        **attribution,
+        **{k: v for k, v in existing_attribution.items() if v not in (None, "")},
+    }
+    normalized.setdefault("source_platform", normalized["attribution"]["source_platform"])
+    normalized.setdefault("source_chat_id", normalized["attribution"]["source_chat_id"])
+    normalized.setdefault("source_thread_id", normalized["attribution"]["source_thread_id"])
+    normalized.setdefault("actor", normalized["attribution"]["actor"])
+    normalized.setdefault("run_type", normalized["attribution"]["run_type"])
     return normalized
 
 
@@ -479,6 +496,81 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
+def validate_cron_script_path(script: Optional[str]) -> Optional[str]:
+    """Return an error string if a cron script path is unsafe, else None.
+
+    Cron job scripts are intentionally constrained to relative paths under
+    ``HERMES_HOME/scripts``.  The scheduler has a second containment check at
+    execution time; this preflight catches bad job definitions before they are
+    persisted.
+    """
+    if script is None:
+        return None
+    raw = str(script).strip()
+    if not raw:
+        return None
+
+    if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
+        return (
+            "Script path must be relative to the Hermes scripts directory "
+            f"(got {raw!r}). Place scripts in ~/.hermes/scripts/ and use the relative filename."
+        )
+
+    scripts_dir = HERMES_DIR / "scripts"
+    scripts_dir_resolved = scripts_dir.resolve()
+    candidate = (scripts_dir / raw).resolve()
+    try:
+        candidate.relative_to(scripts_dir_resolved)
+    except ValueError:
+        return f"Script path escapes the scripts directory via traversal: {raw!r}"
+    return None
+
+
+def validate_job_definition(job_or_fields: Dict[str, Any]) -> Dict[str, Any]:
+    """Preflight a cron job definition and return status/errors/warnings.
+
+    This helper is deliberately small: errors block create/update, warnings are
+    operator-facing lint for risky-but-valid jobs that doctor/status can reuse.
+    """
+    fields = dict(job_or_fields or {})
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    no_agent = bool(fields.get("no_agent", False))
+    prompt = str(fields.get("prompt") or "").strip()
+    script = str(fields.get("script") or "").strip()
+    skills = _normalize_skill_list(fields.get("skill"), fields.get("skills"))
+
+    if no_agent:
+        if not script:
+            errors.append(
+                "no_agent=True requires a script — with no agent and no script there is nothing for the job to run."
+            )
+        if prompt or skills:
+            warnings.append("no_agent=True ignores prompt and skills; only script stdout is delivered.")
+    else:
+        if not prompt and not skills:
+            errors.append("agent cron job requires either prompt or at least one skill.")
+        if script:
+            warnings.append(
+                "script output will be injected into an LLM-run cron job; keep script stdout bounded and non-secret."
+            )
+
+    script_error = validate_cron_script_path(script)
+    if script_error:
+        errors.append(script_error)
+
+    status = "error" if errors else "warning" if warnings else "ok"
+    return {"status": status, "errors": errors, "warnings": warnings}
+
+
+def _raise_on_preflight_errors(fields: Dict[str, Any]) -> Dict[str, Any]:
+    preflight = validate_job_definition(fields)
+    if preflight["errors"]:
+        raise ValueError("; ".join(preflight["errors"]))
+    return preflight
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -575,15 +667,6 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
 
-    # no_agent jobs are meaningless without a script — the script IS the job.
-    # Surface this as a clear ValueError at create time so bad configs never
-    # reach the scheduler.
-    if normalized_no_agent and not normalized_script:
-        raise ValueError(
-            "no_agent=True requires a script — with no agent and no script "
-            "there is nothing for the job to run."
-        )
-
     # Normalize context_from: accept str or list of str, store as list or None
     if isinstance(context_from, str):
         context_from = [context_from.strip()] if context_from.strip() else None
@@ -594,6 +677,7 @@ def create_job(
 
     prompt_text = _coerce_job_text(prompt)
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
+    attribution = normalize_attribution(origin, run_type="cron", actor="cron")
     job = {
         "id": job_id,
         "name": name or label_source[:50].strip(),
@@ -625,9 +709,18 @@ def create_job(
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
+        # Flat attribution aliases keep operator provenance scannable without
+        # replacing legacy delivery/origin fields.
+        "attribution": attribution,
+        "source_platform": attribution["source_platform"],
+        "source_chat_id": attribution["source_chat_id"],
+        "source_thread_id": attribution["source_thread_id"],
+        "actor": attribution["actor"],
+        "run_type": attribution["run_type"],
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    _raise_on_preflight_errors(job)
 
     jobs = load_jobs()
     jobs.append(job)
@@ -669,6 +762,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
 
+        if "script" in updates:
+            _script = updates["script"]
+            updates["script"] = str(_script).strip() if isinstance(_script, str) else _script
+            if updates["script"] in (None, "", False):
+                updates["script"] = None
+
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates
 
@@ -694,6 +793,26 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
             updated["next_run_at"] = compute_next_run(updated["schedule"])
+
+        definition_fields = {
+            "prompt",
+            "skill",
+            "skills",
+            "script",
+            "no_agent",
+            "schedule",
+            "schedule_display",
+            "deliver",
+            "model",
+            "provider",
+            "base_url",
+            "context_from",
+            "enabled_toolsets",
+            "workdir",
+            "repeat",
+        }
+        if definition_fields.intersection(updates):
+            _raise_on_preflight_errors(updated)
 
         jobs[i] = updated
         save_jobs(jobs)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -64,7 +64,7 @@ from .whatsapp_identity import (
     canonical_whatsapp_identifier,
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
-from utils import atomic_replace
+from utils import atomic_replace, normalize_attribution
 
 
 @dataclass
@@ -136,6 +136,10 @@ class SessionSource:
             d["message_id"] = self.message_id
         return d
 
+    def attribution(self, *, run_type: str = "gateway", actor: Optional[str] = None) -> Dict[str, Optional[str]]:
+        """Flat provenance fields shared by gateway, cron, and delegation output."""
+        return normalize_attribution(self, run_type=run_type, actor=actor)
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
         return cls(
@@ -180,6 +184,7 @@ class SessionContext:
     def to_dict(self) -> Dict[str, Any]:
         return {
             "source": self.source.to_dict(),
+            "attribution": self.source.attribution(run_type="gateway"),
             "connected_platforms": [p.value for p in self.connected_platforms],
             "home_channels": {
                 p.value: hc.to_dict() for p, hc in self.home_channels.items()
@@ -521,6 +526,7 @@ class SessionEntry:
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
+            result["attribution"] = self.origin.attribution(run_type="gateway")
         return result
     
     @classmethod

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 import importlib.util
+import time
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -163,6 +164,46 @@ def check_fail(text: str, detail: str = ""):
 
 def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
+
+
+def _print_session_health(issues: list[str]) -> None:
+    """Print bounded, read-only session/token health checks."""
+    from hermes_cli.status import (
+        _collect_session_health,
+        _format_compact_tokens,
+    )
+
+    print()
+    print(color("◆ Session Store", Colors.CYAN, Colors.BOLD))
+    health = _collect_session_health(HERMES_HOME, now=time.time())
+    if not health.get("available"):
+        if health.get("reason") == "error":
+            check_warn("state.db session metadata unreadable")
+        else:
+            check_warn("state.db session store not found", "(no recorded sessions yet)")
+        return
+
+    check_ok(f"state.db sessions: {health.get('total_sessions', 0)}")
+    stale = int(health.get("stale_open_sessions") or 0)
+    open_count = int(health.get("open_sessions") or 0)
+    open_text = f"Open sessions: {open_count} ({stale} stale >24h)"
+    if stale:
+        check_warn(open_text)
+        issues.append("Review stale open sessions")
+    else:
+        check_ok(open_text)
+    checked_limit = health.get("limit", health.get("recent_count", 0))
+    check_info(
+        "Prompt budget: "
+        f"max input {_format_compact_tokens(health.get('max_input_tokens'))} tokens "
+        f"(last {checked_limit} sessions)"
+    )
+    check_info(
+        "Recent tokens: "
+        f"{_format_compact_tokens(health.get('recent_input_tokens'))} in / "
+        f"{_format_compact_tokens(health.get('recent_output_tokens'))} out "
+        f"(last {checked_limit} sessions)"
+    )
 
 
 def _check_gateway_service_linger(issues: list[str]) -> None:
@@ -1774,6 +1815,8 @@ def run_doctor(args):
                 check_warn(f"{_active_memory_provider} plugin not found", "run: hermes memory setup")
         except Exception as _e:
             check_warn(f"{_active_memory_provider} check failed", str(_e))
+
+    _print_session_health(issues)
 
     # =========================================================================
     # Profiles

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -8,6 +8,8 @@ import os
 import sys
 import subprocess  # noqa: F401 — re-exported for tests that monkeypatch status.subprocess to guard against regressions
 import importlib.util
+import sqlite3
+import time
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
@@ -56,6 +58,138 @@ def _format_iso_timestamp(value) -> str:
     except Exception:
         return value
     return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def _format_compact_tokens(value: int | float | None) -> str:
+    """Human-readable token count for bounded session health summaries."""
+    try:
+        count = int(value or 0)
+    except (TypeError, ValueError):
+        count = 0
+    if count >= 1_000_000:
+        return f"{count / 1_000_000:.1f}M"
+    if count >= 1_000:
+        return f"{count / 1_000:.1f}K"
+    return str(count)
+
+
+def _collect_session_health(hermes_home: Path | None = None, *, limit: int = 20, now: float | None = None) -> dict:
+    """Collect bounded, read-only session/token metadata from state.db.
+
+    Uses only the sessions table metadata and caps row reads to recent sessions;
+    it intentionally does not scan message bodies or mutate state.
+    """
+    home = hermes_home or get_hermes_home()
+    db_path = home / "state.db"
+    if not db_path.exists():
+        return {"available": False, "path": db_path, "reason": "missing"}
+
+    current_time = time.time() if now is None else now
+    stale_before = current_time - (24 * 60 * 60)
+    bounded_limit = max(1, min(int(limit), 100))
+    try:
+        uri = f"file:{db_path}?mode=ro"
+        with sqlite3.connect(uri, uri=True) as conn:
+            conn.row_factory = sqlite3.Row
+            totals = conn.execute(
+                """
+                SELECT
+                    COUNT(*) AS total_sessions,
+                    SUM(CASE WHEN ended_at IS NULL THEN 1 ELSE 0 END) AS open_sessions,
+                    SUM(CASE WHEN ended_at IS NULL AND started_at < ? THEN 1 ELSE 0 END) AS stale_open_sessions
+                FROM sessions
+                """,
+                (stale_before,),
+            ).fetchone()
+            recent = conn.execute(
+                """
+                SELECT id, source, model, started_at, ended_at, end_reason,
+                       message_count, input_tokens, output_tokens, cache_read_tokens,
+                       cache_write_tokens, reasoning_tokens, api_call_count, estimated_cost_usd
+                  FROM sessions
+                 ORDER BY COALESCE(started_at, 0) DESC
+                 LIMIT ?
+                """,
+                (bounded_limit,),
+            ).fetchall()
+    except Exception as exc:
+        return {"available": False, "path": db_path, "reason": "error", "error": str(exc)}
+
+    recent_rows = [dict(row) for row in recent]
+    max_input = max((int(row.get("input_tokens") or 0) for row in recent_rows), default=0)
+    max_total = max(
+        (
+            int(row.get("input_tokens") or 0)
+            + int(row.get("output_tokens") or 0)
+            + int(row.get("cache_read_tokens") or 0)
+            + int(row.get("cache_write_tokens") or 0)
+            + int(row.get("reasoning_tokens") or 0)
+            for row in recent_rows
+        ),
+        default=0,
+    )
+    total_input = sum(int(row.get("input_tokens") or 0) for row in recent_rows)
+    total_output = sum(int(row.get("output_tokens") or 0) for row in recent_rows)
+    return {
+        "available": True,
+        "path": db_path,
+        "limit": bounded_limit,
+        "total_sessions": int(totals["total_sessions"] or 0),
+        "open_sessions": int(totals["open_sessions"] or 0),
+        "stale_open_sessions": int(totals["stale_open_sessions"] or 0),
+        "recent_count": len(recent_rows),
+        "max_input_tokens": max_input,
+        "max_total_tokens": max_total,
+        "recent_input_tokens": total_input,
+        "recent_output_tokens": total_output,
+    }
+
+
+def _format_session_health_lines(health: dict) -> list[str]:
+    """Format status-friendly lines for bounded session health."""
+    if not health.get("available"):
+        if health.get("reason") == "error":
+            return ["Store:        state.db (error reading session metadata)"]
+        return ["Store:        state.db not found"]
+
+    total = health.get("total_sessions", 0)
+    open_count = health.get("open_sessions", 0)
+    stale_count = health.get("stale_open_sessions", 0)
+    recent_count = health.get("recent_count", 0)
+    limit = health.get("limit", recent_count)
+    lines = [
+        f"Store:        state.db ({total} sessions)",
+        f"Open:         {open_count} ({stale_count} stale >24h)",
+        (
+            "Prompt budget: "
+            f"max input {_format_compact_tokens(health.get('max_input_tokens'))} tokens "
+            f"(last {limit} sessions)"
+        ),
+        (
+            "Recent tokens: "
+            f"{_format_compact_tokens(health.get('recent_input_tokens'))} in / "
+            f"{_format_compact_tokens(health.get('recent_output_tokens'))} out "
+            f"(last {limit} sessions)"
+        ),
+    ]
+    return lines
+
+
+def _format_job_attribution_line(jobs: list[dict]) -> str:
+    """Summarize whether scheduled jobs carry normalized provenance fields."""
+    total = len(jobs)
+    if total == 0:
+        return "Attributed:   0/0 jobs"
+    attributed = sum(1 for job in jobs if job.get("run_type") or job.get("attribution"))
+    platforms = sorted(
+        {
+            str(job.get("source_platform") or (job.get("attribution") or {}).get("source_platform"))
+            for job in jobs
+            if job.get("source_platform") or (job.get("attribution") or {}).get("source_platform")
+        }
+    )
+    suffix = f" ({', '.join(platforms[:3])})" if platforms else ""
+    return f"Attributed:   {attributed}/{total} jobs{suffix}"
 
 
 def _configured_model_label(config: dict) -> str:
@@ -485,6 +619,7 @@ def show_status(args):
                 jobs = data.get("jobs", [])
                 enabled_jobs = [j for j in jobs if j.get("enabled", True)]
                 print(f"  Jobs:         {len(enabled_jobs)} active, {len(jobs)} total")
+                print(f"  {_format_job_attribution_line(jobs)}")
         except Exception:
             print("  Jobs:         (error reading jobs file)")
     else:
@@ -496,17 +631,19 @@ def show_status(args):
     print()
     print(color("◆ Sessions", Colors.CYAN, Colors.BOLD))
 
+    health = _collect_session_health(get_hermes_home())
+    for line in _format_session_health_lines(health):
+        print(f"  {line}")
+
     sessions_file = get_hermes_home() / "sessions" / "sessions.json"
-    if sessions_file.exists():
+    if not health.get("available") and sessions_file.exists():
         import json
         try:
             with open(sessions_file, encoding="utf-8") as f:
                 data = json.load(f)
-                print(f"  Active:       {len(data)} session(s)")
+                print(f"  Active:       {len(data)} session(s) in sessions.json")
         except Exception:
             print("  Active:       (error reading sessions file)")
-    else:
-        print("  Active:       0")
 
     # =========================================================================
     # Deep checks

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -85,9 +85,10 @@ def test_update_job_roundtrips_no_agent_flag(hermes_env):
     script_path.write_text("echo hi\n")
     job = create_job(prompt=None, schedule="every 5m", script="w.sh", no_agent=True, deliver="local")
 
-    update_job(job["id"], {"no_agent": False})
+    update_job(job["id"], {"no_agent": False, "prompt": "Summarize script output"})
     reloaded = get_job(job["id"])
     assert reloaded["no_agent"] is False
+    assert reloaded["prompt"] == "Summarize script output"
 
     update_job(job["id"], {"no_agent": True})
     reloaded = get_job(job["id"])

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -4,7 +4,7 @@ Tests cover:
 - Script field in job creation / storage / update
 - Script execution and output injection into prompts
 - Error handling (missing script, timeout, non-zero exit)
-- Path resolution (absolute, relative to HERMES_HOME/scripts/)
+- Path resolution (relative to HERMES_HOME/scripts/; unsafe absolute paths block at job definition time)
 """
 
 import json
@@ -50,12 +50,12 @@ class TestJobScriptField:
         job = create_job(
             prompt="Analyze the data",
             schedule="every 30m",
-            script="/path/to/monitor.py",
+            script="monitor.py",
         )
-        assert job["script"] == "/path/to/monitor.py"
+        assert job["script"] == "monitor.py"
 
         loaded = get_job(job["id"])
-        assert loaded["script"] == "/path/to/monitor.py"
+        assert loaded["script"] == "monitor.py"
 
     def test_create_job_without_script(self, cron_env):
         from cron.jobs import create_job
@@ -75,14 +75,14 @@ class TestJobScriptField:
         job = create_job(prompt="Hello", schedule="every 1h")
         assert job.get("script") is None
 
-        updated = update_job(job["id"], {"script": "/new/script.py"})
-        assert updated["script"] == "/new/script.py"
+        updated = update_job(job["id"], {"script": "script.py"})
+        assert updated["script"] == "script.py"
 
     def test_update_job_clear_script(self, cron_env):
         from cron.jobs import create_job, update_job
 
-        job = create_job(prompt="Hello", schedule="every 1h", script="/some/script.py")
-        assert job["script"] == "/some/script.py"
+        job = create_job(prompt="Hello", schedule="every 1h", script="script.py")
+        assert job["script"] == "script.py"
 
         updated = update_job(job["id"], {"script": None})
         assert updated.get("script") is None
@@ -144,6 +144,7 @@ class TestRunJobScript:
         assert success is True
         assert output == ""
 
+    @pytest.mark.live_system_guard_bypass
     def test_script_timeout(self, cron_env, monkeypatch):
         from cron import scheduler as sched_mod
         from cron.scheduler import _run_job_script
@@ -213,6 +214,18 @@ class TestBuildJobPromptWithScript:
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
+    def test_script_empty_output_skips_agent_call(self, cron_env):
+        from cron.scheduler import _build_job_prompt
+
+        script = cron_env / "scripts" / "noop.py"
+        script.write_text("# nothing\n")
+
+        job = {
+            "prompt": "Check status.",
+            "script": str(script),
+        }
+        prompt = _build_job_prompt(job)
+        assert prompt is None
 
 
 class TestCronjobToolScript:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,6 +24,7 @@ from cron.jobs import (
     advance_next_run,
     get_due_jobs,
     save_job_output,
+    validate_job_definition,
 )
 
 
@@ -254,6 +255,72 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_create_job_adds_flat_attribution_without_replacing_origin(self, tmp_cron_dir):
+        origin = {
+            "platform": "telegram",
+            "chat_id": "123",
+            "thread_id": "topic-7",
+            "user_name": "Don",
+        }
+        job = create_job(prompt="Test", schedule="30m", origin=origin)
+
+        assert job["origin"] == origin
+        assert job["attribution"] == {
+            "source_platform": "telegram",
+            "source_chat_id": "123",
+            "source_thread_id": "topic-7",
+            "actor": "cron",
+            "run_type": "cron",
+        }
+        assert job["source_platform"] == "telegram"
+        assert job["source_chat_id"] == "123"
+        assert job["source_thread_id"] == "topic-7"
+        assert job["actor"] == "cron"
+        assert job["run_type"] == "cron"
+
+    def test_list_jobs_backfills_flat_attribution_for_legacy_jobs(self, tmp_cron_dir):
+        save_jobs([
+            {
+                "id": "legacy",
+                "prompt": "Test",
+                "skill": None,
+                "schedule": {"kind": "interval", "minutes": 30},
+                "enabled": True,
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+        ])
+
+        job = list_jobs()[0]
+
+        assert job["origin"] == {"platform": "telegram", "chat_id": "123"}
+        assert job["attribution"]["source_platform"] == "telegram"
+        assert job["source_chat_id"] == "123"
+        assert job["actor"] == "cron"
+        assert job["run_type"] == "cron"
+
+    def test_create_agent_job_requires_prompt_or_skill(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="requires either prompt or at least one skill"):
+            create_job(prompt="", schedule="every 1h")
+
+    def test_create_job_rejects_unsafe_script_path(self, tmp_cron_dir):
+        with pytest.raises(ValueError, match="scripts directory"):
+            create_job(prompt="collect data", schedule="every 1h", script="../escape.sh")
+
+    def test_validate_job_definition_returns_warnings_without_errors(self, tmp_cron_dir):
+        result = validate_job_definition(
+            {
+                "prompt": "Summarize script output",
+                "schedule": {"kind": "interval", "minutes": 60},
+                "script": "collector.py",
+                "no_agent": False,
+                "deliver": "telegram:12345",
+            }
+        )
+
+        assert result["status"] == "warning"
+        assert result["errors"] == []
+        assert result["warnings"]
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -299,6 +366,18 @@ class TestUpdateJob:
     def test_update_nonexistent_returns_none(self, tmp_cron_dir):
         result = update_job("nonexistent_id", {"name": "X"})
         assert result is None
+
+    def test_update_job_rejects_effective_no_agent_without_script(self, tmp_cron_dir):
+        job = create_job(prompt="Run normally", schedule="every 1h")
+
+        with pytest.raises(ValueError, match="no_agent=True requires a script"):
+            update_job(job["id"], {"no_agent": True})
+
+    def test_update_job_rejects_effective_agent_without_prompt_or_skill(self, tmp_cron_dir):
+        job = create_job(prompt="Run normally", schedule="every 1h")
+
+        with pytest.raises(ValueError, match="requires either prompt or at least one skill"):
+            update_job(job["id"], {"prompt": "", "skills": [], "skill": None})
 
 
 class TestPauseResumeJob:

--- a/tests/cron/test_rewrite_skill_refs.py
+++ b/tests/cron/test_rewrite_skill_refs.py
@@ -223,7 +223,7 @@ class TestRewriteSkillRefsMultipleJobs:
 
         j1 = create_job(prompt="", schedule="every 1h", skills=["legacy"])
         j2 = create_job(prompt="", schedule="every 1h", skills=["untouched"])
-        j3 = create_job(prompt="", schedule="every 1h", skills=[])
+        j3 = create_job(prompt="No skill job", schedule="every 1h", skills=[])
 
         report = rewrite_skill_refs(
             consolidated={"legacy": "umbrella"},

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -77,6 +77,37 @@ class TestSessionSourceRoundtrip:
         assert restored.chat_id == "12345"
         assert isinstance(restored.chat_id, str)
 
+    def test_source_attribution_uses_flat_operator_fields(self):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            user_name="alice",
+            thread_id="topic-7",
+        )
+
+        attribution = source.attribution()
+
+        assert attribution == {
+            "source_platform": "telegram",
+            "source_chat_id": "12345",
+            "source_thread_id": "topic-7",
+            "actor": "alice",
+            "run_type": "gateway",
+        }
+
+    def test_context_dict_includes_legacy_source_and_flat_attribution(self):
+        config = GatewayConfig()
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345")
+        context = build_session_context(source, config)
+
+        data = context.to_dict()
+
+        assert data["source"]["platform"] == "telegram"
+        assert data["source"]["chat_id"] == "12345"
+        assert data["attribution"]["source_platform"] == "telegram"
+        assert data["attribution"]["source_chat_id"] == "12345"
+        assert data["attribution"]["run_type"] == "gateway"
+
     def test_missing_optional_fields(self):
         restored = SessionSource.from_dict({
             "platform": "discord",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -5,6 +5,8 @@ import sys
 import types
 import io
 import contextlib
+import sqlite3
+import time
 from argparse import Namespace
 from types import SimpleNamespace
 
@@ -14,6 +16,57 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+from hermes_state import SessionDB
+
+
+def _write_session_health_fixture(home, *, now=None):
+    now = now or time.time()
+    home.mkdir(parents=True, exist_ok=True)
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session("recent-high", source="cli", model="test-model")
+        db.update_token_counts("recent-high", input_tokens=25_000, output_tokens=2_000)
+        db.create_session("recent-open", source="telegram", model="test-model")
+        db.update_token_counts("recent-open", input_tokens=5_000, output_tokens=500)
+        db.create_session("stale-open", source="cron", model="test-model")
+        db.update_token_counts("stale-open", input_tokens=1_000, output_tokens=100)
+
+        conn = sqlite3.connect(home / "state.db")
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 90_000, "stale-open"),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 60, "recent-high"),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 30, "recent-open"),
+        )
+        conn.commit()
+        conn.close()
+    finally:
+        db.close()
+
+
+class TestDoctorSessionHealth:
+    def test_prints_bounded_session_health_and_stale_warning(self, monkeypatch, capsys, tmp_path):
+        home = tmp_path / ".hermes"
+        _write_session_health_fixture(home, now=1_700_000_000)
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod.time, "time", lambda: 1_700_000_000, raising=False)
+
+        issues = []
+        doctor_mod._print_session_health(issues)
+
+        output = capsys.readouterr().out
+        assert "Session Store" in output
+        assert "state.db sessions: 3" in output
+        assert "Open sessions: 3 (1 stale >24h)" in output
+        assert "Prompt budget: max input 25.0K tokens" in output
+        assert "last 20 sessions" in output
+        assert "Review stale open sessions" in issues
 
 
 class TestDoctorPlatformHints:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,17 +1,67 @@
+import sqlite3
+import time
 from types import SimpleNamespace
 
-from hermes_cli.status import show_status
+from hermes_cli.status import _format_job_attribution_line, show_status
+from hermes_state import SessionDB
+
+
+def _write_session_health_fixture(home, *, now=None):
+    now = now or time.time()
+    home.mkdir(parents=True, exist_ok=True)
+    db = SessionDB(db_path=home / "state.db")
+    try:
+        db.create_session("recent-high", source="cli", model="test-model")
+        db.update_token_counts("recent-high", input_tokens=25_000, output_tokens=2_000)
+
+        db.create_session("recent-open", source="telegram", model="test-model")
+        db.update_token_counts("recent-open", input_tokens=5_000, output_tokens=500)
+
+        db.create_session("stale-open", source="cron", model="test-model")
+        db.update_token_counts("stale-open", input_tokens=1_000, output_tokens=100)
+
+        conn = sqlite3.connect(home / "state.db")
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 90_000, "stale-open"),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 60, "recent-high"),
+        )
+        conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (now - 30, "recent-open"),
+        )
+        conn.commit()
+        conn.close()
+    finally:
+        db.close()
 
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_format_job_attribution_line_summarizes_normalized_provenance():
+    jobs = [
+        {
+            "run_type": "cron",
+            "source_platform": "telegram",
+            "source_chat_id": "123",
+        },
+        {"attribution": {"run_type": "cron", "source_platform": "discord"}},
+        {"prompt": "legacy job"},
+    ]
+
+    assert _format_job_attribution_line(jobs) == "Attributed:   2/3 jobs (discord, telegram)"
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
@@ -109,3 +159,33 @@ def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_pa
     assert "oidc-token" not in output
     assert "snapshot filesystem" in output
     assert "live processes do not survive" in output
+
+
+def test_show_status_reports_bounded_session_health_from_state_db(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    home = tmp_path / ".hermes"
+    _write_session_health_fixture(home, now=1_700_000_000)
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: home / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: home, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(status_mod.time, "time", lambda: 1_700_000_000, raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Store:        state.db (3 sessions)" in output
+    assert "Open:         3 (1 stale >24h)" in output
+    assert "Prompt budget:" in output
+    assert "max input 25.0K tokens" in output
+    assert "last 20 sessions" in output

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -279,6 +279,46 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["skills"] == []
         assert updated["job"]["skill"] is None
 
+    def test_update_rejects_effective_agent_job_without_prompt_or_skill(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Check status", schedule="every 1h")
+        )
+        assert created["success"] is True
+
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], prompt="", skills=[])
+        )
+
+        assert result["success"] is False
+        assert "prompt" in result["error"].lower()
+
+    def test_create_surfaces_non_blocking_preflight_warnings(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Summarize collector output",
+                schedule="every 1h",
+                script="collector.py",
+                deliver="telegram:12345",
+            )
+        )
+
+        assert created["success"] is True
+        assert created["warnings"]
+
+    def test_update_surfaces_non_blocking_preflight_warnings(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Check status", schedule="every 1h")
+        )
+        assert created["success"] is True
+
+        updated = json.loads(
+            cronjob(action="update", job_id=created["job_id"], script="collector.py")
+        )
+
+        assert updated["success"] is True
+        assert updated["warnings"]
+
     def test_create_normalizes_list_form_deliver(self):
         """deliver=['telegram'] (list) is stored as the string 'telegram'.
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -196,7 +196,36 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(len(result["results"]), 1)
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "Done!")
+        self.assertEqual(result["results"][0]["run_type"], "delegate")
+        self.assertEqual(result["results"][0]["actor"], "subagent")
+        self.assertEqual(result["results"][0]["source_platform"], "cli")
+        self.assertEqual(result["results"][0]["attribution"]["run_type"], "delegate")
         mock_run.assert_called_once()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_attribution_uses_parent_source_fields(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+        parent.platform = "telegram"
+        parent.chat_id = "123"
+        parent.thread_id = "topic-7"
+        parent.user_name = "Don"
+
+        result = json.loads(delegate_task(goal="Trace source", parent_agent=parent))
+        entry = result["results"][0]
+
+        self.assertEqual(entry["source_platform"], "telegram")
+        self.assertEqual(entry["source_chat_id"], "123")
+        self.assertEqual(entry["source_thread_id"], "topic-7")
+        self.assertEqual(entry["actor"], "subagent")
+        self.assertEqual(entry["run_type"], "delegate")
+        self.assertEqual(entry["attribution"]["source_platform"], "telegram")
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
@@ -555,6 +584,77 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertIn("result_bytes", entry["tool_trace"][0])
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
 
+            # Acceptance gate metadata is additive/backward-compatible.
+            self.assertEqual(entry["acceptance_disposition"], "Done")
+            self.assertEqual(entry["acceptance"]["disposition"], "Done")
+            self.assertEqual(entry["acceptance"]["warnings"], [])
+
+    def test_acceptance_disposition_revision_needed_for_high_risk_self_certification(self):
+        """High-risk delegated work that self-certifies without proof gets a non-blocking warning."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "Done.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Edit files and run tests", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["acceptance_disposition"], "Revision Needed")
+            self.assertTrue(
+                any("proof" in warning.lower() for warning in entry["acceptance"]["warnings"])
+            )
+
+    def test_acceptance_disposition_revision_needed_for_empty_summary(self):
+        """An empty child summary is an output-quality failure, not a useful Done."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Summarize findings", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "failed")
+            self.assertEqual(entry["acceptance_disposition"], "Revision Needed")
+
+    def test_acceptance_disposition_failed_for_child_exception(self):
+        """Runtime child errors classify as Failed."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.side_effect = RuntimeError("boom")
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Trigger error", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "error")
+            self.assertEqual(entry["acceptance_disposition"], "Failed")
+
     def test_tool_trace_detects_error(self):
         """Tool results containing 'error' should be marked as error status."""
         parent = _make_mock_parent(depth=0)
@@ -873,7 +973,50 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolves_full_credentials(self, mock_resolve):
+        """When delegation.provider is set, full credentials are resolved."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(creds["api_key"], "sk-or-test-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(
+            requested="openrouter",
+            target_model="google/gemini-3-flash-preview",
+        )
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_uses_runtime_model_when_config_model_missing(self, mock_resolve):
+        """Named providers should propagate their runtime default model to children."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "https://my-server.example/v1",
+            "api_key": "sk-test-key",
+            "api_mode": "chat_completions",
+            "model": "server-default-model",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"provider": "custom:my-server", "model": ""}
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], "server-default-model")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://my-server.example/v1")
+        mock_resolve.assert_called_once_with(
+            requested="custom:my-server",
+            target_model=None,
+        )
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -922,6 +1065,25 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
+        """Nous provider resolves Nous Portal base_url and api_key."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-agent-key-xyz",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "hermes-3-llama-3.1-8b", "provider": "nous"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
+        mock_resolve.assert_called_once_with(
+            requested="nous",
+            target_model="hermes-3-llama-3.1-8b",
+        )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -1622,20 +1784,22 @@ class TestDelegateHeartbeat(unittest.TestCase):
         }
 
         def slow_run(**kwargs):
-            # Long enough to exceed the OLD idle threshold (5 cycles) at
-            # the patched interval, but shorter than the new in-tool
-            # threshold.
-            time.sleep(0.4)
+            # Long enough to exceed the patched idle threshold (5 cycles) at
+            # the patched interval, but shorter than the patched in-tool
+            # threshold. Keep enough margin for import/thread scheduling jitter.
+            time.sleep(1.0)
             return {"final_response": "done", "completed": True, "api_calls": 1}
 
         child.run_conversation.side_effect = slow_run
 
-        # Patch both the interval AND the idle ceiling so the test proves
+        # Patch the interval and stale ceilings so the test proves
         # the in-tool branch takes effect: with a 0.05s interval and the
-        # default _HEARTBEAT_STALE_CYCLES_IDLE=5, the old behavior would
+        # patched _HEARTBEAT_STALE_CYCLES_IDLE=5, the old behavior would
         # trip after 0.25s and stop firing. We should see heartbeats
-        # continuing through the full 0.4s run.
-        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05):
+        # continuing through the full 1.0s run.
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05), \
+             patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 5), \
+             patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IN_TOOL", 20):
             _run_single_child(
                 task_index=0,
                 goal="Test long-running tool",
@@ -1644,14 +1808,62 @@ class TestDelegateHeartbeat(unittest.TestCase):
             )
 
         # With the old idle threshold (5 cycles = 0.25s), touch_calls
-        # would cap at ~5. With the in-tool threshold (20 cycles = 1.0s),
-        # we should see substantially more heartbeats over 0.4s.
-        self.assertGreater(
+        # would cap at ~5. With the patched in-tool threshold (20 cycles = 1.0s),
+        # we should see heartbeats continue past the idle cap.
+        self.assertGreaterEqual(
             len(touch_calls), 6,
             f"Heartbeat stopped too early while child was inside a tool; "
-            f"got {len(touch_calls)} touches over 0.4s at 0.05s interval",
+            f"got {len(touch_calls)} touches over 1.0s at 0.05s interval",
         )
 
+    def test_heartbeat_still_trips_idle_stale_when_no_tool(self):
+        """A wedged child with no current_tool still trips the idle threshold.
+
+        Regression guard: the fix for #13041 must not disable stale
+        detection entirely. A child that's hung between turns (no tool
+        running, no iteration progress) must still stop touching the
+        parent so the gateway timeout can fire.
+        """
+        from tools.delegate_tool import _run_single_child
+
+        parent = _make_mock_parent()
+        touch_calls = []
+        parent._touch_activity = lambda desc: touch_calls.append(desc)
+
+        child = MagicMock()
+        # Wedged child: no tool running, iteration frozen.
+        child.get_activity_summary.return_value = {
+            "current_tool": None,
+            "api_call_count": 3,
+            "max_iterations": 50,
+            "last_activity_desc": "waiting for API response",
+        }
+
+        def slow_run(**kwargs):
+            time.sleep(0.6)
+            return {"final_response": "done", "completed": True, "api_calls": 3}
+
+        child.run_conversation.side_effect = slow_run
+
+        # At interval 0.05s, idle threshold (5 cycles) trips at ~0.25s.
+        # We should see the heartbeat stop firing well before 0.6s.
+        with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.05), \
+             patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 5):
+            _run_single_child(
+                task_index=0,
+                goal="Test wedged child",
+                child=child,
+                parent_agent=parent,
+            )
+
+        # With idle threshold=5 + interval=0.05s, touches should cap
+        # around 5. Bound loosely to avoid timing flakes.
+        self.assertLess(
+            len(touch_calls), 9,
+            f"Idle stale detection did not fire: got {len(touch_calls)} "
+            f"touches over 0.6s — expected heartbeat to stop after "
+            f"~5 stale cycles",
+        )
 
 
 class TestDelegationReasoningEffort(unittest.TestCase):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -30,6 +30,7 @@ from cron.jobs import (
     resume_job,
     trigger_job,
     update_job,
+    validate_job_definition,
 )
 
 
@@ -369,6 +370,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
             )
+            preflight = validate_job_definition(job)
             return json.dumps(
                 {
                     "success": True,
@@ -380,6 +382,7 @@ def cronjob(
                     "repeat": _repeat_display(job),
                     "deliver": job.get("deliver", "local"),
                     "next_run_at": job["next_run_at"],
+                    "warnings": preflight["warnings"],
                     "job": _format_job(job),
                     "message": f"Cron job '{job['name']}' created.",
                 },
@@ -511,7 +514,8 @@ def cronjob(
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)
-            return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
+            preflight = validate_job_definition(updated)
+            return json.dumps({"success": True, "job": _format_job(updated), "warnings": preflight["warnings"]}, indent=2)
 
         return tool_error(f"Unknown cron action '{action}'", success=False)
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional
 from toolsets import TOOLSETS
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
-from utils import base_url_hostname, is_truthy_value
+from utils import base_url_hostname, is_truthy_value, normalize_attribution
 
 
 # Tools that children must never have access to
@@ -302,6 +302,144 @@ def _looks_like_error_output(content: str) -> bool:
         or first.startswith("traceback ")
         or first.startswith("exception:")
     )
+
+
+def _infer_acceptance_disposition(
+    entry: Dict[str, Any],
+    goal: str = "",
+) -> Dict[str, Any]:
+    """Classify a child result for parent-side acceptance triage.
+
+    This is intentionally advisory.  It never changes the legacy child
+    ``status``/``summary`` fields and it does not fail delegation when proof is
+    missing; it only adds a disposition and warnings for the parent to inspect.
+    """
+    status = str(entry.get("status") or "").strip().lower()
+    exit_reason = str(entry.get("exit_reason") or "").strip().lower()
+    summary = str(entry.get("summary") or "").strip()
+    goal_text = str(goal or "").strip().lower()
+    summary_text = summary.lower()
+    tool_trace = entry.get("tool_trace") if isinstance(entry.get("tool_trace"), list) else []
+
+    warnings: List[str] = []
+    evidence: List[str] = []
+
+    if summary:
+        evidence.append("summary")
+    if tool_trace:
+        evidence.append("tool_trace")
+    if isinstance(entry.get("diagnostic_path"), str) and entry.get("diagnostic_path"):
+        evidence.append("diagnostic_path")
+
+    hard_failure_statuses = {"error", "timeout", "interrupted"}
+    if status in hard_failure_statuses or exit_reason in hard_failure_statuses:
+        if status == "timeout":
+            warnings.append("Child timed out before producing accepted work.")
+        elif status == "interrupted":
+            warnings.append("Child was interrupted before producing accepted work.")
+        else:
+            warnings.append("Child returned an execution error.")
+        return {
+            "disposition": "Failed",
+            "warnings": warnings,
+            "evidence": evidence,
+        }
+
+    if not summary:
+        warnings.append("Child did not produce a final summary for parent review.")
+        return {
+            "disposition": "Revision Needed",
+            "warnings": warnings,
+            "evidence": evidence,
+        }
+
+    if status not in {"completed", ""}:
+        warnings.append(f"Child status is {status!r}, not 'completed'.")
+
+    if exit_reason == "max_iterations":
+        warnings.append("Child hit max_iterations; review the summary before accepting.")
+
+    if any(
+        isinstance(t, dict) and str(t.get("status") or "").lower() == "error"
+        for t in tool_trace
+    ):
+        warnings.append("Child tool trace includes at least one tool error.")
+
+    high_risk_terms = (
+        "edit", "modify", "patch", "write", "implement", "code", "test",
+        "verify", "file", "create", "delete", "deploy", "migrate", "update",
+    )
+    proof_terms = (
+        "test", "passed", "verified", "diff", "path", "file", "artifact",
+        "http", "status", "screenshot", "log", "output", "commit",
+    )
+    high_risk = any(term in goal_text for term in high_risk_terms)
+    has_proof = bool(tool_trace) or any(term in summary_text for term in proof_terms)
+    if high_risk and not has_proof:
+        warnings.append(
+            "High-risk delegated work lacks proof/artifact evidence; parent should verify before accepting."
+        )
+
+    return {
+        "disposition": "Revision Needed" if warnings else "Done",
+        "warnings": warnings,
+        "evidence": evidence,
+    }
+
+
+def _annotate_acceptance_disposition(
+    entry: Dict[str, Any],
+    goal: str = "",
+) -> Dict[str, Any]:
+    """Add advisory acceptance metadata to a delegate result in-place."""
+    acceptance = _infer_acceptance_disposition(entry, goal)
+    entry["acceptance"] = acceptance
+    # Flat alias for clients that prefer a simple field; legacy fields remain.
+    entry["acceptance_disposition"] = acceptance["disposition"]
+    return entry
+
+
+def _parent_attribution_source(parent_agent: Any) -> Dict[str, Any]:
+    """Extract best-effort source fields from the parent without coupling to gateway types."""
+    if parent_agent is None:
+        return {}
+    known_attrs = getattr(parent_agent, "__dict__", {}) or {}
+    for attr in ("session_source", "_session_source", "source", "origin"):
+        source = known_attrs.get(attr)
+        if source is not None:
+            return source
+    session_context = known_attrs.get("session_context") or known_attrs.get(
+        "_session_context"
+    )
+    source = getattr(session_context, "source", None)
+    if source:
+        return source
+    return {
+        "platform": known_attrs.get("platform"),
+        "chat_id": known_attrs.get("chat_id"),
+        "thread_id": known_attrs.get("thread_id"),
+        "user_name": known_attrs.get("user_name"),
+        "user_id": known_attrs.get("user_id"),
+    }
+
+
+def _annotate_delegate_attribution(
+    entry: Dict[str, Any],
+    parent_agent: Any,
+) -> Dict[str, Any]:
+    """Add normalized, flat provenance fields to a delegate result in-place."""
+    attribution = normalize_attribution(
+        _parent_attribution_source(parent_agent),
+        run_type="delegate",
+        actor="subagent",
+    )
+    entry["attribution"] = attribution
+    entry["source_platform"] = attribution["source_platform"]
+    entry["source_chat_id"] = attribution["source_chat_id"]
+    entry["source_thread_id"] = attribution["source_thread_id"]
+    entry["actor"] = attribution["actor"]
+    entry["run_type"] = attribution["run_type"]
+    return entry
 
 
 def _normalize_role(r: Optional[str]) -> str:
@@ -2191,6 +2329,24 @@ def delegate_task(
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])
+
+    # Add non-blocking parent-side acceptance metadata and normalized source
+    # attribution to every child result. Both are additive only: legacy fields
+    # (status, summary, error, etc.) stay unchanged for existing clients.
+    for entry in results:
+        try:
+            _annotate_delegate_attribution(entry, parent_agent)
+        except Exception:
+            logger.debug("delegate attribution annotation failed", exc_info=True)
+        try:
+            _task_goal = (
+                task_list[entry["task_index"]]["goal"]
+                if entry.get("task_index", -1) < len(task_list)
+                else ""
+            )
+            _annotate_acceptance_disposition(entry, _task_goal)
+        except Exception:
+            logger.debug("acceptance disposition annotation failed", exc_info=True)
 
     # Notify parent's memory provider of delegation outcomes
     if (

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ import os
 import stat
 import tempfile
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
 
 import yaml
@@ -31,6 +31,61 @@ def is_truthy_value(value: Any, default: bool = False) -> bool:
 def env_var_enabled(name: str, default: str = "") -> bool:
     """Return True when an environment variable is set to a truthy value."""
     return is_truthy_value(os.getenv(name, default), default=False)
+
+
+def _attribution_value(value: Any) -> Optional[str]:
+    """Return a string value suitable for operator-facing attribution fields."""
+    if value in (None, ""):
+        return None
+    enum_value = getattr(value, "value", None)
+    if enum_value not in (None, ""):
+        return str(enum_value)
+    return str(value)
+
+
+def normalize_attribution(
+    source: Any = None,
+    *,
+    run_type: str,
+    actor: Optional[str] = None,
+) -> Dict[str, Optional[str]]:
+    """Normalize provenance fields across gateway, cron, and delegation surfaces.
+
+    This is deliberately small and schema-free: callers keep their legacy
+    fields, then add these flat aliases so operators can scan where a run came
+    from without learning every subsystem's naming convention.
+    """
+
+    def get_value(key: str) -> Any:
+        if isinstance(source, dict):
+            return source.get(key)
+        if source is not None:
+            return getattr(source, key, None)
+        return None
+
+    source_platform = _attribution_value(
+        get_value("source_platform") or get_value("platform")
+    )
+    source_chat_id = _attribution_value(
+        get_value("source_chat_id") or get_value("chat_id")
+    )
+    source_thread_id = _attribution_value(
+        get_value("source_thread_id") or get_value("thread_id")
+    )
+    resolved_actor = _attribution_value(
+        actor
+        or get_value("actor")
+        or get_value("user_name")
+        or get_value("user_id")
+    )
+
+    return {
+        "source_platform": source_platform,
+        "source_chat_id": source_chat_id,
+        "source_thread_id": source_thread_id,
+        "actor": resolved_actor,
+        "run_type": _attribution_value(run_type),
+    }
 
 
 def _preserve_file_mode(path: Path) -> "int | None":


### PR DESCRIPTION
## Summary
- Add cron job definition validation/preflight warnings for risky or incomplete scheduled jobs
- Surface operational health signals in `hermes status` / `hermes doctor`
- Add delegate child-result acceptance disposition metadata while preserving existing result fields
- Normalize/source-attribution helpers where existing gateway/session data already exists

## Test Plan
- `python -m pytest tests/cron/test_cron_no_agent.py tests/cron/test_cron_script.py tests/cron/test_jobs.py tests/cron/test_rewrite_skill_refs.py tests/gateway/test_session.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_status.py tests/tools/test_cronjob_tools.py tests/tools/test_delegate.py -o 'addopts=' -q`
- Result: 441 passed

## Notes
- Published from `zurbrick/hermes-agent` fork because upstream permission is read-only.
- Internal planning docs were intentionally excluded from the PR branch; this PR contains code and tests only.
