### PR TITLE
fix(auxiliary): resolve api_key_env alias in named custom provider path of resolve_provider_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2911,10 +2911,17 @@ def resolve_provider_client(
         if custom_entry:
             custom_base = custom_entry.get("base_url", "").strip()
             custom_key = custom_entry.get("api_key", "").strip()
-            custom_key_env = custom_entry.get("key_env", "").strip()
+            custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = os.getenv(custom_key_env, "").strip()
             custom_key = custom_key or "no-key-required"
+            if custom_key == "no-key-required":
+                logger.warning(
+                    "resolve_provider_client: named custom provider %r has no resolvable "
+                    "api_key — request will be sent with placeholder no-key-required "
+                    "and will 401 on auth-required endpoints",
+                    custom_entry.get("name") or provider,
+                )
             # An explicit per-task api_mode override (from _resolve_task_provider_model)
             # wins; otherwise fall back to what the provider entry declared.
             entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()


### PR DESCRIPTION
## Summary
In `resolve_provider_client()`, the named custom provider code path only checked the `key_env` field when looking for an environment-variable-based API key. The documented `api_key_env` snake_case alias was silently ignored, causing custom providers configured with `api_key_env` to fall through to the `no-key-required` placeholder.

## Bugs Fixed
- **#25091**: `api_key_env` alias silently dropped in `resolve_provider_client()` named custom provider path in `agent/auxiliary_client.py`
- Mirrors the same fix already applied to `run_agent.py` in commit 6ddc48b05
- Adds `logger.warning()` when key falls back to placeholder for easier debugging

## Testing
Test results (1277 passed, 6 known flaky failures, 3 skipped):
- tests/agent/test_auxiliary_client.py: 155 passed
- tests/agent/test_auxiliary_named_custom_providers.py: 29 passed
- tests/agent/test_auxiliary_main_first.py: 21 passed
- tests/agent/test_auxiliary_config_bridge.py: 2 passed
- tests/agent/test_auxiliary_transport_autodetect.py: 32 passed
- tests/run_agent/test_fallback_model.py: 31 passed
- 6 failures all in tests/hermes_cli/test_api_key_providers.py (pre-existing flaky, unrelated)

## Files Changed
| File | Change |
|---|---|
| agent/auxiliary_client.py | Add `api_key_env` alias check at line 2913; add `logger.warning()` when key falls back to `no-key-required` |

Closes #25091