### PR TITLE
fix(tui): redraw after terminal focus regain

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/App.focus.test.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.focus.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSelectionState } from '../selection.js'
+import { getTerminalFocusState, resetTerminalFocusState } from '../terminal-focus-state.js'
+import { FOCUS_IN, FOCUS_OUT } from '../termio/csi.js'
+
+import App from './App.js'
+
+function makeApp(onTerminalFocusChange = vi.fn()) {
+  const stdin = {
+    isTTY: true,
+    readableLength: 0,
+    read: vi.fn(),
+    ref: vi.fn(),
+    unref: vi.fn(),
+    setEncoding: vi.fn(),
+    setRawMode: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn()
+  } as unknown as NodeJS.ReadStream
+
+  const stdout = {
+    isTTY: true,
+    columns: 80,
+    rows: 24,
+    write: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn()
+  } as unknown as NodeJS.WriteStream
+
+  return new App({
+    children: null,
+    dispatchKeyboardEvent: vi.fn(),
+    exitOnCtrlC: false,
+    getHyperlinkAt: vi.fn(),
+    onClickAt: vi.fn(() => false),
+    onCursorDeclaration: vi.fn(),
+    onExit: vi.fn(),
+    onHoverAt: vi.fn(),
+    onMouseDownAt: vi.fn(() => undefined),
+    onMouseDragAt: vi.fn(),
+    onMouseUpAt: vi.fn(),
+    onMultiClick: vi.fn(),
+    onOpenHyperlink: vi.fn(),
+    onSelectionChange: vi.fn(),
+    onSelectionDrag: vi.fn(),
+    onTerminalFocusChange,
+    selection: createSelectionState(),
+    stderr: stdout,
+    stdin,
+    stdout,
+    terminalColumns: 80,
+    terminalRows: 24
+  })
+}
+
+describe('App terminal focus events', () => {
+  beforeEach(() => {
+    resetTerminalFocusState()
+  })
+
+  it('notifies the renderer on DECSET 1004 focus transitions', () => {
+    const onTerminalFocusChange = vi.fn()
+    const app = makeApp(onTerminalFocusChange)
+
+    app.processInput(FOCUS_OUT)
+    expect(getTerminalFocusState()).toBe('blurred')
+    expect(onTerminalFocusChange).toHaveBeenLastCalledWith(false)
+
+    app.processInput(FOCUS_IN)
+    expect(getTerminalFocusState()).toBe('focused')
+    expect(onTerminalFocusChange).toHaveBeenLastCalledWith(true)
+    expect(onTerminalFocusChange).toHaveBeenCalledTimes(2)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -116,6 +116,11 @@ type Props = {
   // fullscreen) re-enters alt-screen + mouse tracking. Idempotent on the
   // terminal side. Optional so testing.tsx doesn't need to stub it.
   readonly onStdinResume?: () => void
+  // Called for DECSET 1004 terminal focus transitions. The renderer uses
+  // focus-in as a strong signal that the emulator may have coalesced hidden
+  // tab writes or lost physical cursor state, so it can force one clean
+  // repaint instead of trusting incremental damage from before the blur.
+  readonly onTerminalFocusChange?: (isFocused: boolean) => void
   // Receives the declared native-cursor position from useDeclaredCursor
   // so ink.tsx can park the terminal cursor there after each frame.
   // Enables IME composition at the input caret and lets screen readers /
@@ -594,6 +599,7 @@ export default class App extends PureComponent<Props, State> {
     // setTerminalFocused notifies subscribers: TerminalFocusProvider (context)
     // and Clock (interval speed) — no App setState needed.
     setTerminalFocused(isFocused)
+    this.props.onTerminalFocusChange?.(isFocused)
   }
   handleSuspend = (): void => {
     if (!this.isRawModeSupported()) {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -600,6 +600,27 @@ export default class Ink {
     }, 160)
   }
 
+  private handleTerminalFocusChange(isFocused: boolean): void {
+    if (!isFocused || !this.options.stdout.isTTY) {
+      return
+    }
+
+    // Focus-in means the terminal emulator has just made this tab/pane
+    // visible again. Some emulators throttle or coalesce hidden-tab output;
+    // if we continue with the pre-blur virtual cursor/backbuffer, only the
+    // next small dirty region may repaint and stale status/progress rows can
+    // remain visible. Defer one tick so TerminalFocusProvider subscribers
+    // observe the new focus state first, then do the same recovery as /redraw.
+    queueMicrotask(() => {
+      if (this.isUnmounted || this.isPaused || !this.options.stdout.isTTY || this.currentNode === null) {
+        return
+      }
+
+      this.reassertTerminalModes(false)
+      this.forceRedraw()
+    })
+  }
+
   resolveExitPromise: () => void = () => {}
   rejectExitPromise: (reason?: Error) => void = () => {}
   unsubscribeExit: () => void = () => {}
@@ -2398,6 +2419,7 @@ export default class Ink {
         onSelectionChange={this.notifySelectionChange}
         onSelectionDrag={this.handleSelectionDrag}
         onStdinResume={this.reassertTerminalModes}
+        onTerminalFocusChange={this.handleTerminalFocusChange}
         selection={this.selection}
         stderr={this.options.stderr}
         stdin={this.options.stdin}


### PR DESCRIPTION
## Summary
- forward DECSET 1004 terminal focus transitions from the Ink `App` wrapper to the renderer
- on focus regain, reassert terminal modes and force one full redraw instead of trusting pre-blur incremental frame state
- add a focused regression test for the focus transition callback path

## Context
This addresses the terminal-tab/focus-regain variant of the stale TUI repaint issue: after switching away from the Hermes TUI tab and returning, stale status/progress rows can remain visible while only the current indicator continues updating.

Related to #17961, which tracks the same general ghost/stale repaint class for Ink/TUI. I am linking rather than auto-closing because #17961's listed reproduction is terminal resize, while this patch specifically fixes focus/tab-regain invalidation.

## Test plan
- `npm test -- --run packages/hermes-ink/src/ink/components/App.focus.test.tsx`
- `npm run type-check`
- `npx eslint packages/hermes-ink/src/ink/components/App.tsx packages/hermes-ink/src/ink/ink.tsx packages/hermes-ink/src/ink/components/App.focus.test.tsx`
- `npm run build`
- `npm test`
- manually verified the local build no longer accumulates stale status rows after switching terminal tabs
