### PR TITLE
fix(cli): preserve systemd unit paths when service user differs from CLI user

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2288,6 +2288,37 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
         return False
 
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+
+    # ── Service-account mismatch guard ─────────────────────────────────
+    # When the unit's User= points to a dedicated system account whose home
+    # differs from the CLI user's home, remap-based regeneration would write
+    # paths that don't exist on disk (the actual venv/repo live under the
+    # CLI user).  The safest fix is to skip the rewrite entirely — the unit
+    # was hand-configured during the service-account migration and any path
+    # update must be done deliberately by the admin.  (Issue #25282)
+    if system and expected_user:
+        import getpass as _getpass
+        import pwd as _pwd
+        try:
+            cli_user = _getpass.getuser()
+            if cli_user != expected_user:
+                # Check if the homes actually differ — same home (e.g. both
+                # resolve to /home/user) means remap is a no-op and safe.
+                cli_home = Path.home()
+                try:
+                    svc_home = Path(_pwd.getpwnam(expected_user).pw_dir)
+                except KeyError:
+                    svc_home = cli_home  # unknown user, can't compare
+                if cli_home != svc_home:
+                    logger.info(
+                        "Skipping systemd unit refresh: service user %s "
+                        "(home %s) differs from CLI user %s (home %s)",
+                        expected_user, svc_home, cli_user, cli_home,
+                    )
+                    return False
+        except Exception:
+            pass  # non-fatal; proceed with normal refresh
+
     new_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
 
     # ── Test-environment safety belt ─────────────────────────────────────


### PR DESCRIPTION
## Summary

When a gateway systemd unit defines `User=` pointing to a dedicated system account (e.g. `hermes`, home `/var/lib/hermes/`), running `hermes update` would regenerate the unit with paths derived from the CLI user's home directory via `_remap_path_for_user()`. The remapped paths don't exist on disk, so the gateway fails to start after the update.

Fix: detect the service-user / CLI-user mismatch in `refresh_systemd_unit_if_needed()` and skip unit regeneration. The unit was hand-configured during the service-account migration and any path changes must be done deliberately by the admin.

## Bugs Fixed

- **#25282** — `hermes update` resets gateway systemd unit paths to CLI user home, breaking service account deployments

## Root Cause

`_remap_path_for_user()` swaps the CLI user's home prefix to the target user's home. When the gateway runs under a dedicated system account (not a regular user whose home mirrors the CLI user's directory structure), the remapped paths point to non-existent directories.

## Testing

```
tests/hermes_cli/test_gateway_service.py: 132 passed
```

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/gateway.py` | +31 lines in `refresh_systemd_unit_if_needed()` — service-user mismatch guard |

Closes #25282