### PR TITLE
fix: queue rapid text messages, log paste collapses (#4469, #17666)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12258,6 +12258,7 @@ class HermesCLI:
                 paste_dir.mkdir(parents=True, exist_ok=True)
                 paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
                 paste_file.write_text(text, encoding="utf-8")
+                logger.info("Collapsed paste #%d: %d lines, %d chars -> %s (fallback)", _paste_counter[0], line_count + 1, len(text), paste_file)
                 _paste_just_collapsed[0] = True
                 buf.text = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
                 buf.cursor_position = len(buf.text)

--- a/cli.py
+++ b/cli.py
@@ -12090,6 +12090,7 @@ class HermesCLI:
                     paste_dir.mkdir(parents=True, exist_ok=True)
                     paste_file = paste_dir / f"paste_{_paste_counter[0]}_{datetime.now().strftime('%H%M%S')}.txt"
                     paste_file.write_text(pasted_text, encoding="utf-8")
+                    logger.info("Collapsed paste #%d: %d lines, %d chars -> %s", _paste_counter[0], line_count + 1, len(pasted_text), paste_file)
                     placeholder = f"[Pasted text #{_paste_counter[0]}: {line_count + 1} lines \u2192 {paste_file}]"
                     prefix = ""
                     if buf.cursor_position > 0 and buf.text[buf.cursor_position - 1] != '\n':


### PR DESCRIPTION
What does this PR do?

Two independent bug fixes for message delivery reliability:
1. Rapid text messages no longer silently dropped (#4469). When multiple text messages arrive while the agent is busy, _queue_or_replace_pending_event() called merge_pending_message_event() without merge_text=True. The function's default behavior replaced the existing pending event with the new one — only the last message survived. Now TEXT messages are merged via concatenation so all messages reach the agent in order when the current turn finishes.
2. Paste collapse events now logged (#17666). Large pastes (5+ lines) are collapsed to file references to avoid flooding the TUI buffer. When the paste file goes missing between creation and expansion (temp cleanup, race condition), the placeholder text was returned silently with only a logger.warning. Added logger.info recording the paste ID, line count, character count, and file path so operators can correlate missing-content reports with specific paste files.

Related Issue
Fixes #4469, #17666

Type of Change
- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made
- gateway/run.py (_queue_or_replace_pending_event) — Changed merge_pending_message_event() call to pass merge_text=True when the incoming event is MessageType.TEXT. This appends rapid text messages instead of replacing the pending slot.
- cli.py (paste handler) — Added logger.info() call after paste file is written, recording paste counter, line count, character count, and file path.

How to Test
1. Rapid messages: While the agent is processing a long task, send "message one" then immediately "message two" from the same user in a gateway platform. When the agent finishes, both messages should appear in order (not just "message two").
2. Paste logging: Paste 10+ lines of text in the CLI. Check the log for "Collapsed paste #1: 11 lines, 500 chars -> ~/.hermes/pastes/paste_1_*.txt". Delete the paste file, then send the message. The placeholder should remain visible and the warning log should fire.