### PR TITLE
[codex] Add gateway workspace restrictions and local model fixes

### DIFF
--- a/DISCORD_GATEWAY_QUICKSTART.md
+++ b/DISCORD_GATEWAY_QUICKSTART.md
@@ -1,0 +1,244 @@
+# Hermes Discord Gateway Quickstart
+
+這份小抄是給平常使用看的。
+
+目前你的 Hermes 設定是：
+
+- Discord gateway
+- 目前預設主模型：`openrouter:openrouter/free`
+- 保留可切回的雲端模型：`openrouter:openrouter/free`
+- 額外可切換的本機模型 provider：`ollama-local`
+- 額外可切換的 WSL vLLM provider：`vllm-local`
+
+## 1. 進入專案
+
+每次操作前，先進入專案並啟用環境：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+source venv/bin/activate
+```
+
+## 2. 啟動 Hermes Discord
+
+建議用背景模式啟動：
+
+```bash
+setsid bash -lc 'source /home/dachen/.hermes/hermes-agent/venv/bin/activate && hermes gateway run >> /home/dachen/.hermes/logs/gateway.log 2>&1' >/dev/null 2>&1 < /dev/null &
+```
+
+啟動後可再查一次狀態：
+
+```bash
+hermes gateway status
+```
+
+## 3. 確認 Hermes 有沒有在跑
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+source venv/bin/activate
+hermes gateway status
+```
+
+正常會看到類似：
+
+```text
+✓ Gateway is running
+```
+
+## 4. 關掉 Hermes Discord
+
+```bash
+pkill -f "hermes gateway run"
+```
+
+關掉後可以再查一次：
+
+```bash
+hermes gateway status
+```
+
+## 5. 看 log
+
+看最近 50 行：
+
+```bash
+tail -n 50 ~/.hermes/logs/gateway.log
+```
+
+持續追 log：
+
+```bash
+tail -f ~/.hermes/logs/gateway.log
+```
+
+## 6. 在 Discord 怎麼用
+
+- 私訊 bot：直接傳訊息就可以
+- Server 頻道：預設要先 `@` bot，它才會回
+
+測試範例：
+
+```text
+@hermes 你好
+```
+
+或私訊：
+
+```text
+你好，你現在用的是什麼模型？
+```
+
+### 模型切換小抄
+
+在 Discord 裡直接用 `/model ...` 切換。
+
+建議優先使用這些：
+
+```text
+/model openrouter:openrouter/free
+/model llama3.2:latest --provider ollama-local
+/model qwen3-14b-64k:latest --provider ollama-local
+/model qwen2.5:7b --provider ollama-local
+/model qwen3.5:9b --provider vllm-local
+```
+
+說明：
+
+- `openrouter:openrouter/free`：切回雲端免費模型
+- `llama3.2:latest --provider ollama-local`：目前最推薦的快速本機主力，已安裝、128K context、支援 tools
+- `qwen3-14b-64k:latest --provider ollama-local`：能力較強，但明顯更慢
+- `qwen2.5:7b --provider ollama-local`：本機較省資源、比較快
+- `qwen3.5:9b --provider vllm-local`：WSL 版 vLLM 路線，預留給較穩定的本機 agent 服務
+
+你現在本機也可切這些：
+
+```text
+/model openrouter:openrouter/free
+/model llama3.2:latest --provider ollama-local
+/model qwen3-14b-64k:latest --provider ollama-local
+/model qwen2.5:7b --provider ollama-local
+/model qwen3.5:9b --provider vllm-local
+```
+
+切完之後建議馬上問一句確認：
+
+```text
+你現在是甚麼模型？
+```
+
+如果切完怪怪的，先重置 session：
+
+```text
+/reset
+```
+
+再重新切一次。
+
+### 切到本機 Ollama
+
+目前我幫你掛進 Hermes 的本機 provider 名稱是：
+
+```text
+ollama-local
+vllm-local
+```
+
+在 Discord 裡可以這樣切：
+
+```text
+/model llama3.2:latest --provider ollama-local
+```
+
+如果你想切到另一顆本機 Ollama：
+
+```text
+/model qwen3-14b-64k:latest --provider ollama-local
+```
+
+如果你想切到 WSL 上的 vLLM：
+
+```text
+/model qwen3.5:9b --provider vllm-local
+```
+
+如果你想切回原本的 OpenRouter：
+
+```text
+/model openrouter:openrouter/free
+```
+
+你目前本機可用或即將可用的 Ollama 模型：
+
+```text
+gemma3:12b
+qwen3:14b
+qwen3-14b-64k
+qwen2.5:7b
+gemma2:9b
+llama3.2:latest
+qwen3.5:9b
+```
+
+目前狀態：
+
+- 立刻可用的主預設：`openrouter:openrouter/free`
+- `gemma3:12b` 已下載完成，但目前不建議當 Hermes 主模型
+- 如果要重新切回雲端預設：`/model openrouter:openrouter/free`
+- 如果要切到 WSL vLLM：`/model qwen3.5:9b --provider vllm-local`
+
+建議：
+
+- 想切回雲端預設：`/model openrouter:openrouter/free`
+- 想要目前 Hermes 最快的穩定本機主力：`/model llama3.2:latest --provider ollama-local`
+- 想要較強但較慢：`/model qwen3-14b-64k:latest --provider ollama-local`
+- 想要比較省資源、比較快：`/model qwen2.5:7b --provider ollama-local`
+- 想用 WSL 上的 vLLM：`/model qwen3.5:9b --provider vllm-local`
+
+## 8. WSL vLLM 小抄
+
+啟動 `qwen3.5:9b` 的 vLLM：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+./scripts/start_vllm_qwen35_9b.sh
+```
+
+查狀態：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+./scripts/status_vllm_qwen35_9b.sh
+```
+
+停止：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+./scripts/stop_vllm_qwen35_9b.sh
+```
+
+## 7. 最短版指令
+
+啟動：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+source venv/bin/activate
+setsid bash -lc 'source /home/dachen/.hermes/hermes-agent/venv/bin/activate && hermes gateway run >> /home/dachen/.hermes/logs/gateway.log 2>&1' >/dev/null 2>&1 < /dev/null &
+```
+
+查狀態：
+
+```bash
+cd /home/dachen/.hermes/hermes-agent
+source venv/bin/activate
+hermes gateway status
+```
+
+關掉：
+
+```bash
+pkill -f "hermes gateway run"
+```

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -814,6 +814,7 @@ DOCUMENT_CACHE_DIR = get_hermes_dir("cache/documents", "document_cache")
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
+    ".ics": "text/calendar",
     ".md": "text/markdown",
     ".txt": "text/plain",
     ".csv": "text/csv",
