### PR TITLE
fix(background-review): silence memory provider teardown output leak

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4312,6 +4312,19 @@ class AIAgent:
                         conversation_history=messages_snapshot,
                     )
 
+                    # Tear down memory providers while stdout is still
+                    # redirected so background thread teardown (Honcho flush,
+                    # Hindsight sync, etc.) stays silent.  The finally block
+                    # below is a safety net for the exception path.
+                    try:
+                        review_agent.shutdown_memory_provider()
+                    except Exception:
+                        pass
+                    try:
+                        review_agent.close()
+                    except Exception:
+                        pass
+
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user. Tool messages
                 # already present in messages_snapshot must be skipped, since
@@ -4341,21 +4354,24 @@ class AIAgent:
                 logger.warning("Background memory/skill review failed: %s", e)
                 self._emit_auxiliary_failure("background review", e)
             finally:
-                # Background review agents can initialize memory providers
-                # (for example Hindsight) that own their own network clients.
-                # Explicitly stop those providers before closing the agent so
-                # their aiohttp sessions do not leak until GC/process exit.
-                # Then close all remaining resources (httpx client,
-                # subprocesses, etc.) so GC doesn't try to clean them up on a
-                # dead asyncio event loop (which produces "Event loop is
-                # closed" errors).
+                # Safety-net cleanup for the exception path.  Normal
+                # completion already shut down inside redirect_stdout above.
+                # Re-open devnull here so any teardown output (Honcho flush,
+                # Hindsight sync, background thread joins) stays silent even
+                # on the exception path where redirect_stdout already exited.
                 if review_agent is not None:
                     try:
-                        review_agent.shutdown_memory_provider()
-                    except Exception:
-                        pass
-                    try:
-                        review_agent.close()
+                        with open(os.devnull, "w", encoding="utf-8") as _fn, \
+                             contextlib.redirect_stdout(_fn), \
+                             contextlib.redirect_stderr(_fn):
+                            try:
+                                review_agent.shutdown_memory_provider()
+                            except Exception:
+                                pass
+                            try:
+                                review_agent.close()
+                            except Exception:
+                                pass
                     except Exception:
                         pass
                 # Clear the approval callback on this bg-review thread so a

--- a/run_agent.py
+++ b/run_agent.py
@@ -4213,6 +4213,23 @@ class AIAgent:
                 actions.append(f"{label} updated")
         return actions
 
+    @staticmethod
+    def _silent_teardown(agent: "AIAgent") -> None:
+        """Shut down *agent* and suppress all exceptions.
+
+        Extracted so the success path (inside ``redirect_stdout``) and the
+        exception-path ``finally`` block share identical teardown logic with
+        no risk of drift.
+        """
+        try:
+            agent.shutdown_memory_provider()
+        except Exception:
+            pass
+        try:
+            agent.close()
+        except Exception:
+            pass
+
     def _spawn_background_review(
         self,
         messages_snapshot: List[Dict],
@@ -4315,15 +4332,13 @@ class AIAgent:
                     # Tear down memory providers while stdout is still
                     # redirected so background thread teardown (Honcho flush,
                     # Hindsight sync, etc.) stays silent.  The finally block
-                    # below is a safety net for the exception path.
-                    try:
-                        review_agent.shutdown_memory_provider()
-                    except Exception:
-                        pass
-                    try:
-                        review_agent.close()
-                    except Exception:
-                        pass
+                    # below is a safety net for the exception path only.
+                    # Note: redirect_stdout reassigns sys.stdout for this
+                    # thread; threads already running in Honcho/Hindsight
+                    # that hold references to the original fd are not covered
+                    # here — those are silenced by shutdown() joining them.
+                    _silent_teardown(review_agent)
+                    review_agent = None  # prevent double-teardown in finally
 
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user. Tool messages
@@ -4354,24 +4369,14 @@ class AIAgent:
                 logger.warning("Background memory/skill review failed: %s", e)
                 self._emit_auxiliary_failure("background review", e)
             finally:
-                # Safety-net cleanup for the exception path.  Normal
-                # completion already shut down inside redirect_stdout above.
-                # Re-open devnull here so any teardown output (Honcho flush,
-                # Hindsight sync, background thread joins) stays silent even
-                # on the exception path where redirect_stdout already exited.
+                # Safety-net for the exception path — review_agent is None
+                # when the success path already called _silent_teardown().
                 if review_agent is not None:
                     try:
                         with open(os.devnull, "w", encoding="utf-8") as _fn, \
                              contextlib.redirect_stdout(_fn), \
                              contextlib.redirect_stderr(_fn):
-                            try:
-                                review_agent.shutdown_memory_provider()
-                            except Exception:
-                                pass
-                            try:
-                                review_agent.close()
-                            except Exception:
-                                pass
+                            _silent_teardown(review_agent)
                     except Exception:
                         pass
                 # Clear the approval callback on this bg-review thread so a


### PR DESCRIPTION
## Summary
- Background review agents' memory provider teardown (`shutdown_memory_provider()` / `close()`) ran after `contextlib.redirect_stdout(devnull)` had already exited, so any output from Honcho background thread joins (`_prefetch_thread`, `_sync_thread`, `flush_all()`) or Hindsight async client teardown leaked directly to the user's terminal.
- The fix moves normal-path teardown inside the `redirect_stdout` block and wraps the exception-path `finally` cleanup in a fresh `redirect_stdout(devnull)` context so all teardown output is silenced in both code paths.

## Root cause
`_run_review()` wrapped `run_conversation()` in a `with redirect_stdout(devnull)` block, but the `finally` clause that called `shutdown_memory_provider()` and `close()` sat outside that `with` block. By the time `finally` ran, Python had already restored `sys.stdout` to the real terminal. Honcho's `shutdown()` joins two background threads that may still be writing, and Hindsight's teardown may issue async network calls — all of that output reached the user verbatim.

## Test
1. Run the agent with a Honcho or Hindsight memory provider configured.
2. Trigger a background review cycle (e.g. fill `_review_interval` turns).
3. Before the fix: observe stray lines like `"[Honcho] flushing…"` or aiohttp teardown warnings appear in the terminal mid-conversation.
4. After the fix: no output appears from teardown; the terminal stays clean.