### PR TITLE
fix(model-switch): support inline provider syntax

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -13,9 +13,11 @@ This module ties together the foundation layers:
 - ``hermes_cli.providers``        -- canonical provider identity + overlays
 - ``hermes_cli.model_normalize``  -- per-provider name formatting
 
-Provider switching uses the ``--provider`` flag exclusively.
-No colon-based ``provider:model`` syntax — colons are reserved for
-OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
+Provider switching supports the ``--provider`` flag plus inline provider
+qualification with ``provider:model`` and, when the current provider is not an
+aggregator, ``provider/model``. Aggregator slugs such as
+``anthropic/claude-sonnet-4.5:extended`` remain model ids on the current
+aggregator.
 """
 
 from __future__ import annotations
@@ -608,6 +610,116 @@ def resolve_display_context_length(
     return None
 
 
+_AGGREGATOR_VENDOR_NAMESPACES = {
+    # Common OpenRouter / aggregator vendor namespaces.  When the current
+    # provider is an aggregator, ``vendor:model`` is legacy shorthand for
+    # ``vendor/model`` and must not be stolen by inline provider parsing.
+    "anthropic",
+    "cohere",
+    "deepseek",
+    "google",
+    "meta-llama",
+    "mistral",
+    "mistralai",
+    "moonshotai",
+    "nousresearch",
+    "nvidia",
+    "openai",
+    "perplexity",
+    "qwen",
+    "x-ai",
+    "z-ai",
+    "zai-org",
+}
+
+
+def _user_provider_lists_model(raw_model: str, current_provider: str, user_providers: dict | None) -> bool:
+    """Return True if current user-provider config explicitly lists ``raw_model``.
+
+    Private endpoints often expose vendor-qualified model ids such as
+    ``moonshotai/Kimi-K2.6-ACED``. Those are model ids on the current private
+    provider, not inline provider switches.
+    """
+    if not user_providers or not current_provider:
+        return False
+    cfg = user_providers.get(current_provider)
+    if not isinstance(cfg, dict):
+        return False
+    cfg_models = cfg.get("models", {})
+    if isinstance(cfg_models, dict):
+        return raw_model in cfg_models
+    if isinstance(cfg_models, list):
+        if raw_model in cfg_models:
+            return True
+        return any(
+            isinstance(entry, dict) and entry.get("name") == raw_model
+            for entry in cfg_models
+        )
+    return False
+
+
+def _inline_provider_matches_exact_id(raw_provider: str, provider_id: str) -> bool:
+    """Return True when ``raw_provider`` is an explicit provider id, not an alias.
+
+    ``resolve_provider_full('openai')`` intentionally maps to OpenRouter for
+    historical vendor-shorthand behavior. Inline provider syntax should not let
+    that alias steal aggregator slugs like ``openai/gpt-5.5``.  Require the
+    resolved provider id to match the raw left-hand side exactly.
+    """
+    left = (raw_provider or "").strip().lower()
+    return bool(left and provider_id and left == provider_id.strip().lower())
+
+
+def _parse_inline_provider_model(
+    raw_input: str,
+    current_provider: str,
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+) -> Optional[tuple[str, str]]:
+    """Parse ``provider:model`` or ``provider/model`` when unambiguous.
+
+    Colon is the strongest signal because OpenRouter-style variant tags appear
+    only after a slash (``vendor/model:free``), so ``provider:model`` can be
+    treated as a provider switch when the left-hand side is an exact provider
+    id. On aggregators, common vendor namespaces keep legacy ``vendor:model``
+    behavior. Slash is ambiguous with aggregator ``vendor/model`` slugs, so
+    slash shorthand is accepted only when the current provider is not an
+    aggregator.
+    """
+    raw = (raw_input or "").strip()
+    if not raw or "://" in raw:
+        return None
+    if _user_provider_lists_model(raw, current_provider, user_providers):
+        return None
+
+    # provider:model. Skip already-slash-qualified slugs with variant tags,
+    # e.g. anthropic/claude-sonnet-4.5:extended.
+    colon_pos = raw.find(":")
+    if colon_pos > 0 and "/" not in raw[:colon_pos]:
+        left = raw[:colon_pos].strip()
+        right = raw[colon_pos + 1 :].strip()
+        if left and right:
+            if is_aggregator(current_provider) and left.lower() in _AGGREGATOR_VENDOR_NAMESPACES:
+                return None
+            pdef = resolve_provider_full(left, user_providers, custom_providers)
+            if pdef is not None and _inline_provider_matches_exact_id(left, pdef.id):
+                return pdef.id, right
+
+    # provider/model. On aggregators, slash already means vendor/model and must
+    # remain a model id. Off aggregators, slash can be accepted as a friendly
+    # provider switch shorthand.
+    slash_pos = raw.find("/")
+    if slash_pos > 0 and not is_aggregator(current_provider):
+        left = raw[:slash_pos].strip()
+        right = raw[slash_pos + 1 :].strip()
+        if left and right:
+            pdef = resolve_provider_full(left, user_providers, custom_providers)
+            if pdef is not None and _inline_provider_matches_exact_id(left, pdef.id):
+                return pdef.id, right
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Core model-switching pipeline
 # ---------------------------------------------------------------------------
@@ -672,19 +784,31 @@ def switch_model(
     new_model = raw_input.strip()
     target_provider = current_provider
 
+    inline_provider = None
+    if not explicit_provider:
+        inline_provider = _parse_inline_provider_model(
+            raw_input,
+            current_provider,
+            user_providers,
+            custom_providers,
+        )
+        if inline_provider is not None:
+            target_provider, new_model = inline_provider
+
     # =================================================================
-    # PATH A: Explicit --provider given
+    # PATH A: Explicit --provider given OR inline provider qualification
     # =================================================================
-    if explicit_provider:
+    if explicit_provider or inline_provider is not None:
         # Resolve the provider
+        provider_to_resolve = explicit_provider or target_provider
         pdef = resolve_provider_full(
-            explicit_provider,
+            provider_to_resolve,
             user_providers,
             custom_providers,
         )
         if pdef is None:
             _switch_err = (
-                f"Unknown provider '{explicit_provider}'. "
+                f"Unknown provider '{provider_to_resolve}'. "
                 f"Check 'hermes model' for available providers, or define it "
                 f"in config.yaml under 'providers:'."
             )
@@ -721,7 +845,7 @@ def switch_model(
                         is_global=is_global,
                         error_message=(
                             f"No model detected on {pdef.name} ({pdef.base_url}). "
-                            f"Specify the model explicitly: /model <model-name> --provider {explicit_provider}"
+                            f"Specify the model explicitly: /model <model-name> --provider {provider_to_resolve}"
                         ),
                     )
             else:
@@ -732,7 +856,7 @@ def switch_model(
                     is_global=is_global,
                     error_message=(
                         f"Provider '{pdef.name}' has no base URL configured. "
-                        f"Specify a model: /model <model-name> --provider {explicit_provider}"
+                        f"Specify a model: /model <model-name> --provider {provider_to_resolve}"
                     ),
                 )
 

--- a/tests/hermes_cli/test_model_switch_inline_provider_syntax.py
+++ b/tests/hermes_cli/test_model_switch_inline_provider_syntax.py
@@ -1,0 +1,89 @@
+"""Regression tests for inline provider syntax in the shared /model pipeline.
+
+The gateway/CLI /model command uses hermes_cli.model_switch.switch_model(), not
+hermes_cli.models.parse_model_input(). Provider-qualified inputs must therefore
+be recognized in this pipeline directly.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {"accepted": True, "persist": True, "recognized": True, "message": None}
+
+
+def _switch(raw_input: str, *, current_provider: str = "openrouter", catalog=None):
+    """Run switch_model with network/catalog/metadata calls mocked out."""
+    catalog = [] if catalog is None else catalog
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=catalog), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+               return_value={"api_key": "test", "base_url": "https://example.invalid/v1", "api_mode": "chat_completions"}), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model="anthropic/claude-sonnet-4.5",
+            current_base_url="https://openrouter.ai/api/v1",
+            current_api_key="test",
+        )
+
+
+def test_colon_provider_model_switches_provider_before_catalog_logic():
+    result = _switch("openai-codex:gpt-5.5", current_provider="openrouter")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_colon_provider_model_does_not_get_normalized_on_old_provider():
+    result = _switch("openai-codex:gpt-5.5", current_provider="claude-api-proxy")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.5"
+
+
+def test_slash_provider_model_switches_from_non_aggregator_provider():
+    result = _switch("nous/hermes-4", current_provider="claude-api-proxy")
+
+    assert result.success, result.error_message
+    assert result.provider_changed is True
+    assert result.target_provider == "nous"
+    assert result.new_model == "hermes-4"
+
+
+def test_slash_openrouter_catalog_slug_stays_on_current_aggregator():
+    result = _switch(
+        "anthropic/claude-sonnet-4.5",
+        current_provider="openrouter",
+        catalog=["anthropic/claude-sonnet-4.5"],
+    )
+
+    assert result.success, result.error_message
+    assert result.provider_changed is False
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "anthropic/claude-sonnet-4.5"
+
+
+def test_slash_alias_namespace_does_not_switch_provider_when_slug_exists():
+    # `openai` is an alias to OpenRouter in provider resolution. Do not treat
+    # every vendor namespace as an inline provider switch; OpenRouter slugs such
+    # as openai/gpt-5.5 must keep working.
+    result = _switch(
+        "openai/gpt-5.5",
+        current_provider="openrouter",
+        catalog=["openai/gpt-5.5"],
+    )
+
+    assert result.success, result.error_message
+    assert result.provider_changed is False
+    assert result.target_provider == "openrouter"
+    assert result.new_model == "openai/gpt-5.5"


