### PR TITLE
feat: add native Codex compaction

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -269,6 +269,20 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                 content_text = str(content) if content is not None else ""
 
             if role == "assistant":
+                # Replay encrypted native compaction items from previous
+                # Codex /responses/compact calls. These are opaque checkpoint
+                # blobs and must be sent back as top-level Responses input
+                # items before the subsequent conversation turn.
+                codex_compaction = msg.get("codex_compaction_items")
+                if isinstance(codex_compaction, list):
+                    for ci in codex_compaction:
+                        if isinstance(ci, dict) and ci.get("encrypted_content"):
+                            item_type = ci.get("type") if ci.get("type") in {"compaction", "compaction_summary"} else "compaction_summary"
+                            items.append({
+                                "type": item_type,
+                                "encrypted_content": ci["encrypted_content"],
+                            })
+
                 # Replay encrypted reasoning items from previous turns
                 # so the API can maintain coherent reasoning chains.
                 codex_reasoning = msg.get("codex_reasoning_items")
@@ -527,6 +541,12 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                     "output": output,
                 }
             )
+            continue
+
+        if item_type in {"compaction", "compaction_summary"}:
+            encrypted = item.get("encrypted_content")
+            if isinstance(encrypted, str) and encrypted:
+                normalized.append({"type": item_type, "encrypted_content": encrypted})
             continue
 
         if item_type == "reasoning":

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -22,6 +22,9 @@ import logging
 import re
 import time
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import httpx
 
 from agent.auxiliary_client import call_llm, _is_connection_error
 from agent.context_engine import ContextEngine
@@ -74,6 +77,8 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+_CODEX_NATIVE_HOST = "chatgpt.com"
+_CODEX_NATIVE_PATH = "/backend-api/codex"
 
 
 def _content_length_for_budget(raw_content: Any) -> int:
@@ -790,6 +795,118 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
+    def _is_codex_native_compaction_available(self, focus_topic: str = None) -> bool:
+        """Return True when we can use OpenAI Codex remote compaction.
+
+        Native compaction is only safe for the first-party Codex Responses
+        backend. Manual focused compaction (``/compress <topic>``) still uses
+        the textual summarizer because Codex remote compaction has no focus
+        instruction channel.
+        """
+        if focus_topic:
+            return False
+        provider = (self.provider or "").strip().lower()
+        api_mode = (self.api_mode or "").strip().lower()
+        base_url = (self.base_url or "").strip().rstrip("/")
+        parsed = urlparse(base_url)
+        scheme = (parsed.scheme or "").lower()
+        host = (parsed.hostname or "").lower().rstrip(".")
+        path = parsed.path.rstrip("/")
+        return (
+            provider == "openai-codex"
+            and api_mode == "codex_responses"
+            and scheme == "https"
+            and host == _CODEX_NATIVE_HOST
+            and path == _CODEX_NATIVE_PATH
+            and bool((self.api_key or "").strip())
+        )
+
+    @staticmethod
+    def _as_plain_data(value: Any) -> Any:
+        if isinstance(value, dict):
+            return value
+        if hasattr(value, "model_dump"):
+            return value.model_dump()
+        if hasattr(value, "__dict__"):
+            return value.__dict__
+        return value
+
+    @classmethod
+    def _extract_single_codex_compaction_item(cls, payload: Any) -> Optional[Dict[str, str]]:
+        data = cls._as_plain_data(payload)
+        if not isinstance(data, dict):
+            return None
+        raw_items = data.get("output") or data.get("items") or data.get("data")
+        if not isinstance(raw_items, list):
+            return None
+        compaction_items: List[Dict[str, str]] = []
+        for raw in raw_items:
+            item = cls._as_plain_data(raw)
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") not in {"compaction", "compaction_summary"}:
+                continue
+            encrypted = item.get("encrypted_content")
+            if isinstance(encrypted, str) and encrypted:
+                compaction_items.append({"type": item.get("type"), "encrypted_content": encrypted})
+        if len(compaction_items) != 1:
+            return None
+        return compaction_items[0]
+
+    def _codex_compaction_instructions(self, all_messages: List[Dict[str, Any]]) -> str:
+        for msg in all_messages or []:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                content = msg.get("content")
+                text = _content_text_for_contains(content).strip()
+                if text:
+                    return text
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+        return DEFAULT_AGENT_IDENTITY
+
+    def _generate_codex_native_compaction(
+        self,
+        turns_to_compact: List[Dict[str, Any]],
+        all_messages: List[Dict[str, Any]],
+    ) -> Optional[List[Dict[str, str]]]:
+        """Call ``/responses/compact`` and return replayable compaction item(s).
+
+        Returns ``None`` on any failure so callers fall back to the existing
+        textual summarizer.
+        """
+        if not turns_to_compact:
+            return None
+        try:
+            from agent.auxiliary_client import _codex_cloudflare_headers
+            from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+            base_url = (self.base_url or "").strip().rstrip("/")
+            headers = {
+                **_codex_cloudflare_headers(self.api_key),
+                "Authorization": f"Bearer {self.api_key}",
+                "x-codex-beta-features": "remote_compaction_v2",
+            }
+            payload = {
+                "model": self.model,
+                "instructions": self._codex_compaction_instructions(all_messages),
+                "input": _chat_messages_to_responses_input(turns_to_compact),
+                "tools": [],
+            }
+            response = httpx.post(
+                f"{base_url}/responses/compact",
+                headers=headers,
+                json=payload,
+                timeout=60,
+            )
+            response.raise_for_status()
+            item = self._extract_single_codex_compaction_item(response.json())
+            if not item:
+                logger.warning("Codex native compaction returned no unique compaction item; falling back to textual summary")
+                return None
+            return [item]
+        except Exception as exc:
+            logger.warning("Codex native compaction failed; falling back to textual summary: %s", exc)
+            return None
+
     def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
