### PR TITLE
fix: skip memory prefetch on trivial user prompts (greetings)

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -994,7 +994,8 @@ class HonchoMemoryProvider(MemoryProvider):
     _TRIVIAL_PROMPT_RE = re.compile(
         r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
         r'hi|hey|hello|yo|sup|'
-        r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$',
+        r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)'
+        r'[\s!?.:;,~]*$',
         re.IGNORECASE,
     )
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -988,11 +988,12 @@ class HonchoMemoryProvider(MemoryProvider):
                 return r
         return ""
 
-    # Prompts that carry no semantic signal — trivial acknowledgements, slash
-    # commands, empty input. Skipping injection here saves tokens and prevents
+    # Prompts that carry no semantic signal — trivial acknowledgements, greetings,
+    # slash commands, empty input. Skipping injection here saves tokens and prevents
     # stale user-model context from derailing one-word replies.
     _TRIVIAL_PROMPT_RE = re.compile(
         r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
+        r'hi|hey|hello|yo|sup|'
         r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$',
         re.IGNORECASE,
     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -12118,11 +12118,27 @@ class AIAgent:
         # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
+        #
+        # Skip prefetch on trivial prompts (greetings, acknowledgements) to
+        # prevent memory-context injection on turns that carry no semantic signal.
+        _TRIVIAL_QUERY_RE = re.compile(
+            r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
+            r'hi|hey|hello|yo|sup|'
+            r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$',
+            re.IGNORECASE,
+        )
+
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
+                _is_trivial = (
+                    not _query
+                    or _query.strip().startswith("/")
+                    or re.match(_TRIVIAL_QUERY_RE, _query.strip())
+                )
+                if not _is_trivial:
+                    _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -189,6 +189,36 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+
+# Trivial user-input pattern — used by run_conversation() to gate
+# memory-provider prefetch on short, semantically-empty queries.
+# Covers greetings, acknowledgements, and trailing-punctuation variants
+# (e.g. "hi!", "hey.", "thanks :)").
+_RE_TRIVIAL_USER_QUERY = re.compile(
+    r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
+    r'hi|hey|hello|yo|sup|'
+    r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)'
+    r'[\s!?.:;,"' + "'" + r'~\u2018\u2019\u201c\u201d\u2014\u2013\u2026()\[\]{}<>*&^%$#@!+=`\u00a0]*$',
+    re.IGNORECASE,
+)
+
+
+def _is_trivial_user_query(query: str) -> bool:
+    """Return True if the query is a greeting or too trivial to warrant prefetch.
+
+    Strips leading/trailing whitespace first, then checks against
+    _RE_TRIVIAL_USER_QUERY which permits common trailing punctuation
+    (exclamation, question mark, emoji, etc.) so variants like "hi!",
+    "hey.", and "thanks :)" register as trivial.
+    """
+    if not query:
+        return True
+    stripped = query.strip()
+    if not stripped:
+        return True
+    if stripped.startswith("/"):
+        return True
+    return bool(_RE_TRIVIAL_USER_QUERY.match(stripped))
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
 from hermes_cli.config import cfg_get
 
@@ -12121,23 +12151,11 @@ class AIAgent:
         #
         # Skip prefetch on trivial prompts (greetings, acknowledgements) to
         # prevent memory-context injection on turns that carry no semantic signal.
-        _TRIVIAL_QUERY_RE = re.compile(
-            r'^(yes|no|ok|okay|sure|thanks|thank you|y|n|yep|nope|yeah|nah|'
-            r'hi|hey|hello|yo|sup|'
-            r'continue|go ahead|do it|proceed|got it|cool|nice|great|done|next|lgtm|k)$',
-            re.IGNORECASE,
-        )
-
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
-                _is_trivial = (
-                    not _query
-                    or _query.strip().startswith("/")
-                    or re.match(_TRIVIAL_QUERY_RE, _query.strip())
-                )
-                if not _is_trivial:
+                if not _is_trivial_user_query(_query):
                     _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -88,6 +88,7 @@ AUTHOR_MAP = {
     "mike@grossmann.at": "ReqX",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
+    "ayushere@users.noreply.github.com": "ayushere",
     "daniellsmarta@gmail.com": "DanielLSM",
     "264291321+v1b3coder@users.noreply.github.com": "v1b3coder",
     "silverchris@foxmail.com": "ming1523",

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1134,6 +1134,11 @@ class TestTrivialPromptHeuristic:
         for t in ("ok", "OK", " ok ", "y", "yes", "sure", "thanks", "lgtm", "/help", "", "   "):
             assert HonchoMemoryProvider._is_trivial_prompt(t), f"expected trivial: {t!r}"
 
+    def test_classifier_catches_greetings(self):
+        """Greeting words must register as trivial so context injection is skipped."""
+        for t in ("hi", "HI", "hey", "hello", "yo", "sup", " hi ", "hey!", "hello."):
+            assert HonchoMemoryProvider._is_trivial_prompt(t), f"expected trivial: {t!r}"
+
     def test_classifier_lets_substantive_prompts_through(self):
         for t in ("hello world", "what's my name", "explain this", "ok so what's next"):
             assert not HonchoMemoryProvider._is_trivial_prompt(t), f"expected non-trivial: {t!r}"


### PR DESCRIPTION
## Problem

When a user opens a session with a simple greeting (`hi`, `hey`, `hello`) or trivial acknowledgement (`ok`, `thanks`, `cool`), the memory provider prefetch fires unconditionally and dumps the full memory-context block into the API message. This causes instruction-like directives embedded in memory to override the configured persona on the very first turn.

## Root Cause

`run_agent.py` calls `self._memory_manager.prefetch_all(_query)` unconditionally, with no filter for query content. The Honcho plugin has its own `_is_trivial_prompt()` check internally — but it only fires inside the plugin, after the agent has already dumped the full memory context into the API message.

## Changes

### `run_agent.py`
Add a trivial-query gate before the `prefetch_all()` call. If the user message is empty, starts with `/` (slash command), or matches the trivial-prompt regex, the prefetch is skipped entirely. No memory-context dump fires on short/meaningless first-turn messages.

### `plugins/memory/honcho/__init__.py`
Add greeting words (`hi`, `hey`, `hello`, `yo`, `sup`) to `_TRIVIAL_PROMPT_RE` so the plugin-level gate also catches greetings for subsequent turns within the same session.

## Why Both Files?

The `run_agent.py` fix is the primary gate — it prevents the dump at the agent level before any memory provider is queried. The Honcho regex fix is a defence-in-depth measure ensuring the plugin-level gate (which also gates dialectic fetches) catches the same patterns.

## Impact

- Prevents persona override on session start
- Reduces token usage on trivial first-turn messages
- No breaking changes — the gate only skips prefetch for queries that already return no useful result; existing behaviour is preserved for all meaningful queries
- Regex mirrors the existing `_TRIVIAL_PROMPT_RE` pattern already in the Honcho plugin for consistency