### PR TITLE
docs: update CLI skill preload example

### DIFF
--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -32,7 +32,7 @@ hermes chat --provider openrouter  # Force OpenRouter
 hermes chat --toolsets "web,terminal,skills"
 
 # Start with one or more skills preloaded
-hermes -s hermes-agent-dev,github-auth
+hermes -s hermes-agent,github-auth
 hermes chat -s github-pr-workflow -q "open a draft PR"
 
 # Resume previous sessions
@@ -159,7 +159,7 @@ Then type `/status`, `/gpu`, or `/restart` in any chat. See the [Configuration g
 If you already know which skills you want active for the session, pass them at launch time:
 
 ```bash
-hermes -s hermes-agent-dev,github-auth
+hermes -s hermes-agent,github-auth
 hermes chat -s github-pr-workflow -s github-auth
 ```
 


### PR DESCRIPTION
## Summary
- Replace stale `hermes-agent-dev` skill preload examples with `hermes-agent` in the CLI docs.

## Test Plan
- `git diff --check`
- `git grep -n 'hermes-agent-dev' -- website/docs/user-guide/cli.md` returns no matches

Created from Codex CLI smoke test.