@@ -1419,6 +1536,13 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if summary_body and not self._previous_summary:
                 self._previous_summary = summary_body
             turns_to_summarize = messages[summary_idx + 1:compress_end]
+        native_turns_to_compact = turns_to_summarize
+        if summary_idx is not None:
+            # Native Codex compaction is a replacement checkpoint, not an
+            # iterative textual summary. Include the prior text handoff itself
+            # so migrating from a text summary to an encrypted Codex compaction
+            # does not silently drop older context.
+            native_turns_to_compact = messages[summary_idx:compress_end]
 
         if not self.quiet_mode:
             logger.info(
@@ -1442,8 +1566,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 tail_msgs,
             )
 
-        # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        # Phase 3: Generate a compaction checkpoint. For first-party Codex
+        # Responses, prefer the native encrypted compaction endpoint; otherwise
+        # use the existing textual summarizer. Endpoint failures fall through to
+        # the textual path.
+        native_compaction_items = None
+        if self._is_codex_native_compaction_available(focus_topic=focus_topic):
+            native_compaction_items = self._generate_codex_native_compaction(
+                native_turns_to_compact,
+                messages,
+            )
+        summary = None
+        if not native_compaction_items:
+            summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
         # Phase 4: Assemble compressed message list
         compressed = []
@@ -1458,6 +1593,48 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                         "\n\n" + _compression_note if isinstance(existing, str) and existing else _compression_note,
                     )
             compressed.append(msg)
