### PR TITLE
fix(agent): preserve prompt cache + tree-dedup across background review (reference impl for #25322 Option B)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3975,7 +3975,9 @@ class AIAgent:
         "2. Has the user expressed expectations about how you should behave, their work "
         "style, or ways they want you to operate?\n\n"
         "If something stands out, save it using the memory tool. "
-        "If nothing is worth saving, just say 'Nothing to save.' and stop."
+        "If nothing is worth saving, just say 'Nothing to save.' and stop.\n\n"
+        "Scope: this is a background review. Only use memory/skill tools; "
+        "do not invoke any other tool."
     )
 
     _SKILL_REVIEW_PROMPT = (
@@ -4071,7 +4073,9 @@ class AIAgent:
         "'Nothing to save.' is a real option but should NOT be the "
         "default. If the session ran smoothly with no corrections and "
         "produced no new technique, just say 'Nothing to save.' and stop. "
-        "Otherwise, act."
+        "Otherwise, act.\n\n"
+        "Scope: this is a background review. Only use memory/skill tools; "
+        "do not invoke any other tool."
     )
 
     _COMBINED_REVIEW_PROMPT = (
@@ -4147,7 +4151,9 @@ class AIAgent:
         "standalone constraint.\n\n"
         "Act on whichever of the two dimensions has real signal. If "
         "genuinely nothing stands out on either, say 'Nothing to save.' "
-        "and stop — but don't reach for that conclusion as a default."
+        "and stop — but don't reach for that conclusion as a default.\n\n"
+        "Scope: this is a background review. Only use memory/skill tools; "
+        "do not invoke any other tool."
     )
 
     @staticmethod
@@ -4278,7 +4284,14 @@ class AIAgent:
                         api_key=_parent_runtime.get("api_key") or None,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
-                        enabled_toolsets=["memory", "skills"],
+                        # Inherit parent's full toolset rather than narrowing to
+                        # ["memory", "skills"]: the review prompt is tool-scoped
+                        # by instruction, and matching the parent's tool surface
+                        # keeps the review's system prompt bit-identical to the
+                        # parent's, preserving Anthropic prompt-cache hits AND
+                        # letting preprocessing tree-dedup collapse the review
+                        # into the same conversation leaf as the main session.
+                        enabled_toolsets=self.enabled_toolsets,
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"
@@ -4295,6 +4308,19 @@ class AIAgent:
                     # _vprint and leak past the stdout redirect (they go via
                     # _print_fn/status_callback, which bypass sys.stdout).
                     review_agent.suppress_status_output = True
