### PR TITLE
fix: resolve MiniMax OAuth auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2376,6 +2376,14 @@ def _refresh_provider_credentials(provider: str) -> bool:
                 return False
             _evict_cached_clients(normalized)
             return True
+        if normalized == "minimax-oauth":
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+
+            creds = resolve_minimax_oauth_runtime_credentials()
+            if not str(creds.get("api_key", "") or "").strip():
+                return False
+            _evict_cached_clients(normalized)
+            return True
         if normalized == "anthropic":
             from agent.anthropic_adapter import read_claude_code_credentials, _refresh_oauth_token, resolve_anthropic_token
 
@@ -2652,7 +2660,7 @@ def resolve_provider_client(
     Args:
         provider: Provider identifier.  One of:
             "openrouter", "nous", "openai-codex" (or "codex"),
-            "zai", "kimi-coding", "minimax", "minimax-cn",
+            "zai", "kimi-coding", "minimax", "minimax-oauth", "minimax-cn",
             "custom" (OPENAI_BASE_URL + OPENAI_API_KEY),
             "auto" (full auto-detection chain).
         model: Model slug override.  If None, uses the provider's default
@@ -2812,6 +2820,40 @@ def resolve_provider_client(
         final_model = _normalize_resolved_model(model or default, provider)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
+
+    # ── MiniMax OAuth (Anthropic-compatible Messages API) ─────────────
+    if provider == "minimax-oauth":
+        try:
+            from agent.anthropic_adapter import build_anthropic_client
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+
+            creds = resolve_minimax_oauth_runtime_credentials()
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but OAuth "
+                "credentials could not be resolved: %s",
+                exc,
+            )
+            return None, None
+
+        token = str(creds.get("api_key", "") or "").strip()
+        base_url = str(creds.get("base_url", "") or "").strip().rstrip("/")
+        if not token or not base_url:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth credentials are incomplete"
+            )
+            return None, None
+
+        final_model = _normalize_resolved_model(
+            model or _get_aux_model_for_provider(provider), provider
+        )
+        real_client = build_anthropic_client(token, base_url)
+        client = AnthropicAuxiliaryClient(
+            real_client, final_model, token, base_url, is_oauth=False
+        )
+        if async_mode:
+            return AsyncAnthropicAuxiliaryClient(client), final_model
+        return client, final_model
 
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":

--- a/run_agent.py
+++ b/run_agent.py
@@ -8896,15 +8896,27 @@ class AIAgent:
             # Without this, compression decisions use the primary model's
             # context window (e.g. 200K) instead of the fallback's (e.g. 32K),
             # causing oversized sessions to overflow the fallback.
