### PR TITLE
fix(mem0): exclude secret fields from mem0.json on save_config

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -144,7 +144,12 @@ class Mem0MemoryProvider(MemoryProvider):
         return bool(cfg.get("api_key"))
 
     def save_config(self, values, hermes_home):
-        """Write config to $HERMES_HOME/mem0.json."""
+        """Write config to $HERMES_HOME/mem0.json.
+
+        Secret fields (those with ``secret=True`` in the config schema) are
+        excluded — they belong in ``~/.hermes/.env``, not in a plain-text JSON
+        file that may be committed, shared, or backed up without scrubbing.
+        """
         import json
         from pathlib import Path
         config_path = Path(hermes_home) / "mem0.json"
@@ -154,7 +159,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 existing = json.loads(config_path.read_text())
             except Exception:
                 pass
-        existing.update(values)
+        secret_keys = {f["key"] for f in self.get_config_schema() if f.get("secret")}
+        filtered = {k: v for k, v in values.items() if k not in secret_keys}
+        existing.update(filtered)
+        # Remove any secret keys that were written by older versions
+        for sk in secret_keys:
+            existing.pop(sk, None)
         config_path.write_text(json.dumps(existing, indent=2))
 
     def get_config_schema(self):

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -225,3 +225,45 @@ class TestMem0Defaults:
         provider.initialize("test")
 
         assert provider._agent_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# save_config secret filtering (#25085)
+# ---------------------------------------------------------------------------
+
+
+class TestMem0SaveConfigSecretFiltering:
+    """save_config must never write secret fields (api_key) to mem0.json."""
+
+    def test_save_config_excludes_api_key(self, tmp_path):
+        provider = Mem0MemoryProvider()
+        provider.save_config(
+            {"api_key": "sk-secret-123", "user_id": "alice", "agent_id": "bot"},
+            str(tmp_path),
+        )
+        saved = json.loads((tmp_path / "mem0.json").read_text())
+        assert "api_key" not in saved
+        assert saved["user_id"] == "alice"
+        assert saved["agent_id"] == "bot"
+
+    def test_save_config_strips_existing_api_key_from_file(self, tmp_path):
+        """Older versions may have written api_key — save_config removes it."""
+        mem0_json = tmp_path / "mem0.json"
+        mem0_json.write_text(json.dumps({
+            "api_key": "old-key", "user_id": "bob", "rerank": True,
+        }))
+        provider = Mem0MemoryProvider()
+        provider.save_config({"user_id": "bob", "agent_id": "hermes"}, str(tmp_path))
+        saved = json.loads(mem0_json.read_text())
+        assert "api_key" not in saved
+        assert saved["user_id"] == "bob"
+        assert saved["rerank"] is True
+
+    def test_save_config_preserves_non_secret_fields(self, tmp_path):
+        provider = Mem0MemoryProvider()
+        provider.save_config(
+            {"user_id": "carol", "agent_id": "alpha", "rerank": False},
+            str(tmp_path),
+        )
+        saved = json.loads((tmp_path / "mem0.json").read_text())
+        assert saved == {"user_id": "carol", "agent_id": "alpha", "rerank": False}


### PR DESCRIPTION
Fixes #25085

## Summary

The mem0 plugin's `save_config()` wrote ALL config values (including `api_key`) to `~/.hermes/mem0.json`. This broke the secret-storage boundary — config files are routinely committed to git, shared in screenshots, or bundled in backups without scrubbing.

## Changes

- `save_config()` now filters out fields with `secret=True` in the config schema before writing to `mem0.json`
- Existing `api_key` entries in `mem0.json` (from older versions) are cleaned up on next save
- Added 3 unit tests covering the filtering behavior

## Details

The config schema already declares `api_key` with `secret=True` and `env_var=MEM0_API_KEY`, signaling that it belongs in `.env`. But `save_config()` merged all values into the JSON file indiscriminately.

The fix uses `get_config_schema()` to identify secret keys and excludes them from the write. It also removes any pre-existing secret keys from the file, handling the migration case where older versions wrote them.

## Tests

```
tests/plugins/memory/test_mem0_v2.py::TestMem0SaveConfigSecretFiltering::test_save_config_excludes_api_key PASSED
tests/plugins/memory/test_mem0_v2.py::TestMem0SaveConfigSecretFiltering::test_save_config_strips_existing_api_key_from_file PASSED
tests/plugins/memory/test_mem0_v2.py::TestMem0SaveConfigSecretFiltering::test_save_config_preserves_non_secret_fields PASSED
```