### PR TITLE
fix: do not inherit api_mode when delegating across providers

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1017,7 +1017,18 @@ def _build_child_agent(
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key
-    effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
+    # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
+    # different provider than the parent — each provider has its own API surface
+    # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
+    # Inheriting the parent's mode causes 404 errors when the child routes to the
+    # wrong endpoint.  Derive the mode from the target provider when it differs.
+    _parent_provider = getattr(parent_agent, "provider", None) or ""
+    if override_api_mode is not None:
+        effective_api_mode = override_api_mode
+    elif effective_provider != _parent_provider:
+        effective_api_mode = None  # force re-derivation from provider's defaults
+    else:
+        effective_api_mode = getattr(parent_agent, "api_mode", None)
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )


### PR DESCRIPTION
## Bug

Cross-provider delegation (e.g. MiniMax parent → DeepSeek child) fails with 404 because `api_mode` is incorrectly inherited from the parent agent.

Each provider uses a different API surface:
- MiniMax → `anthropic_messages`
- DeepSeek → `chat_completions`

When a child agent is spawned on a different provider, inheriting the parent's `api_mode` causes it to route to the wrong endpoint.

## Fix

In `_build_child_agent`, when the effective provider differs from the parent's provider, set `api_mode = None` instead of inheriting. This triggers re-derivation from the target provider's defaults.

```python
# Before (buggy)
effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)

# After (fixed)
if override_api_mode is not None:
    effective_api_mode = override_api_mode
elif effective_provider != _parent_provider:
    effective_api_mode = None  # force re-derivation from provider's defaults
else:
    effective_api_mode = getattr(parent_agent, "api_mode", None)
```

## Testing

Delegated a task to a DeepSeek child agent while running the parent on MiniMax — child successfully called DeepSeek API and returned correct result.

Refs: Bug #20558, PR #20563