### PR TITLE
feat: add /goal --confirm mode for pre-execution confirmation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8603,25 +8603,65 @@ class HermesCLI:
                 _cprint(f"  {_DIM}No active goal.{_RST}")
             return
 
+        # ── Parse --confirm flag ──
+        confirm = False
+        goal_text = arg
+        if arg.startswith("--confirm"):
+            confirm = True
+            # /goal --confirm <text>  or  /goal --confirm  (no text → error)
+            remainder = arg[len("--confirm"):].strip()
+            if not remainder:
+                _cprint(f"  Usage: /goal --confirm <text>")
+                return
+            goal_text = remainder
+
         # Otherwise treat the arg as the goal text.
         try:
-            state = mgr.set(arg)
+            state = mgr.set(goal_text, confirm=confirm)
         except ValueError as exc:
             _cprint(f"  Invalid goal: {exc}")
             return
 
-        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
-        _cprint(
-            f"  {_DIM}After each turn, a judge model will check if the goal is done. "
-            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
-            f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
-        )
-        # Kick the loop off immediately so the user doesn't have to send a
-        # separate message after setting the goal.
-        try:
-            self._pending_input.put(state.goal)
-        except Exception:
-            pass
+        if confirm:
+            # ── Confirm mode: do NOT inject into _pending_input ──
+            _cprint(f"  ⏳ Goal set (awaiting confirmation, {state.max_turns}-turn budget): {state.goal}")
+            _cprint(
+                f"  {_DIM}Send any message to confirm and start, or /goal clear to cancel."
+                f"  Hermes will not begin until you confirm.{_RST}"
+            )
+        else:
+            _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
+            _cprint(
+                f"  {_DIM}After each turn, a judge model will check if the goal is done. "
+                f"Hermes keeps working until it is, you pause/clear it, or the budget is "
+                f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
+            )
+            # Kick the loop off immediately so the user doesn't have to send a
+            # separate message after setting the goal.
+            try:
+                self._pending_input.put(state.goal)
+            except Exception:
+                pass
+
+    def _check_goal_confirmation(self, user_input: str) -> bool:
+        """If a goal is pending_confirmation, treat user_input as confirmation.
+
+        Returns True if a confirmation was processed (input consumed),
+        False if no confirmation needed (input should be handled normally).
+        """
+        mgr = self._get_goal_manager()
+        if not mgr or not mgr.state or mgr.state.status != "pending_confirmation":
+            return False
+
+        # User sent any message → confirm the goal
+        state = mgr.confirm()
+        if state:
+            _cprint(f"  ▶ Goal confirmed — starting: {state.goal}")
+            try:
+                self._pending_input.put(state.goal)
+            except Exception:
+                pass
+        return True  # Input consumed as confirmation signal
 
     def _handle_subgoal_command(self, cmd: str) -> None:
         """Dispatch /subgoal subcommands.
@@ -13591,6 +13631,17 @@ class HermesCLI:
                                 f"[User attached file: {_drop_path}]"
                                 + (f"\n{_remainder}" if _remainder else "")
                             )
+
+                    # ── Goal confirmation intercept ──
+                    # If a goal is pending_confirmation, treat any non-command user
+                    # input as confirmation and kick off the goal instead of sending
+                    # the input to the agent.
+                    if (
+                        isinstance(user_input, str)
+                        and not _looks_like_slash_command(user_input)
+                        and self._check_goal_confirmation(user_input)
+                    ):
+                        continue
 
                     if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
                         _cprint(f"\n⚙️  {user_input}")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -103,7 +103,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
-               args_hint="[text | pause | resume | clear | status]"),
+               args_hint="[--confirm] [text | pause | resume | clear | status]"),
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session info", "Session"),

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -144,7 +144,7 @@ class GoalState:
     """Serializable goal state stored per session."""
 
     goal: str
-    status: str = "active"          # active | paused | done | cleared
+    status: str = "active"          # active | paused | done | cleared | pending_confirmation
     turns_used: int = 0
     max_turns: int = DEFAULT_MAX_TURNS
     created_at: float = 0.0
@@ -159,6 +159,7 @@ class GoalState:
     # them into the verdict. Backwards-compatible: defaults to empty so
     # old state_meta rows load unchanged.
     subgoals: List[str] = field(default_factory=list)
+    confirm_mode: bool = False                # True when goal was set with --confirm
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False)
@@ -182,6 +183,7 @@ class GoalState:
             paused_reason=data.get("paused_reason"),
             consecutive_parse_failures=int(data.get("consecutive_parse_failures", 0) or 0),
             subgoals=subgoals,
+            confirm_mode=bool(data.get("confirm_mode", False)),
         )
 
     # --- subgoals helpers -------------------------------------------------
@@ -500,7 +502,7 @@ class GoalManager:
         return self._state is not None and self._state.status == "active"
 
     def has_goal(self) -> bool:
-        return self._state is not None and self._state.status in {"active", "paused"}
+        return self._state is not None and self._state.status in {"active", "paused", "pending_confirmation"}
 
     def status_line(self) -> str:
         s = self._state
@@ -508,6 +510,8 @@ class GoalManager:
             return "No active goal. Set one with /goal <text>."
         turns = f"{s.turns_used}/{s.max_turns} turns"
         sub = f", {len(s.subgoals)} subgoal{'s' if len(s.subgoals) != 1 else ''}" if s.subgoals else ""
+        if s.status == "pending_confirmation":
+            return f"⏳ Goal (awaiting confirmation, {turns}{sub}): {s.goal}"
         if s.status == "active":
             return f"⊙ Goal (active, {turns}{sub}): {s.goal}"
         if s.status == "paused":
@@ -519,17 +523,26 @@ class GoalManager:
 
     # --- mutation -----------------------------------------------------
 
-    def set(self, goal: str, *, max_turns: Optional[int] = None) -> GoalState:
+    def set(self, goal: str, *, max_turns: Optional[int] = None, confirm: bool = False) -> GoalState:
+        """Create a new standing goal.
+
+        Args:
+            confirm: If True, set status to 'pending_confirmation' instead of
+                     'active'. The caller must then confirm before the agent
+                     starts working.
+        """
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
+        initial_status = "pending_confirmation" if confirm else "active"
         state = GoalState(
             goal=goal,
-            status="active",
+            status=initial_status,
             turns_used=0,
             max_turns=int(max_turns) if max_turns else self.default_max_turns,
             created_at=time.time(),
             last_turn_at=0.0,
+            confirm_mode=confirm,
         )
         self._state = state
         save_goal(self.session_id, state)
@@ -543,9 +556,24 @@ class GoalManager:
         save_goal(self.session_id, self._state)
         return self._state
 
+    def confirm(self) -> Optional[GoalState]:
+        """Transition a pending_confirmation goal to active.
+
+        Returns the updated state, or None if no goal or not in
+        pending_confirmation status.
+        """
+        if not self._state or self._state.status != "pending_confirmation":
+            return None
+        self._state.status = "active"
+        save_goal(self.session_id, self._state)
+        return self._state
+
     def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
         if not self._state:
             return None
+        # pending_confirmation 的 resume 等同于 confirm
+        if self._state.status == "pending_confirmation":
+            return self.confirm()
         self._state.status = "active"
         self._state.paused_reason = None
         if reset_budget:

--- a/tests/hermes_cli/test_goals_confirm.py
+++ b/tests/hermes_cli/test_goals_confirm.py
@@ -1,0 +1,237 @@
+"""Tests for /goal --confirm mode (pending_confirmation status).
+
+Covers GoalState, GoalManager, and the confirm flow.
+"""
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the package is importable from the checkout
+# ---------------------------------------------------------------------------
+import sys
+
+_HERE = os.path.dirname(__file__)
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from hermes_cli.goals import GoalState, GoalManager, DEFAULT_MAX_TURNS, save_goal, load_goal
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_session() -> str:
+    """Return a unique session id that won't collide with other tests."""
+    return f"test_confirm_{time.time_ns()}"
+
+
+# ---------------------------------------------------------------------------
+# GoalState
+# ---------------------------------------------------------------------------
+
+class TestGoalStateConfirmMode:
+    def test_default_confirm_mode_is_false(self):
+        s = GoalState(goal="test")
+        assert s.confirm_mode is False
+
+    def test_confirm_mode_can_be_set(self):
+        s = GoalState(goal="test", confirm_mode=True)
+        assert s.confirm_mode is True
+
+    def test_to_json_includes_confirm_mode(self):
+        s = GoalState(goal="test", confirm_mode=True)
+        data = json.loads(s.to_json())
+        assert data["confirm_mode"] is True
+
+    def test_from_json_with_confirm_mode(self):
+        raw = json.dumps({
+            "goal": "test",
+            "status": "pending_confirmation",
+            "turns_used": 0,
+            "max_turns": 20,
+            "created_at": 0.0,
+            "last_turn_at": 0.0,
+            "confirm_mode": True,
+        })
+        s = GoalState.from_json(raw)
+        assert s.confirm_mode is True
+        assert s.status == "pending_confirmation"
+
+    def test_from_json_backward_compat_no_confirm_mode(self):
+        """Old data without confirm_mode field should default to False."""
+        raw = json.dumps({
+            "goal": "test",
+            "status": "active",
+            "turns_used": 0,
+            "max_turns": 20,
+            "created_at": 0.0,
+            "last_turn_at": 0.0,
+        })
+        s = GoalState.from_json(raw)
+        assert s.confirm_mode is False
+
+
+# ---------------------------------------------------------------------------
+# GoalManager.set() with confirm
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerSetConfirm:
+    def test_set_without_confirm_is_active(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        state = mgr.set("do something")
+        assert state.status == "active"
+        assert state.confirm_mode is False
+
+    def test_set_with_confirm_is_pending_confirmation(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        state = mgr.set("do something", confirm=True)
+        assert state.status == "pending_confirmation"
+        assert state.confirm_mode is True
+
+
+# ---------------------------------------------------------------------------
+# GoalManager.confirm()
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerConfirm:
+    def test_confirm_transitions_to_active(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        state = mgr.confirm()
+        assert state is not None
+        assert state.status == "active"
+
+    def test_confirm_on_active_goal_returns_none(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something")
+        result = mgr.confirm()
+        assert result is None
+
+    def test_confirm_on_no_goal_returns_none(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        result = mgr.confirm()
+        assert result is None
+
+    def test_confirm_is_idempotent(self):
+        """Second confirm() after first one succeeds should return None."""
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        mgr.confirm()
+        result = mgr.confirm()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_active() / has_goal()
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerStatusChecks:
+    def test_is_active_false_for_pending_confirmation(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        assert mgr.is_active() is False
+
+    def test_is_active_true_after_confirm(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        mgr.confirm()
+        assert mgr.is_active() is True
+
+    def test_has_goal_true_for_pending_confirmation(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        assert mgr.has_goal() is True
+
+    def test_has_goal_true_for_active(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something")
+        assert mgr.has_goal() is True
+
+
+# ---------------------------------------------------------------------------
+# status_line()
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerStatusLine:
+    def test_status_line_pending_confirmation(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        line = mgr.status_line()
+        assert "⏳" in line
+        assert "awaiting confirmation" in line
+
+    def test_status_line_active(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something")
+        line = mgr.status_line()
+        assert "⊙" in line
+        assert "active" in line
+
+
+# ---------------------------------------------------------------------------
+# resume() for pending_confirmation
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerResume:
+    def test_resume_pending_confirmation_is_confirm(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        state = mgr.resume()
+        assert state is not None
+        assert state.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_after_turn() skips pending_confirmation
+# ---------------------------------------------------------------------------
+
+class TestGoalManagerEvaluate:
+    def test_evaluate_skips_pending_confirmation(self):
+        mgr = GoalManager(session_id=_fresh_session())
+        mgr.set("do something", confirm=True)
+        decision = mgr.evaluate_after_turn("some response")
+        assert decision["should_continue"] is False
+
+
+# ---------------------------------------------------------------------------
+# Persistence roundtrip
+# ---------------------------------------------------------------------------
+
+class TestGoalPersistence:
+    def test_roundtrip_pending_confirmation(self):
+        sid = _fresh_session()
+        mgr = GoalManager(session_id=sid)
+        mgr.set("do something", confirm=True)
+
+        # Reload from disk
+        loaded = load_goal(sid)
+        assert loaded is not None
+        assert loaded.status == "pending_confirmation"
+        assert loaded.confirm_mode is True
+
+    def test_roundtrip_after_confirm(self):
+        sid = _fresh_session()
+        mgr = GoalManager(session_id=sid)
+        mgr.set("do something", confirm=True)
+        mgr.confirm()
+
+        # Reload from disk
+        loaded = load_goal(sid)
+        assert loaded is not None
+        assert loaded.status == "active"
+        assert loaded.confirm_mode is True
+
+
+def test_slash_command_input_should_not_confirm_pending_goal():
+    """Regression: slash commands such as /goal clear must not confirm a pending goal."""
+    # Mirrors the process_loop guard before _check_goal_confirmation.
+    from cli import _looks_like_slash_command
+
+    assert _looks_like_slash_command("/goal clear") is True
+    assert _looks_like_slash_command("确认开始") is False


### PR DESCRIPTION
## Summary
- Add `/goal --confirm <text>` to set a standing goal without starting execution immediately
- Introduce `pending_confirmation` goal status and `GoalManager.confirm()` transition
- Consume the next non-command CLI input as confirmation, then kick off the goal
- Preserve existing `/goal <text>` behavior exactly when `--confirm` is not used

## Why
`/goal` currently kicks off execution immediately by enqueueing the goal text into `_pending_input`. That is useful for autonomous execution, but problematic for workflows that need a pre-execution review/acceptance checklist before the agent starts (for example large research tasks or other high-cost/high-risk goals).

`--confirm` provides an explicit opt-in mode for those workflows while keeping the default fast path unchanged.

## Design notes
- `pending_confirmation` is intentionally not considered active by `GoalManager.is_active()`.
- As a result, existing continuation hooks and judge logic automatically skip pending goals; no changes were needed in `_maybe_continue_goal_after_turn()` or `evaluate_after_turn()`.
- `/goal resume` on a pending-confirmation goal acts like confirmation.

## Test plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_goals_confirm.py -q -o addopts=''`
- `/usr/local/lib/hermes-agent/venv/bin/python -m py_compile hermes_cli/goals.py hermes_cli/commands.py cli.py`

Both pass locally.