### PR TITLE
fix(context): retry summary transport failures with reduced prompt

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -790,7 +790,13 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: str = None,
+        *,
+        _reduced_retry: bool = False,
+    ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -817,7 +823,36 @@ class ContextCompressor(ContextEngine):
             return None
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        if _reduced_retry:
+            summary_budget = max(1000, min(2500, summary_budget // 2))
+            # Temporarily shrink serialization limits for this retry. Keep
+            # enough head/tail detail to preserve file paths, errors, and the
+            # active task, but avoid replaying a huge prompt to a backend that
+            # just dropped a chunked response.
+            old_limits = (
+                self._CONTENT_MAX,
+                self._CONTENT_HEAD,
+                self._CONTENT_TAIL,
+                self._TOOL_ARGS_MAX,
+                self._TOOL_ARGS_HEAD,
+            )
+            try:
+                self._CONTENT_MAX = 1800
+                self._CONTENT_HEAD = 1200
+                self._CONTENT_TAIL = 400
+                self._TOOL_ARGS_MAX = 500
+                self._TOOL_ARGS_HEAD = 400
+                content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+            finally:
+                (
+                    self._CONTENT_MAX,
+                    self._CONTENT_HEAD,
+                    self._CONTENT_TAIL,
+                    self._TOOL_ARGS_MAX,
+                    self._TOOL_ARGS_HEAD,
+                ) = old_limits
+        else:
+            content_to_summarize = self._serialize_for_summary(turns_to_summarize)
 
         # Preamble shared by both first-compaction and iterative-update prompts.
         # Keep the wording deliberately plain: Azure/OpenAI-compatible content
@@ -1052,6 +1087,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             ):
                 self._fallback_to_main_for_compression(e, "failed")
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+
+            if not _reduced_retry and (_is_timeout or _is_streaming_closed):
+                logging.warning(
+                    "Context summary transport failed (%s). Retrying once with "
+                    "a reduced summary prompt before entering cooldown.",
+                    e,
+                )
+                self._summary_failure_cooldown_until = 0.0
+                return self._generate_summary(
+                    turns_to_summarize,
+                    focus_topic=focus_topic,
+                    _reduced_retry=True,
+                )
 
             # Transient errors (timeout, rate limit, network, JSON decode,
             # streaming premature-close) — shorter cooldown for JSON decode and

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -265,6 +265,36 @@ class TestSummaryFailureCooldown:
         assert second is None
         assert mock_call.call_count == 1
 
+    def test_incomplete_chunked_read_retries_once_with_reduced_prompt(self):
+        mock_ok = MagicMock()
+        mock_ok.choices = [MagicMock()]
+        mock_ok.choices[0].message.content = "summary after reduced retry"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        big_payload = "important file path /tmp/example.py\n" + ("x" * 12000)
+        messages = [
+            {"role": "user", "content": big_payload},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        err = Exception(
+            "peer closed connection without sending complete message body "
+            "(incomplete chunked read)"
+        )
+        with patch("agent.context_compressor.call_llm", side_effect=[err, mock_ok]) as mock_call:
+            result = c._generate_summary(messages)
+
+        assert mock_call.call_count == 2
+        first_prompt = mock_call.call_args_list[0].kwargs["messages"][0]["content"]
+        second_prompt = mock_call.call_args_list[1].kwargs["messages"][0]["content"]
+        assert len(second_prompt) < len(first_prompt)
+        assert mock_call.call_args_list[1].kwargs["max_tokens"] < mock_call.call_args_list[0].kwargs["max_tokens"]
+        assert result is not None
+        assert "summary after reduced retry" in result
+        assert c._last_summary_error is None
+
 
 class TestSummaryFallbackToMainModel:
     """When ``summary_model`` differs from the main model and the summary LLM


### PR DESCRIPTION
## Summary
- Retry transient context-summary transport failures once with a reduced prompt/max-token budget.
- Classify incomplete chunked reads / peer-close / timeout-like failures as retryable.
- Add regression coverage proving the retry uses a smaller prompt and clears the fallback error on success.

## Test Plan
- scripts/run_tests.sh tests/agent/test_context_compressor.py::TestSummaryFailureCooldown tests/agent/test_context_compressor.py::TestNonStringContent::test_summary_prompt_avoids_filter_sensitive_handoff_framing tests/agent/test_context_compressor_summary_continuity.py -q
- scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_context_compressor_summary_continuity.py -q
- uv run ruff check agent/context_compressor.py tests/agent/test_context_compressor.py

## Notes
- The observed initdb root failure is treated as runner-environment noise; this PR closes the code-side compressor gap identified in the remaining failures.