### PR TITLE
fix(agent): honor provider timeout config in streaming API calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7856,15 +7856,18 @@ class AIAgent:
                         "Local provider detected (%s) — stream read timeout raised to %.0fs",
                         self.base_url, _stream_read_timeout,
                     )
+            # Cap connect/pool at 60s even when provider timeout is higher.
+            # connect/pool cover TCP handshake, not model inference.
+            _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
             stream_kwargs = {
                 **api_kwargs,
                 "stream": True,
                 "stream_options": {"include_usage": True},
                 "timeout": _httpx.Timeout(
-                    connect=_base_timeout if _provider_timeout_cfg is not None else 30.0,
+                    connect=_conn_cap,
                     read=_stream_read_timeout,
                     write=_base_timeout,
-                    pool=_base_timeout if _provider_timeout_cfg is not None else 30.0,
+                    pool=_conn_cap,
                 ),
             }
             request_client_holder["client"] = self._create_request_openai_client(

--- a/run_agent.py
+++ b/run_agent.py
@@ -7861,10 +7861,10 @@ class AIAgent:
                 "stream": True,
                 "stream_options": {"include_usage": True},
                 "timeout": _httpx.Timeout(
-                    connect=30.0,
+                    connect=_base_timeout if _provider_timeout_cfg is not None else 30.0,
                     read=_stream_read_timeout,
                     write=_base_timeout,
-                    pool=30.0,
+                    pool=_base_timeout if _provider_timeout_cfg is not None else 30.0,
                 ),
             }
             request_client_holder["client"] = self._create_request_openai_client(
@@ -8443,7 +8443,12 @@ class AIAgent:
                 if request_client is not None:
                     self._close_request_openai_client(request_client, reason="stream_request_complete")
 
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        # Provider-configured stale timeout takes priority over env default.
+        _cfg_stale = get_provider_stale_timeout(self.provider, self.model)
+        if _cfg_stale is not None:
+            _stream_stale_timeout_base = _cfg_stale
+        else:
+            _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
         # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
         # for prefill on large contexts.  Disable the stale detector unless
         # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.


### PR DESCRIPTION
## Summary

Fixes two bugs in the streaming chat-completions path that caused `stale_timeout_seconds` and `request_timeout_seconds` provider configs to be silently ignored.

## Bugs Fixed

### Bug 1: Hardcoded connect/pool timeout

The `httpx.Timeout` for streaming calls used hardcoded `connect=30.0` and `pool=30.0` regardless of the user\`s `providers.<id>.request_timeout_seconds` config. If a custom provider (e.g. Ollama) was unreachable, the call always waited exactly 30s before failing.

**Fix**: Use `_base_timeout` (from config) for connect and pool phases when the user has set `request_timeout_seconds`. Fall back to 30.0 when no config is set (preserving existing behavior).

### Bug 2: Streaming stale timeout ignored provider config

The stream stale detector read only the `HERMES_STREAM_STALE_TIMEOUT` env var (default 180s). The `providers.<id>.stale_timeout_seconds` config key was never consulted for streaming calls, despite being correctly used for non-streaming calls.

**Fix**: Check `get_provider_stale_timeout()` first, then fall back to the env var. Aligns streaming path with non-streaming priority chain: config → env → default.

## Before/After

**Before** (custom provider unreachable):
- `stale_timeout_seconds: 5` → ignored, always times out at 30s
- `request_timeout_seconds: 10` → only affects read/write, connect stuck at 30s

**After**:
- `stale_timeout_seconds: 5` → stale detector triggers at 5s
- `request_timeout_seconds: 10` → connect/read/write/pool all capped at 10s

## Testing

- All 12 tests in `test_timeouts.py` pass
- All 17 tests in `test_provider_config_validation.py` pass

## Files Changed

| File | Change |
|------|--------|
| `run_agent.py` | Streaming httpx.Timeout: use config for connect/pool; streaming stale: read provider config |

Closes #25249