### PR TITLE
fix(gateway): respect disabled Home Assistant env override

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -748,7 +748,7 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
-                    if plat_name == Platform.SLACK.value and "enabled" in plat_block:
+                    if plat_name in {Platform.SLACK.value, Platform.HOMEASSISTANT.value} and "enabled" in plat_block:
                         merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
                     if merged_extra:
@@ -820,7 +820,7 @@ def load_gateway_config() -> GatewayConfig:
                 if not isinstance(extra, dict):
                     extra = {}
                     plat_data["extra"] = extra
-                if plat == Platform.SLACK and enabled_was_explicit:
+                if plat in {Platform.SLACK, Platform.HOMEASSISTANT} and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1353,7 +1353,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
-        config.platforms[Platform.HOMEASSISTANT].enabled = True
+            config.platforms[Platform.HOMEASSISTANT].enabled = True
+        else:
+            ha_config = config.platforms[Platform.HOMEASSISTANT]
+            enabled_was_explicit = bool(ha_config.extra.pop("_enabled_explicit", False))
+            if not ha_config.enabled and not enabled_was_explicit:
+                ha_config.enabled = True
         config.platforms[Platform.HOMEASSISTANT].token = hass_token
         hass_url = os.getenv("HASS_URL")
         if hass_url:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -97,6 +97,7 @@ AUTHOR_MAP = {
     "nicoechaniz@altermundi.net": "nicoechaniz",
     "ninso112@proton.me": "Ninso112",
     "wesleysimplicio@live.com": "wesleysimplicio",
+    "wesley.simplicio.ext@siemens-energy.com": "wesleysimplicio",
     "matthew.dean.cater@gmail.com": "SiliconID",
     "xieniu@proton.me": "xieNniu",
     "rw8143a@american.edu": "wali-reheman",

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -437,6 +437,70 @@ class TestConfigIntegration:
         assert ha.token == "env-token"
         assert ha.extra["url"] == "http://10.0.0.5:8123"
 
+    def test_env_override_preserves_explicit_ha_platform_disabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  homeassistant:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is False
+        assert ha.token == "env-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
+        assert Platform.HOMEASSISTANT not in config.get_connected_platforms()
+
+    def test_env_override_preserves_top_level_ha_platform_disabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "homeassistant:\n"
+            "  enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is False
+        assert ha.token == "env-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
+        assert Platform.HOMEASSISTANT not in config.get_connected_platforms()
+
+    def test_env_override_enables_ha_platform_when_enabled_not_explicit(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  homeassistant:\n"
+            "    extra:\n"
+            "      watch_all: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.enabled is True
+        assert ha.token == "env-token"
+        assert ha.extra["watch_all"] is True
+
     def test_no_env_no_platform(self, monkeypatch):
         for v in ["HASS_TOKEN", "HASS_URL", "TELEGRAM_BOT_TOKEN",
                    "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN"]:


### PR DESCRIPTION
﻿## Problem

`HASS_TOKEN` currently auto-enables the Home Assistant gateway platform even when the user explicitly opted out in config:

```yaml
platforms:
  homeassistant:
    enabled: false
```

That makes the platform appear connected because the token is present, so the gateway can start the Home Assistant adapter even though config says it should stay disabled.

Fixes #25065.

## Root cause

`_apply_env_overrides()` always set `config.platforms[Platform.HOMEASSISTANT].enabled = True` whenever `HASS_TOKEN` existed. Slack already had an `_enabled_explicit` sentinel to distinguish an explicit YAML `enabled` value from a default false value, but Home Assistant did not reuse that pattern.

## Fix

- Preserve an explicit Home Assistant `enabled` setting while merging both supported config shapes:
  - `platforms.homeassistant.enabled`
  - top-level `homeassistant.enabled`
- Only auto-enable Home Assistant from `HASS_TOKEN` when the platform is missing or `enabled` was not explicitly configured.
- Still record `HASS_TOKEN` and `HASS_URL`, so Home Assistant tools can use credentials without forcing the gateway adapter on.
- Add my contributor email to `scripts/release.py` `AUTHOR_MAP`, which the repository's attribution check requires for new author emails.

## Solution sketch

```mermaid
flowchart TD
    A[Gateway config load] --> B{Home Assistant present?}
    B -- no --> C[create platform config if env exists]
    B -- yes --> D[read enabled and explicit marker]
    C --> E[apply HASS_TOKEN and HASS_URL]
    D --> F{enabled explicitly set false?}
    F -- yes --> G[keep adapter disabled]
    F -- no --> H[allow env token to auto-enable]
    E --> I[credentials available to tools]
    G --> I
    H --> I
```

## Duplicate check

I checked issue #25065 and searched for open Home Assistant / `HASS_TOKEN` PRs before implementing. I did not find an active duplicate PR for this exact behavior.

## Tests

Local Windows checkout did not have `uv` or a repo `.venv`, so I used a temporary venv outside the repo:

```powershell
C:\Users\wesley.simplicio\AppData\Local\Temp\hermes-test-venv\Scripts\python.exe -m pytest tests/gateway/test_homeassistant.py -q -n 4
# 48 passed
```

```powershell
C:\Users\wesley.simplicio\AppData\Local\Temp\hermes-test-venv\Scripts\python.exe -m pytest tests/gateway/test_config.py::TestLoadGatewayConfig -q -n 4
# 18 passed
```

```powershell
C:\Users\wesley.simplicio\AppData\Local\Temp\hermes-test-venv\Scripts\python.exe -m py_compile scripts\release.py
# passed
```

```powershell
git diff --check
# no errors; only Windows LF -> CRLF warnings
```