@@ -2113,7 +2114,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|ics|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2136,7 +2137,7 @@ class BasePlatformAdapter(ABC):
         Detect bare local file paths in response text for native media delivery.
 
         Matches absolute paths (/...) and tilde paths (~/) ending in common
-        image or video extensions.  Validates each candidate with
+        media or document extensions. Validates each candidate with
         ``os.path.isfile()`` to avoid false positives from URLs or
         non-existent paths.
 
@@ -2147,11 +2148,16 @@ class BasePlatformAdapter(ABC):
             Tuple of (list of expanded file paths, cleaned text with the
             raw path strings removed).
         """
-        _LOCAL_MEDIA_EXTS = (
+        _LOCAL_FILE_EXTS = (
             '.png', '.jpg', '.jpeg', '.gif', '.webp',
             '.mp4', '.mov', '.avi', '.mkv', '.webm',
+            '.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac',
+            '.epub', '.pdf', '.ics', '.zip', '.rar', '.7z',
+            '.doc', '.docx', '.xlsx', '.xls', '.ppt', '.pptx',
+            '.txt', '.md', '.csv', '.json', '.xml', '.yaml', '.yml',
+            '.toml', '.ini', '.cfg', '.apk', '.ipa',
         )
-        ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_MEDIA_EXTS)
+        ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_FILE_EXTS)
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6926,7 +6926,16 @@ class GatewayRunner:
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                try:
+                    from gateway.user_workspace_policy import resolve_policy_for_source
+
+                    _source_policy = resolve_policy_for_source(source)
+                    if _source_policy and _source_policy.restricted:
+                        _msg_cwd = _source_policy.workspace_dir
+                    else:
+                        _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                except Exception:
+                    _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_runtime = _resolve_runtime_agent_kwargs()
                 _msg_config_ctx = None
                 try:
@@ -15412,6 +15421,13 @@ class GatewayRunner:
                         _run_message = message
                 else:
                     _run_message = message
+
+                try:
+                    from gateway.user_workspace_policy import apply_policy_to_task
+
+                    apply_policy_to_task(session_id, source)
+                except Exception as _policy_exc:
+                    logger.debug("user workspace policy apply failed: %s", _policy_exc)
 
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:

--- a/gateway/user_workspace_policy.py
+++ b/gateway/user_workspace_policy.py
@@ -1,0 +1,304 @@
+"""Per-user workspace policy for gateway sessions.
+
+Provides a generic way to confine non-owner gateway users to dedicated
+workspace directories while letting trusted owner IDs retain full access.
+
+Current behavior:
+  - policy is opt-in via ``user_workspaces.enabled`` in config.yaml
+  - supports platform scoping (default: Discord only)
+  - owner IDs bypass restrictions
+  - restricted users get a dedicated workspace tree under ``base_dir``
+  - restricted users can be blocked from ``terminal`` / ``execute_code``
+  - file/search tools are confined to that workspace tree
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+_PATCH_PATH_RE = re.compile(
+    r"^\*\*\* (?:Add|Update|Delete) File: (.+)$",
+    re.MULTILINE,
+)
+_PATCH_MOVE_RE = re.compile(r"^\*\*\* Move to: (.+)$", re.MULTILINE)
+
+_POLICY_LOCK = threading.Lock()
+_POLICY_BY_TASK: dict[str, "UserWorkspacePolicy"] = {}
+
+
+@dataclass(frozen=True)
+class UserWorkspacePolicy:
+    enabled: bool
+    restricted: bool
+    is_owner: bool
+    platform: str
+    user_id: str
+    user_name: str
+    base_dir: str
+    user_dir: str
+    workspace_dir: str
+    outputs_dir: str
+    venv_dir: str
+    tmp_dir: str
+    allow_terminal: bool
+    allow_execute_code: bool
+
+
+def _load_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _cfg_section() -> dict[str, Any]:
+    cfg = _load_config()
+    raw = cfg.get("user_workspaces")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _string_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {part.strip() for part in value.split(",") if part.strip()}
+    if isinstance(value, (list, tuple, set)):
+        return {str(part).strip() for part in value if str(part).strip()}
+    return set()
+
+
+def _bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _safe_slug(value: str, fallback: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", (value or "").strip())
+    cleaned = cleaned.strip("-._")
+    return cleaned or fallback
+
+
+def _default_base_dir() -> str:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return str(get_hermes_home() / "user-workspaces")
+    except Exception:
+        return os.path.expanduser("~/.hermes/user-workspaces")
+
+
+def _is_isolated_terminal_backend() -> bool:
+    env_type = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    return env_type in {"docker", "modal", "vercel_sandbox", "daytona", "singularity"}
+
+
+def _ensure_workspace_layout(policy: UserWorkspacePolicy) -> None:
+    for path in (
+        policy.base_dir,
+        policy.user_dir,
+        policy.workspace_dir,
+        policy.outputs_dir,
+        policy.venv_dir,
+        policy.tmp_dir,
+    ):
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def resolve_policy_for_source(source: Any) -> Optional[UserWorkspacePolicy]:
+    section = _cfg_section()
+    if not _bool(section.get("enabled"), False):
+        return None
+
+    platform = str(getattr(getattr(source, "platform", None), "value", "") or "").lower()
+    user_id = str(getattr(source, "user_id", "") or "").strip()
+    if not platform or not user_id:
+        return None
+
+    platforms = _string_set(section.get("platforms") or ["discord"])
+    if platforms and platform not in platforms:
+        return None
+
+    owner_ids = _string_set(section.get("owner_user_ids"))
+    trusted_ids = _string_set(section.get("trusted_user_ids"))
+    is_owner = user_id in owner_ids
+    is_trusted = is_owner or user_id in trusted_ids
+    restricted = not is_trusted and _bool(section.get("restricted_by_default"), True)
+
+    base_dir = os.path.realpath(
+        os.path.expanduser(str(section.get("base_dir") or _default_base_dir()))
+    )
+    user_name = str(getattr(source, "user_name", "") or "").strip()
+    user_slug = _safe_slug(user_name, f"user-{user_id}")
+    user_dir = os.path.join(base_dir, platform, f"{user_slug}-{user_id}")
+    workspace_dir = os.path.join(user_dir, "workspace")
+    outputs_dir = os.path.join(user_dir, "outputs")
+    venv_dir = os.path.join(user_dir, ".venv")
+    tmp_dir = os.path.join(user_dir, "tmp")
+
+    allow_terminal = is_trusted or (
+        _bool(section.get("allow_restricted_terminal"), False)
+        and _is_isolated_terminal_backend()
+    )
+    allow_execute_code = is_trusted or (
+        _bool(section.get("allow_restricted_execute_code"), False)
+        and _is_isolated_terminal_backend()
+    )
+
+    policy = UserWorkspacePolicy(
+        enabled=True,
+        restricted=restricted,
+        is_owner=is_owner,
+        platform=platform,
+        user_id=user_id,
+        user_name=user_name,
+        base_dir=base_dir,
+        user_dir=user_dir,
+        workspace_dir=workspace_dir,
+        outputs_dir=outputs_dir,
+        venv_dir=venv_dir,
+        tmp_dir=tmp_dir,
+        allow_terminal=allow_terminal,
+        allow_execute_code=allow_execute_code,
+    )
+    if restricted or _bool(section.get("create_owner_workspace"), False):
+        _ensure_workspace_layout(policy)
+    return policy
+
+
+def apply_policy_to_task(task_id: str, source: Any) -> Optional[UserWorkspacePolicy]:
+    if not task_id:
+        return None
+    policy = resolve_policy_for_source(source)
+    if policy is None:
+        return None
+    with _POLICY_LOCK:
+        _POLICY_BY_TASK[task_id] = policy
+    if policy.restricted:
+        try:
+            from tools.terminal_tool import register_task_env_overrides
+
+            register_task_env_overrides(task_id, {"cwd": policy.workspace_dir})
+        except Exception:
+            pass
+    return policy
+
+
+def get_policy_for_task(task_id: str) -> Optional[UserWorkspacePolicy]:
+    if not task_id:
+        return None
+    with _POLICY_LOCK:
+        return _POLICY_BY_TASK.get(task_id)
+
+
+def resolve_task_cwd(task_id: str = "", fallback: Optional[str] = None) -> str:
+    policy = get_policy_for_task(task_id)
+    if policy and policy.restricted:
+        return policy.workspace_dir
+
+    try:
+        from tools.terminal_tool import _task_env_overrides
+
+        override = _task_env_overrides.get(task_id or "", {})
+        cwd = override.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            return cwd
+    except Exception:
+        pass
+
+    env_cwd = os.getenv("TERMINAL_CWD", "").strip()
+    if env_cwd:
+        return os.path.expanduser(env_cwd)
+    return fallback or os.getcwd()
+
+
+def _resolve_path_from_workspace(policy: UserWorkspacePolicy, raw_path: str) -> str:
+    candidate = Path(raw_path or "").expanduser()
+    if not candidate.is_absolute():
+        candidate = Path(policy.workspace_dir) / candidate
+    return str(candidate.resolve())
+
+
+def _is_within_workspace(policy: UserWorkspacePolicy, raw_path: str) -> bool:
+    resolved = _resolve_path_from_workspace(policy, raw_path)
+    root = os.path.realpath(policy.workspace_dir)
+    return resolved == root or resolved.startswith(root + os.sep)
+
+
+def _extract_tool_paths(tool_name: str, args: dict[str, Any]) -> list[str]:
+    if tool_name in {"read_file", "write_file"}:
+        path = args.get("path")
+        return [path] if isinstance(path, str) and path.strip() else []
+
+    if tool_name == "search_files":
+        path = args.get("path", ".")
+        return [path] if isinstance(path, str) and path.strip() else ["."]
+
+    if tool_name == "patch":
+        mode = str(args.get("mode", "replace") or "replace").strip().lower()
+        if mode == "replace":
+            path = args.get("path")
+            return [path] if isinstance(path, str) and path.strip() else []
+        if mode == "patch":
+            content = args.get("patch")
+            if not isinstance(content, str) or not content.strip():
+                return []
+            paths = [p.strip() for p in _PATCH_PATH_RE.findall(content) if p.strip()]
+            paths.extend(p.strip() for p in _PATCH_MOVE_RE.findall(content) if p.strip())
+            return paths
+    return []
+
+
+def get_tool_block_message(
+    tool_name: str,
+    args: Optional[dict[str, Any]],
+    task_id: str = "",
+) -> Optional[str]:
+    policy = get_policy_for_task(task_id)
+    if policy is None or not policy.restricted:
+        return None
+
+    normalized_args = args if isinstance(args, dict) else {}
+
+    if tool_name in {"delegate_task", "skill_manage", "cronjob", "memory"}:
+        return (
+            f"Access denied: restricted users cannot use the '{tool_name}' tool."
+        )
+
+    if tool_name == "terminal" and not policy.allow_terminal:
+        return (
+            "This user is restricted to a dedicated workspace and cannot use "
+            "the terminal tool on the host machine. Use file tools inside "
+            f"{policy.workspace_dir} instead."
+        )
+
+    if tool_name == "execute_code" and not policy.allow_execute_code:
+        return (
+            "This user is restricted to a dedicated workspace and cannot use "
+            "execute_code on the host machine."
+        )
+
+    if tool_name in {"read_file", "write_file", "patch", "search_files"}:
+        for raw_path in _extract_tool_paths(tool_name, normalized_args):
+            if not _is_within_workspace(policy, raw_path):
+                return (
+                    f"Access denied: this user may only access files inside "
+                    f"{policy.workspace_dir}."
+                )
+
+    return None

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -663,6 +663,7 @@ def switch_model(
     from hermes_cli.models import (
         copilot_model_api_mode,
         detect_provider_for_model,
+        parse_model_input,
         validate_requested_model,
         opencode_model_api_mode,
     )
@@ -745,8 +746,30 @@ def switch_model(
     # PATH B: No explicit provider — resolve from model input
     # =================================================================
     else:
+        # --- Step 0: Parse provider:model input up front ---
+        #
+        # ``parse_model_input`` already knows which left-hand prefixes are
+        # real provider identifiers and when a colon should remain part of the
+        # model id (for example OpenRouter ``:free`` variants).  Running this
+        # first prevents session /model switches from accidentally persisting
+        # the entire raw string as the model name, e.g.:
+        #
+        #   /model custom:qwen3-14b-64k
+        #   /model openrouter:openrouter/free
+        #
+        # Without this pre-parse, the downstream path treated those as bare
+        # model ids on the current provider, which then stored
+        # ``custom:qwen3-14b-64k`` as the actual model name and later produced
+        # runtime 404s against Ollama / other custom endpoints.
+        parsed_provider, parsed_model = parse_model_input(raw_input, current_provider)
+        if parsed_provider != current_provider or parsed_model != raw_input.strip():
+            target_provider = parsed_provider
+            new_model = parsed_model
+
         # --- Step a: Try alias resolution on current provider ---
-        alias_result = resolve_alias(raw_input, current_provider)
+        alias_lookup = new_model if target_provider != current_provider else raw_input
+        alias_provider = target_provider
+        alias_result = resolve_alias(alias_lookup, alias_provider)
 
         if alias_result is not None:
             target_provider, new_model, resolved_alias = alias_result
@@ -756,14 +779,14 @@ def switch_model(
             )
         else:
             # --- Step b: Alias exists but not on current provider -> fallback ---
-            key = raw_input.strip().lower()
+            key = (alias_lookup or "").strip().lower()
             if key in MODEL_ALIASES:
                 authed = get_authenticated_provider_slugs(
                     current_provider=current_provider,
                     user_providers=user_providers,
                     custom_providers=custom_providers,
                 )
-                fallback_result = _resolve_alias_fallback(raw_input, authed)
+                fallback_result = _resolve_alias_fallback(alias_lookup, authed)
                 if fallback_result is not None:
                     target_provider, new_model, resolved_alias = fallback_result
                     logger.debug(
@@ -786,16 +809,17 @@ def switch_model(
                 # Only convert when there's no slash — a slash means the name
                 # is already in vendor/model format and the colon is a variant
                 # tag (:free, :extended, :fast) that must be preserved.
-                colon_pos = raw_input.find(":")
-                if colon_pos > 0 and "/" not in raw_input and is_aggregator(current_provider):
-                    left = raw_input[:colon_pos].strip().lower()
-                    right = raw_input[colon_pos + 1:].strip()
+                raw_for_conversion = alias_lookup
+                colon_pos = raw_for_conversion.find(":")
+                if colon_pos > 0 and "/" not in raw_for_conversion and is_aggregator(target_provider):
+                    left = raw_for_conversion[:colon_pos].strip().lower()
+                    right = raw_for_conversion[colon_pos + 1:].strip()
                     if left and right:
                         # Colons become slashes for aggregator slugs
                         new_model = f"{left}/{right}"
                         logger.debug(
                             "Converted vendor:model '%s' to aggregator slug '%s'",
-                            raw_input, new_model,
+                            raw_for_conversion, new_model,
                         )
 
         # --- Step d: Aggregator catalog search ---

--- a/model_tools.py
+++ b/model_tools.py
@@ -751,6 +751,20 @@ def handle_function_call(
             except Exception as _hook_err:
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 
+            if block_message is None:
+                try:
+                    from gateway.user_workspace_policy import (
+                        get_tool_block_message as _workspace_tool_block_message,
+                    )
+
+                    block_message = _workspace_tool_block_message(
+                        function_name,
+                        function_args if isinstance(function_args, dict) else {},
+                        task_id=task_id or "",
+                    )
+                except Exception as _policy_err:
+                    logger.debug("workspace policy check error: %s", _policy_err)
+
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2380,8 +2380,18 @@ class AIAgent:
             except Exception as _ce_err:
                 logger.debug("Context engine on_session_start: %s", _ce_err)
 
+        try:
+            from gateway.user_workspace_policy import resolve_task_cwd as _resolve_task_cwd
+
+            _subdir_working_dir = _resolve_task_cwd(
+                getattr(self, "_current_task_id", "") or "",
+                fallback=None,
+            )
+        except Exception:
+            _subdir_working_dir = os.getenv("TERMINAL_CWD") or None
+
         self._subdirectory_hints = SubdirectoryHintTracker(
-            working_dir=os.getenv("TERMINAL_CWD") or None,
+            working_dir=_subdir_working_dir,
         )
         self._user_turn_count = 0
 
@@ -5980,7 +5990,15 @@ class AIAgent:
             # mode).  The gateway process runs from the hermes-agent install
             # dir, so os.getcwd() would pick up the repo's AGENTS.md and
             # other dev files — inflating token usage by ~10k for no benefit.
-            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            try:
+                from gateway.user_workspace_policy import resolve_task_cwd as _resolve_task_cwd
+
+                _context_cwd = _resolve_task_cwd(
+                    getattr(self, "_current_task_id", "") or "",
+                    fallback=None,
+                )
+            except Exception:
+                _context_cwd = os.getenv("TERMINAL_CWD") or None
             context_files_prompt = build_context_files_prompt(
                 cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:
@@ -10527,6 +10545,19 @@ class AIAgent:
                 )
             except Exception:
                 pass
+            if block_message is None:
+                try:
+                    from gateway.user_workspace_policy import (
+                        get_tool_block_message as _workspace_tool_block_message,
+                    )
+
+                    block_message = _workspace_tool_block_message(
+                        function_name,
+                        function_args if isinstance(function_args, dict) else {},
+                        task_id=effective_task_id or "",
+                    )
+                except Exception:
+                    pass
         if block_message is not None:
             return json.dumps({"error": block_message}, ensure_ascii=False)
 
@@ -10674,7 +10705,15 @@ class AIAgent:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
-                        cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        try:
+                            from gateway.user_workspace_policy import resolve_task_cwd as _resolve_task_cwd
+
+                            cwd = function_args.get("workdir") or _resolve_task_cwd(
+                                effective_task_id or "",
+                                fallback=os.getcwd(),
+                            )
+                        except Exception:
+                            cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )
@@ -10690,6 +10729,19 @@ class AIAgent:
                 )
             except Exception:
                 block_message = None
+            if block_message is None:
+                try:
+                    from gateway.user_workspace_policy import (
+                        get_tool_block_message as _workspace_tool_block_message,
+                    )
+
+                    block_message = _workspace_tool_block_message(
+                        function_name,
+                        function_args if isinstance(function_args, dict) else {},
+                        task_id=effective_task_id or "",
+                    )
+                except Exception:
+                    pass
 
             if block_message is not None:
                 block_result = json.dumps({"error": block_message}, ensure_ascii=False)
@@ -11072,6 +11124,19 @@ class AIAgent:
                 )
             except Exception:
                 pass
+            if _block_msg is None:
+                try:
+                    from gateway.user_workspace_policy import (
+                        get_tool_block_message as _workspace_tool_block_message,
+                    )
+
+                    _block_msg = _workspace_tool_block_message(
+                        function_name,
+                        function_args if isinstance(function_args, dict) else {},
+                        task_id=effective_task_id or "",
+                    )
+                except Exception:
+                    pass
 
             _guardrail_block_decision: ToolGuardrailDecision | None = None
             if _block_msg is None:
@@ -11144,7 +11209,15 @@ class AIAgent:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
-                        cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        try:
+                            from gateway.user_workspace_policy import resolve_task_cwd as _resolve_task_cwd
+
+                            cwd = function_args.get("workdir") or _resolve_task_cwd(
+                                effective_task_id or "",
+                                fallback=os.getcwd(),
+                            )
+                        except Exception:
+                            cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )

--- a/scripts/bootstrap_vllm_qwen35_9b.sh
+++ b/scripts/bootstrap_vllm_qwen35_9b.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="/home/dachen/.hermes/hermes-agent"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+VLLM_VENV="${HERMES_VLLM_VENV:-$HERMES_HOME/vllm-venv}"
+BOOTSTRAP_LOG="${HERMES_VLLM_BOOTSTRAP_LOG:-$HERMES_HOME/logs/vllm-bootstrap.log}"
+
+mkdir -p "$(dirname "$BOOTSTRAP_LOG")"
+exec >>"$BOOTSTRAP_LOG" 2>&1
+
+echo "[$(date -Is)] bootstrap start"
+
+if [[ ! -f "$VLLM_VENV/bin/activate" ]]; then
+  python3.11 -m venv "$VLLM_VENV"
+fi
+
+source "$VLLM_VENV/bin/activate"
+
+python - <<'PY' >/dev/null 2>&1 || pip install -U pip setuptools wheel
+import vllm
+PY
+
+python - <<'PY' >/dev/null 2>&1 || pip install vllm --extra-index-url https://wheels.vllm.ai/nightly
+import vllm
+PY
+
+python - <<'PY' >/dev/null 2>&1 || pip install bitsandbytes huggingface_hub
+import bitsandbytes, huggingface_hub
+PY
+
+cd "$REPO_DIR"
+./scripts/start_vllm_qwen35_9b.sh || true
+
+echo "[$(date -Is)] waiting for vLLM health"
+for _ in $(seq 1 720); do
+  if curl -fsS http://127.0.0.1:8010/health >/dev/null 2>&1; then
+    echo "[$(date -Is)] vLLM health ok"
+    break
+  fi
+  sleep 10
+done
+
+if ! curl -fsS http://127.0.0.1:8010/health >/dev/null 2>&1; then
+  echo "[$(date -Is)] vLLM did not become healthy in time"
+  exit 1
+fi
+
+source "$REPO_DIR/venv/bin/activate"
+python - <<'PY'
+from pathlib import Path
+import yaml
+
+cfg_path = Path("/home/dachen/.hermes/config.yaml")
+cfg = yaml.safe_load(cfg_path.read_text()) or {}
+
+cfg.setdefault("model", {})
+cfg["model"]["provider"] = "vllm-local"
+cfg["model"]["default"] = "qwen3.5:9b"
+cfg["model"]["base_url"] = "http://127.0.0.1:8010/v1"
+cfg["model"]["api_mode"] = "chat_completions"
+cfg["model"]["context_length"] = 65536
+
+cfg.setdefault("auxiliary", {})
+cfg["auxiliary"].setdefault("compression", {})
+cfg["auxiliary"]["compression"]["provider"] = "vllm-local"
+cfg["auxiliary"]["compression"]["model"] = "qwen3.5:9b"
+cfg["auxiliary"]["compression"]["base_url"] = "http://127.0.0.1:8010/v1"
+cfg["auxiliary"]["compression"]["context_length"] = 65536
+
+cfg_path.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True))
+PY
+
+pkill -f "hermes gateway run" || true
+setsid bash -lc 'source /home/dachen/.hermes/hermes-agent/venv/bin/activate && hermes gateway run --replace >> /home/dachen/.hermes/logs/gateway.log 2>&1' >/dev/null 2>&1 < /dev/null &
+
+echo "[$(date -Is)] gateway restarted on vLLM default"

