### PR TITLE
fix(agent): hide codex commentary messages

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -903,7 +903,15 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     saw_final_answer_phase = True
             message_text = _extract_responses_message_text(item)
             if message_text:
-                content_parts.append(message_text)
+                # Codex Responses may emit assistant ``message`` items in a
+                # ``commentary``/``analysis`` phase immediately before tool
+                # calls.  Those items are provider state, not user-visible
+                # assistant output.  Keep them in codex_message_items for
+                # exact replay, but do not promote them to Chat Completions
+                # ``content`` where gateway interim-message delivery can leak
+                # them as chat bubbles like "Need read docs.".
+                if normalized_phase not in {"commentary", "analysis"}:
+                    content_parts.append(message_text)
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",
@@ -985,7 +993,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
+    if not final_text and hasattr(response, "output_text") and not message_items_raw:
         out_text = getattr(response, "output_text", "")
         if isinstance(out_text, str):
             final_text = out_text.strip()

--- a/run_agent.py
+++ b/run_agent.py
@@ -6844,6 +6844,53 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
+    @staticmethod
+    def _codex_stream_event_value(event: Any, name: str, default: Any = None) -> Any:
+        if isinstance(event, dict):
+            return event.get(name, default)
+        return getattr(event, name, default)
+
+    @staticmethod
+    def _codex_stream_item_value(item: Any, name: str, default: Any = None) -> Any:
+        if isinstance(item, dict):
+            return item.get(name, default)
+        return getattr(item, name, default)
+
+    def _record_hidden_codex_stream_item(
+        self,
+        event: Any,
+        hidden_item_ids: set[str],
+        hidden_output_indices: set[int],
+    ) -> None:
+        item = self._codex_stream_event_value(event, "item")
+        phase = self._codex_stream_item_value(item, "phase")
+        if not isinstance(phase, str) or phase.strip().lower() not in {"commentary", "analysis"}:
+            return
+        item_type = self._codex_stream_item_value(item, "type")
+        if item_type != "message":
+            return
+        item_id = self._codex_stream_item_value(item, "id") or self._codex_stream_event_value(event, "item_id")
+        if isinstance(item_id, str) and item_id:
+            hidden_item_ids.add(item_id)
+        output_index = self._codex_stream_event_value(event, "output_index")
+        if isinstance(output_index, int):
+            hidden_output_indices.add(output_index)
+
+    def _is_hidden_codex_stream_delta(
+        self,
+        event: Any,
+        hidden_item_ids: set[str],
+        hidden_output_indices: set[int],
+    ) -> bool:
+        phase = self._codex_stream_event_value(event, "phase")
+        if isinstance(phase, str) and phase.strip().lower() in {"commentary", "analysis"}:
+            return True
+        item_id = self._codex_stream_event_value(event, "item_id")
+        if isinstance(item_id, str) and item_id in hidden_item_ids:
+            return True
+        output_index = self._codex_stream_event_value(event, "output_index")
+        return isinstance(output_index, int) and output_index in hidden_output_indices
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
@@ -6852,6 +6899,8 @@ class AIAgent:
         max_stream_retries = 1
         has_tool_calls = False
         first_delta_fired = False
+        hidden_message_item_ids: set[str] = set()
+        hidden_message_output_indices: set[int] = set()
         # Accumulate streamed text so we can recover if get_final_response()
         # returns empty output (e.g. chatgpt.com backend-api sends
         # response.incomplete instead of response.completed).
@@ -6867,9 +6916,24 @@ class AIAgent:
                         if self._interrupt_requested:
                             break
                         event_type = getattr(event, "type", "")
-                        # Fire callbacks on text content deltas (suppress during tool calls)
+                        # Track provider-state commentary/analysis messages so their
+                        # text deltas do not become visible chat content before a tool call.
+                        if event_type in {"response.output_item.added", "response.output_item.done"}:
+                            self._record_hidden_codex_stream_item(
+                                event,
+                                hidden_message_item_ids,
+                                hidden_message_output_indices,
+                            )
+                        # Fire callbacks on text content deltas (suppress during tool calls
+                        # and provider-state commentary/analysis messages)
                         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
                             delta_text = getattr(event, "delta", "")
+                            if self._is_hidden_codex_stream_delta(
+                                event,
+                                hidden_message_item_ids,
+                                hidden_message_output_indices,
+                            ):
+                                continue
                             if delta_text:
                                 self._codex_streamed_text_parts.append(delta_text)
                             if delta_text and not has_tool_calls:
