### PR TITLE
fix(prompt-builder): ignore inaccessible cwd during context discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1432,16 +1432,25 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     if cwd is None:
         cwd = os.getcwd()
 
-    cwd_path = Path(cwd).resolve()
     sections = []
+    project_context = ""
 
-    # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
-    )
+    try:
+        cwd_path = Path(cwd).resolve()
+    except OSError as e:
+        logger.debug("Could not resolve context cwd %s: %s", cwd, e)
+    else:
+        # Priority-based project context: first match wins
+        try:
+            project_context = (
+                _load_hermes_md(cwd_path)
+                or _load_agents_md(cwd_path)
+                or _load_claude_md(cwd_path)
+                or _load_cursorrules(cwd_path)
+            )
+        except OSError as e:
+            logger.debug("Could not discover project context files for %s: %s", cwd_path, e)
+
     if project_context:
         sections.append(project_context)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -688,6 +689,36 @@ class TestBuildContextFilesPrompt:
         (tmp_path / ".cursorrules").write_text("Use ESLint.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "ESLint" in result
+
+    def test_inaccessible_cwd_still_loads_soul_md(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("Soul survives cwd failures.", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        real_resolve = Path.resolve
+
+        def fake_resolve(path_obj, *args, **kwargs):
+            if str(path_obj) == str(tmp_path):
+                raise PermissionError("cwd blocked")
+            return real_resolve(path_obj, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+        result = build_context_files_prompt(cwd=str(tmp_path))
+
+        assert "Soul survives cwd failures." in result
+        assert "Project Context" in result
+
+    def test_project_context_discovery_permission_error_is_ignored(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "agent.prompt_builder._load_hermes_md",
+            lambda cwd_path: (_ for _ in ()).throw(PermissionError("blocked")),
+        )
+
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert result == ""
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Prevent `build_context_files_prompt()` from failing when the provided `cwd` cannot be resolved or project-context discovery hits a filesystem access error.

This keeps prompt construction alive in remote/containerized setups where the backend cwd may not be accessible from the host process.

## What changed

- Guarded `Path(cwd).resolve()` in `agent/prompt_builder.py`
- Guarded project-context discovery (`.hermes.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`) against `OSError` / `PermissionError`
- Preserved existing behavior for `SOUL.md` loading, so identity/context loading still works even when project cwd discovery fails
- Added regression tests covering:
  - inaccessible `cwd` still allowing `SOUL.md` to load
  - project-context discovery `PermissionError` being ignored instead of crashing prompt build

## Why

In remote or sandboxed environments, the cwd seen by terminal-backed tools may be inaccessible to the host process building the prompt. Before this change, that could cause prompt construction to fail during context-file discovery. The safer behavior is to skip project-context loading for that cwd and continue.

## Tests

- `uv run pytest tests/agent/test_prompt_builder.py -q`
- `uv run pytest tests/agent/test_prompt_builder.py -q -k "inaccessible_cwd or permission_error"`

Results on local verification:
- full file: `123 passed, 1 skipped`
- targeted regressions: `2 passed`