--- a/scripts/start_gateway_with_vllm.sh
+++ b/scripts/start_gateway_with_vllm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+GATEWAY_LOG="${HERMES_GATEWAY_LOG:-$HERMES_HOME/logs/gateway.log}"
+GATEWAY_PID_PATH="${HERMES_GATEWAY_PID:-$HERMES_HOME/gateway.pid}"
+
+mkdir -p "$(dirname "$GATEWAY_LOG")"
+
+"$ROOT_DIR/scripts/start_vllm_qwen35_9b.sh"
+
+if [[ -f "$GATEWAY_PID_PATH" ]]; then
+  if python - "$GATEWAY_PID_PATH" <<'PY'
+import json, os, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    data = json.loads(path.read_text())
+    pid = int(data.get("pid", 0) or 0)
+except Exception:
+    pid = 0
+
+if pid > 0:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        sys.exit(1)
+    print(f"Hermes gateway already running on PID {pid}")
+    sys.exit(0)
+
+sys.exit(1)
+PY
+  then
+    exit 0
+  else
+    rm -f "$GATEWAY_PID_PATH"
+  fi
+fi
+
+if [[ -f "$ROOT_DIR/venv/bin/activate" ]]; then
+  VENV_ACTIVATE="$ROOT_DIR/venv/bin/activate"
+elif [[ -f "$ROOT_DIR/.venv/bin/activate" ]]; then
+  VENV_ACTIVATE="$ROOT_DIR/.venv/bin/activate"
+else
+  echo "Missing Hermes virtualenv (.venv or venv)"
+  exit 1
+fi
+
+cmd=$(cat <<EOF
+cd "$ROOT_DIR"
+source "$VENV_ACTIVATE"
+exec hermes gateway run
+EOF
+)
+
+setsid bash -lc "$cmd" >>"$GATEWAY_LOG" 2>&1 < /dev/null &
+new_pid=$!
+
+echo "Started Hermes gateway bootstrap on PID $new_pid"
+echo "Gateway log: $GATEWAY_LOG"
+echo "vLLM and gateway startup requested together."

