### PR TITLE
fix: add Xiaomi MiMo to reasoning_content echo-back providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9152,11 +9152,12 @@ class AIAgent:
 
         DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
         of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        #15250, #17400). Xiaomi MiMo thinking mode has the same requirement.
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -9186,6 +9187,22 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        MiMo thinking mode requires ``reasoning_content`` on every assistant
+        tool-call message when replaying history; omitting it causes HTTP 400.
+        Refs: https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or "mimo" in model
+            or base_url_host_matches(self.base_url, "api.xiaomimimo.com")
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:


### PR DESCRIPTION
## Problem

MiMo thinking mode requires `reasoning_content` on every assistant tool-call message when replaying history. Without it, the API returns HTTP 400:

> The reasoning_content in the thinking mode must be passed back to the API

This is the same requirement as DeepSeek V4 thinking and Kimi/Moonshot thinking modes.

## Affected Models

- MiMo-V2.5-Pro
- MiMo-V2.5
- MiMo-V2-Pro
- MiMo-V2-Omni
- MiMo-V2-Flash

## Fix

Added `_needs_mimo_tool_reasoning()` method that detects Xiaomi MiMo provider by:
- Provider name: `xiaomi`
- Model name containing: `mimo`
- Base URL: `api.xiaomimimo.com` or `xiaomimimo.com`

Updated `_needs_thinking_reasoning_pad()` to include MiMo alongside DeepSeek and Kimi/Moonshot.

## References

- Xiaomi MiMo documentation: https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content
- Related to existing fixes for DeepSeek (#15250) and Kimi (#17400)

## Testing

- All existing tests pass (77 passed)
- Verified MiMo provider detection works correctly
- Non-MiMo providers unaffected