### PR TITLE
feat(skills): add deepseek-tui skill for DeepSeek V4 coding agent

### DIFF
--- a/skills/autonomous-ai-agents/deepseek-tui/SKILL.md
+++ b/skills/autonomous-ai-agents/deepseek-tui/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: deepseek-tui
+description: "Delegate coding to DeepSeek TUI — terminal coding agent for DeepSeek V4 models (flash/pro) with agentic tool use, sub-agents, and 1M context. Covers both `deepseek` (CLI/binary) and `deepseek-tui` (interactive TUI)."
+version: 2.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Coding-Agent, DeepSeek, Terminal, Agentic, Sub-Agents]
+    related_skills: [claude-code, codex, opencode, local-llm-servers]
+---
+
+# DeepSeek TUI — Hermes Orchestration Guide
+
+Delegate coding tasks to [DeepSeek TUI](https://github.com/Hmbown/DeepSeek-TUI), a Rust-based terminal coding agent built around DeepSeek V4 models (flash/pro). Supports file ops, shell execution, git, web search, sub-agents, MCP servers, and 1M-token context.
+
+## Binary Locations
+
+```bash
+/root/.hermes/node/bin/deepseek       # Full CLI (27 subcommands, agentic exec)
+/root/.hermes/node/bin/deepseek-tui   # Interactive TUI
+```
+
+> **Note:** Ensure `/root/.hermes/node/bin` is in `$PATH`. Add `export PATH="/root/.hermes/node/bin:$PATH"` to `~/.bashrc` if `command not found`.
+
+## When to Use
+
+- User explicitly asks to use DeepSeek-TUI / deepseek CLI
+- You want a DeepSeek-native coding agent (better reasoning with flash/pro models)
+- Task benefits from DeepSeek's long context (1M tokens)
+- Need concurrent sub-agent execution (up to 10-20 parallel)
+- User has a DeepSeek API key but no Anthropic/OpenAI key
+
+## Prerequisites
+
+- **Install:** `npm install -g deepseek-tui` (or `cargo install deepseek-tui-cli deepseek-tui`)
+- **China mirror:** `npm install -g deepseek-tui --registry=https://registry.npmmirror.com`
+- **Verify:** `deepseek-tui --version` and `deepseek doctor`
+- **Auth:** set `DEEPSEEK_API_KEY` env var, or run `deepseek login --api-key sk-xxx`, or configure `~/.deepseek/config.toml`
+- The npm package is a wrapper that downloads prebuilt Rust binaries (`deepseek` dispatcher + `deepseek-tui` TUI)
+
+## Two Orchestration Modes
+
+### Mode 1: `deepseek exec` — Non-Interactive One-Shot (PREFERRED)
+
+```bash
+# Fully autonomous agent (YOLO = auto-approve all tool calls)
+deepseek exec "Add error handling to all API calls" --auto --yolo
+
+# JSON output for scripting
+deepseek exec "List all Python files" --auto --json --yolo
+
+# Continue last session
+deepseek exec "Continue the refactoring work" --continue --auto
+
+# With specific model
+deepseek exec "Analyze this codebase" --auto --model deepseek-v4-flash --yolo
+```
+
+**When to use exec mode:**
+- One-shot coding tasks (fix bug, add feature, refactor)
+- Code review over a diff
+- Structured extraction with `--json`
+- Piped input: `cat error.log | deepseek exec "diagnose these errors" --auto --yolo`
+
+### Mode 2: Interactive TUI — Multi-Turn Sessions
+
+```bash
+# Start interactive TUI
+deepseek-tui
+
+# Or with workspace
+deepseek-tui -w /path/to/project
+```
+
+## Key Subcommands (27 total)
+
+### Agent Execution (主力)
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek exec "prompt" --auto` | **非交互式 agent 模式，最常用** |
+| `deepseek exec "prompt" --auto --yolo` | 全自动批准（YOLO 模式） |
+| `deepseek exec "prompt" --auto --json` | JSON 结构化输出 |
+| `deepseek exec "prompt" --continue --auto` | 继续最近会话 |
+| `deepseek run` | 交互式/非交互式通用入口 |
+| `deepseek review` | 对 git diff 进行 AI 代码审查 |
+| `deepseek eval` | 离线 TUI 评估框架 |
+
+### Session Management
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek thread list` | 列出所有 thread |
+| `deepseek thread resume <id>` | 恢复指定 thread |
+| `deepseek thread fork <id>` | 复刻指定 thread |
+| `deepseek thread set-name <id> "名称"` | 重命名 thread |
+| `deepseek thread archive <id>` | 归档 thread |
+| `deepseek sessions` | 列出已保存的 TUI 会话 |
+| `deepseek resume` | 恢复已保存的会话 |
+| `deepseek fork` | 复刻已保存的会话 |
+
+### Configuration & Auth
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek config list` | 列出所有配置 |
+| `deepseek config path` | 显示配置文件路径 |
+| `deepseek config set <key> <value>` | 设置配置值 |
+| `deepseek config get <key>` | 获取配置值 |
+| `deepseek auth status` | 认证状态 |
+| `deepseek auth list` | 所有 provider |
+| `deepseek auth set --api-key sk-xxx` | 保存 API key |
+| `deepseek login --api-key sk-xxx` | 保存到用户配置 |
+| `deepseek logout` | 删除认证状态 |
+
+### Model Management
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek model list` | 列出可用模型 |
+| `deepseek model resolve` | 当前使用的模型 |
+
+### Server Modes
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek app-server --port 8787` | HTTP API 服务器 |
+| `deepseek serve` | 本地 TUI 服务器 |
+| `deepseek mcp-server` | MCP over stdio |
+| `deepseek mcp` | 管理 TUI MCP 服务器 |
+
+### Diagnostics & Monitoring
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek doctor` | 环境诊断 |
+| `deepseek metrics --since 7d` | 用量统计（最近7天） |
+| `deepseek metrics --since 30d --json` | 用量 JSON 导出 |
+| `deepseek sandbox` | 评估沙箱/审批策略决策 |
+| `deepseek features` | 检查功能标志 |
+
+### Utilities
+
+| Command | Purpose |
+|---------|---------|
+| `deepseek update` | 更新二进制 |
+| `deepseek completion bash` | 生成 shell 补全 |
+| `deepseek init` | 创建默认 AGENTS.md |
+| `deepseek setup` | 引导初始化配置 |
+| `deepseek apply` | 应用 patch 文件到工作树 |
+
+## Global Options (apply to all subcommands)
+
+| Option | Description |
+|--------|-------------|
+| `--provider` | `deepseek`, `nvidia-nim`, `openai`, `openrouter`, `novita`, `fireworks`, `sglang`, `vllm`, `ollama` |
+| `--model` | Model name |
+| `--api-key` | API key (overrides config) |
+| `--base-url` | Custom API base URL |
+| `--yolo` | Auto-approve all tool calls |
+| `--config` | Config file path |
+| `--approval-policy` | Approval policy |
+| `--sandbox-mode` | Sandbox mode |
+| `--output-mode` | Output mode |
+| `--log-level` | Log level |
+| `--telemetry` | `true` / `false` |
+| `--skip-onboarding` | Skip first-run onboarding |
+| `-p, --prompt` | Pass prompt via argument |
+
+## exec Flags
+
+| Flag | Description |
+|------|-------------|
+| `--auto` | Enable agentic mode (tool access) |
+| `--json` | JSON summary output |
+| `--resume <ID>` | Resume session by ID |
+| `--continue` | Continue most recent session |
+| `--output-format` | `text` or `stream-json` |
+
+## Common Workflows
+
+### Non-interactive agent (primary CLI mode)
+```bash
+deepseek exec "analyze this project" --auto --yolo
+deepseek exec "refactor module X" --auto --model deepseek-v4-flash --yolo
+```
+
+### Pipe input
+```bash
+cat error.log | deepseek exec "diagnose these errors" --auto --yolo
+git diff HEAD~1 | deepseek exec "review this diff" --auto --json --yolo
+```
+
+### Multi-provider
+```bash
+deepseek exec "..." --auto --provider openai --model gpt-4.1 --api-key sk-xxx
+deepseek exec "..." --auto --provider ollama --model deepseek-coder:1.3b
+```
+
+### Session continuity
+```bash
+deepseek exec "start task A" --auto
+deepseek exec "continue task A" --continue --auto
+deepseek thread resume <id>
+```
+
+## Config File
+
+- **Path:** `~/.deepseek/config.toml` (run `deepseek config path` to confirm)
+- **Auth lookup order:** config → secret store → env var (`DEEPSEEK_API_KEY`)
+
+```toml
+api_key = "sk-xxx"
+provider = "deepseek"
+default_text_model = "deepseek-v4-pro"
+reasoning_effort = "max"
+
+[projects."/root"]
+trust_level = "trusted"
+```
+
+## Sub-Agents (Concurrent Background Execution)
+
+DeepSeek TUI can dispatch multiple sub-agents that run in parallel:
+
+- Non-blocking launch: parent keeps working while children execute
+- Default cap: 10 concurrent sub-agents (configurable to 20)
+- Completion notification: structured `<deepseek:subagent.done>` event with summary
+- Bounded result retrieval: large transcripts parked behind `var_handle` references
+
+In agentic mode (`--auto`), the model can autonomously spawn sub-agents for parallel work.
+
+## Feature Flags
+
+| Flag | Stage | Default | Description |
+|------|-------|---------|-------------|
+| `shell_tool` | stable | ✅ | Shell execution in agentic mode |
+| `subagents` | experimental | ✅ | Concurrent background sub-agents |
+| `web_search` | experimental | ✅ | Web search/browse tools |
+| `apply_patch` | experimental | ✅ | Patch application |
+| `mcp` | experimental | ✅ | MCP server support |
+| `exec_policy` | experimental | ✅ | Execution policy tooling |
+| `vision_model` | experimental | ❌ | Vision model support |
+
+Enable/disable via `--enable <FEATURE>` or `--disable <FEATURE>` on any command.
+
+## Environment Variables
+
+| Variable | Effect |
+|----------|--------|
+| `DEEPSEEK_API_KEY` | API key (overrides config file) |
+| `DEEPSEEK_CORS_ORIGINS` | Comma-separated CORS origins for HTTP server |
+| `DEEPSEEK_RUNTIME_TOKEN` | Bearer token for runtime API auth |
+
+## Cost & Performance Tips
+
+1. **Use `--model deepseek-v4-flash`** for most tasks (fast, cheap). Reserve `--model deepseek-v4-pro` for complex multi-step reasoning.
+2. **Use `--yolo` for one-shots** — avoids interactive approval dialogs.
+3. **Use `--json`** for programmatic result parsing.
+4. **Use pipe input** — `cat file | deepseek exec "..." --auto --yolo` instead of pasting content.
+5. **Use `--continue`** to resume long-running sessions.
+6. **Sub-agents for parallel work** — the model can spawn up to 20 concurrent children.
+
+## Pitfalls & Gotchas
+
+1. **npm wrapper downloads binaries on first run** — the `deepseek` dispatcher (~17MB) downloads immediately; `deepseek-tui` TUI (~47MB) downloads on first TUI/exec invocation. Total ~64MB.
+2. **WSL2 GitHub download speeds can be very slow** (~100KB/s). Use `--registry=https://registry.npmmirror.com` for npm, but binary downloads still go through GitHub. The built-in downloader handles retries well — just set a long timeout (300s+).
+3. **`exec` subcommand requires a prompt argument** — `deepseek exec "task"` not `deepseek "task"`.
+4. **API key via env var or login** — `export DEEPSEEK_API_KEY="sk-..."` works; `deepseek login` persists it to user config.
+5. **Auto mode enables tool access** — without `--auto`, exec mode is read-only analysis.
+6. **Chinese locale auto-detected** — UI defaults to `zh-Hans` if system locale is Chinese.
+7. **PATH issue** — If `deepseek: command not found`, add `/root/.hermes/node/bin` to `$PATH` in `~/.bashrc`.
+
+## Advanced Commands
+
+### HTTP Server Mode (Headless Orchestration)
+
+```bash
+# Start server in background
+deepseek app-server --port 8787
+
+# Or use deepseek-tui serve
+deepseek-tui serve --http --port 7878 --insecure
+```
+
+### MCP Management
+
+```bash
+deepseek mcp list                    # List configured servers
+deepseek mcp add <name> -- <cmd>     # Add server
+deepseek mcp connect                 # Test connections
+deepseek mcp tools                   # List discovered tools
+deepseek mcp enable/disable <name>   # Toggle server
+deepseek mcp add-self                # Register as MCP stdio server
+```
+
+## Rules for Hermes Agents
+
+1. **Prefer `deepseek exec --auto --yolo` for single tasks** — clean, non-interactive, auto-approved.
+2. **Always set `workdir`** — keep DeepSeek focused on the right project directory.
+3. **Set long timeouts (120-300s)** — binary download on first run and model inference both take time.
+4. **Use `--model deepseek-v4-flash` by default** — best price/performance ratio.
+5. **Use `--json` for structured output** — easier to parse results programmatically.
+6. **Check `deepseek doctor` before running** — verify config and API connectivity if issues arise.
+7. **Report concrete outcomes** — files changed, tests run, remaining risks.
+8. **Use `--continue` or `deepseek thread resume`** — don't start new sessions for follow-up work.
+
+## Full Reference
+
+For complete documentation of all 27 subcommands, detailed options, environment variables, and additional workflow examples, see `references/cli-reference.md`.

--- a/skills/autonomous-ai-agents/deepseek-tui/references/cli-reference.md
+++ b/skills/autonomous-ai-agents/deepseek-tui/references/cli-reference.md
@@ -1,0 +1,577 @@
+# DeepSeek CLI 完整参考手册
+
+> DeepSeek TUI 版本: 0.8.33
+> 生成日期: 2026-05-14
+> 配置文件: `~/.deepseek/config.toml`
+
+---
+
+## 目录
+
+1. [快速入门](#快速入门)
+2. [全局选项](#全局选项)
+3. [命令分类索引](#命令分类索引)
+4. [会话管理](#会话管理)
+5. [Agent 执行](#agent-执行)
+6. [配置与认证](#配置与认证)
+7. [模型管理](#模型管理)
+8. [服务与传输](#服务与传输)
+9. [诊断与监控](#诊断与监控)
+10. [实用工具](#实用工具)
+11. [常用工作流示例](#常用工作流示例)
+12. [环境变量](#环境变量)
+13. [配置文件参考](#配置文件参考)
+
+---
+
+## 快速入门
+
+```bash
+# 最简单的调用：直接传 prompt
+deepseek "解释这段代码的作用"
+
+# 非交互式 agent 模式（最常用）
+deepseek exec "帮我创建一个 Python 项目" --auto --yolo
+
+# 管道输入
+echo "这段代码有什么问题？" | deepseek exec --auto
+cat error.log | deepseek exec "分析这些错误" --auto --yolo
+
+# 启动交互式 TUI
+deepseek-tui
+```
+
+---
+
+## 全局选项
+
+所有子命令都可以使用以下全局选项：
+
+| 选项 | 说明 |
+|------|------|
+| `--config <CONFIG>` | 指定配置文件路径 |
+| `--profile <PROFILE>` | 指定配置 profile |
+| `--provider <PROVIDER>` | 指定 AI provider：`deepseek`, `nvidia-nim`, `openai`, `atlascloud`, `openrouter`, `novita`, `fireworks`, `sglang`, `vllm`, `ollama` |
+| `--model <MODEL>` | 指定模型名称 |
+| `--api-key <API_KEY>` | 指定 API key（覆盖配置文件） |
+| `--base-url <BASE_URL>` | 自定义 API 基础 URL |
+| `--output-mode <MODE>` | 输出模式 |
+| `--log-level <LEVEL>` | 日志级别 |
+| `--telemetry <BOOL>` | 遥测开关：`true` / `false` |
+| `--approval-policy <POLICY>` | 审批策略 |
+| `--sandbox-mode <MODE>` | 沙箱模式 |
+| `--yolo` | YOLO 模式：自动批准所有工具调用 |
+| `--mouse-capture` / `--no-mouse-capture` | 鼠标捕获开关 |
+| `--skip-onboarding` | 跳过首次引导 |
+| `-p, --prompt <PROMPT>` | 通过参数传入 prompt |
+| `-h, --help` | 打印帮助信息 |
+| `-V, --version` | 打印版本号 |
+
+---
+
+## 命令分类索引
+
+### 会话管理
+| 命令 | 说明 |
+|------|------|
+| `sessions` | 列出已保存的 TUI 会话 |
+| `resume` | 恢复一个已保存的 TUI 会话 |
+| `fork` | 复刻一个已保存的 TUI 会话 |
+| `thread` | 管理线程/会话元数据及恢复/复刻流程 |
+
+### Agent 执行
+| 命令 | 说明 |
+|------|------|
+| `run` | 运行交互式/非交互式流程 |
+| `exec` | **非交互式 agent 命令（主力 CLI 入口）** |
+| `review` | 对 git diff 进行 AI 代码审查 |
+| `eval` | 运行离线 TUI 评估框架 |
+
+### 配置与认证
+| 命令 | 说明 |
+|------|------|
+| `config` | 读取/写入/列出配置值 |
+| `login` | 保存 provider API key 到配置 |
+| `logout` | 删除已保存的认证状态 |
+| `auth` | 管理认证凭据和 provider 模式 |
+| `init` | 在当前目录创建默认 `AGENTS.md` |
+| `setup` | 引导初始化 MCP 配置和/或 skills 目录 |
+
+### 模型管理
+| 命令 | 说明 |
+|------|------|
+| `models` | 列出可用的 DeepSeek API 模型 |
+| `model` | 解析或列出各 provider 的可用模型 |
+
+### 服务与传输
+| 命令 | 说明 |
+|------|------|
+| `serve` | 运行本地 TUI 服务器 |
+| `app-server` | 运行 app-server 传输层 |
+| `mcp-server` | 通过 stdio 运行 MCP 服务器模式 |
+| `mcp` | 管理 TUI MCP 服务器 |
+
+### 诊断与监控
+| 命令 | 说明 |
+|------|------|
+| `doctor` | 运行 DeepSeek TUI 诊断 |
+| `metrics` | 打印用量汇总（来自审计日志和会话存储） |
+| `sandbox` | 评估沙箱/审批策略决策 |
+| `features` | 检查 TUI 功能标志 |
+
+### 实用工具
+| 命令 | 说明 |
+|------|------|
+| `apply` | 将 patch 文件或 stdin 应用到工作树 |
+| `completion` / `completions` | 生成 shell 补全脚本 |
+| `update` | 检查并应用 `deepseek` 二进制更新 |
+
+---
+
+## 会话管理
+
+### `deepseek sessions`
+
+列出已保存的 TUI 会话。
+
+```bash
+deepseek sessions
+```
+
+### `deepseek resume`
+
+恢复一个已保存的 TUI 会话。
+
+```bash
+deepseek resume [ARGS]...
+```
+
+### `deepseek fork`
+
+复刻（复制）一个已保存的 TUI 会话。
+
+```bash
+deepseek fork [ARGS]...
+```
+
+### `deepseek thread`
+
+管理线程/会话元数据。
+
+```bash
+deepseek thread <SUBCOMMAND>
+
+子命令:
+  list        列出所有 thread
+  read        读取指定 thread 详情
+  resume      恢复一个 thread
+  fork        复刻一个 thread
+  archive     归档一个 thread
+  unarchive   取消归档
+  set-name    设置 thread 名称
+```
+
+示例：
+
+```bash
+deepseek thread list                          # 列出所有 thread
+deepseek thread read <THREAD_ID>              # 查看 thread 详情
+deepseek thread resume <THREAD_ID>            # 恢复指定 thread
+deepseek thread fork <THREAD_ID>              # 复刻指定 thread
+deepseek thread set-name <THREAD_ID> "名称"   # 重命名 thread
+deepseek thread archive <THREAD_ID>           # 归档 thread
+```
+
+---
+
+## Agent 执行
+
+### `deepseek run`
+
+运行交互式/非交互式流程（通用入口）。
+
+```bash
+deepseek run [ARGS]...
+```
+
+### `deepseek exec` ⭐ 主力 CLI 命令
+
+非交互式 agent 模式，适合脚本集成和自动化。
+
+```bash
+deepseek exec [ARGS]...
+```
+
+**核心标志：**
+
+| 标志 | 说明 |
+|------|------|
+| `--auto` | **启用 agentic 模式**，允许调用工具（读写文件、执行命令等） |
+| `--json` | 输出结构化 JSON 摘要 |
+| `--resume <SESSION_ID>` | 通过 ID 或前缀恢复之前的会话 |
+| `--session-id <SESSION_ID>` | 同上 |
+| `--continue` | 继续当前工作空间最近的会话 |
+| `--output-format <FORMAT>` | 输出格式：`text` 或 `stream-json` |
+
+**典型用法：**
+
+```bash
+# 基础 agent 调用
+deepseek exec "分析项目结构" --auto
+
+# 自动批准所有操作（全自动模式）
+deepseek exec "重构 fanren_project 的模块" --auto --yolo
+
+# 输出 JSON 结果供脚本消费
+deepseek exec "列出所有 Python 文件" --auto --json --yolo
+
+# 流式 JSON 输出（适合实时管道处理）
+deepseek exec "..." --auto --output-format stream-json
+
+# 继续最近的会话
+deepseek exec "继续上一步的工作" --continue --auto
+
+# 恢复指定会话
+deepseek exec "..." --resume abc123 --auto
+
+# 管道输入
+cat requirements.txt | deepseek exec "根据依赖生成 Dockerfile" --auto --yolo
+
+# 指定模型和 provider
+deepseek exec "..." --auto --model deepseek-v4-flash --provider deepseek --yolo
+```
+
+### `deepseek review`
+
+对 git diff 进行 AI 代码审查。
+
+```bash
+deepseek review [ARGS]...
+```
+
+**典型用法：**
+
+```bash
+# 审查暂存区的变更
+deepseek review
+
+# 审查指定文件
+deepseek review path/to/file.py
+
+# 审查最近的提交
+git diff HEAD~1 | deepseek review
+```
+
+### `deepseek eval`
+
+运行离线 TUI 评估框架。
+
+```bash
+deepseek eval [ARGS]...
+```
+
+---
+
+## 配置与认证
+
+### `deepseek config`
+
+读取/写入/列出配置值。
+
+```bash
+deepseek config <SUBCOMMAND>
+
+子命令:
+  list        列出所有配置项
+  path        显示配置文件路径
+  set <key> <value>  设置配置值
+  get <key>   获取配置值
+```
+
+示例：
+
+```bash
+deepseek config list                    # 列出所有配置
+deepseek config path                    # 查看配置文件路径
+deepseek config set provider deepseek   # 设置默认 provider
+deepseek config get default_text_model  # 获取默认模型
+```
+
+### `deepseek login`
+
+保存 provider API key 到配置。
+
+```bash
+deepseek login --api-key sk-xxx                    # 默认 provider
+deepseek login --provider openai --api-key sk-xxx  # 指定 provider
+```
+
+### `deepseek logout`
+
+删除已保存的认证状态。
+
+```bash
+deepseek logout                     # 删除所有
+deepseek logout --provider openai   # 删除指定 provider
+```
+
+### `deepseek auth`
+
+管理认证凭据和 provider 模式。
+
+```bash
+deepseek auth status                # 查看认证状态
+deepseek auth list                  # 列出所有 provider 认证状态
+deepseek auth set --api-key sk-xxx  # 保存 API key
+deepseek auth set --provider openai --api-key sk-xxx
+```
+
+### `deepseek init`
+
+在当前目录创建默认 `AGENTS.md` 文件。
+
+```bash
+deepseek init                       # 使用默认模板
+deepseek init --template python     # 指定模板
+```
+
+### `deepseek setup`
+
+引导初始化配置。
+
+```bash
+deepseek setup                      # 引导式设置
+```
+
+---
+
+## 模型管理
+
+### `deepseek models`
+
+列出可用的 DeepSeek API 模型。
+
+```bash
+deepseek models
+```
+
+### `deepseek model`
+
+解析或列出各 provider 的可用模型。
+
+```bash
+deepseek model list                          # 列出所有 provider 的模型
+deepseek model list --provider deepseek      # 列出 DeepSeek 的模型
+deepseek model resolve                       # 显示当前解析出的模型
+```
+
+---
+
+## 服务与传输
+
+### `deepseek serve`
+
+运行本地 TUI 服务器。
+
+```bash
+deepseek serve [ARGS]...
+
+常用标志:
+  --http          启用 HTTP/SSE 服务器
+  --port <PORT>   绑定端口（默认 7878）
+  --host <HOST>   绑定地址（默认 127.0.0.1）
+  --workers <N>   后台 worker 数量（1-8，默认 2）
+  --auth-token    认证 token
+  --insecure      跳过认证（仅用于 localhost）
+```
+
+### `deepseek app-server`
+
+运行 app-server 传输层。
+
+```bash
+deepseek app-server [ARGS]...
+
+常用标志:
+  --port <PORT>   绑定端口（默认 8787）
+  --host <HOST>   绑定地址
+```
+
+### `deepseek mcp-server`
+
+通过 stdio 运行 MCP 服务器模式。
+
+```bash
+deepseek mcp-server
+```
+
+### `deepseek mcp`
+
+管理 TUI MCP 服务器。
+
+```bash
+deepseek mcp list                    # 列出配置的服务器
+deepseek mcp add <name> -- <cmd>     # 添加服务器
+deepseek mcp connect                 # 测试连接
+deepseek mcp tools                   # 列出发现的工具
+deepseek mcp enable <name>           # 启用服务器
+deepseek mcp disable <name>          # 禁用服务器
+deepseek mcp add-self                # 注册为 MCP stdio 服务器
+```
+
+---
+
+## 诊断与监控
+
+### `deepseek doctor`
+
+运行诊断检查。
+
+```bash
+deepseek doctor
+```
+
+### `deepseek metrics`
+
+打印用量汇总。
+
+```bash
+deepseek metrics --since 7d                    # 最近 7 天
+deepseek metrics --since 30d --json            # JSON 格式
+```
+
+### `deepseek sandbox`
+
+评估沙箱/审批策略决策。
+
+```bash
+deepseek sandbox [ARGS]...
+```
+
+### `deepseek features`
+
+检查 TUI 功能标志。
+
+```bash
+deepseek features
+```
+
+---
+
+## 实用工具
+
+### `deepseek apply`
+
+将 patch 文件或 stdin 应用到工作树。
+
+```bash
+deepseek apply <patch_file>      # 应用 patch 文件
+cat diff.patch | deepseek apply  # 从 stdin 读取
+```
+
+### `deepseek completion`
+
+生成 shell 补全脚本。
+
+```bash
+deepseek completion bash         # Bash 补全
+deepseek completion zsh          # Zsh 补全
+```
+
+### `deepseek update`
+
+检查并应用更新。
+
+```bash
+deepseek update
+```
+
+---
+
+## 常用工作流示例
+
+### 代码重构
+
+```bash
+# 分析项目结构
+deepseek exec "分析项目结构，找出可以优化的模块" --auto --yolo
+
+# 重构指定模块
+deepseek exec "重构 auth 模块，使用 JWT 替代 session" --auto --yolo
+
+# 继续重构工作
+deepseek exec "继续重构工作" --continue --auto --yolo
+```
+
+### 错误诊断
+
+```bash
+# 分析错误日志
+cat /var/log/app/error.log | deepseek exec "分析这些错误，找出根本原因" --auto --yolo
+
+# 生成修复方案
+deepseek exec "根据上面的错误分析，生成修复方案" --continue --auto --yolo
+```
+
+### 代码审查
+
+```bash
+# 审查当前变更
+deepseek review --json
+
+# 审查特定文件
+deepseek review src/auth/ --json
+
+# 审查 PR
+deepseek review --pr 123 --json
+```
+
+### 多 provider 切换
+
+```bash
+# 使用 OpenAI
+deepseek exec "..." --auto --provider openai --model gpt-4.1 --yolo
+
+# 使用本地 Ollama
+deepseek exec "..." --auto --provider ollama --model deepseek-coder:1.3b --yolo
+```
+
+---
+
+## 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `DEEPSEEK_API_KEY` | DeepSeek API key（优先级最高） |
+| `DEEPSEEK_CORS_ORIGINS` | CORS 允许的源（HTTP 服务器用） |
+| `DEEPSEEK_RUNTIME_TOKEN` | 运行时 API 认证 token |
+
+---
+
+## 配置文件参考
+
+**路径:** `~/.deepseek/config.toml`
+
+```toml
+# 默认 provider
+provider = "deepseek"
+
+# API key（也可通过 deepseek login 设置）
+api_key = "sk-xxx"
+
+# 默认模型
+default_text_model = "deepseek-v4-pro"
+
+# 推理努力程度: low, medium, high, max
+reasoning_effort = "max"
+
+# 项目特定配置
+[projects."/root/my-project"]
+trust_level = "trusted"
+default_model = "deepseek-v4-flash"
+
+[projects."/root/sandbox"]
+trust_level = "sandbox"
+```
+
+**认证查找顺序:** config → secret store → env var (`DEEPSEEK_API_KEY`)


### PR DESCRIPTION
## Summary

Add a comprehensive skill for orchestrating [DeepSeek TUI](https://github.com/Hmbown/DeepSeek-TUI) via the Hermes terminal tool. This fills the gap in the `autonomous-ai-agents` category alongside the existing `claude-code`, `codex`, and `opencode` skills.

## What this adds

- **`skills/autonomous-ai-agents/deepseek-tui/SKILL.md`** — Hermes orchestration guide covering both `deepseek` CLI (27 subcommands, agentic exec, review, sessions) and `deepseek-tui` interactive TUI
- **`references/cli-reference.md`** — Full CLI reference manual with all 27 subcommands, auth/config/model management, environment variables, and config file format

## Key features documented

| Mode | Command | Use Case |
|------|---------|----------|
| Non-interactive agent | `deepseek exec "..." --auto --yolo` | One-shot coding tasks, scripting |
| Interactive TUI | `deepseek-tui` | Multi-turn sessions |
| Code review | `deepseek review` | Git diff analysis |
| Session management | `deepseek thread list/resume/fork` | Session continuity |

## Compatibility

- deepseek-tui v0.8.33
- Linux/macOS/Windows
- DeepSeek V4 Flash/Pro models
- Supports npm wrapper + native binary paths

## Motivation

DeepSeek TUI is a Rust-based terminal coding agent with 1M context, sub-agents, and strong reasoning via V4 models. This skill enables Hermes to delegate coding tasks to DeepSeek alongside existing Claude Code, Codex, and OpenCode options — giving users provider choice based on their API keys and preferences.