### PR TITLE
fix(copilot): remove gh auth token fallback from Copilot auth resolution

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -9,11 +9,14 @@ Token type support (per GitHub docs):
   ghu_          GitHub App token      ✓  (via environment variable)
   ghp_          Classic PAT           ✗  NOT SUPPORTED
 
-Credential search order (matching Copilot CLI behaviour):
+Credential search order (explicit configuration only):
   1. COPILOT_GITHUB_TOKEN env var
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
-  4. gh auth token  CLI fallback
+
+Note: gh auth token fallback was removed because a GitHub API token (from gh)
+does NOT grant Copilot API access. Users without a Copilot subscription who
+have gh installed were seeing Copilot as "authenticated" when it wasn't.
 """
 
 from __future__ import annotations
@@ -82,16 +85,14 @@ def resolve_copilot_token() -> tuple[str, str]:
                 continue
             return val, env_var
 
-    # 2. Fall back to gh auth token
-    token = _try_gh_cli_token()
-    if token:
-        valid, msg = validate_copilot_token(token)
-        if not valid:
-            raise ValueError(
-                f"Token from `gh auth token` is a classic PAT (ghp_*). {msg}"
-            )
-        return token, "gh auth token"
-
+    # Do NOT fall back to gh auth token.
+    # gh auth token provides a GitHub API token (repo access), NOT a Copilot
+    # API token. Users with gh installed but without an active Copilot
+    # subscription were getting Copilot models listed as "available" when
+    # they weren't actually usable. Copilot should only appear as
+    # authenticated when the user has explicitly configured it via
+    # COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN env vars or the
+    # OAuth device code flow.
     return "", ""
 
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -78,24 +78,29 @@ class TestResolveToken:
         assert token == "gho_valid_oauth"
         assert source == "GITHUB_TOKEN"
 
-    def test_gh_cli_fallback(self, monkeypatch):
+    def test_no_env_vars_returns_empty_without_gh_cli_fallback(self, monkeypatch):
+        """gh auth token fallback removed — only explicit env vars count."""
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        # Even if gh CLI would return a token, it must NOT be used
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
             token, source = resolve_copilot_token()
-        assert token == "gho_from_cli"
-        assert source == "gh auth token"
+        assert token == ""
+        assert source == ""
 
-    def test_gh_cli_classic_pat_raises(self, monkeypatch):
+    def test_gh_cli_classic_pat_not_consulted(self, monkeypatch):
+        """gh auth token fallback removed — classic PAT from gh is irrelevant."""
         from hermes_cli.copilot_auth import resolve_copilot_token
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        # Even if gh CLI would return a classic PAT, it must NOT raise
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_classic"):
-            with pytest.raises(ValueError, match="classic PAT"):
-                resolve_copilot_token()
+            token, source = resolve_copilot_token()
+        assert token == ""
+        assert source == ""
 
     def test_no_token_returns_empty(self, monkeypatch):
         from hermes_cli.copilot_auth import resolve_copilot_token


### PR DESCRIPTION
## Summary

Removes the `gh auth token` CLI fallback from `resolve_copilot_token()` in `hermes_cli/copilot_auth.py`.

## Problem

`hermes model` shows GitHub Copilot as an authenticated provider for any user with `gh` CLI installed and logged in — even without a Copilot subscription. Selecting a Copilot model then fails at runtime with an auth error.

**Root cause**: `gh auth token` returns a GitHub API OAuth token (`gho_*`) that passes prefix-based validation but does NOT grant Copilot API access.

## Fix

Remove the `gh auth token` fallback (step 4 in the credential search order). Copilot now only appears as authenticated when explicitly configured via:
- `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` env vars
- The OAuth device code flow (`hermes model` → Copilot)

The `_try_gh_cli_token()` and `_gh_cli_candidates()` helpers are preserved as dead code for potential future opt-in use.

## Testing

- Updated 2 tests in `test_copilot_auth.py` to verify gh CLI is no longer consulted
- All 25 tests in `test_copilot_auth.py` pass

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/copilot_auth.py` | Removed gh auth token fallback; updated docstring |
| `tests/hermes_cli/test_copilot_auth.py` | Updated 2 tests for new no-fallback behavior |

Closes #25246