### PR TITLE
fix(gateway): keep QQBot reconnect loop alive

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -176,6 +176,28 @@ class QQAdapter(BasePlatformAdapter):
                 fut.set_exception(RuntimeError(reason))
         self._pending_responses.clear()
 
+    def _mark_transport_disconnected(self) -> None:
+        """Mark QQ WS down without stopping the reconnect loop.
+
+        BasePlatformAdapter uses _running for both process lifecycle and
+        connection status. QQBot needs to keep the listener task alive across
+        transient transport drops so it can continue reconnect attempts after a
+        short-lived gateway or network failure.
+        """
+        if self.has_fatal_error:
+            return
+        self._write_runtime_status_safe(
+            "disconnected",
+            platform_state="disconnected",
+            error_code=None,
+            error_message=None,
+        )
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True only when the QQ WebSocket transport is usable."""
+        return bool(self._running and self._ws and not self._ws.closed)
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.QQBOT)
 
@@ -509,7 +531,7 @@ class QQAdapter(BasePlatformAdapter):
                 else:
                     quick_disconnect_count = 0
 
-                self._mark_disconnected()
+                self._mark_transport_disconnected()
                 self._fail_pending("Connection closed")
 
                 # Stop reconnecting for fatal codes
@@ -531,6 +553,7 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        self._mark_disconnected()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -584,17 +607,19 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        self._mark_disconnected()
                         return
 
             except Exception as exc:
                 if not self._running:
                     return
                 logger.warning("[%s] WebSocket error: %s", self._log_tag, exc)
-                self._mark_disconnected()
+                self._mark_transport_disconnected()
                 self._fail_pending("Connection interrupted")
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
+                    self._mark_disconnected()
                     return
 
                 if await self._reconnect(backoff_idx):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -578,6 +579,7 @@ class TestWaitForReconnection:
         async def reconnect_after_delay():
             await asyncio.sleep(0.3)
             adapter._running = True
+            adapter._ws = SimpleNamespace(closed=False)
 
         asyncio.get_event_loop().create_task(reconnect_after_delay())
 
@@ -603,6 +605,7 @@ class TestWaitForReconnection:
         """send() should not wait when already connected."""
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
         adapter._http_client = mock.MagicMock()
 
         async def fake_api_request(*args, **kwargs):


### PR DESCRIPTION
## What does this PR do?

Keeps the QQBot adapter's reconnect loop alive after transient WebSocket disconnects.

Previously, QQBot used `_mark_disconnected()` for transport-level drops. That method also sets `_running = False`, so if a reconnect attempt failed once, for example while fetching the QQ gateway URL, the listener loop could stop permanently. The adapter would then stay disconnected until the whole gateway process was restarted.

This PR separates transient WebSocket transport state from adapter lifecycle state, so QQBot can keep retrying reconnects while still reporting itself as disconnected to runtime status.

## Related Issue

No issue yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`
  - Added `_mark_transport_disconnected()` for transient QQ WebSocket drops.
  - Updated QQBot reconnect handling to avoid stopping the listener loop on recoverable disconnects.
  - Made `is_connected` check the actual WebSocket transport state.
- `tests/gateway/test_qqbot.py`
  - Updated reconnect tests to model an active WebSocket transport.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_qqbot.py -q`.
2. Run `venv/bin/python scripts/check-windows-footguns.py gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py`.
3. Manually run a QQBot gateway and verify it reconnects after transient WebSocket drops without restarting the gateway process.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Validation:

```text
scripts/run_tests.sh tests/gateway/test_qqbot.py -q
144 passed, 1 warning

venv/bin/python scripts/check-windows-footguns.py gateway/platforms/qqbot/adapter.py tests/gateway/test_qqbot.py
✓ No Windows footguns found (2 file(s) scanned).

[QQBot] Reconnect failed: Failed to get QQ Bot gateway URL
[QQBot] Still not connected after 15s

