### PR TITLE
fix(gateway): release cached agents on eviction

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4038,6 +4038,17 @@ class GatewayRunner:
                         # be garbage-collected.  Otherwise the cache grows
                         # unbounded across the gateway's lifetime.
                         self._evict_cached_agent(key)
+                        # Session-scoped override/request state has the same
+                        # lifetime as the expired session.  Drop it here so
+                        # long-lived gateways serving many rotating sessions
+                        # don't retain stale per-session maps forever.
+                        if hasattr(self, "_session_model_overrides"):
+                            self._session_model_overrides.pop(key, None)
+                        self._set_session_reasoning_override(key, None)
+                        if hasattr(self, "_pending_approvals"):
+                            self._pending_approvals.pop(key, None)
+                        if hasattr(self, "_update_prompt_pending"):
+                            self._update_prompt_pending.pop(key, None)
                         # Mark as finalized and persist to disk so the flag
                         # survives gateway restarts.
                         with self.session_store._lock:
@@ -13751,9 +13762,32 @@ class GatewayRunner:
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc)."""
         _lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            return
+        evicted = None
         if _lock:
             with _lock:
-                self._agent_cache.pop(session_key, None)
+                evicted = _cache.pop(session_key, None)
+        else:
+            evicted = _cache.pop(session_key, None)
+
+        agent = None
+        if isinstance(evicted, tuple) and evicted:
+            agent = evicted[0]
+        elif evicted is not None:
+            agent = evicted
+
+        if agent is not None:
+            try:
+                threading.Thread(
+                    target=self._release_evicted_agent_soft,
+                    args=(agent,),
+                    daemon=True,
+                    name=f"agent-cache-evict-{session_key[:24]}",
+                ).start()
+            except Exception:
+                pass
 
     @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
@@ -13793,6 +13827,12 @@ class GatewayRunner:
                 # Older agent instance (shouldn't happen in practice) —
                 # fall back to the legacy full-close path.
                 self._cleanup_agent_resources(agent)
+        except Exception:
+            pass
+        try:
+            session_messages = getattr(agent, "_session_messages", None)
+            if isinstance(session_messages, list):
+                session_messages.clear()
         except Exception:
             pass
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -259,6 +259,7 @@ _LEGACY_TOOLSET_MAP = {
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_TOOL_DEFS_CACHE_MAX_ENTRIES = 8
 
 
 def _clear_tool_defs_cache() -> None:
@@ -320,6 +321,8 @@ def get_tool_definitions(
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode)
     if quiet_mode:
+        if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX_ENTRIES and cache_key not in _tool_defs_cache:
+            _tool_defs_cache.clear()
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -386,6 +386,48 @@ class TestAgentCacheLifecycle:
         with runner._agent_cache_lock:
             assert session_key not in runner._agent_cache
 
+    def test_evict_runs_soft_cleanup_and_clears_session_messages(self):
+        """Hard evictions should release clients and drop large message history."""
+        from run_agent import AIAgent
+
+        runner = _make_runner()
+        session_key = "telegram:12345"
+        session_messages = [
+            {"role": "user", "content": "please clear memory"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4", api_key="test",
+            base_url="https://openrouter.ai/api/v1", provider="openrouter",
+            max_iterations=5, quiet_mode=True, skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._session_messages = session_messages
+
+        release_calls = MagicMock()
+        original_release = agent.release_clients
+
+        def release_with_signal():
+            original_release()
+            release_calls(agent)
+
+        agent.release_clients = release_with_signal
+        with runner._agent_cache_lock:
+            runner._agent_cache[session_key] = (agent, "sig123")
+
+        runner._evict_cached_agent(session_key)
+
+        import time as _t
+        deadline = _t.time() + 2.0
+        while _t.time() < deadline and not release_calls.called:
+            _t.sleep(0.02)
+
+        with runner._agent_cache_lock:
+            assert session_key not in runner._agent_cache
+        release_calls.assert_called_once_with(agent)
+        assert session_messages == []
+        assert agent.client is None
+
     def test_evict_does_not_affect_other_sessions(self):
         """Evicting one session leaves other sessions cached."""
         runner = _make_runner()

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -243,3 +243,67 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
     )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
+async def test_idle_expiry_clears_session_scoped_state(mock_invoke_hook):
+    """Expired sessions should clear per-session caches to avoid leaks."""
+    from datetime import datetime, timedelta
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._last_session_store_prune_ts = 0.0
+
+    session_key = "agent:main:telegram:dm:42"
+    runner._session_model_overrides = {session_key: {"model": "x", "provider": "y"}}
+    runner._session_reasoning_overrides = {session_key: {"effort": "high"}}
+    runner._pending_approvals = {session_key: {"command": "rm -rf /tmp"}}
+    runner._update_prompt_pending = {session_key: True}
+
+    expired_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-expired",
+        created_at=datetime.now() - timedelta(hours=2),
+        updated_at=datetime.now() - timedelta(hours=2),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    expired_entry.expiry_finalized = False
+
+    runner.session_store = MagicMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: expired_entry}
+    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._lock = MagicMock()
+    runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+    runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+    runner.session_store._save = MagicMock()
+
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+    original_sleep = __import__("asyncio").sleep
+
+    async def fast_sleep(_):
+        await original_sleep(0)
+
+    def hook_and_stop(*_args, **_kwargs):
+        runner._running = False
+        return None
+
+    mock_invoke_hook.side_effect = hook_and_stop
+
+    with patch("gateway.run.asyncio.sleep", side_effect=fast_sleep):
+        await runner._session_expiry_watcher(interval=0)
+
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_approvals
+    assert session_key not in runner._update_prompt_pending

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -87,6 +87,20 @@ class TestQuietModeCacheIsolation:
             f"baseline={baseline}, final={len(final)}."
         )
 
+    def test_cache_is_capped_and_clears_when_over_limit(self, monkeypatch):
+        """Quiet-mode cache keeps at most 8 entries by dropping all cached keys."""
+        def mock_compute(*_args, **_kwargs):
+            return [{"type": "function", "function": {"name": "mock_tool"}}]
+
+        monkeypatch.setattr(model_tools, "_compute_tool_definitions", mock_compute)
+
+        for idx in range(8):
+            model_tools.get_tool_definitions(enabled_toolsets=[f"set-{idx}"], quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 8
+
+        model_tools.get_tool_definitions(enabled_toolsets=["overflow"], quiet_mode=True)
+        assert len(model_tools._tool_defs_cache) == 1
+
     def test_non_quiet_mode_does_not_use_cache(self):
         """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
         explains why the bug only hit Gateway."""


### PR DESCRIPTION
## Summary
- release cached AIAgent clients when explicit session eviction removes cache entries
- clear cached agents' _session_messages during soft cleanup to free large histories
- clear expired sessions' per-session override/pending maps
- cap quiet-mode tool definition cache to avoid unbounded config-mtime growth

Fixes #25315

## Test Plan
- python -m pytest tests/gateway/test_agent_cache.py::TestAgentCacheLifecycle::test_evict_runs_soft_cleanup_and_clears_session_messages tests/gateway/test_session_boundary_hooks.py::test_idle_expiry_clears_session_scoped_state tests/test_get_tool_definitions_cache_isolation.py::TestQuietModeCacheIsolation::test_cache_is_capped_and_clears_when_over_limit -q -o 'addopts='
- python -m pytest tests/gateway/test_agent_cache.py tests/gateway/test_session_boundary_hooks.py tests/test_get_tool_definitions_cache_isolation.py -q -o 'addopts='
- python -m pytest tests/gateway/test_session_model_reset.py -q -o 'addopts='
- python -m ruff check gateway/run.py model_tools.py tests/gateway/test_agent_cache.py tests/gateway/test_session_boundary_hooks.py tests/test_get_tool_definitions_cache_isolation.py
- git diff --check