@@ -6986,6 +7050,8 @@ class AIAgent:
         terminal_response = None
         collected_output_items: list = []
         collected_text_deltas: list = []
+        hidden_message_item_ids: set[str] = set()
+        hidden_message_output_indices: set[int] = set()
         try:
             for event in stream_or_response:
                 self._touch_activity("receiving stream response")
@@ -6994,6 +7060,12 @@ class AIAgent:
                     event_type = event.get("type")
 
                 # Collect output items and text deltas for backfill
+                if event_type in {"response.output_item.added", "response.output_item.done"}:
+                    self._record_hidden_codex_stream_item(
+                        event,
+                        hidden_message_item_ids,
+                        hidden_message_output_indices,
+                    )
                 if event_type == "response.output_item.done":
                     done_item = getattr(event, "item", None)
                     if done_item is None and isinstance(event, dict):
@@ -7001,6 +7073,12 @@ class AIAgent:
                     if done_item is not None:
                         collected_output_items.append(done_item)
                 elif event_type in {"response.output_text.delta",}:
+                    if self._is_hidden_codex_stream_delta(
+                        event,
+                        hidden_message_item_ids,
+                        hidden_message_output_indices,
+                    ):
+                        continue
                     delta = getattr(event, "delta", "")
                     if not delta and isinstance(event, dict):
                         delta = event.get("delta", "")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -157,9 +157,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -168,7 +169,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -485,6 +486,95 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_suppresses_commentary_phase_text_deltas(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    streamed = []
+    agent.stream_delta_callback = streamed.append
+    final_response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_plan",
+                phase="commentary",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="Need inspect files.")],
+            ),
+            SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+                arguments="{}",
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="gpt-5-codex",
+    )
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(type="message", id="msg_plan", phase="commentary"),
+        ),
+        SimpleNamespace(
+            type="response.output_text.delta",
+            output_index=0,
+            item_id="msg_plan",
+            delta="Need inspect files.",
+        ),
+        SimpleNamespace(type="response.output_item.added", output_index=1, item=SimpleNamespace(type="function_call")),
+    ]
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(final_response=final_response, events=events),
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response is final_response
+    assert streamed == []
+    assert agent._codex_streamed_text_parts == []
+
+
+def test_run_codex_create_stream_fallback_does_not_synthesize_commentary_deltas(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    terminal_response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="gpt-5-codex",
+    )
+    create_stream = _FakeCreateStream(
+        [
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {"type": "message", "id": "msg_plan", "phase": "commentary"},
+            },
+            {
+                "type": "response.output_text.delta",
+                "output_index": 0,
+                "item_id": "msg_plan",
+                "delta": "Need inspect files.",
+            },
+            {"type": "response.completed", "response": terminal_response},
+        ]
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert response is terminal_response
+    assert response.output == []
+    assert create_stream.closed is True
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))
@@ -704,7 +794,7 @@ def test_run_conversation_codex_tool_round_trip(monkeypatch):
     responses = [_codex_tool_call_response(), _codex_message_response("done")]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -872,7 +962,7 @@ def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
 
     monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -907,7 +997,7 @@ def test_run_conversation_codex_continues_after_incomplete_interim_message(monke
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -932,7 +1022,7 @@ def test_run_conversation_codex_continues_after_incomplete_interim_message(monke
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
-def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(monkeypatch):
+def test_normalize_codex_response_keeps_commentary_out_of_visible_content(monkeypatch):
     agent = _build_agent(monkeypatch)
     from agent.codex_responses_adapter import _normalize_codex_response
     assistant_message, finish_reason = _normalize_codex_response(
@@ -940,7 +1030,80 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
     )
 
     assert finish_reason == "incomplete"
-    assert "inspect the repository" in (assistant_message.content or "")
+    assert (assistant_message.content or "") == ""
+    assert assistant_message.codex_message_items[0]["phase"] == "commentary"
+    assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
+
+
+def test_normalize_codex_response_does_not_resurrect_commentary_from_output_text(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = _codex_commentary_message_response("Need locate files.")
+    response.output_text = "Need locate files."
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "incomplete"
+    assert (assistant_message.content or "") == ""
+    assert assistant_message.codex_message_items[0]["content"][0]["text"] == "Need locate files."
+
+
+
+def test_codex_commentary_before_tool_call_is_not_emitted_as_interim(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    emitted = []
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: emitted.append(text)
+
+    responses = [
+        SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    id="msg_commentary_tool_plan",
+                    phase="commentary",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="Need read docs.")],
+                ),
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="terminal",
+                    arguments="{}",
+                ),
+            ],
+            usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+            status="completed",
+            model="gpt-5-codex",
+        ),
+        _codex_message_response("done"),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
+        for call in assistant_message.tool_calls:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": '{"ok":true}',
+                }
+            )
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("inspect the docs")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    assert emitted == []
+    tool_turn = next(
+        msg for msg in result["messages"]
+        if msg.get("role") == "assistant" and msg.get("tool_calls")
+    )
+    assert (tool_turn.get("content") or "") == ""
+    assert tool_turn["codex_message_items"][0]["content"][0]["text"] == "Need read docs."
 
 
 def test_normalize_codex_response_preserves_message_status_for_replay(monkeypatch):
