### PR TITLE
fix(agent): trigger fallback on 429 rate-limit and billing errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14132,10 +14132,6 @@ class AIAgent:
                             not classified.retryable
                             and not classified.should_compress
                             and classified.reason not in {
-                                FailoverReason.rate_limit,
-                                FailoverReason.billing,
-                                FailoverReason.overloaded,
-                                FailoverReason.context_overflow,
                                 FailoverReason.payload_too_large,
                                 FailoverReason.long_context_tier,
                                 FailoverReason.thinking_signature,


### PR DESCRIPTION
## Problem

When the primary provider returns 429 (rate limit) or billing errors (e.g. quota exhausted), Hermes does not activate the fallback model. The user is stuck with a non-functional agent until the quota recovers (which can take hours).

### Root cause

At `run_agent.py` L14136-14137, `FailoverReason.rate_limit` and `FailoverReason.billing` are excluded from the `is_client_error` check:

```python
is_client_error = (
    is_local_validation_error
    or (
        not classified.retryable
        and not classified.should_compress
        and classified.reason not in {
            FailoverReason.rate_limit,      # ← prevents fallback on 429
            FailoverReason.billing,         # ← prevents fallback on quota exhaustion
            FailoverReason.payload_too_large,
            FailoverReason.long_context_tier,
            FailoverReason.thinking_signature,
        }
    )
) and not is_context_length_error
```

When `is_client_error` is False, the code falls through to retry logic. With single-credential pools (e.g. Coding Plan subscriptions), retrying 429 is futile — the quota will not recover within the retry window, and the fallback is never activated.

### Fix

Remove `FailoverReason.rate_limit` and `FailoverReason.billing` from the exclusion set. This allows these errors to reach `_try_activate_fallback()`, which already handles the rate-limit cooldown and fallback chain correctly.

### Real-world scenario

- Hermes configured with Coding Plan (GLM-5.1) as primary + DeepSeek V4 Pro as fallback
- Coding Plan quota exhausted → 429 "AccountQuotaExceeded"
- Hermes retries 5 times, all 429 → gives up without trying fallback
- DeepSeek V4 Pro fallback is configured but never activated
- User must manually switch models via `hermes config set`

After this fix, the fallback activates automatically after rate-limit retries are exhausted.

### Changes

1 file, -2 lines: remove two `FailoverReason` entries from the exclusion set.
