### PR TITLE
fix(tools-config): write video_gen.provider on Reconfigure tool path

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2469,6 +2469,11 @@ def _reconfigure_provider(provider: dict, config: dict):
         if plugin_name:
             _select_plugin_image_gen_provider(plugin_name, config)
             return
+        # Plugin-registered video_gen provider — same flow, different registry.
+        video_plugin = provider.get("video_gen_plugin_name")
+        if video_plugin:
+            _select_plugin_video_gen_provider(video_plugin, config)
+            return
         # Imagegen backends prompt for model selection on reconfig too.
         backend = provider.get("imagegen_backend")
         if backend:
@@ -2499,6 +2504,12 @@ def _reconfigure_provider(provider: dict, config: dict):
     plugin_name = provider.get("image_gen_plugin_name")
     if plugin_name:
         _select_plugin_image_gen_provider(plugin_name, config)
+        return
+
+    # Plugin-registered video_gen provider — same flow, different registry.
+    video_plugin = provider.get("video_gen_plugin_name")
+    if video_plugin:
+        _select_plugin_video_gen_provider(video_plugin, config)
         return
 
     backend = provider.get("imagegen_backend")

--- a/tests/hermes_cli/test_video_gen_picker.py
+++ b/tests/hermes_cli/test_video_gen_picker.py
@@ -1,0 +1,148 @@
+"""Tests for plugin video_gen providers in the tools picker.
+
+Covers the reconfigure path that previously failed to write
+``video_gen.provider`` when a user picked an xAI/etc. plugin backend
+through Reconfigure tool → Video Generation. The first-time configure
+path already handled it; the reconfigure path forgot to mirror it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from agent import video_gen_registry
+from agent.video_gen_provider import VideoGenProvider
+
+
+class _FakeVideoProvider(VideoGenProvider):
+    def __init__(
+        self,
+        name: str,
+        available: bool = True,
+        schema: Optional[Dict[str, Any]] = None,
+        models: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self._name = name
+        self._available = available
+        self._schema = schema or {
+            "name": name.title(),
+            "badge": "test",
+            "tag": f"{name} test tag",
+            "env_vars": [{"key": f"{name.upper()}_API_KEY", "prompt": f"{name} key"}],
+        }
+        self._models = models or [
+            {
+                "id": f"{name}-video-v1",
+                "display": f"{name} v1",
+                "speed": "~10s",
+                "strengths": "test",
+                "price": "$",
+            },
+        ]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def list_models(self):
+        return list(self._models)
+
+    def default_model(self):
+        return self._models[0]["id"] if self._models else None
+
+    def get_setup_schema(self):
+        return dict(self._schema)
+
+    def generate(self, prompt, **kw):
+        return {"success": True, "video": f"{self._name}://{prompt}"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    video_gen_registry._reset_for_tests()
+    yield
+    video_gen_registry._reset_for_tests()
+
+
+class TestReconfigureWritesProvider:
+    """Regression tests for the video_gen reconfigure path.
+
+    Before the fix, _reconfigure_provider() handled image_gen_plugin_name
+    in both the no-env-vars branch and the post-env-vars branch but
+    missed video_gen_plugin_name in both. Picking xAI via Reconfigure
+    tool → Video Generation silently no-op'd: the env var was already
+    set, the env-var loop ran (Enter to keep), and the function fell
+    through without ever writing config["video_gen"]["provider"].
+    """
+
+    def test_reconfigure_with_env_vars_already_set_writes_provider(
+        self, monkeypatch, tmp_path
+    ):
+        """Env vars present and user accepts current value → still writes
+        video_gen.provider via the post-env-vars branch."""
+        from hermes_cli import tools_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeVideoProvider("xai_fake"))
+
+        # Picker prompts replaced — no TTY in tests.
+        monkeypatch.setattr(tools_config, "_prompt_choice", lambda *a, **kw: 0)
+        # User presses Enter to keep the existing key.
+        monkeypatch.setattr(tools_config, "_prompt", lambda *a, **kw: "")
+        # Pretend the env var is already set so the reconfigure path
+        # hits the "Kept current" branch.
+        monkeypatch.setattr(
+            tools_config,
+            "get_env_value",
+            lambda key: "sk-fake" if key == "XAI_FAKE_API_KEY" else "",
+        )
+
+        config: dict = {}
+        provider_row = {
+            "name": "xAI",
+            "env_vars": [{"key": "XAI_FAKE_API_KEY", "prompt": "xAI key"}],
+            "video_gen_plugin_name": "xai_fake",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        assert config["video_gen"]["provider"] == "xai_fake"
+        assert config["video_gen"]["model"] == "xai_fake-video-v1"
+        assert config["video_gen"]["use_gateway"] is False
+
+    def test_reconfigure_with_no_env_vars_writes_provider(
+        self, monkeypatch, tmp_path
+    ):
+        """No env vars at all (managed-style plugin) → writes
+        video_gen.provider via the no-env-vars early-return branch."""
+        from hermes_cli import tools_config
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        video_gen_registry.register_provider(_FakeVideoProvider(
+            "noenv_video",
+            schema={
+                "name": "NoEnvVideo",
+                "badge": "free",
+                "tag": "",
+                "env_vars": [],
+            },
+        ))
+        monkeypatch.setattr(tools_config, "_prompt_choice", lambda *a, **kw: 0)
+
+        config: dict = {}
+        provider_row = {
+            "name": "NoEnvVideo",
+            "env_vars": [],
+            "video_gen_plugin_name": "noenv_video",
+        }
+
+        tools_config._reconfigure_provider(provider_row, config)
+
+        assert config["video_gen"]["provider"] == "noenv_video"
+        assert config["video_gen"]["model"] == "noenv_video-video-v1"
+        assert config["video_gen"]["use_gateway"] is False


### PR DESCRIPTION
## Summary

`Reconfigure tool` → `Video Generation` → pick xAI silently no-op'd when the relevant env var (`XAI_API_KEY`) was already set. The video_gen config block was never written, so the `video_generate` tool kept reporting "No video generation backend is configured" even though the picker had visibly accepted the selection.

## Root cause

`_reconfigure_provider()` in `hermes_cli/tools_config.py` mirrors most of the first-time `_configure_provider()` flow but is missing the `video_gen_plugin_name` branch in BOTH code paths:

- the no-env-vars early-return branch (around line 2468)
- the post-env-vars branch (around line 2499)

It handles `image_gen_plugin_name` and `imagegen_backend` correctly in both spots; `video_gen_plugin_name` was just never added. The first-time configure path on the same provider row works fine — it routes to `_select_plugin_video_gen_provider()` which writes `video_gen.provider`, `video_gen.use_gateway`, and prompts for a model. Reconfigure dropped that.

## Repro (current main)

1. `hermes tools` → Configure for All Platforms → enable Video Generation.
2. `hermes tools` → Reconfigure tool → Video Generation.
3. Pick xAI (with `XAI_API_KEY` already in `~/.hermes/.env`).
4. Press Enter at the "keep current key?" prompt.

Expected: `video_gen:` block lands in `~/.hermes/config.yaml`.
Actual: function returns; no block written; `video_generate` tool errors with `No video generation backend is configured. Run hermes tools -> Video Generation to enable one (xAI, FAL, or Google Veo).`

## Fix

Add the missing `video_gen_plugin_name` branch in both code paths of `_reconfigure_provider()`, mirroring how `image_gen_plugin_name` is already handled and how the first-time configure flow already routes for video_gen.

```python
video_plugin = provider.get("video_gen_plugin_name")
if video_plugin:
    _select_plugin_video_gen_provider(video_plugin, config)
    return
```

## Tests

`tests/hermes_cli/test_video_gen_picker.py` — two new tests:

- `test_reconfigure_with_env_vars_already_set_writes_provider` — env vars present, user keeps current value, verifies `video_gen.provider`/`model`/`use_gateway` land. This is the actual user-hit failure path.
- `test_reconfigure_with_no_env_vars_writes_provider` — managed-style plugin with no env vars, verifies the no-env-vars branch.

Both follow the pattern of the existing `test_reconfiguring_plugin_provider_writes_provider_and_model` in `test_image_gen_picker.py`.

Targeted run (4 workers, hermetic):

```
tests/hermes_cli/test_video_gen_picker.py::TestReconfigureWritesProvider::test_reconfigure_with_env_vars_already_set_writes_provider PASSED
tests/hermes_cli/test_video_gen_picker.py::TestReconfigureWritesProvider::test_reconfigure_with_no_env_vars_writes_provider PASSED
```

Full image_gen/tools_config/video_gen picker test surface (79 tests including pre-existing) — all green, no regressions.

## Scope

Targeted fix only. Doesn't touch the first-time configure path (already correct), doesn't touch the image_gen handling (already correct), doesn't refactor the duplicated branches into a helper — that's a separate cleanup.