+                    # Pin the review's session metadata to the parent's so the
+                    # system prompt rebuilds (if any) produce identical output.
+                    # session_start drives the "Conversation started:" line;
+                    # session_id can appear in the prompt for pass_session_id
+                    # setups.
+                    review_agent.session_start = self.session_start
+                    review_agent.session_id = self.session_id
+                    # And inherit the parent's already-assembled system prompt
+                    # so the review skips _build_system_prompt entirely — this
+                    # is what actually makes the first HTTP request's prefix
+                    # match the parent's.
+                    if self._cached_system_prompt is not None:
+                        review_agent._cached_system_prompt = self._cached_system_prompt
 
                     review_agent.run_conversation(
                         user_message=prompt,

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -7,6 +7,7 @@ from run_agent import AIAgent
 
 
 def _bare_agent() -> AIAgent:
+    import datetime as _dt
     agent = object.__new__(AIAgent)
     agent.model = "fake-model"
     agent.platform = "telegram"
@@ -15,11 +16,14 @@ def _bare_agent() -> AIAgent:
     agent.api_key = ""
     agent.api_mode = ""
     agent.session_id = "test-session"
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._parent_session_id = ""
     agent._credential_pool = None
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
+    agent._cached_system_prompt = None
+    agent.enabled_toolsets = None
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
@@ -190,3 +194,75 @@ def test_background_review_summary_is_attributed_to_self_improvement_loop(monkey
     assert captured_bg_callback[0].startswith("💾 Self-improvement review:"), (
         captured_bg_callback[0]
     )
+
+
+def test_background_review_inherits_parent_system_prompt_and_toolsets(monkeypatch):
+    """Regression guard: the background review must be bit-identical to the
+    parent's system-prompt prefix so Anthropic prompt cache hits survive AND
+    preprocessing tree-dedup can collapse the review into the same
+    conversation leaf as the main session.
+
+    Two things must hold:
+      1. ``enabled_toolsets`` is inherited from the parent (not narrowed to
+         ["memory", "skills"], which would produce a different skills-block
+         in the system prompt).
+      2. The parent's already-assembled ``_cached_system_prompt`` is copied
+         onto the review agent so _build_system_prompt is skipped entirely.
+      3. The parent's ``session_start`` and ``session_id`` are also mirrored
+         onto the review agent in case any rebuild path runs.
+    """
+    captured_init: dict = {}
+    captured_attrs: dict = {}
+
+    parent_toolsets = ["terminal", "web", "memory", "skills"]
+    parent_cached_prompt = "PARENT_CACHED_SYSTEM_PROMPT"
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            captured_init.update(kwargs)
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # Snapshot the review agent's attrs at run time so we can
+            # assert the parent's values were installed BEFORE dispatch.
+            captured_attrs["_cached_system_prompt"] = self._cached_system_prompt
+            captured_attrs["session_start"] = self.session_start
+            captured_attrs["session_id"] = self.session_id
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    agent = _bare_agent()
+    agent.enabled_toolsets = parent_toolsets
+    agent._cached_system_prompt = parent_cached_prompt
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    # (1) Full toolset inheritance — NOT hard-coded to a narrow subset.
+    assert captured_init["enabled_toolsets"] == parent_toolsets, (
+        f"Background review must inherit the parent's full toolset to keep "
+        f"its system prompt bit-identical to the parent's; got "
+        f"{captured_init['enabled_toolsets']!r} instead of {parent_toolsets!r}."
+    )
+
+    # (2) Parent's cached system prompt installed before run_conversation.
+    assert captured_attrs["_cached_system_prompt"] == parent_cached_prompt, (
+        "Background review must inherit the parent's _cached_system_prompt "
+        "so _build_system_prompt is skipped and the first HTTP request's "
+        "prefix matches the parent's verbatim (Anthropic prompt-cache hit, "
+        "preprocessing tree-dedup)."
+    )
+
+    # (3) session_start + session_id mirrored for any rebuild paths.
+    assert captured_attrs["session_start"] == agent.session_start
+    assert captured_attrs["session_id"] == agent.session_id

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -1,8 +1,18 @@
-"""Tests that the background review agent is restricted to memory+skills toolsets.
+"""Tests covering the background review agent's toolset wiring.
 
-Regression coverage for issue #15204: the background skill-review agent
+Original context (issue #15204): the background skill-review agent once
 inherited the full default toolset, allowing it to perform non-skill side
-effects (terminal, send_message, delegate_task, etc.).
+effects (terminal, send_message, delegate_task, etc.). The mitigation at
+that time was to hard-restrict ``enabled_toolsets`` to ``["memory", "skills"]``.
+
+Updated design (cache + tree-dedup): restricting the toolset ALSO makes the
+review agent's system prompt diverge from the parent's (different skills-block,
+different tool-guidance layers), which busts the Anthropic prompt cache AND
+prevents preprocessing tree-dedup from collapsing the review into the same
+conversation leaf as the main session. To preserve both properties, the review
+now inherits the parent's full toolset, and the review prompts carry an
+explicit "only use memory/skill tools" instruction. Tool-call safety is
+enforced at the prompt layer rather than at the toolset layer.
 """
 
 import threading
@@ -11,17 +21,21 @@ from unittest.mock import patch
 
 def _make_agent_stub(agent_cls):
     """Create a minimal AIAgent-like object with just enough state for _spawn_background_review."""
+    import datetime as _dt
     agent = object.__new__(agent_cls)
     agent.model = "test-model"
     agent.platform = "test"
     agent.provider = "openai"
     agent.session_id = "sess-123"
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent.quiet_mode = True
     agent._memory_store = None
     agent._memory_enabled = True
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 5
     agent._skill_nudge_interval = 5
+    agent._cached_system_prompt = None
+    agent.enabled_toolsets = ["terminal", "web", "memory", "skills"]
     agent.background_review_callback = None
     agent.status_callback = None
     agent._MEMORY_REVIEW_PROMPT = "review memory"
@@ -41,8 +55,13 @@ class _SyncThread:
             self._target()
 
 
-def test_background_review_agent_uses_restricted_toolsets():
-    """The review agent must only have access to 'memory' and 'skills' toolsets."""
+def test_background_review_agent_inherits_parent_toolsets():
+    """The review agent must inherit the parent's full enabled_toolsets so
+    its system prompt stays bit-identical to the parent's (Anthropic prompt
+    cache + preprocessing tree-dedup). Tool-call scoping is enforced by the
+    review prompt's "only use memory/skill tools" instruction, not by a
+    narrowed toolset.
+    """
     import run_agent
 
     agent = _make_agent_stub(run_agent.AIAgent)
@@ -61,22 +80,31 @@ def test_background_review_agent_uses_restricted_toolsets():
         )
 
     assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
-    assert sorted(captured["enabled_toolsets"]) == ["memory", "skills"]
+    assert captured["enabled_toolsets"] == agent.enabled_toolsets, (
+        "Background review must inherit the parent's full toolset. "
+        "Narrowing it would diverge the review's system prompt from the "
+        "parent's, breaking Anthropic prompt cache + preprocessing tree-dedup."
+    )
 
 
-def test_background_review_agent_tools_are_limited():
-    """Verify the resolved memory+skills toolsets only contain memory and skill tools."""
-    from toolsets import resolve_multiple_toolsets
+def test_background_review_prompts_instruct_tool_restriction():
+    """Since the review inherits the full toolset (see above), the prompts
+    themselves must carry the scoping instruction — this is the safety layer
+    that replaces the old toolset narrowing from issue #15204.
+    """
+    import run_agent
 
-    expected_tools = set(resolve_multiple_toolsets(["memory", "skills"]))
-
-    assert "memory" in expected_tools
-    assert "skill_manage" in expected_tools
-    assert "skill_view" in expected_tools
-    assert "skills_list" in expected_tools
-
-    assert "terminal" not in expected_tools
-    assert "send_message" not in expected_tools
-    assert "delegate_task" not in expected_tools
-    assert "web_search" not in expected_tools
-    assert "execute_code" not in expected_tools
+    for attr in (
+        "_MEMORY_REVIEW_PROMPT",
+        "_SKILL_REVIEW_PROMPT",
+        "_COMBINED_REVIEW_PROMPT",
+    ):
+        prompt = getattr(run_agent.AIAgent, attr)
+        assert "memory/skill tools" in prompt or "memory and skill" in prompt, (
+            f"{attr} must instruct the review agent to only use memory/skill "
+            f"tools; this is the safety layer now that the toolset itself is "
+            f"inherited from the parent (regression guard for #15204)."
+        )
+        assert "do not invoke any other tool" in prompt, (
+            f"{attr} must explicitly forbid calling non-memory/non-skill tools."
+        )


### PR DESCRIPTION
## What does this PR do?

Reference implementation of **Option B** from issue #25322. Fixes the bug where the background self-improvement review's freshly-spawned AIAgent generates a system prompt that bytes-differs from the parent's, busting Anthropic prompt cache + preprocessing tree-dedup.

**See #25322 for the full diagnosis, reproducer, and trade-off discussion.** That issue lays out three options for fixing this bug, with different safety vs cache-hit trade-offs. This PR implements Option B (the one with maximum cache hit, at the cost of moving the safety boundary from "mechanical narrow toolset" to "prompt-layer instruction"). I'm filing it for maintainer reference / evaluation — happy to rewrite as Option A (preserves mechanical safety, accepts a slightly leaky system prompt) or Option C (smaller change, partial cache hit) if maintainers prefer.

Posting this PR alongside the issue because @teknium asked for the code to be available as a reference; treat this as the worked-out version of one of the three branches in the discussion, not as a "please merge this" PR until we've agreed on which option is right.

## Related Issue

Refs #25322 (the bug + design-space discussion)

The safety motivation for the original narrow-toolset design is #15204.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

(Behavior change for the background review pass: still produces the same memory/skill side effects, but now does so with a system message that prefix-matches the parent's.)

## Changes Made

- `run_agent.py`: `_spawn_background_review` now constructs the fork inheriting
  `enabled_toolsets`, `session_start`, `session_id`, and `_cached_system_prompt`
  from the parent. The narrow-toolset call (`enabled_toolsets=["memory", "skills"]`)
  is removed; the safety boundary moves to a prompt-layer instruction baked into
  each review prompt (`_MEMORY_REVIEW_PROMPT`, `_SKILL_REVIEW_PROMPT`,
  `_COMBINED_REVIEW_PROMPT`).
- `tests/run_agent/test_background_review.py`:
  new `test_background_review_inherits_parent_system_prompt_and_toolsets`
  asserts that the spawned review agent gets the parent's `_cached_system_prompt`,
  `session_start`, `session_id`, and `enabled_toolsets` verbatim.
- `tests/run_agent/test_background_review_toolset_restriction.py`:
  **inverted** the existing assertions:
  - was: `assert sorted(captured["enabled_toolsets"]) == ["memory", "skills"]`
  - now: `captured["enabled_toolsets"] == parent_toolsets`
  - plus new test: review prompts contain "Only use memory/skill tools" instruction
  - this is the most reviewer-controversial diff and the part that needs careful judgment

## How to Test

Run the impacted test files:

```sh
pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_toolset_restriction.py -v
```

6/6 pass on this branch.

To observe the cache-hit improvement manually: configure Anthropic provider, run an interactive session, trigger a background review (memory- or skill-relevant turn), and inspect `cached_tokens` in the response of the review's HTTP call. Before this PR: 0. After: matches the parent's cached prefix size.

The empirical reproducer for the underlying bug (showing that parent and review system messages bytes-differ) is in #25322.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the impacted test files; all pass
- [x] I've added tests for my changes — new positive test for inheritance + inverted the existing restriction tests + new test for prompt-layer instruction
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal behavior change; no user-facing config keys or commands added)
- [x] cli-config.yaml.example — N/A, no config key changes
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact — N/A, internal agent logic
- [x] Tool descriptions/schemas — N/A

## Open question for maintainers

The safety relaxation is the part of this PR that I genuinely don't know is the right move. The two questions I'd want maintainer judgment on:

1. **How often do background-review passes empirically try to invoke non-memory/skill tools?** If literally never, prompt-layer enforcement is fine. If sometimes, mechanical lockdown (Option A) is the better fix shape.
2. **Are there downstream invariants in run_agent.py that assume `_cached_system_prompt` content matches the agent's actual `tool_schemas`?** I haven't found any, but a more careful audit by someone who knows the cache-control machinery would catch what I missed. Option A would put us in that "system prompt describes tools the model can't call" state, which is benign in API semantics (the model just discovers unavailability when it tries) but might break some sanity check.

If maintainers prefer either Option A or Option C from #25322, I'll close this PR and re-open with the alternative. The work to switch is small — most of the diff here is the test inversions, not the production change.
