### PR TITLE
test: keep optional tool tests hermetic

### DIFF
--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -12,10 +12,22 @@ Covers:
 import json
 import os
 import time
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
+
+
+def _fake_botocore_session_module(mock_session=None, side_effect=None):
+    """Installable fake botocore.session module for tests without botocore."""
+    botocore_mod = ModuleType("botocore")
+    session_mod = ModuleType("botocore.session")
+    if side_effect is not None:
+        session_mod.get_session = MagicMock(side_effect=side_effect)
+    else:
+        session_mod.get_session = MagicMock(return_value=mock_session)
+    botocore_mod.session = session_mod
+    return botocore_mod, session_mod
 
 
 # ---------------------------------------------------------------------------
@@ -117,24 +129,35 @@ class TestResolveBedrocRegion:
 
     def test_defaults_to_us_east_1(self):
         from agent.bedrock_adapter import resolve_bedrock_region
-        from unittest.mock import patch, MagicMock
         mock_session = MagicMock()
         mock_session.get_config_variable.return_value = None
-        with patch("botocore.session.get_session", return_value=mock_session):
+        botocore_mod, session_mod = _fake_botocore_session_module(mock_session)
+        with patch.dict(
+            "sys.modules",
+            {"botocore": botocore_mod, "botocore.session": session_mod},
+        ):
             assert resolve_bedrock_region({}) == "us-east-1"
 
     def test_falls_back_to_botocore_profile_region(self):
         from agent.bedrock_adapter import resolve_bedrock_region
-        from unittest.mock import patch, MagicMock
         mock_session = MagicMock()
         mock_session.get_config_variable.return_value = "eu-central-1"
-        with patch("botocore.session.get_session", return_value=mock_session):
+        botocore_mod, session_mod = _fake_botocore_session_module(mock_session)
+        with patch.dict(
+            "sys.modules",
+            {"botocore": botocore_mod, "botocore.session": session_mod},
+        ):
             assert resolve_bedrock_region({}) == "eu-central-1"
 
     def test_botocore_failure_falls_back_to_us_east_1(self):
         from agent.bedrock_adapter import resolve_bedrock_region
-        from unittest.mock import patch
-        with patch("botocore.session.get_session", side_effect=Exception("no botocore")):
+        botocore_mod, session_mod = _fake_botocore_session_module(
+            side_effect=Exception("no botocore")
+        )
+        with patch.dict(
+            "sys.modules",
+            {"botocore": botocore_mod, "botocore.session": session_mod},
+        ):
             assert resolve_bedrock_region({}) == "us-east-1"
 
 

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -263,10 +263,11 @@ class TestPackaging:
         content = toml_path.read_text()
         assert 'bedrock = ["boto3' in content
 
-    def test_bedrock_in_all_extra(self):
+    def test_bedrock_not_in_all_extra(self):
         from pathlib import Path
         content = (Path(__file__).parent.parent.parent / "pyproject.toml").read_text()
-        assert '"hermes-agent[bedrock]"' in content
+        assert '"hermes-agent[bedrock]"' not in content
+        assert "bedrock = [\"boto3" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -97,6 +97,9 @@ def _redirect_cache(tmp_path, monkeypatch):
 def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    # These tests mock the actual download. Do not let host DNS/proxy mappings
