### PR TITLE
fix(approval): distinguish cancelled approval from explicit user deny

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1299,7 +1299,16 @@ def check_all_command_guards(command: str, env_type: str,
             )
 
             if not resolved or choice is None or choice == "deny":
-                reason = "timed out" if not resolved else "denied by user"
+                if not resolved:
+                    reason = "timed out"
+                elif choice is None:
+                    # The approval was cancelled (session ended, notify
+                    # callback unregistered, or agent interrupted) without
+                    # the user ever responding — distinct from an explicit
+                    # deny.  (Issue #22992)
+                    reason = "approval cancelled (prompt not delivered or session ended)"
+                else:
+                    reason = "denied by user"
                 return {
                     "approved": False,
                     "message": f"BLOCKED: Command {reason}. Do NOT retry this command.",


### PR DESCRIPTION
## Summary

When a gateway session ends or the approval notify callback is unregistered while an approval prompt is pending, `unregister_gateway_notify()` signals the blocked thread by setting the event without assigning a result. The code then reported this as `"denied by user"` even though the user never saw or responded to the prompt.

Fix: differentiate three outcomes in the gateway approval wait:
- **timed out** — event never set within deadline
- **cancelled** — event set but no result (session ended or interrupted)
- **denied by user** — explicit `/deny` response

## Bugs Fixed

- **#22992** — Approval flow can return 'User denied' when no prompt is delivered

## Root Cause

`unregister_gateway_notify()` calls `entry.event.set()` without setting `entry.result`. The wait loop sees `resolved=True` and `choice=None`, which fell into the same `"denied by user"` branch as an explicit deny.

## Testing

```
tests/tools/test_approval.py: 154 passed
```

## Files Changed

| File | Change |
|------|--------|
| `tools/approval.py` | +10/-1 in gateway approval wait — three-way outcome differentiation |

Closes #22992