### PR TITLE
fix(copilot): remove gh auth token fallback to prevent false positive availability

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -82,15 +82,13 @@ def resolve_copilot_token() -> tuple[str, str]:
                 continue
             return val, env_var
 
-    # 2. Fall back to gh auth token
-    token = _try_gh_cli_token()
-    if token:
-        valid, msg = validate_copilot_token(token)
-        if not valid:
-            raise ValueError(
-                f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
-            )
-        return token, "gh auth token"
+    # 2. Do NOT fall back to gh auth token.
+    # gh auth token provides a GitHub API token (repo access), NOT a Copilot
+    # API token. Users with gh installed but without an active Copilot
+    # subscription were getting Copilot models listed as "available" when
+    # they weren't actually usable. Users who want Copilot must explicitly
+    # set COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN, or use the
+    # OAuth device code flow.
 
     return "", ""
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -358,13 +358,15 @@ class TestApiKeyProviderStatus:
         assert status["configured"] is True
         assert status["base_url"] == STEPFUN_STEP_PLAN_CN_BASE_URL
 
-    def test_copilot_status_uses_gh_cli_token(self, monkeypatch):
+    def test_copilot_status_ignores_gh_cli_token(self, monkeypatch):
+        """gh auth token alone should NOT make Copilot appear configured."""
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_gh_cli_token")
         status = get_api_key_provider_status("copilot")
-        assert status["configured"] is True
-        assert status["logged_in"] is True
-        assert status["key_source"] == "gh auth token"
-        assert status["base_url"] == "https://api.githubcopilot.com"
+        assert status["configured"] is False
+        assert status["logged_in"] is False
 
     def test_get_auth_status_dispatches_to_api_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
@@ -421,13 +423,17 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "https://api.githubcopilot.com"
         assert creds["source"] == "GITHUB_TOKEN"
 
-    def test_resolve_copilot_with_gh_cli_fallback(self, monkeypatch):
+    def test_resolve_copilot_ignores_gh_cli_fallback(self, monkeypatch):
+        """gh auth token is no longer used as Copilot credential source."""
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gho_cli_secret"
-        assert creds["base_url"] == "https://api.githubcopilot.com"
-        assert creds["source"] == "gh auth token"
+        assert creds["api_key"] == ""
+        # source falls back to "default" when key_source is empty
+        assert creds["source"] == "default"
 
     def test_resolve_lmstudio_uses_token_and_base_url_from_env(self, monkeypatch):
         monkeypatch.setenv("LM_API_KEY", "lm-token")
@@ -665,17 +671,19 @@ class TestRuntimeProviderResolution:
         assert result["provider"] == "kimi-coding"
         assert result["api_key"] == "auto-kimi-key"
 
-    def test_runtime_copilot_uses_gh_cli_token(self, monkeypatch):
+    def test_runtime_copilot_requires_explicit_token(self, monkeypatch):
+        """gh auth token alone does not provide Copilot credentials."""
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="copilot")
         assert result["provider"] == "copilot"
-        assert result["api_mode"] == "chat_completions"
-        assert result["api_key"] == "gho_cli_secret"
-        assert result["base_url"] == "https://api.githubcopilot.com"
+        assert result["api_key"] == ""
 
     def test_runtime_copilot_uses_responses_for_gpt_5_4(self, monkeypatch):
