### PR TITLE
fix(anthropic): preserve unsigned thinking blocks on Xiaomi MiMo /anthropic

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -467,6 +467,24 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     return "/anthropic" in normalized.rstrip("/").lower()
 
 
+def _is_xiaomi_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for Xiaomi MiMo's Anthropic-compatible endpoint.
+
+    Xiaomi MiMo's ``/anthropic`` route speaks Anthropic Messages but, in
+    thinking mode, requires unsigned thinking blocks from prior assistant
+    turns to round-trip on subsequent requests — same contract as Kimi
+    ``/coding`` and DeepSeek ``/anthropic``. Without this, replay fails
+    with HTTP 400 "The reasoning_content in the thinking mode must be
+    passed back to the API."
+    """
+    if not base_url_host_matches(base_url or "", "xiaomimimo.com"):
+        return False
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return "/anthropic" in normalized.rstrip("/").lower()
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1754,6 +1772,7 @@ def convert_messages_to_anthropic(
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
         or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_xiaomi_anthropic_endpoint(base_url)
     )
 
     last_assistant_idx = None

--- a/tests/agent/test_xiaomi_anthropic_thinking.py
+++ b/tests/agent/test_xiaomi_anthropic_thinking.py
@@ -1,0 +1,84 @@
+"""Regression guard: preserve thinking blocks on Xiaomi MiMo's /anthropic endpoint.
+
+Xiaomi MiMo's ``token-plan-cn.xiaomimimo.com/anthropic`` route speaks the
+Anthropic Messages protocol but, in thinking mode, requires the
+``reasoning_content`` / unsigned ``thinking`` blocks from prior assistant
+turns to round-trip on subsequent requests — same contract as Kimi
+``/coding`` and DeepSeek ``/anthropic``. Without an MiMo-specific
+carve-out the generic third-party path strips the unsigned thinking
+blocks and the next tool-call turn fails with HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to
+    the API.
+
+Handling mirrors the DeepSeek policy: strip Anthropic-signed blocks
+(MiMo cannot validate Anthropic signatures) but preserve unsigned
+blocks that Hermes synthesises from ``reasoning_content``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestXiaomiAnthropicPreservesThinking:
+    """convert_messages_to_anthropic must replay Xiaomi MiMo thinking blocks."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://token-plan-cn.xiaomimimo.com/anthropic",
+            "https://token-plan-cn.xiaomimimo.com/anthropic/",
+            "https://token-plan-cn.xiaomimimo.com/anthropic/v1",
+            "https://Token-Plan-CN.XiaoMiMimo.com/anthropic",
+        ],
+    )
+    def test_unsigned_thinking_block_survives_replay(self, base_url: str) -> None:
+        """Unsigned thinking (synthesised from reasoning_content) must be preserved."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "reasoning_content": "planning the tool call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "skill_view", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url=base_url
+        )
+
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1, (
+            f"Xiaomi MiMo /anthropic ({base_url}) must preserve unsigned "
+            "thinking blocks synthesised from reasoning_content — upstream "
+            "rejects replayed tool-call messages without them."
+        )
+        assert thinking_blocks[0]["thinking"] == "planning the tool call"
+        # Synthesised block — never has a signature
+        assert "signature" not in thinking_blocks[0]
+
+    def test_openai_compat_xiaomi_base_is_not_matched(self) -> None:
+        """Only the ``/anthropic`` path triggers the preservation policy.
+
+        Other Xiaomi base URLs (OpenAI-compat / bare host) reach this adapter
+        only via misconfiguration; the helper must not misclassify them.
+        """
+        from agent.anthropic_adapter import _is_xiaomi_anthropic_endpoint
+
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com") is False
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com/v1") is False
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com/anthropic") is True
+        assert _is_xiaomi_anthropic_endpoint("https://token-plan-cn.xiaomimimo.com/anthropic/v1") is True


### PR DESCRIPTION
## Summary

Xiaomi MiMo's `token-plan-cn.xiaomimimo.com/anthropic` endpoint speaks the Anthropic Messages protocol but, in thinking mode, requires `reasoning_content` / unsigned thinking blocks from prior assistant turns to round-trip on subsequent requests — same contract as Kimi `/coding` (#13848) and DeepSeek `/anthropic` (#16748).

Without an MiMo-specific carve-out the generic third-party path strips the unsigned thinking blocks and the next tool-call turn fails with:

```
HTTP 400: Param Incorrect
The reasoning_content in the thinking mode must be passed back to the API.
```

This reproduces reliably across multi-turn sessions for users configured with `provider: xiaomi` + `base_url: https://token-plan-cn.xiaomimimo.com/anthropic`.

## Change

- Add `_is_xiaomi_anthropic_endpoint()` — host match on `xiaomimimo.com` + `/anthropic` path pin, mirroring `_is_deepseek_anthropic_endpoint()`.
- Include it in the `_preserve_unsigned_thinking` predicate in `convert_messages_to_anthropic()` so signed Anthropic blocks are still stripped (MiMo can't validate Anthropic signatures) while synthesised unsigned blocks survive replay.

The change is additive and scoped strictly to the MiMo `/anthropic` host+path — no other provider's behavior changes.

## Test plan

- [x] New `tests/agent/test_xiaomi_anthropic_thinking.py` parallel to the DeepSeek/Kimi tests:
  - Unsigned `reasoning_content` block survives replay across all public MiMo `/anthropic` URL variants (trailing slash, `/v1`, mixed case).
  - Synthesised block carries no signature.
  - Path pinning: bare host and `/v1` (non-Anthropic) routes do NOT match the helper.
- [x] CI lint + pytest pass on the changed paths.
- [x] Smoke-tested locally: multi-turn tool-using session against `provider: xiaomi`, `model: mimo-v2-flash` — turns no longer 400 on replay.

## Refs

- #13848 — Kimi `/coding` precedent
- #16748 — DeepSeek `/anthropic` precedent