### PR TITLE
fix(gateway): restart via service in containers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -375,7 +375,7 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, is_container
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -8737,12 +8737,13 @@ class GatewayRunner:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
         active_agents = self._running_agent_count()
-        # When running under a service manager (systemd/launchd), use the
+        # When running under a service manager or a container, use the
         # service restart path: exit with code 75 so the service manager
-        # restarts us.  The detached subprocess approach (setsid + bash)
-        # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # or container restart policy restarts us.  The detached subprocess
+        # approach (setsid + bash) doesn't work under systemd because
+        # KillMode=mixed kills all processes in the cgroup, and it doesn't
+        # survive a Docker PID 1 exit either.
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or is_container()
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -19,6 +19,7 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
     # Ensure INVOCATION_ID is NOT set — systemd sets this in service mode,
     # which changes the restart call signature.
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run, "is_container", lambda: False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     event = MessageEvent(

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -68,6 +68,29 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
     """Under systemd (INVOCATION_ID set), /restart uses via_service=True."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("INVOCATION_ID", "abc123")
+    monkeypatch.setattr(gateway_run, "is_container", lambda: False)
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_service_restart_in_container(tmp_path, monkeypatch):
+    """In Docker/Podman, /restart exits for the container restart policy."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run, "is_container", lambda: True)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
@@ -89,6 +112,7 @@ async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypat
     """Without systemd, /restart uses the detached subprocess approach."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setattr(gateway_run, "is_container", lambda: False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary

Closes #25217.

`/restart` currently uses a detached helper whenever the gateway is not running under systemd. That works for a normal shell process, but not for Docker/Podman: once the gateway exits as PID 1, the container stops and the detached helper goes with it.

This routes container restarts through the existing service-restart path instead:

- systemd: unchanged, `detached=False, via_service=True`
- Docker/Podman: now also `detached=False, via_service=True`
- plain non-container process: still uses the detached helper

The service path exits with the existing restart code, so a Docker/Podman restart policy such as `unless-stopped` or `on-failure` can bring the container back.

## Tests

```text
python -m py_compile gateway\run.py tests\gateway\test_restart_notification.py tests\gateway\test_restart_drain.py
python -m ruff check gateway\run.py tests\gateway\test_restart_notification.py tests\gateway\test_restart_drain.py
python -m pytest -o addopts='' tests\gateway\test_restart_notification.py tests\gateway\test_restart_drain.py::test_restart_command_while_busy_requests_drain_without_interrupt -q --basetemp .tmp\pytest -p no:cacheprovider
```

Result: `27 passed`.

Note: the full `tests\gateway\test_restart_drain.py` file has an existing Windows-only failure in `test_launch_detached_restart_command_uses_setsid`: this Windows run enters the `sys.executable -c` detached watcher branch, while that test expects the POSIX `setsid bash` path.