-        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_cli_secret")
         monkeypatch.setattr(
             "hermes_cli.runtime_provider._get_model_config",
             lambda: {"provider": "copilot", "default": "gpt-5.4"},
@@ -739,15 +747,19 @@ class TestHasAnyProviderConfigured:
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is True
 
-    def test_gh_cli_token_counts(self, monkeypatch, tmp_path):
+    def test_gh_cli_token_no_longer_counts(self, monkeypatch, tmp_path):
+        """gh auth token alone does not count as a configured provider."""
         from hermes_cli import config as config_module
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
         monkeypatch.setattr(config_module, "get_hermes_home", lambda: hermes_home)
         from hermes_cli.main import _has_any_provider_configured
-        assert _has_any_provider_configured() is True
+        assert _has_any_provider_configured() is False
 
     def test_claude_code_creds_ignored_on_fresh_install(self, monkeypatch, tmp_path):
         """Claude Code credentials should NOT skip the wizard when Hermes is unconfigured."""

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -78,32 +78,24 @@ class TestResolveToken:
         assert token == "gho_valid_oauth"
         assert source == "GITHUB_TOKEN"
 
-    def test_gh_cli_fallback(self, monkeypatch):
+    def test_gh_cli_fallback_removed(self, monkeypatch):
+        """gh auth token is no longer used as fallback for Copilot."""
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        # Even if gh auth token would return a valid token, it should be ignored
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
             token, source = resolve_copilot_token()
-        assert token == "gho_from_cli"
-        assert source == "gh auth token"
-
-    def test_gh_cli_classic_pat_raises(self, monkeypatch):
-        from hermes_cli.copilot_auth import resolve_copilot_token
-        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
-        monkeypatch.delenv("GH_TOKEN", raising=False)
-        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_classic"):
-            with pytest.raises(ValueError, match="classic PAT"):
-                resolve_copilot_token()
+        assert token == ""
+        assert source == ""
 
     def test_no_token_returns_empty(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value=None):
-            token, source = resolve_copilot_token()
+        token, source = resolve_copilot_token()
         assert token == ""
         assert source == ""
 


### PR DESCRIPTION
## Summary

Remove the `gh auth token` fallback from `resolve_copilot_token()` so Copilot only appears available when the user has explicitly configured it.

## Root Cause

`resolve_copilot_token()` in `hermes_cli/copilot_auth.py` fell back to `gh auth token` after checking env vars. `gh auth token` returns a GitHub API OAuth token (`gho_*`) — valid for repos, workflows, gists — **not** a Copilot API token. `validate_copilot_token()` only checks the token prefix (accepts `gho_*`, `github_pat_*`, `ghu_*`), so the `gho_*` token passed validation and Copilot was marked as `authenticated: true`.

Any user with `gh` installed and logged in (via `gh auth login`) would see Copilot as an available provider with a full model list, even without a Copilot subscription. Selecting a Copilot model would fail at runtime with an auth error.

## Fix

Remove the `gh auth token` fallback from `resolve_copilot_token()`. Users who want Copilot must explicitly set `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`, or use the OAuth device code flow.

The `_try_gh_cli_token()` and `_gh_cli_candidates()` helpers are preserved (they may be used by other code paths or future features) but are no longer called from the token resolution path.

## Code Intelligence

- Analyzed: `resolve_copilot_token` (callers: 2, callees: 2, flows: 1)
- Blast radius: LOW — direct callers are `_resolve_api_key_provider_secret` (auth.py) and `_seed_from_singletons` (credential_pool.py); both handle empty token gracefully
- Related patterns: PR #24781 adds `COPILOT_GH_USER` selector and `.env` fallback to the same file (different concern, no conflict)

## Regression Coverage

- Updated `test_gh_cli_fallback` → `test_gh_cli_fallback_removed`: verifies `gh auth token` is ignored even when it returns a valid token
- Removed `test_gh_cli_classic_pat_raises`: no longer applicable (fallback removed)
- Updated `test_no_token_returns_empty`: simplified (no mock needed)
- Updated `test_copilot_status_uses_gh_cli_token` → `test_copilot_status_ignores_gh_cli_token`: verifies Copilot is not configured from `gh auth token` alone
- Updated `test_resolve_copilot_with_gh_cli_fallback` → `test_resolve_copilot_ignores_gh_cli_fallback`: verifies empty credentials returned
- Updated `test_runtime_copilot_uses_gh_cli_token` → `test_runtime_copilot_requires_explicit_token`: verifies empty api_key from runtime
- Updated `test_runtime_copilot_uses_responses_for_gpt_5_4`: uses env var instead of mock
- Updated `test_gh_cli_token_counts` → `test_gh_cli_token_no_longer_counts`: verifies `_has_any_provider_configured` returns False

## Testing

- `tests/hermes_cli/test_copilot_auth.py`: 24 passed
- `tests/hermes_cli/test_api_key_providers.py`: 157 passed
