### PR TITLE
feat(dashboard): add Setup Codex configuration guide

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -116,6 +116,7 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/config/defaults",
     "/api/config/schema",
     "/api/model/info",
+    "/api/setup-codex/state",
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
@@ -874,6 +875,216 @@ async def get_defaults():
 @app.get("/api/config/schema")
 async def get_schema():
     return {"fields": CONFIG_SCHEMA, "category_order": _CATEGORY_ORDER}
+
+
+_SETUP_CODEX_PLATFORMS: Tuple[str, ...] = ("telegram", "feishu", "api_server", "discord", "slack")
+_SETUP_CODEX_PLATFORM_ENV_KEYS: Dict[str, Tuple[str, ...]] = {
+    "telegram": ("TELEGRAM_BOT_TOKEN",),
+    "feishu": ("FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_APP_TOKEN", "LARK_APP_ID", "LARK_APP_SECRET"),
+    "api_server": ("HERMES_API_KEY",),
+    "discord": ("DISCORD_BOT_TOKEN",),
+    "slack": ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"),
+}
+_SETUP_CODEX_SECRET_KEY_PARTS: Tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "cookie",
+    "credential",
+    "private_key",
+    "connection_string",
+    "dsn",
+)
+
+
+def _setup_codex_str(value: Any) -> str:
+    return str(value or "")
+
+
+def _setup_codex_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() not in {"", "0", "false", "no", "off", "none"}
+    return bool(value)
+
+
+def _setup_codex_list(value: Any) -> List[str]:
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value if isinstance(v, (str, int, float, bool))]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def _setup_codex_is_secret_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in _SETUP_CODEX_SECRET_KEY_PARTS)
+
+
+def _setup_codex_has_secret_value(mapping: Any) -> bool:
+    if not isinstance(mapping, dict):
+        return False
+    for key, value in mapping.items():
+        if _setup_codex_is_secret_key(str(key)) and _setup_codex_bool(value):
+            return True
+    return False
+
+
+def _setup_codex_model_summary(config: Dict[str, Any]) -> Dict[str, Any]:
+    model_cfg = config.get("model", "")
+    if isinstance(model_cfg, dict):
+        model_name = _setup_codex_str(model_cfg.get("default", model_cfg.get("name", "")))
+        provider = _setup_codex_str(model_cfg.get("provider", ""))
+        base_url_configured = _setup_codex_bool(model_cfg.get("base_url"))
+        api_key_configured = _setup_codex_bool(model_cfg.get("api_key"))
+        context_length_configured = isinstance(model_cfg.get("context_length"), int) and model_cfg.get("context_length", 0) > 0
+    else:
+        model_name = _setup_codex_str(model_cfg)
+        provider = ""
+        base_url_configured = False
+        api_key_configured = False
+        context_length_configured = False
+    return {
+        "provider": provider,
+        "model": model_name,
+        "base_url_configured": base_url_configured,
+        "api_key_configured": api_key_configured,
+        "context_length_configured": context_length_configured,
+    }
+
+
+def _setup_codex_platform_summary(
+    platform: str,
+    config: Dict[str, Any],
+    env_on_disk: Dict[str, str],
+    runtime_platforms: Dict[str, Any],
+) -> Dict[str, Any]:
+    platforms_cfg = config.get("platforms") if isinstance(config.get("platforms"), dict) else {}
+    platform_cfg = platforms_cfg.get(platform) if isinstance(platforms_cfg.get(platform), dict) else {}
+    env_keys = _SETUP_CODEX_PLATFORM_ENV_KEYS.get(platform, ())
+    env_configured = any(_setup_codex_bool(env_on_disk.get(key)) for key in env_keys)
+    config_credential_configured = _setup_codex_has_secret_value(platform_cfg)
+    explicit_enabled = platform_cfg.get("enabled") if isinstance(platform_cfg, dict) else None
+    runtime = runtime_platforms.get(platform) if isinstance(runtime_platforms.get(platform), dict) else {}
+    runtime_state = _setup_codex_str(runtime.get("state")) if runtime else ""
+    return {
+        "configured": _setup_codex_bool(explicit_enabled) or env_configured or config_credential_configured or bool(runtime_state),
+        "enabled": _setup_codex_bool(explicit_enabled),
+        "credential_configured": env_configured or config_credential_configured,
+        "env_credentials_configured": env_configured,
+        "config_credentials_configured": config_credential_configured,
+        "runtime_state": runtime_state,
+    }
+
+
+def _setup_codex_toolsets_summary(config: Dict[str, Any]) -> Dict[str, Any]:
+    platform_toolsets_cfg = config.get("platform_toolsets") if isinstance(config.get("platform_toolsets"), dict) else {}
+    platform_toolsets = {
+        str(platform): _setup_codex_list(toolsets)
+        for platform, toolsets in platform_toolsets_cfg.items()
+        if isinstance(platform, str)
+    }
+    agent_cfg = config.get("agent") if isinstance(config.get("agent"), dict) else {}
+    disabled_toolsets = _setup_codex_list(agent_cfg.get("disabled_toolsets"))
+    enabled_toolsets = _setup_codex_list(agent_cfg.get("enabled_toolsets"))
+    custom_toolsets_cfg = config.get("custom_toolsets")
+    custom_toolsets: List[str] = []
+    if isinstance(custom_toolsets_cfg, dict):
+        custom_toolsets = [str(k) for k in custom_toolsets_cfg.keys()]
+    elif isinstance(custom_toolsets_cfg, list):
+        custom_toolsets = [str(item.get("name")) for item in custom_toolsets_cfg if isinstance(item, dict) and item.get("name")]
+    return {
+        "enabled_toolsets": enabled_toolsets,
+        "disabled_toolsets": disabled_toolsets,
+        "platform_toolsets": platform_toolsets,
+        "custom_toolsets": custom_toolsets,
+    }
+
+
+def _setup_codex_delegation_summary(config: Dict[str, Any]) -> Dict[str, Any]:
+    delegation = config.get("delegation") if isinstance(config.get("delegation"), dict) else {}
+    return {
+        "configured": bool(delegation),
+        "model_override_configured": _setup_codex_bool(delegation.get("model")),
+        "provider_override_configured": _setup_codex_bool(delegation.get("provider")),
+        "max_concurrent_children": delegation.get("max_concurrent_children"),
+        "max_spawn_depth": delegation.get("max_spawn_depth"),
+        "orchestrator_enabled": _setup_codex_bool(delegation.get("orchestrator_enabled")),
+    }
+
+
+@app.get("/api/setup-codex/state")
+def get_setup_codex_state():
+    """Read-only, secret-safe state for the Setup Codex dashboard guide.
+
+    This endpoint intentionally returns configuration *presence* and status
+    only. It must never return API keys, tokens, OAuth values, passwords,
+    private keys, or connection strings.
+    """
+    try:
+        config = load_config()
+        env_on_disk = load_env()
+        runtime = read_runtime_status() or {}
+        runtime_platforms = runtime.get("platforms") if isinstance(runtime.get("platforms"), dict) else {}
+        gateway_pid = get_running_pid()
+        gateway_running = gateway_pid is not None
+        gateway_state = runtime.get("gateway_state")
+        if gateway_running and not gateway_state:
+            gateway_state = "running"
+
+        env_secret_keys = [
+            key for key, value in env_on_disk.items()
+            if _setup_codex_is_secret_key(key) and _setup_codex_bool(value)
+        ]
+
+        return {
+            "read_only": True,
+            "title": "Hermes配置宝典",
+            "route": "/setup-codex",
+            "paths": {
+                "hermes_home": str(get_hermes_home()),
+                "config_path": str(get_config_path()),
+                "env_path": str(get_env_path()),
+            },
+            "model": _setup_codex_model_summary(config),
+            "delegation": _setup_codex_delegation_summary(config),
+            "gateway": {
+                "running": gateway_running,
+                "pid": gateway_pid,
+                "state": gateway_state,
+                "updated_at": runtime.get("updated_at"),
+                "platforms": {
+                    str(name): {"state": _setup_codex_str(value.get("state"))}
+                    for name, value in runtime_platforms.items()
+                    if isinstance(name, str) and isinstance(value, dict)
+                },
+            },
+            "platforms": {
+                platform: _setup_codex_platform_summary(platform, config, env_on_disk, runtime_platforms)
+                for platform in _SETUP_CODEX_PLATFORMS
+            },
+            "toolsets": _setup_codex_toolsets_summary(config),
+            "secrets": {
+                "env_secret_keys_configured_count": len(env_secret_keys),
+                "env_secret_key_names": sorted(env_secret_keys),
+                "values_redacted": True,
+            },
+            "safety": {
+                "can_write_config": False,
+                "can_write_env": False,
+                "can_execute_commands": False,
+                "can_restart_gateway": False,
+                "requires_manual_copy": True,
+            },
+        }
+    except Exception:
+        _log.exception("GET /api/setup-codex/state failed")
+        raise HTTPException(status_code=500, detail="Failed to build setup codex state")
 
 
 _EMPTY_MODEL_INFO: dict = {

--- a/scripts/setup_codex_launcher.py
+++ b/scripts/setup_codex_launcher.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Windows-friendly prototype launcher for Hermes配置宝典 / Setup Codex.
+
+Intended PyInstaller name: Hermes配置宝典.exe
+
+The launcher is deliberately conservative:
+- binds the dashboard to 127.0.0.1 by default;
+- never passes --host 0.0.0.0 or --insecure;
+- only starts `hermes dashboard` when /api/status is not already reachable;
+- opens /setup-codex in the user's browser after the dashboard responds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+from dataclasses import dataclass
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 9119
+STATUS_PATH = "/api/status"
+SETUP_CODEX_PATH = "/setup-codex"
+
+
+@dataclass
+class ProbeResult:
+    ok: bool
+    detail: str
+
+
+def _url(host: str, port: int, path: str) -> str:
+    return f"http://{host}:{port}{path}"
+
+
+def probe_dashboard(host: str, port: int, timeout: float = 1.5) -> ProbeResult:
+    try:
+        with urllib.request.urlopen(_url(host, port, STATUS_PATH), timeout=timeout) as response:
+            body = response.read(1024).decode("utf-8", errors="replace")
+            if response.status == 200:
+                try:
+                    data = json.loads(body or "{}")
+                    return ProbeResult(True, str(data.get("status") or "running"))
+                except json.JSONDecodeError:
+                    return ProbeResult(True, "running")
+            return ProbeResult(False, f"HTTP {response.status}")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return ProbeResult(False, str(exc))
+
+
+def start_dashboard(host: str, port: int) -> subprocess.Popen:
+    hermes = shutil.which("hermes")
+    if not hermes:
+        raise RuntimeError(
+            "Hermes CLI was not found on PATH. Install Hermes or open a shell where `hermes --version` works."
+        )
+    cmd = [hermes, "dashboard", "--host", host, "--port", str(port)]
+    creationflags = 0
+    if sys.platform.startswith("win"):
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, creationflags=creationflags)
+
+
+def wait_until_ready(host: str, port: int, seconds: float) -> ProbeResult:
+    deadline = time.monotonic() + seconds
+    last = ProbeResult(False, "not checked")
+    while time.monotonic() < deadline:
+        last = probe_dashboard(host, port, timeout=1.0)
+        if last.ok:
+            return last
+        time.sleep(0.4)
+    return last
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Open Hermes配置宝典 / Setup Codex safely")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Dashboard host; default is 127.0.0.1")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Dashboard port; default is 9119")
+    parser.add_argument("--wait", type=float, default=20.0, help="Seconds to wait for dashboard startup")
+    parser.add_argument("--no-open", action="store_true", help="Start/probe only; do not open a browser")
+    args = parser.parse_args(argv)
+
+    if args.host != DEFAULT_HOST:
+        print("Refusing non-localhost host. Setup Codex launcher only binds to 127.0.0.1 by default.", file=sys.stderr)
+        return 2
+
+    probe = probe_dashboard(args.host, args.port)
+    if not probe.ok:
+        print(f"Dashboard not reachable yet ({probe.detail}); starting Hermes dashboard...")
+        try:
+            start_dashboard(args.host, args.port)
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        probe = wait_until_ready(args.host, args.port, args.wait)
+
+    if not probe.ok:
+        print(
+            "Hermes dashboard did not become ready. Try manually: "
+            f"hermes dashboard --host {DEFAULT_HOST} --port {args.port}",
+            file=sys.stderr,
+        )
+        return 1
+
+    target = _url(args.host, args.port, SETUP_CODEX_PATH)
+    print(f"Opening {target}")
+    if not args.no_open:
+        webbrowser.open(target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_setup_codex_launcher.py
+++ b/tests/hermes_cli/test_setup_codex_launcher.py
@@ -1,0 +1,40 @@
+"""Tests for the Setup Codex Windows launcher prototype."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "setup_codex_launcher.py"
+
+
+def load_launcher():
+    spec = importlib.util.spec_from_file_location("setup_codex_launcher", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["setup_codex_launcher"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launcher_refuses_non_localhost_host(capsys):
+    launcher = load_launcher()
+
+    rc = launcher.main(["--host", "0.0.0.0", "--no-open"])
+
+    assert rc == 2
+    assert "Refusing non-localhost" in capsys.readouterr().err
+
+
+def test_launcher_opens_setup_codex_when_dashboard_already_running(monkeypatch):
+    launcher = load_launcher()
+    opened = []
+
+    monkeypatch.setattr(launcher, "probe_dashboard", lambda host, port: launcher.ProbeResult(True, "running"))
+    monkeypatch.setattr(launcher, "start_dashboard", lambda host, port: (_ for _ in ()).throw(AssertionError("should not start")))
+    monkeypatch.setattr(launcher.webbrowser, "open", lambda url: opened.append(url))
+
+    rc = launcher.main([])
+
+    assert rc == 0
+    assert opened == ["http://127.0.0.1:9119/setup-codex"]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -218,6 +218,131 @@ class TestWebServerEndpoints:
         # Should contain known env var names
         assert any(k.endswith("_API_KEY") or k.endswith("_TOKEN") for k in data.keys())
 
+    def test_setup_codex_state_is_read_only_and_sanitized(self, monkeypatch):
+        """GET /api/setup-codex/state returns guide-ready state without secret values."""
+        import hermes_cli.web_server as web_server
+
+        config_secret = "sk-" + "test-config-secret-should-not-leak"
+        env_secret = "telegram-secret-should-not-leak"
+        monkeypatch.setattr(
+            web_server,
+            "load_config",
+            lambda: {
+                "model": {
+                    "provider": "openai-codex",
+                    "default": "gpt-5.5",
+                    "api_key": config_secret,
+                    "base_url": "https://api.example.test/v1",
+                },
+                "delegation": {"max_spawn_depth": 1, "max_concurrent_children": 3},
+                "platforms": {
+                    "telegram": {"enabled": True, "token": "telegram-config-secret"},
+                    "feishu": {"enabled": False, "app_secret": "feishu-config-secret"},
+                },
+                "platform_toolsets": {
+                    "telegram": ["safe", "skills"],
+                    "feishu": ["safe"],
+                },
+                "agent": {"disabled_toolsets": ["terminal"]},
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "load_env",
+            lambda: {
+                "TELEGRAM_BOT_TOKEN": env_secret,
+                "FEISHU_APP_SECRET": "feishu-env-secret-should-not-leak",
+            },
+        )
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: 4242)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "platforms": {"telegram": {"state": "connected"}},
+            },
+        )
+
+        resp = self.client.get("/api/setup-codex/state")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["read_only"] is True
+        assert data["model"] == {
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "base_url_configured": True,
+            "api_key_configured": True,
+            "context_length_configured": False,
+        }
+        assert data["platforms"]["telegram"]["configured"] is True
+        assert data["platforms"]["telegram"]["credential_configured"] is True
+        assert data["platforms"]["telegram"]["runtime_state"] == "connected"
+        assert data["toolsets"]["platform_toolsets"]["telegram"] == ["safe", "skills"]
+        assert data["toolsets"]["disabled_toolsets"] == ["terminal"]
+        assert data["gateway"]["running"] is True
+
+        dumped = json.dumps(data, ensure_ascii=False)
+        assert config_secret not in dumped
+        assert env_secret not in dumped
+        assert "telegram-config-secret" not in dumped
+        assert "feishu-config-secret" not in dumped
+        assert "feishu-env-secret-should-not-leak" not in dumped
+
+    def test_setup_codex_state_is_publicly_safe_without_session_token(self, monkeypatch):
+        """The read-only guide state is safe for the SPA bootstrap allowlist."""
+        from starlette.testclient import TestClient
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "load_config", lambda: {"model": "anthropic/claude"})
+        monkeypatch.setattr(web_server, "load_env", lambda: {"OPENAI_API_KEY": "secret-should-not-leak"})
+
+        resp = TestClient(web_server.app).get("/api/setup-codex/state")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"]["model"] == "anthropic/claude"
+        assert "secret-should-not-leak" not in json.dumps(data)
+
+    def test_setup_codex_state_never_emits_common_secret_shapes(self, monkeypatch):
+        """Setup Codex exposes presence and key names, never secret-looking values."""
+        import hermes_cli.web_server as web_server
+
+        raw_values = {
+            "OPENAI_API_KEY": "sk-" + "unit-test-value-that-must-not-leak",
+            "GITHUB_TOKEN": "ghp_" + "unitTestValueThatMustNotLeak",
+            "GITHUB_FINE_GRAINED_PAT": "github" + "_pat_" + "unitTestValueThatMustNotLeak",
+            "TELEGRAM_BOT_TOKEN": "1234567890:unit-test-bot-token-must-not-leak",
+            "OAUTH_REFRESH_TOKEN": "refresh-token-value-must-not-leak",
+            "DATABASE_URL": "postgres://user:password@db.example.test:5432/hermes",
+            "SSH_PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----\\nunit-test-key\\n-----END PRIVATE KEY-----",
+        }
+        monkeypatch.setattr(
+            web_server,
+            "load_config",
+            lambda: {
+                "model": {"provider": "openrouter", "default": "anthropic/claude", "api_key": raw_values["OPENAI_API_KEY"]},
+                "platforms": {"telegram": {"enabled": True, "token": raw_values["TELEGRAM_BOT_TOKEN"]}},
+            },
+        )
+        monkeypatch.setattr(web_server, "load_env", lambda: raw_values)
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: None)
+        monkeypatch.setattr(web_server, "read_runtime_status", lambda: {})
+
+        resp = self.client.get("/api/setup-codex/state")
+
+        assert resp.status_code == 200
+        dumped = json.dumps(resp.json(), ensure_ascii=False)
+        for value in raw_values.values():
+            assert value not in dumped
+        assert "sk-unit-test" not in dumped
+        assert "ghp_unitTest" not in dumped
+        assert "github_pat_unitTest" not in dumped
+        assert "-----BEGIN " + "PRIVATE KEY-----" not in dumped
+        assert "postgres://user:" + "password@" not in dumped
+        assert resp.json()["secrets"]["values_redacted"] is True
+
     def test_reveal_env_var(self, tmp_path):
         """POST /api/env/reveal should return the real unredacted value."""
         from hermes_cli.config import save_env_value

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,7 @@ import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
 import ProfilesPage from "@/pages/ProfilesPage";
+import SetupCodexPage from "@/pages/SetupCodexPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
@@ -114,6 +115,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
   "/profiles": ProfilesPage,
+  "/setup-codex": SetupCodexPage,
   "/config": ConfigPage,
   "/env": EnvPage,
   "/docs": DocsPage,
@@ -151,6 +153,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/profiles", labelKey: "profiles", label: "Profiles", icon: Users },
+  { path: "/setup-codex", label: "配置宝典", icon: Sparkles },
   { path: "/config", labelKey: "config", label: "Config", icon: Settings },
   { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
   {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -91,6 +91,7 @@ export const api = {
   getDefaults: () => fetchJSON<Record<string, unknown>>("/api/config/defaults"),
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
   getModelInfo: () => fetchJSON<ModelInfoResponse>("/api/model/info"),
+  getSetupCodexState: () => fetchJSON<SetupCodexState>("/api/setup-codex/state"),
   getModelOptions: () => fetchJSON<ModelOptionsResponse>("/api/model/options"),
   getAuxiliaryModels: () => fetchJSON<AuxiliaryModelsResponse>("/api/model/auxiliary"),
   setModelAssignment: (body: ModelAssignmentRequest) =>
@@ -593,6 +594,69 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+}
+
+// ── Setup Codex types ─────────────────────────────────────────────────
+
+export interface SetupCodexPlatformState {
+  configured: boolean;
+  enabled: boolean;
+  credential_configured: boolean;
+  env_credentials_configured: boolean;
+  config_credentials_configured: boolean;
+  runtime_state: string;
+}
+
+export interface SetupCodexState {
+  read_only: boolean;
+  title: string;
+  route: string;
+  paths: {
+    hermes_home: string;
+    config_path: string;
+    env_path: string;
+  };
+  model: {
+    provider: string;
+    model: string;
+    base_url_configured: boolean;
+    api_key_configured: boolean;
+    context_length_configured: boolean;
+  };
+  delegation: {
+    configured: boolean;
+    model_override_configured: boolean;
+    provider_override_configured: boolean;
+    max_concurrent_children?: number | null;
+    max_spawn_depth?: number | null;
+    orchestrator_enabled: boolean;
+  };
+  gateway: {
+    running: boolean;
+    pid?: number | null;
+    state?: string | null;
+    updated_at?: string | null;
+    platforms: Record<string, { state: string }>;
+  };
+  platforms: Record<string, SetupCodexPlatformState>;
+  toolsets: {
+    enabled_toolsets: string[];
+    disabled_toolsets: string[];
+    platform_toolsets: Record<string, string[]>;
+    custom_toolsets: string[];
+  };
+  secrets: {
+    env_secret_keys_configured_count: number;
+    env_secret_key_names: string[];
+    values_redacted: boolean;
+  };
+  safety: {
+    can_write_config: boolean;
+    can_write_env: boolean;
+    can_execute_commands: boolean;
+    can_restart_gateway: boolean;
+    requires_manual_copy: boolean;
+  };
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/pages/SetupCodexPage.tsx
+++ b/web/src/pages/SetupCodexPage.tsx
@@ -1,0 +1,474 @@
+import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react";
+import {
+  Bot,
+  CheckCircle2,
+  Clipboard,
+  KeyRound,
+  MessageCircle,
+  Route,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+  Users,
+  Wrench,
+} from "lucide-react";
+import { api, type SetupCodexState } from "@/lib/api";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/useToast";
+import { Toast } from "@/components/Toast";
+
+type TopicId =
+  | "new-agent"
+  | "telegram"
+  | "feishu"
+  | "model"
+  | "toolsets"
+  | "subagents"
+  | "gateway"
+  | "security";
+
+type Topic = {
+  id: TopicId;
+  title: string;
+  subtitle: string;
+  icon: ComponentType<{ className?: string }>;
+  tone: string;
+  steps: string[];
+  commands: string[];
+};
+
+const AGENT_TYPES = [
+  { id: "personal", label: "个人助理", preset: "safe,skills,session_search" },
+  { id: "coding", label: "代码助手", preset: "safe,terminal,file,web,skills" },
+  { id: "group", label: "群聊 Bot", preset: "safe,skills,session_search" },
+  { id: "research", label: "研究助手", preset: "safe,web,search,skills,session_search" },
+];
+const PLATFORM_CHOICES = ["cli", "telegram", "feishu", "api_server"];
+const PROFILE_RE = /^[a-z][a-z0-9-]{1,31}$/;
+
+const TOPICS: Topic[] = [
+  {
+    id: "new-agent",
+    title: "新建 Agent",
+    subtitle: "用 profile 创建一个独立身份、独立配置的 Hermes Agent。",
+    icon: Bot,
+    tone: "from-cyan-500/20 to-blue-500/10",
+    steps: [
+      "先决定用途：个人助理、代码助手、群聊 Bot、定时任务 Bot 或研究助手。",
+      "给 profile 起一个小写英文名，例如 research-bot；不要把 token 或隐私放进名字。",
+      "选择 clone 策略：小白建议先 --clone，继承当前可用模型与工具。",
+      "进入新 profile 后检查模型、工具和入口平台，再做第一次 hello 测试。",
+    ],
+    commands: [
+      "hermes profile create research-bot --clone",
+      "hermes -p research-bot model",
+      "hermes -p research-bot tools",
+      "hermes -p research-bot chat -q \"hello\"",
+      "hermes profile list",
+    ],
+  },
+  {
+    id: "telegram",
+    title: "连接 Telegram",
+    subtitle: "检查 Bot token、配对状态和 Gateway 运行状态。",
+    icon: MessageCircle,
+    tone: "from-sky-500/20 to-cyan-500/10",
+    steps: [
+      "在 BotFather 创建 bot 并拿到 token；不要在群聊里粘贴 token。",
+      "把 token 存到 .env，然后重启 gateway。",
+      "第一次私聊 bot 时使用 pairing flow 授权，而不是开放所有用户。",
+    ],
+    commands: [
+      "hermes config env-path",
+      "hermes gateway status",
+      "hermes pairing list",
+      "hermes pairing approve telegram <code>",
+    ],
+  },
+  {
+    id: "feishu",
+    title: "连接 Feishu / Lark",
+    subtitle: "检查 App 凭据、机器人事件订阅和 Gateway 状态。",
+    icon: Route,
+    tone: "from-indigo-500/20 to-violet-500/10",
+    steps: [
+      "确认飞书开放平台应用已创建，并启用机器人能力。",
+      "凭据只存 .env；页面只显示是否配置，不显示 secret。",
+      "确认事件订阅与权限范围后，再在飞书里 @bot 测试。",
+    ],
+    commands: [
+      "hermes config env-path",
+      "hermes gateway status",
+      "hermes status --all",
+    ],
+  },
+  {
+    id: "model",
+    title: "选择模型",
+    subtitle: "主模型负责正常对话，auxiliary 模型负责视觉、压缩、搜索等辅助任务。",
+    icon: Sparkles,
+    tone: "from-amber-500/20 to-orange-500/10",
+    steps: [
+      "先确认主 provider/model 是否可用。",
+      "需要长上下文或低成本时，再分别配置 auxiliary 任务。",
+      "OAuth provider 出问题时优先用 hermes auth list / reset 排查。",
+    ],
+    commands: ["hermes model", "hermes auth list", "hermes status --all"],
+  },
+  {
+    id: "toolsets",
+    title: "配置工具权限",
+    subtitle: "toolsets 是 Agent 的行动权限包；平台级 toolsets 可以给 Telegram/Feishu 不同权限。",
+    icon: Wrench,
+    tone: "from-emerald-500/20 to-green-500/10",
+    steps: [
+      "小白默认从 safe / skills / session_search 开始。",
+      "terminal、messaging、cronjob、homeassistant 属于高风险工具，要按平台最小授权。",
+      "修改工具权限后，新 session 才会加载新的 tool schema。",
+    ],
+    commands: ["hermes tools list", "hermes tools", "hermes config path"],
+  },
+  {
+    id: "subagents",
+    title: "开启 Subagents",
+    subtitle: "delegate_task 适合短任务并行；长任务应该用 cron 或 background terminal。",
+    icon: Users,
+    tone: "from-fuchsia-500/20 to-pink-500/10",
+    steps: [
+      "默认 leaf subagent 不能继续委派，也不能 clarify/memory/send_message/execute_code。",
+      "只有 max_spawn_depth > 1 且 orchestrator_enabled=true 时，orchestrator 才有意义。",
+      "并发和深度会指数放大成本；先从 max_concurrent_children=2~3 开始。",
+    ],
+    commands: ["hermes config path", "hermes status --all"],
+  },
+  {
+    id: "gateway",
+    title: "排查 Gateway",
+    subtitle: "确认 gateway 进程、平台连接状态、日志和重启方式。",
+    icon: Terminal,
+    tone: "from-slate-500/20 to-zinc-500/10",
+    steps: [
+      "先看 status，再看 gateway.log；不要盲目 --replace。",
+      "systemd 管理时让 systemd 负责生命周期，ExecStart 不要带 --replace。",
+      "本页 MVP 不会自动重启 gateway，只给复制命令。",
+    ],
+    commands: ["hermes gateway status", "hermes logs --level warning", "hermes doctor"],
+  },
+  {
+    id: "security",
+    title: "安全检查",
+    subtitle: "确认 secret 不进聊天、不进页面、不进代码；高风险配置必须二次确认。",
+    icon: ShieldCheck,
+    tone: "from-red-500/20 to-rose-500/10",
+    steps: [
+      "API key、token、OAuth、private key 只看存在性，不显示原文。",
+      "allowlist、platform_toolsets、terminal/messaging/cronjob 权限属于高风险变更。",
+      "后续若做一键 apply，必须先展示 diff，再要求确认短语。",
+    ],
+    commands: ["hermes doctor", "hermes config check", "hermes tools list"],
+  },
+];
+
+function yesNo(value?: boolean): string {
+  return value ? "已配置" : "未配置";
+}
+
+function platformLabel(id: string): string {
+  if (id === "api_server") return "API Server";
+  if (id === "feishu") return "Feishu";
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function CopyButton({ text, onCopied }: { text: string; onCopied: () => void }) {
+  return (
+    <Button
+      ghost
+      size="xs"
+      className="shrink-0"
+      onClick={async () => {
+        await navigator.clipboard.writeText(text);
+        onCopied();
+      }}
+    >
+      <Clipboard className="h-3.5 w-3.5" />
+      Copy
+    </Button>
+  );
+}
+
+function CommandBlock({ commands, onCopied }: { commands: string[]; onCopied: () => void }) {
+  return (
+    <div className="space-y-2">
+      {commands.map((cmd) => (
+        <div
+          key={cmd}
+          className="flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-3 py-2 font-mono text-xs"
+        >
+          <span className="overflow-x-auto whitespace-nowrap pr-2">{cmd}</span>
+          <CopyButton text={cmd} onCopied={onCopied} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FieldLabel({ children }: { children: string }) {
+  return <label className="text-xs font-medium text-muted-foreground">{children}</label>;
+}
+
+function NativeSelect({ value, onChange, children }: { value: string; onChange: (value: string) => void; children: ReactNode }) {
+  return (
+    <select
+      className="h-9 rounded-md border bg-background px-3 text-sm"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {children}
+    </select>
+  );
+}
+
+export default function SetupCodexPage() {
+  const [state, setState] = useState<SetupCodexState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeId, setActiveId] = useState<TopicId>("new-agent");
+  const [profileName, setProfileName] = useState("research-bot");
+  const [agentType, setAgentType] = useState("research");
+  const [entryPlatform, setEntryPlatform] = useState("telegram");
+  const { toast, showToast } = useToast();
+
+  useEffect(() => {
+    api
+      .getSetupCodexState()
+      .then(setState)
+      .catch(() => showToast("配置宝典状态加载失败", "error"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const activeTopic = useMemo(
+    () => TOPICS.find((topic) => topic.id === activeId) ?? TOPICS[0],
+    [activeId],
+  );
+  const selectedAgentType = AGENT_TYPES.find((item) => item.id === agentType) ?? AGENT_TYPES[0];
+  const profileValid = PROFILE_RE.test(profileName);
+  const generatedAgentCommands = [
+    `hermes profile create ${profileName || "<profile-name>"} --clone`,
+    `hermes -p ${profileName || "<profile-name>"} model`,
+    `hermes -p ${profileName || "<profile-name>"} config set agent.enabled_toolsets ${selectedAgentType.preset}`,
+    entryPlatform === "cli"
+      ? `hermes -p ${profileName || "<profile-name>"} chat -q "hello"`
+      : `hermes -p ${profileName || "<profile-name>"} gateway status`,
+    entryPlatform === "telegram"
+      ? `hermes -p ${profileName || "<profile-name>"} pairing list`
+      : `hermes -p ${profileName || "<profile-name>"} status --all`,
+  ];
+  const ActiveIcon = activeTopic.icon;
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 md:p-6">
+      <div className="overflow-hidden rounded-3xl border bg-gradient-to-br from-background via-background to-muted/60 p-6 shadow-sm">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-4">
+            <div className="inline-flex items-center gap-2 rounded-full border bg-background/70 px-3 py-1 text-xs text-muted-foreground">
+              <Sparkles className="h-3.5 w-3.5 text-primary" />
+              Setup Codex · read-only MVP
+            </div>
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">Hermes配置宝典</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground md:text-base">
+                官方新手村 + 配置驾驶舱。先读状态、解释风险、生成可复制命令；当前版本不会写 config、不会写 .env、不会执行命令、不会重启 Gateway。
+              </p>
+            </div>
+          </div>
+          <div className="grid gap-2 rounded-2xl border bg-background/70 p-4 text-sm sm:grid-cols-2 lg:min-w-[420px]">
+            <div>
+              <div className="text-xs text-muted-foreground">Model</div>
+              <div className="font-medium">{state?.model.provider || "auto"} / {state?.model.model || "未设置"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Gateway</div>
+              <div className="font-medium">{state?.gateway.running ? "running" : state?.gateway.state || "stopped"}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Config</div>
+              <div className="truncate font-mono text-xs">{state?.paths.config_path}</div>
+            </div>
+            <div>
+              <div className="text-xs text-muted-foreground">Secrets</div>
+              <div className="font-medium">{state?.secrets.env_secret_keys_configured_count ?? 0} keys · values redacted</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {TOPICS.map((topic) => {
+          const Icon = topic.icon;
+          const active = topic.id === activeId;
+          return (
+            <button
+              key={topic.id}
+              className={`rounded-2xl border bg-gradient-to-br ${topic.tone} p-4 text-left transition hover:-translate-y-0.5 hover:shadow-md ${
+                active ? "ring-2 ring-primary/50" : ""
+              }`}
+              onClick={() => setActiveId(topic.id)}
+            >
+              <Icon className="mb-3 h-5 w-5 text-primary" />
+              <div className="font-medium">{topic.title}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{topic.subtitle}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.35fr_0.85fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ActiveIcon className="h-5 w-5 text-primary" />
+              {activeTopic.title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <ol className="space-y-3">
+              {activeTopic.steps.map((step, index) => (
+                <li key={step} className="flex gap-3 rounded-xl border bg-muted/20 p-3 text-sm">
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                    {index + 1}
+                  </span>
+                  <span>{step}</span>
+                </li>
+              ))}
+            </ol>
+            <div>
+              <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                <Clipboard className="h-4 w-4" />
+                复制命令，手动执行
+              </div>
+              <CommandBlock commands={activeTopic.commands} onCopied={() => showToast("已复制命令", "success")} />
+            </div>
+            {activeId === "new-agent" && (
+              <div className="rounded-2xl border bg-muted/20 p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium">新建 Agent 向导（只生成命令）</div>
+                    <div className="text-xs text-muted-foreground">调整用途、profile 名称和入口平台；本页不会创建 profile，也不会写配置。</div>
+                  </div>
+                  <Badge tone={profileValid ? "success" : "destructive"}>{profileValid ? "name ok" : "name invalid"}</Badge>
+                </div>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="space-y-1.5">
+                    <FieldLabel>Agent 类型</FieldLabel>
+                    <NativeSelect value={agentType} onChange={setAgentType}>
+                      {AGENT_TYPES.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
+                    </NativeSelect>
+                  </div>
+                  <div className="space-y-1.5">
+                    <FieldLabel>Profile 名称</FieldLabel>
+                    <Input value={profileName} onChange={(event) => setProfileName(event.target.value)} placeholder="research-bot" />
+                  </div>
+                  <div className="space-y-1.5">
+                    <FieldLabel>入口平台</FieldLabel>
+                    <NativeSelect value={entryPlatform} onChange={setEntryPlatform}>
+                      {PLATFORM_CHOICES.map((item) => <option key={item} value={item}>{item}</option>)}
+                    </NativeSelect>
+                  </div>
+                </div>
+                <div className="mt-3 rounded-xl border bg-background/60 p-3 text-xs text-muted-foreground">
+                  建议权限模板：<span className="font-mono text-foreground">{selectedAgentType.preset}</span>。如果包含 terminal/messaging/cronjob，请先确认平台级 toolsets 和 owner allowlist。
+                </div>
+                <div className="mt-3">
+                  <CommandBlock commands={generatedAgentCommands} onCopied={() => showToast("已复制向导命令", "success")} />
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <CheckCircle2 className="h-4 w-4 text-primary" />
+                当前状态快照
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {state && (
+                <>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Provider</span>
+                    <Badge tone="secondary">{state.model.provider || "auto"}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Model</span>
+                    <span className="font-mono text-xs">{state.model.model || "未设置"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Delegation</span>
+                    <span>{state.delegation.configured ? "已配置" : "默认继承"}</span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground">Platform toolsets</span>
+                    <span>{Object.keys(state.toolsets.platform_toolsets).length} platforms</span>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <KeyRound className="h-4 w-4 text-primary" />
+                平台连接
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {state && Object.entries(state.platforms).map(([id, platform]) => (
+                <div key={id} className="rounded-xl border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">{platformLabel(id)}</span>
+                    <Badge tone={platform.configured ? "success" : "secondary"}>{yesNo(platform.configured)}</Badge>
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    credential: {yesNo(platform.credential_configured)} · runtime: {platform.runtime_state || "unknown"}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Settings2 className="h-4 w-4 text-primary" />
+                安全边界
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-primary" /> 不返回 secret 原文</div>
+              <div className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-primary" /> 不写 config.yaml / .env</div>
+              <div className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-primary" /> 不执行 shell 命令</div>
+              <div className="flex items-center gap-2"><ShieldCheck className="h-4 w-4 text-primary" /> 不自动重启 Gateway</div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      <Toast toast={toast} />
+    </div>
+  );
+}

--- a/website/docs/user-guide/setup-codex.md
+++ b/website/docs/user-guide/setup-codex.md
@@ -1,0 +1,105 @@
+---
+title: Setup Codex / 配置宝典
+sidebar_position: 9
+---
+
+# Setup Codex / Hermes配置宝典
+
+Setup Codex is the built-in, read-only setup guide in the Hermes Dashboard. It is designed as an official “configuration cockpit” for new users: pick a setup goal, read the current local state, copy the suggested commands, and complete the change manually.
+
+Open it from the Dashboard sidebar as **配置宝典**, or visit:
+
+```text
+http://127.0.0.1:9119/setup-codex
+```
+
+## MVP safety boundary
+
+The first version is intentionally read-only:
+
+- It does **not** write `config.yaml`.
+- It does **not** write `.env`.
+- It does **not** execute shell commands.
+- It does **not** restart the gateway.
+- It does **not** return secret values to the browser.
+
+The page can show that a credential exists, but never the credential itself.
+
+## Read-only state API
+
+The page reads its status from:
+
+```http
+GET /api/setup-codex/state
+```
+
+This endpoint returns setup-ready state such as:
+
+- Hermes home, config path, and env path.
+- Current model/provider names.
+- Whether model base URL or API key fields are configured.
+- Delegation/subagent settings.
+- Gateway running state and platform runtime state.
+- Telegram, Feishu/Lark, API server, Discord, and Slack configuration presence.
+- Platform toolsets and disabled/enabled toolsets.
+- Secret key names and counts only, with values redacted.
+- Safety flags confirming that the guide cannot write files or execute commands.
+
+The endpoint must never return API keys, tokens, OAuth credentials, cookies, passwords, private keys, connection strings, or raw `.env` values.
+
+## Guide topics
+
+The Dashboard page includes starter cards for:
+
+- New Agent
+- Telegram
+- Feishu / Lark
+- Model selection
+- Tool permissions / toolsets
+- Subagents / delegation
+- Gateway troubleshooting
+- Security checks
+
+Each topic provides small steps and copyable commands. Users run commands themselves in a terminal.
+
+### New Agent guided wizard
+
+The **新建 Agent** card includes a small command generator. It asks for:
+
+- agent type, such as personal assistant, coding assistant, group-chat bot, or research assistant;
+- profile name, validated with the safe pattern `^[a-z][a-z0-9-]{1,31}$`;
+- entry platform, such as CLI, Telegram, Feishu/Lark, or API server;
+- a recommended toolset template.
+
+The generated commands are still copy-only. The Dashboard does not create the profile, write config, write `.env`, execute the command, or restart Gateway.
+
+### Windows launcher prototype
+
+A conservative launcher prototype lives at:
+
+```text
+scripts/setup_codex_launcher.py
+```
+
+It is intended to be packaged as **Hermes配置宝典.exe** later. The prototype:
+
+- checks `http://127.0.0.1:9119/api/status`;
+- starts `hermes dashboard --host 127.0.0.1 --port 9119` only if no dashboard is reachable;
+- waits for readiness, then opens `http://127.0.0.1:9119/setup-codex`;
+- refuses non-localhost hosts, and never passes `--host 0.0.0.0` or `--insecure`.
+
+Run it directly during development:
+
+```bash
+python scripts/setup_codex_launcher.py --no-open
+python scripts/setup_codex_launcher.py
+```
+
+## Future phases
+
+Later versions may add generated YAML patches and controlled apply flows. Those flows must preserve the same security model:
+
+1. Generate a human-readable diff first.
+2. Redact all secret values.
+3. Require explicit confirmation before applying changes.
+4. Keep high-risk operations, such as gateway restart or tool permission expansion, behind an additional confirmation step.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/windows-native',
         'user-guide/windows-wsl-quickstart',
         'user-guide/configuration',
+        'user-guide/setup-codex',
         'user-guide/configuring-models',
         'user-guide/sessions',
         'user-guide/profiles',


### PR DESCRIPTION
## Summary
- Add a read-only Hermes配置宝典 / Setup Codex dashboard route at `/setup-codex`.
- Add a bootstrap-safe `GET /api/setup-codex/state` endpoint that returns setup status and presence booleans without secret values.
- Add topic cards, status panels, copy-only command blocks, and a New Agent guided command generator.
- Add docs and a conservative Windows launcher prototype intended for a future `Hermes配置宝典.exe` package.

## Safety model
- No config writes.
- No `.env` writes.
- No shell execution from the dashboard page.
- No gateway restart.
- No raw API keys, tokens, OAuth values, passwords, private keys, cookies, or connection strings returned to the browser.
- Launcher binds only to `127.0.0.1` and refuses non-localhost hosts.

## Test plan
- [x] `python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_setup_codex_state_is_read_only_and_sanitized tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_setup_codex_state_is_publicly_safe_without_session_token tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_setup_codex_state_never_emits_common_secret_shapes tests/hermes_cli/test_setup_codex_launcher.py -q -o 'addopts='`
- [x] `python -m py_compile hermes_cli/web_server.py scripts/setup_codex_launcher.py`
- [x] `git diff --check`
- [x] added-line secret pattern scan
- [x] `cd web && npm run build` with Node v20.19.6

## Notes
This PR is intentionally read-only for v1. Future generated patch/apply flows should require a human-readable diff, redaction, and explicit confirmation before any write operation.
