### PR TITLE
fix: gateway PID detection fails on Windows (two issues)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -128,6 +128,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
 
     On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
     platforms without /proc, falls back to ``ps -p <pid> -o command=``.
+    On Windows (no /proc, no ps), uses psutil.
     """
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
@@ -148,6 +149,16 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    # Windows fallback: psutil (already used by _pid_exists)
+    try:
+        import psutil  # type: ignore
+        proc = psutil.Process(pid)
+        cmdline_parts = proc.cmdline()
+        if cmdline_parts:
+            return " ".join(cmdline_parts)
+    except Exception:
         pass
 
     return None
@@ -178,7 +189,8 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     if not isinstance(argv, list) or not argv:
         return False
 
-    cmdline = " ".join(str(part) for part in argv)
+    # Normalize Windows backslashes so patterns match cross-platform.
+    cmdline = " ".join(str(part) for part in argv).replace("\\", "/")
     patterns = (
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",


### PR DESCRIPTION
## Summary

Fixes two Windows compatibility bugs in `gateway/status.py` that cause `get_running_pid()` to always return `None` on Windows, making the dashboard report the gateway as "stopped" even when it's running normally.

## Root Cause

### Bug 1: `_read_process_cmdline` cannot read process cmdline on Windows

The function tries `/proc/{pid}/cmdline` (Linux-only) then falls back to `ps -p ...` (Unix command). On Windows, neither works, so `_looks_like_gateway_process()` always returns `False`.

**Fix:** Add a `psutil` fallback (already a hard dependency, used by `_pid_exists` in the same module).

### Bug 2: `_record_looks_like_gateway` fails on Windows paths

The fallback record check joins `argv` but Windows paths use backslashes (e.g. `hermes_cli\main.py`), while matching patterns use forward slashes/dots. The pattern never matches.

**Fix:** Normalize backslashes to forward slashes before matching with `cmdline.replace("\\", "/")`.

## Reproduction

On Windows with gateway running:

```
>>> from gateway.status import get_running_pid
>>> get_running_pid()  # Returns None (bug)
```

Dashboard at `/api/status` shows `gateway_running: false, gateway_state: "stopped"`.

After fix: `get_running_pid()` returns the actual PID, dashboard correctly shows `gateway_running: true`.

## Changes

- `gateway/status.py` `_read_process_cmdline`: add psutil fallback for Windows (+4 lines)
- `gateway/status.py` `_record_looks_like_gateway`: normalize `\` to `/` before matching (+1 line)

Linux/macOS behavior is unchanged.