### PR TITLE
fix(windows): keep gateway terminal backend config authoritative

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -387,6 +387,65 @@ _env_path = _hermes_home / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
 
 
+_TERMINAL_CONFIG_ENV_MAP = {
+    "backend": "TERMINAL_ENV",
+    "cwd": "TERMINAL_CWD",
+    "timeout": "TERMINAL_TIMEOUT",
+    "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
+    "docker_image": "TERMINAL_DOCKER_IMAGE",
+    "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+    "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+    "modal_image": "TERMINAL_MODAL_IMAGE",
+    "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
+    "ssh_host": "TERMINAL_SSH_HOST",
+    "ssh_user": "TERMINAL_SSH_USER",
+    "ssh_port": "TERMINAL_SSH_PORT",
+    "ssh_key": "TERMINAL_SSH_KEY",
+    "container_cpu": "TERMINAL_CONTAINER_CPU",
+    "container_memory": "TERMINAL_CONTAINER_MEMORY",
+    "container_disk": "TERMINAL_CONTAINER_DISK",
+    "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+    "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+    "docker_env": "TERMINAL_DOCKER_ENV",
+    "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+    "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+}
+
+
+def _bridge_terminal_config_to_env(cfg: dict) -> None:
+    """Apply config.yaml terminal settings to env vars used by terminal tools.
+
+    Gateway reloads ~/.hermes/.env during long-running sessions so new secrets
+    are picked up.  config.yaml remains the documented source of truth for
+    terminal backend selection, so these bridged TERMINAL_* values must be
+    re-applied after each .env reload instead of only at process startup.
+    """
+    terminal_cfg = cfg.get("terminal", {})
+    if not terminal_cfg or not isinstance(terminal_cfg, dict):
+        return
+
+    for cfg_key, env_var in _TERMINAL_CONFIG_ENV_MAP.items():
+        if cfg_key not in terminal_cfg:
+            continue
+        val = terminal_cfg[cfg_key]
+        # Skip cwd placeholder values (".", "auto", "cwd") — the gateway
+        # resolves these to Path.home() later.  Writing the raw placeholder
+        # here would just be noise.
+        if cfg_key == "cwd" and str(val) in {".", "auto", "cwd"}:
+            continue
+        # Expand shell tilde in cwd so subprocess.Popen never receives a
+        # literal "~/" which the kernel rejects.
+        if cfg_key == "cwd" and isinstance(val, str):
+            val = os.path.expanduser(val)
+        if isinstance(val, (list, dict)):
+            os.environ[env_var] = json.dumps(val)
+        else:
+            os.environ[env_var] = str(val)
+
+
 def _reload_runtime_env_preserving_config_authority() -> None:
     """Reload .env for fresh credentials without letting stale .env override config.
 
@@ -416,6 +475,8 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
         os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
 
+    _bridge_terminal_config_to_env(cfg)
+
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
 _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
@@ -437,51 +498,7 @@ if _config_path.exists():
                 os.environ[_key] = str(_val)
         # Terminal config is nested — bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
-        _terminal_cfg = _cfg.get("terminal", {})
-        if _terminal_cfg and isinstance(_terminal_cfg, dict):
-            _terminal_env_map = {
-                "backend": "TERMINAL_ENV",
-                "cwd": "TERMINAL_CWD",
-                "timeout": "TERMINAL_TIMEOUT",
-                "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
-                "docker_image": "TERMINAL_DOCKER_IMAGE",
-                "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-                "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-                "modal_image": "TERMINAL_MODAL_IMAGE",
-                "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-                "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-                "ssh_host": "TERMINAL_SSH_HOST",
-                "ssh_user": "TERMINAL_SSH_USER",
-                "ssh_port": "TERMINAL_SSH_PORT",
-                "ssh_key": "TERMINAL_SSH_KEY",
-                "container_cpu": "TERMINAL_CONTAINER_CPU",
-                "container_memory": "TERMINAL_CONTAINER_MEMORY",
-                "container_disk": "TERMINAL_CONTAINER_DISK",
-                "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-                "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-                "docker_env": "TERMINAL_DOCKER_ENV",
-                "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-                "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-                "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-                "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
-            }
-            for _cfg_key, _env_var in _terminal_env_map.items():
-                if _cfg_key in _terminal_cfg:
-                    _val = _terminal_cfg[_cfg_key]
-                    # Skip cwd placeholder values (".", "auto", "cwd") — the
-                    # gateway resolves these to Path.home() later (line ~255).
-                    # Writing the raw placeholder here would just be noise.
-                    # Only bridge explicit absolute paths from config.yaml.
-                    if _cfg_key == "cwd" and str(_val) in {".", "auto", "cwd"}:
-                        continue
-                    # Expand shell tilde in cwd so subprocess.Popen never
-                    # receives a literal "~/" which the kernel rejects.
-                    if _cfg_key == "cwd" and isinstance(_val, str):
-                        _val = os.path.expanduser(_val)
-                    if isinstance(_val, (list, dict)):
-                        os.environ[_env_var] = json.dumps(_val)
-                    else:
-                        os.environ[_env_var] = str(_val)
+        _bridge_terminal_config_to_env(_cfg)
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract).

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -195,11 +195,46 @@ def get_startup_entry_path() -> Path:
 # Script rendering
 # ---------------------------------------------------------------------------
 
+_DOCKER_TERMINAL_ENV_KEYS = (
+    "TERMINAL_DOCKER_IMAGE",
+    "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "TERMINAL_DOCKER_VOLUMES",
+    "TERMINAL_DOCKER_ENV",
+)
+
+
+def _gateway_terminal_env_overlay(config: dict | None) -> dict[str, str]:
+    """Return terminal env vars that Windows gateway launchers must pin.
+
+    The gateway loads dotenv/config again inside its long-lived process. On
+    Windows service startup, stale Docker env inherited from the user/session can
+    otherwise override ``terminal.backend: local`` and route terminal tools back
+    into Docker after a restart. Bake the configured backend into the generated
+    launcher/direct-spawn environment and explicitly clear Docker-only vars when
+    the backend is not Docker.
+    """
+    terminal_cfg = (config or {}).get("terminal")
+    if not isinstance(terminal_cfg, dict):
+        terminal_cfg = {}
+
+    backend = str(terminal_cfg.get("backend") or os.environ.get("TERMINAL_ENV") or "").strip()
+    overlay: dict[str, str] = {}
+    if backend:
+        overlay["TERMINAL_ENV"] = backend
+
+    if backend.lower() != "docker":
+        for key in _DOCKER_TERMINAL_ENV_KEYS:
+            overlay[key] = ""
+
+    return overlay
+
+
 def _build_gateway_cmd_script(
     python_path: str,
     working_dir: str,
     hermes_home: str,
     profile_arg: str,
+    terminal_env_overlay: dict[str, str] | None = None,
 ) -> str:
     """Build the ``gateway.cmd`` wrapper content (CRLF-terminated).
 
