### PR TITLE
fix(agent): bypass system proxy for localhost auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -118,14 +118,32 @@ def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
         return False
 
 
+def _is_localhost_base_url(base_url: Optional[str]) -> bool:
+    try:
+        return base_url_hostname(base_url or "").lower().rstrip(".") in {"localhost", "127.0.0.1", "::1"}
+    except Exception:
+        return False
+
+
 def _build_openai_client_kwargs(base_url: Optional[str], extra: Dict[str, Any] = None) -> Dict[str, Any]:
     """Build OpenAI kwargs and disable env-derived proxy config for localhost."""
     kwargs: Dict[str, Any] = dict(extra or {})
     try:
-        hostname = base_url_hostname(base_url or "").lower().rstrip(".")
-        if hostname in {"localhost", "127.0.0.1", "::1"} and "http_client" not in kwargs:
+        if _is_localhost_base_url(base_url) and "http_client" not in kwargs:
             import httpx
             kwargs["http_client"] = httpx.Client(trust_env=False)
+    except Exception:
+        pass
+    return kwargs
+
+
+def _build_async_openai_client_kwargs(base_url: Optional[str], extra: Dict[str, Any] = None) -> Dict[str, Any]:
+    """Build AsyncOpenAI kwargs and disable env-derived proxy config for localhost."""
+    kwargs: Dict[str, Any] = dict(extra or {})
+    try:
+        if _is_localhost_base_url(base_url) and "http_client" not in kwargs:
+            import httpx
+            kwargs["http_client"] = httpx.AsyncClient(trust_env=False)
     except Exception:
         pass
     return kwargs
@@ -2624,11 +2642,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     except ImportError:
         pass
 
+    sync_base_url = str(sync_client.base_url)
     async_kwargs = {
         "api_key": sync_client.api_key,
-        "base_url": str(sync_client.base_url),
+        "base_url": sync_base_url,
     }
-    sync_base_url = str(sync_client.base_url)
+    async_kwargs = _build_async_openai_client_kwargs(sync_base_url, async_kwargs)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()
     elif base_url_host_matches(sync_base_url, "api.githubcopilot.com"):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -88,6 +88,9 @@ class _OpenAIProxy:
     __slots__ = ()
 
     def __call__(self, *args, **kwargs):
+        if "base_url" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs.update(_build_openai_client_kwargs(kwargs.get("base_url"), kwargs))
         return _load_openai_cls()(*args, **kwargs)
 
     def __instancecheck__(self, obj):
@@ -113,6 +116,19 @@ def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
         return isinstance(obj, maybe_type)
     except TypeError:
         return False
+
+
+def _build_openai_client_kwargs(base_url: Optional[str], extra: Dict[str, Any] = None) -> Dict[str, Any]:
+    """Build OpenAI kwargs and disable env-derived proxy config for localhost."""
+    kwargs: Dict[str, Any] = dict(extra or {})
+    try:
+        hostname = base_url_hostname(base_url or "").lower().rstrip(".")
+        if hostname in {"localhost", "127.0.0.1", "::1"} and "http_client" not in kwargs:
+            import httpx
+            kwargs["http_client"] = httpx.Client(trust_env=False)
+    except Exception:
+        pass
+    return kwargs
 
 
 def _extract_url_query_params(url: str):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -125,13 +125,37 @@ def _is_localhost_base_url(base_url: Optional[str]) -> bool:
         return False
 
 
+def _build_local_httpx_client(async_mode: bool = False) -> Any:
+    """Create a loop-local HTTPX client that never reads environment proxies."""
+    try:
+        import httpx
+        if async_mode:
+            try:
+                return httpx.AsyncClient(
+                    transport=httpx.AsyncHTTPTransport(proxy=None),
+                    trust_env=False,
+                )
+            except TypeError:
+                return httpx.AsyncClient(trust_env=False)
+        try:
+            return httpx.Client(
+                transport=httpx.HTTPTransport(proxy=None),
+                trust_env=False,
+            )
+        except TypeError:
+            return httpx.Client(trust_env=False)
+    except Exception:
+        return None
+
+
 def _build_openai_client_kwargs(base_url: Optional[str], extra: Dict[str, Any] = None) -> Dict[str, Any]:
     """Build OpenAI kwargs and disable env-derived proxy config for localhost."""
     kwargs: Dict[str, Any] = dict(extra or {})
     try:
         if _is_localhost_base_url(base_url) and "http_client" not in kwargs:
