### PR TITLE
fix(discord): keep free-response channels inline

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4223,7 +4223,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels)
+            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -446,6 +446,37 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
     assert event.source.chat_type == "group"
 
 
+@pytest.mark.asyncio
+async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypatch):
+    """Free-response channels should reply inline, never spawn a new thread.
+
+    Without this, every message in a free-response channel would auto-create
+    a fresh thread (since the channel bypasses the @mention gate, every
+    message looks like a fresh trigger).  That turns a "lightweight chat"
+    channel into a thread-spawning machine — see the docs at
+    website/docs/user-guide/messaging/discord.md which already describe
+    this as the intended behavior.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="casual chat in free-response channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "casual chat in free-response channel"
+    assert event.source.chat_type == "group"
+
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fix a code-vs-docs gap in Discord auto-threading. Free-response channels are documented as "skip auto-threading — reply inline," but the production code only checks `DISCORD_NO_THREAD_CHANNELS` when deciding whether to skip thread creation, not `DISCORD_FREE_RESPONSE_CHANNELS`. So every message in a free-response channel currently spawns its own thread, turning a documented "lightweight chat" channel into a thread-spawning machine.

One-line production change: OR `is_free_channel` into the existing `skip_thread` calculation.

The existing docstring for `discord.free_response_channels` at `website/docs/user-guide/messaging/discord.md:347` already promises this behavior:

> "Free-response channels also **skip auto-threading** — the bot replies inline rather than spinning off a new thread per message. This keeps the channel usable as a lightweight chat surface."

so no docs change is needed — this PR makes the code match the docs.

## Related Issue

Fixes #25310

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/discord.py`: in `_handle_message`'s auto-thread block, `skip_thread = bool(channel_ids & no_thread_channels)` becomes `bool(channel_ids & no_thread_channels) or is_free_channel`. The `is_free_channel` variable is already computed earlier in the function (used by the mention gate) — this propagates it to the auto-thread gate as well.
- `tests/gateway/test_discord_free_response.py`: new regression test `test_discord_free_response_channel_skips_auto_thread` that mocks `_auto_create_thread` and asserts it is **not** awaited when a message arrives in a free-response channel with `auto_thread=true` (the default).

## How to Test

To verify the bug exists without the fix:

1. Check out `main`.
2. Apply only the test addition from this PR.
3. Run `pytest tests/gateway/test_discord_free_response.py::test_discord_free_response_channel_skips_auto_thread`.
4. Expect: failure with `AssertionError: Expected mock to not have been awaited. Awaited 1 times.` (i.e. the production bug is real — auto-thread *is* fired).

To verify the fix:

1. Apply this full PR.
2. Run the same test — passes.
3. Run the full `tests/gateway/test_discord_free_response.py` suite — 22 tests pass (was 21).

Manual verification: configure a Discord bot with `discord.free_response_channels: [<channel-id>]` and `discord.auto_thread: true`. Send any message in that channel. Before this PR: bot spawns a thread. After this PR: bot replies inline.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the impacted test files and all tests pass
- [x] I've added tests — regression test added that demonstrably fails without the fix
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; existing docs already describe the intended behavior, this PR makes code match docs
- [x] cli-config.yaml.example — N/A, no config key changes
- [x] CONTRIBUTING.md / AGENTS.md — N/A, no architecture/workflow changes
- [x] Cross-platform impact — N/A, purely server-side adapter logic
- [x] Tool descriptions/schemas — N/A
