### PR TITLE
fix(run_agent): split concatenated streamed tool-call args

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -775,6 +775,42 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _split_concatenated_tool_call_arguments(raw_args: str) -> list[str] | None:
+    """Split ``{"..."}{"..."}`` tool-call payloads into separate JSON objects.
+
+    Some providers can concatenate multiple complete top-level argument
+    objects without delimiters when emitting parallel tool calls in a single
+    streaming chunk. Only return a split when the entire payload can be
+    losslessly decoded as 2+ complete dict objects; otherwise return None so
+    existing truncation handling stays in control.
+    """
+    if not isinstance(raw_args, str):
+        return None
+
+    raw_stripped = raw_args.strip()
+    if not raw_stripped:
+        return None
+
+    decoder = json.JSONDecoder()
+    pos = 0
+    decoded: list[str] = []
+    while pos < len(raw_stripped):
+        while pos < len(raw_stripped) and raw_stripped[pos].isspace():
+            pos += 1
+        if pos >= len(raw_stripped):
+            break
+        try:
+            parsed, end = decoder.raw_decode(raw_stripped, pos)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+        decoded.append(json.dumps(parsed, separators=(",", ":")))
+        pos = end
+
+    return decoded if len(decoded) > 1 else None
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -8071,6 +8107,26 @@ class AIAgent:
                     tc = tool_calls_acc[idx]
                     arguments = tc["function"]["arguments"]
                     tool_name = tc["function"]["name"] or "?"
+                    split_arguments = _split_concatenated_tool_call_arguments(arguments)
+                    if split_arguments:
+                        logger.warning(
+                            "Split concatenated tool_call arguments for %s into %d calls",
+                            tool_name,
+                            len(split_arguments),
+                        )
+                        base_id = tc["id"] or f"call_{idx}"
+                        for split_idx, split_arg in enumerate(split_arguments):
+                            split_id = base_id if split_idx == 0 else f"{base_id}-split-{split_idx + 1}"
+                            mock_tool_calls.append(SimpleNamespace(
+                                id=split_id,
+                                type=tc["type"],
+                                extra_content=tc.get("extra_content"),
+                                function=SimpleNamespace(
+                                    name=tc["function"]["name"],
+                                    arguments=split_arg,
+                                ),
+                            ))
+                        continue
                     if arguments and arguments.strip():
                         try:
                             json.loads(arguments)

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -3,7 +3,10 @@
 import json
 import pytest
 
-from run_agent import _repair_tool_call_arguments
+from run_agent import (
+    _repair_tool_call_arguments,
+    _split_concatenated_tool_call_arguments,
+)
 
 
 class TestRepairToolCallArguments:
@@ -141,3 +144,13 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+    # -- Concatenated top-level tool-call payloads --
+
+    def test_split_concatenated_tool_call_arguments(self):
+        raw = '{"entity":"Don Bowman"}{"entity":"Agilicus"}'
+        result = _split_concatenated_tool_call_arguments(raw)
+        assert result == ['{"entity":"Don Bowman"}', '{"entity":"Agilicus"}']
+
+    def test_split_concatenated_tool_call_arguments_rejects_partial_tail(self):
+        raw = '{"entity":"Don Bowman"}{"entity":"Agilic'
+        assert _split_concatenated_tool_call_arguments(raw) is None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4633,6 +4633,36 @@ class TestStreamingApiCall:
         assert tc[1].function.arguments == '{"path":"x.py"}'
         assert tc[1].id == "call_b"
 
+    def test_concatenated_json_arguments_split_into_parallel_tool_calls(self, agent):
+        chunks = [
+            _make_chunk(tool_calls=[_make_tc_delta(
+                0,
+                "call_relate",
+                "yantrikdb_relate",
+                (
+                    '{"entity":"Don Bowman","relationship":"works_at","target":"Agilicus"}'
+                    '{"entity":"Agilicus","relationship":"employs","target":"Don Bowman"}'
+                ),
+            )]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 2
+        assert tc[0].function.name == "yantrikdb_relate"
+        assert tc[0].function.arguments == (
+            '{"entity":"Don Bowman","relationship":"works_at","target":"Agilicus"}'
+        )
+        assert tc[0].id == "call_relate"
+        assert tc[1].function.name == "yantrikdb_relate"
+        assert tc[1].function.arguments == (
+            '{"entity":"Agilicus","relationship":"employs","target":"Don Bowman"}'
+        )
+        assert tc[1].id == "call_relate-split-2"
+
     def test_ollama_reused_index_streamed_args(self, agent):
         """Ollama with streamed arguments across multiple chunks at same index."""
         chunks = [


### PR DESCRIPTION
## Summary
- split fully decodable concatenated tool-call argument blobs like `{"a":1}{"b":2}` into separate streamed tool calls
- keep existing truncation handling for partial or otherwise non-lossless payloads
- add regression coverage for both the splitter and streaming assembly path

## Testing
- `uv run --frozen pytest -o addopts='' tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_concatenated_json_arguments_split_into_parallel_tool_calls tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_ollama_reused_index_separate_tool_calls tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_truncated_tool_call_args_upgrade_finish_reason_to_length`
- `git diff --check`
- `uv run --frozen ruff check run_agent.py tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_run_agent.py`

## Attribution
Known red `Tests` on recent company PRs and `origin/main` is treated as `preexisting_unrelated` baseline noise; this candidate's targeted local gate is green.

Closes #25333.
