### PR TITLE
fix(auxiliary): preserve :free suffix in auxiliary fallback models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1410,15 +1410,21 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
+        _model = _OPENROUTER_MODEL
+        if _main_model_has_free_suffix():
+            _model = f"{_model}:free"
         return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+                       default_headers=build_or_headers()), _model
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
+    _model = _OPENROUTER_MODEL
+    if _main_model_has_free_suffix():
+        _model = f"{_model}:free"
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
-                   default_headers=build_or_headers()), _OPENROUTER_MODEL
+                   default_headers=build_or_headers()), _model
 
 
 def _describe_openrouter_unavailable() -> str:
@@ -1465,6 +1471,10 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     # _NOUS_MODEL (google/gemini-3-flash-preview) when the Portal is unreachable
     # or returns a null recommendation for this task type.
     model = _NOUS_MODEL
+    if not vision and _main_model_has_free_suffix():
+        # User configured a :free model — choose a free-tier fallback instead
+        # of the paid _NOUS_MODEL when the Portal recommendation is absent.
+        model = f"{model}:free"
     try:
         from hermes_cli.models import get_nous_recommended_aux_model
         recommended = get_nous_recommended_aux_model(vision=vision)
@@ -1579,6 +1589,16 @@ def clear_runtime_main() -> None:
     global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
     _RUNTIME_MAIN_PROVIDER = ""
     _RUNTIME_MAIN_MODEL = ""
+
+
+def _main_model_has_free_suffix() -> bool:
+    """Check if the user's configured main model has a :free suffix.
+
+    When the user sets ``model.default: deepseek-v4-flash:free``, this returns
+    True so that auxiliary fallback paths preserve the ``:free`` tier.
+    """
+    model = _read_main_model()
+    return bool(model and model.endswith(":free"))
 
 
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:


### PR DESCRIPTION
## Summary

Fixes #24029 — When a user configures a `:free` model (e.g. `deepseek-v4-flash:free`) for auxiliary tasks, the fallback chain was silently falling back to the paid variant of the hardcoded fallback models.

## Bugs Fixed

- `_try_openrouter()` always returned `google/gemini-3-flash-preview` (paid) as the fallback model, ignoring the user's `:free` suffix.
- `_try_nous()` hardcoded fallback `_NOUS_MODEL` was also the paid variant, used when the Portal recommendation is absent.

## Root Cause

The auxiliary fallback model list was hardcoded with paid model names. When a user configures `:free` models, the fallback logic ignored the `:free` suffix and fell back to the paid variant, silently costing the user money.

## Testing

- All existing auxiliary client tests pass (21/21 relevant tests: openrouter, nous, pool)
- Pre-existing test failure in `test_codex_timeout_evicts_cached_wrapper` is unrelated (Codex timeout component)
- Syntax verified via `ast.parse`

## Files Changed

| File | Change |
|------|--------|
| `agent/auxiliary_client.py` | Added `_main_model_has_free_suffix()` helper; modified `_try_openrouter()` and `_try_nous()` to append `:free` to fallback models when the user's configured model carries that suffix |