@@ -1259,7 +1422,7 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1275,12 +1438,13 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
 
     assert result["completed"] is True
     assert result["final_response"] == "Architecture summary complete."
-    assert any(
-        msg.get("role") == "assistant"
+    interim_msg = next(
+        msg for msg in result["messages"]
+        if msg.get("role") == "assistant"
         and msg.get("finish_reason") == "incomplete"
-        and "inspect the repo structure" in (msg.get("content") or "")
-        for msg in result["messages"]
     )
+    assert (interim_msg.get("content") or "") == ""
+    assert "inspect the repo structure" in interim_msg["codex_message_items"][0]["content"][0]["text"]
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
 
 
@@ -1295,7 +1459,7 @@ def test_run_conversation_codex_continues_after_ack_stop_message(monkeypatch):
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {
@@ -1336,7 +1500,7 @@ def test_run_conversation_codex_continues_after_ack_for_directory_listing_prompt
     ]
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
 
-    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id):
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count=None):
         for call in assistant_message.tool_calls:
             messages.append(
                 {


### PR DESCRIPTION
## What does this PR do?

Suppresses user-invisible Codex Responses commentary/analysis text so it does not leak into gateway-visible interim assistant messages.

The bug shows up as short internal-looking chat bubbles such as “Need inspect files” or “Use tool X” before the actual tool call runs. Those phase=`commentary`/`analysis` message items are provider state for replay/debugging, not final assistant content.

This PR keeps that metadata in `codex_message_items` for replay, but prevents it from being promoted into visible assistant content or streamed gateway deltas.

Related existing PR: #21568 addresses the same family of leak, but this branch is rebased on current `main` and also covers streaming delta suppression / create-stream fallback behavior.

## Related Issue

Fixes #24933

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_responses_adapter.py`
  - Does not promote phase=`commentary` or phase=`analysis` Codex message text into normalized assistant content.
  - Avoids falling back to `response.output_text` when hidden message items were already present.
- `run_agent.py`
  - Tracks hidden commentary/analysis stream items by item id and output index.
  - Suppresses matching `response.output_text.delta` events before gateway callbacks can deliver them.
  - Applies the same suppression to create-stream fallback reconstruction.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds regressions for commentary message normalization, streaming delta suppression, and create-stream fallback behavior.

## How to Test

1. `python -m compileall -q agent/codex_responses_adapter.py run_agent.py tests/run_agent/test_run_agent_codex_responses.py`
2. `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
3. `ruff check agent/codex_responses_adapter.py run_agent.py tests/run_agent/test_run_agent_codex_responses.py`
4. `git diff --check origin/main...HEAD`

Local result:

- `tests/run_agent/test_run_agent_codex_responses.py`: 63 passed
- `ruff check`: passed
- `compileall`: passed
- `git diff --check`: passed

CI note:

- All non-`test` PR checks passed: ruff/ty, Windows footguns, attribution, Nix, Docker builds, supply chain audit, and e2e.
- The full `test` job currently fails on this PR, but the same failure set is present on `main`'s latest `Tests` workflow runs. The failures are unrelated to this Codex commentary change, e.g. missing `botocore`, missing `faster_whisper`, missing `numpy`, DingTalk mock errors, WeCom/Weixin OpenSSL/cffi errors, Matrix requirements, and `test_switch_model_preserves_config_context_length`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted local verification:

```text
63 passed in 40.79s
All checks passed!
```