+
+        # If native Codex compaction succeeded, store the encrypted blob as
+        # assistant replay metadata. The Responses adapter will resend it as a
+        # ``{type: "compaction", encrypted_content: ...}`` input item on future
+        # calls.
+        if native_compaction_items:
+            compressed.append({
+                "role": "assistant",
+                "content": "",
+                "codex_compaction_items": native_compaction_items,
+            })
+            for i in range(compress_end, n_messages):
+                compressed.append(messages[i].copy())
+
+            self.compression_count += 1
+            compressed = self._sanitize_tool_pairs(compressed)
+            new_estimate = estimate_messages_tokens_rough(compressed)
+            saved_estimate = display_tokens - new_estimate
+            savings_pct = (saved_estimate / display_tokens * 100) if display_tokens > 0 else 0
+            self._last_compression_savings_pct = savings_pct
+            if savings_pct < 10:
+                self._ineffective_compression_count += 1
+            else:
+                self._ineffective_compression_count = 0
+            if not self.quiet_mode:
+                logger.info(
+                    "Compressed with Codex native compaction: %d -> %d messages (~%d tokens saved, %.0f%%)",
+                    n_messages,
+                    len(compressed),
+                    saved_estimate,
+                    savings_pct,
+                )
+            return compressed
+
+        # A previous native Codex checkpoint may live inside the region that is
+        # now being text-summarized (for example when a later native compaction
+        # attempt fails and falls back). Preserve those opaque encrypted blobs
+        # as replay metadata; otherwise a transient /responses/compact failure
+        # would silently downgrade all prior native context to text only.
+        for i in range(compress_start, compress_end):
+            if messages[i].get("codex_compaction_items"):
+                compressed.append(messages[i].copy())
 
         # If LLM summary failed, insert a static fallback so the model
         # knows context was lost rather than silently dropping everything.
@@ -1476,7 +1653,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         _merge_summary_into_tail = False
-        last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
+        last_head_role = compressed[-1].get("role", "user") if compressed else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
         # Pick a role that avoids consecutive same-role with both neighbors.
         # Priority: avoid colliding with head (already committed), then tail.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -122,7 +122,11 @@ class ChatCompletionsTransport(ProviderTransport):
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if "codex_reasoning_items" in msg or "codex_message_items" in msg:
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "codex_compaction_items" in msg
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -140,18 +144,30 @@ class ChatCompletionsTransport(ProviderTransport):
             return messages
 
         sanitized = copy.deepcopy(messages)
+        result: list[dict[str, Any]] = []
         for msg in sanitized:
             if not isinstance(msg, dict):
+                result.append(msg)
                 continue
+            had_compaction_only_metadata = "codex_compaction_items" in msg
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
+            msg.pop("codex_compaction_items", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)
                         tc.pop("response_item_id", None)
-        return sanitized
+            if (
+                had_compaction_only_metadata
+                and msg.get("role") == "assistant"
+                and not msg.get("content")
+                and not msg.get("tool_calls")
+            ):
+                continue
+            result.append(msg)
+        return result
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Tools are already in OpenAI format — identity."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -236,7 +236,8 @@ CREATE TABLE IF NOT EXISTS messages (
     reasoning_content TEXT,
     reasoning_details TEXT,
     codex_reasoning_items TEXT,
-    codex_message_items TEXT
+    codex_message_items TEXT,
+    codex_compaction_items TEXT
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -1445,6 +1446,7 @@ class SessionDB:
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
         codex_message_items: Any = None,
+        codex_compaction_items: Any = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -1465,6 +1467,10 @@ class SessionDB:
             json.dumps(codex_message_items)
             if codex_message_items else None
         )
+        codex_compaction_items_json = (
+            json.dumps(codex_compaction_items)
+            if codex_compaction_items else None
+        )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
@@ -1480,8 +1486,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, codex_compaction_items)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -1497,6 +1503,7 @@ class SessionDB:
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,
+                    codex_compaction_items_json,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -1547,6 +1554,9 @@ class SessionDB:
                 codex_message_items = (
                     msg.get("codex_message_items") if role == "assistant" else None
                 )
+                codex_compaction_items = (
+                    msg.get("codex_compaction_items") if role == "assistant" else None
+                )
 
                 reasoning_details_json = (
                     json.dumps(reasoning_details) if reasoning_details else None
@@ -1557,14 +1567,17 @@ class SessionDB:
                 codex_message_items_json = (
                     json.dumps(codex_message_items) if codex_message_items else None
                 )
+                codex_compaction_items_json = (
+                    json.dumps(codex_compaction_items) if codex_compaction_items else None
+                )
                 tool_calls_json = json.dumps(tool_calls) if tool_calls else None
 
                 conn.execute(
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
                        reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       codex_message_items, codex_compaction_items)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
@@ -1580,6 +1593,7 @@ class SessionDB:
                         reasoning_details_json,
                         codex_items_json,
                         codex_message_items_json,
+                        codex_compaction_items_json,
                     ),
                 )
                 total_messages += 1