--- a/scripts/start_vllm_qwen35_9b.sh
+++ b/scripts/start_vllm_qwen35_9b.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+VENV_PATH="${HERMES_VLLM_VENV:-$HERMES_HOME/vllm-venv}"
+PORT="${HERMES_VLLM_PORT:-8010}"
+API_KEY="${HERMES_VLLM_API_KEY:-hermes-local}"
+MODEL_ID="${HERMES_VLLM_MODEL_ID:-Qwen/Qwen3.5-9B}"
+SERVED_MODEL="${HERMES_VLLM_SERVED_MODEL:-qwen3.5:9b}"
+LOG_PATH="${HERMES_VLLM_LOG:-$HERMES_HOME/logs/vllm-qwen35-9b.log}"
+PID_PATH="${HERMES_VLLM_PID:-$HERMES_HOME/vllm-qwen35-9b.pid}"
+
+mkdir -p "$(dirname "$LOG_PATH")"
+
+if [[ -f "$PID_PATH" ]]; then
+  old_pid="$(cat "$PID_PATH" 2>/dev/null || true)"
+  if [[ -n "${old_pid}" ]] && kill -0 "${old_pid}" 2>/dev/null; then
+    echo "vLLM already running on PID ${old_pid}"
+    exit 0
+  fi
+  rm -f "$PID_PATH"
+fi
+
+if [[ ! -f "$VENV_PATH/bin/activate" ]]; then
+  echo "Missing vLLM virtualenv: $VENV_PATH"
+  exit 1
+fi
+
+cmd=$(cat <<EOF
+source "$VENV_PATH/bin/activate"
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export CC=/usr/bin/gcc-12
+export CXX=/usr/bin/g++-12
+exec vllm serve "$MODEL_ID" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --api-key "$API_KEY" \
+  --served-model-name "$SERVED_MODEL" \
+  --language-model-only \
+  --max-model-len 65536 \
+  --gpu-memory-utilization 0.88 \
+  --max-num-seqs 2 \
+  --dtype bfloat16 \
+  --reasoning-parser qwen3 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --quantization bitsandbytes \
+  --load-format bitsandbytes
+EOF
+)
+
+setsid bash -lc "$cmd" >>"$LOG_PATH" 2>&1 < /dev/null &
+new_pid=$!
+echo "$new_pid" > "$PID_PATH"
+
+echo "Started vLLM on PID $new_pid"
+echo "Log: $LOG_PATH"

