### PR TITLE
fix(kanban): auto-subscribe notifications for agent-created tasks

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1139,3 +1139,145 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
     out = kt._handle_complete({"task_id": tid, "summary": "orchestrator close"})
     d = json.loads(out)
     assert d.get("ok") is True and d.get("task_id") == tid
+
+
+# ---------------------------------------------------------------------------
+# Auto-subscribe tests (PR #2: agent-created tasks get notify subscriptions)
+# ---------------------------------------------------------------------------
+
+
+def test_create_no_subscription_outside_gateway(worker_env):
+    """Normal tool invocation outside a gateway session must NOT create
+    notify subscriptions."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    out = kt._handle_create({
+        "title": "outside-gw-task",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    tid = d["task_id"]
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert subs == [], (
+            f"Expected no subscription outside gateway, got {len(subs)}"
+        )
+    finally:
+        conn.close()
+
+
+def test_create_auto_subscribes_in_gateway_context(monkeypatch, tmp_path):
+    """When gateway session context is present, _handle_create must
+    auto-subscribe the originating chat to the new task's notifications."""
+    import json
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Mock gateway session context as it would be set by a Feishu session
+    mock_platform = "feishu"
+    mock_chat_id = "oc_fake_chat_123"
+    mock_user_id = "user_abc"
+
+    def mock_get_session_env(name, default=""):
+        mapping = {
+            "HERMES_SESSION_PLATFORM": mock_platform,
+            "HERMES_SESSION_CHAT_ID": mock_chat_id,
+            "HERMES_SESSION_THREAD_ID": "",
+            "HERMES_SESSION_USER_ID": mock_user_id,
+        }
+        return mapping.get(name, default)
+
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        mock_get_session_env,
+    )
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_create({
+        "title": "gw-created-task",
+        "assignee": "worker1",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, f"create failed: {d}"
+    tid = d["task_id"]
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1, (
+            f"Expected 1 subscription, got {len(subs)}: {subs}"
+        )
+        assert subs[0]["platform"] == mock_platform
+        assert subs[0]["chat_id"] == mock_chat_id
+        assert subs[0]["user_id"] == mock_user_id
+    finally:
+        conn.close()
+
+
+def test_try_auto_subscribe_creates_subscription(monkeypatch, tmp_path):
+    """_try_auto_subscribe helper must register a notify sub when gateway
+    session env vars are available, and be a no-op otherwise."""
+    from pathlib import Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="sub-test", assignee="worker1")
+
+        # Phase 1: no gateway context → no subscription
+        from tools.kanban_tools import _try_auto_subscribe
+        _try_auto_subscribe(kb, conn, tid)
+        subs_before = kb.list_notify_subs(conn, tid)
+        assert subs_before == [], (
+            f"Expected no sub without gateway context, got {len(subs_before)}"
+        )
+
+        # Phase 2: mock gateway context → subscription created
+        mock_platform = "discord"
+        mock_chat_id = "123456789"
+
+        def mock_get_env(name, default=""):
+            mapping = {
+                "HERMES_SESSION_PLATFORM": mock_platform,
+                "HERMES_SESSION_CHAT_ID": mock_chat_id,
+                "HERMES_SESSION_THREAD_ID": "thread-42",
+                "HERMES_SESSION_USER_ID": "",
+            }
+            return mapping.get(name, default)
+
+        monkeypatch.setattr(
+            "gateway.session_context.get_session_env",
+            mock_get_env,
+        )
+
+        _try_auto_subscribe(kb, conn, tid)
+        subs_after = kb.list_notify_subs(conn, tid)
+        assert len(subs_after) == 1, (
+            f"Expected 1 sub with gateway context, got {len(subs_after)}"
+        )
+        assert subs_after[0]["platform"] == mock_platform
+        assert subs_after[0]["chat_id"] == mock_chat_id
+        assert subs_after[0]["thread_id"] == "thread-42"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -614,6 +614,11 @@ def _handle_create(args: dict, **kw) -> str:
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
+            # Auto-subscribe notifications: if we're running inside a
+            # gateway session, register a subscription so the user who
+            # initiated this task receives terminal-state notifications
+            # (completed, blocked, qc_review, etc.) directly in their chat.
+            _try_auto_subscribe(kb, conn, new_tid)
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
@@ -625,6 +630,34 @@ def _handle_create(args: dict, **kw) -> str:
     except Exception as e:
         logger.exception("kanban_create failed")
         return tool_error(f"kanban_create: {e}")
+
+
+def _try_auto_subscribe(kb, conn, task_id: str) -> None:
+    """Best-effort auto-subscribe to a task's terminal events.
+
+    Called after creating a task via the kanban_create tool. Uses the
+    gateway session context (when available) to subscribe the current
+    chat to the task's completed/blocked/qc_review events.
+
+    Designed to be a no-op outside of a gateway context (CLI, tests).
+    """
+    try:
+        from gateway.session_context import get_session_env
+        platform = get_session_env("HERMES_SESSION_PLATFORM")
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
+        thread_id = get_session_env("HERMES_SESSION_THREAD_ID")
+        user_id = get_session_env("HERMES_SESSION_USER_ID")
+        if platform and chat_id:
+            kb.add_notify_sub(
+                conn, task_id=task_id,
+                platform=platform, chat_id=chat_id,
+                thread_id=thread_id or None,
+                user_id=user_id or None,
+            )
+    except ImportError:
+        pass  # Not running in a gateway context — skip silently.
+    except Exception:
+        logger.debug("kanban auto-subscribe failed (non-fatal)", exc_info=True)
 
 
 def _handle_unblock(args: dict, **kw) -> str:


### PR DESCRIPTION
## Problem
Tasks created by typing `/kanban create` in a chat were auto-subscribed to notifications. But tasks created by an agent via the `kanban_create` tool were not — the user had no visibility into when the task finished, blocked, or needed QC review, short of manually polling the board.

## Solution
Add `_try_auto_subscribe()` to `_handle_create` in `kanban_tools.py`. After a task is created, it reads the gateway session context (`platform`, `chat_id`, `thread_id`) via `gateway.session_context.get_session_env` and registers a notify subscription.

Outside a gateway context (CLI, tests) the call is a no-op — no import error, no side effects.

## Changes
`tools/kanban_tools.py`:
- `_handle_create` calls `_try_auto_subscribe` after successful creation
- New `_try_auto_subscribe()` helper reads gateway session context and calls `kb.add_notify_sub()`
- Gracefully degrades: `ImportError` -> silent skip (not in gateway)

`tests/tools/test_kanban_tools.py`:
- `test_create_no_subscription_outside_gateway` — no subscription in non-gateway context
- `test_create_auto_subscribes_in_gateway_context` — creates subscription with correct platform/chat_id
- `test_try_auto_subscribe_creates_subscription` — unit test for the helper function itself

## Backward Compatibility
- No changes to DB schema or CLI behaviour
- No subscription in CLI/test contexts — zero side effects
- Idempotent subscription: `INSERT OR IGNORE` prevents duplicates

Closes: #25195