### PR TITLE
fix(kanban): prevent false task completion with QC verifier scoring gate

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4161,7 +4161,7 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "completed_awaiting_qc")
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -4372,6 +4372,24 @@ class GatewayRunner:
                             msg = (
                                 f"⏱ {tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
+                            )
+                        elif kind == "completed_awaiting_qc":
+                            threshold = ""
+                            if ev.payload and ev.payload.get("qc_threshold"):
+                                threshold = f" (threshold: {ev.payload['qc_threshold']})"
+                            handoff = ""
+                            payload_summary = None
+                            if ev.payload and ev.payload.get("summary"):
+                                payload_summary = str(ev.payload["summary"])
+                            if payload_summary:
+                                h = payload_summary.strip().splitlines()[0][:200]
+                                handoff = f"\n{h}"
+                            elif task and task.result:
+                                r = task.result.strip().splitlines()[0][:160]
+                                handoff = f"\n{r}"
+                            msg = (
+                                f"🔍 {tag}Kanban {sub['task_id']} done — "
+                                f"awaiting QC review{threshold}{handoff}"
                             )
                         else:
                             continue

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,7 +90,7 @@ from toolsets import get_toolset_names
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived", "qc_review"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 
@@ -606,6 +606,12 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    # --- QC / verifier gate fields ---
+    require_qc: bool = False
+    qc_threshold: Optional[float] = None
+    qc_score: Optional[float] = None
+    rework_count: int = 0
+    last_qc_feedback: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -669,6 +675,15 @@ class Task:
             skills=skills_value,
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
+            ),
+            require_qc=bool(row["require_qc"]) if "require_qc" in keys else False,
+            qc_threshold=row["qc_threshold"] if "qc_threshold" in keys else None,
+            qc_score=row["qc_score"] if "qc_score" in keys else None,
+            rework_count=(
+                row["rework_count"] if "rework_count" in keys else 0
+            ),
+            last_qc_feedback=(
+                row["last_qc_feedback"] if "last_qc_feedback" in keys else None
             ),
         )
 
@@ -1076,6 +1091,30 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
 
+    # --- QC/verifier columns (kanban-review gate) ---
+    if "require_qc" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "require_qc", "require_qc INTEGER NOT NULL DEFAULT 0"
+        )
+    if "qc_threshold" not in cols:
+        # Minimum acceptable quality score (0.0 – 1.0). NULL = default 0.7.
+        _add_column_if_missing(
+            conn, "tasks", "qc_threshold", "qc_threshold REAL"
+        )
+    if "qc_score" not in cols:
+        # Score assigned by the QC reviewer (agent or human).
+        _add_column_if_missing(conn, "tasks", "qc_score", "qc_score REAL")
+    if "rework_count" not in cols:
+        # How many times this task was returned for rework.
+        _add_column_if_missing(
+            conn, "tasks", "rework_count", "rework_count INTEGER NOT NULL DEFAULT 0"
+        )
+    if "last_qc_feedback" not in cols:
+        # Most recent QC rejection feedback text.
+        _add_column_if_missing(
+            conn, "tasks", "last_qc_feedback", "last_qc_feedback TEXT"
+        )
+
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
@@ -1244,6 +1283,8 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    require_qc: bool = False,
+    qc_threshold: Optional[float] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1377,8 +1418,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         tenant, idempotency_key, max_runtime_seconds, skills,
-                        max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        max_retries, require_qc, qc_threshold
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1396,6 +1437,8 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        1 if require_qc else 0,
+                        float(qc_threshold) if qc_threshold is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -1413,6 +1456,8 @@ def create_task(
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
+                        "require_qc": require_qc,
+                        "qc_threshold": qc_threshold,
                     },
                 )
             return task_id