--- a/scripts/status_vllm_qwen35_9b.sh
+++ b/scripts/status_vllm_qwen35_9b.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+PORT="${HERMES_VLLM_PORT:-8010}"
+PID_PATH="${HERMES_VLLM_PID:-$HERMES_HOME/vllm-qwen35-9b.pid}"
+LOG_PATH="${HERMES_VLLM_LOG:-$HERMES_HOME/logs/vllm-qwen35-9b.log}"
+
+if [[ -f "$PID_PATH" ]]; then
+  pid="$(cat "$PID_PATH" 2>/dev/null || true)"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    echo "vLLM is running on PID ${pid}"
+  else
+    echo "vLLM pid file exists, but process is not alive"
+  fi
+else
+  echo "No vLLM pid file found"
+fi
+
+echo "Health check:"
+curl -fsS "http://127.0.0.1:${PORT}/health" || true
+echo
+echo "Models:"
+curl -fsS "http://127.0.0.1:${PORT}/v1/models" || true
+echo
+echo "Log tail:"
+tail -n 20 "$LOG_PATH" 2>/dev/null || true

--- a/scripts/stop_gateway_with_vllm.sh
+++ b/scripts/stop_gateway_with_vllm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATEWAY_PID_PATH="${HERMES_GATEWAY_PID:-$HOME/.hermes/gateway.pid}"
+
+python - "$GATEWAY_PID_PATH" <<'PY'
+import json, os, signal, sys, time
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if not path.exists():
+    print("No gateway pid file")
+    raise SystemExit(0)
+
+try:
+    data = json.loads(path.read_text())
+    pid = int(data.get("pid", 0) or 0)
+except Exception:
+    pid = 0
+
+if pid <= 0:
+    print("Gateway pid file invalid; removing stale file")
+    path.unlink(missing_ok=True)
+    raise SystemExit(0)
+
+try:
+    os.kill(pid, 0)
+except OSError:
+    print(f"Gateway process {pid} not running; removing stale pid file")
+    path.unlink(missing_ok=True)
+    raise SystemExit(0)
+
+print(f"Stopping gateway pid {pid}")
+os.kill(pid, signal.SIGTERM)
+for _ in range(20):
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        print("Gateway stopped")
+        path.unlink(missing_ok=True)
+        raise SystemExit(0)
+    time.sleep(0.5)
+
+print(f"Gateway pid {pid} still alive; sending SIGKILL")
+os.kill(pid, signal.SIGKILL)
+path.unlink(missing_ok=True)
+print("Gateway killed")
+PY
+
+"$ROOT_DIR/scripts/stop_vllm_qwen35_9b.sh"
+
+echo "vLLM and gateway shutdown requested together."

