### PR TITLE
fix(gateway): prevent memory leak from agent cache eviction and unbounded session data

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13753,7 +13753,17 @@ class GatewayRunner:
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                entry = self._agent_cache.pop(session_key, None)
+            # Release clients on a daemon thread, same as _enforce_agent_cache_cap.
+            if entry is not None:
+                agent = entry[0] if isinstance(entry, tuple) and entry else None
+                if agent is not None:
+                    threading.Thread(
+                        target=self._release_evicted_agent_soft,
+                        args=(agent,),
+                        daemon=True,
+                        name=f"agent-cache-cmd-evict-{session_key[:24]}",
+                    ).start()
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -13795,6 +13805,10 @@ class GatewayRunner:
                 self._cleanup_agent_resources(agent)
         except Exception:
             pass
+        # Free conversation history memory — can be tens of MB with tool
+        # outputs (file reads, terminal output, search results).
+        if hasattr(agent, '_session_messages'):
+            agent._session_messages = []
 
     def _enforce_agent_cache_cap(self) -> None:
         """Evict oldest cached agents when cache exceeds _AGENT_CACHE_MAX_SIZE.
@@ -13919,6 +13933,22 @@ class GatewayRunner:
                 daemon=True,
                 name=f"agent-cache-idle-{key[:24]}",
             ).start()
+        # Prune stale entries from per-session dicts for keys no longer in
+        # the agent cache.  This prevents unbounded growth over long uptimes.
+        if to_evict:
+            evicted_keys = {key for key, _ in to_evict}
+            with _lock:
+                live_keys = set(_cache.keys())
+            stale_keys = evicted_keys - live_keys
+            for d in (
+                getattr(self, "_session_model_overrides", None),
+                getattr(self, "_session_reasoning_overrides", None),
+                getattr(self, "_pending_approvals", None),
+                getattr(self, "_update_prompt_pending", None),
+            ):
+                if d is not None:
+                    for sk in stale_keys:
+                        d.pop(sk, None)
         return len(to_evict)
 
     # ------------------------------------------------------------------

--- a/model_tools.py
+++ b/model_tools.py
@@ -327,6 +327,8 @@ def get_tool_definitions(
         # agent inits and providers that enforce unique tool names
         # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
         # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
+        if len(_tool_defs_cache) >= 8:
+            _tool_defs_cache.clear()
         _tool_defs_cache[cache_key] = result
         return list(result)
     return result

--- a/model_tools.py
+++ b/model_tools.py
@@ -328,7 +328,7 @@ def get_tool_definitions(
         # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
         # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
         if len(_tool_defs_cache) >= 8:
-            _tool_defs_cache.clear()
+            _tool_defs_cache.pop(next(iter(_tool_defs_cache)))  # evict oldest
         _tool_defs_cache[cache_key] = result
         return list(result)
     return result

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -44,6 +44,7 @@ AUTHOR_MAP = {
     "mgongzai@gmail.com": "vKongv",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",
+    "jeanclawdai@proton.me": "mssteuer",
     "m@mobrienv.dev": "mikeyobrien",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "oleksii.lisikh@gmail.com": "olisikh",

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -87,6 +87,25 @@ class TestQuietModeCacheIsolation:
             f"baseline={baseline}, final={len(final)}."
         )
 
+    def test_cache_bounded_by_lru_eviction(self):
+        """The cache evicts the oldest entry when it reaches 8 entries,
+        keeping 7 warm entries instead of clearing everything."""
+        # Fill cache with 8 distinct keys by varying enabled_toolsets
+        toolset_names = [f"fake_toolset_{i}" for i in range(8)]
+        for name in toolset_names:
+            model_tools.get_tool_definitions(
+                enabled_toolsets=[name], quiet_mode=True,
+            )
+        assert len(model_tools._tool_defs_cache) == 8
+
+        # Adding a 9th should evict the oldest, not clear all
+        model_tools.get_tool_definitions(
+            enabled_toolsets=["fake_toolset_overflow"], quiet_mode=True,
+        )
+        assert len(model_tools._tool_defs_cache) == 8, (
+            "LRU eviction should keep the cache at 8 entries, not clear it"
+        )
+
     def test_non_quiet_mode_does_not_use_cache(self):
         """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
         explains why the bug only hit Gateway."""


### PR DESCRIPTION
## Summary

Fixes gateway memory leak that causes OOM after 20–35 hours of uptime. The gateway grows from ~400 MB to 20–37 GB and eventually crashes.

Four targeted fixes:

1. **`_evict_cached_agent()`** now calls `_release_evicted_agent_soft()` via a daemon thread instead of silently dropping the agent. This ensures OpenAI clients, httpx transports, and SSL contexts are properly closed. Previously, every `/new` or `/model` command leaked a full agent object.

2. **`_release_evicted_agent_soft()`** now clears `_session_messages` after `release_clients()`, freeing conversation history memory. Tool outputs (file reads, terminal output, search results) can be tens of MB per session.

3. **`_sweep_idle_cached_agents()`** now prunes stale entries from per-session dicts (`_session_model_overrides`, `_session_reasoning_overrides`, `_pending_approvals`, `_update_prompt_pending`) for keys no longer in the agent cache.

4. **`_tool_defs_cache`** in `model_tools.py` is now bounded to 8 entries — clears entirely when exceeded (repopulates on next call).

## Root Cause

The primary leak: `_evict_cached_agent()` (called on `/new`, `/model`, etc.) did `self._agent_cache.pop(session_key, None)` but **never** called `release_clients()`. Meanwhile, `_sweep_idle_cached_agents()` and `_enforce_agent_cache_cap()` both properly called `_release_evicted_agent_soft()`. Each orphaned agent leaked an OpenAI client, httpx transport, SSL context, and full conversation history.

Contributing factors: `_session_messages` was never cleared even on proper soft eviction, per-session dicts grew unbounded, and `_tool_defs_cache` accumulated entries on every config touch.

## Evidence

- May 9: 24.9 GB peak after 21h → OOM crash
- May 11: 20.2 GB peak after 28h → OOM crash
- May 12: 37.3 GB peak after 35h → OOM crash
- May 14: 32.1 GB peak after 36h → manual restart

## Files Changed

- `gateway/run.py` — fixes 1, 2, 3
- `model_tools.py` — fix 4

Fixes #25315
Related: #18438, #19251
