### PR TITLE
chore(release): map jake@nousresearch.com and simpolism@gmail.com to @simpolism

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -538,6 +538,8 @@ AUTHOR_MAP = {
     "balyan.sid@gmail.com": "alt-glitch",
     "52913345+alt-glitch@users.noreply.github.com": "alt-glitch",
     "oluwadareab12@gmail.com": "oluwadareab12",
+    "simpolism@gmail.com": "simpolism",
+    "jake@nousresearch.com": "simpolism",
     "simon@simonmarcus.org": "simon-marcus",
     "xowiekk@gmail.com": "Xowiek",
     "1243352777@qq.com": "zons-zhaozhy",


### PR DESCRIPTION
## What does this PR do?

Map both addresses I commit from (`simpolism@gmail.com` for personal-account work, `jake@nousresearch.com` for work-account commits) to the existing GitHub account `@simpolism` in `scripts/release.py`'s `AUTHOR_MAP`. Both addresses route to the same person; this prevents release notes from listing them as separate contributors and avoids each future PR carrying its own `scripts/release.py` noise.

## Related Issue

None — this is housekeeping ahead of a small batch of feature/fix PRs from this account.

## Type of Change

- [x] ♻️ Refactor (no behavior change)

(Strictly speaking this is metadata, not refactor — the change has no runtime effect at all. Closest checkbox.)

## Changes Made

- `scripts/release.py`: add two entries to `AUTHOR_MAP`:
  - `"simpolism@gmail.com": "simpolism"`
  - `"jake@nousresearch.com": "simpolism"`

## How to Test

1. Inspect the diff: `git diff main -- scripts/release.py`
2. Confirm: only two lines added inside the `AUTHOR_MAP` dict, alphabetically near `simon@simonmarcus.org`
3. No code changes, no behavior to verify at runtime

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` — not run; metadata-only author-map change
- [x] I've added tests for my changes — N/A, metadata-only change
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