--- a/scripts/stop_vllm_qwen35_9b.sh
+++ b/scripts/stop_vllm_qwen35_9b.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+PID_PATH="${HERMES_VLLM_PID:-$HERMES_HOME/vllm-qwen35-9b.pid}"
+
+if [[ ! -f "$PID_PATH" ]]; then
+  echo "No pid file at $PID_PATH"
+  exit 0
+fi
+
+pid="$(cat "$PID_PATH" 2>/dev/null || true)"
+if [[ -z "$pid" ]]; then
+  rm -f "$PID_PATH"
+  echo "Pid file was empty; cleaned up."
+  exit 0
+fi
+
+if kill -0 "$pid" 2>/dev/null; then
+  kill "$pid"
+  echo "Stopped vLLM PID $pid"
+else
+  echo "Process $pid was not running"
+fi
+
+rm -f "$PID_PATH"

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,7 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".ics", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -67,6 +67,20 @@ class TestBasicDetection:
             assert len(paths) == 1, f"Failed for {ext}"
             assert paths[0] == f"/tmp/clip{ext}"
 
+    def test_document_extensions(self):
+        for ext in (".pdf", ".ics", ".docx", ".xlsx", ".pptx", ".txt", ".md", ".csv", ".json"):
+            text = f"Document at /tmp/report{ext} here"
+            paths, _ = _extract(text)
+            assert len(paths) == 1, f"Failed for {ext}"
+            assert paths[0] == f"/tmp/report{ext}"
+
+    def test_audio_extensions(self):
+        for ext in (".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"):
+            text = f"Audio at /tmp/speech{ext} here"
+            paths, _ = _extract(text)
+            assert len(paths) == 1, f"Failed for {ext}"
+            assert paths[0] == f"/tmp/speech{ext}"
+
     def test_image_extensions(self):
         for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp"):
             text = f"Image at /tmp/pic{ext} here"
