### PR TITLE
fix(gateway): make Feishu ws connect override sync to preserve context manager protocol

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1300,12 +1300,12 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    async def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
         if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
+        return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:


### PR DESCRIPTION
## Problem

When the Feishu WebSocket client is running, `_run_official_feishu_ws_client` patches `ws_client_module.websockets.connect` with `_connect_with_overrides`. Because `ws_client_module.websockets` is the actual `websockets` module singleton, this patch affects **all consumers** of `websockets.connect` for the entire lifetime of the Feishu WS thread.

`_connect_with_overrides` was an `async def` coroutine function. The DingTalk Stream SDK connects with:

```python
async with websockets.connect(uri, ...)  # dingtalk_stream/stream.py:74
```

`websockets.connect` normally returns a `Connect` object that supports both `await` and `async with`. Replacing it with a coroutine function broke the `async with` path, raising:

```
TypeError: 'coroutine' object does not support the asynchronous context manager protocol
```

DingTalk would then retry every 3 seconds, looping indefinitely, while appearing completely unresponsive to the user. The `finally` block does restore the original after `ws_client.start()` returns, but Feishu's client runs indefinitely, so the patch is active the whole time both platforms are online.

## Fix

Change `_connect_with_overrides` from `async def` to a regular `def` that forwards to `original_connect` and returns its result directly (no `await`). The return value is the real `Connect` context manager, so both `await` and `async with` callers continue to work correctly.

```python
# Before
async def _connect_with_overrides(*args, **kwargs):
    ...
    return await original_connect(*args, **kwargs)

# After
def _connect_with_overrides(*args, **kwargs):
    ...
    return original_connect(*args, **kwargs)
```

## Testing

Reproduced by running Feishu + DingTalk gateways simultaneously and observing the `TypeError` in logs. After this fix, both platforms connect and receive messages without interference.