@@ -1699,7 +1713,7 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items "
+                "codex_reasoning_items, codex_message_items, codex_compaction_items "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
                 tuple(session_ids),
             ).fetchall()
@@ -1748,6 +1762,12 @@ class SessionDB:
                     except (json.JSONDecodeError, TypeError):
                         logger.warning("Failed to deserialize codex_message_items, falling back to None")
                         msg["codex_message_items"] = None
+                if row["codex_compaction_items"]:
+                    try:
+                        msg["codex_compaction_items"] = json.loads(row["codex_compaction_items"])
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning("Failed to deserialize codex_compaction_items, falling back to None")
+                        msg["codex_compaction_items"] = None
             if include_ancestors and self._is_duplicate_replayed_user_message(messages, msg):
                 continue
             messages.append(msg)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2227,6 +2227,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=getattr(self, "api_key", ""),
                 provider=self.provider,
+                api_mode=self.api_mode,
             )
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)
@@ -2395,6 +2396,7 @@ class AIAgent:
             "compressor_base_url": getattr(_cc, "base_url", self.base_url),
             "compressor_api_key": getattr(_cc, "api_key", ""),
             "compressor_provider": getattr(_cc, "provider", self.provider),
+            "compressor_api_mode": getattr(_cc, "api_mode", self.api_mode),
             "compressor_context_length": _cc.context_length,
             "compressor_threshold_tokens": _cc.threshold_tokens,
         }
@@ -2670,6 +2672,7 @@ class AIAgent:
             "compressor_base_url": getattr(_cc, "base_url", self.base_url) if _cc else self.base_url,
             "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
             "compressor_provider": getattr(_cc, "provider", self.provider) if _cc else self.provider,
+            "compressor_api_mode": getattr(_cc, "api_mode", self.api_mode) if _cc else self.api_mode,
             "compressor_context_length": _cc.context_length if _cc else 0,
             "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
         }
@@ -4520,6 +4523,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    codex_compaction_items=msg.get("codex_compaction_items") if role == "assistant" else None,
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -8584,6 +8588,7 @@ class AIAgent:
                     base_url=self.base_url,
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
+                    api_mode=self.api_mode,
                 )
 
             self._emit_status(
@@ -8663,6 +8668,7 @@ class AIAgent:
                 base_url=rt["compressor_base_url"],
                 api_key=rt["compressor_api_key"],
                 provider=rt["compressor_provider"],
+                api_mode=rt.get("compressor_api_mode", rt.get("api_mode", "")),
             )
 
             # ── Reset fallback chain for the new turn ──

