### PR TITLE
fix(gateway): harden channel directory cache loading

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -244,15 +244,44 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 # Read / resolve
 # ---------------------------------------------------------------------------
 
+def _empty_directory() -> Dict[str, Any]:
+    return {"updated_at": None, "platforms": {}}
+
+
 def load_directory() -> Dict[str, Any]:
-    """Load the cached channel directory from disk."""
+    """Load the cached channel directory from disk.
+
+    The cache file is user-visible state and can be hand-edited or left in a
+    partially migrated shape.  Treat parseable-but-invalid JSON as an empty
+    directory so callers like send_message(action="list") degrade gracefully
+    instead of crashing on ``.get``/iteration assumptions.
+    """
     if not DIRECTORY_PATH.exists():
-        return {"updated_at": None, "platforms": {}}
+        return _empty_directory()
     try:
         with open(DIRECTORY_PATH, encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
     except Exception:
-        return {"updated_at": None, "platforms": {}}
+        return _empty_directory()
+
+    if not isinstance(data, dict):
+        return _empty_directory()
+
+    platforms = data.get("platforms")
+    if not isinstance(platforms, dict):
+        data["platforms"] = {}
+        return data
+
+    normalized_platforms: Dict[str, List[Dict[str, Any]]] = {}
+    for platform_name, channels in platforms.items():
+        key = str(platform_name)
+        if not isinstance(channels, list):
+            normalized_platforms[key] = []
+            continue
+        normalized_platforms[key] = [ch for ch in channels if isinstance(ch, dict)]
+
+    data["platforms"] = normalized_platforms
+    return data
 
 
 def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -49,6 +49,40 @@ class TestLoadDirectory:
             result = load_directory()
         assert result["updated_at"] is None
 
+    def test_parseable_non_object_file_returns_empty_directory(self, tmp_path):
+        cache_file = tmp_path / "channel_directory.json"
+        cache_file.write_text(json.dumps([]))
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = load_directory()
+        assert result == {"updated_at": None, "platforms": {}}
+
+    def test_invalid_platforms_shape_is_normalized(self, tmp_path):
+        cache_file = tmp_path / "channel_directory.json"
+        cache_file.write_text(json.dumps({"updated_at": "now", "platforms": []}))
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = load_directory()
+        assert result["updated_at"] == "now"
+        assert result["platforms"] == {}
+
+    def test_invalid_channel_entries_are_ignored(self, tmp_path):
+        cache_file = tmp_path / "channel_directory.json"
+        cache_file.write_text(json.dumps({
+            "updated_at": "now",
+            "platforms": {
+                "telegram": [
+                    "not-a-channel",
+                    {"id": "123", "name": "Alice", "type": "dm"},
+                ],
+                "slack": "not-a-list",
+            },
+        }))
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = load_directory()
+        assert result["platforms"]["telegram"] == [
+            {"id": "123", "name": "Alice", "type": "dm"}
+        ]
+        assert result["platforms"]["slack"] == []
+
 
 class TestBuildChannelDirectoryWrites:
     def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Harden `gateway.channel_directory.load_directory()` so parseable but malformed
`channel_directory.json` cache files degrade gracefully instead of crashing
callers.

The channel directory cache is user-visible state and may be hand-edited,
partially written by older versions, or left in an unexpected shape. Before this
change, valid JSON such as `[]` or `{"platforms": []}` could be returned directly
and later crash `send_message(action="list")`, channel name resolution, or channel
type lookup when they assumed a dictionary shape.

## Changes

- Return an empty channel directory for non-object JSON cache contents.
- Normalize missing or non-dict `platforms` values to `{}`.
- Normalize per-platform channel lists, ignoring non-dict channel entries.
- Add regression coverage for parseable malformed cache shapes.

## Testing

- `tests/gateway/test_channel_directory.py`

Result:

```text
36 passed in 4.03s
