### PR TITLE
fix: remove CREATE_NO_WINDOW from _exec_schtasks to fix stderr capture on Windows

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -111,10 +111,6 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             capture_output=True,
             text=True,
             timeout=_SCHTASKS_TIMEOUT_S,
-            # CREATE_NO_WINDOW avoids a flashing console window when the CLI
-            # is itself hosted in a TUI. See tools/browser_tool.py for the
-            # same pattern and the windows-subprocess-sigint-storm.md ref.
-            creationflags=0x08000000,  # CREATE_NO_WINDOW
         )
         return (proc.returncode, proc.stdout or "", proc.stderr or "")
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Problem

On Chinese Windows, `subprocess.run(creationflags=0x08000000)` (`CREATE_NO_WINDOW`) causes `schtasks.exe` stderr to be lost entirely -- `proc.stderr` is `None` instead of a string.

This prevents the fallback-to-Startup detection in `_should_fall_back()` from matching error patterns like `"ERROR: Access is denied."`, leading to a hard `RuntimeError` instead of gracefully falling back to the Startup folder installation path.

## Root Cause

The `CREATE_NO_WINDOW` flag, while suppressing the console popup, also redirects stderr in some Windows locales (particularly Chinese Windows), making it inaccessible to Python's `subprocess` module.

## Fix

Removing the `creationflags=0x08000000` parameter from `_exec_schtasks()` in `hermes_cli/gateway_windows.py`. The console flash is a minor cosmetic concern compared to the functional breakage of the installation flow.

## Testing

- Tested on Chinese Windows 10: `hermes gateway install` with schtasks access denied now correctly detects the error and falls back to Startup folder installation.
- Python syntax validated via `py_compile`.