### PR TITLE
fix(gateway): decode schtasks output as utf-8 on Windows

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -110,6 +110,8 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             [schtasks, *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the

--- a/tests/hermes_cli/test_gateway_windows_encoding.py
+++ b/tests/hermes_cli/test_gateway_windows_encoding.py
@@ -1,0 +1,45 @@
+import subprocess
+import unittest
+from unittest import mock
+
+from hermes_cli import gateway_windows
+
+
+class GatewayWindowsEncodingTests(unittest.TestCase):
+    def test_exec_schtasks_uses_utf8_replace_for_captured_output(self):
+        run = mock.Mock(
+            return_value=subprocess.CompletedProcess(
+                args=[r"C:\Windows\System32\schtasks.exe", "/Query"],
+                returncode=0,
+                stdout="ok",
+                stderr="",
+            )
+        )
+        with (
+            mock.patch.object(gateway_windows, "_assert_windows", lambda: None),
+            mock.patch.object(
+                gateway_windows.shutil,
+                "which",
+                lambda name: r"C:\Windows\System32\schtasks.exe",
+            ),
+            mock.patch.object(gateway_windows.subprocess, "run", run),
+        ):
+            code, out, err = gateway_windows._exec_schtasks(["/Query"])
+
+        run.assert_called_once()
+        argv = run.call_args.args[0]
+        kwargs = run.call_args.kwargs
+
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "ok")
+        self.assertEqual(err, "")
+        self.assertEqual(
+            argv,
+            [
+                r"C:\Windows\System32\schtasks.exe",
+                "/Query",
+            ],
+        )
+        self.assertIs(kwargs["text"], True)
+        self.assertEqual(kwargs["encoding"], "utf-8")
+        self.assertEqual(kwargs["errors"], "replace")


### PR DESCRIPTION
## Summary

- Decode `schtasks.exe` output with explicit UTF-8 and replacement handling in the native Windows gateway backend.
- Add a regression test that keeps `_exec_schtasks()` from falling back to the Windows process locale when `text=True` is used.

## Context

Native Windows Early Beta installs via `scripts/install.ps1` into `%LOCALAPPDATA%\hermes\hermes-agent`, as documented in the Windows native guide. During `hermes setup` on a Polish Windows locale, gateway setup crashed after messaging platform configuration when the setup flow checked or started the Windows gateway backend.

The traceback came from `subprocess._readerthread` while decoding captured `schtasks.exe` output with the process default locale (`cp1250`). Because `_exec_schtasks()` used `capture_output=True, text=True` without `encoding`/`errors`, Python could raise `UnicodeDecodeError` before the setup flow reached the "Start the gateway service?" step cleanly.

This matches the UTF-8 posture already used elsewhere in the Windows gateway path, for example the `wmic`/PowerShell process scanning code in `hermes_cli/gateway.py`.

## Testing

- `uv run --no-project --with pytest --with pytest-xdist python -m pytest tests\hermes_cli\test_gateway_windows_encoding.py -q`
- `python -m unittest tests.hermes_cli.test_gateway_windows_encoding -v`
- `python -m py_compile hermes_cli\gateway_windows.py tests\hermes_cli\test_gateway_windows_encoding.py`
- `PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python scripts\check-windows-footguns.py hermes_cli\gateway_windows.py`
- Manual native Windows smoke test:
  - `hermes gateway status`
  - `hermes gateway start`
  - verified gateway process running and messaging gateway started successfully

## Notes

I intentionally did not change `install.ps1`. The installer path is relevant for reproduction, but the crash is in the runtime Windows `schtasks.exe` wrapper.