-            # Also pass _config_context_length so the explicit config override
-            # (model.context_length in config.yaml) is respected — without this,
-            # the fallback activation drops to 128K even when config says 204800.
+            #
+            # Do not reuse the primary model.context_length override here:
+            # provider-imposed context windows can differ across the fallback
+            # chain. Use fallback_providers[].context_length when present,
+            # otherwise let provider-aware metadata resolve the fallback limit.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
+                _fb_config_context_length = None
+                _fb_raw_context_length = fb.get("context_length")
+                if _fb_raw_context_length is not None:
+                    try:
+                        _fb_config_context_length = int(_fb_raw_context_length)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Invalid fallback context_length for %s via %s: %r",
+                            fb_model, fb_provider, _fb_raw_context_length,
+                        )
                 fb_context_length = get_model_context_length(
                     self.model, base_url=self.base_url,
                     api_key=self.api_key, provider=self.provider,
-                    config_context_length=getattr(self, "_config_context_length", None),
+                    config_context_length=_fb_config_context_length,
                 )
                 self.context_compressor.update_model(
                     model=self.model,

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -84,6 +84,66 @@ class TestMinimaxAuxModel:
         assert "highspeed" not in _get_aux_model_for_provider("minimax-cn")
 
 
+class TestMinimaxOAuthAuxResolution:
+    """MiniMax OAuth must resolve through the Anthropic-compatible aux client."""
+
+    def test_minimax_oauth_returns_anthropic_aux_client(self, monkeypatch):
+        from types import SimpleNamespace
+        from agent import auxiliary_client as aux
+
+        real_client = SimpleNamespace()
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            lambda: {
+                "provider": "minimax-oauth",
+                "api_key": "mm-oauth-token",
+                "base_url": "https://api.minimax.io/anthropic",
+                "source": "oauth",
+            },
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda api_key, base_url: real_client,
+        )
+
+        client, model = aux.resolve_provider_client(
+            "minimax-oauth", model="MiniMax-M2.7"
+        )
+
+        assert isinstance(client, aux.AnthropicAuxiliaryClient)
+        assert model == "MiniMax-M2.7"
+        assert client.api_key == "mm-oauth-token"
+        assert client.base_url == "https://api.minimax.io/anthropic"
+        assert client._real_client is real_client
+
+    def test_minimax_oauth_async_returns_async_anthropic_aux_client(self, monkeypatch):
+        from types import SimpleNamespace
+        from agent import auxiliary_client as aux
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            lambda: {
+                "provider": "minimax-oauth",
+                "api_key": "mm-oauth-token",
+                "base_url": "https://api.minimax.io/anthropic",
+                "source": "oauth",
+            },
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda api_key, base_url: SimpleNamespace(),
+        )
+
+        client, model = aux.resolve_provider_client(
+            "minimax-oauth", model="MiniMax-M2.7", async_mode=True
+        )
+
+        assert isinstance(client, aux.AsyncAnthropicAuxiliaryClient)
+        assert model == "MiniMax-M2.7"
+        assert client.api_key == "mm-oauth-token"
+        assert client.base_url == "https://api.minimax.io/anthropic"
+
+
 class TestMinimaxBetaHeaders:
     """MiniMax Anthropic-compat endpoints reject fine-grained-tool-streaming beta.
 

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -89,3 +89,50 @@ def test_compressor_not_present_does_not_crash(mock_ctx_len, mock_resolve):
 
     result = agent._try_activate_fallback()
     assert result is True
+
+
+@patch("agent.auxiliary_client.resolve_provider_client")
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+def test_fallback_context_length_does_not_reuse_primary_override(mock_ctx_len, mock_resolve):
+    """Primary model.context_length overrides must not leak to fallback compression."""
+    agent = _make_agent_with_compressor()
+    agent._config_context_length = 204_800
+
+    fb_client = MagicMock()
+    fb_client.base_url = "https://api.openai.com/v1"
+    fb_client.api_key = "sk-fallback"
+    mock_resolve.return_value = (fb_client, None)
+
+    agent._is_direct_openai_url = lambda url: "api.openai.com" in url
+    agent._emit_status = lambda msg: None
+
+    result = agent._try_activate_fallback()
+
+    assert result is True
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] is None
+
+
+@patch("agent.auxiliary_client.resolve_provider_client")
+@patch("agent.model_metadata.get_model_context_length", return_value=32_768)
+def test_fallback_context_length_uses_fallback_override(mock_ctx_len, mock_resolve):
+    """fallback_providers[].context_length should drive fallback compression limits."""
+    agent = _make_agent_with_compressor()
+    agent._fallback_model = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "context_length": "32768",
+    }
+    agent._fallback_chain = [agent._fallback_model]
+
+    fb_client = MagicMock()
+    fb_client.base_url = "https://api.openai.com/v1"
+    fb_client.api_key = "sk-fallback"
+    mock_resolve.return_value = (fb_client, None)
+
+    agent._is_direct_openai_url = lambda url: "api.openai.com" in url
+    agent._emit_status = lambda msg: None
+
+    result = agent._try_activate_fallback()
+
+    assert result is True
+    assert mock_ctx_len.call_args.kwargs["config_context_length"] == 32_768


### PR DESCRIPTION
## Summary
- Resolve MiniMax OAuth auxiliary-client handling so OAuth runtime credentials are resolved before building the auxiliary Anthropic-compatible client.
- Add/adjust targeted regression coverage for MiniMax OAuth auth status and auxiliary resolution.

## Test plan
- Targeted Hermes tests for MiniMax OAuth auth status / auxiliary provider resolution.
- Live resolver smoke check confirmed the MiniMax OAuth auxiliary client resolves without the prior `unhandled auth_type oauth_minimax` path.

## Notes
Prepared from Binary Rogue fork branch after live gateway issue investigation.
