### PR TITLE
feat(whatsapp): surface quoted reply metadata from Baileys

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -300,7 +300,10 @@ async function startSocket() {
       const messageContent = getMessageContent(msg);
       const contextInfo = getContextInfo(messageContent);
       const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
-      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || contextInfo?.remoteJid || '');
+      const quotedMessageId = contextInfo?.stanzaId || null;
+      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
+      const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
+      const hasQuotedMessage = !!contextInfo?.quotedMessage;
 
       // Extract message body
       let body = '';
@@ -412,7 +415,10 @@ async function startSocket() {
         mediaType,
         mediaUrls,
         mentionedIds,
+        quotedMessageId,
         quotedParticipant,
+        quotedRemoteJid,
+        hasQuotedMessage,
         botIds,
         timestamp: msg.messageTimestamp,
       };

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -46,6 +46,10 @@ def _make_adapter():
     adapter._message_queue = asyncio.Queue()
     adapter._http_session = MagicMock()
     adapter._mention_patterns = []
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
     return adapter
 
 
@@ -285,6 +289,41 @@ class TestSendChunking:
         result = await adapter.send("chat1", "hello")
         assert not result.success
         assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# bridge event metadata
+# ---------------------------------------------------------------------------
+
+class TestBridgeEventMetadata:
+    """WhatsApp bridge metadata is preserved for downstream consumers."""
+
+    @pytest.mark.asyncio
+    async def test_quoted_reply_metadata_is_preserved_in_raw_message(self):
+        adapter = _make_adapter()
+        data = {
+            "messageId": "incoming-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Tester",
+            "chatName": "Tester",
+            "isGroup": False,
+            "body": "approved",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "quotedMessageId": "outbound-msg",
+            "quotedParticipant": "99999999999@s.whatsapp.net",
+            "quotedRemoteJid": "15551234567@s.whatsapp.net",
+            "hasQuotedMessage": True,
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert event.raw_message["quotedMessageId"] == "outbound-msg"
+        assert event.raw_message["quotedParticipant"] == "99999999999@s.whatsapp.net"
+        assert event.raw_message["quotedRemoteJid"] == "15551234567@s.whatsapp.net"
+        assert event.raw_message["hasQuotedMessage"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR exposes native WhatsApp quoted/reply metadata from the Baileys bridge into Hermes' queued WhatsApp message events.

Hermes already receives Baileys message `contextInfo` for inbound WhatsApp messages, but reply anchors such as `contextInfo.stanzaId` were not surfaced in the normalized bridge event. That means downstream Hermes workflows cannot reliably tell when a user has replied to a specific prior outbound message.

This change adds quoted-message metadata as passive raw event fields, without changing existing message routing or normal message handling.

## Motivation

WhatsApp native replies are important for agent workflows where "this" or "approve this" needs to refer to a specific previous Hermes message.

Examples this enables:
- peer review routing
- threaded approvals
- "reply to this result" workflows
- reminder/result follow-ups
- multi-agent review loops
- external runners mapping user replies back to prior agent sessions

This is platform metadata, not application-specific routing logic. Hermes should surface the metadata; downstream systems can decide how to use it.

## Changes

### `scripts/whatsapp-bridge/bridge.js`

Adds quoted reply metadata to queued inbound events, derived from Baileys `contextInfo`:

- `quotedMessageId: contextInfo?.stanzaId || null`
- `quotedParticipant`
- `quotedRemoteJid: contextInfo?.remoteJid || null`
- `hasQuotedMessage: !!contextInfo?.quotedMessage`

### `gateway/platforms/whatsapp.py`

No behavioural routing changes.

The Python WhatsApp adapter continues preserving the raw bridge event in `raw_message`, which now includes the quoted metadata fields when present.

### Tests

Adds coverage that an inbound WhatsApp event containing quoted metadata retains those fields in `raw_message`.

## Non-goals

This PR intentionally does not add OrbStack Agent Runner-specific logic to Hermes.

It does not:
- map quoted message IDs to runner sessions
- change Hermes conversation threading
- change allowed-user/group handling
- alter normal WhatsApp message processing
- require consumers to use the new metadata

Downstream tools can consume `quotedMessageId` separately and implement their own reply-routing behaviour.

## Compatibility

The new fields are nullable and additive. Existing consumers should continue working unchanged.

When a WhatsApp message is not a native reply, the quoted fields are `null`/`false`.