### PR DESCRIPTION
## Problem

The shared `/model` pipeline does **not** use `hermes_cli.models.parse_model_input()`. It uses `hermes_cli.model_switch.switch_model()`, which had its own resolution chain.

That meant user-facing commands such as:

```text
/model openai-codex:gpt-5.5
```

could be treated as a literal model name on the current provider instead of switching to provider `openai-codex` with model `gpt-5.5`.

This reproduced the class of failure reported in Telegram screenshots:

```text
Model openai-codex:gpt-5.5 was not found in this provider's model listing.
```

## Fix

Add inline provider qualification to `hermes_cli/model_switch.py::switch_model()` itself:

- `provider:model` switches provider when `provider` resolves to an exact Hermes provider id.
- `provider/model` switches provider when the current provider is **not** an aggregator.
- Aggregator slugs such as `anthropic/claude-sonnet-4.5`, `openai/gpt-5.5`, and variant tags such as `nvidia/nemotron:free` continue to be treated as model ids on the current aggregator.
- Provider aliases such as `openai -> openrouter` are intentionally not accepted as inline provider ids, so `openai/gpt-5.5` does not get stolen from OpenRouter-style slug syntax.
- Private user-provider model lists win over inline parsing so vendor-qualified private model ids such as `moonshotai/Kimi-K2.6-ACED` remain valid model ids on that private provider.

