### PR TITLE
fix(auxiliary): forward custom_providers to compression model context-length detection

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2195,6 +2195,10 @@ class AIAgent:
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
 
+        # Store for reuse by _check_compression_model_feasibility (auxiliary
+        # compression model context-length detection needs the same list).
+        self._custom_providers = _custom_providers
+
         # Check custom_providers per-model context_length
         if _config_context_length is None and _custom_providers:
             try:
@@ -3237,6 +3241,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=self._custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least


### PR DESCRIPTION
What does this PR do?                                                                                                                 
                                                                                                                                          
Fix a bug where the auxiliary compression model skips custom_providers per-model                                                      
context_length overrides when auxiliary.compression.provider is "auto".                                                               
                                                                                                                                          
Root Cause                                                                                                                            
                                                                                                                                          
When the main model starts up during init, it correctly reads                                                                         
custom_providers per-model context_length overrides. However,                                                                         
_check_compression_model_feasibility — which probes the auxiliary compression                                                         
model's context length — was calling get_model_context_length() without                                                               
the custom_providers parameter.                                                                                                       
                                                                                                                                          
This caused the resolution to skip step 0b (custom_providers per-model                                                                
override) and fall through to models.dev instead.                                                                                     
                                                                                                                                          
Impact                                                                                                                                
                                                                                                                                          
For providers where the user has a per-model context_length in                                                                        
custom_providers (e.g. 196608 for minimaxai/minimax-m2.7 on NVIDIA NIM),
the auxiliary compression model would use the models.dev value (204800)
instead of the user-configured one.
     
This resulted in a higher-than-expected compression threshold, since
context_compressor.threshold_tokens is capped at the detected auxiliary
context_length.
     
Fix
     
Two changes:
     
1. Store _custom_providers as an instance attr (self._custom_providers)
    during init, so _check_compression_model_feasibility can access it.
2. Pass custom_providers=self._custom_providers to the
    get_model_context_length() call for the auxiliary compression model.
     
| Line | Change |
|------|--------|
| run_agent.py:2198 | self._custom_providers = _custom_providers — store as instance attr |
| run_agent.py:3244 | custom_providers=self._custom_providers — forward to get_model_context_length |
     
Related Issue
     
Fixes # (no existing issue)
     
Type of Change
     
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
     
How to Test
     
1. Configure custom_providers with a per-model context_length for a
   specific provider+model pair (e.g. 196608 for minimaxai/minimax-m2.7 on
   NVIDIA NIM).
2. Set auxiliary.compression.provider: auto.
3. Start a session with hermes --verbose and check the log output — the
   auxiliary compression model's detected context_length should match the
   custom_providers value, not the models.dev value.
