### PR TITLE
fix(api_server): surface cached_tokens in OpenAI-compat usage emission

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -51,6 +51,34 @@ from gateway.platforms.base import (
     is_network_accessible,
 )
 
+
+def _build_chat_usage(usage: dict) -> dict:
+    """Build OpenAI Chat Completions-compatible usage dict with cache details."""
+    result = {
+        "prompt_tokens": usage.get("input_tokens", 0),
+        "completion_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("total_tokens", 0),
+    }
+    cached = usage.get("cache_read_tokens", 0)
+    if cached:
+        result["prompt_tokens_details"] = {"cached_tokens": cached}
+    return result
+
+
+def _build_responses_usage(usage: dict) -> dict:
+    """Build OpenAI Responses API-compatible usage dict with cache details."""
+    result = {
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "total_tokens": usage.get("total_tokens", 0),
+    }
+    cached = usage.get("cache_read_tokens", 0)
+    if cached:
+        result["input_tokens_details"] = {"cached_tokens": cached}
+    return result
+
+
+
 logger = logging.getLogger(__name__)
 
 # Default settings
@@ -1320,11 +1348,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "finish_reason": finish_reason,
                 }
             ],
-            "usage": {
-                "prompt_tokens": usage.get("input_tokens", 0),
-                "completion_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
+            "usage": _build_chat_usage(usage),
         }
         if is_partial or is_failed or not completed:
             response_data["hermes"] = {
@@ -1449,11 +1473,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                "usage": {
-                    "prompt_tokens": usage.get("input_tokens", 0),
-                    "completion_tokens": usage.get("output_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                },
+                "usage": _build_chat_usage(usage),
             }
             await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
             await response.write(b"data: [DONE]\n\n")
@@ -1641,11 +1661,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
             incomplete_env = _envelope("incomplete")
             incomplete_env["output"] = incomplete_items
-            incomplete_env["usage"] = {
-                "input_tokens": usage.get("input_tokens", 0),
-                "output_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            }
+            incomplete_env["usage"] = _build_responses_usage(usage)
             incomplete_history = list(conversation_history)
             incomplete_history.append({"role": "user", "content": user_message})
             if incomplete_text:
@@ -1984,11 +2000,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 failed_env = _envelope("failed")
                 failed_env["output"] = final_items
                 failed_env["error"] = {"message": agent_error, "type": "server_error"}
-                failed_env["usage"] = {
-                    "input_tokens": usage.get("input_tokens", 0),
-                    "output_tokens": usage.get("output_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                }
+                failed_env["usage"] = _build_responses_usage(usage)
                 _failed_history = list(conversation_history)
                 _failed_history.append({"role": "user", "content": user_message})
                 if final_response_text or agent_error:
@@ -2008,11 +2020,7 @@ class APIServerAdapter(BasePlatformAdapter):
             else:
                 completed_env = _envelope("completed")
                 completed_env["output"] = final_items
-                completed_env["usage"] = {
-                    "input_tokens": usage.get("input_tokens", 0),
-                    "output_tokens": usage.get("output_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                }
+                completed_env["usage"] = _build_responses_usage(usage)
                 full_history = self._build_response_conversation_history(
                     conversation_history,
                     user_message,
@@ -2074,11 +2082,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 failed_env = _envelope("failed")
                 failed_env["output"] = list(emitted_items)
                 failed_env["error"] = {"message": str(_exc)[:500], "type": "server_error"}
-                failed_env["usage"] = {
-                    "input_tokens": usage.get("input_tokens", 0),
-                    "output_tokens": usage.get("output_tokens", 0),
-                    "total_tokens": usage.get("total_tokens", 0),
-                }
+                failed_env["usage"] = _build_responses_usage(usage)
                 await _write_event("response.failed", {
                     "type": "response.failed",
                     "response": failed_env,
@@ -2344,11 +2348,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "created_at": created_at,
             "model": body.get("model", self._model_name),
             "output": output_items,
-            "usage": {
-                "input_tokens": usage.get("input_tokens", 0),
-                "output_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
+            "usage": _build_responses_usage(usage),
         }
 
         # Store the complete response object for future chaining / GET retrieval
@@ -2779,6 +2779,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0) or 0,
             }
             # Include the effective session ID in the result so callers
             # (e.g. X-Hermes-Session-Id header) can track compression-
@@ -3047,6 +3049,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
+                        "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0) or 0,
                     }
                     return r, u
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -410,6 +410,8 @@ class TestAgentExecution:
         mock_agent.session_prompt_tokens = 1
         mock_agent.session_completion_tokens = 2
         mock_agent.session_total_tokens = 3
+        mock_agent.session_cache_read_tokens = 0
+        mock_agent.session_cache_write_tokens = 0
 
         with patch.object(adapter, "_create_agent", return_value=mock_agent):
             result, usage = await adapter._run_agent(
@@ -424,7 +426,7 @@ class TestAgentExecution:
         # here doesn't set an explicit session_id string so the guard skips
         # the annotation — header will fall back to the provided session_id.
         assert result["final_response"] == "ok"
-        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3, "cache_read_tokens": 0, "cache_write_tokens": 0}
         mock_agent.run_conversation.assert_called_once_with(
             user_message="hello",
             conversation_history=[],
@@ -3264,6 +3266,8 @@ class TestSessionKeyHeader:
             mock_agent.session_prompt_tokens = 0
             mock_agent.session_completion_tokens = 0
             mock_agent.session_total_tokens = 0
+            mock_agent.session_cache_read_tokens = 0
+            mock_agent.session_cache_write_tokens = 0
             return mock_agent
 
         app = _create_app(auth_adapter)

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -81,6 +81,8 @@ def _make_slow_agent(**kwargs):
     mock_agent.session_prompt_tokens = 0
     mock_agent.session_completion_tokens = 0
     mock_agent.session_total_tokens = 0
+    mock_agent.session_cache_read_tokens = 0
+    mock_agent.session_cache_write_tokens = 0
 
     return mock_agent, ready, interrupted
 
@@ -111,6 +113,8 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 10
                 mock_agent.session_completion_tokens = 5
                 mock_agent.session_total_tokens = 15
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
@@ -182,6 +186,8 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -208,6 +214,8 @@ class TestRunStatus:
                 mock_agent.session_prompt_tokens = 4
                 mock_agent.session_completion_tokens = 2
                 mock_agent.session_total_tokens = 6
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
@@ -237,6 +245,8 @@ class TestRunStatus:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -289,6 +299,8 @@ class TestRunEvents:
                 mock_agent.session_prompt_tokens = 10
                 mock_agent.session_completion_tokens = 5
                 mock_agent.session_total_tokens = 15
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 # Start run
@@ -318,6 +330,8 @@ class TestRunEvents:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post("/v1/runs", json={"input": "hello"})
@@ -445,6 +459,8 @@ class TestStopRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.session_cache_write_tokens = 0
                 mock_create.return_value = mock_agent
 
                 # Start and wait for completion


### PR DESCRIPTION
## Summary

Fixes #25400

The API server's OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/responses`, `/v1/runs`) emitted usage objects with only `prompt_tokens`, `completion_tokens`, and `total_tokens`. Cache hit statistics (`prompt_tokens_details.cached_tokens` for Chat Completions, `input_tokens_details.cached_tokens` for Responses API) were silently dropped even though the agent internally tracks them via `session_cache_read_tokens`.

This made prompt-cache effectiveness unobservable from the API consumer side (e.g. Paperclip's heartbeat usage normalizer always sees `cachedInputTokens: 0`).

## Changes

- Add `_build_chat_usage()` and `_build_responses_usage()` module-level helpers that conditionally include `cached_tokens` in the details sub-object when `cache_read_tokens > 0`
- Propagate `cache_read_tokens` and `cache_write_tokens` from the agent through `_run_agent()`'s usage dict (both the main path and the `/v1/runs` executor)
- Replace all 7 inline usage dict literals across Chat Completions, streaming, and Responses API emission sites with the appropriate helper call
- Update test mocks in `test_api_server.py` and `test_api_server_runs.py` to include `session_cache_read_tokens` / `session_cache_write_tokens` attributes

## Testing

All 270 api_server tests pass (`pytest tests/ -k api_server` — 270 passed, 4 skipped).

## Scope

1 file changed (`gateway/platforms/api_server.py`) + 2 test files.