--- a/tests/agent/test_codex_native_compaction.py
+++ b/tests/agent/test_codex_native_compaction.py
@@ -1,0 +1,271 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _preflight_codex_input_items,
+)
+from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from hermes_state import SessionDB
+
+
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def _compressor(**overrides):
+    kwargs = dict(
+        model="gpt-5-codex",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url=CODEX_BASE_URL,
+        api_key="codex-token",
+        protect_first_n=1,
+        protect_last_n=1,
+        quiet_mode=True,
+    )
+    kwargs.update(overrides)
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        c = ContextCompressor(**kwargs)
+    # Force a small protected tail so the fixture's middle turns are compacted.
+    c.tail_token_budget = 1
+    return c
+
+
+def _messages():
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "First compactable turn"},
+        {"role": "assistant", "content": "Assistant compactable turn"},
+        {"role": "user", "content": "Second compactable turn"},
+        {"role": "assistant", "content": "Second assistant compactable turn"},
+        {"role": "user", "content": "Current task stays in tail"},
+    ]
+
+
+class _FakeCompactResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_codex_native_compaction_posts_to_compact_endpoint_and_stores_encrypted_item():
+    c = _compressor()
+    compact_payload = {"output": [{"type": "compaction_summary", "encrypted_content": "enc_blob"}]}
+
+    with patch("agent.context_compressor.httpx.post", return_value=_FakeCompactResponse(compact_payload)) as post, \
+         patch("agent.context_compressor.call_llm") as call_llm:
+        compressed = c.compress(_messages(), current_tokens=90000)
+
+    call_llm.assert_not_called()
+    assert post.call_count == 1
+    url = post.call_args.args[0]
+    kwargs = post.call_args.kwargs
+    assert url == f"{CODEX_BASE_URL}/responses/compact"
+    assert kwargs["headers"]["Authorization"] == "Bearer codex-token"
+    assert kwargs["headers"]["x-codex-beta-features"] == "remote_compaction_v2"
+    assert kwargs["json"]["model"] == "gpt-5-codex"
+    assert kwargs["json"]["instructions"] == "You are Hermes."
+    assert kwargs["json"]["tools"] == []
+    assert "store" not in kwargs["json"]
+    assert {"role": "user", "content": "First compactable turn"} in kwargs["json"]["input"]
+    assert all(item.get("type") != "trigger" for item in kwargs["json"]["input"])
+
+    compaction_messages = [m for m in compressed if m.get("codex_compaction_items")]
+    assert len(compaction_messages) == 1
+    assert compaction_messages[0]["role"] == "assistant"
+    assert compaction_messages[0]["content"] == ""
+    assert compaction_messages[0]["codex_compaction_items"] == [
+        {"type": "compaction_summary", "encrypted_content": "enc_blob"}
+    ]
+
+
+def test_native_compaction_rejects_non_chatgpt_codex_like_base_url():
+    c = _compressor(base_url="https://unit.test/codex")
+    summary_response = MagicMock()
+    summary_response.choices = [MagicMock()]
+    summary_response.choices[0].message.content = "Textual fallback summary"
+
+    with patch("agent.context_compressor.httpx.post") as post, \
+         patch("agent.context_compressor.call_llm", return_value=summary_response) as call_llm:
+        c.compress(_messages(), current_tokens=90000)
+
+    post.assert_not_called()
+    call_llm.assert_called_once()
+
+
+def test_native_compaction_requires_https_codex_base_url():
+    c = _compressor(base_url="http://chatgpt.com/backend-api/codex")
+    summary_response = MagicMock()
+    summary_response.choices = [MagicMock()]
+    summary_response.choices[0].message.content = "Textual fallback summary"
+
+    with patch("agent.context_compressor.httpx.post") as post, \
+         patch("agent.context_compressor.call_llm", return_value=summary_response) as call_llm:
+        c.compress(_messages(), current_tokens=90000)
+
+    post.assert_not_called()
+    call_llm.assert_called_once()
+
+
+def test_native_compaction_after_text_summary_includes_prior_summary_in_compact_input():
+    c = _compressor()
+    prior_summary = f"{SUMMARY_PREFIX}\nOLD CRITICAL SUMMARY"
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "older turn already summarized"},
+        {"role": "assistant", "content": prior_summary},
+        {"role": "user", "content": "new middle 1"},
+        {"role": "assistant", "content": "answer 1"},
+        {"role": "user", "content": "new middle 2"},
+        {"role": "assistant", "content": "answer 2"},
+        {"role": "user", "content": "tail"},
+    ]
+    compact_payload = {"output": [{"type": "compaction_summary", "encrypted_content": "enc_blob"}]}
+
+    with patch("agent.context_compressor.httpx.post", return_value=_FakeCompactResponse(compact_payload)) as post, \
+         patch("agent.context_compressor.call_llm") as call_llm:
+        compressed = c.compress(messages, current_tokens=90000)
+
+    call_llm.assert_not_called()
+    compact_input_text = "\n".join(str(item.get("content", "")) for item in post.call_args.kwargs["json"]["input"])
+    assert "OLD CRITICAL SUMMARY" in compact_input_text
+    assert any(m.get("codex_compaction_items") for m in compressed)
+    assert not any(
+        isinstance(m.get("content"), str) and "OLD CRITICAL SUMMARY" in m["content"]
+        for m in compressed
+    )
+
+
+def test_codex_compaction_item_replayed_as_responses_input():
+    messages = [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_compaction_items": [
+                {"type": "compaction_summary", "encrypted_content": "enc_blob"}
+            ],
+        },
+        {"role": "user", "content": "after"},
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert {"type": "compaction_summary", "encrypted_content": "enc_blob"} in items
+
+
+def test_codex_preflight_accepts_compaction_items():
+    normalized = _preflight_codex_input_items([
+        {"role": "user", "content": "before"},
+        {"type": "compaction_summary", "encrypted_content": "enc_blob"},
+        {"role": "user", "content": "after"},
+    ])
+
+    assert normalized[1] == {"type": "compaction_summary", "encrypted_content": "enc_blob"}
+
+
+def test_native_compaction_falls_back_to_textual_summary_on_endpoint_failure():
+    c = _compressor()
+    summary_response = MagicMock()
+    summary_response.choices = [MagicMock()]
+    summary_response.choices[0].message.content = "Textual fallback summary"
+
+    with patch("agent.context_compressor.httpx.post", side_effect=RuntimeError("boom")), \
+         patch("agent.context_compressor.call_llm", return_value=summary_response) as call_llm:
+        compressed = c.compress(_messages(), current_tokens=90000)
+
+    call_llm.assert_called_once()
+    assert not any(m.get("codex_compaction_items") for m in compressed)
+    assert any(
+        isinstance(m.get("content"), str) and m["content"].startswith(SUMMARY_PREFIX)
+        for m in compressed
+    )
+
+
+def test_fallback_summary_preserves_existing_codex_compaction_checkpoint():
+    c = _compressor()
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "before old checkpoint"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_compaction_items": [
+                {"type": "compaction_summary", "encrypted_content": "old_enc_blob"}
+            ],
+        },
+        {"role": "user", "content": "new middle turn"},
+        {"role": "assistant", "content": "new middle answer"},
+        {"role": "user", "content": "tail"},
+    ]
+    summary_response = MagicMock()
+    summary_response.choices = [MagicMock()]
+    summary_response.choices[0].message.content = "Textual fallback summary"
+
+    with patch("agent.context_compressor.httpx.post", side_effect=RuntimeError("boom")), \
+         patch("agent.context_compressor.call_llm", return_value=summary_response):
+        compressed = c.compress(messages, current_tokens=90000)
+
+    preserved = [m for m in compressed if m.get("codex_compaction_items")]
+    assert preserved == [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_compaction_items": [
+                {"type": "compaction_summary", "encrypted_content": "old_enc_blob"}
+            ],
+        }
+    ]
+    assert any(
+        isinstance(m.get("content"), str) and m["content"].startswith(SUMMARY_PREFIX)
+        for m in compressed
+    )
+
+
+def test_manual_focus_compaction_uses_textual_summary_not_native_endpoint():
+    c = _compressor()
+    summary_response = MagicMock()
+    summary_response.choices = [MagicMock()]
+    summary_response.choices[0].message.content = "Focused textual summary"
+
+    with patch("agent.context_compressor.httpx.post") as post, \
+         patch("agent.context_compressor.call_llm", return_value=summary_response) as call_llm:
+        compressed = c.compress(_messages(), current_tokens=90000, focus_topic="billing")
+
+    post.assert_not_called()
+    call_llm.assert_called_once()
+    assert not any(m.get("codex_compaction_items") for m in compressed)
+
+
+def test_codex_compaction_items_survive_session_history_reload(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        session_id = "s1"
+        db.create_session(session_id=session_id, source="test", model="gpt-5-codex")
+        db.append_message(
+            session_id,
+            role="assistant",
+            content="",
+            codex_compaction_items=[{"type": "compaction_summary", "encrypted_content": "enc_blob"}],
+        )
+
+        restored = db.get_messages_as_conversation(session_id)
+    finally:
+        db.close()
+
+    assert restored == [
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_compaction_items": [
+                {"type": "compaction_summary", "encrypted_content": "enc_blob"}
+            ],
+        }
+    ]

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -46,6 +46,27 @@ class TestChatCompletionsBasic:
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
 
