### PR TITLE
fix(agent): repair concatenated JSON tool_call arguments from Gemini parallel calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -862,6 +862,30 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 
+
+    # Repair pass 5: split concatenated JSON objects (e.g. `{...}{...}`).
+    # Gemini-3-Flash-Preview emits parallel tool calls as multiple JSON
+    # objects glued together without any delimiter.  The streaming
+    # reassembler assigns one tool_call per object, but the raw arguments
+    # string can still contain the concatenation.  Extract the first
+    # complete object. (#25333)
+    if raw_stripped.startswith("{"):
+        try:
+            decoder = json.JSONDecoder()
+            first_obj, end_idx = decoder.raw_decode(raw_stripped)
+            # Only treat as concatenation if there's meaningful trailing content
+            tail = raw_stripped[end_idx:].strip()
+            if tail and tail.startswith("{"):
+                first_json = json.dumps(first_obj, separators=(",", ":"))
+                logger.warning(
+                    "Extracted first object from concatenated tool_call arguments "
+                    "for %s (split at position %d): %s",
+                    tool_name, end_idx, raw_stripped[:80],
+                )
+                return first_json
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pass
+
     # Last resort: replace with empty object so the API request doesn't
     # crash the entire session.
     logger.warning(

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -141,3 +141,25 @@ class TestRepairToolCallArguments:
         parsed = json.loads(result)
         assert "line" in parsed["msg"]
 
+
+    # -- Stage 5: concatenated JSON objects (#25333) --
+
+    def test_concatenated_json_objects_extracts_first(self):
+        """Gemini-3-Flash-Preview emits parallel tool calls as }{ without delimiter."""
+        raw = '{"entity": "Don Bowman", "relationship": "works_at", "target": "Agilicus"}{"entity": "Alice", "relationship": "knows", "target": "Bob"}'
+        result = _repair_tool_call_arguments(raw, "yantrikdb_relate")
+        parsed = json.loads(result)
+        assert parsed == {"entity": "Don Bowman", "relationship": "works_at", "target": "Agilicus"}
+
+    def test_concatenated_json_objects_with_nested_braces(self):
+        """Concatenated objects where values contain braces."""
+        raw = '{"query": "SELECT * FROM t WHERE a = {1}"}{"query": "SELECT 1"}'
+        result = _repair_tool_call_arguments(raw, "sql_tool")
+        parsed = json.loads(result)
+        assert parsed == {"query": "SELECT * FROM t WHERE a = {1}"}
+
+    def test_single_valid_json_not_affected_by_concat_pass(self):
+        """Normal single object must pass through unchanged."""
+        raw = '{"entity": "Don Bowman"}'
+        result = _repair_tool_call_arguments(raw, "t")
+        assert json.loads(result) == {"entity": "Don Bowman"}


### PR DESCRIPTION
## Summary

When Gemini-3-Flash-Preview emits parallel tool calls, it produces concatenated JSON objects like `{...}{...}` without any delimiter. The existing repair passes in `_repair_tool_call_arguments()` fail to parse this and replace both calls with empty objects (`{}`), dropping user intent entirely.

## Changes

- **`run_agent.py`**: Add repair pass 5 using `json.JSONDecoder.raw_decode()` to extract the first complete JSON object when trailing `{` content is detected after a valid object. This preserves at least the first tool call instead of discarding both.
- **`tests/run_agent/test_repair_tool_call_arguments.py`**: Add 3 tests covering concatenated objects, nested braces in values, and regression for single valid objects.

## Root Cause

The `raw_decode()` method parses exactly one JSON value from the start of a string and returns the end index. When the remainder starts with `{`, we know the arguments contain concatenated objects from parallel tool calls. We extract and return just the first valid object.

## Testing

```
pytest tests/run_agent/test_repair_tool_call_arguments.py -v
# 24 passed
```

Fixes #25333