### PR TITLE
feat(backup): add configurable exclusions

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -8,6 +8,7 @@ Backup and import commands for hermes CLI.
 HERMES_HOME root.
 """
 
+import fnmatch
 import json
 import logging
 import os
@@ -207,8 +208,231 @@ def _iter_external_files(base: Path) -> List[Path]:
             files.append(fpath)
     return files
 
+_GLOB_CHARS = frozenset("*?[")
 
-def _should_exclude(rel_path: Path) -> bool:
+
+def _coerce_exclusion_list(value: Any) -> List[str]:
+    """Coerce a config/CLI value into a list of exclusion strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if item is not None]
+    return []
+
+
+def _normalise_exclusion_pattern(raw: str, hermes_root: Path) -> Optional[str]:
+    """Normalise a user exclusion entry to a relative, POSIX-style pattern.
+
+    Entries are interpreted relative to ``HERMES_HOME``.  Absolute paths under
+    ``HERMES_HOME`` are converted back to relative paths so users can paste
+    either form.  Blank lines and ``#`` comments are ignored.
+    """
+    pattern = os.path.expandvars(os.path.expanduser(str(raw))).strip()
+    if not pattern or pattern.startswith("#"):
+        return None
+
+    pattern = pattern.replace("\\", "/")
+
+    if Path(pattern).is_absolute():
+        # Absolute paths are accepted only when they point inside HERMES_HOME;
+        # otherwise ignore them so `/tmp/foo` cannot accidentally become a
+        # relative `tmp/foo` or `foo` exclusion.  Compare against both the
+        # user-facing root and its resolved path so symlinked homes/macOS path
+        # aliases (for example /var vs /private/var) still work.
+        root_candidates: List[str] = []
+        for root in (hermes_root.expanduser().absolute(), hermes_root.expanduser().resolve()):
+            root_posix = root.as_posix().rstrip("/")
+            if root_posix and root_posix not in root_candidates:
+                root_candidates.append(root_posix)
+
+        matched_root = False
+        for root_posix in sorted(root_candidates, key=len, reverse=True):
+            if pattern == root_posix:
+                return None
+            if pattern.startswith(f"{root_posix}/"):
+                pattern = pattern[len(root_posix) + 1:]
+                matched_root = True
+                break
+        if not matched_root:
+            return None
+
+    while pattern.startswith("./"):
+        pattern = pattern[2:]
+    pattern = pattern.strip("/")
+    return pattern or None
+
+
+def _read_exclusion_file(
+    path_value: str,
+    hermes_root: Path,
+    *,
+    prefer_hermes_root: bool = False,
+) -> List[str]:
+    """Read newline-delimited exclusion patterns from a text file."""
+    raw_path = os.path.expandvars(os.path.expanduser(str(path_value))).strip()
+    if not raw_path:
+        return []
+
+    path = Path(raw_path)
+    candidates = [path]
+    if not path.is_absolute():
+        hermes_path = hermes_root / path
+        candidates = [hermes_path, path] if prefer_hermes_root else [path, hermes_path]
+
+    for candidate in candidates:
+        try:
+            return candidate.read_text(encoding="utf-8").splitlines()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.warning("Could not read backup exclusions file %s: %s", candidate, exc)
+            return []
+
+    if candidates:
+        logger.warning("Could not read backup exclusions file %s: file not found", candidates[0])
+    return []
+
+
+def _read_root_backup_config(hermes_root: Path) -> Dict[str, Any]:
+    """Read ``<hermes_root>/config.yaml`` without merging defaults.
+
+    Full backups archive the Hermes *root* returned by
+    :func:`get_default_hermes_root`, even when the active process is running
+    inside a named profile.  Backup exclusions therefore come from the root
+    config for that archive, not from a profile-local config that would
+    otherwise control exclusions for sibling profiles.
+    """
+    config_path = hermes_root / "config.yaml"
+    try:
+        from utils import fast_safe_load
+
+        with open(config_path, encoding="utf-8") as f:
+            cfg = fast_safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.debug("Could not read backup exclusions from %s: %s", config_path, exc)
+        return {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _configured_exclusions_from_config(hermes_root: Path) -> tuple[List[str], List[str]]:
+    """Return (inline_patterns, exclusion_files) from root ``config.yaml``.
+
+    Supported config:
+
+        backup:
+          exclusions:
+            - cache
+            - profiles/*/home/.cache
+          exclusions_file: ~/.hermes/backup-exclusions.txt
+
+    ``backup.exclusions_file`` may also be a list of files.  The singular
+    aliases ``exclusion_file`` and ``exclude_from`` are accepted for ergonomics.
+    """
+    cfg = _read_root_backup_config(hermes_root)
+
+    if not isinstance(cfg, dict):
+        return [], []
+
+    backup_cfg = cfg.get("backup", {})
+    if not isinstance(backup_cfg, dict):
+        return [], []
+
+    patterns: List[str] = []
+    files: List[str] = []
+
+    exclusions = backup_cfg.get("exclusions")
+    if isinstance(exclusions, dict):
+        for key in ("paths", "directories", "patterns"):
+            patterns.extend(_coerce_exclusion_list(exclusions.get(key)))
+        for key in ("file", "files", "from_file", "exclude_from", "exclusions_file"):
+            files.extend(_coerce_exclusion_list(exclusions.get(key)))
+    else:
+        patterns.extend(_coerce_exclusion_list(exclusions))
+
+    # Also support explicit sibling keys for the common text-file case.
+    for key in ("exclusions_file", "exclusion_file", "exclude_from"):
+        files.extend(_coerce_exclusion_list(backup_cfg.get(key)))
+
+    return patterns, files
+
+
+def _collect_backup_exclusions(
+    args: Optional[Any] = None,
+    hermes_root: Optional[Path] = None,
+) -> List[str]:
+    """Collect user-configured backup exclusion patterns.
+
+    Sources, in precedence order, are additive: ``backup.exclusions`` in
+    config.yaml, ``backup.exclusions_file`` text files, ``--exclude``, and
+    ``--exclude-from``.  Patterns are de-duplicated while preserving order.
+    """
+    root = hermes_root or get_default_hermes_root()
+    raw_patterns, config_exclusion_files = _configured_exclusions_from_config(root)
+
+    for exclusion_file in config_exclusion_files:
+        raw_patterns.extend(_read_exclusion_file(exclusion_file, root, prefer_hermes_root=True))
+
+    if args is not None:
+        raw_patterns.extend(_coerce_exclusion_list(getattr(args, "exclude", None)))
+        for exclusion_file in _coerce_exclusion_list(getattr(args, "exclude_from", None)):
+            raw_patterns.extend(_read_exclusion_file(exclusion_file, root, prefer_hermes_root=False))
+
+    patterns: List[str] = []
+    seen = set()
+    for raw in raw_patterns:
+        pattern = _normalise_exclusion_pattern(raw, root)
+        if pattern and pattern not in seen:
+            patterns.append(pattern)
+            seen.add(pattern)
+    return patterns
+
+
+def _path_prefixes(rel_path: Path) -> List[str]:
+    rel = rel_path.as_posix().strip("/")
+    if not rel:
+        return []
+    parts = rel.split("/")
+    return ["/".join(parts[:idx]) for idx in range(1, len(parts) + 1)]
+
+
+def _matches_user_exclusion(rel_path: Path, patterns: List[str]) -> bool:
+    """Return True when a relative path matches a user exclusion pattern."""
+    if not patterns:
+        return False
+
+    rel = rel_path.as_posix().strip("/")
+    parts = rel_path.parts
+    prefixes = _path_prefixes(rel_path)
+
+    for pattern in patterns:
+        has_glob = any(ch in pattern for ch in _GLOB_CHARS)
+
+        # Bare names are convenient for directory-name exclusions: ``cache``
+        # skips any path component called ``cache``.
+        if "/" not in pattern:
+            if has_glob:
+                if any(fnmatch.fnmatchcase(part, pattern) for part in parts):
+                    return True
+            elif pattern in parts:
+                return True
+
+        # Exact/prefix relative-path match.
+        if rel == pattern or rel.startswith(f"{pattern}/"):
+            return True
+
+        # Glob match against the full path and each parent prefix so patterns
+        # like ``profiles/*/home/.cache`` exclude all descendants too.
+        if has_glob and any(fnmatch.fnmatchcase(prefix, pattern) for prefix in prefixes):
+            return True
+
+    return False
+
+
+def _should_exclude(rel_path: Path, extra_exclusions: Optional[List[str]] = None) -> bool:
     """Return True if *rel_path* (relative to hermes root) should be skipped."""
     parts = rel_path.parts
 
@@ -230,12 +454,20 @@ def _should_exclude(rel_path: Path) -> bool:
     if name.endswith(_EXCLUDED_SUFFIXES):
         return True
 
+    if extra_exclusions and _matches_user_exclusion(rel_path, extra_exclusions):
+        return True
+
     return False
 
 
-def _should_skip_backup_file(abs_path: Path, rel_path: Path, out_path: Path) -> bool:
+def _should_skip_backup_file(
+    abs_path: Path,
+    rel_path: Path,
+    out_path: Path,
+    extra_exclusions: Optional[List[str]] = None,
+) -> bool:
     """Return True when a candidate file should not be written to a backup zip."""
-    if _should_exclude(rel_path):
+    if _should_exclude(rel_path, extra_exclusions):
         return True
 
     # zipfile.write() follows file symlinks, so skip links before any archive
@@ -317,6 +549,7 @@ def run_backup(args) -> None:
 
     # Collect files
     print(f"Scanning {display_hermes_home()} ...")
+    extra_exclusions = _collect_backup_exclusions(args, hermes_root)
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
 
@@ -331,7 +564,7 @@ def run_backup(args) -> None:
         orig_dirnames = dirnames[:]
         dirnames[:] = [
             d for d in dirnames
-            if d not in _EXCLUDED_DIRS or (d == "hermes-agent" and not is_root)
+            if not _should_exclude(rel_dir / d, extra_exclusions)
         ]
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
@@ -340,7 +573,7 @@ def run_backup(args) -> None:
             fpath = dp / fname
             rel = fpath.relative_to(hermes_root)
 
-            if _should_skip_backup_file(fpath, rel, out_path):
+            if _should_skip_backup_file(fpath, rel, out_path, extra_exclusions):
                 continue
 
             files_to_add.append((fpath, rel))
@@ -1153,11 +1386,16 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     or write error — caller should surface the outcome but not raise).
     """
     files_to_add: list[tuple[Path, Path]] = []
+    extra_exclusions = _collect_backup_exclusions(hermes_root=hermes_root)
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
+            rel_dir = dp.relative_to(hermes_root)
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            dirnames[:] = [
+                d for d in dirnames
+                if not _should_exclude(rel_dir / d, extra_exclusions)
+            ]
 
             for fname in filenames:
                 fpath = dp / fname
@@ -1166,7 +1404,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 except ValueError:
                     continue
 
-                if _should_skip_backup_file(fpath, rel, out_path):
+                if _should_skip_backup_file(fpath, rel, out_path, extra_exclusions):
                     continue
 
                 files_to_add.append((fpath, rel))

--- a/hermes_cli/subcommands/backup.py
+++ b/hermes_cli/subcommands/backup.py
@@ -19,7 +19,9 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
         help="Back up Hermes home directory to a zip file",
         description="Create a zip archive of your entire Hermes configuration, "
         "skills, sessions, and data (excludes the hermes-agent codebase). "
-        "Use --quick for a fast snapshot of just critical state files.",
+        "Additional exclusions can be set with backup.exclusions in config.yaml, "
+        "--exclude, or --exclude-from. Use --quick for a fast snapshot of just "
+        "critical state files.",
     )
     backup_parser.add_argument(
         "-o",
@@ -34,5 +36,23 @@ def build_backup_parser(subparsers, *, cmd_backup: Callable) -> None:
     )
     backup_parser.add_argument(
         "-l", "--label", help="Label for the snapshot (only used with --quick)"
+    )
+    backup_parser.add_argument(
+        "--exclude",
+        action="append",
+        metavar="PATTERN",
+        help=(
+            "Exclude a directory name, relative path, or glob from full backups; "
+            "repeatable. Also configurable as backup.exclusions in config.yaml."
+        ),
+    )
+    backup_parser.add_argument(
+        "--exclude-from",
+        action="append",
+        metavar="FILE",
+        help=(
+            "Read full-backup exclusions from a text file, one pattern per line; "
+            "repeatable. Also configurable as backup.exclusions_file in config.yaml."
+        ),
     )
     backup_parser.set_defaults(func=cmd_backup)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sqlite3
+import uuid
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -110,6 +111,36 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_user_exclusions_extend_existing_default_exclusions(self):
+        """User patterns add paths beyond the built-in regeneratable caches."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("profiles/coder/home/.cache/huggingface/model.safetensors"))
+        assert not _should_exclude(Path("heapdumps/hermes-auto-high.heapsnapshot"))
+        assert not _should_exclude(Path("state-snapshots/20260514-005651/state.db"))
+
+        user_patterns = ["heapdumps", "state-snapshots"]
+        assert _should_exclude(Path("heapdumps/hermes-auto-high.heapsnapshot"), user_patterns)
+        assert _should_exclude(Path("state-snapshots/20260514-005651/state.db"), user_patterns)
+
+    def test_user_exclusion_matches_bare_directory_name(self):
+        """A bare user pattern excludes any matching path component."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("profiles/coder/scratch/blob.bin"), ["scratch"])
+        assert not _should_exclude(Path("profiles/coder/config.yaml"), ["scratch"])
+
+    def test_user_exclusion_matches_relative_path_prefix(self):
+        """A relative user pattern excludes the directory and all descendants."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("profiles/coder/big-cache/model.bin"), ["profiles/coder/big-cache"])
+        assert not _should_exclude(Path("profiles/other/big-cache/model.bin"), ["profiles/coder/big-cache"])
+
+    def test_user_exclusion_matches_glob_parent(self):
+        """Glob user patterns can match parent directories and exclude descendants."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("profiles/coder/home/.cache/model.bin"), ["profiles/*/home/.cache"])
+        assert not _should_exclude(Path("profiles/coder/home/data/model.bin"), ["profiles/*/home/.cache"])
+
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -185,6 +216,77 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert not _should_exclude(Path("skills/my-skill/venv-notes.md"))
         assert not _should_exclude(Path("memories/cache.json"))
+
+class TestCollectBackupExclusions:
+    def test_config_exclusion_file_relative_to_hermes_home_prefers_hermes_root(self, tmp_path, monkeypatch):
+        """Config-file relative exclusion files are resolved from HERMES_HOME first."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "backup:\n"
+            "  exclusions_file: backup-exclusions.txt\n"
+        )
+        (hermes_home / "backup-exclusions.txt").write_text("from-hermes\n")
+
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        (cwd / "backup-exclusions.txt").write_text("from-cwd\n")
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        from hermes_cli.backup import _collect_backup_exclusions
+        assert _collect_backup_exclusions(hermes_root=hermes_home) == ["from-hermes"]
+
+    def test_absolute_glob_under_hermes_home_is_normalised(self, tmp_path):
+        """Absolute glob patterns under HERMES_HOME are converted to relative patterns."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        args = Namespace(output=None, exclude=[str(hermes_home / "profiles" / "*" / "scratch")], exclude_from=None)
+
+        from hermes_cli.backup import _collect_backup_exclusions, _should_exclude
+        patterns = _collect_backup_exclusions(args, hermes_home)
+
+        assert patterns == ["profiles/*/scratch"]
+        assert _should_exclude(Path("profiles/coder/scratch/blob.bin"), patterns)
+
+    def test_absolute_glob_under_symlinked_hermes_home_is_normalised(self, tmp_path):
+        """Absolute patterns under a symlinked root still resolve to archive-relative patterns."""
+        real_home = tmp_path / f"real-{uuid.uuid4().hex}"
+        link_home = tmp_path / f"link-{uuid.uuid4().hex}"
+        real_home.mkdir()
+        try:
+            link_home.symlink_to(real_home, target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        args = Namespace(
+            output=None,
+            exclude=[
+                str(link_home / "profiles" / "*" / "scratch"),
+                str(real_home.resolve() / "profiles" / "*" / "cache"),
+            ],
+            exclude_from=None,
+        )
+
+        from hermes_cli.backup import _collect_backup_exclusions, _should_exclude
+        patterns = _collect_backup_exclusions(args, link_home)
+
+        assert patterns == ["profiles/*/scratch", "profiles/*/cache"]
+        assert _should_exclude(Path("profiles/demo/scratch/blob.bin"), patterns)
+        assert _should_exclude(Path("profiles/demo/cache/blob.bin"), patterns)
+
+    def test_external_absolute_pattern_stays_unmatched(self, tmp_path):
+        """Absolute paths outside HERMES_HOME should not accidentally match relative backup paths."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        args = Namespace(output=None, exclude=[str(tmp_path / "elsewhere" / "scratch")], exclude_from=None)
+
+        from hermes_cli.backup import _collect_backup_exclusions, _should_exclude
+        patterns = _collect_backup_exclusions(args, hermes_home)
+
+        assert not _should_exclude(Path("scratch/blob.bin"), patterns)
+
 
 # ---------------------------------------------------------------------------
 # Backup tests
