### PR TITLE
feat(gateway): add Feishu slash confirm buttons

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -228,6 +228,11 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
     "always": "Approved permanently",
     "deny": "Denied",
 }
+_SLASH_CONFIRM_LABEL_MAP: Dict[str, str] = {
+    "once": "Approved once",
+    "always": "Always approved",
+    "cancel": "Cancelled",
+}
 
 
 async def _read_limited_feishu_webhook_body(request: Any, max_bytes: int) -> bytes:
@@ -1495,6 +1500,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Slash-confirm button state (confirm_id → {session_key, message_id, chat_id, metadata})
+        self._slash_confirm_state: Dict[str, Dict[str, Any]] = {}
+        self._slash_confirm_lock = threading.RLock()
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2051,6 +2059,155 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
+    def _build_slash_confirm_card(*, title: str, message: str, confirm_id: str) -> Dict[str, Any]:
+        body = message[:3000] + "..." if len(message) > 3000 else message
+
+        def _btn(label: str, choice: str, btn_type: str) -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_slash_confirm_action": choice,
+                    "slash_confirm_id": confirm_id,
+                },
+            }
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title or "Confirm", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": [
+                {"tag": "markdown", "content": body},
+                {
+                    "tag": "action",
+                    "actions": [
+                        _btn("✓ Approve Once", "once", "primary"),
+                        _btn("Always Approve", "always", "default"),
+                        _btn("✗ Cancel", "cancel", "danger"),
+                    ],
+                },
+            ],
+        }
+
+    def _drop_superseded_slash_confirm_state(self, session_key: str) -> None:
+        """Remove stale slash-confirm cards for a session before storing a newer one."""
+        normalized = str(session_key)
+        with self._slash_confirm_lock:
+            for existing_id, state in list(self._slash_confirm_state.items()):
+                if str(state.get("session_key", "")) == normalized:
+                    self._slash_confirm_state.pop(existing_id, None)
+
+    @staticmethod
+    def _slash_confirm_chat_type(
+        *,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Resolve chat type for slash-confirm authorization."""
+        raw = str((metadata or {}).get("chat_type", "") or "").strip().lower()
+        if raw:
+            return raw
+        parts = str(session_key or "").split(":")
+        if len(parts) >= 5:
+            return parts[3].strip().lower()
+        return ""
+
+    @staticmethod
+    def _slash_confirm_participant_id(
+        *,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Return per-user participant id encoded in a slash-confirm session key."""
+        parts = str(session_key or "").split(":")
+        if len(parts) <= 5 or parts[0] != "agent" or not parts[1]:
+            return ""
+        chat_type = parts[3].strip().lower()
+        if chat_type in {"dm", "direct", "private", "p2p"}:
+            return ""
+        extras = parts[5:]
+        thread_id = str((metadata or {}).get("thread_id", "") or "")
+        if thread_id and extras and extras[0] == thread_id:
+            extras = extras[1:]
+        return extras[-1] if extras else ""
+
+    def _claim_slash_confirm_pending(
+        self,
+        *,
+        session_key: str,
+        confirm_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Atomically claim matching gateway slash-confirm state."""
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            return _slash_confirm_mod.claim(session_key, confirm_id)
+        except Exception as exc:
+            logger.error("[Feishu] Failed to validate slash-confirm state: %s", exc, exc_info=True)
+            return None
+
+    @staticmethod
+    def _restore_slash_confirm_pending(session_key: str, claimed: Optional[Dict[str, Any]]) -> None:
+        """Best-effort restore for claimed gateway state when scheduling fails."""
+        if not claimed:
+            return
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            _slash_confirm_mod.restore_claim(session_key, claimed)
+        except Exception as exc:
+            logger.error("[Feishu] Failed to restore slash-confirm state: %s", exc, exc_info=True)
+
+    async def send_slash_confirm(
+        self, chat_id: str, title: str, message: str, session_key: str,
+        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive slash-command confirmation card."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            self._drop_superseded_slash_confirm_state(session_key)
+            payload = json.dumps(
+                self._build_slash_confirm_card(
+                    title=title,
+                    message=message,
+                    confirm_id=confirm_id,
+                ),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                with self._slash_confirm_lock:
+                    self._slash_confirm_state[str(confirm_id)] = {
+                        "session_key": session_key,
+                        "message_id": result.message_id or "",
+                        "chat_id": chat_id,
+                        "chat_type": self._slash_confirm_chat_type(
+                            session_key=session_key,
+                            metadata=metadata,
+                        ),
+                        "participant_id": self._slash_confirm_participant_id(
+                            session_key=session_key,
+                            metadata=metadata,
+                        ),
+                        "metadata": dict(metadata or {}),
+                    }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
     def _build_update_prompt_card(*, prompt: str, default: str, prompt_id: int) -> Dict[str, Any]:
         default_hint = f"\n\nDefault: `{default}`" if default else ""
 
@@ -2149,6 +2306,22 @@ class FeishuAdapter(BasePlatformAdapter):
             },
             "elements": [
                 {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_slash_confirm_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        cancelled = choice == "cancel"
+        label = _SLASH_CONFIRM_LABEL_MAP.get(choice, "Resolved")
+        icon = "❌" if cancelled else "✅"
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": f"{icon} {label}", "tag": "plain_text"},
+                "template": "red" if cancelled else "green",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"{icon} **{label}** by {user_name}"},
             ],
         }
 
@@ -2657,11 +2830,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if slash_confirm_action is not None:
+            return self._handle_slash_confirm_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2700,6 +2883,36 @@ class FeishuAdapter(BasePlatformAdapter):
         if not allowed_ids:
             return True
         return "*" in allowed_ids or normalized in allowed_ids
+
+    def _is_slash_confirm_operator_authorized(
+        self,
+        *,
+        operator_id: Any,
+        chat_id: str,
+        chat_type: str,
+        participant_id: str = "",
+    ) -> bool:
+        """Return whether a Feishu user may answer a slash-confirm card."""
+        open_id = str(getattr(operator_id, "open_id", "") or "").strip()
+        user_id = str(getattr(operator_id, "user_id", "") or "").strip()
+        union_id = str(getattr(operator_id, "union_id", "") or "").strip()
+        identity = {value for value in (open_id, user_id, union_id) if value}
+        if not identity:
+            return False
+        normalized_participant = str(participant_id or "").strip()
+        if normalized_participant and normalized_participant not in identity:
+            return False
+        if "*" in self._admins or bool(identity & set(self._admins)):
+            return True
+        normalized_chat_type = str(chat_type or "").strip().lower()
+        if normalized_chat_type in {"dm", "direct", "private", "p2p"}:
+            return True
+        if not chat_id:
+            allowed_ids = set(self._admins) | set(self._allowed_group_users)
+            if not allowed_ids:
+                return True
+            return "*" in allowed_ids or bool(identity & allowed_ids)
+        return self._allow_group_message(operator_id, chat_id, is_bot=False)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2814,6 +3027,82 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+    def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule slash-confirm resolution and build the synchronous callback response."""
+        confirm_id = str(action_value.get("slash_confirm_id", "") or "")
+        if not confirm_id:
+            logger.debug("[Feishu] Card action missing slash_confirm_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        with self._slash_confirm_lock:
+            state = self._slash_confirm_state.get(confirm_id)
+        if state is None:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = str(action_value.get("hermes_slash_confirm_action", "") or "").strip().lower()
+        if choice not in {"once", "always", "cancel"}:
+            logger.debug("[Feishu] Card action has invalid slash-confirm choice=%r", choice)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        context = getattr(event, "context", None)
+        callback_chat_id = str(getattr(context, "open_chat_id", "") or "")
+        state_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and state_chat_id and callback_chat_id != state_chat_id:
+            logger.warning(
+                "[Feishu] Slash-confirm callback chat mismatch: callback=%s state=%s",
+                callback_chat_id,
+                state_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        chat_id = state_chat_id or callback_chat_id
+        chat_type = str(state.get("chat_type", "") or "")
+        if not self._is_slash_confirm_operator_authorized(
+            operator_id=operator,
+            chat_id=chat_id,
+            chat_type=chat_type,
+            participant_id=str(state.get("participant_id", "") or ""),
+        ):
+            logger.warning("[Feishu] Unauthorized slash-confirm click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        session_key = str(state.get("session_key", ""))
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        with self._slash_confirm_lock:
+            reserved_state = self._slash_confirm_state.pop(confirm_id, None)
+            if reserved_state is None:
+                logger.debug("[Feishu] Slash confirm %s already reserved or resolved", confirm_id)
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+            claimed = self._claim_slash_confirm_pending(session_key=session_key, confirm_id=confirm_id)
+            if not claimed:
+                logger.debug("[Feishu] Slash confirm %s no longer matches gateway pending state", confirm_id)
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+            if not self._submit_on_loop(
+                loop,
+                self._resolve_slash_confirm(
+                    confirm_id,
+                    choice,
+                    user_name,
+                    state=reserved_state,
+                    claimed=claimed,
+                ),
+            ):
+                self._slash_confirm_state[confirm_id] = reserved_state
+                self._restore_slash_confirm_pending(session_key, claimed)
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_slash_confirm_card(choice=choice, user_name=user_name)
+            response.card = card
+        return response
+
     async def _resolve_approval(
         self,
         approval_id: Any,
@@ -2892,6 +3181,43 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
+
+    async def _resolve_slash_confirm(
+        self,
+        confirm_id: str,
+        choice: str,
+        user_name: str,
+        *,
+        state: Optional[Dict[str, Any]] = None,
+        claimed: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Resolve a slash-confirm card click and send any follow-up response."""
+        state = state if state is not None else self._slash_confirm_state.pop(str(confirm_id), None)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            if claimed is None:
+                result_text = await _slash_confirm_mod.resolve(
+                    str(state["session_key"]),
+                    str(confirm_id),
+                    choice,
+                )
+            else:
+                result_text = await _slash_confirm_mod.resolve_claimed(claimed, choice)
+            if result_text:
+                await self.send(
+                    chat_id=str(state["chat_id"]),
+                    content=result_text,
+                    metadata=state.get("metadata") or None,
+                )
+            logger.info(
+                "Feishu button resolved slash-confirm for session %s (choice=%s, user=%s)",
+                state["session_key"], choice, user_name,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve slash-confirm from Feishu button: %s", exc, exc_info=True)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -4297,7 +4623,8 @@ class FeishuAdapter(BasePlatformAdapter):
         """Per-group policy gate for non-DM traffic."""
         sender_open_id = getattr(sender_id, "open_id", None)
         sender_user_id = getattr(sender_id, "user_id", None)
-        sender_ids = {sender_open_id, sender_user_id} - {None}
+        sender_union_id = getattr(sender_id, "union_id", None)
+        sender_ids = {sender_open_id, sender_user_id, sender_union_id} - {None, ""}
 
         if sender_ids and self._admins and (sender_ids & self._admins):
             return True

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -1,5 +1,6 @@
 """Tests for Feishu interactive card approval buttons."""
 
+import asyncio
 import importlib.util
 import json
 import sys
@@ -39,7 +40,7 @@ _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
 import plugins.platforms.feishu.adapter as feishu_module
-from plugins.platforms.feishu.adapter import FeishuAdapter
+from plugins.platforms.feishu.adapter import FeishuAdapter, FeishuGroupRule
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,8 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
+    union_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +68,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id, union_id=union_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -78,6 +81,17 @@ def _close_submitted_coro(coro, _loop):
     """Close scheduled coroutines in sync-handler tests to avoid unawaited warnings."""
     coro.close()
     return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+def _register_slash_confirm(session_key: str, confirm_id: str, result=None) -> None:
+    """Register gateway slash-confirm state for Feishu callback tests."""
+    from tools import slash_confirm
+
+    async def _handler(_choice: str):
+        return result
+
+    slash_confirm.clear(session_key)
+    slash_confirm.register(session_key, confirm_id, "test", _handler)
 
 
 # ===========================================================================
@@ -302,6 +316,209 @@ class TestFeishuUpdatePrompt:
         assert result.success is False
         assert "timed out" in (result.error or "")
 
+
+# ===========================================================================
+# send_slash_confirm — interactive card with three confirmation buttons
+# ===========================================================================
+
+class TestFeishuSlashConfirm:
+    """Test send_slash_confirm sends and resolves an interactive card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm /reload-mcp",
+                message="Reload MCP tools?",
+                session_key="agent:main:feishu:group:oc_12345",
+                confirm_id="confirm-1",
+                metadata={"thread_id": "th_1"},
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc_001"
+
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["metadata"] == {"thread_id": "th_1"}
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "orange"
+        assert card["header"]["title"]["content"] == "Confirm /reload-mcp"
+        assert "Reload MCP tools?" in card["elements"][0]["content"]
+        actions = card["elements"][1]["actions"]
+        assert [a["value"]["hermes_slash_confirm_action"] for a in actions] == [
+            "once", "always", "cancel",
+        ]
+        assert [a["value"]["slash_confirm_id"] for a in actions] == [
+            "confirm-1", "confirm-1", "confirm-1",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stores_slash_confirm_state(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_002"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Proceed?",
+                session_key="my-session-key",
+                confirm_id="42",
+                metadata={"thread_id": "th_2"},
+            )
+
+        state = adapter._slash_confirm_state["42"]
+        assert state["session_key"] == "my-session-key"
+        assert state["message_id"] == "msg_sc_002"
+        assert state["chat_id"] == "oc_12345"
+        assert state["metadata"] == {"thread_id": "th_2"}
+
+    @pytest.mark.asyncio
+    async def test_new_confirm_supersedes_old_confirm_for_same_session(self):
+        adapter = _make_adapter()
+
+        first_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_old"),
+        )
+        second_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_new"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            side_effect=[first_response, second_response],
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Old prompt?",
+                session_key="same-session",
+                confirm_id="old-confirm",
+            )
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="New prompt?",
+                session_key="same-session",
+                confirm_id="new-confirm",
+            )
+
+        assert "old-confirm" not in adapter._slash_confirm_state
+        assert adapter._slash_confirm_state["new-confirm"]["message_id"] == "msg_sc_new"
+
+    @pytest.mark.asyncio
+    async def test_failed_new_confirm_still_drops_old_confirm_for_same_session(self):
+        adapter = _make_adapter()
+
+        first_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_old"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            side_effect=[first_response, TimeoutError("timed out")],
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Old prompt?",
+                session_key="same-session-fail",
+                confirm_id="old-confirm",
+            )
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="New prompt?",
+                session_key="same-session-fail",
+                confirm_id="new-confirm",
+            )
+
+        assert result.success is False
+        assert "old-confirm" not in adapter._slash_confirm_state
+        assert "new-confirm" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_resolves_and_sends_followup(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["confirm-2"] = {
+            "session_key": "sess-sc-2",
+            "message_id": "msg_sc_003",
+            "chat_id": "oc_12345",
+            "metadata": {"thread_id": "th_3"},
+        }
+
+        async def _resolve(session_key, confirm_id, choice):
+            assert session_key == "sess-sc-2"
+            assert confirm_id == "confirm-2"
+            assert choice == "always"
+            return "Reloaded."
+
+        with (
+            patch("tools.slash_confirm.resolve", side_effect=_resolve) as mock_resolve,
+            patch.object(adapter, "send", new_callable=AsyncMock) as mock_send,
+        ):
+            await adapter._resolve_slash_confirm("confirm-2", "always", "Alice")
+
+        assert mock_resolve.called
+        mock_send.assert_called_once_with(
+            chat_id="oc_12345",
+            content="Reloaded.",
+            metadata={"thread_id": "th_3"},
+        )
+        assert "confirm-2" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_resolves_without_followup(self):
+        adapter = _make_adapter()
+        adapter._slash_confirm_state["confirm-3"] = {
+            "session_key": "sess-sc-3",
+            "message_id": "msg_sc_004",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+
+        with (
+            patch("tools.slash_confirm.resolve", new_callable=AsyncMock, return_value=None) as mock_resolve,
+            patch.object(adapter, "send", new_callable=AsyncMock) as mock_send,
+        ):
+            await adapter._resolve_slash_confirm("confirm-3", "cancel", "Alice")
+
+        mock_resolve.assert_awaited_once_with("sess-sc-3", "confirm-3", "cancel")
+        mock_send.assert_not_called()
+        assert "confirm-3" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = await adapter.send_slash_confirm(
+            chat_id="oc_12345",
+            title="Confirm",
+            message="Proceed?",
+            session_key="s",
+            confirm_id="c",
+        )
+        assert result.success is False
 
 # ===========================================================================
 # _resolve_approval — approval state pop + gateway resolution
@@ -803,6 +1020,635 @@ class TestCardActionCallbackResponse:
         assert 8 in adapter._update_prompt_state
         mock_submit.assert_not_called()
 
+
+    def test_returns_card_for_slash_confirm_always(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        _register_slash_confirm("sess-sc-1", "confirm-1")
+        adapter._slash_confirm_state["confirm-1"] = {
+            "session_key": "sess-sc-1",
+            "message_id": "msg_sc_004",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "always",
+                "slash_confirm_id": "confirm-1",
+            },
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Always approved" in card["header"]["title"]["content"]
+        assert "Bob" in card["elements"][0]["content"]
+
+    def test_returns_card_for_slash_confirm_cancel(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-2", "confirm-2")
+        adapter._slash_confirm_state["confirm-2"] = {
+            "session_key": "sess-sc-2",
+            "message_id": "msg_sc_005",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "cancel",
+                "slash_confirm_id": "confirm-2",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "red"
+        assert "Cancelled" in card["header"]["title"]["content"]
+
+    def test_unknown_slash_confirm_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "missing",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_gateway_missing_slash_confirm_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        adapter._slash_confirm_state["confirm-missing-pending"] = {
+            "session_key": "sess-sc-missing-pending",
+            "message_id": "msg_sc_missing_pending",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-missing-pending",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "confirm-missing-pending" not in adapter._slash_confirm_state
+
+    def test_gateway_mismatched_slash_confirm_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-mismatch", "new-confirm")
+        adapter._slash_confirm_state["old-confirm"] = {
+            "session_key": "sess-sc-mismatch",
+            "message_id": "msg_sc_old",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "old-confirm",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "old-confirm" not in adapter._slash_confirm_state
+
+    def test_expired_gateway_slash_confirm_returns_no_card(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-expired", "confirm-expired")
+        slash_confirm._pending["sess-sc-expired"]["created_at"] = 0
+        adapter._slash_confirm_state["confirm-expired"] = {
+            "session_key": "sess-sc-expired",
+            "message_id": "msg_sc_expired",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-expired",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "confirm-expired" not in adapter._slash_confirm_state
+        assert slash_confirm.get_pending("sess-sc-expired") is None
+
+    def test_superseded_slash_confirm_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["new-confirm"] = {
+            "session_key": "same-session",
+            "message_id": "msg_sc_new",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "old-confirm",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_slash_confirm_unauthorized_operator_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_allowed"}
+        _register_slash_confirm("sess-sc-3", "confirm-3")
+        adapter._slash_confirm_state["confirm-3"] = {
+            "session_key": "sess-sc-3",
+            "message_id": "msg_sc_006",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-3",
+            },
+            open_id="ou_intruder",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_slash_confirm_schedule_failure_returns_no_card(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-4", "confirm-4")
+        adapter._slash_confirm_state["confirm-4"] = {
+            "session_key": "sess-sc-4",
+            "message_id": "msg_sc_007",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-4",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("loop closed")):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert "confirm-4" in adapter._slash_confirm_state
+        assert slash_confirm.get_pending("sess-sc-4") is not None
+
+    def test_invalid_slash_confirm_action_returns_no_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["confirm-5"] = {
+            "session_key": "sess-sc-5",
+            "message_id": "msg_sc_008",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "bogus",
+                "slash_confirm_id": "confirm-5",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_duplicate_slash_confirm_click_is_reserved_synchronously(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-dup", "confirm-dup")
+        adapter._slash_confirm_state["confirm-dup"] = {
+            "session_key": "sess-sc-dup",
+            "message_id": "msg_sc_dup",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-dup",
+            },
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit:
+            first_response = adapter._on_card_action_trigger(data)
+            second_response = adapter._on_card_action_trigger(data)
+
+        assert first_response.card is not None
+        assert second_response.card is None
+        assert mock_submit.call_count == 1
+        assert slash_confirm.get_pending("sess-sc-dup") is None
+
+    def test_slash_confirm_duplicate_during_claim_does_not_steal_pending(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-race", "confirm-race")
+        adapter._slash_confirm_state["confirm-race"] = {
+            "session_key": "sess-sc-race",
+            "message_id": "msg_sc_race",
+            "chat_id": "oc_12345",
+            "chat_type": "group",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-race",
+            },
+        )
+        nested_responses = []
+        original_claim = adapter._claim_slash_confirm_pending
+
+        def _claim_with_nested_click(**kwargs):
+            nested_responses.append(adapter._on_card_action_trigger(data))
+            return original_claim(**kwargs)
+
+        with (
+            patch.object(adapter, "_claim_slash_confirm_pending", side_effect=_claim_with_nested_click),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+        assert nested_responses[0].card is None
+        assert mock_submit.call_count == 1
+        assert slash_confirm.get_pending("sess-sc-race") is None
+
+    def test_slash_confirm_dm_ignores_group_allowlist(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_someone_else"}
+        _register_slash_confirm("agent:main:feishu:dm:oc_dm", "confirm-dm")
+        adapter._slash_confirm_state["confirm-dm"] = {
+            "session_key": "agent:main:feishu:dm:oc_dm",
+            "message_id": "msg_sc_dm",
+            "chat_id": "oc_dm",
+            "chat_type": "dm",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-dm",
+            },
+            chat_id="oc_dm",
+            open_id="ou_dm_user",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+
+    @pytest.mark.asyncio
+    async def test_valid_slash_confirm_callback_resolves_and_sends_followup(
+        self,
+        _patch_callback_card_types,
+    ):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = asyncio.get_running_loop()
+        adapter._allowed_group_users = {"ou_user1"}
+        _register_slash_confirm("sess-sc-e2e", "confirm-e2e", result="Resolved follow-up")
+        adapter._slash_confirm_state["confirm-e2e"] = {
+            "session_key": "sess-sc-e2e",
+            "message_id": "msg_sc_e2e",
+            "chat_id": "oc_12345",
+            "metadata": {"thread_id": "th_e2e"},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "always",
+                "slash_confirm_id": "confirm-e2e",
+            },
+        )
+
+        with patch.object(adapter, "send", new_callable=AsyncMock) as mock_send:
+            response = adapter._on_card_action_trigger(data)
+            await asyncio.sleep(0.01)
+
+        assert response is not None
+        assert response.card is not None
+        mock_send.assert_awaited_once_with(
+            chat_id="oc_12345",
+            content="Resolved follow-up",
+            metadata={"thread_id": "th_e2e"},
+        )
+        assert slash_confirm.get_pending("sess-sc-e2e") is None
+        assert "confirm-e2e" not in adapter._slash_confirm_state
+
+    def test_slash_confirm_respects_per_chat_group_rule_allowlist(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._group_rules["oc_12345"] = FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"ou_allowed"},
+        )
+        _register_slash_confirm("sess-sc-rule", "confirm-rule")
+        adapter._slash_confirm_state["confirm-rule"] = {
+            "session_key": "sess-sc-rule",
+            "message_id": "msg_sc_rule",
+            "chat_id": "oc_12345",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-rule",
+            },
+            open_id="ou_intruder",
+            chat_id="oc_12345",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "confirm-rule" in adapter._slash_confirm_state
+
+    def test_slash_confirm_group_rule_allows_operator_user_id(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._group_rules["oc_12345"] = FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"u_allowed"},
+        )
+        _register_slash_confirm("sess-sc-user-id-rule", "confirm-user-id-rule")
+        adapter._slash_confirm_state["confirm-user-id-rule"] = {
+            "session_key": "sess-sc-user-id-rule",
+            "message_id": "msg_sc_user_id_rule",
+            "chat_id": "oc_12345",
+            "chat_type": "group",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-user-id-rule",
+            },
+            open_id="ou_other",
+            user_id="u_allowed",
+            chat_id="oc_12345",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+
+    def test_slash_confirm_group_rule_allows_operator_union_id(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._group_rules["oc_12345"] = FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"on_allowed"},
+        )
+        _register_slash_confirm("sess-sc-union-rule", "confirm-union-rule")
+        adapter._slash_confirm_state["confirm-union-rule"] = {
+            "session_key": "sess-sc-union-rule",
+            "message_id": "msg_sc_union_rule",
+            "chat_id": "oc_12345",
+            "chat_type": "group",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-union-rule",
+            },
+            open_id="ou_other",
+            union_id="on_allowed",
+            chat_id="oc_12345",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+
+    def test_slash_confirm_group_rule_rejects_blacklisted_union_id(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._group_rules["oc_12345"] = FeishuGroupRule(
+            policy="blacklist",
+            blacklist={"on_blocked"},
+        )
+        _register_slash_confirm("sess-sc-union-blacklist", "confirm-union-blacklist")
+        adapter._slash_confirm_state["confirm-union-blacklist"] = {
+            "session_key": "sess-sc-union-blacklist",
+            "message_id": "msg_sc_union_blacklist",
+            "chat_id": "oc_12345",
+            "chat_type": "group",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-union-blacklist",
+            },
+            open_id="ou_other",
+            union_id="on_blocked",
+            chat_id="oc_12345",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+
+    def test_named_profile_group_session_rejects_different_participant(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"alice_id", "bob_id"}
+        session_key = "agent:research:feishu:group:oc_12345:alice_id"
+        _register_slash_confirm(session_key, "confirm-alice")
+        adapter._slash_confirm_state["confirm-alice"] = {
+            "session_key": session_key,
+            "message_id": "msg_sc_alice",
+            "chat_id": "oc_12345",
+            "chat_type": "group",
+            "participant_id": adapter._slash_confirm_participant_id(
+                session_key=session_key,
+            ),
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-alice",
+            },
+            open_id="bob_id",
+            chat_id="oc_12345",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "confirm-alice" in adapter._slash_confirm_state
+        assert slash_confirm.get_pending(session_key) is not None
+
+    @pytest.mark.asyncio
+    async def test_send_slash_confirm_stores_group_participant_from_session_key(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_participant"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Proceed?",
+                session_key="agent:research:feishu:group:oc_12345:alice_id",
+                confirm_id="confirm-participant",
+            )
+
+        assert adapter._slash_confirm_state["confirm-participant"]["participant_id"] == "alice_id"
+
+    def test_slash_confirm_rejects_callback_from_different_chat(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._group_rules["oc_b"] = FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"ou_user1"},
+        )
+        _register_slash_confirm("sess-sc-chat-mismatch", "confirm-chat-mismatch")
+        adapter._slash_confirm_state["confirm-chat-mismatch"] = {
+            "session_key": "sess-sc-chat-mismatch",
+            "message_id": "msg_sc_chat_mismatch",
+            "chat_id": "oc_a",
+            "chat_type": "group",
+            "metadata": {},
+        }
+        data = _make_card_action_data(
+            {
+                "hermes_slash_confirm_action": "once",
+                "slash_confirm_id": "confirm-chat-mismatch",
+            },
+            chat_id="oc_b",
+            open_id="ou_user1",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
+        assert "confirm-chat-mismatch" in adapter._slash_confirm_state
+        assert slash_confirm.get_pending("sess-sc-chat-mismatch") is not None
 
 class TestResolveUpdatePrompt:
     """Test update prompt resolution persists the response file."""

--- a/tests/tools/test_slash_confirm.py
+++ b/tests/tools/test_slash_confirm.py
@@ -154,6 +154,65 @@ class TestResolve:
         assert (r1 == "ran") ^ (r2 == "ran")
 
 
+class TestClaim:
+    def test_claim_pops_matching_entry(self):
+        async def handler(choice):
+            return f"resolved {choice}"
+
+        slash_confirm.register("sess1", "cid1", "cmd", handler)
+
+        claimed = slash_confirm.claim("sess1", "cid1")
+
+        assert claimed is not None
+        assert claimed["confirm_id"] == "cid1"
+        assert claimed["handler"] is handler
+        assert slash_confirm.get_pending("sess1") is None
+
+    def test_claim_mismatch_preserves_entry(self):
+        async def handler(choice):
+            return "should not run"
+
+        slash_confirm.register("sess1", "cid1", "cmd", handler)
+
+        claimed = slash_confirm.claim("sess1", "wrong")
+
+        assert claimed is None
+        assert slash_confirm.get_pending("sess1") is not None
+
+    @pytest.mark.asyncio
+    async def test_resolve_claimed_runs_handler(self):
+        calls = []
+
+        async def handler(choice):
+            calls.append(choice)
+            return f"resolved {choice}"
+
+        slash_confirm.register("sess1", "cid1", "cmd", handler)
+        claimed = slash_confirm.claim("sess1", "cid1")
+
+        result = await slash_confirm.resolve_claimed(claimed, "always")
+
+        assert result == "resolved always"
+        assert calls == ["always"]
+
+    def test_restore_claim_only_when_session_empty(self):
+        async def old_handler(choice):
+            return "old"
+
+        async def new_handler(choice):
+            return "new"
+
+        slash_confirm.register("sess1", "old", "cmd", old_handler)
+        claimed = slash_confirm.claim("sess1", "old")
+        slash_confirm.restore_claim("sess1", claimed)
+        assert slash_confirm.get_pending("sess1")["confirm_id"] == "old"
+
+        claimed = slash_confirm.claim("sess1", "old")
+        slash_confirm.register("sess1", "new", "cmd", new_handler)
+        slash_confirm.restore_claim("sess1", claimed)
+        assert slash_confirm.get_pending("sess1")["confirm_id"] == "new"
+
+
 class TestClear:
     def test_clear_removes_entry(self):
         async def h(c):

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -96,6 +96,57 @@ def clear_if_stale(session_key: str, timeout: float = DEFAULT_TIMEOUT_SECONDS) -
         return False
 
 
+def claim(
+    session_key: str,
+    confirm_id: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """Atomically claim and remove a pending confirmation.
+
+    Returns the claimed entry when ``confirm_id`` still matches and is not
+    stale.  The caller is then responsible for running the handler via
+    ``resolve_claimed``.  This is for platform callbacks that must decide
+    synchronously whether to update an interactive prompt as resolved.
+    """
+    with _lock:
+        entry = _pending.get(session_key)
+        if not entry:
+            return None
+        if entry.get("confirm_id") != confirm_id:
+            return None
+        _pending.pop(session_key, None)
+        if time.time() - float(entry.get("created_at", 0) or 0) > timeout:
+            return None
+        return dict(entry)
+
+
+def restore_claim(session_key: str, claimed: Dict[str, Any]) -> None:
+    """Restore a claimed confirmation if the session has not moved on."""
+    if not claimed:
+        return
+    with _lock:
+        _pending.setdefault(session_key, dict(claimed))
+
+
+async def resolve_claimed(claimed: Dict[str, Any], choice: str) -> Optional[str]:
+    """Run the handler from a previously claimed confirmation."""
+    if not claimed:
+        return None
+    handler = claimed.get("handler")
+    command = claimed.get("command", "?")
+    if not handler:
+        return None
+    try:
+        result = await handler(choice)
+    except Exception as exc:
+        logger.error(
+            "Slash-confirm handler for /%s raised: %s",
+            command, exc, exc_info=True,
+        )
+        return f"❌ Error handling confirmation: {exc}"
+    return result if isinstance(result, str) else None
+
+
 async def resolve(
     session_key: str,
     confirm_id: str,
@@ -112,32 +163,10 @@ async def resolve(
     Safe to call from an asyncio callback (button click) or from the
     gateway's message intercept path.
     """
-    with _lock:
-        entry = _pending.get(session_key)
-        if not entry:
-            return None
-        if entry.get("confirm_id") != confirm_id:
-            # Stale confirm_id — superseded by a newer prompt on the same session.
-            return None
-        # Pop before we run the handler to prevent duplicate callbacks
-        # (e.g. button double-click) from running it twice.
-        _pending.pop(session_key, None)
-        if time.time() - float(entry.get("created_at", 0) or 0) > timeout:
-            return None
-        handler = entry.get("handler")
-        command = entry.get("command", "?")
-
-    if not handler:
+    claimed = claim(session_key, confirm_id, timeout=timeout)
+    if not claimed:
         return None
-    try:
-        result = await handler(choice)
-    except Exception as exc:
-        logger.error(
-            "Slash-confirm handler for /%s raised: %s",
-            command, exc, exc_info=True,
-        )
-        return f"❌ Error handling confirmation: {exc}"
-    return result if isinstance(result, str) else None
+    return await resolve_claimed(claimed, choice)
 
 
 def resolve_sync_compat(


### PR DESCRIPTION
Add Feishu interactive card support for generic slash confirmations.

Coordinate callback resolution with the shared slash_confirm claim API to avoid stale cards, duplicate clicks, and text fallback races.

## What does this PR do?

This PR adds Feishu interactive-card support for generic slash confirmations, matching the existing Telegram/Discord approval flow more closely.

When Hermes needs confirmation from a Feishu user, the gateway can now send an interactive card with approve-once, always-approve, and cancel actions. Callback handling validates the originating chat/user, claims the pending confirmation atomically, and resolves it through the shared `tools.slash_confirm` state so stale cards, duplicate clicks, and text fallback races do not resolve the same confirmation twice.

The shared `slash_confirm` module now exposes a claim/restore/resolve-claimed flow while preserving the existing `resolve()` behavior for other platforms.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `send_slash_confirm` support to `plugins/platforms/feishu/adapter.py`.
- Added Feishu interactive-card rendering for slash confirmation choices.
- Added Feishu card callback handling with operator/chat authorization.
- Added local Feishu confirm state tracking to reject stale or mismatched callbacks.
- Added shared `claim`, `restore_claim`, and `resolve_claimed` helpers in `tools/slash_confirm.py`.
- Preserved the existing `tools.slash_confirm.resolve()` API for current callers.
- Added Feishu gateway tests covering successful callbacks, duplicate clicks, stale cards, authorization, chat mismatch, scheduling failure restore, and group/user allowlist behavior.
- Added shared slash-confirm tests for claim, restore, and claimed-resolution behavior.

## How to Test

1. Run the targeted Feishu and slash-confirm test suite:

   ```bash
   scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py tests/tools/test_slash_confirm.py
   ```

2. Run syntax checks:

   ```bash
   python3 -m py_compile plugins/platforms/feishu/adapter.py tools/slash_confirm.py tests/gateway/test_feishu_approval_buttons.py tests/tools/test_slash_confirm.py
   ```

3. Run lint/checks for the touched files:

   ```bash
   .venv/bin/python -m ruff check plugins/platforms/feishu/adapter.py tools/slash_confirm.py tests/gateway/test_feishu_approval_buttons.py tests/tools/test_slash_confirm.py
   git diff --check -- plugins/platforms/feishu/adapter.py tools/slash_confirm.py tests/gateway/test_feishu_approval_buttons.py tests/tools/test_slash_confirm.py
   ```

Result from local targeted tests:

```text
86 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output:

```text
86 passed
```