## Why not make slash universal everywhere?

Slash is already the canonical syntax for aggregator/vendor model slugs. Treating every `left/right` as provider/model would break common OpenRouter inputs. The safe compromise implemented here is:

- colon is the unambiguous provider switch syntax everywhere;
- slash is accepted as friendly provider syntax off aggregators;
- slash stays model-slug syntax on aggregators.

## Tests

New regression file:

```text
tests/hermes_cli/test_model_switch_inline_provider_syntax.py
```

Covers:

- `/model openai-codex:gpt-5.5` switches to provider `openai-codex` and model `gpt-5.5`.
- The same input no longer gets normalized on the old provider (`gpt-5.5` does not become `gpt-5-5` inside a literal model string).
- `/model nous/hermes-4` switches from a non-aggregator current provider.
- OpenRouter-style slugs stay on OpenRouter.
- `openai/gpt-5.5` stays an OpenRouter slug, not an alias-driven provider switch.

Also verified existing variant-tag and user-provider tests to avoid regressions.

## Verification

```bash
pytest -q tests/hermes_cli/test_model_switch_inline_provider_syntax.py
pytest -q \
  tests/hermes_cli/test_model_switch_inline_provider_syntax.py \
  tests/hermes_cli/test_model_switch_variant_tags.py \
  tests/hermes_cli/test_model_validation.py \
  tests/hermes_cli/test_models.py \
  tests/hermes_cli/test_openai_codex_model_validation_fallback.py \
  tests/hermes_cli/test_user_providers_model_switch.py
```

Result: `197 passed`.

Manual reproduction probe after fix:

```text
openai-codex:gpt-5.5 from claude-api-proxy => True openai-codex gpt-5.5 changed=True
openai-codex/gpt-5.5 from claude-api-proxy => True openai-codex gpt-5.5 changed=True
anthropic/claude-sonnet-4.5 from openrouter => True openrouter anthropic/claude-sonnet-4.5 changed=False
nvidia:nemotron-3-super-120b-a12b from openrouter => True openrouter nvidia/nemotron-3-super-120b-a12b changed=False
```
