### PR TITLE
test: lock web search into default platform coverage

### DIFF
--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -83,6 +83,12 @@ def test_get_platform_tools_default_telegram_includes_messaging():
     assert "messaging" in enabled
 
 
+def test_get_platform_tools_default_whatsapp_includes_web():
+    enabled = _get_platform_tools({}, "whatsapp")
+
+    assert "web" in enabled
+
+
 def test_get_platform_tools_homeassistant_platform_keeps_homeassistant_toolset():
     enabled = _get_platform_tools({}, "homeassistant")
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -246,3 +246,11 @@ class TestPluginToolsets:
         all_toolsets = get_all_toolsets()
         assert "plugin_bundle" in all_toolsets
         assert all_toolsets["plugin_bundle"]["tools"] == ["plugin_tool"]
+
+
+class TestDefaultPlatformWebSearchCoverage:
+    def test_hermes_whatsapp_toolset_includes_web_search(self):
+        assert "web_search" in resolve_toolset("hermes-whatsapp")
+
+    def test_hermes_api_server_toolset_includes_web_search(self):
+        assert "web_search" in resolve_toolset("hermes-api-server")


### PR DESCRIPTION
## Summary
- add regression coverage that WhatsApp default platform tools include the `web` toolset
- add toolset-level assertions that `hermes-whatsapp` and `hermes-api-server` resolve `web_search`
- preserve current behavior while making future regressions obvious

## Context
`web_search` is already present on current main in the shared/default platform toolsets. This PR locks that behavior in with tests so Ask Agent-style proposal research keeps web search available by default.

## Testing
- `source venv/bin/activate && python -m pytest tests/test_toolsets.py tests/hermes_cli/test_tools_config.py -q`