+    def test_convert_messages_drops_compaction_only_assistant_for_chat_providers(self, transport):
+        msgs = [
+            {"role": "user", "content": "before"},
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_compaction_items": [
+                    {"type": "compaction", "encrypted_content": "enc_blob"}
+                ],
+            },
+            {"role": "user", "content": "after"},
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert result == [
+            {"role": "user", "content": "before"},
+            {"role": "user", "content": "after"},
+        ]
+        assert msgs[1]["codex_compaction_items"]
+
 
 class TestChatCompletionsBuildKwargs:
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -32,7 +32,12 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    api_mode=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -43,6 +48,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             api_key="test-key-12345678",
             base_url=base_url,
             provider=provider,
+            api_mode=api_mode,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -84,6 +90,15 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["compressor_provider"] == cc.provider
         assert rt["compressor_context_length"] == cc.context_length
         assert rt["compressor_threshold_tokens"] == cc.threshold_tokens
+
+    def test_snapshot_preserves_compressor_api_mode_for_codex(self):
+        agent = _make_agent(
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+        )
+        assert agent.context_compressor.api_mode == "codex_responses"
+        assert agent._primary_runtime["compressor_api_mode"] == "codex_responses"
 
     def test_snapshot_includes_anthropic_state_when_applicable(self):
         """Anthropic-mode agents should snapshot Anthropic-specific state."""
