### PR TITLE
fix(gateway): detect Docker/Podman containers for /restart service path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8742,7 +8742,17 @@ class GatewayRunner:
         # restarts us.  The detached subprocess approach (setsid + bash)
         # doesn't work under systemd because KillMode=mixed kills all
         # processes in the cgroup, including the detached helper.
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Detect service-managed environments: systemd (INVOCATION_ID),
+        # Docker (/.dockerenv), or Podman (/run/.containerenv).  In these
+        # environments the detached-subprocess restart approach doesn't work
+        # because the container/service kills all child processes when the
+        # main process exits.  Use the service restart path (exit code 75)
+        # instead, letting the supervisor handle the restart.
+        _under_service = bool(
+            os.environ.get("INVOCATION_ID")  # systemd
+            or os.path.isfile("/.dockerenv")  # Docker
+            or os.path.isfile("/run/.containerenv")  # Podman
+        )
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:


### PR DESCRIPTION
## Summary

The `/restart` gateway command only detected systemd (`INVOCATION_ID`) when choosing between the detached-subprocess and service-restart approaches. In Docker/Podman containers, the detached subprocess approach fails because the container stops when PID 1 exits, killing the helper before it can restart anything.

## Problem

In a Docker container (e.g. `nousresearch/hermes-agent:latest` on Unraid):
1. User sends `/restart`
2. Gateway exits to spawn a detached restart helper
3. tini (PID 1) exits because the gateway exited
4. Docker stops the container
5. The detached helper is killed before it can restart anything
6. Gateway stays dead until manually restarted

## Fix

Detect Docker (`/.dockerenv`) and Podman (`/run/.containerenv`) alongside systemd. In container environments, use the service restart path (exit code 75) instead of the detached subprocess approach. Combined with a restart policy (`unless-stopped` or `on-failure`), Docker/Podman handles the restart correctly.

```python
_under_service = bool(
    os.environ.get("INVOCATION_ID")       # systemd
    or os.path.isfile("/.dockerenv")       # Docker
    or os.path.isfile("/run/.containerenv") # Podman
)
```

## Testing

- All 132 gateway restart-related tests pass

## Files Changed

| File | Change |
|------|--------|
| `gateway/run.py` | Added Docker/Podman detection to `_under_service` check |

Closes #25217