@@ -2388,6 +2433,20 @@ def complete_task(
     """
     now = int(time.time())
 
+    # Read QC gate: if the task requires QC, transition to qc_review
+    # instead of done so a verifier agent or human can approve/reject.
+    target_status = "done"
+    new_event_kind = "completed"
+    qc_threshold_val: Optional[float] = None
+    row = conn.execute(
+        "SELECT require_qc, qc_threshold FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is not None and row["require_qc"]:
+        target_status = "qc_review"
+        new_event_kind = "completed_awaiting_qc"
+        qc_threshold_val = row["qc_threshold"]
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
@@ -2420,7 +2479,7 @@ def complete_task(
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -2429,13 +2488,13 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
-                (result, now, task_id),
+                (target_status, result, now, task_id),
             )
         else:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -2445,7 +2504,7 @@ def complete_task(
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (target_status, result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
@@ -2478,8 +2537,10 @@ def complete_task(
         }
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
+        if qc_threshold_val is not None:
+            completed_payload["qc_threshold"] = qc_threshold_val
         _append_event(
-            conn, task_id, "completed",
+            conn, task_id, new_event_kind,
             completed_payload,
             run_id=run_id,
         )
@@ -2511,6 +2572,111 @@ def complete_task(
     _clear_failure_counter(conn, task_id)
     # Recompute ready status for dependents (separate txn so children see done).
     recompute_ready(conn)
+    return True
+
+
+MAX_REWORK_LIMIT = 3
+
+
+def qc_approve(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    score: float,
+    feedback: Optional[str] = None,
+) -> bool:
+    """Approve a QC review — transition ``qc_review → done``.
+
+    Records the score and optional feedback on the task and emits
+    a ``qc_approved`` event. The task is marked done and becomes
+    available as a dependency for any children waiting on it.
+
+    Returns ``True`` on success, ``False`` if the task is not in
+    ``qc_review`` state.
+    """
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status       = 'done',
+                   qc_score     = ?,
+                   last_qc_feedback = ?,
+                   completed_at = ?
+             WHERE id = ?
+               AND status = 'qc_review'
+            """,
+            (float(score), feedback, int(time.time()), task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn, task_id, "qc_approved",
+            {"score": score, "feedback": feedback},
+        )
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    return True
+
+
+def qc_reject(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    score: float,
+    feedback: str,
+) -> bool:
+    """Reject a QC review — transition ``qc_review → ready``.
+
+    Increments the rework counter. If ``rework_count`` exceeds
+    ``MAX_REWORK_LIMIT`` (3), the task is moved to ``blocked``
+    instead of ``ready`` so a human can intervene.
+
+    ``feedback`` is required — the assignee needs to know what
+    to fix. The previous result and completed_at are preserved
+    on the task row (the worker was not wrong to complete; it
+    just needs to iterate). Returns ``True`` on success.
+    """
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET qc_score        = ?,
+                   last_qc_feedback = ?,
+                   rework_count    = rework_count + 1
+             WHERE id = ?
+               AND status = 'qc_review'
+            """,
+            (float(score), feedback, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+
+        row = conn.execute(
+            "SELECT rework_count FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        rework = row["rework_count"] if row else 1
+
+        if rework > MAX_REWORK_LIMIT:
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked' WHERE id = ? AND status = 'qc_review'",
+                (task_id,),
+            )
+        else:
+            conn.execute(
+                "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'qc_review'",
+                (task_id,),
+            )
+
+        _append_event(
+            conn, task_id, "qc_rejected",
+            {
+                "score": score,
+                "feedback": feedback,
+                "rework_count": rework,
+                "exceeded_limit": rework > MAX_REWORK_LIMIT,
+            },
+        )
     return True
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -219,6 +219,10 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "children": children,
         "parent_count": len(parents),
         "child_count": len(children),
+        "require_qc": bool(task.require_qc),
+        "qc_score": task.qc_score,
+        "qc_threshold": task.qc_threshold,
+        "rework_count": task.rework_count,
     }
 
 
@@ -258,6 +262,11 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "require_qc": bool(t.require_qc),
+                    "qc_score": t.qc_score,
+                    "qc_threshold": t.qc_threshold,
+                    "rework_count": t.rework_count,
+                    "last_qc_feedback": t.last_qc_feedback,
                 }
 
             def _run_dict(r):
@@ -427,7 +436,13 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            # Check whether the task entered QC review instead of done.
+            task = kb.get_task(conn, tid)
+            qc_info = {}
+            if task and task.status == "qc_review":
+                qc_info["status"] = "qc_review"
+                qc_info["qc_threshold"] = task.qc_threshold
+            return _ok(task_id=tid, run_id=run.id if run else None, **qc_info)
         finally:
             conn.close()
     except Exception as e:
@@ -591,6 +606,10 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
+    require_qc, bool_error = _parse_bool_arg(args, "require_qc")
+    if bool_error:
+        return tool_error(bool_error)
+    qc_threshold = args.get("qc_threshold")
     try:
         kb, conn = _connect()
         try:
@@ -611,6 +630,10 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                require_qc=require_qc,
+                qc_threshold=(
+                    float(qc_threshold) if qc_threshold is not None else None
+                ),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -673,6 +696,65 @@ def _handle_link(args: dict, **kw) -> str:
         return tool_error(f"kanban_link: {e}")
 
 
+def _handle_review(args: dict, **kw) -> str:
+    """Approve or reject a QC review."""
+    tid = args.get("task_id")
+    if not tid:
+        return tool_error("task_id is required")
+    approve = args.get("approve")
+    if not isinstance(approve, bool):
+        return tool_error("approve must be a boolean (true/false)")
+    score = args.get("score")
+    if score is None:
+        return tool_error("score is required")
+    try:
+        score = float(score)
+    except (TypeError, ValueError):
+        return tool_error("score must be a number (0.0 – 1.0)")
+    if score < 0.0 or score > 1.0:
+        return tool_error("score must be between 0.0 and 1.0")
+    feedback = args.get("feedback") or ""
+    try:
+        kb, conn = _connect()
+        try:
+            if approve:
+                ok = kb.qc_approve(
+                    conn, tid, score=score,
+                    feedback=feedback if feedback else None,
+                )
+                if not ok:
+                    return tool_error(
+                        f"could not approve {tid}: not in qc_review state"
+                    )
+                return _ok(
+                    task_id=tid, status="done",
+                    qc_score=score,
+                )
+            else:
+                if not feedback:
+                    return tool_error(
+                        "feedback is required when rejecting a QC review"
+                    )
+                ok = kb.qc_reject(
+                    conn, tid, score=score, feedback=feedback,
+                )
+                if not ok:
+                    return tool_error(
+                        f"could not reject {tid}: not in qc_review state"
+                    )
+                task = kb.get_task(conn, tid)
+                target = task.status if task else "ready"
+                return _ok(
+                    task_id=tid, status=target,
+                    qc_score=score,
+                )
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.exception("kanban_review failed")
+        return tool_error(f"kanban_review: {e}")
+
+
 # ---------------------------------------------------------------------------
 # Schemas
 # ---------------------------------------------------------------------------
@@ -727,7 +809,7 @@ KANBAN_LIST_SCHEMA = {
                 "type": "string",
                 "enum": [
                     "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "blocked", "done", "archived", "qc_review",
                 ],
                 "description": "Optional task status filter.",
             },
@@ -1011,6 +1093,23 @@ KANBAN_CREATE_SCHEMA = {
                     "assignee's profile."
                 ),
             },
+            "require_qc": {
+                "type": "boolean",
+                "description": (
+                    "If true, the task enters 'qc_review' after the "
+                    "worker completes, instead of going straight to "
+                    "'done'. A verifier must call kanban_review to "
+                    "approve or reject the deliverable. Default: false."
+                ),
+            },
+            "qc_threshold": {
+                "type": "number",
+                "description": (
+                    "Minimum acceptable quality score (0.0 – 1.0) for "
+                    "QC review. The verifier's pass/fail decision is "
+                    "based on this threshold. Default: 0.7."
+                ),
+            },
         },
         "required": ["title", "assignee"],
     },
@@ -1049,6 +1148,53 @@ KANBAN_LINK_SCHEMA = {
             "child_id":  {"type": "string", "description": "Child task id."},
         },
         "required": ["parent_id", "child_id"],
+    },
+}
+
+KANBAN_REVIEW_SCHEMA = {
+    "name": "kanban_review",
+    "description": (
+        "Approve or reject a task that is awaiting QC review. Only "
+        "visible when the kanban toolset is enabled OR when dispatched "
+        "to a task that is in 'qc_review' status. "
+        "``approve=True`` moves the task to 'done' with a quality score. "
+        "``approve=False`` sends the task back to 'ready' for rework "
+        "with detailed feedback; after 3 rework cycles the task is "
+        "automatically blocked for human intervention."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task id to review.",
+            },
+            "approve": {
+                "type": "boolean",
+                "description": (
+                    "True to approve (task → done), False to reject "
+                    "(task → ready or blocked for rework)."
+                ),
+            },
+            "score": {
+                "type": "number",
+                "description": (
+                    "Quality score (0.0 – 1.0). When approve=True, "
+                    "scores below qc_threshold should typically result "
+                    "in rejection, but the final decision is yours. "
+                    "Required."
+                ),
+            },
+            "feedback": {
+                "type": "string",
+                "description": (
+                    "Detailed feedback. Required when approve=False; "
+                    "optional when approve=True. Explains what passed "
+                    "or what needs improvement."
+                ),
+            },
+        },
+        "required": ["task_id", "approve", "score"],
     },
 }
 
@@ -1136,4 +1282,13 @@ registry.register(
     handler=_handle_link,
     check_fn=_check_kanban_mode,
     emoji="🔗",
+)
+
+registry.register(
+    name="kanban_review",
+    toolset="kanban",
+    schema=KANBAN_REVIEW_SCHEMA,
+    handler=_handle_review,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="🔍",
 )


### PR DESCRIPTION
## Problem
Workers completing Kanban tasks had no quality gate — any task that called `kanban_complete` immediately transitioned to `done` regardless of output quality, correctness, or completeness. This allowed false task completion to go undetected.

Refs: #25288, #21925

## Solution
A new `qc_review` status sits between `running`/`ready` and `done`. Tasks created with `require_qc=true` enter `qc_review` upon completion instead of `done`. A verifier (agent or human) calls `kanban_review` to approve or reject.

### Database layer
- **VALID_STATUSES**: Added `qc_review`
- **Schema migration** (auto, safe for existing DBs): `require_qc` (INTEGER), `qc_threshold` (REAL), `qc_score` (REAL), `rework_count` (INTEGER), `last_qc_feedback` (TEXT)
- **`create_task()`**: Accepts `require_qc` (bool) and `qc_threshold` (float)
- **`complete_task()`**: Reads `require_qc` before write txn; transitions to `qc_review` instead of `done` when QC is required; emits `completed_awaiting_qc` event
- **`qc_approve()`**: `qc_review → done` with score + feedback
- **`qc_reject()`**: `qc_review → ready` (or `→ blocked` after 3 rework cycles) with feedback

### Tool layer
- **`kanban_review`** (new orchestrator tool): approve/reject with score (0.0–1.0) and feedback
- **`kanban_create`**: New `require_qc` + `qc_threshold` params
- **`kanban_complete`**: Returns `status: qc_review` in OK response when QC gate engaged
- All list/show tools surface QC fields

### Notification layer
- Gateway watcher subscribes to `completed_awaiting_qc` events
- Renders: 🔍 Kanban {id} done — awaiting QC review (threshold: 0.7)

## Backward Compatibility
- Existing tasks without `require_qc` behave exactly as before (straight to `done`)
- All new columns have defaults (NULL/0) — zero migration burden