@@ -189,6 +204,25 @@ class TestRestorePrimaryRuntime:
 
         assert agent.context_compressor.context_length == original_ctx_len
         assert agent.context_compressor.threshold_tokens == original_threshold
+
+    def test_restores_compressor_api_mode_for_codex_after_fallback(self):
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+        )
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        assert agent.context_compressor.api_mode != "codex_responses"
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.context_compressor.api_mode == "codex_responses"
+        assert agent.context_compressor._is_codex_native_compaction_available() is True
 
     def test_restores_prompt_caching_flag(self):
         agent = _make_agent()


### PR DESCRIPTION
## Summary
- Add native Codex `/responses/compact` support for `openai-codex` in Codex Responses mode.
- Persist and replay encrypted `compaction_summary` items through SessionDB/conversation reload paths.
- Preserve textual fallback behavior and prior Codex checkpoints when native compaction fails.
- Harden token-bearing endpoint gating to `https://chatgpt.com/backend-api/codex` only.
- Sanitize Codex compaction metadata before chat-completions providers and preserve compressor `api_mode` across fallback/restore.

## Verification
- `scripts/run_tests.sh tests/agent/test_codex_native_compaction.py tests/run_agent/test_primary_runtime_restore.py tests/agent/transports/test_chat_completions.py tests/agent/test_context_compressor.py tests/agent/test_context_compressor_summary_continuity.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/transports/test_codex_transport.py tests/test_hermes_state.py tests/test_hermes_state_wal_fallback.py` — 511 passed
- `python -m compileall -q` on touched Python files — passed
- `git diff --check` — passed
- Live smoke test against `https://chatgpt.com/backend-api/codex/responses/compact` — returned `compaction_summary` with encrypted content
- Independent reviewer re-review — approved after blocker fixes

## Notes
- Full suite was run and had unrelated/orthogonal failures outside the changed Codex compaction surface. Focused coverage for the modified surfaces is green.
- Security-sensitive endpoint detection avoids substring matching and requires HTTPS, exact host, and exact path.
- The live endpoint rejects `store` on `/responses/compact`; replay still uses the normal Codex Responses path semantics.
