### PR TITLE
feat: add context compression hooks

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -136,6 +136,13 @@ VALID_HOOKS: Set[str] = {
     "transform_llm_output",
     "pre_llm_call",
     "post_llm_call",
+    # Fired immediately before context compression mutates/discards older
+    # messages.  Shell hooks can use this to run durable handoff/recap
+    # automation before the transcript is compacted.
+    "pre_context_compress",
+    # Fired after a compression pass completes and the continuation session id
+    # has been created (when applicable).  Observer hook; return values ignored.
+    "post_context_compress",
     "pre_api_request",
     "post_api_request",
     "on_session_start",

--- a/run_agent.py
+++ b/run_agent.py
@@ -10269,6 +10269,34 @@ class AIAgent:
             focus_topic,
         )
 
+        # Plugin/shell hook: pre_context_compress
+        # Fired before compression mutates/discards older messages. This gives
+        # operators a deterministic place to run durable handoff/recap scripts
+        # (for example Richard's /chores backstop) before compaction rotates the
+        # session. Return values are intentionally ignored; hook failures must
+        # not block compression or strand the agent over context.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            try:
+                from hermes_cli.profiles import get_active_profile_name as _get_active_profile_name
+                _active_profile = _get_active_profile_name() or ""
+            except Exception:
+                _active_profile = os.environ.get("HERMES_PROFILE") or ""
+            _invoke_hook(
+                "pre_context_compress",
+                session_id=self.session_id,
+                message_count=_pre_msg_count,
+                approx_tokens=approx_tokens,
+                model=self.model,
+                platform=getattr(self, "platform", None) or "",
+                profile=_active_profile,
+                task_id=task_id,
+                focus_topic=focus_topic or "",
+                cwd=str(Path.cwd()),
+            )
+        except Exception as exc:
+            logger.warning("pre_context_compress hook failed: %s", exc)
+
         # Notify external memory provider before compression discards context
         if self._memory_manager:
             try:
@@ -10388,6 +10416,33 @@ class AIAgent:
                 )
         except Exception as _me_err:
             logger.debug("memory manager on_session_switch (compression): %s", _me_err)
+
+        # Plugin/shell hook: post_context_compress
+        # Fired after the continuation session has been established, so hooks
+        # can record the parent/child session mapping. Observer-only.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            try:
+                from hermes_cli.profiles import get_active_profile_name as _get_active_profile_name
+                _active_profile = _get_active_profile_name() or ""
+            except Exception:
+                _active_profile = os.environ.get("HERMES_PROFILE") or ""
+            _invoke_hook(
+                "post_context_compress",
+                session_id=self.session_id,
+                parent_session_id=locals().get("old_session_id") or "",
+                original_message_count=_pre_msg_count,
+                compressed_message_count=len(compressed),
+                approx_tokens=approx_tokens,
+                model=self.model,
+                platform=getattr(self, "platform", None) or "",
+                profile=_active_profile,
+                task_id=task_id,
+                focus_topic=focus_topic or "",
+                cwd=str(Path.cwd()),
+            )
+        except Exception as exc:
+            logger.warning("post_context_compress hook failed: %s", exc)
 
         # Warn on repeated compressions (quality degrades with each pass)
         _cc = self.context_compressor.compression_count

--- a/tests/agent/test_shell_hooks_consent.py
+++ b/tests/agent/test_shell_hooks_consent.py
@@ -311,3 +311,34 @@ class TestHooksAutoAcceptParsing:
             {"hooks_auto_accept": "false"}, accept_hooks_arg=True,
         ) is True
 
+
+# ── Context-compression hook events ───────────────────────────────────────
+
+
+def test_context_compression_hook_events_are_valid(tmp_path):
+    """Regression guard for /chores-style compaction backstops.
+
+    Users can configure shell hooks for these events only if they are in
+    VALID_HOOKS; otherwise the config parser skips them as unknown.
+    """
+    from hermes_cli import plugins
+
+    script = _write_hook_script(tmp_path)
+    plugins._plugin_manager = plugins.PluginManager()
+
+    registered = shell_hooks.register_from_config(
+        {
+            "hooks_auto_accept": True,
+            "hooks": {
+                "pre_context_compress": [{"command": str(script)}],
+                "post_context_compress": [{"command": str(script)}],
+            },
+        },
+        accept_hooks=False,
+    )
+
+    assert {spec.event for spec in registered} == {
+        "pre_context_compress",
+        "post_context_compress",
+    }
+

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -377,6 +377,8 @@ def register(ctx):
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
+| [`pre_context_compress`](#pre_context_compress) | Immediately before context compression mutates/discards older messages | ignored |
+| [`post_context_compress`](#post_context_compress) | After context compression completes and the continuation session is established | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
 | [`on_session_finalize`](#on_session_finalize) | CLI/gateway tears down an active session (flush, save, stats) | ignored |
@@ -643,6 +645,43 @@ def log_response_length(session_id, assistant_response, model, **kwargs):
 def register(ctx):
     ctx.register_hook("post_llm_call", log_response_length)
 ```
+
+---
+
+### `pre_context_compress`
+
+Fires **immediately before** Hermes runs context compression and may summarize/discard older messages. This is the right hook for durable handoff/recap automation that must happen before compaction.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, message_count: int, approx_tokens: int | None,
+                model: str, platform: str, task_id: str, focus_topic: str,
+                cwd: str, **kwargs):
+```
+
+**Return value:** Ignored.
+
+**Use cases:** Handoff/recap backstops, pre-compaction audit logs, session lineage diagnostics.
+
+---
+
+### `post_context_compress`
+
+Fires **after** context compression completes and after the continuation session id has been established when session storage is available.
+
+**Callback signature:**
+
+```python
+def my_callback(session_id: str, parent_session_id: str,
+                original_message_count: int, compressed_message_count: int,
+                approx_tokens: int | None, model: str, platform: str,
+                task_id: str, focus_topic: str, cwd: str, **kwargs):
+```
+
+**Return value:** Ignored.
+
+**Use cases:** Recording parent/child session mappings after compression, post-compaction audit logs, cleanup of temporary pre-compaction artifacts.
 
 ---
 


### PR DESCRIPTION
## Summary
- add pre_context_compress and post_context_compress hook events
- fire observer hooks around context compression for durable recap/handoff automation
- include profile in hook payloads for profile-scoped automation
- document the new hooks and add regression coverage

## Test plan
- python -m pytest tests/agent/test_shell_hooks_consent.py -q -o 'addopts='
- git diff --check
- git show --check --oneline --stat HEAD
- python -m py_compile run_agent.py hermes_cli/plugins.py