### PR TITLE
fix(web): AutoField list type renders objects as [object Object]

### DIFF
--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -33,6 +33,12 @@ function serializeListItem(item: unknown): string {
 /**
  * Split a user-edited list string on commas that are NOT inside JSON
  * objects/arrays, then attempt to parse each token back to its original type.
+ *
+ * JSON.parse is intentionally restricted to tokens that start with `{` or `[`
+ * — i.e. structured items. Primitive-looking tokens (numbers, `true`,
+ * `null`, bare strings) are kept verbatim as strings so that pre-existing
+ * string-list fields (e.g. `enabled_toolsets: ["web", "terminal"]`) are not
+ * silently coerced into other types and corrupt unrelated config.
  */
 function parseListInput(raw: string): unknown[] {
   const tokens = raw.split(/,(?![^{\[]*[}\]])/g);
@@ -40,11 +46,14 @@ function parseListInput(raw: string): unknown[] {
     .map((s) => {
       const t = s.trim();
       if (!t) return undefined;
-      try {
-        return JSON.parse(t);
-      } catch {
-        return t;
+      if (t.startsWith("{") || t.startsWith("[")) {
+        try {
+          return JSON.parse(t);
+        } catch {
+          return t;
+        }
       }
+      return t;
     })
     .filter((v) => v !== undefined && v !== "");
 }

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -17,6 +17,38 @@ function FieldHint({ schema, schemaKey }: { schema: Record<string, unknown>; sch
   );
 }
 
+
+/**
+ * Serialize a single list item for display. Primitive values are stringified
+ * directly; objects/arrays are JSON-encoded so they round-trip correctly
+ * instead of rendering as "[object Object]".
+ */
+function serializeListItem(item: unknown): string {
+  if (typeof item === "object" && item !== null) {
+    return JSON.stringify(item);
+  }
+  return String(item);
+}
+
+/**
+ * Split a user-edited list string on commas that are NOT inside JSON
+ * objects/arrays, then attempt to parse each token back to its original type.
+ */
+function parseListInput(raw: string): unknown[] {
+  const tokens = raw.split(/,(?![^{\[]*[}\]])/g);
+  return tokens
+    .map((s) => {
+      const t = s.trim();
+      if (!t) return undefined;
+      try {
+        return JSON.parse(t);
+      } catch {
+        return t;
+      }
+    })
+    .filter((v) => v !== undefined && v !== "");
+}
+
 export function AutoField({
   schemaKey,
   schema,
@@ -99,15 +131,8 @@ export function AutoField({
         <Label className="text-sm">{label}</Label>
         <FieldHint schema={schema} schemaKey={schemaKey} />
         <Input
-          value={Array.isArray(value) ? value.join(", ") : String(value ?? "")}
-          onChange={(e) =>
-            onChange(
-              e.target.value
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean),
-            )
-          }
+          value={Array.isArray(value) ? value.map(serializeListItem).join(", ") : String(value ?? "")}
+          onChange={(e) => onChange(parseListInput(e.target.value))}
           placeholder="comma-separated values"
         />
       </div>


### PR DESCRIPTION
## Summary

Fixes the `fallback_providers` field in Settings UI rendering as `[object Object], [object Object]` instead of readable JSON. Saving from this state would corrupt the config by replacing provider objects with literal strings.

## Problem

`AutoField.tsx` handles the `"list"` schema type with a plain text input using `Array.join(", ")`. When list items are objects (like `fallback_providers`: `[{provider: "openai", model: "gpt-5.5"}, ...]`), JavaScript's `.toString()` returns `[object Object]` for each element.

The `onChange` handler compounds the issue: splitting on commas and returning plain strings replaces the structured objects with garbage strings on save.

## Fix

- **Display**: serialize each item via `JSON.stringify()` before joining (primitives are unaffected)
- **Parse**: use `JSON.parse()` on each token when splitting back, with a regex `/,(?![^{[]*[}\]])/g` that avoids splitting on commas inside JSON braces/brackets
- Helper functions `serializeListItem()` and `parseListInput()` are extracted for clarity

## Testing

- Verified that primitive lists (strings, numbers) behave identically to before
- Object lists now display as readable JSON and round-trip correctly through edit → save

Closes #25352