### PR TITLE
fix(compression): increase default auxiliary.compression.timeout from 120s to 300s

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -829,7 +829,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 300,        # seconds — compression summarises large contexts; increase for local models
             "extra_body": {},
         },
         "session_search": {

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -224,7 +224,7 @@ def test_reset_aux_to_auto_clears_routing_preserves_timeouts(tmp_path, monkeypat
     # User-tuned timeout survives reset
     assert cfg["auxiliary"]["vision"]["timeout"] == 300
     # Default compression timeout preserved
-    assert cfg["auxiliary"]["compression"]["timeout"] == 120
+    assert cfg["auxiliary"]["compression"]["timeout"] == 300
 
 
 def test_reset_aux_to_auto_idempotent(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Increase the default `auxiliary.compression.timeout` from **120s → 300s** to prevent spurious `APIConnectionError` retries on Codex auxiliary (compression) tasks with large contexts.

## Bugs Fixed

- Closes #22986 — Codex `APIConnectionError` retry rate ~8x higher post-v0.13.0

## Root Cause

Commit 5533ad764 enforces a strict total-elapsed stream timeout on Codex Responses API calls via `_CodexCompletionsAdapter`. The timeout value is sourced from `auxiliary.compression.timeout` in the user config. The default of **120s** is too aggressive for context compression on large sessions (200K+ tokens), causing `_close_client_on_timeout()` to fire mid-compression. The client.close() surfaces as `APIConnectionError`, triggering retries which cascade into an ~8x increase in Codex API calls.

## Testing

- All 21 `tests/hermes_cli/test_aux_config.py` pass (including updated assertion)
- All 4 Codex adapter timeout tests pass (`TestCodexAuxiliaryAdapterTimeout`)
- Verified by user workaround: setting `auxiliary.compression.timeout: 300` in `config.yaml` eliminates the symptom

## Files Changed

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Default `auxiliary.compression.timeout` 120 → 300 |
| `tests/hermes_cli/test_aux_config.py` | Updated assertion to match new default |