### PR TITLE
fix(honcho): filter deriver noise and label dialectic context injection

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -28,6 +28,26 @@ from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Dialectic noise filter
+# ---------------------------------------------------------------------------
+# The deriver (memory-formation agent) sometimes returns housekeeping strings
+# instead of actionable context when session history is sparse — e.g. after
+# only a few greeting messages.  These patterns are derived from the deriver's
+# own prompt wording ("if nothing is worth saving, just say 'Nothing to save.'").
+# Matching is done on a lowercased, stripped copy; exact-phrase prefixes keep
+# false-positive risk low.  The bare `startswith("nothing")` guard is
+# intentionally excluded to avoid discarding legitimate responses like
+# "Nothing in the user's history suggests X, but they did mention Y…".
+_DERIVER_NOISE_PHRASES = (
+    "nothing to save",
+    "no new information",
+    "no information",
+    "no relevant information",
+    "nothing relevant",
+    "nothing notable",
+)
+
 
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
@@ -673,15 +693,11 @@ class HonchoMemoryProvider(MemoryProvider):
             dialectic_result = ""
 
         if dialectic_result and dialectic_result.strip():
-            # Discard deriver-style non-responses that slip through on sparse context.
-            _dr = dialectic_result.strip().lower()
-            _is_deriver_noise = (
-                _dr.startswith("nothing to save")
-                or _dr.startswith("no new information")
-                or _dr.startswith("no information")
-                or (_dr.startswith("nothing") and len(_dr) < 120)
+            normalized = dialectic_result.strip().lower()
+            is_deriver_noise = any(
+                normalized.startswith(phrase) for phrase in _DERIVER_NOISE_PHRASES
             )
-            if not _is_deriver_noise:
+            if not is_deriver_noise:
                 parts.append(f"## Honcho Contextual Analysis\n{dialectic_result.strip()}")
 
         if not parts:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -673,7 +673,16 @@ class HonchoMemoryProvider(MemoryProvider):
             dialectic_result = ""
 
         if dialectic_result and dialectic_result.strip():
-            parts.append(dialectic_result)
+            # Discard deriver-style non-responses that slip through on sparse context.
+            _dr = dialectic_result.strip().lower()
+            _is_deriver_noise = (
+                _dr.startswith("nothing to save")
+                or _dr.startswith("no new information")
+                or _dr.startswith("no information")
+                or (_dr.startswith("nothing") and len(_dr) < 120)
+            )
+            if not _is_deriver_noise:
+                parts.append(f"## Honcho Contextual Analysis\n{dialectic_result.strip()}")
 
         if not parts:
             return ""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "mike@grossmann.at": "ReqX",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
+    "ayushere@users.noreply.github.com": "ayushere",
     "daniellsmarta@gmail.com": "DanielLSM",
     "264291321+v1b3coder@users.noreply.github.com": "v1b3coder",
     "silverchris@foxmail.com": "ming1523",


### PR DESCRIPTION
## Summary
- In `HonchoMemoryProvider.prefetch()`, the dialectic result was appended raw to `parts` with no label and no validation, so deriver-style non-responses like `"Nothing to save. Two greeting exchanges, no work done."` got injected verbatim as `<memory-context>`, causing the main LLM to echo that text instead of answering the user.
- The fix discards known deriver noise patterns (startswith `"nothing to save"`, `"no new information"`, `"no information"`, or short `"nothing …"` strings) before injection, and labels valid results with a `## Honcho Contextual Analysis` heading so the LLM can distinguish memory context from user input.

## Root cause
`_run_dialectic_depth()` occasionally returns deriver-style housekeeping strings instead of actionable memory context, especially on sparse sessions (few turns, greeting-only exchanges). These strings passed the existing `dialectic_result.strip()` guard and were appended without sanitization. The main model received the `<memory-context>` block containing the non-response, matched its instructed pattern of "answer what's in context," and reproduced the noise string verbatim as its reply — breaking the persona entirely for that turn.

## Test
1. Configure the agent with a Honcho memory provider.
2. Start a new session and send only 1–2 short greeting messages (sparse context).
3. Trigger `prefetch()` so `_run_dialectic_depth()` fires.
4. Before the fix: the agent's next reply is something like `"Nothing to save. Two greeting exchanges, no work done."`.
5. After the fix: deriver noise is silenced; the agent replies normally. Valid dialectic results appear under the `## Honcho Contextual Analysis` heading in the injected context.