@@ -268,10 +282,12 @@ class TestEdgeCases:
         assert paths == []
         assert cleaned == ""
 
-    def test_no_media_extensions(self):
-        """Non-media extensions should not be matched."""
-        paths, _ = _extract("See /tmp/data.csv and /tmp/script.py and /tmp/notes.txt")
+    def test_unsupported_extensions_not_matched(self):
+        """Extensions outside the delivery allowlist should not be matched."""
+        paths, cleaned = _extract("See /tmp/script.py and /tmp/archive.tar.gz")
         assert paths == []
+        assert "/tmp/script.py" in cleaned
+        assert "/tmp/archive.tar.gz" in cleaned
 
     def test_path_with_spaces_not_matched(self):
         """Paths with spaces are intentionally not matched (avoids false positives)."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,12 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_calendar_files(self):
+        content = "MEDIA:/tmp/invites/team-sync.ics"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/invites/team-sync.ics", False)]
+        assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the
@@ -728,4 +734,3 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
-

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -221,7 +221,7 @@ async def test_streaming_delivery_routes_bare_pdf_path_to_document_sender(monkey
     monkeypatch.setattr("os.path.isfile", lambda p: p == "/tmp/report.pdf")
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _fake_runner({"thread_id": "topic-1"}),
         "Finished. File saved to /tmp/report.pdf",
         event,
         adapter,
@@ -251,7 +251,7 @@ async def test_streaming_delivery_routes_bare_ics_path_to_document_sender(monkey
     monkeypatch.setattr("os.path.isfile", lambda p: p == "/tmp/team-sync.ics")
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _fake_runner({"thread_id": "topic-1"}),
         "Calendar ready at /tmp/team-sync.ics",
         event,
         adapter,

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -203,3 +203,63 @@ async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(
         metadata={"thread_id": "topic-1"},
     )
     adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_routes_bare_pdf_path_to_document_sender(monkeypatch):
+    event = _event(thread_id="topic-1")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+    monkeypatch.setattr("os.path.isfile", lambda p: p == "/tmp/report.pdf")
+
+    await GatewayRunner._deliver_media_from_response(
+        object(),
+        "Finished. File saved to /tmp/report.pdf",
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path="/tmp/report.pdf",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_voice.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_delivery_routes_bare_ics_path_to_document_sender(monkeypatch):
+    event = _event(thread_id="topic-1")
+    adapter = SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+    )
+    monkeypatch.setattr("os.path.isfile", lambda p: p == "/tmp/team-sync.ics")
+
+    await GatewayRunner._deliver_media_from_response(
+        object(),
+        "Calendar ready at /tmp/team-sync.ics",
+        event,
+        adapter,
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path="/tmp/team-sync.ics",
+        metadata={"thread_id": "topic-1"},
+    )
+    adapter.send_voice.assert_not_awaited()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -18,6 +18,79 @@ _MOCK_VALIDATION = {
 }
 
 
+def test_switch_model_parses_custom_prefix_as_provider(monkeypatch):
+    """Typed `/model custom:<model>` should switch the model on the existing
+    custom endpoint instead of persisting the full prefixed string as the model.
+
+    Regression: gateway session overrides were storing ``custom:qwen...`` as
+    the actual model name, which later caused Ollama 404s because the endpoint
+    only knows ``qwen...``.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "custom",
+            "api_key": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="custom:qwen3-14b-64k",
+        current_provider="custom",
+        current_model="llama3.2:latest",
+        current_base_url="http://127.0.0.1:11434/v1",
+        current_api_key="ollama",
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom"
+    assert result.new_model == "qwen3-14b-64k"
+    assert result.base_url == "http://127.0.0.1:11434/v1"
+
+
+def test_switch_model_parses_named_provider_prefix_for_openrouter(monkeypatch):
+    """Typed `/model openrouter:openrouter/free` should switch providers even
+    when the current session is on a custom/Ollama endpoint.
+
+    Regression: the full string was validated against the current custom
+    endpoint instead of resolving OpenRouter credentials first.
+    """
+    calls = []
+
+    def _fake_runtime(*, requested, target_model):
+        calls.append((requested, target_model))
+        return {
+            "provider": "openrouter",
+            "api_key": "sk-or-test",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _fake_runtime)
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="openrouter:openrouter/free",
+        current_provider="custom",
+        current_model="llama3.2:latest",
+        current_base_url="http://127.0.0.1:11434/v1",
+        current_api_key="ollama",
+    )
+
+    assert result.success is True
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "openrouter/free"
+    assert result.base_url == "https://openrouter.ai/api/v1"
+    assert calls == [("openrouter", "openrouter/free")]
+
+
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     """No-args /model menus should include saved custom_providers entries."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -113,6 +113,16 @@ def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     except Exception:
         pass
 
+    try:
+        from tools.terminal_tool import _task_env_overrides
+
+        override = _task_env_overrides.get(container_key, {}) or _task_env_overrides.get(task_id, {})
+        override_cwd = override.get("cwd")
+        if isinstance(override_cwd, str) and override_cwd:
+            return override_cwd
+    except Exception:
+        pass
+
     return None
 
 


### PR DESCRIPTION
## What changed

This PR bundles four related commits:

- add per-user gateway workspace restrictions and task-scoped workspace cwd resolution
- extend gateway local file/media detection for additional document and audio types, including `.ics`
- fix `/model` parsing for `provider:model` inputs on custom and OpenRouter-backed sessions
- add local vLLM helper scripts plus a Discord gateway quickstart note
- adjust the new media-routing tests so they use the current `GatewayRunner` helper contract on `main`

## Why

There were three separate issues in the current workflow:

- restricted gateway users needed a safe way to stay inside dedicated workspaces instead of inheriting host cwd access
- bare local file paths such as PDFs and calendar files were not consistently routed through document delivery
- `/model custom:...` and similar prefixed inputs could be persisted as the literal model name on custom endpoints, which later caused runtime lookup failures

The helper scripts and quickstart doc make the local vLLM + Discord gateway setup repeatable for daily use.

## Impact

- gateway sessions can now enforce per-user workspace confinement and optional terminal / execute-code restrictions
- gateway responses can deliver more local files directly as media/documents
- session model switching is more reliable for custom providers and OpenRouter-style prefixed model inputs
- local ops around vLLM-backed gateway usage are easier to start, inspect, and stop

## Validation

- `bash -n scripts/bootstrap_vllm_qwen35_9b.sh scripts/start_gateway_with_vllm.sh scripts/start_vllm_qwen35_9b.sh scripts/status_vllm_qwen35_9b.sh scripts/stop_gateway_with_vllm.sh scripts/stop_vllm_qwen35_9b.sh`
- `source venv/bin/activate && pytest -q tests/hermes_cli/test_model_switch_custom_providers.py tests/gateway/test_document_cache.py tests/gateway/test_extract_local_files.py tests/gateway/test_platform_base.py tests/gateway/test_tts_media_routing.py`
