### PR TITLE
fix(file_operations): fix macOS/BSD find fallback sorting and pagination

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -2,7 +2,6 @@
 
 import os
 import pytest
-import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -390,25 +389,6 @@ class TestSearchPathValidation:
 
 
 class TestSearchFilesFallbackHiddenPaths:
-    def _make_env(self):
-        env = MagicMock()
-        env.cwd = "/"
-
-        def execute(command, **kwargs):
-            completed = subprocess.run(
-                command,
-                shell=True,
-                text=True,
-                capture_output=True,
-            )
-            return {
-                "output": completed.stdout,
-                "returncode": completed.returncode,
-            }
-
-        env.execute = execute
-        return env
-
     def test_hidden_root_with_hidden_ancestor_includes_files(self, tmp_path, monkeypatch):
         """Fallback find should include visible files when path is inside hidden root."""
         root = tmp_path / ".hermes" / "logs"
@@ -422,12 +402,36 @@ class TestSearchFilesFallbackHiddenPaths:
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text("x")
 
-        ops = ShellFileOperations(self._make_env())
+        env = MagicMock()
+        env.cwd = "/"
+        commands = []
+
+        def execute(command, **kwargs):
+            commands.append(command)
+            if "-printf '%T@ %p\\n'" in command:
+                return {"output": "", "returncode": 1}
+            if "stat -f '%m %N'" in command:
+                return {
+                    "output": (
+                        f"400 {visible_nested_file}\n"
+                        f"300 {nested_hidden_file}\n"
+                        f"200 {visible_file}\n"
+                        f"100 {hidden_dir_file}\n"
+                    ),
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        env.execute = execute
+        ops = ShellFileOperations(env)
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
         result = ops._search_files("*.log", str(root), limit=50, offset=0)
 
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+        stat_commands = [cmd for cmd in commands if "stat -f '%m %N'" in cmd]
+        assert stat_commands
+        assert "-not -path '*/.*'" not in stat_commands[0]
 
     def test_normal_root_still_excludes_hidden_descendants(self, tmp_path, monkeypatch):
         """Fallback find should still exclude hidden descendant paths for normal roots."""
@@ -441,12 +445,98 @@ class TestSearchFilesFallbackHiddenPaths:
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text("x")
 
-        ops = ShellFileOperations(self._make_env())
+        env = MagicMock()
+        env.cwd = "/"
+        commands = []
+
+        def execute(command, **kwargs):
+            commands.append(command)
+            if "-printf '%T@ %p\\n'" in command:
+                return {
+                    "output": (
+                        f"300 {visible_nested_file}\n"
+                        f"200 {visible_file}\n"
+                    ),
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        env.execute = execute
+        ops = ShellFileOperations(env)
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
         result = ops._search_files("*.log", str(root), limit=50, offset=0)
 
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+        printf_commands = [cmd for cmd in commands if "-printf '%T@ %p\\n'" in cmd]
+        assert printf_commands
+        assert "-not -path '*/.*'" in printf_commands[0]
+
+    def test_bsd_stat_fallback_preserves_recent_first_order(self, monkeypatch):
+        """BSD/macOS fallback should recover mtime sorting via `stat -f`."""
+        env = MagicMock()
+        env.cwd = "/"
+        commands = []
+
+        def execute(command, **kwargs):
+            commands.append(command)
+            if "-printf '%T@ %p\\n'" in command:
+                return {"output": "", "returncode": 1}
+            if "stat -f '%m %N'" in command:
+                return {
+                    "output": "200 /repo/new.log\n100 /repo/old.log\n",
+                    "returncode": 0,
+                }
+            return {"output": "", "returncode": 0}
+
+        env.execute = execute
+        ops = ShellFileOperations(env)
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        result = ops._search_files("*.log", "/repo", limit=1, offset=0)
+
+        assert result.error is None
+        assert result.files == ["/repo/new.log"]
+        stat_commands = [cmd for cmd in commands if "stat -f '%m %N'" in cmd]
+        assert stat_commands
+        assert "| tail -n +1 | head -n 1" in stat_commands[0]
+
+    def test_plain_find_last_resort_avoids_numeric_sort_and_paginates_in_python(self, monkeypatch):
+        """Final plain-find fallback must not build the broken `sort -rn` pipeline."""
+        env = MagicMock()
+        env.cwd = "/"
+        commands = []
+
+        def execute(command, **kwargs):
+            commands.append(command)
+            if "-printf '%T@ %p\\n'" in command:
+                return {"output": "", "returncode": 1}
+            if "stat -f '%m %N'" in command:
+                return {"output": "", "returncode": 1}
+            return {
+                "output": "/repo/old.log\n/repo/new.log\n",
+                "returncode": 0,
+            }
+
+        env.execute = execute
+        ops = ShellFileOperations(env)
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        result = ops._search_files("*.log", "/repo", limit=1, offset=1)
+
+        assert result.error is None
+        assert result.files == ["/repo/new.log"]
+        plain_find_commands = [
+            cmd
+            for cmd in commands
+            if cmd.startswith("find ")
+            and "-printf '%T@ %p\\n'" not in cmd
+            and "stat -f '%m %N'" not in cmd
+        ]
+        assert plain_find_commands
+        assert "sort -rn" not in plain_find_commands[0]
+        assert "| tail -n +" not in plain_find_commands[0]
+        assert "| head -n " not in plain_find_commands[0]
 
 
 class TestShellFileOpsWriteDenied:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1458,23 +1458,43 @@ class ShellFileOperations(FileOperations):
         hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
         hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
 
-        # Use shell pagination for standard roots. For hidden roots, gather full
-        # output so we can re-apply hidden-descendant filtering while allowing
-        # explicit hidden-root searches.
+        # Use shell pagination only when the shell command itself is producing
+        # mtime-sorted output. Hidden roots need post-filtering in Python, and
+        # the final plain-find fallback does not have sortable timestamps.
         pagination_expr = ""
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
+        paginated_in_shell = False
 
         cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
+        if result.stdout.strip():
+            paginated_in_shell = not has_hidden_path_ancestor
 
         if not result.stdout.strip():
-            # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
-                        f"2>/dev/null | sort -rn{pagination_expr}"
+            # BSD/macOS find lacks -printf. Recover mtime ordering with BSD
+            # stat so we keep recent-first semantics and correct pagination.
+            cmd_bsd = (
+                f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f "
+                f"-name {self._escape_shell_arg(search_pattern)} -exec stat -f '%m %N' {{}} \\; "
+                f"2>/dev/null | sort -rn{pagination_expr}"
+            )
+            result = self._exec(cmd_bsd, timeout=60)
+            if result.stdout.strip():
+                paginated_in_shell = not has_hidden_path_ancestor
+
+        if not result.stdout.strip():
+            # Last-ditch fallback when neither GNU -printf nor BSD stat is
+            # available. Do not apply numeric sort/pagination in-shell: plain
+            # file paths sort incorrectly under `sort -rn` and break offset/limit.
+            cmd_simple = (
+                f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f "
+                f"-name {self._escape_shell_arg(search_pattern)} 2>/dev/null"
+            )
             result = self._exec(cmd_simple, timeout=60)
+            paginated_in_shell = False
 
         files = []
         for line in result.stdout.strip().split('\n'):
@@ -1500,8 +1520,15 @@ class ShellFileOperations(FileOperations):
                 if any(part not in {".", ".."} and part.startswith(".") for part in rel_parts):
                     continue
                 filtered_files.append(file_path)
-            files = filtered_files[offset:offset + limit]
-        # pagination for standard roots is already applied in shell
+            files = filtered_files
+
+        if not paginated_in_shell:
+            files = files[offset:offset + limit]
+        else:
+            # Shell pagination already handled offset; still cap the final
+            # result length here so mocked/odd shells that skip `head -n`
+            # cannot leak extra rows past the requested limit.
+            files = files[:limit]
 
         return SearchResult(
             files=files,


### PR DESCRIPTION
## Summary

Fix `ShellFileOperations._search_files()` so the non-ripgrep fallback preserves recent-first ordering and correct pagination on BSD/macOS-style environments.

This keeps file-name search behavior aligned across:
- GNU `find -printf` environments
- BSD/macOS `find` environments
- minimal shells that lack both `-printf` and BSD `stat` support

## Problem

The fallback path in `tools/file_operations.py` assumed GNU-style `find -printf` output.

When `-printf` was unavailable, the code fell back to plain `find` output but still reused a numeric `sort -rn` pipeline and shell pagination assumptions that only make sense when each row starts with a timestamp.

That caused two issues:
- recent-first ordering could be lost on BSD/macOS fallback paths
- `offset` / `limit` could become unreliable when the shell pipeline did not actually enforce the expected truncation

## Fix

Updated `_search_files()` to use a three-stage fallback chain:

1. GNU path:
   - `find ... -printf '%T@ %p' | sort -rn`
2. BSD/macOS path:
   - `find ... -exec stat -f '%m %N' {} \; | sort -rn`
3. last-resort plain `find` path:
   - no numeric shell sort
   - pagination applied in Python

Also added a final Python-side clamp when shell pagination is expected, so the requested `limit` is still enforced even if an odd or mocked shell path does not truncate correctly.

## Tests

Added/updated regression coverage for:
- hidden-root fallback behavior without leaking hidden descendants
- normal-root hidden path exclusion
- BSD `stat -f` fallback preserving recent-first ordering
- plain `find` last-resort fallback avoiding the broken `sort -rn` pipeline and paginating in Python

Validated with:

- `uv run python -m pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/tools/test_file_operations.py::TestSearchFilesFallbackHiddenPaths`
- `uv run python -m pytest -o "addopts=" -n 4 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/tools/test_file_operations.py`

