### PR TITLE
fix(session_search): omit failed commands from summaries

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -205,9 +205,12 @@ async def _summarize_session(
         "1. What the user asked about or wanted to accomplish\n"
         "2. What actions were taken and what the outcomes were\n"
         "3. Key decisions, solutions found, or conclusions reached\n"
-        "4. Any specific commands, files, URLs, or technical details that were important\n"
+        "4. Commands, files, URLs, or technical details that SUCCEEDED (exit_code 0, no error). "
+        "For tool calls that failed (non-zero exit_code, error output, or 'unexpected argument'), "
+        "describe only what failed and why — do NOT reproduce the broken command itself, "
+        "as repeating it would cause the same failure again\n"
         "5. Anything left unresolved or notable\n\n"
-        "Be thorough but concise. Preserve specific details (commands, paths, error messages) "
+        "Be thorough but concise. Preserve specific details (paths, URLs, conclusions) "
         "that would be useful to recall. Write in past tense as a factual recap."
     )
 


### PR DESCRIPTION
## Problem

The session summarisation prompt instructs the auxiliary model to *"preserve specific details (commands, paths, error messages) that would be useful to recall."* This causes broken tool calls to be faithfully reproduced in session summaries.

When the main model reads those summaries in a later session, it re-executes the same failing commands verbatim, producing an identical failure — indefinitely.

**Concrete example:** a series of `himalaya` calls with an invalid `--account` flag (global instead of subcommand-level) each failed with `unexpected argument '--account' found`. The session_search auxiliary model dutifully included `himalaya --account …` in every summary. Subsequent sessions read those summaries and repeated the broken call, never reaching the skill that had the correct syntax.

## Fix

Point 4 of the system prompt now distinguishes succeeded calls from failed ones:

- **Succeeded** (`exit_code 0`, no error output): preserve the command as before — it is useful to recall.
- **Failed** (non-zero `exit_code`, error output, or `'unexpected argument'`): describe what failed and why in prose, **without reproducing the broken command**. Repeating it would cause the same failure again.

The trailing word `"commands"` is also removed from the `"preserve specific details"` sentence for consistency.

## Why this is general

Any user whose session history contains failed tool calls is affected: the summariser turns those failures into "here is a command to try" hints for future sessions. The fix is a one-line clarification to the existing prompt — no behaviour change for successful calls.

## Test

Run `session_search` against a session that contains a failed terminal call (non-zero exit_code). Before: the summary includes the broken command. After: the summary says the command failed and describes why, without reproducing it.