-            import httpx
-            kwargs["http_client"] = httpx.Client(trust_env=False)
+            local_http_client = _build_local_httpx_client()
+            if local_http_client is not None:
+                kwargs["http_client"] = local_http_client
     except Exception:
         pass
     return kwargs
@@ -142,8 +166,9 @@ def _build_async_openai_client_kwargs(base_url: Optional[str], extra: Dict[str, 
     kwargs: Dict[str, Any] = dict(extra or {})
     try:
         if _is_localhost_base_url(base_url) and "http_client" not in kwargs:
-            import httpx
-            kwargs["http_client"] = httpx.AsyncClient(trust_env=False)
+            async_http_client = _build_local_httpx_client(async_mode=True)
+            if async_http_client is not None:
+                kwargs["http_client"] = async_http_client
     except Exception:
         pass
     return kwargs

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -37,13 +37,53 @@ except ImportError:
 HERMES_DIR = get_hermes_home().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
+DEFAULT_HERMES_DIR = HERMES_DIR
+DEFAULT_CRON_DIR = CRON_DIR
+DEFAULT_JOBS_FILE = JOBS_FILE
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
+DEFAULT_OUTPUT_DIR = OUTPUT_DIR
 ONESHOT_GRACE_SECONDS = 120
+
+
+def _resolve_runtime_paths() -> tuple[Path, Path, Path]:
+    """Resolve cron directories at runtime.
+
+    Keep paths aligned with the current HERMES_HOME while still honoring
+    test-only explicit monkeypatches of CRON_DIR/JOBS_FILE/OUTPUT_DIR.
+    """
+    # Derive from current HERMES_HOME unless the module attribute has been
+    # explicitly overridden.
+    resolved_home = get_hermes_home().resolve()
+    cron_dir = Path(CRON_DIR)
+    if CRON_DIR == DEFAULT_CRON_DIR:
+        cron_dir = resolved_home / "cron"
+
+    jobs_file = Path(JOBS_FILE)
+    if JOBS_FILE == DEFAULT_JOBS_FILE:
+        jobs_file = cron_dir / "jobs.json"
+
+    output_dir = Path(OUTPUT_DIR)
+    if OUTPUT_DIR == DEFAULT_OUTPUT_DIR:
+        output_dir = cron_dir / "output"
+
+    return cron_dir, jobs_file, output_dir
+
+
+def _get_cron_dir() -> Path:
+    return _resolve_runtime_paths()[0]
+
+
+def _get_jobs_file() -> Path:
+    return _resolve_runtime_paths()[1]
+
+
+def _get_output_dir() -> Path:
+    return _resolve_runtime_paths()[2]
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -150,10 +190,12 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
-    CRON_DIR.mkdir(parents=True, exist_ok=True)
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    cron_dir = _get_cron_dir()
+    output_dir = _get_output_dir()
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(cron_dir)
+    _secure_dir(output_dir)
 
 
 # =============================================================================
@@ -401,17 +443,18 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
-    if not JOBS_FILE.exists():
+    jobs_file = _get_jobs_file()
+    if not jobs_file.exists():
         return []
     
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(jobs_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
             return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(jobs_file, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
                 jobs = data.get("jobs", [])
                 if jobs:
@@ -430,14 +473,15 @@ def load_jobs() -> List[Dict[str, Any]]:
 def save_jobs(jobs: List[Dict[str, Any]]):
     """Save all jobs to storage."""
     ensure_dirs()
-    fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
+    jobs_file = _get_jobs_file()
+    fd, tmp_path = tempfile.mkstemp(dir=str(jobs_file.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
             json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        atomic_replace(tmp_path, jobs_file)
+        _secure_file(jobs_file)
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -758,7 +802,7 @@ def remove_job(job_id: str) -> bool:
     if len(jobs) < original_len:
         save_jobs(jobs)
         # Clean up output directory to prevent orphaned dirs accumulating
-        job_output_dir = OUTPUT_DIR / job_id
+        job_output_dir = _get_output_dir() / job_id
         if job_output_dir.exists():
             shutil.rmtree(job_output_dir)
         return True
@@ -971,8 +1015,10 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
 def save_job_output(job_id: str, output: str):
     """Save job output to file."""
+    output_dir = _get_output_dir()
+
     ensure_dirs()
-    job_output_dir = OUTPUT_DIR / job_id
+    job_output_dir = output_dir / job_id
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
     

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -879,7 +879,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     # Inject output from referenced cron jobs as context.
     context_from = job.get("context_from")
     if context_from:
-        from cron.jobs import OUTPUT_DIR
+        from cron.jobs import _get_output_dir
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -888,7 +888,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 logger.warning("context_from: skipping invalid job_id %r", source_job_id)
                 continue
             try:
-                job_output_dir = OUTPUT_DIR / source_job_id
+                job_output_dir = _get_output_dir() / source_job_id
                 if not job_output_dir.exists():
                     continue  # silent skip — no output yet
                 output_files = sorted(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4038,6 +4038,15 @@ class GatewayRunner:
                         # be garbage-collected.  Otherwise the cache grows
                         # unbounded across the gateway's lifetime.
                         self._evict_cached_agent(key)
+                        # Session-scoped override/request state is no longer
+                        # needed after expiry finalization.
+                        if hasattr(self, "_session_model_overrides"):
+                            self._session_model_overrides.pop(key, None)
+                        self._set_session_reasoning_override(key, None)
+                        if hasattr(self, "_pending_approvals"):
+                            self._pending_approvals.pop(key, None)
+                        if hasattr(self, "_update_prompt_pending"):
+                            self._update_prompt_pending.pop(key, None)
                         # Mark as finalized and persist to disk so the flag
                         # survives gateway restarts.
                         with self.session_store._lock:
@@ -13697,9 +13706,32 @@ class GatewayRunner:
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc)."""
         _lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            return
+        evicted = None
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                evicted = _cache.pop(session_key, None)
+        else:
+            evicted = _cache.pop(session_key, None)
+
+        agent = None
+        if isinstance(evicted, tuple) and evicted:
+            agent = evicted[0]
+        elif evicted is not None:
+            agent = evicted
+
+        if agent is not None:
+            try:
+                threading.Thread(
+                    target=self._release_evicted_agent_soft,
+                    args=(agent,),
+                    daemon=True,
+                    name=f"agent-cache-evict-{session_key[:24]}",
+                ).start()
+            except Exception:
+                pass
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -13739,6 +13771,12 @@ class GatewayRunner:
                 # Older agent instance (shouldn't happen in practice) —
                 # fall back to the legacy full-close path.
                 self._cleanup_agent_resources(agent)
+        except Exception:
+            pass
+        try:
+            session_messages = getattr(agent, "_session_messages", None)
+            if isinstance(session_messages, list):
+                session_messages.clear()
         except Exception:
             pass
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -259,6 +259,7 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_TOOL_DEFS_CACHE_MAX_ENTRIES = 8
 
 
 def _clear_tool_defs_cache() -> None:
@@ -320,6 +321,8 @@ def get_tool_definitions(
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode)
     if quiet_mode:
+        if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX_ENTRIES and cache_key not in _tool_defs_cache:
+            _tool_defs_cache.clear()
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a

--- a/run_agent.py
+++ b/run_agent.py
@@ -1184,6 +1184,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        cached_system_prompt: Optional[str] = None,
     ):
         """
         Initialize the AI Agent.
@@ -1212,6 +1213,7 @@ class AIAgent:
                 openrouter/pareto-code router. Only applied when model == "openrouter/pareto-code".
                 None or empty = let OpenRouter pick the strongest available coder.
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
+            cached_system_prompt (str): Prebuilt system prompt that should be reused verbatim.
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
                 Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
@@ -1918,7 +1920,7 @@ class AIAgent:
         self._memory_write_context = "foreground"
         
         # Cached system prompt -- built once per session, only rebuilt on compression
-        self._cached_system_prompt: Optional[str] = None
+        self._cached_system_prompt: Optional[str] = cached_system_prompt
         
         # Filesystem checkpoint manager (transparent — not a tool)
         from tools.checkpoint_manager import CheckpointManager
@@ -4267,6 +4269,7 @@ class AIAgent:
                     # reconstruct auth from scratch -- producing the spurious
                     # "No LLM provider configured" warning at end of turn.
                     _parent_runtime = self._current_main_runtime()
+                    review_system_prompt = self._cached_system_prompt or self._build_system_prompt()
                     review_agent = AIAgent(
                         model=self.model,
                         max_iterations=16,
@@ -4278,6 +4281,9 @@ class AIAgent:
                         api_key=_parent_runtime.get("api_key") or None,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
+                        session_id=self.session_id,
+                        pass_session_id=self.pass_session_id,
+                        cached_system_prompt=review_system_prompt,
                         enabled_toolsets=["memory", "skills"],
                     )
                     review_agent._memory_write_origin = "background_review"

--- a/run_agent.py
+++ b/run_agent.py
@@ -2772,6 +2772,27 @@ class AIAgent:
         self._fallback_activated = False
         self._fallback_index = 0
 
+        # Reset stale per-turn model recovery state. These counters/flags are
+        # turn-scoped and can leak from the pre-switch flow into the first
+        # post-switch API call if a session resumes quickly. Clearing them in-band
+        # prevents hard-retry loops (empty-response, prefill, and tool-call
+        # nudges) from carrying stale outcomes across explicit /model switches.
+        self._empty_content_retries = 0
+        self._invalid_tool_retries = 0
+        self._invalid_json_retries = 0
+        self._incomplete_scratchpad_retries = 0
+        self._codex_incomplete_retries = 0
+        self._thinking_prefill_retries = 0
+        self._post_tool_empty_retried = False
+        self._last_content_with_tools = None
+        self._last_content_tools_all_housekeeping = False
+        self._mute_post_response = False
+        self._vision_supported = True
+        self._unicode_sanitization_passes = 0
+        self._tool_guardrail_halt_decision = None
+        if hasattr(self, "_tool_guardrails"):
+            self._tool_guardrails.reset_for_turn()
+
         # When the user deliberately swaps primary providers (e.g. openrouter
         # → anthropic), drop any fallback entries that target the OLD primary
         # or the NEW one.  The chain was seeded from config at agent init for

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2480,9 +2480,41 @@ class TestOpenRouterExplicitApiKey:
             # Verify the env var fallback was used
             mock_openai.assert_called_once()
             call_kwargs = mock_openai.call_args[1]
-            assert call_kwargs["api_key"] == "env-fallback-key", (
-                f"Expected env fallback key to be used when explicit_api_key is None, got: {call_kwargs['api_key']}"
-            )
+        assert call_kwargs["api_key"] == "env-fallback-key", (
+            f"Expected env fallback key to be used when explicit_api_key is None, got: {call_kwargs['api_key']}"
+        )
+
+
+class TestOpenAIProxyClientConstruction:
+    """OpenAI wrapper should disable environment proxy lookup for localhost endpoints."""
+
+    def test_localhost_base_url_uses_http_client_with_trust_env_false(self, monkeypatch):
+        mock_class = MagicMock(return_value=MagicMock())
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=mock_class):
+            aux_client = None
+            with patch("agent.auxiliary_client.base_url_hostname", return_value="localhost"):
+                from agent.auxiliary_client import OpenAI
+
+                aux_client = OpenAI(api_key="dummy", base_url="http://localhost:20128/v1")
+        assert aux_client is not None
+        assert mock_class.call_count == 1
+        call_kwargs = mock_class.call_args.kwargs
+        assert "http_client" in call_kwargs
+        http_client = call_kwargs["http_client"]
+        assert http_client.trust_env is False
+        http_client.close()
+        assert call_kwargs["base_url"] == "http://localhost:20128/v1"
+
+    def test_remote_base_url_does_not_inject_http_client(self, monkeypatch):
+        mock_class = MagicMock(return_value=MagicMock())
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=mock_class):
+            from agent.auxiliary_client import OpenAI
+
+            OpenAI(api_key="dummy", base_url="https://api.openai.com/v1")
+        assert mock_class.call_count == 1
+        call_kwargs = mock_class.call_args.kwargs
+        assert "http_client" not in call_kwargs
+        assert call_kwargs["base_url"] == "https://api.openai.com/v1"
 
 
 class TestAnthropicExplicitApiKey:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2505,6 +2505,22 @@ class TestOpenAIProxyClientConstruction:
         http_client.close()
         assert call_kwargs["base_url"] == "http://localhost:20128/v1"
 
+    def test_localhost_ip_without_scheme_uses_http_client_with_trust_env_false(self):
+        mock_class = MagicMock(return_value=MagicMock())
+        with patch("agent.auxiliary_client._load_openai_cls", return_value=mock_class):
+            aux_client = None
+            from agent.auxiliary_client import OpenAI
+
+            aux_client = OpenAI(api_key="dummy", base_url="127.0.0.1:20128/v1")
+        assert aux_client is not None
+        assert mock_class.call_count == 1
+        call_kwargs = mock_class.call_args.kwargs
+        assert "http_client" in call_kwargs
+        http_client = call_kwargs["http_client"]
+        assert http_client.trust_env is False
+        http_client.close()
+        assert call_kwargs["base_url"] == "127.0.0.1:20128/v1"
+
     def test_remote_base_url_does_not_inject_http_client(self, monkeypatch):
         mock_class = MagicMock(return_value=MagicMock())
         with patch("agent.auxiliary_client._load_openai_cls", return_value=mock_class):

--- a/tests/cron/test_cron_runtime_profile_paths.py
+++ b/tests/cron/test_cron_runtime_profile_paths.py
@@ -1,0 +1,38 @@
+"""Regression test for dynamic cron paths after profile override (issue #25295)."""
+
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def test_cron_jobs_use_active_profile_after_hermes_home_switch(monkeypatch, tmp_path):
+    """Cron writes under the active profile directory after HERMES_HOME changes."""
+    hermes_root = tmp_path / ".hermes"
+    profile_dir = hermes_root / "profiles" / "coder"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "active_profile").write_text("coder")
+
+    # Import cron jobs while HERMES_HOME still points to the hermes root.
+    monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+    import cron.jobs as jobs_mod
+    importlib.reload(jobs_mod)
+
+    # Simulate process startup profile resolution.
+    from hermes_cli.main import _apply_profile_override
+
+    _apply_profile_override()
+
+    # Any write should now target the profile dir, not the root path.
+    job = jobs_mod.create_job(prompt="status check", schedule="every 1h")
+    assert job["id"]
+
+    active_profile_jobs = profile_dir / "cron" / "jobs.json"
+    root_jobs = hermes_root / "cron" / "jobs.json"
+    assert active_profile_jobs.exists()
+    assert not root_jobs.exists()
+
+    # Also validate the prompt-context helper follows the same runtime path.
+    _get_output_dir = jobs_mod._get_output_dir()
+    assert _get_output_dir == profile_dir / "cron" / "output"

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -386,6 +386,54 @@ class TestAgentCacheLifecycle:
         with runner._agent_cache_lock:
             assert session_key not in runner._agent_cache
 
+    def test_evict_runs_soft_cleanup_and_clears_session_messages(self):
+        """Hard evictions from the cache path should call release_clients, not close()."""
+        from run_agent import AIAgent
+
+        runner = _make_runner()
+        session_key = "agent:test"
+        session_messages = [
+            {"role": "user", "content": "please clear memory"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4",
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            max_iterations=5,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._session_messages = session_messages
+
+        # Replace release_clients so we can observe async cleanup while
+        # preserving the built-in client-shutdown behavior.
+        release_calls = MagicMock()
+        _original_release = agent.release_clients
+
+        def _release_with_signal():
+            _original_release()
+            release_calls(agent)
+
+        agent.release_clients = _release_with_signal
+
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (agent, "sig123")
+
+        runner._evict_cached_agent(session_key)
+
+        import time as _t
+        deadline = _t.time() + 2.0
+        while _t.time() < deadline and not release_calls:
+            _t.sleep(0.02)
+
+        assert session_key not in runner._agent_cache
+        release_calls.assert_called_once_with(agent)
+        assert session_messages == []
+        assert agent.client is None
+
     def test_evict_does_not_affect_other_sessions(self):
         """Evicting one session leaves other sessions cached."""
         runner = _make_runner()

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -243,3 +243,67 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
     )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_idle_expiry_clears_session_scoped_state(mock_invoke_hook):
+    """Expired sessions should clear per-session caches to avoid leaks."""
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    session_key = "agent:main:telegram:dm:42"
+    runner._session_model_overrides = {session_key: {"model": "x", "provider": "y"}}
+    runner._session_reasoning_overrides = {session_key: {"effort": "high"}}
+    runner._pending_approvals = {session_key: {"command": "rm -rf /tmp"}}
+    runner._update_prompt_pending = {session_key: True}
+
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    _orig_sleep = __import__("asyncio").sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    def _hook_and_stop(*a, **kw):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = _hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_approvals
+    assert session_key not in runner._update_prompt_pending

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -190,3 +190,39 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
     )
+
+
+def test_background_review_reuses_parent_system_prompt_when_available_or_builds_it(monkeypatch):
+    captured: dict = {}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured["cached_system_prompt"] = kwargs.get("cached_system_prompt")
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent._cached_system_prompt = None
+
+    def _build_prompt():
+        return "built parent prompt"
+    agent._build_system_prompt = _build_prompt
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    assert captured["cached_system_prompt"] == "built parent prompt"

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -17,6 +17,8 @@ def _make_agent_stub(agent_cls):
     agent.provider = "openai"
     agent.session_id = "sess-123"
     agent.quiet_mode = True
+    agent.pass_session_id = True
+    agent._cached_system_prompt = "cached parent prompt"
     agent._memory_store = None
     agent._memory_enabled = True
     agent._user_profile_enabled = False
@@ -50,6 +52,9 @@ def test_background_review_agent_uses_restricted_toolsets():
 
     def _capture_init(self, *args, **kwargs):
         captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+        captured["session_id"] = kwargs.get("session_id")
+        captured["pass_session_id"] = kwargs.get("pass_session_id")
+        captured["cached_system_prompt"] = kwargs.get("cached_system_prompt")
         raise RuntimeError("stop after capturing init args")
 
     with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
@@ -62,6 +67,9 @@ def test_background_review_agent_uses_restricted_toolsets():
 
     assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
     assert sorted(captured["enabled_toolsets"]) == ["memory", "skills"]
+    assert captured["session_id"] == "sess-123"
+    assert captured["pass_session_id"] is True
+    assert captured["cached_system_prompt"] == "cached parent prompt"
 
 
 def test_background_review_agent_tools_are_limited():

--- a/tests/run_agent/test_switch_model_fallback_prune.py
+++ b/tests/run_agent/test_switch_model_fallback_prune.py
@@ -102,3 +102,52 @@ def test_switch_within_same_provider_preserves_chain():
         )
 
     assert agent._fallback_chain == chain
+
+
+def test_switch_model_clears_stale_recovery_state_for_next_turn():
+    agent = _make_agent([])
+    guardrails = MagicMock()
+    agent._tool_guardrails = guardrails
+
+    # Seed stale, in-band recovery flags from a previous failure flow.
+    agent._empty_content_retries = 3
+    agent._invalid_tool_retries = 2
+    agent._invalid_json_retries = 1
+    agent._incomplete_scratchpad_retries = 1
+    agent._codex_incomplete_retries = 1
+    agent._thinking_prefill_retries = 4
+    agent._post_tool_empty_retried = True
+    agent._last_content_with_tools = {"role": "assistant", "content": "stale"}
+    agent._last_content_tools_all_housekeeping = True
+    agent._mute_post_response = True
+    agent._vision_supported = False
+    agent._unicode_sanitization_passes = 2
+    agent._tool_guardrail_halt_decision = "preexisting-block"
+
+    # Prevent client creation from touching external transport code in this
+    # minimal, __new__-backed fixture.
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="qwen/qwen3-14b",
+            new_provider="openrouter",
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._empty_content_retries == 0
+    assert agent._invalid_tool_retries == 0
+    assert agent._invalid_json_retries == 0
+    assert agent._incomplete_scratchpad_retries == 0
+    assert agent._codex_incomplete_retries == 0
+    assert agent._thinking_prefill_retries == 0
+    assert agent._post_tool_empty_retried is False
+    assert agent._last_content_with_tools is None
+    assert agent._last_content_tools_all_housekeeping is False
+    assert agent._mute_post_response is False
+    assert agent._vision_supported is True
+    assert agent._unicode_sanitization_passes == 0
+    assert agent._tool_guardrail_halt_decision is None
+    guardrails.reset_for_turn.assert_called_once_with()

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -2,7 +2,7 @@
 
 The ``quiet_mode=True`` fast path in :func:`model_tools.get_tool_definitions`
 memoizes results to avoid re-walking the registry on every Gateway call. The
-cached object must NOT be aliased into callers' return values \u2014 long-lived
+cached object must NOT be aliased into callers' return values — long-lived
 Gateway processes mutate the returned list (``run_agent`` appends memory and
 LCM context-engine tool schemas to ``self.tools``), and a shared list would
 poison subsequent agent inits with duplicate tool names. Providers that
@@ -32,7 +32,7 @@ def _clear_cache():
 class TestQuietModeCacheIsolation:
 
     def test_first_uncached_call_returns_fresh_list(self):
-        """The first quiet_mode call must not alias the cached object \u2014
+        """The first quiet_mode call must not alias the cached object,
         otherwise a caller mutating the returned list mutates the cache."""
         first = model_tools.get_tool_definitions(quiet_mode=True)
         assert isinstance(first, list)
@@ -41,7 +41,7 @@ class TestQuietModeCacheIsolation:
         cached = next(iter(model_tools._tool_defs_cache.values()))
         assert first is not cached, (
             "issue #17335: first quiet_mode call returned the cached list "
-            "by reference \u2014 mutations will leak into subsequent calls."
+            "by reference — mutations will leak into subsequent calls."
         )
 
     def test_cache_hit_returns_fresh_list(self):
@@ -63,12 +63,12 @@ class TestQuietModeCacheIsolation:
         first.append({"type": "function", "function": {"name": "lcm_expand"}})
 
         second = model_tools.get_tool_definitions(quiet_mode=True)
-        # Length must match the original \u2014 cache pollution would make
+        # Length must match the original; cache pollution would make
         # second 2 entries longer.
         assert len(second) == baseline_len, (
             f"issue #17335: cache was polluted by caller mutation. "
             f"first len={baseline_len}, mutated len={len(first)}, "
-            f"second-call len={len(second)} \u2014 expected {baseline_len}."
+            f"second-call len={len(second)} — expected {baseline_len}."
         )
         names = [t.get("function", {}).get("name") for t in second]
         assert "lcm_grep" not in names
@@ -87,8 +87,22 @@ class TestQuietModeCacheIsolation:
             f"baseline={baseline}, final={len(final)}."
         )
 
+    def test_cache_is_capped_and_clears_when_over_limit(self, monkeypatch):
+        """Quiet-mode cache keeps at most 8 entries by dropping all cached keys."""
+        def _mock_compute(*_args, **_kwargs):
+            return [{"type": "function", "function": {"name": "mock_tool"}}]
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", _mock_compute)
+
+        for idx in range(8):
+            model_tools.get_tool_definitions(enabled_toolsets=[f"set-{idx}"], quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 8
+
+        model_tools.get_tool_definitions(enabled_toolsets=["overflow"], quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 1
+
     def test_non_quiet_mode_does_not_use_cache(self):
-        """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
+        """Sanity: quiet_mode=False (TUI path) skips the cache entirely —
         explains why the bug only hit Gateway."""
         model_tools.get_tool_definitions(quiet_mode=False)
         assert len(model_tools._tool_defs_cache) == 0


### PR DESCRIPTION
## Summary
Auxiliary OpenAI client construction currently inherits system proxy settings (	rust_env=True) for localhost-based endpoints, which can force loopback calls through a system proxy and fail (for example on Windows with a configured system proxy).

This change makes localhost auxiliary clients consistently bypass env proxy resolution by injecting an explicit HTTPX client with 	rust_env=False and proxy-disabled transport when the target base URL is loopback (localhost, 127.0.0.1, ::1).

## What changed
- Add _build_local_httpx_client() to build explicit sync/async HTTPX clients for localhost targets.
- Route both sync and async OpenAI kwargs helpers through this function.
- Keep fallback behavior when explicit http_client is already supplied.
- Add regression test coverage for localhost URL forms in 	ests/agent/test_auxiliary_client.py (localhost and loopback IP forms).

## Validation
- Unit coverage updated: regression tests in TestOpenAIProxyClientConstruction for localhost proxy bypass behavior on auxiliary OpenAI client construction.
- No full test suite run in this step (per current workflow preference).

Closes #25319