+    # for cdn.discordapp.com decide whether document handling is exercised.
+    monkeypatch.setattr(discord_platform, "is_safe_url", lambda _url: True)
 
     config = PlatformConfig(enabled=True, token="fake-token")
     a = DiscordAdapter(config)

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -17,6 +17,7 @@ All Bedrock API calls are mocked — no real AWS credentials needed.
 """
 
 import os
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,6 +42,15 @@ _US_MODELS = [
 def _mock_discover(region: str):
     """Return EU models for eu-* regions, US models otherwise."""
     return _EU_MODELS if region.startswith("eu-") else _US_MODELS
+
+
+def _fake_botocore_session_module(mock_session):
+    """Installable fake botocore.session module for tests without botocore."""
+    botocore_mod = ModuleType("botocore")
+    session_mod = ModuleType("botocore.session")
+    session_mod.get_session = MagicMock(return_value=mock_session)
+    botocore_mod.session = session_mod
+    return botocore_mod, session_mod
 
 
 # ---------------------------------------------------------------------------
@@ -267,16 +277,19 @@ class TestBedrockRegionRouting:
     """End-to-end: region from botocore profile is used for discovery, so EU/AP
     users get eu.*/ap.* model IDs rather than the hardcoded us-east-1 list."""
 
-    def test_eu_region_from_botocore_profile_yields_eu_models(self):
+    def test_eu_region_from_botocore_profile_yields_eu_models(self, monkeypatch):
         """When botocore resolves eu-central-1, picker shows eu.* model IDs."""
         from hermes_cli.model_switch import list_authenticated_providers
 
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         mock_session = MagicMock()
         mock_session.get_config_variable.return_value = "eu-central-1"
+        botocore_mod, session_mod = _fake_botocore_session_module(mock_session)
 
         with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
              patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
-             patch("botocore.session.get_session", return_value=mock_session):
+             patch.dict("sys.modules", {"botocore": botocore_mod, "botocore.session": session_mod}):
             providers = list_authenticated_providers(current_provider="bedrock")
 
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
@@ -309,8 +322,9 @@ class TestBedrockRegionRouting:
 
         mock_session = MagicMock()
         mock_session.get_config_variable.return_value = "eu-central-1"
+        botocore_mod, session_mod = _fake_botocore_session_module(mock_session)
 
-        with patch("botocore.session.get_session", return_value=mock_session):
+        with patch.dict("sys.modules", {"botocore": botocore_mod, "botocore.session": session_mod}):
             region = resolve_bedrock_region()
 
         assert region == "us-west-2", "env var should override botocore profile"

--- a/tests/tools/test_browser_hybrid_routing.py
+++ b/tests/tools/test_browser_hybrid_routing.py
@@ -39,6 +39,7 @@ class TestNavigationSessionKey:
     def test_public_url_uses_bare_task_id(self, monkeypatch):
         """Public URL with cloud provider configured → bare task_id (cloud)."""
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: Mock())
+        monkeypatch.setattr(browser_tool, "_url_is_private", lambda _url: False)
         key = browser_tool._navigation_session_key("default", "https://github.com/x/y")
         assert key == "default"
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -318,6 +318,7 @@ class TestBuiltinDiscovery:
             "tools.todo_tool",
             "tools.tts_tool",
             "tools.vision_tools",
+            "tools.video_generation_tool",
             "tools.web_tools",
             "tools.yuanbao_tools",
         }

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -7,6 +7,7 @@ dispatch.  All external dependencies (faster_whisper, openai) are mocked.
 import json
 import os
 import tempfile
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch, mock_open
 
@@ -136,9 +137,11 @@ class TestTranscribeLocal:
 
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
+        fake_whisper_cls = MagicMock(return_value=mock_model)
+        fake_whisper_module = types.SimpleNamespace(WhisperModel=fake_whisper_cls)
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch.dict("sys.modules", {"faster_whisper": fake_whisper_module}), \
              patch("tools.transcription_tools._local_model", None):
             from tools.transcription_tools import _transcribe_local
             result = _transcribe_local(str(audio_file), "base")
@@ -292,6 +295,8 @@ class TestNormalizeLocalModel:
         try:
             mock_model = MagicMock()
             mock_model.transcribe.return_value = (iter([]), MagicMock(language="en", duration=1.0))
+            fake_whisper_cls = MagicMock(return_value=mock_model)
+            fake_whisper_module = types.SimpleNamespace(WhisperModel=fake_whisper_cls)
             with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
                  patch("tools.transcription_tools._load_stt_config", return_value={
                      "enabled": True,
@@ -300,11 +305,11 @@ class TestNormalizeLocalModel:
                  }), \
                  patch("tools.transcription_tools._local_model", None), \
                  patch("tools.transcription_tools._local_model_name", None), \
-                 patch("faster_whisper.WhisperModel", return_value=mock_model) as mock_cls:
+                 patch.dict("sys.modules", {"faster_whisper": fake_whisper_module}):
                 from tools.transcription_tools import transcribe_audio
                 transcribe_audio(audio_file)
                 # WhisperModel must NOT have been called with "whisper-1"
-                call_args = mock_cls.call_args
+                call_args = fake_whisper_cls.call_args
                 assert call_args is not None
                 assert call_args[0][0] != "whisper-1", (
                     "WhisperModel was called with the cloud-only name 'whisper-1'"

--- a/tests/tools/test_tts_kittentts.py
+++ b/tests/tools/test_tts_kittentts.py
@@ -3,7 +3,6 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
 
@@ -26,8 +25,9 @@ def clear_kittentts_cache():
 def mock_kittentts_module():
     """Inject a fake kittentts + soundfile module that return stub objects."""
     fake_model = MagicMock()
-    # 24kHz float32 PCM at ~2s of silence
-    fake_model.generate.return_value = np.zeros(48000, dtype=np.float32)
+    # 24kHz PCM at ~2s of silence. Keep this as a plain sequence so the
+    # test stays hermetic when numpy is not installed.
+    fake_model.generate.return_value = [0.0] * 48000
     fake_cls = MagicMock(return_value=fake_model)
     fake_kittentts = MagicMock()
     fake_kittentts.KittenTTS = fake_cls

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -246,6 +246,7 @@ class TestBraveFreeSearchOnlyErrors:
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "brave-free"})
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         result_str = asyncio.get_event_loop().run_until_complete(
@@ -264,6 +265,7 @@ class TestBraveFreeSearchOnlyErrors:
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         result_str = asyncio.get_event_loop().run_until_complete(

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -217,6 +217,7 @@ class TestDDGSSearchOnlyErrors:
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         result_str = asyncio.get_event_loop().run_until_complete(
@@ -235,6 +236,7 @@ class TestDDGSSearchOnlyErrors:
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         result_str = asyncio.get_event_loop().run_until_complete(

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -309,6 +309,7 @@ class TestSearXNGOnlyExtractCrawlErrors:
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         import json
@@ -326,6 +327,7 @@ class TestSearXNGOnlyExtractCrawlErrors:
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "searxng"})
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda _url: True)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         import json


### PR DESCRIPTION
Summary
- mock optional Bedrock, transcription, and KittenTTS dependencies so default test installs do not need botocore, faster_whisper, or numpy
- align Bedrock packaging expectations with the current optional-extra policy and add the missing video generation tool to the builtin registry expectation
- isolate Discord document, browser routing, and search-only web provider tests from local DNS/private-URL policy when the network/download path is already mocked

Tests
- `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_bedrock_model_picker.py tests/gateway/test_discord_document_handling.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_registry.py tests/tools/test_tts_kittentts.py tests/tools/test_transcription.py tests/tools/test_transcription_tools.py` -> 439 passed, 13 skipped
- `uv run --frozen pytest tests/hermes_cli/test_bedrock_model_picker.py::TestBedrockRegionRouting -q -o 'addopts='` -> 3 passed
- `uv run --frozen ruff check tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_bedrock_model_picker.py tests/gateway/test_discord_document_handling.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_registry.py tests/tools/test_tts_kittentts.py tests/tools/test_transcription.py`
- `python3 -m py_compile tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_integration.py tests/hermes_cli/test_bedrock_model_picker.py tests/gateway/test_discord_document_handling.py tests/tools/test_browser_hybrid_routing.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_registry.py tests/tools/test_tts_kittentts.py tests/tools/test_transcription.py`
- `git diff --check`

Full-suite note
- `scripts/run_tests.sh` now reports 8 unrelated failures, down from 10 before the Bedrock model picker hermeticity fix: 1 Feishu bot identity test, 6 Google Chat platform enum/config tests, and 1 switch_model context-length test. Those areas are intentionally left out of this PR because they overlap with separate in-flight work.