@@ -406,6 +508,129 @@ class TestBackup:
             names = zf.namelist()
             pid_files = [n for n in names if n.endswith(".pid")]
             assert pid_files == []
+
+    def test_config_exclusions_are_applied(self, tmp_path, monkeypatch):
+        """backup.exclusions in config.yaml excludes matching paths from full backups."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        (hermes_home / "scratch").mkdir()
+        (hermes_home / "scratch" / "large.bin").write_bytes(b"x")
+        (hermes_home / "profiles" / "coder" / "build-output").mkdir()
+        (hermes_home / "profiles" / "coder" / "build-output" / "artifact.bin").write_bytes(b"x")
+        (hermes_home / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n"
+            "backup:\n"
+            "  exclusions:\n"
+            "    - scratch\n"
+            "    - profiles/*/build-output\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            assert "scratch/large.bin" not in names
+            assert "profiles/coder/build-output/artifact.bin" not in names
+            assert "skills/my-skill/SKILL.md" in names
+
+    def test_profile_mode_uses_root_backup_config_for_root_archive(self, tmp_path, monkeypatch):
+        """Profile-local config must not control a full-root backup archive."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        root_excluded = f"root-excluded-{uuid.uuid4().hex}"
+        root_kept = f"root-kept-{uuid.uuid4().hex}"
+        payload_name = f"payload-{uuid.uuid4().hex}.bin"
+        (hermes_home / root_excluded).mkdir()
+        (hermes_home / root_excluded / payload_name).write_bytes(b"x")
+        (hermes_home / root_kept).mkdir()
+        (hermes_home / root_kept / payload_name).write_bytes(b"x")
+
+        profile_home = hermes_home / "profiles" / "coder"
+        (hermes_home / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n"
+            "backup:\n"
+            "  exclusions:\n"
+            f"    - {root_excluded}\n"
+        )
+        (profile_home / "config.yaml").write_text(
+            "model:\n  provider: anthropic\n"
+            "backup:\n"
+            "  exclusions:\n"
+            f"    - {root_kept}\n"
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            assert f"{root_excluded}/{payload_name}" not in names
+            assert f"{root_kept}/{payload_name}" in names
+            assert "profiles/coder/config.yaml" in names
+
+    def test_cli_exclude_is_applied(self, tmp_path, monkeypatch):
+        """--exclude adds per-run full-backup exclusions."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        (hermes_home / "scratch").mkdir()
+        (hermes_home / "scratch" / "large.bin").write_bytes(b"x")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip), exclude=["scratch"], exclude_from=None)
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            assert "scratch/large.bin" not in names
+            assert "config.yaml" in names
+
+    def test_exclude_from_file_is_applied(self, tmp_path, monkeypatch):
+        """--exclude-from reads newline-delimited patterns, ignoring comments."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        (hermes_home / "scratch").mkdir()
+        (hermes_home / "scratch" / "large.bin").write_bytes(b"x")
+        (hermes_home / "tmp-output").mkdir()
+        (hermes_home / "tmp-output" / "artifact.bin").write_bytes(b"x")
+        (hermes_home / "backup-exclusions.txt").write_text("# comment\nscratch\ntmp-output\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip), exclude=None, exclude_from=["backup-exclusions.txt"])
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            assert "scratch/large.bin" not in names
+            assert "tmp-output/artifact.bin" not in names
+            assert "backup-exclusions.txt" in names
 
     def test_default_output_path(self, tmp_path, monkeypatch):
         """When no output path given, zip goes to ~/hermes-backup-*.zip."""

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -804,6 +804,20 @@ Create a zip archive of your Hermes configuration, skills, sessions, and data. T
 | `-o`, `--output <path>` | Output path for the zip file (default: `~/hermes-backup-<timestamp>.zip`). |
 | `-q`, `--quick` | Quick snapshot: only critical state files (config.yaml, state.db, .env, auth, cron jobs). Much faster than a full backup. |
 | `-l`, `--label <name>` | Label for the snapshot (only used with `--quick`). |
+| `--exclude <pattern>` | Exclude a directory name, relative path, or glob from a full backup. Repeat for multiple patterns. |
+| `--exclude-from <file>` | Read full-backup exclusions from a text file, one pattern per line. Blank lines and `#` comments are ignored. Repeat for multiple files. |
+
+Full backups also read persistent exclusions from the root Hermes `config.yaml`:
+
+```yaml
+backup:
+  exclusions:
+    - scratch
+    - profiles/*/build-output
+  exclusions_file: backup-exclusions.txt
+```
+
+Exclusion patterns are relative to the Hermes root being archived. Bare names match any path component, relative paths match that subtree, and globs match the full path and parent prefixes. Absolute patterns are accepted only when they resolve under the Hermes root; outside paths are ignored. In profile mode, `hermes backup` archives the Hermes root, so these settings are read from the root `config.yaml`, not from a profile-local config.
 
 The backup uses SQLite's `backup()` API for safe copying, so it works correctly even when Hermes is running (WAL-mode safe).
 


### PR DESCRIPTION
## Summary

Adds user-configurable full-backup exclusions for `hermes backup` without adding any new upstream default exclusions.

Users can now exclude workflow-specific heavyweight paths from full zip backups via:

```yaml
backup:
  exclusions:
    - .venv
    - profiles/*/home/.cache
  exclusions_file: backup-exclusions.txt
```

or per run:

```bash
hermes backup --exclude .venv --exclude-from backup-exclusions.txt
```

## Intent

Large Hermes homes can accumulate generated/runtime data that is useful for one user but not necessarily safe to hard-code as a global default. This PR keeps the existing built-in exclusions unchanged and gives users an explicit opt-in mechanism instead.

Notable behavior:

- `backup.exclusions` accepts strings/lists, plus nested forms such as `paths`, `directories`, and `patterns`.
- `backup.exclusions_file` / `backup.exclusion_file` / `backup.exclude_from` read newline-delimited pattern files.
- CLI overrides `--exclude` and `--exclude-from` are additive for one-off runs.
- Patterns are interpreted relative to `HERMES_HOME`.
- Bare names match any path component; relative paths match descendants; globs are supported.
- Absolute paths are accepted only when they point under `HERMES_HOME`; unrelated absolute paths are ignored rather than transformed into surprising relative matches.
- Config discovery uses `read_raw_config()` so backup scanning does not create or mutate config as a side effect.

## Related work

Related to #16988 and #17051.

This is intentionally a config/CLI-based alternative to #17051's environment-variable-only approach. The goal is to align with Hermes' existing config-first behavior while still allowing one-off command-line exclusions.

## Test plan

- [x] `python -m py_compile hermes_cli/backup.py hermes_cli/main.py`
- [x] `python -m pytest -o addopts='' tests/hermes_cli/test_backup.py -q`

Local result:

```text
107 passed in 25.15s
```
