### PR TITLE
fix(memory/honcho): respect host-scoped cadence/frequency fields

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -306,13 +306,29 @@ class HonchoMemoryProvider(MemoryProvider):
             # ----- B5: cost-awareness config -----
             try:
                 raw = cfg.raw or {}
-                self._injection_frequency = raw.get("injectionFrequency", "every-turn")
-                self._context_cadence = int(raw.get("contextCadence", 1))
+                # Resolve host-scoped overrides first, then fall back to root,
+                # then to defaults — matches client.py:from_global_config pattern
+                # so `hosts.<host>.dialecticCadence` etc. actually take effect.
+                host_block = (raw.get("hosts") or {}).get(cfg.host, {})
+                self._injection_frequency = (
+                    host_block.get("injectionFrequency")
+                    or raw.get("injectionFrequency")
+                    or "every-turn"
+                )
+                self._context_cadence = int(
+                    host_block.get("contextCadence")
+                    or raw.get("contextCadence")
+                    or 1
+                )
                 # Backwards-compat: unset dialecticCadence falls back to 1
                 # (every turn) so existing honcho.json configs without the key
                 # behave as they did before. New setups via `hermes honcho setup`
                 # get dialecticCadence=2 written explicitly by the wizard.
-                self._dialectic_cadence = int(raw.get("dialecticCadence", 1))
+                self._dialectic_cadence = int(
+                    host_block.get("dialecticCadence")
+                    or raw.get("dialecticCadence")
+                    or 1
+                )
                 self._dialectic_depth = max(1, min(cfg.dialectic_depth, 3))
                 self._dialectic_depth_levels = cfg.dialectic_depth_levels
                 self._reasoning_heuristic = cfg.reasoning_heuristic


### PR DESCRIPTION
## Summary

The B5 cost-awareness config block in `MemoryHonchoPlugin._init_plugin` reads `injectionFrequency`, `contextCadence`, and `dialecticCadence` only from `cfg.raw` (root of `honcho.json`), silently ignoring values placed inside `hosts.<host>.{...}`.

Every other host-resolvable field in `HonchoClientConfig.from_global_config` (workspace, aiPeer, apiKey, dialecticReasoningLevel, dialecticDepth, etc.) uses the `host_block.get(...) or raw.get(...)` pattern. These three fields were added later and missed the host-block resolution.

## Symptom

```json
{
  "hosts": {
    "hermes.unconscious": { "dialecticCadence": 100 }
  }
}
```

is silently a no-op — cadence falls back to the default `1`, and dialectic fires every turn. On a local Honcho stack with cold-topic dialectic taking ~30s, warm DMs paid ~60s per turn on 2× 30s dialectic timeouts (~46% of wall clock on a ~130s baseline). The same config placed at the root works.

## Fix

Resolve `host_block` from `(raw.get("hosts") or {}).get(cfg.host, {})`, then read each of the three fields with the same host-first-then-root-then-default pattern used throughout `client.py:from_global_config`. No new config surface, no behavior change when the host block is absent.

## Diff scope

- One file changed: `plugins/memory/honcho/__init__.py`
- 19 lines added, 3 lines deleted
- No tests added — happy to add unit tests for cadence/frequency host-block resolution in a follow-up if maintainers prefer.

## Test plan

- [ ] With `hosts.<host>.dialecticCadence: 100` set in `honcho.json` (no root-level `dialecticCadence`), confirm `agent.log` shows `Honcho dialectic prefetch skipped: effective cadence 100` on turn 2+ of a session.
- [ ] With root-level `dialecticCadence` only (no host block), confirm behavior is unchanged.
- [ ] With `hosts.<host>.injectionFrequency: "on-search"` set, confirm `<memory-context>` is injected only on search-keyword turns, not every turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)