### PR TITLE
Fix duplicate Slack final replies after stream finalize failure

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -528,6 +528,18 @@ class GatewayStreamConsumer:
                             self._final_response_sent = await self._send_or_edit(
                                 self._accumulated, finalize=True,
                             )
+                            if (
+                                not self._final_response_sent
+                                and self._visible_matches_final(self._accumulated)
+                            ):
+                                # The final content is already visible from a
+                                # prior streamed edit; only the finalize edit
+                                # failed.  Suppress the base gateway's normal
+                                # final send so it does not post the same
+                                # answer again as a fresh Slack/Discord/etc.
+                                # message.  Best-effort strip any stuck cursor.
+                                await self._try_strip_cursor()
+                                self._final_response_sent = True
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                     return
@@ -661,6 +673,20 @@ class GatewayStreamConsumer:
         if prefix and final_text.startswith(prefix):
             return final_text[len(prefix):].lstrip()
         return final_text
+
+    def _visible_matches_final(self, final_text: str) -> bool:
+        """Return True when the currently visible stream already equals final.
+
+        Finalize edits are best-effort on platforms like Slack.  A transient
+        ``chat.update``/rate-limit failure can happen after the previous
+        streamed edit already displayed the complete answer (usually with only
+        the cursor removed by ``_visible_prefix()``).  In that case the normal
+        gateway fallback must *not* resend the full answer as a new message, or
+        the user sees a duplicate final reply.
+        """
+        final_clean = self._clean_for_display(final_text).strip()
+        visible_clean = self._visible_prefix().strip()
+        return bool(final_clean and visible_clean and visible_clean == final_clean)
 
     @staticmethod
     def _split_text_chunks(

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -133,6 +133,53 @@ class TestFinalizeCapabilityGate:
         assert picky.edit_message.call_args[1]["finalize"] is True
 
 
+class TestFinalizeDuplicateSuppression:
+    """Regression coverage for duplicate final replies after finalize failures."""
+
+    @pytest.mark.asyncio
+    async def test_finalize_edit_failure_does_not_resend_when_visible_matches_final(self):
+        """If the streamed preview already shows the final text, suppress fallback.
+
+        Slack can transiently fail the final ``chat.update`` after the prior
+        streaming edit already displayed the complete answer with only the
+        cursor still present.  The stream consumer must mark final delivery as
+        confirmed so the gateway does not post the same answer again as a new
+        message.
+        """
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="msg_1",
+        ))
+        adapter.edit_message = AsyncMock(side_effect=[
+            SimpleNamespace(success=False, error="rate_limited"),
+            SimpleNamespace(success=True, message_id="msg_1"),
+        ])
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉"),
+        )
+        task = asyncio.create_task(consumer.run())
+
+        consumer.on_delta("Complete answer")
+        for _ in range(50):
+            if adapter.send.await_count:
+                break
+            await asyncio.sleep(0.01)
+
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert consumer.final_response_sent is True
+        assert adapter.send.await_count == 1
+        # First edit is the failed finalize; second is best-effort cursor strip.
+        assert adapter.edit_message.await_count == 2
+        assert adapter.edit_message.await_args_list[0].kwargs["finalize"] is True
+
+
 class TestEditMessageFinalizeSignature:
     """Every concrete platform adapter must accept the ``finalize`` kwarg.
 


### PR DESCRIPTION
## Summary
- Prevent duplicate final Slack replies when a streamed message already shows the complete answer but the final `chat.update`/finalize edit fails transiently.
- Add `_visible_matches_final()` to confirm the visible streamed body equals the cleaned final response before suppressing the normal gateway fallback send.
- Add regression coverage for the finalize-failure path.

Fixes #25256

## Test plan
- `python -m pytest tests/gateway/test_stream_consumer.py::TestFinalizeDuplicateSuppression -q`
- `python -m pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_draft.py -q`