@@ -221,6 +256,12 @@ def _build_gateway_cmd_script(
     # if someone imports hermes_constants-based logic during startup.
     venv_dir = str(Path(python_path).resolve().parent.parent)
     lines.append(f'set "VIRTUAL_ENV={venv_dir}"')
+    for key, value in (terminal_env_overlay or {}).items():
+        if "\r" in key or "\n" in key or "=" in key:
+            raise ValueError(f"invalid environment variable name: {key!r}")
+        if "\r" in value or "\n" in value:
+            raise ValueError(f"invalid environment variable value for {key!r}")
+        lines.append(f'set "{key}={value}"')
 
     prog_args = [python_path, "-m", "hermes_cli.main"]
     if profile_arg:
@@ -246,7 +287,7 @@ def _write_task_script() -> Path:
     """Generate and write the gateway.cmd wrapper. Return its absolute path."""
     _assert_windows()
     # Local imports to avoid circular-init at module load time.
-    from hermes_cli.config import get_hermes_home
+    from hermes_cli.config import get_hermes_home, load_config
     from hermes_cli.gateway import (
         PROJECT_ROOT,
         _profile_arg,
@@ -257,8 +298,15 @@ def _write_task_script() -> Path:
     working_dir = str(PROJECT_ROOT)
     hermes_home = str(Path(get_hermes_home()).resolve())
     profile_arg = _profile_arg(hermes_home)
+    terminal_env_overlay = _gateway_terminal_env_overlay(load_config())
 
-    content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
+    content = _build_gateway_cmd_script(
+        python_path,
+        working_dir,
+        hermes_home,
+        profile_arg,
+        terminal_env_overlay=terminal_env_overlay,
+    )
     script_path = get_task_script_path()
     script_path.write_text(content, encoding="utf-8", newline="")
     return script_path
@@ -352,7 +400,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     layer in between.
     """
     _assert_windows()
-    from hermes_cli.config import get_hermes_home
+    from hermes_cli.config import get_hermes_home, load_config
     from hermes_cli.gateway import (
         PROJECT_ROOT,
         _profile_arg,
@@ -375,6 +423,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
         "HERMES_GATEWAY_DETACHED": "1",
         "VIRTUAL_ENV": str(Path(python_exe).resolve().parent.parent),
     }
+    env_overlay.update(_gateway_terminal_env_overlay(load_config()))
     return argv, working_dir, env_overlay
 
 

--- a/tests/gateway/test_runtime_env_reload_terminal_config.py
+++ b/tests/gateway/test_runtime_env_reload_terminal_config.py
@@ -1,0 +1,47 @@
+"""Regression tests for gateway .env reload preserving terminal config authority."""
+
+import os
+
+import yaml
+
+
+def test_runtime_env_reload_reapplies_terminal_backend_from_config(monkeypatch, tmp_path):
+    """A stale .env TERMINAL_ENV must not override config.yaml after reload.
+
+    Gateway sessions reload ~/.hermes/.env between turns to pick up fresh
+    credentials.  If that reload restores TERMINAL_ENV=docker, terminal tools
+    can keep executing in Docker even though config.yaml says local.  The reload
+    path must re-bridge terminal.backend from config.yaml after loading .env.
+    """
+    from gateway import run as gateway_run
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "agent": {"max_turns": 90},
+                "terminal": {
+                    "backend": "local",
+                    "cwd": ".",
+                    "timeout": 180,
+                    "docker_mount_cwd_to_workspace": False,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_load_dotenv(*args, **kwargs):
+        os.environ["TERMINAL_ENV"] = "docker"
+        os.environ["TERMINAL_DOCKER_IMAGE"] = "nikolaik/python-nodejs:python3.11-nodejs20"
+        os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] = "true"
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "load_hermes_dotenv", fake_load_dotenv)
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    gateway_run._reload_runtime_env_preserving_config_authority()
+
+    assert os.environ["TERMINAL_ENV"] == "local"
+    assert os.environ["TERMINAL_TIMEOUT"] == "180"
+    assert os.environ["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] == "False"

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -1,0 +1,46 @@
+"""Tests for Windows gateway service wrapper generation."""
+
+import hermes_cli.gateway_windows as gateway_windows
+
+
+class TestWindowsGatewayTerminalEnv:
+    def test_gateway_cmd_forces_configured_local_backend_and_clears_docker_env(self):
+        content = gateway_windows._build_gateway_cmd_script(
+            r"C:\Hermes\venv\Scripts\pythonw.exe",
+            r"C:\Hermes\hermes-agent",
+            r"C:\Users\Vineel\AppData\Local\hermes",
+            "",
+            terminal_env_overlay={
+                "TERMINAL_ENV": "local",
+                "TERMINAL_DOCKER_IMAGE": "",
+                "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE": "",
+                "TERMINAL_DOCKER_VOLUMES": "",
+                "TERMINAL_DOCKER_ENV": "",
+            },
+        )
+
+        assert 'set "TERMINAL_ENV=local"' in content
+        assert 'set "TERMINAL_DOCKER_IMAGE="' in content
+        assert 'set "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE="' in content
+        assert 'set "TERMINAL_DOCKER_VOLUMES="' in content
+        assert 'set "TERMINAL_DOCKER_ENV="' in content
+        assert content.index('set "TERMINAL_ENV=local"') < content.index("pythonw.exe")
+
+    def test_terminal_env_overlay_clears_docker_settings_when_backend_is_not_docker(self):
+        overlay = gateway_windows._gateway_terminal_env_overlay(
+            {
+                "terminal": {
+                    "backend": "local",
+                    "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+                    "docker_mount_cwd_to_workspace": False,
+                    "docker_volumes": [],
+                    "docker_env": {},
+                }
+            }
+        )
+
+        assert overlay["TERMINAL_ENV"] == "local"
+        assert overlay["TERMINAL_DOCKER_IMAGE"] == ""
+        assert overlay["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] == ""
+        assert overlay["TERMINAL_DOCKER_VOLUMES"] == ""
+        assert overlay["TERMINAL_DOCKER_ENV"] == ""


### PR DESCRIPTION
## Summary
- Preserve `terminal.backend` config authority after gateway `.env` reloads so stale `TERMINAL_ENV=docker` cannot override `terminal.backend: local`.
- Pin the configured terminal backend in the generated Windows gateway launcher/direct detached spawn environment.
- Clear stale Docker-only terminal env vars from Windows gateway startup when backend is not Docker.
- Add regression tests for both the runtime reload path and Windows launcher env overlay.

## Why
On Windows Discord gateway restarts, stale Docker terminal env/config values can make terminal tools run in Docker/WSL even when `config.yaml` says `terminal.backend: local`. The Windows scheduled-task gateway can also fail to recover if the launcher inherits Docker-specific env before Python loads config.

## Test plan
- `python -m py_compile hermes_cli/gateway_windows.py tests/hermes_cli/test_gateway_windows.py`
- `python -m pytest tests/hermes_cli/test_gateway_windows.py -q`
- Live Windows validation: regenerate `%LOCALAPPDATA%\hermes\gateway-service\Hermes_Gateway.cmd` and confirm it contains:
  - `set "TERMINAL_ENV=local"`
  - blank `TERMINAL_DOCKER_IMAGE`, `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE`, `TERMINAL_DOCKER_VOLUMES`, `TERMINAL_DOCKER_ENV`
- Live Discord validation after gateway restart:
  - `uname` reports `MINGW64_NT-*`
  - `dockerenv=no`
  - `cmd.exe`/`schtasks.exe` available
