### PR TITLE
feat: add opt-in frontdesk live control plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ __pycache__/model_tools.cpython-310.pyc
 __pycache__/web_tools.cpython-310.pyc
 logs/
 data/
+!tests/agent/data/
+!tests/agent/data/frontdesk_intents_ko.yaml
 .pytest_cache/
 tmp/
 temp_vision_images/

--- a/agent/control_plane.py
+++ b/agent/control_plane.py
@@ -1,0 +1,475 @@
+"""Frontdesk control plane — schema + classify (Phase 2 substrate).
+
+This module sits one layer above :mod:`agent.frontdesk_policy`.  Where the
+policy module returns a *routing verdict*, the control plane wraps it into a
+richer :class:`ControlPlaneDecision` carrying:
+
+* an explicit **Intent** (STOP / STATUS / STEER / NEW_TASK_MAIN /
+  NEW_TASK_WORKER / ACK / DUPLICATE / NOISE) — the single-most-likely
+  interpretation that drives the surface adapter's downstream branch,
+* a **mode-gated recommendation** — when frontdesk mode is off, an otherwise
+  worker-lane verdict is downgraded to ``MAIN`` so legacy callers keep their
+  existing behaviour (design review §3.1 mode-gating invariant),
+* a **fingerprint** for replay tests (INV-6 deterministic classification),
+* a **transcript_render flag** so the surface knows whether to emit a
+  ``control:`` line for the user (INV-2 visibility).
+
+The :class:`WorkerTaskSpec` / :class:`WorkerTaskResult` dataclasses also live
+here even though the lane manager that consumes them is Phase 4.  Putting the
+schema next to the decision keeps the substrate file count small and lets
+Phase 2 tests pin the exact field shapes Phase 4 will rely on.
+
+What this module does NOT do:
+
+* It does **not** dispatch.  Calling :func:`classify` does not run a worker,
+  steer a turn, drop a queue entry, or emit a transcript line.  Those are
+  surface-adapter responsibilities; the control plane just returns the
+  decision object.
+* It does **not** consult any runtime state.  Mode gating is supplied by the
+  caller via the ``frontdesk_mode_active`` keyword; the module has no idea
+  whether a worker lane is registered, a turn is in flight, or a queue is
+  empty.  Verifying any of those is the surface adapter's job.
+* It does **not** mutate inputs or any imported object.  Every dataclass is
+  ``frozen=True``.
+
+Hard boundaries (PRD §9.2 / design review §9.2):
+
+* No persona changes.
+* No ``/mode frontdesk`` exposure.
+* No worker dispatch wiring.
+* No mutation of ``_pending_input`` or the existing ``/busy integrated`` drain
+  semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import FrozenSet, Literal
+
+from agent.frontdesk_policy import (
+    FrontdeskConfidence,
+    FrontdeskPolicyDecision,
+    FrontdeskRecommendation,
+    FrontdeskSignal,
+    classify_request,
+    fingerprint as _fingerprint,
+)
+
+__all__ = [
+    # enum re-exports (the canonical short names)
+    "Signal",
+    "Recommendation",
+    "Confidence",
+    "Intent",
+    "WorkerLaneCancelMode",
+    # decision schema
+    "ControlPlaneDecision",
+    # worker schemas (Phase 4 consumers import them from here)
+    "WorkerTaskSpec",
+    "WorkerTaskResult",
+    # entrypoints
+    "classify",
+    "decide_intent_from_policy",
+]
+
+
+# --------------------------------------------------------------------------
+# Enum re-exports (so callers can use the short names from design review §3.1)
+# --------------------------------------------------------------------------
+Signal = FrontdeskSignal
+Recommendation = FrontdeskRecommendation
+Confidence = FrontdeskConfidence
+
+
+class Intent(Enum):
+    """The single-most-likely interpretation of one user-input fragment.
+
+    Closed set — each value drives a distinct downstream branch:
+
+    * ``STOP``             — INV-1: hard purge of the queue, never re-inject.
+    * ``STATUS``           — answer locally / via ``/tasks`` snapshot.
+    * ``STEER``            — surface invokes ``running_agent.steer`` (after
+                             verifying main is actually in flight).
+    * ``NEW_TASK_MAIN``    — foreground main turn (the conservative default).
+    * ``NEW_TASK_WORKER``  — worker lane dispatch (frontdesk-mode-only).
+    * ``ACK``              — pure acknowledgement, drop silently with a
+                             ``control:`` line.
+    * ``DUPLICATE``        — covered by a recent turn, drop with a line.
+    * ``NOISE``            — un-classifiable / empty, drop with a line.
+    """
+
+    STOP = "stop"
+    STATUS = "status"
+    STEER = "steer"
+    NEW_TASK_MAIN = "new_task_main"
+    NEW_TASK_WORKER = "new_task_worker"
+    ACK = "ack"
+    DUPLICATE = "duplicate"
+    NOISE = "noise"
+
+
+class WorkerLaneCancelMode(Enum):
+    """PRD §7.2 three-tier cancel escalation.
+
+    Surface adapters pass this enum into ``worker_lane_manager.cancel`` (Phase
+    4).  The schema lives here so transcript-replay tests can fix the spelling
+    before any lane manager exists.
+    """
+
+    GRACEFUL = "graceful"  # cancel.flag + cancel_token; escalate to HARD after 5s
+    HARD = "hard"          # subprocess SIGTERM; escalate to FORCE after 5s
+    FORCE = "force"        # subprocess SIGKILL; mark task CANCELLED
+
+
+# --------------------------------------------------------------------------
+# ControlPlaneDecision
+# --------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ControlPlaneDecision:
+    """The single object the surface adapters consume.
+
+    Hashable (frozen + ``frozenset`` for ``signals``).  ``to_dict()`` returns a
+    JSON-safe view suitable for transcript logging, replay-test fixtures, or
+    corpus regeneration.
+
+    Invariants (enforced by :func:`classify` and verified by
+    ``tests/agent/test_control_plane.py``):
+
+    * ``intent == Intent.STOP`` ⇒ ``recommendation == Recommendation.CONTROL``
+      and ``transcript_render is True``.
+    * ``intent in {STOP, NEW_TASK_WORKER, STEER}`` ⇒ ``transcript_render
+      is True``.
+    * ``frontdesk_mode_active is False`` ⇒ ``recommendation in {MAIN,
+      CONTROL}`` (worker/steer-shaped policy verdicts are downgraded to MAIN).
+    * Same ``(text, frontdesk_mode_active)`` ⇒ same ``fingerprint``.
+    """
+
+    intent: Intent
+    signals: FrozenSet[Signal]
+    recommendation: Recommendation
+    confidence: Confidence
+    debug_label: str
+    transcript_render: bool
+    raw_text: str
+    frontdesk_mode_active: bool
+    fingerprint: str
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    # -- convenience -----------------------------------------------------
+    @property
+    def is_stop(self) -> bool:
+        return self.intent is Intent.STOP
+
+    @property
+    def is_control(self) -> bool:
+        return self.recommendation is Recommendation.CONTROL
+
+    @property
+    def should_delegate(self) -> bool:
+        return self.recommendation is Recommendation.WORKER_LANE
+
+    @property
+    def should_steer(self) -> bool:
+        return self.recommendation is Recommendation.STEER
+
+    # -- serialization --------------------------------------------------
+    def to_dict(self) -> dict:
+        return {
+            "intent": self.intent.value,
+            "signals": sorted(s.value for s in self.signals),
+            "recommendation": self.recommendation.value,
+            "confidence": self.confidence.value,
+            "debug_label": self.debug_label,
+            "transcript_render": self.transcript_render,
+            "raw_text": self.raw_text,
+            "frontdesk_mode_active": self.frontdesk_mode_active,
+            "fingerprint": self.fingerprint,
+            "notes": list(self.notes),
+        }
+
+
+# --------------------------------------------------------------------------
+# WorkerTaskSpec / WorkerTaskResult — schemas Phase 4 will consume
+# --------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class WorkerTaskSpec:
+    """One unit of work dispatched to a worker lane.
+
+    Created from a :class:`ControlPlaneDecision` (or directly by a test) and
+    handed to ``worker_lane_manager.dispatch`` in Phase 4.  Phase 2 only pins
+    the schema so transcript-replay fixtures stay stable across phases.
+
+    Field meanings:
+
+    * ``title`` — short human-readable label ("draft frontdesk PRD review").
+    * ``user_intent`` — the verbatim (or minimally trimmed) user fragment.
+    * ``context`` — optional caller-supplied background prose.
+    * ``requested_artifacts`` — filenames the user explicitly asked for; the
+      lane MUST place them under ``$HERMES_HOME/workers/<task_id>/artifacts/``
+      (design review §5.2).
+    * ``source_surface`` — which surface enqueued it (logging/parity).
+    * ``priority`` — lane scheduler hint; "high" can pre-empt "normal".
+    * ``lane_name`` — explicit lane name; ``None`` means "default lane"
+      (``"claude_code"`` once Phase 4 registers it).
+    * ``allow_memory_writes`` — must default False (INV-7).  The user has to
+      explicitly opt the worker into memory writes; bare dispatch does not.
+    * ``decision_fingerprint`` — the
+      :attr:`ControlPlaneDecision.fingerprint` that produced this spec.  Lets a
+      replay test link spec → decision → fragment.
+    """
+
+    title: str
+    user_intent: str
+    context: str = ""
+    requested_artifacts: tuple[str, ...] = ()
+    source_surface: Literal["cli", "tui", "gateway"] = "cli"
+    priority: Literal["normal", "high"] = "normal"
+    lane_name: str | None = None
+    allow_memory_writes: bool = False
+    decision_fingerprint: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "title": self.title,
+            "user_intent": self.user_intent,
+            "context": self.context,
+            "requested_artifacts": list(self.requested_artifacts),
+            "source_surface": self.source_surface,
+            "priority": self.priority,
+            "lane_name": self.lane_name,
+            "allow_memory_writes": self.allow_memory_writes,
+            "decision_fingerprint": self.decision_fingerprint,
+        }
+
+    @classmethod
+    def from_decision(
+        cls,
+        decision: ControlPlaneDecision,
+        *,
+        title: str | None = None,
+        context: str = "",
+        requested_artifacts: tuple[str, ...] = (),
+        source_surface: Literal["cli", "tui", "gateway"] = "cli",
+        priority: Literal["normal", "high"] = "normal",
+        lane_name: str | None = None,
+        allow_memory_writes: bool = False,
+    ) -> "WorkerTaskSpec":
+        """Build a spec from a control-plane decision.
+
+        Title defaults to the first 60 characters of ``raw_text``.  Memory
+        writes default off (INV-7); callers MUST pass
+        ``allow_memory_writes=True`` to opt in.  The decision's fingerprint is
+        copied through for replay linkage.
+        """
+        derived_title = title if title is not None else decision.raw_text[:60].strip()
+        return cls(
+            title=derived_title or "(untitled)",
+            user_intent=decision.raw_text,
+            context=context,
+            requested_artifacts=tuple(requested_artifacts),
+            source_surface=source_surface,
+            priority=priority,
+            lane_name=lane_name,
+            allow_memory_writes=allow_memory_writes,
+            decision_fingerprint=decision.fingerprint,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerTaskResult:
+    """The shape returned by ``worker_lane_manager.result(task_id)``.
+
+    INV-7 wiring (Phase 4 / Phase 5):
+
+    * ``summary`` — one-line notification the main turn IS allowed to render
+      automatically ("워커 #2 완료, artifact: PATH, /tasks import <id>로
+      가져오기").
+    * ``body`` — the full worker output.  MUST NOT be auto-imported into the
+      main conversation.  The main agent reads it only when the user invokes
+      ``/tasks import <task_id>`` or explicitly says "워커 결과 가져와줘".
+    * ``gate_required`` — ``True`` iff ``body`` is non-empty AND not yet
+      imported.  Surface adapters use this flag to render an ``[import gated]``
+      chrome in the status bar.
+    """
+
+    task_id: str
+    status: Literal["queued", "running", "done", "cancelled", "failed"]
+    summary: str
+    body: str = ""
+    artifacts: tuple[str, ...] = ()
+    log_path: str | None = None
+    started_at: float | None = None
+    finished_at: float | None = None
+    error: str | None = None
+    cancel_mode: Literal["none", "graceful", "hard", "force"] = "none"
+    gate_required: bool = False
+
+    def __post_init__(self) -> None:
+        # INV-7 enforcement: a non-empty body MUST come with gate_required=True.
+        # We enforce this in __post_init__ rather than in factory functions so
+        # any direct construction (tests, replay fixtures, future Phase 4
+        # callers) cannot accidentally land an importable body.
+        if self.body and not self.gate_required:
+            # Using object.__setattr__ because the dataclass is frozen.
+            object.__setattr__(self, "gate_required", True)
+
+    def to_dict(self) -> dict:
+        return {
+            "task_id": self.task_id,
+            "status": self.status,
+            "summary": self.summary,
+            "body": self.body,
+            "artifacts": list(self.artifacts),
+            "log_path": self.log_path,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "error": self.error,
+            "cancel_mode": self.cancel_mode,
+            "gate_required": self.gate_required,
+        }
+
+
+# --------------------------------------------------------------------------
+# Intent mapping
+# --------------------------------------------------------------------------
+def decide_intent_from_policy(
+    policy_decision: FrontdeskPolicyDecision,
+    *,
+    frontdesk_mode_active: bool,
+) -> tuple[Intent, Recommendation]:
+    """Map a policy verdict to ``(Intent, Recommendation)``.
+
+    Pure mapping, no side effects.  The two outputs are *not* a degenerate
+    pair: the recommendation can downgrade (e.g. ``WORKER_LANE`` →
+    ``MAIN``) when frontdesk mode is off, while the intent stays the
+    semantically-correct ``NEW_TASK_MAIN`` (matching the *effective* routing).
+    Design review §3.1 mode-gating invariant.
+    """
+    rec = policy_decision.recommendation
+    signals = policy_decision.signals
+
+    # ------------------------------------------------------------------
+    # CONTROL bucket — STOP / ACK / NOISE / STATUS-flagged-as-CONTROL.
+    # ------------------------------------------------------------------
+    if rec is Recommendation.CONTROL:
+        if Signal.STOP in signals:
+            return Intent.STOP, Recommendation.CONTROL
+        if Signal.ACK in signals:
+            return Intent.ACK, Recommendation.CONTROL
+        if Signal.NOISE in signals:
+            return Intent.NOISE, Recommendation.CONTROL
+        if Signal.DUPLICATE in signals:
+            return Intent.DUPLICATE, Recommendation.CONTROL
+        # CONTROL with no specific signal -> NOISE as the conservative default.
+        return Intent.NOISE, Recommendation.CONTROL
+
+    # ------------------------------------------------------------------
+    # MAIN bucket — STATUS hits land here; the rest become NEW_TASK_MAIN.
+    # ------------------------------------------------------------------
+    if rec is Recommendation.MAIN:
+        if Signal.STATUS in signals:
+            return Intent.STATUS, Recommendation.MAIN
+        return Intent.NEW_TASK_MAIN, Recommendation.MAIN
+
+    # ------------------------------------------------------------------
+    # STEER bucket — mode-gated. Surface verifies in-flight before invoking
+    # steer(), but Phase 2 must not change legacy off-mode UX; off ⇒ MAIN.
+    # ------------------------------------------------------------------
+    if rec is Recommendation.STEER:
+        if not frontdesk_mode_active:
+            return Intent.NEW_TASK_MAIN, Recommendation.MAIN
+        return Intent.STEER, Recommendation.STEER
+
+    # ------------------------------------------------------------------
+    # WORKER_LANE bucket — mode-gated.  Off ⇒ downgrade to MAIN.
+    # ------------------------------------------------------------------
+    if rec is Recommendation.WORKER_LANE:
+        if not frontdesk_mode_active:
+            return Intent.NEW_TASK_MAIN, Recommendation.MAIN
+        return Intent.NEW_TASK_WORKER, Recommendation.WORKER_LANE
+
+    # ------------------------------------------------------------------
+    # Defensive fallback — an unknown Recommendation value (forward-compat).
+    # ------------------------------------------------------------------
+    return Intent.NEW_TASK_MAIN, Recommendation.MAIN
+
+
+# Intents that the surface adapter must surface to the user via a
+# ``control:`` transcript line (INV-2 + design review §3.1 visibility rule).
+_TRANSCRIPT_VISIBLE_INTENTS: frozenset[Intent] = frozenset(
+    {Intent.STOP, Intent.NEW_TASK_WORKER, Intent.STEER, Intent.ACK, Intent.DUPLICATE, Intent.NOISE}
+)
+
+
+# --------------------------------------------------------------------------
+# Public entrypoint
+# --------------------------------------------------------------------------
+def classify(
+    text: str,
+    *,
+    lang_hint: str | None = None,
+    frontdesk_mode_active: bool = False,
+) -> ControlPlaneDecision:
+    """Classify a single user-input fragment into a :class:`ControlPlaneDecision`.
+
+    Pure function: same ``(text, lang_hint, frontdesk_mode_active)`` always
+    returns the same value.
+
+    Parameters
+    ----------
+    text:
+        Raw user input.  Leading/trailing whitespace is stripped by the
+        underlying policy classifier.
+    lang_hint:
+        Optional language hint (``"ko"`` short-circuits Korean detection).
+    frontdesk_mode_active:
+        ``True`` only when the surface has confirmed frontdesk mode is on for
+        this session.  When ``False``, worker-lane and steer policy verdicts
+        are downgraded to ``MAIN`` so legacy callers keep their existing
+        behaviour — this is the central invariant that makes Phase 2 substrate
+        safe to land without any UX change.
+
+    Returns
+    -------
+    ControlPlaneDecision
+        A frozen dataclass with the dispatcher's verdict.  Never raises for
+        any string input.
+    """
+    policy_decision = classify_request(text, lang_hint=lang_hint)
+    intent, recommendation = decide_intent_from_policy(
+        policy_decision, frontdesk_mode_active=frontdesk_mode_active
+    )
+
+    transcript_render = intent in _TRANSCRIPT_VISIBLE_INTENTS
+    # STATUS is rendered when frontdesk is on (the user wants to see "main
+    # answering locally") but kept silent on legacy off-mode to avoid surfacing
+    # a new chrome line for unchanged behaviour.
+    if intent is Intent.STATUS and frontdesk_mode_active:
+        transcript_render = True
+
+    # Forward any policy-side notes; add a mode-downgrade note when the policy
+    # said WORKER_LANE or STEER but mode is off.
+    notes: tuple[str, ...] = tuple(policy_decision.notes)
+    if not frontdesk_mode_active and policy_decision.recommendation in {
+        Recommendation.WORKER_LANE,
+        Recommendation.STEER,
+    }:
+        notes = notes + (
+            f"downgraded {policy_decision.recommendation.name} -> MAIN: frontdesk mode off",
+        )
+
+    return ControlPlaneDecision(
+        intent=intent,
+        signals=policy_decision.signals,
+        recommendation=recommendation,
+        confidence=policy_decision.confidence,
+        debug_label=policy_decision.debug_label,
+        transcript_render=transcript_render,
+        raw_text=policy_decision.raw_text,
+        frontdesk_mode_active=frontdesk_mode_active,
+        fingerprint=_fingerprint(
+            policy_decision.raw_text, frontdesk_mode_active=frontdesk_mode_active
+        ),
+        notes=notes,
+    )

--- a/agent/frontdesk_live.py
+++ b/agent/frontdesk_live.py
@@ -1,0 +1,81 @@
+"""Opt-in live frontdesk pre-dispatch helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from utils import is_truthy_value
+
+
+def frontdesk_live_enabled(owner: Any, *, session: dict | None = None) -> bool:
+    """Return whether live frontdesk interception is explicitly enabled."""
+    for carrier in (session, owner):
+        if not carrier:
+            continue
+        if isinstance(carrier, dict):
+            if "frontdesk_live_enabled" in carrier:
+                return bool(carrier.get("frontdesk_live_enabled"))
+            cfg = carrier.get("config")
+        else:
+            if hasattr(carrier, "frontdesk_live_enabled"):
+                return bool(getattr(carrier, "frontdesk_live_enabled"))
+            if hasattr(carrier, "_frontdesk_live_enabled"):
+                return bool(getattr(carrier, "_frontdesk_live_enabled"))
+            cfg = getattr(carrier, "config", None)
+        if isinstance(cfg, dict):
+            orchestration = cfg.get("orchestration") or {}
+            if isinstance(orchestration, dict):
+                raw = orchestration.get("frontdesk_live_enabled")
+                if raw is not None:
+                    return is_truthy_value(raw, default=False)
+    return False
+
+
+def handle_frontdesk_live_input(
+    owner: Any,
+    request_text: Any,
+    *,
+    session: dict | None = None,
+    session_key: str | None = None,
+    source_surface: str,
+    main_in_flight: bool = False,
+    steer_callback: Callable[[str], Any] | None = None,
+    cancel_callback: Callable[[str], Any] | None = None,
+):
+    """Run the frontdesk control gate and return a consumed result or ``None``.
+
+    ``None`` means the caller should continue its existing main-model path.
+    Every non-``None`` result is a local control response and must not be
+    enqueued, replayed, or sent to the main model.
+    """
+    if not frontdesk_live_enabled(owner, session=session):
+        return None
+    if not isinstance(request_text, str) or not request_text.strip():
+        return None
+
+    from agent.orchestration_runtime import (
+        OrchestrationRuntime,
+        get_or_create_orchestration_runtime,
+    )
+
+    runtime_owner = session if session is not None else owner
+    if isinstance(runtime_owner, dict):
+        runtime = runtime_owner.get("_orchestration_runtime")
+        if not isinstance(runtime, OrchestrationRuntime):
+            runtime = OrchestrationRuntime.create()
+            runtime_owner["_orchestration_runtime"] = runtime
+    else:
+        runtime = get_or_create_orchestration_runtime(runtime_owner)
+    result = runtime.handle_frontdesk_input(
+        request_text,
+        frontdesk_mode_active=True,
+        session_key=session_key,
+        source_surface=source_surface,
+        main_in_flight=main_in_flight,
+        steer_callback=steer_callback,
+    )
+    if result.action == "main":
+        return None
+    if result.action == "stopped" and cancel_callback is not None:
+        cancel_callback(request_text)
+    return result

--- a/agent/frontdesk_live.py
+++ b/agent/frontdesk_live.py
@@ -2,9 +2,117 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
 from typing import Any, Callable
 
 from utils import is_truthy_value
+
+
+_DEFAULT_WORKER_LANE = "main"
+_DEFAULT_WORKER_TIMEOUT_SECONDS = 60 * 60
+_FRONTDESK_NOTIFIERS: dict[tuple[int, str | None], Callable[[str], Any]] = {}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _worker_prompt(goal: str) -> str:
+    return (
+        "You are a background worker lane launched by Hermes frontdesk. "
+        "Complete the user's task independently. Do not ask clarification unless absolutely impossible. "
+        "If the task references local files, inspect and edit them directly as requested. "
+        "Return a concise Korean completion report with paths/artifacts changed and any caveats.\n\n"
+        f"USER TASK:\n{goal}"
+    )
+
+
+def _run_default_worker_subprocess(goal: str, token: Any) -> str:
+    """Run one frontdesk worker task in a detached Hermes oneshot subprocess."""
+    cmd = [sys.executable, "-m", "hermes_cli.main", "-z", _worker_prompt(goal)]
+    env = dict(os.environ)
+    env["HERMES_FRONTDESK_WORKER"] = "1"
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(_repo_root()),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    started = time.monotonic()
+    while proc.poll() is None:
+        if getattr(token, "cancelled", False):
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+            from agent.worker_lanes import WorkerCancelled
+
+            raise WorkerCancelled("frontdesk worker cancelled")
+        if time.monotonic() - started > _DEFAULT_WORKER_TIMEOUT_SECONDS:
+            proc.kill()
+            stdout, stderr = proc.communicate(timeout=5)
+            raise TimeoutError(
+                f"frontdesk worker timed out after {_DEFAULT_WORKER_TIMEOUT_SECONDS}s\n{stderr or stdout}"
+            )
+        time.sleep(0.5)
+    stdout, stderr = proc.communicate()
+    if proc.returncode != 0:
+        detail = (stderr or stdout or "").strip()
+        raise RuntimeError(f"frontdesk worker exited {proc.returncode}: {detail}")
+    return (stdout or "").strip() or "worker completed with no output"
+
+
+def ensure_default_worker_lane(
+    owner: Any,
+    *,
+    session_key: str | None = None,
+    notify_callback: Callable[[str], Any] | None = None,
+) -> None:
+    """Ensure every live frontdesk runtime has a default worker lane.
+
+    The live gate must not expose a worker-capable control plane with an empty
+    registry.  This registers one conservative Hermes oneshot-backed lane per
+    runtime.  Results are also pushed back through a per-session notifier when a
+    gateway/TUI surface supplies one.
+    """
+    from agent.orchestration_runtime import get_or_create_orchestration_runtime
+    from agent.worker_lanes import ThreadWorkerLane, WorkerSpec, CancelToken
+
+    runtime = get_or_create_orchestration_runtime(owner)
+    if notify_callback is not None:
+        _FRONTDESK_NOTIFIERS[(id(owner), session_key)] = notify_callback
+
+    if _DEFAULT_WORKER_LANE in runtime.worker_registry.lane_names():
+        return
+
+    owner_id = id(owner)
+
+    def runner(spec: WorkerSpec, token: CancelToken) -> str:
+        result = _run_default_worker_subprocess(spec.goal, token)
+        sk = None
+        if isinstance(spec.metadata, dict):
+            raw_sk = spec.metadata.get("session_key")
+            sk = raw_sk if isinstance(raw_sk, str) else None
+        notifier = _FRONTDESK_NOTIFIERS.get((owner_id, sk)) or _FRONTDESK_NOTIFIERS.get(
+            (owner_id, None)
+        )
+        if notifier is not None:
+            try:
+                notifier(f"worker complete: {spec.task_id or 'untracked'}\n\n{result}")
+            except Exception:
+                pass
+        return result
+
+    runtime.worker_registry.register(ThreadWorkerLane(runner=runner, name=_DEFAULT_WORKER_LANE))
 
 
 def frontdesk_live_enabled(owner: Any, *, session: dict | None = None) -> bool:
@@ -41,6 +149,7 @@ def handle_frontdesk_live_input(
     main_in_flight: bool = False,
     steer_callback: Callable[[str], Any] | None = None,
     cancel_callback: Callable[[str], Any] | None = None,
+    notify_callback: Callable[[str], Any] | None = None,
 ):
     """Run the frontdesk control gate and return a consumed result or ``None``.
 
@@ -57,6 +166,13 @@ def handle_frontdesk_live_input(
         OrchestrationRuntime,
         get_or_create_orchestration_runtime,
     )
+
+    if session is None:
+        ensure_default_worker_lane(
+            owner,
+            session_key=session_key,
+            notify_callback=notify_callback,
+        )
 
     runtime_owner = session if session is not None else owner
     if isinstance(runtime_owner, dict):

--- a/agent/frontdesk_policy.py
+++ b/agent/frontdesk_policy.py
@@ -1,0 +1,868 @@
+"""Frontdesk routing policy — pure deterministic classifier (Phase 2 substrate).
+
+This module is the *classifier* half of the frontdesk control plane.  Given a
+single user-input fragment it returns a :class:`FrontdeskPolicyDecision` whose
+``recommendation`` is one of ``MAIN`` / ``WORKER_LANE`` / ``STEER`` /
+``CONTROL`` and whose ``signals`` enumerate the contributing observations.
+
+What this module is — and isn't:
+
+* **Pure.**  No I/O, no side effects, no logging, no clocks, no randomness.
+  Every call with the same ``(text, lang_hint)`` returns the same value.  This
+  is what PRD §5.2 INV-6 ("Replayable, deterministic classification") demands.
+* **Stdlib-only.**  No third-party imports.  The classifier is a leaf module
+  that ``agent.control_plane`` and ``agent.orchestration_runtime`` may import
+  without dragging in a heavyweight dependency graph.
+* **Decision schema lives here.**  The dataclass and the four enums
+  (``FrontdeskRecommendation`` / ``FrontdeskConfidence`` / ``FrontdeskSignal``)
+  are *the* source of truth for the vocabulary the rest of the control plane
+  uses.  ``agent/control_plane.py`` re-exports them as ``Recommendation`` /
+  ``Confidence`` / ``Signal`` for the shorter name (design review §3.1).
+* **Not a dispatcher.**  Producing ``Recommendation.WORKER_LANE`` does not
+  start a worker; producing ``Recommendation.STEER`` does not inject into a
+  running turn; producing ``Recommendation.CONTROL`` does not purge a queue.
+  Those are surface-adapter responsibilities (CLI / TUI / Gateway each act on
+  the decision in their own idiom).  This module is read-only.
+* **Not a runtime-state inspector.**  It does not consult the task registry,
+  the worker registry, the pending queue, or the running agent.  The
+  recommendation is derived solely from the input text — which means a
+  ``STEER`` recommendation is only a *candidate* (the surface must verify a
+  turn is actually in flight before invoking ``running_agent.steer``).  PRD
+  §6.5 and design review §4.5 call this out explicitly.
+* **Not a model classifier.**  Only deterministic Korean/English vocabulary
+  anchors and shape-based heuristics.  Design review §8.1 DR-1 locks Phase 2
+  to whole-body equality for STOP/ACK; model-based intent classification is a
+  future phase.
+
+Hard boundaries (PRD §3.1 Non-goals + design review §9.2):
+
+* No persona changes here.
+* No worker-lane registration.
+* No exposure of ``/mode frontdesk``.
+* No mutation of any caller-supplied object.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import FrozenSet, Iterable, Sequence
+
+__all__ = [
+    "FrontdeskRecommendation",
+    "FrontdeskConfidence",
+    "FrontdeskSignal",
+    "FrontdeskPolicyDecision",
+    "classify_request",
+    "fingerprint",
+    "STOP_TOKENS_EN",
+    "STOP_TOKENS_KO",
+    "ACK_TOKENS_EN",
+    "ACK_TOKENS_KO",
+]
+
+
+# --------------------------------------------------------------------------
+# Enums
+# --------------------------------------------------------------------------
+class FrontdeskRecommendation(Enum):
+    """Where the dispatcher should send the fragment.
+
+    The enum is closed: every value drives a distinct downstream branch in the
+    surface adapter (see design review §4.1).  A future category must be
+    added explicitly here and in :class:`agent.control_plane.Recommendation`.
+    """
+
+    MAIN = "main"             # foreground main turn (default conservative)
+    WORKER_LANE = "worker_lane"  # delegate to a background worker (Phase 4+)
+    STEER = "steer"           # in-flight inject candidate (surface must verify)
+    CONTROL = "control"       # purely informational (STOP / ACK / NOISE)
+
+
+class FrontdeskConfidence(Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class FrontdeskSignal(Enum):
+    """Contributing observations the classifier made about the fragment.
+
+    Multiple signals may fire per fragment.  Signals are advisory — it is the
+    ``recommendation`` field that drives the downstream branch.  Vocabulary is
+    deliberately open-ended in spirit (a new signal is additive; existing tests
+    stay valid) but expressed as an ``Enum`` for static-checker friendliness.
+    """
+
+    RESEARCH = "research"               # "investigate", "조사", "search", "research"
+    ARTIFACT = "artifact"               # "report.md", "리포트", "draft", "정리해줘"
+    CODE_EDIT = "code_edit"             # "고쳐", "수정", "implement", "refactor"
+    LONG = "long"                       # heuristic >= 2 minutes of work
+    MANY_TOOLS = "many_tools"           # heuristic >= 3 tool calls
+    STATUS = "status"                   # "status?", "어디까지", "뭐 했어"
+    STOP = "stop"                       # whole-body stop token
+    STEER = "steer"                     # short addition / "근데", "그리고"
+    ACK = "ack"                         # whole-body thanks/감사
+    DUPLICATE = "duplicate"             # caller-supplied; the classifier itself
+                                        # does not detect duplicates (no history)
+    NOISE = "noise"                     # empty / unparseable
+    KOREAN = "korean"                   # Hangul detected or lang_hint='ko'
+    EXPLICIT_WORKER_REQ = "explicit_worker_req"  # "백그라운드", "워커에 맡겨"
+    EXPLICIT_MAIN_REQ = "explicit_main_req"      # "지금 해", "직접 해"
+
+
+# --------------------------------------------------------------------------
+# Vocabularies — whole-body match for STOP/ACK (DR-1 lock-in), substring for
+# anchors.  Korean entries match as plain substrings (Hangul has no useful word
+# boundary); English entries match against tokenised lowercase text.
+# --------------------------------------------------------------------------
+
+# STOP — whole-body equality (after trim + lowercase + trailing punctuation
+# strip).  PRD §7.1 + design review §8.1 DR-1.  PAUSE is intentionally folded
+# into STOP-graceful (design review §8.2 OQ-4).
+STOP_TOKENS_EN: tuple[str, ...] = (
+    "stop",
+    "cancel",
+    "abort",
+    "halt",
+    "nevermind",
+    "never mind",
+    "forget it",
+    "/stop",
+    "/cancel",
+    "/abort",
+    "/kill",
+)
+
+STOP_TOKENS_KO: tuple[str, ...] = (
+    "그만",
+    "그만해",
+    "그만둬",
+    "중단",
+    "취소",
+    "됐어",
+    "멈춰",
+    "잠깐만",  # soft pause folded into STOP-graceful per design review §8.2
+    "잠깐",
+    "기다려",
+)
+
+# ACK — whole-body equality only (the TUI integrated module's whole-body
+# heuristic, faithfully mirrored).  "ok" / "응" are intentionally NOT here:
+# both lead steering in their respective languages.
+ACK_TOKENS_EN: tuple[str, ...] = (
+    "thanks",
+    "thanks!",
+    "thank you",
+    "thank you!",
+    "thx",
+    "ty",
+)
+
+ACK_TOKENS_KO: tuple[str, ...] = (
+    "고마워",
+    "고맙습니다",
+    "감사",
+    "감사합니다",
+    "수고",
+    "수고했어",
+)
+
+# Status query anchors.  These are *substring* matches — a status fragment is
+# usually short and contains one of these tokens whole-cloth.
+_STATUS_ANCHORS_EN: tuple[str, ...] = (
+    "status",
+    "what are you doing",
+    "what's running",
+    "show me",
+    "list",
+    "/tasks",
+    "/agents",
+    "/mode",
+)
+
+_STATUS_ANCHORS_KO: tuple[str, ...] = (
+    "상태",
+    "어디까지",
+    "뭐 했어",
+    "뭐해",
+    "뭐 해",
+    "진행",
+    "어떤 lane",
+    "어떤 워커",
+    "지금 뭐",
+)
+
+# Artifact-creation anchors.  Single-anchor → strong WORKER recommendation
+# (PRD §8.1 final paragraph).
+_ARTIFACT_ANCHORS_EN: tuple[str, ...] = (
+    ".md",
+    "report",
+    "report.md",
+    "summary",
+    "summary.md",
+    "draft",
+    "write up",
+    "writeup",
+    "write a",
+    "write the",
+    "compose",
+    "produce a",
+    ".csv",
+    ".svg",
+    ".png",
+    ".pdf",
+    ".tsv",
+    ".json",
+)
+
+_ARTIFACT_ANCHORS_KO: tuple[str, ...] = (
+    "리포트",
+    "보고서",
+    "정리해",
+    "정리해줘",
+    "작성해",
+    "작성해줘",
+    "초안",
+    "문서로",
+)
+
+# External-research anchors.  Single-anchor → strong WORKER recommendation.
+_RESEARCH_ANCHORS_EN: tuple[str, ...] = (
+    "investigate",
+    "research",
+    "search for",
+    "look up",
+    "find out",
+    "crawl",
+    "scrape",
+    "audit",
+    "deep dive",
+    "deep-dive",
+    "explore the",
+    "study the",
+)
+
+_RESEARCH_ANCHORS_KO: tuple[str, ...] = (
+    "조사",
+    "조사해",
+    "조사해줘",
+    "찾아봐",       # "look it up" — investigative
+    # NOTE: "찾아줘" alone is intentionally NOT a research anchor.  "이 파일에서
+    # X 함수 찾아줘" (PRD §8.2) is a localised lookup and should stay on MAIN;
+    # "찾아봐" / "조사" / "리서치" are the investigative-flavour variants.
+    "리서치",
+    "크롤",
+    "크롤링",
+    "탐색",
+    "분석해",
+)
+
+# Code-edit anchors.  Single-anchor → worker candidate; combined with artifact
+# or research → strong worker.
+_CODE_EDIT_ANCHORS_EN: tuple[str, ...] = (
+    "implement",
+    "refactor",
+    "fix the",
+    "patch",
+    "rewrite",
+    "port the",
+    "migrate the",
+    "build the",
+    "add a tool",
+)
+
+_CODE_EDIT_ANCHORS_KO: tuple[str, ...] = (
+    "구현해",
+    "구현해줘",
+    "고쳐",
+    "고쳐줘",
+    "수정해",
+    "수정해줘",
+    "리팩",
+    "리팩터",
+    "재작성",
+)
+
+# Explicit overrides — the user is telling the policy where to route.
+_EXPLICIT_WORKER_ANCHORS_EN: tuple[str, ...] = (
+    "in the background",
+    "background",
+    "delegate this",
+    "delegate it",
+    "delegate to",
+    "give it to a worker",
+    "worker lane",
+    "kick off a worker",
+    "spawn a worker",
+)
+
+_EXPLICIT_WORKER_ANCHORS_KO: tuple[str, ...] = (
+    "백그라운드",
+    "워커에 맡겨",
+    "워커에게 맡겨",
+    "워커한테 맡겨",
+    "클로드한테 맡겨",
+    "위임해",
+    "위임해줘",
+    "맡겨줘",
+)
+
+_EXPLICIT_MAIN_ANCHORS_EN: tuple[str, ...] = (
+    "do it yourself",
+    "do it now",
+    "right now",
+    "yourself",
+    "main thread",
+    "in line",
+    "inline",
+    "directly",
+    "no worker",
+    "no workers",
+)
+
+_EXPLICIT_MAIN_ANCHORS_KO: tuple[str, ...] = (
+    "직접 해",
+    "직접해",
+    "지금 해",
+    "지금해",
+    "지금 보여줘",
+    "바로 해",
+    "바로해",
+    "여기서 해",
+    "메인에서",
+)
+
+# Steer prefixes / additions.  Substring at the start (after trim).  A fragment
+# that begins with a steer prefix is a candidate for in-flight injection.
+_STEER_PREFIXES_EN: tuple[str, ...] = (
+    "also ",
+    "and also ",
+    "additionally ",
+    "btw ",
+    "by the way ",
+    "actually ",
+    "wait ",
+    "oh, ",
+    "oh ",
+)
+
+_STEER_PREFIXES_KO: tuple[str, ...] = (
+    "근데 ",
+    "그리고 ",
+    "추가로 ",
+    "참, ",
+    "참 ",
+    "아 그리고 ",
+    "아, 그리고 ",
+)
+
+
+# --------------------------------------------------------------------------
+# FrontdeskPolicyDecision
+# --------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class FrontdeskPolicyDecision:
+    """Read-only verdict from :func:`classify_request`.
+
+    Hashable (frozen + ``frozenset`` for ``signals``).  Designed to be passed
+    around / logged / stored without defensive copies.  The ``debug_label`` is
+    a stable, one-line summary safe to render to a transcript ``control:`` line.
+    """
+
+    recommendation: FrontdeskRecommendation
+    signals: FrozenSet[FrontdeskSignal]
+    confidence: FrontdeskConfidence
+    debug_label: str
+    raw_text: str = ""
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    # -- convenience -----------------------------------------------------
+    @property
+    def should_delegate(self) -> bool:
+        """``True`` iff the recommendation is to dispatch to a worker lane."""
+        return self.recommendation is FrontdeskRecommendation.WORKER_LANE
+
+    @property
+    def is_control(self) -> bool:
+        """``True`` for STOP / ACK / NOISE — no model call needed."""
+        return self.recommendation is FrontdeskRecommendation.CONTROL
+
+    @property
+    def is_stop(self) -> bool:
+        return FrontdeskSignal.STOP in self.signals
+
+    @property
+    def is_ack(self) -> bool:
+        return FrontdeskSignal.ACK in self.signals
+
+    @property
+    def has_korean(self) -> bool:
+        return FrontdeskSignal.KOREAN in self.signals
+
+    # -- serialization --------------------------------------------------
+    def to_dict(self) -> dict:
+        """Return a JSON-safe view (sorted signal values for stable logs)."""
+        return {
+            "recommendation": self.recommendation.value,
+            "confidence": self.confidence.value,
+            "signals": sorted(s.value for s in self.signals),
+            "debug_label": self.debug_label,
+            "raw_text": self.raw_text,
+            "notes": list(self.notes),
+        }
+
+
+# --------------------------------------------------------------------------
+# Language detection
+# --------------------------------------------------------------------------
+_HANGUL_SYLLABLE_RE = re.compile(r"[가-힯ᄀ-ᇿ㄰-㆏]")
+
+
+def _looks_korean(text: str) -> bool:
+    """``True`` iff *text* contains at least one Hangul character."""
+    return bool(_HANGUL_SYLLABLE_RE.search(text))
+
+
+# --------------------------------------------------------------------------
+# Whole-body equality helpers
+# --------------------------------------------------------------------------
+# Trailing punctuation we tolerate without breaking whole-body equality.  Kept
+# narrow on purpose: "stop, do X" must NOT be whole-body equal to "stop".
+_WHOLE_BODY_TRAILING_RE = re.compile(r"[\s.!?…~^\"'`)\-:,;]+$", re.UNICODE)
+# Smiley/emote suffix that often follows an ack ("thanks :)", "고마워 ㅎㅎ").
+_WHOLE_BODY_EMOTE_RE = re.compile(r"(?:[:;][-]?[)dpo](?:[)dpo])*|ㅎ+|ㅋ+)$", re.IGNORECASE | re.UNICODE)
+
+
+def _strip_trailing_noise(body: str) -> str:
+    """Strip trailing punctuation / whitespace / smileys for whole-body match.
+
+    Repeats up to three times so "thanks!!! :)" reduces to "thanks".
+    """
+    trimmed = body.strip()
+    for _ in range(3):
+        before = trimmed
+        trimmed = _WHOLE_BODY_TRAILING_RE.sub("", trimmed).strip()
+        trimmed = _WHOLE_BODY_EMOTE_RE.sub("", trimmed).strip()
+        if trimmed == before:
+            break
+    return trimmed
+
+
+def _is_whole_body_match(low_body: str, vocab: Sequence[str]) -> bool:
+    """``True`` iff the stripped lowercase body equals one of *vocab*."""
+    core = _strip_trailing_noise(low_body)
+    if not core:
+        return False
+    return core in {v.lower() for v in vocab}
+
+
+# --------------------------------------------------------------------------
+# Substring helpers
+# --------------------------------------------------------------------------
+def _contains_any(haystack: str, needles: Iterable[str]) -> bool:
+    return any(n in haystack for n in needles)
+
+
+def _starts_with_any(low_body: str, prefixes: Iterable[str]) -> bool:
+    return any(low_body.startswith(p) for p in prefixes)
+
+
+# --------------------------------------------------------------------------
+# Heuristics for shape-based signals
+# --------------------------------------------------------------------------
+# Tool-call estimator.  A fragment that asks for multiple distinct actions
+# ("read X and grep Y and write Z") generally needs >= 3 tool calls.
+_TOOL_ACTION_KEYWORDS_EN: tuple[str, ...] = (
+    "read",
+    "grep",
+    "search",
+    "find",
+    "write",
+    "edit",
+    "patch",
+    "fetch",
+    "crawl",
+    "build",
+    "run",
+    "test",
+    "deploy",
+    "list",
+    "show",
+)
+
+_TOOL_ACTION_KEYWORDS_KO: tuple[str, ...] = (
+    "읽어",
+    "찾아",
+    "써",
+    "수정",
+    "빌드",
+    "테스트",
+    "실행",
+    "보여",
+)
+
+# Long-task heuristic words — these are duration hints not vocabulary anchors.
+_LONG_WORDS_EN: tuple[str, ...] = (
+    "all the",
+    "every",
+    "across the codebase",
+    "across the repo",
+    "the whole",
+    "comprehensive",
+    "thorough",
+    "deep",
+    "end-to-end",
+    "end to end",
+)
+
+_LONG_WORDS_KO: tuple[str, ...] = (
+    "전체",
+    "모든",
+    "꼼꼼",
+    "철저",
+    "전반",
+)
+
+
+def _estimate_tool_calls(low_body: str, body: str) -> int:
+    """Rough lower-bound on tool-call count.
+
+    Counts distinct action verbs (English keyword hits plus Korean substring
+    hits) and adds one per ``and`` / ``and then`` conjunction.  Pure heuristic;
+    used only to fire :data:`FrontdeskSignal.MANY_TOOLS`.
+    """
+    count = 0
+    seen = set()
+    for kw in _TOOL_ACTION_KEYWORDS_EN:
+        if kw in low_body and kw not in seen:
+            seen.add(kw)
+            count += 1
+    for kw in _TOOL_ACTION_KEYWORDS_KO:
+        if kw in body and kw not in seen:
+            seen.add(kw)
+            count += 1
+    # Conjunctions multiply effective tool calls.
+    count += low_body.count(" and then ")
+    count += low_body.count(" and ") // 2  # only every other "and" counts
+    return count
+
+
+def _looks_long(body: str, low_body: str) -> bool:
+    """``True`` if the request shape suggests >= 2 minutes of work."""
+    if _contains_any(low_body, _LONG_WORDS_EN):
+        return True
+    if _contains_any(body, _LONG_WORDS_KO):
+        return True
+    # Long prose body (> 240 chars) — likely a multi-step request.
+    if len(body) >= 240:
+        return True
+    return False
+
+
+def _looks_many_tools(low_body: str, body: str) -> bool:
+    return _estimate_tool_calls(low_body, body) >= 3
+
+
+def _has_artifact_anchor(low_body: str, body: str) -> bool:
+    return _contains_any(low_body, _ARTIFACT_ANCHORS_EN) or _contains_any(body, _ARTIFACT_ANCHORS_KO)
+
+
+def _has_research_anchor(low_body: str, body: str) -> bool:
+    return _contains_any(low_body, _RESEARCH_ANCHORS_EN) or _contains_any(body, _RESEARCH_ANCHORS_KO)
+
+
+def _has_code_edit_anchor(low_body: str, body: str) -> bool:
+    return _contains_any(low_body, _CODE_EDIT_ANCHORS_EN) or _contains_any(body, _CODE_EDIT_ANCHORS_KO)
+
+
+def _is_status_query(body: str, low_body: str) -> bool:
+    if _contains_any(low_body, _STATUS_ANCHORS_EN) or _contains_any(body, _STATUS_ANCHORS_KO):
+        return True
+    # A naked "?" or trailing-only "?" with very short body counts as status.
+    if len(body) <= 12 and body.endswith("?"):
+        return True
+    return False
+
+
+def _looks_like_steer(low_body: str, body: str) -> bool:
+    """Detect a steering candidate.
+
+    Two patterns:
+
+    * Direct prefix — the body starts with a steer marker (``also ``, ``근데 ``).
+    * Post-comma prefix — the body begins with an ack/stop-shaped token but a
+      steer marker follows the first comma (``thanks, also do X`` /
+      ``그만, 근데 Y``).  PRD §7.1 calls this out as STEER rather than STOP/ACK
+      so the steering instruction never gets silently dropped.
+    """
+    if _starts_with_any(low_body, _STEER_PREFIXES_EN):
+        return True
+    if _starts_with_any(body, _STEER_PREFIXES_KO):
+        return True
+    # Post-comma scan.  We check ASCII comma variants and the full-width
+    # comma variants common from Korean/IME input.
+    for sep in (", ", ",\n", ",  ", "， ", "，\n", "，  "):
+        if sep in low_body:
+            tail_low = low_body.split(sep, 1)[1].lstrip()
+            if any(tail_low.startswith(p) for p in _STEER_PREFIXES_EN):
+                return True
+        if sep in body:
+            tail = body.split(sep, 1)[1].lstrip()
+            if any(tail.startswith(p) for p in _STEER_PREFIXES_KO):
+                return True
+    return False
+
+
+def _is_explicit_worker_request(low_body: str, body: str) -> bool:
+    return _contains_any(low_body, _EXPLICIT_WORKER_ANCHORS_EN) or _contains_any(
+        body, _EXPLICIT_WORKER_ANCHORS_KO
+    )
+
+
+def _is_explicit_main_request(low_body: str, body: str) -> bool:
+    return _contains_any(low_body, _EXPLICIT_MAIN_ANCHORS_EN) or _contains_any(
+        body, _EXPLICIT_MAIN_ANCHORS_KO
+    )
+
+
+# --------------------------------------------------------------------------
+# Fingerprint helper — INV-6 replay anchor (design review §3.1)
+# --------------------------------------------------------------------------
+def fingerprint(text: str, *, frontdesk_mode_active: bool = False) -> str:
+    """Return a stable sha1 fingerprint of (text, mode) for replay tests.
+
+    Lives here so both ``frontdesk_policy`` and ``control_plane`` can hash the
+    same way without importing each other.  The mode bit is included so a
+    transcript-replay test can distinguish a fragment classified with frontdesk
+    on vs. off.
+    """
+    h = hashlib.sha1()
+    h.update(text.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(b"1" if frontdesk_mode_active else b"0")
+    return h.hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Public entrypoint
+# --------------------------------------------------------------------------
+def classify_request(
+    text: str, *, lang_hint: str | None = None
+) -> FrontdeskPolicyDecision:
+    """Classify a single user-input fragment into a frontdesk routing verdict.
+
+    Pure function: same ``(text, lang_hint)`` always returns the same value.
+    Empty or non-string input is treated as :data:`FrontdeskSignal.NOISE` with
+    :data:`FrontdeskRecommendation.CONTROL`.
+
+    Parameters
+    ----------
+    text:
+        The raw user input.  Leading/trailing whitespace is stripped before
+        analysis.  Empty or whitespace-only input becomes NOISE/CONTROL.
+    lang_hint:
+        Optional caller-supplied language code.  ``"ko"`` short-circuits the
+        Korean detection (useful for surfaces that already know the user's
+        primary language).  Any other value is treated as "no hint".
+
+    Returns
+    -------
+    FrontdeskPolicyDecision
+        A frozen dataclass with the routing verdict, signals, confidence and a
+        stable ``debug_label``.  Never raises for any string input.
+    """
+    raw = text if isinstance(text, str) else ""
+    body = raw.strip()
+    # Normalise to NFC so visually-identical Hangul matches consistently.
+    body = unicodedata.normalize("NFC", body)
+    low_body = body.lower()
+
+    signals: set[FrontdeskSignal] = set()
+
+    # ------------------------------------------------------------------
+    # 1. Empty body → NOISE / CONTROL (no model call).
+    # ------------------------------------------------------------------
+    if not body:
+        signals.add(FrontdeskSignal.NOISE)
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.CONTROL,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.HIGH,
+            debug_label="noise:empty",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 2. Language hint.
+    # ------------------------------------------------------------------
+    is_korean = lang_hint == "ko" or _looks_korean(body)
+    if is_korean:
+        signals.add(FrontdeskSignal.KOREAN)
+
+    # ------------------------------------------------------------------
+    # 3. STOP — whole-body equality (PRD §7.1, DR-1).
+    # ------------------------------------------------------------------
+    if _is_whole_body_match(low_body, STOP_TOKENS_EN) or _is_whole_body_match(
+        body, STOP_TOKENS_KO
+    ):
+        signals.add(FrontdeskSignal.STOP)
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.CONTROL,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.HIGH,
+            debug_label="stop",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 4. ACK — whole-body equality (mirrors busyIntegrated.ts ack heuristic).
+    # ------------------------------------------------------------------
+    if _is_whole_body_match(low_body, ACK_TOKENS_EN) or _is_whole_body_match(
+        body, ACK_TOKENS_KO
+    ):
+        signals.add(FrontdeskSignal.ACK)
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.CONTROL,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.HIGH,
+            debug_label="ack",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 5. Explicit overrides (read but applied after worker/main signals).
+    # ------------------------------------------------------------------
+    if _is_explicit_worker_request(low_body, body):
+        signals.add(FrontdeskSignal.EXPLICIT_WORKER_REQ)
+    if _is_explicit_main_request(low_body, body):
+        signals.add(FrontdeskSignal.EXPLICIT_MAIN_REQ)
+
+    # ------------------------------------------------------------------
+    # 6. Status query — short MAIN hit (returns immediately, beats worker
+    #    anchors so "status of the report.md task?" stays on MAIN).
+    # ------------------------------------------------------------------
+    if _is_status_query(body, low_body):
+        signals.add(FrontdeskSignal.STATUS)
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.MAIN,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.MEDIUM,
+            debug_label="status",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 7. STEER — prefix-only candidate; surface verifies in-flight.
+    # ------------------------------------------------------------------
+    steer_candidate = _looks_like_steer(low_body, body)
+    if steer_candidate:
+        signals.add(FrontdeskSignal.STEER)
+
+    # ------------------------------------------------------------------
+    # 8. Worker-candidate signals.
+    # ------------------------------------------------------------------
+    if _has_artifact_anchor(low_body, body):
+        signals.add(FrontdeskSignal.ARTIFACT)
+    if _has_research_anchor(low_body, body):
+        signals.add(FrontdeskSignal.RESEARCH)
+    if _has_code_edit_anchor(low_body, body):
+        signals.add(FrontdeskSignal.CODE_EDIT)
+    if _looks_long(body, low_body):
+        signals.add(FrontdeskSignal.LONG)
+    if _looks_many_tools(low_body, body):
+        signals.add(FrontdeskSignal.MANY_TOOLS)
+
+    # ------------------------------------------------------------------
+    # 9. Tie-breakers (PRD §8.3).
+    # ------------------------------------------------------------------
+    if FrontdeskSignal.EXPLICIT_MAIN_REQ in signals:
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.MAIN,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.HIGH,
+            debug_label="main:explicit",
+            raw_text=raw,
+        )
+
+    if FrontdeskSignal.EXPLICIT_WORKER_REQ in signals:
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.WORKER_LANE,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.HIGH,
+            debug_label="worker:explicit",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 10. Strong worker signals (artifact / research / code_edit).
+    #     PRD §8.1 final paragraph: single anchor is enough.
+    # ------------------------------------------------------------------
+    strong = signals & {
+        FrontdeskSignal.ARTIFACT,
+        FrontdeskSignal.RESEARCH,
+        FrontdeskSignal.CODE_EDIT,
+    }
+    if strong:
+        # Multiple strong anchors -> HIGH; one strong anchor -> MEDIUM unless
+        # accompanied by a shape-based anchor (LONG / MANY_TOOLS) which pushes
+        # to HIGH (the audit transcript's report-writing case fires LONG too).
+        has_shape = bool(signals & {FrontdeskSignal.LONG, FrontdeskSignal.MANY_TOOLS})
+        if len(strong) >= 2 or has_shape:
+            conf = FrontdeskConfidence.HIGH
+        else:
+            conf = FrontdeskConfidence.MEDIUM
+        label = "worker:" + "+".join(sorted(s.value for s in strong))
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.WORKER_LANE,
+            signals=frozenset(signals),
+            confidence=conf,
+            debug_label=label,
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 11. Weak worker shape only (LONG + MANY_TOOLS together).
+    # ------------------------------------------------------------------
+    if (
+        FrontdeskSignal.LONG in signals
+        and FrontdeskSignal.MANY_TOOLS in signals
+    ):
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.WORKER_LANE,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.MEDIUM,
+            debug_label="worker:shape",
+            raw_text=raw,
+        )
+
+    # ------------------------------------------------------------------
+    # 12. STEER candidate without strong worker signal → STEER recommendation.
+    #     The surface adapter MUST verify a turn is in flight before invoking
+    #     ``running_agent.steer``; otherwise it downgrades to MAIN.  Design
+    #     review §4.5 explains why this verification cannot live in the
+    #     classifier.
+    # ------------------------------------------------------------------
+    if steer_candidate:
+        return FrontdeskPolicyDecision(
+            recommendation=FrontdeskRecommendation.STEER,
+            signals=frozenset(signals),
+            confidence=FrontdeskConfidence.LOW,
+            debug_label="steer:candidate",
+            raw_text=raw,
+            notes=("surface must verify main is in flight",),
+        )
+
+    # ------------------------------------------------------------------
+    # 13. Default → MAIN (conservative bias, PRD §8.3).
+    # ------------------------------------------------------------------
+    return FrontdeskPolicyDecision(
+        recommendation=FrontdeskRecommendation.MAIN,
+        signals=frozenset(signals),
+        confidence=FrontdeskConfidence.MEDIUM if signals else FrontdeskConfidence.LOW,
+        debug_label="main:default",
+        raw_text=raw,
+    )

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -30,30 +30,28 @@ What this module is -- and isn't:
   :data:`RUNTIME_ATTR`; "create if absent" attaches a fresh empty runtime so an
   observability surface always has *something* truthful to read (an empty board),
   never a fabricated one.
-* It is **not** the Ralph / focused-agent runtime, **not** a worker-dispatch or
-  ``delegate_task(background=True)`` mechanism (it starts, polls, kills no
-  workers -- a future phase that wants a lane calls
-  ``runtime.worker_registry.register(lane)`` itself), **not** a follow-up
-  classifier or natural-language router (that is :mod:`agent.followup_router`),
-  **not** automatic Telegram/gateway routing of status queries, **not** a
-  cancel/stop/force-kill surface, **not** a durable routing DB / SQLite schema,
-  **not** an LLM classifier, and **not** a global singleton -- there is no
-  module-level registry; every runtime lives on the object that owns it.  It also
-  does **not** register or rewire the existing ``/tasks`` / ``/agents`` slash
-  commands here: those names are already taken by an unrelated background-process
-  / subagent listing in ``cli.py`` and ``gateway/run.py``, so repurposing them --
-  or threading a runtime through that dispatch -- is exactly the broad
-  CLI/gateway refactor this phase stops short of; the helpers below are what a
-  later, focused command-wiring phase will build on.  See the Phase 7 notes doc.
+* It now includes the first *library-level* frontdesk loop:
+  :meth:`OrchestrationRuntime.handle_frontdesk_input` consumes the Phase 2
+  control-plane verdict and performs the minimal injected-registry side effects
+  needed for STOP / STATUS / STEER / WORKER.  This loop is still not live
+  CLI/Gateway wiring and still starts only lanes that a caller explicitly
+  registered on the runtime.
+* It is **not** the Ralph / focused-agent runtime, **not** a
+  ``delegate_task(background=True)`` mechanism, **not** automatic
+  Telegram/gateway routing of arbitrary natural-language messages, **not** a
+  durable routing DB / SQLite schema, **not** an LLM classifier, and **not** a
+  global singleton -- there is no module-level registry; every runtime lives on
+  the object that owns it.  It also does **not** register or rewire the existing
+  ``/tasks`` / ``/agents`` slash commands here: those names are already taken by
+  an unrelated background-process / subagent listing in ``cli.py`` and
+  ``gateway/run.py``, so repurposing them -- or threading a runtime through that
+  dispatch -- remains a focused command-wiring phase.
 
 Scope discipline (mirrors the Phase 2-6 leaf/presentation modules):
 
-* This module is read-only with respect to user/task state: it never mutates a
-  task, a worker, a queue, or a follow-up.  It only *holds* the registries and
-  *reads* them via the Phase 6 formatter, which itself counts
-  ``pending_followups`` (``len(...)``) and never iterates their payloads -- so
-  :attr:`~agent.pending_turn_queue.PendingTurnItem.raw` is never serialised,
-  copied, deep-copied, or otherwise touched anywhere on this path.
+* Status/advisory helpers remain read-only: they never mutate a task, a worker,
+  a queue, or a follow-up.  The explicit frontdesk loop is the only mutating
+  path in this module, and it mutates only the injected task/worker registries.
 * Everything :meth:`OrchestrationRuntime.snapshot` returns is the Phase 6
   :class:`~agent.orchestration_status.OrchestrationSnapshot`, whose ``to_dict``
   is plain JSON-safe data (strings, ints, ``None``, lists/dicts of those).
@@ -68,10 +66,12 @@ Scope discipline (mirrors the Phase 2-6 leaf/presentation modules):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from agent.control_plane import (
     ControlPlaneDecision,
+    Intent,
+    Recommendation,
     classify as _classify_frontdesk,
 )
 from agent.orchestration_status import (
@@ -81,11 +81,21 @@ from agent.orchestration_status import (
     format_overview as _format_overview,
     format_tasks as _format_tasks,
 )
-from agent.task_registry import TaskRegistry
-from agent.worker_lanes import WorkerLaneRegistry
+from agent.task_registry import (
+    STATUS_CANCELLED,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    TaskRegistry,
+)
+from agent.worker_lanes import (
+    WorkerLaneRegistry,
+    WorkerSpec,
+    link_worker_to_task,
+)
 
 __all__ = [
     "RUNTIME_ATTR",
+    "FrontdeskTurnResult",
     "OrchestrationRuntime",
     "get_orchestration_runtime",
     "get_or_create_orchestration_runtime",
@@ -100,6 +110,37 @@ __all__ = [
 # place so every helper agrees; underscore-prefixed so it reads as internal state
 # on whatever ``HermesCLI`` / gateway runner / session it lands on.
 RUNTIME_ATTR = "_orchestration_runtime"
+
+
+@dataclass(frozen=True, slots=True)
+class FrontdeskTurnResult:
+    """Result of the minimal frontdesk control loop for one input fragment.
+
+    ``action`` is deliberately a small string vocabulary rather than an enum so
+    adapters can render it without importing another type.  The runtime returns
+    this object instead of raising for ordinary routing outcomes; caller-visible
+    errors (for example, no worker lane registered) are represented as a control
+    message and a task note.
+    """
+
+    decision: ControlPlaneDecision
+    action: str
+    message: str
+    task_id: str | None = None
+    worker_id: str | None = None
+    cancelled_tasks: int = 0
+    cancelled_workers: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.decision.to_dict(),
+            "action": self.action,
+            "message": self.message,
+            "task_id": self.task_id,
+            "worker_id": self.worker_id,
+            "cancelled_tasks": self.cancelled_tasks,
+            "cancelled_workers": self.cancelled_workers,
+        }
 
 
 # --------------------------------------------------------------------------
@@ -172,6 +213,163 @@ class OrchestrationRuntime:
         return _classify_frontdesk(
             request_text, frontdesk_mode_active=frontdesk_mode_active
         )
+
+    # -- minimal frontdesk control loop ----------------------------------
+    def handle_frontdesk_input(
+        self,
+        request_text: str,
+        *,
+        frontdesk_mode_active: bool = False,
+        session_key: str | None = None,
+        source_surface: str = "cli",
+        main_in_flight: bool = False,
+        steer_callback: Callable[[str], Any] | None = None,
+    ) -> FrontdeskTurnResult:
+        """Route one input fragment through the first functional frontdesk loop.
+
+        This is intentionally still a *library* loop, not live CLI/Gateway
+        wiring.  It consumes the Phase 2 control-plane decision and performs the
+        smallest safe side effects on the injected registries:
+
+        * STOP cancels active tasks/workers for the session and returns a local
+          control line; the stopped text is never converted into a follow-up.
+        * STATUS returns the local runtime overview.
+        * STEER calls an explicit ``steer_callback`` only when the caller says a
+          main turn is in flight; otherwise it falls back to ``MAIN``.
+        * NEW_TASK_WORKER creates a focused task, starts a registered worker lane,
+          and links task <-> worker.  If no lane is registered, the task is
+          cancelled with a local control message instead of fabricating work.
+        """
+        decision = self.advise_frontdesk(
+            request_text, frontdesk_mode_active=frontdesk_mode_active
+        )
+
+        if decision.intent is Intent.STOP:
+            cancelled_tasks, cancelled_workers = self._cancel_active_frontdesk_work(
+                session_key=session_key
+            )
+            return FrontdeskTurnResult(
+                decision=decision,
+                action="stopped",
+                message=(
+                    f"control: stopped {cancelled_tasks} task(s), "
+                    f"{cancelled_workers} worker(s)"
+                ),
+                cancelled_tasks=cancelled_tasks,
+                cancelled_workers=cancelled_workers,
+            )
+
+        if decision.intent is Intent.STATUS:
+            return FrontdeskTurnResult(
+                decision=decision,
+                action="status",
+                message=self.format_overview(session_key=session_key),
+            )
+
+        if decision.intent is Intent.STEER:
+            if main_in_flight and steer_callback is not None:
+                steer_callback(decision.raw_text)
+                return FrontdeskTurnResult(
+                    decision=decision,
+                    action="steered",
+                    message="control: steered active main turn",
+                )
+            return FrontdeskTurnResult(
+                decision=decision,
+                action="main",
+                message="control: no active main turn to steer; route as main input",
+            )
+
+        if decision.intent is Intent.NEW_TASK_WORKER:
+            return self._start_worker_task(
+                decision,
+                session_key=session_key,
+                source_surface=source_surface,
+            )
+
+        if decision.recommendation is Recommendation.CONTROL:
+            return FrontdeskTurnResult(
+                decision=decision,
+                action=decision.intent.value,
+                message=f"control: {decision.intent.value}",
+            )
+
+        return FrontdeskTurnResult(
+            decision=decision,
+            action="main",
+            message="route: main",
+        )
+
+    def _start_worker_task(
+        self,
+        decision: ControlPlaneDecision,
+        *,
+        session_key: str | None,
+        source_surface: str,
+    ) -> FrontdeskTurnResult:
+        task = self.task_registry.create_task(
+            decision.raw_text,
+            session_key=session_key,
+            origin={"platform": source_surface, "session_key": session_key},
+            status=STATUS_QUEUED,
+        )
+        lane_names = self.worker_registry.lane_names()
+        if not lane_names:
+            self.task_registry.update_status(
+                task.task_id,
+                STATUS_CANCELLED,
+                note="frontdesk worker requested but no worker lane is registered",
+            )
+            return FrontdeskTurnResult(
+                decision=decision,
+                action="worker_unavailable",
+                message="control: worker lane unavailable",
+                task_id=task.task_id,
+            )
+
+        lane_name = lane_names[0]
+        spec = WorkerSpec(
+            goal=decision.raw_text,
+            task_id=task.task_id,
+            lane=lane_name,
+            metadata={
+                "frontdesk_fingerprint": decision.fingerprint,
+                "source_surface": source_surface,
+            },
+        )
+        handle = self.worker_registry.start(spec)
+        link_worker_to_task(self.task_registry, task.task_id, handle)
+        self.task_registry.update_status(
+            task.task_id,
+            STATUS_RUNNING,
+            note=f"worker started: {handle.worker_id}",
+        )
+        return FrontdeskTurnResult(
+            decision=decision,
+            action="worker_started",
+            message=f"control: worker started {handle.worker_id}",
+            task_id=task.task_id,
+            worker_id=handle.worker_id,
+        )
+
+    def _cancel_active_frontdesk_work(
+        self, *, session_key: str | None = None
+    ) -> tuple[int, int]:
+        cancelled_workers = 0
+        for worker in self.snapshot(session_key=session_key).workers:
+            if worker.get("status") in {"queued", "running"}:
+                worker_id = worker.get("worker_id")
+                if isinstance(worker_id, str) and self.worker_registry.cancel(worker_id):
+                    cancelled_workers += 1
+
+        cancelled_tasks = 0
+        for task in self.task_registry.list_tasks(
+            session_key=session_key, active_only=True
+        ):
+            if task.status != STATUS_CANCELLED:
+                self.task_registry.cancel_task(task.task_id, reason="frontdesk stop")
+                cancelled_tasks += 1
+        return cancelled_tasks, cancelled_workers
 
 
 # --------------------------------------------------------------------------

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -268,11 +268,20 @@ class OrchestrationRuntime:
 
         if decision.intent is Intent.STEER:
             if main_in_flight and steer_callback is not None:
-                steer_callback(decision.raw_text)
+                try:
+                    accepted = bool(steer_callback(decision.raw_text))
+                except Exception:
+                    accepted = False
+                if accepted:
+                    return FrontdeskTurnResult(
+                        decision=decision,
+                        action="steered",
+                        message="control: steered active main turn",
+                    )
                 return FrontdeskTurnResult(
                     decision=decision,
-                    action="steered",
-                    message="control: steered active main turn",
+                    action="main",
+                    message="control: steer not accepted; route as main input",
                 )
             return FrontdeskTurnResult(
                 decision=decision,
@@ -293,6 +302,22 @@ class OrchestrationRuntime:
                 action=decision.intent.value,
                 message=f"control: {decision.intent.value}",
             )
+
+        if (
+            main_in_flight
+            and steer_callback is not None
+            and decision.intent is Intent.NEW_TASK_MAIN
+        ):
+            try:
+                accepted = bool(steer_callback(decision.raw_text))
+            except Exception:
+                accepted = False
+            if accepted:
+                return FrontdeskTurnResult(
+                    decision=decision,
+                    action="steered",
+                    message="control: steered active main turn",
+                )
 
         return FrontdeskTurnResult(
             decision=decision,

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -187,14 +187,24 @@ class OrchestrationRuntime:
     def format_agents(self, *, compact: bool = True) -> str:
         """Render the worker/agent board; the graceful empty-state line when
         there are none."""
-        return _format_agents(self.worker_registry, compact=compact)
+        rendered = _format_agents(self.worker_registry, compact=compact)
+        if rendered == "No active workers are currently registered.":
+            lanes = self.worker_registry.lane_names()
+            if lanes:
+                return "No active workers are currently running. Available worker lanes: " + ", ".join(lanes) + "."
+        return rendered
 
     def format_overview(self, *, session_key: str | None = None, compact: bool = True) -> str:
         """Render the combined board (summary, then tasks, then workers); the
         graceful empty-state line when there is neither."""
-        return _format_overview(
+        rendered = _format_overview(
             self.task_registry, self.worker_registry, session_key=session_key, compact=compact
         )
+        if rendered == "No active tasks or workers are currently registered.":
+            lanes = self.worker_registry.lane_names()
+            if lanes:
+                return "No active tasks or workers are currently running. Available worker lanes: " + ", ".join(lanes) + "."
+        return rendered
 
     # -- frontdesk policy advisory (read-only) ---------------------------
     def advise_frontdesk(

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -70,6 +70,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from agent.control_plane import (
+    ControlPlaneDecision,
+    classify as _classify_frontdesk,
+)
 from agent.orchestration_status import (
     OrchestrationSnapshot,
     build_snapshot,
@@ -89,6 +93,7 @@ __all__ = [
     "format_runtime_tasks",
     "format_runtime_agents",
     "format_runtime_overview",
+    "advise_frontdesk_for_owner",
 ]
 
 # The private attribute name a runtime is stored under on an owner object.  One
@@ -148,6 +153,24 @@ class OrchestrationRuntime:
         graceful empty-state line when there is neither."""
         return _format_overview(
             self.task_registry, self.worker_registry, session_key=session_key, compact=compact
+        )
+
+    # -- frontdesk policy advisory (read-only) ---------------------------
+    def advise_frontdesk(
+        self, request_text: str, *, frontdesk_mode_active: bool = False
+    ) -> ControlPlaneDecision:
+        """Return a :class:`~agent.control_plane.ControlPlaneDecision` for
+        *request_text*.
+
+        Side-effect-free: this is a thin pass-through to
+        :func:`agent.control_plane.classify`, including its mode-gating
+        invariant.  Defaulting ``frontdesk_mode_active`` to ``False`` preserves
+        legacy UX: worker/steer-shaped policy verdicts are advisories only and
+        downgrade to ``MAIN`` until a future phase explicitly enables
+        frontdesk mode.  The runtime's own task/worker state is *not* consulted.
+        """
+        return _classify_frontdesk(
+            request_text, frontdesk_mode_active=frontdesk_mode_active
         )
 
 
@@ -221,4 +244,21 @@ def format_runtime_overview(
     runtime on *owner* first if needed."""
     return get_or_create_orchestration_runtime(owner).format_overview(
         session_key=session_key, compact=compact
+    )
+
+
+def advise_frontdesk_for_owner(
+    owner: Any, request_text: str, *, frontdesk_mode_active: bool = False
+) -> ControlPlaneDecision:
+    """Return the frontdesk policy verdict for *request_text* against *owner*'s
+    runtime, creating an empty runtime on *owner* first if needed.
+
+    Read-only: no task, worker, or queue state is mutated.  Callers that only
+    need the verdict (and not the runtime) can call
+    :func:`agent.frontdesk_policy.classify_request` directly; this helper
+    matches the per-owner shape of the other ``*_runtime_*`` formatters so a
+    thin command handler can stay a one-liner.
+    """
+    return get_or_create_orchestration_runtime(owner).advise_frontdesk(
+        request_text, frontdesk_mode_active=frontdesk_mode_active
     )

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -360,6 +360,7 @@ class OrchestrationRuntime:
             metadata={
                 "frontdesk_fingerprint": decision.fingerprint,
                 "source_surface": source_surface,
+                "session_key": session_key,
             },
         )
         handle = self.worker_registry.start(spec)

--- a/agent/orchestration_runtime.py
+++ b/agent/orchestration_runtime.py
@@ -1,0 +1,224 @@
+"""Runtime orchestration context for Hermes (orchestrator Phase 7).
+
+Phase 6 built the read-only *presentation* layer (:mod:`agent.orchestration_status`):
+given a :class:`~agent.task_registry.TaskRegistry` and/or a
+:class:`~agent.worker_lanes.WorkerLaneRegistry` it produces concise, Telegram-
+friendly status text.  But it deliberately stopped short of wiring ``/tasks`` /
+``/agents`` because there was no *live* place for a command handler to find those
+registries -- the formatter was a library, not an observable runtime.
+
+This module is the smallest bridge across that gap.  :class:`OrchestrationRuntime`
+is a tiny container that simply holds one :class:`~agent.task_registry.TaskRegistry`
+and one :class:`~agent.worker_lanes.WorkerLaneRegistry` and forwards
+``snapshot`` / ``format_tasks`` / ``format_agents`` / ``format_overview`` to the
+Phase 6 functions against them.  The module-level helpers
+(:func:`get_orchestration_runtime`, :func:`get_or_create_orchestration_runtime`,
+:func:`set_orchestration_runtime`, :func:`format_runtime_tasks`,
+:func:`format_runtime_agents`, :func:`format_runtime_overview`) let a *CLI / gateway
+runner / session object / test dummy* carry such a runtime on a private
+``_orchestration_runtime`` attribute -- so a later thin command handler can do
+``format_runtime_overview(self)`` without this module knowing or caring what
+``self`` is, and without any global mutable state.
+
+What this module is -- and isn't:
+
+* It is a *container + accessor* substrate.  ``OrchestrationRuntime.create()``
+  makes a fresh, empty, in-memory :class:`~agent.task_registry.TaskRegistry`
+  (``path=None`` -- no file persistence) and an empty
+  :class:`~agent.worker_lanes.WorkerLaneRegistry` (no lanes registered).  The
+  per-owner helpers store/fetch a runtime on a private attribute named by
+  :data:`RUNTIME_ATTR`; "create if absent" attaches a fresh empty runtime so an
+  observability surface always has *something* truthful to read (an empty board),
+  never a fabricated one.
+* It is **not** the Ralph / focused-agent runtime, **not** a worker-dispatch or
+  ``delegate_task(background=True)`` mechanism (it starts, polls, kills no
+  workers -- a future phase that wants a lane calls
+  ``runtime.worker_registry.register(lane)`` itself), **not** a follow-up
+  classifier or natural-language router (that is :mod:`agent.followup_router`),
+  **not** automatic Telegram/gateway routing of status queries, **not** a
+  cancel/stop/force-kill surface, **not** a durable routing DB / SQLite schema,
+  **not** an LLM classifier, and **not** a global singleton -- there is no
+  module-level registry; every runtime lives on the object that owns it.  It also
+  does **not** register or rewire the existing ``/tasks`` / ``/agents`` slash
+  commands here: those names are already taken by an unrelated background-process
+  / subagent listing in ``cli.py`` and ``gateway/run.py``, so repurposing them --
+  or threading a runtime through that dispatch -- is exactly the broad
+  CLI/gateway refactor this phase stops short of; the helpers below are what a
+  later, focused command-wiring phase will build on.  See the Phase 7 notes doc.
+
+Scope discipline (mirrors the Phase 2-6 leaf/presentation modules):
+
+* This module is read-only with respect to user/task state: it never mutates a
+  task, a worker, a queue, or a follow-up.  It only *holds* the registries and
+  *reads* them via the Phase 6 formatter, which itself counts
+  ``pending_followups`` (``len(...)``) and never iterates their payloads -- so
+  :attr:`~agent.pending_turn_queue.PendingTurnItem.raw` is never serialised,
+  copied, deep-copied, or otherwise touched anywhere on this path.
+* Everything :meth:`OrchestrationRuntime.snapshot` returns is the Phase 6
+  :class:`~agent.orchestration_status.OrchestrationSnapshot`, whose ``to_dict``
+  is plain JSON-safe data (strings, ints, ``None``, lists/dicts of those).
+* The per-owner helpers are duck-typed about the owner: they only ever
+  ``getattr`` / ``setattr`` the single private attribute, so a ``HermesCLI``, a
+  gateway runner, a session object, or a hand-built test dummy all work
+  identically.  ``OrchestrationRuntime`` itself takes its two registries by
+  position/keyword (the "explicit injection" path used by tests) with
+  ``create()`` as the only sugar -- there is no implicit shared default.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent.orchestration_status import (
+    OrchestrationSnapshot,
+    build_snapshot,
+    format_agents as _format_agents,
+    format_overview as _format_overview,
+    format_tasks as _format_tasks,
+)
+from agent.task_registry import TaskRegistry
+from agent.worker_lanes import WorkerLaneRegistry
+
+__all__ = [
+    "RUNTIME_ATTR",
+    "OrchestrationRuntime",
+    "get_orchestration_runtime",
+    "get_or_create_orchestration_runtime",
+    "set_orchestration_runtime",
+    "format_runtime_tasks",
+    "format_runtime_agents",
+    "format_runtime_overview",
+]
+
+# The private attribute name a runtime is stored under on an owner object.  One
+# place so every helper agrees; underscore-prefixed so it reads as internal state
+# on whatever ``HermesCLI`` / gateway runner / session it lands on.
+RUNTIME_ATTR = "_orchestration_runtime"
+
+
+# --------------------------------------------------------------------------
+# OrchestrationRuntime
+# --------------------------------------------------------------------------
+@dataclass
+class OrchestrationRuntime:
+    """A live home for one :class:`~agent.task_registry.TaskRegistry` and one
+    :class:`~agent.worker_lanes.WorkerLaneRegistry`, plus thin pass-throughs to
+    the Phase 6 status formatter.
+
+    Construct it directly with explicit registries -- ``OrchestrationRuntime(
+    task_registry=tr, worker_registry=wr)`` -- when you want to share existing
+    ones (tests, or a future phase that already owns them); use
+    :meth:`create` for the common case of "give me a fresh empty pair".  The
+    object is intentionally tiny: it owns no threads, no locks, no background
+    work; the registries it holds bring their own semantics.
+    """
+
+    task_registry: TaskRegistry
+    worker_registry: WorkerLaneRegistry
+
+    @classmethod
+    def create(cls) -> "OrchestrationRuntime":
+        """Return a runtime with a fresh, empty, in-memory task registry
+        (``path=None`` -- no file persistence) and a fresh, empty worker-lane
+        registry (no lanes registered)."""
+        return cls(task_registry=TaskRegistry(), worker_registry=WorkerLaneRegistry())
+
+    # -- read-only views (delegate to Phase 6) ---------------------------
+    def snapshot(self, *, session_key: str | None = None) -> OrchestrationSnapshot:
+        """Build an :class:`~agent.orchestration_status.OrchestrationSnapshot` of
+        the held registries (all tasks for *session_key*, the active/total split
+        living in ``snapshot.counts``).  ``snapshot.to_dict()`` is JSON-safe."""
+        return build_snapshot(
+            self.task_registry, self.worker_registry, session_key=session_key
+        )
+
+    def format_tasks(self, *, session_key: str | None = None, compact: bool = True) -> str:
+        """Render the focused-task board (active tasks for *session_key*); the
+        graceful empty-state line when there are none."""
+        return _format_tasks(self.task_registry, compact=compact, session_key=session_key)
+
+    def format_agents(self, *, compact: bool = True) -> str:
+        """Render the worker/agent board; the graceful empty-state line when
+        there are none."""
+        return _format_agents(self.worker_registry, compact=compact)
+
+    def format_overview(self, *, session_key: str | None = None, compact: bool = True) -> str:
+        """Render the combined board (summary, then tasks, then workers); the
+        graceful empty-state line when there is neither."""
+        return _format_overview(
+            self.task_registry, self.worker_registry, session_key=session_key, compact=compact
+        )
+
+
+# --------------------------------------------------------------------------
+# Per-owner attach / fetch helpers (no global state)
+# --------------------------------------------------------------------------
+def get_orchestration_runtime(owner: Any) -> OrchestrationRuntime | None:
+    """Return the :class:`OrchestrationRuntime` carried by *owner*, or ``None``.
+
+    Only an actual :class:`OrchestrationRuntime` (or subclass) at the private
+    :data:`RUNTIME_ATTR` slot counts -- a missing attribute, ``None``, or some
+    other value all read as "no runtime here".  This never creates or attaches
+    anything.
+    """
+    existing = getattr(owner, RUNTIME_ATTR, None)
+    return existing if isinstance(existing, OrchestrationRuntime) else None
+
+
+def set_orchestration_runtime(owner: Any, runtime: OrchestrationRuntime) -> OrchestrationRuntime:
+    """Attach *runtime* to *owner* at the private :data:`RUNTIME_ATTR` slot and
+    return it.  Replaces any prior value.  Raises ``TypeError`` if *runtime* is
+    not an :class:`OrchestrationRuntime` -- the slot is ours and a later
+    :func:`get_orchestration_runtime` would otherwise silently ignore a bad
+    value."""
+    if not isinstance(runtime, OrchestrationRuntime):
+        raise TypeError("runtime must be an OrchestrationRuntime")
+    setattr(owner, RUNTIME_ATTR, runtime)
+    return runtime
+
+
+def get_or_create_orchestration_runtime(owner: Any) -> OrchestrationRuntime:
+    """Return *owner*'s :class:`OrchestrationRuntime`, attaching a fresh empty one
+    (via :meth:`OrchestrationRuntime.create`) if it does not already carry one.
+
+    The "create if absent" path attaches an *empty* runtime -- a status surface
+    built on it reads as a graceful empty board, never as fabricated state -- and
+    leaves it in place so later work that populates the registries is visible
+    through the same handle.  Two different owners get two independent runtimes;
+    there is no shared/global instance.
+    """
+    existing = get_orchestration_runtime(owner)
+    if existing is not None:
+        return existing
+    return set_orchestration_runtime(owner, OrchestrationRuntime.create())
+
+
+# --------------------------------------------------------------------------
+# Owner-facing formatting convenience (get-or-create, then delegate)
+# --------------------------------------------------------------------------
+def format_runtime_tasks(
+    owner: Any, *, session_key: str | None = None, compact: bool = True
+) -> str:
+    """The focused-task board for *owner*'s runtime, creating an empty runtime on
+    *owner* first if needed -- so a thin ``/tasks``-style handler can be a one-liner
+    and an owner with no runtime yet still gets the graceful empty-state line."""
+    return get_or_create_orchestration_runtime(owner).format_tasks(
+        session_key=session_key, compact=compact
+    )
+
+
+def format_runtime_agents(owner: Any, *, compact: bool = True) -> str:
+    """The worker/agent board for *owner*'s runtime, creating an empty runtime on
+    *owner* first if needed."""
+    return get_or_create_orchestration_runtime(owner).format_agents(compact=compact)
+
+
+def format_runtime_overview(
+    owner: Any, *, session_key: str | None = None, compact: bool = True
+) -> str:
+    """The combined orchestration board for *owner*'s runtime, creating an empty
+    runtime on *owner* first if needed."""
+    return get_or_create_orchestration_runtime(owner).format_overview(
+        session_key=session_key, compact=compact
+    )

--- a/agent/orchestration_status.py
+++ b/agent/orchestration_status.py
@@ -1,0 +1,857 @@
+"""Read-only orchestration observatory for Hermes (orchestrator Phase 6).
+
+Hermes is a concierge / front-desk / butler orchestrator: the user should be
+able to *speak naturally* while Hermes coordinates work behind the scenes -- the
+desired UX is not command-heavy.  But once there are focused tasks and worker
+lanes in flight, the user still needs a lightweight status board: *what tasks are
+active, which workers are running, what follow-ups are queued, is anything
+blocked or waiting for me?*  This module is that read-only presentation layer
+over the Phase 2-5 substrates -- it answers those four questions and nothing more.
+
+What this module is -- and isn't:
+
+* :class:`OrchestrationSnapshot` is a flat, JSON-safe point-in-time view: a list
+  of compact task dicts, a list of compact worker dicts, a ``counts`` summary,
+  and a ``warnings`` list of cheap cross-consistency notes (a task pointing at a
+  worker no lane knows about, a worker pointing at a task no registry knows
+  about).  :class:`OrchestrationStatusFormatter` turns a snapshot -- or, directly,
+  a :class:`~agent.task_registry.TaskRegistry` / a
+  :class:`~agent.worker_lanes.WorkerLaneRegistry` / a single lane / a plain list
+  of handle-ish objects -- into concise, deterministic, Telegram-friendly text:
+  :func:`format_tasks`, :func:`format_agents`, :func:`format_overview`.  Bullets
+  and labels, never markdown tables.  :func:`looks_like_orchestration_status_query`
+  is a deterministic Korean/English predicate that *only* says "this message reads
+  like a request for the status board"; it routes nothing by itself.
+* It is **not** the Ralph / focused-agent runtime, **not** an LLM/model
+  classifier, **not** automatic Telegram/gateway routing of natural-language
+  status queries, **not** a live worker process dashboard (it reads whatever a
+  :class:`~agent.worker_lanes.WorkerLaneRegistry` snapshot already exposes -- it
+  starts, polls, kills nothing), **not** force-kill / force-cancel, **not** the
+  public ``delegate_task(background=True)`` API, **not** a durable routing DB, and
+  **not** a global singleton registry.  It registers no ``/tasks`` / ``/agents``
+  slash commands here: there is no long-lived task/worker runtime in the CLI or
+  gateway for such a command to read yet, and wiring one in would be exactly the
+  broad CLI/gateway refactor this phase stops short of.  When that runtime
+  exists, a thin command handler can call :func:`format_tasks` /
+  :func:`format_agents` directly (or, until then, return a graceful "no focused
+  tasks are currently registered in this session" message); see the Phase 6
+  notes doc for why this is deferred.
+
+Scope discipline (mirrors the Phase 2-5 modules):
+
+* This module is read-only.  Nothing here mutates a task, a worker, a registry,
+  or a queue: it only *reads* and *formats*.  It never serialises, copies, deep-
+  copies, or otherwise touches :attr:`~agent.pending_turn_queue.PendingTurnItem.raw`
+  -- it counts ``pending_followups`` (``len(...)``) and never iterates their
+  payloads; the one place a worker's appended follow-ups are touched at all is
+  through ``WorkerLane.snapshot(worker_id)``, whose existing contract serialises
+  them via :meth:`PendingTurnItem.to_dict` (which drops ``raw`` without reading
+  it) -- and even that call is best-effort and wrapped, so a worker carrying a
+  non-JSON-safe spec ``metadata`` degrades to a goal-less worker line instead of
+  raising.
+* Everything :class:`OrchestrationSnapshot` carries -- and everything in
+  :meth:`OrchestrationSnapshot.to_dict` -- is plain JSON-safe data (strings,
+  ints, ``None``, lists and dicts of those).  Compact goal/result/error strings
+  are stored *untruncated* in the snapshot; truncation is a formatting concern.
+* Inputs are used purely duck-typed: ``TaskRegistry`` is reached via
+  ``list_tasks(...)`` and per-task attributes (``task_id`` / ``status`` /
+  ``user_goal`` / ``active_worker_id`` / ``worker_kind`` / ``pending_followups``
+  / ``notes`` / ``artifacts`` / ``session_key``); ``WorkerLaneRegistry`` via
+  ``lane_names()`` / ``get_lane()``; a lane via ``name`` / ``worker_ids()`` /
+  ``status()`` / ``result()`` / ``snapshot()``; a handle/result via attributes or
+  dict keys.  So the formatter works against the real Phase 3/4 objects, a future
+  injected runtime registry, or hand-built fixtures alike.  The small task/worker
+  *status* string sets are imported from the substrates so there is one source of
+  truth, but nothing requires the inputs to be those concrete classes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Iterable
+
+from agent.task_registry import (
+    STATUS_BLOCKED as _TASK_STATUS_BLOCKED,
+    STATUS_ERROR as _TASK_STATUS_ERROR,
+    TERMINAL_STATUSES as _TERMINAL_TASK_STATUSES,
+)
+from agent.worker_lanes import (
+    ACTIVE_WORKER_STATUSES as _ACTIVE_WORKER_STATUSES,
+    TERMINAL_WORKER_STATUSES as _TERMINAL_WORKER_STATUSES,
+    WorkerStatus as _WorkerStatus,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only; never imported at runtime
+    from agent.task_registry import FocusedTask, TaskRegistry
+    from agent.worker_lanes import WorkerHandle, WorkerLane, WorkerLaneRegistry, WorkerResult
+
+__all__ = [
+    "OrchestrationSnapshot",
+    "OrchestrationStatusFormatter",
+    "build_snapshot",
+    "format_tasks",
+    "format_agents",
+    "format_overview",
+    "looks_like_orchestration_status_query",
+]
+
+# Truncation budgets for the *formatted* text.  ``compact=True`` (the default)
+# keeps goal/result/error short for a glanceable Telegram board; ``compact=False``
+# gives more room without becoming a developer dump.
+_GOAL_COMPACT = 60
+_GOAL_FULL = 140
+_DETAIL_COMPACT = 60
+_DETAIL_FULL = 200
+
+# Empty-state lines (kept identical between the class and the module functions).
+_EMPTY_TASKS = "No active tasks are currently registered."
+_EMPTY_AGENTS = "No active workers are currently registered."
+_EMPTY_OVERVIEW = "No active tasks or workers are currently registered."
+
+
+# --------------------------------------------------------------------------
+# Tiny helpers
+# --------------------------------------------------------------------------
+def _truncate(text: Any, limit: int) -> str:
+    """Strip *text*, then clip to *limit* chars with a trailing ``…`` if needed."""
+    s = text.strip() if isinstance(text, str) else ("" if text is None else str(text).strip())
+    if len(s) <= limit:
+        return s
+    return s[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return *value* if it is a non-empty string, else ``None``."""
+    return value if isinstance(value, str) and value else None
+
+
+def _plural(n: int, word: str) -> str:
+    """``"1 task"`` / ``"2 tasks"`` -- naive ``+ "s"`` (fine for our nouns)."""
+    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
+def _is_plain_iterable(value: Any) -> bool:
+    """True for a non-string, non-mapping iterable (a list/tuple/generator of items)."""
+    if isinstance(value, (str, bytes, dict)):
+        return False
+    try:
+        iter(value)
+    except TypeError:
+        return False
+    return True
+
+
+def _task_is_active(status: Any) -> bool:
+    """Active == not terminal (so an unknown status counts as active, like FocusedTask)."""
+    return status not in _TERMINAL_TASK_STATUSES
+
+
+def _worker_is_terminal(status: Any) -> bool:
+    return status in _TERMINAL_WORKER_STATUSES
+
+
+def _safe_call(fn: Any) -> Any:
+    """Call a zero-arg callable, swallowing *any* exception (best-effort probes)."""
+    if not callable(fn):
+        return None
+    try:
+        return fn()
+    except Exception:  # noqa: BLE001 - duck-typed probe; a failure just means "no data"
+        return None
+
+
+def _safe_call1(fn: Any, arg: Any) -> Any:
+    if not callable(fn):
+        return None
+    try:
+        return fn(arg)
+    except Exception:  # noqa: BLE001 - see _safe_call
+        return None
+
+
+# --------------------------------------------------------------------------
+# Building compact task / worker dicts
+# --------------------------------------------------------------------------
+def _count_value(value: Any) -> int:
+    """Return a safe non-negative count for list-ish or integer-ish values."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return max(0, value)
+    if value is None:
+        return 0
+    try:
+        return max(0, len(value))  # type: ignore[arg-type]
+    except Exception:  # noqa: BLE001 - foreign fixture values become zero, not fatal
+        return 0
+
+
+def _task_to_dict(task: Any) -> dict[str, Any]:
+    """A flat, JSON-safe presentation dict for one focused task.
+
+    Goal is stored *untruncated*.  Only follow-up / note / artifact *counts* are
+    captured -- the follow-up payloads (and their ``raw``) are never touched.
+    Dict inputs are normalized too, so a caller-provided object in ``goal`` or
+    other fields cannot leak into the advertised JSON-safe snapshot.
+    """
+    if isinstance(task, dict):
+        status = task.get("status")
+        goal = _str_or_none(task.get("goal")) or _str_or_none(task.get("user_goal")) or ""
+        worker_id = _str_or_none(task.get("worker_id")) or _str_or_none(task.get("active_worker_id"))
+        followups = _count_value(task.get("followups", task.get("pending_followups")))
+        notes = _count_value(task.get("notes"))
+        artifacts = _count_value(task.get("artifacts"))
+        st = status if isinstance(status, str) else "?"
+        return {
+            "task_id": _str_or_none(task.get("task_id")) or "?",
+            "status": st,
+            "goal": goal,
+            "session_key": _str_or_none(task.get("session_key")),
+            "worker_id": worker_id,
+            "worker_kind": _str_or_none(task.get("worker_kind")),
+            "followups": followups,
+            "notes": notes,
+            "artifacts": artifacts,
+            "active": _task_is_active(st),
+            "blocked": st == _TASK_STATUS_BLOCKED,
+            "error": st == _TASK_STATUS_ERROR,
+        }
+
+    status = getattr(task, "status", None)
+    goal = _str_or_none(getattr(task, "user_goal", None)) or ""
+    worker_id = _str_or_none(getattr(task, "active_worker_id", None))
+    followups = getattr(task, "pending_followups", None) or []
+    notes = getattr(task, "notes", None) or []
+    artifacts = getattr(task, "artifacts", None) or []
+    return {
+        "task_id": _str_or_none(getattr(task, "task_id", None)) or "?",
+        "status": status if isinstance(status, str) else "?",
+        "goal": goal,
+        "session_key": _str_or_none(getattr(task, "session_key", None)),
+        "worker_id": worker_id,
+        "worker_kind": _str_or_none(getattr(task, "worker_kind", None)),
+        "followups": len(followups),
+        "notes": len(notes),
+        "artifacts": len(artifacts),
+        "active": _task_is_active(status),
+        "blocked": status == _TASK_STATUS_BLOCKED,
+        "error": status == _TASK_STATUS_ERROR,
+    }
+
+
+def _worker_dict(
+    *,
+    worker_id: Any,
+    status: Any,
+    lane: Any,
+    task_id: Any,
+    cancel_requested: Any,
+    goal: Any = None,
+    result: Any = None,
+    error: Any = None,
+) -> dict[str, Any]:
+    """A flat, JSON-safe presentation dict for one worker (strings/ints/None only)."""
+    st = status if isinstance(status, str) else "?"
+    return {
+        "worker_id": _str_or_none(worker_id) or "?",
+        "status": st,
+        "lane": _str_or_none(lane),
+        "task_id": _str_or_none(task_id),
+        "goal": _str_or_none(goal),
+        "result": _str_or_none(result),
+        "error": _str_or_none(error),
+        "cancel_requested": bool(cancel_requested),
+        "active": st in _ACTIVE_WORKER_STATUSES or not _worker_is_terminal(st),
+    }
+
+
+def _worker_goal_from_lane(lane: Any, worker_id: str) -> str | None:
+    """Best-effort goal lookup for *worker_id* via ``lane.snapshot(worker_id)``.
+
+    ``snapshot(worker_id)`` is the only documented way to reach a worker's
+    originating :class:`~agent.worker_lanes.WorkerSpec` (and therefore its goal);
+    that call serialises the worker's appended follow-ups via
+    :meth:`PendingTurnItem.to_dict` (which drops ``raw`` without reading it) and
+    may raise ``TypeError`` if the spec carries non-JSON-safe ``metadata``.  Both
+    are tolerated here: on any failure the worker line just goes goal-less.
+    """
+    snap_fn = getattr(lane, "snapshot", None)
+    snap = _safe_call1(snap_fn, worker_id)
+    if isinstance(snap, dict):
+        spec = snap.get("spec")
+        if isinstance(spec, dict):
+            return _str_or_none(spec.get("goal"))
+        # Some snapshot shapes inline the goal at the top level.
+        return _str_or_none(snap.get("goal"))
+    return None
+
+
+def _worker_from_lane_by_id(lane: Any, worker_id: str, lane_name: str | None) -> dict[str, Any]:
+    handle = _safe_call1(getattr(lane, "status", None), worker_id)
+    result_obj = _safe_call1(getattr(lane, "result", None), worker_id)
+    status = getattr(handle, "status", None)
+    task_id = getattr(handle, "task_id", None)
+    cancel_requested = getattr(handle, "cancel_requested", False)
+    handle_lane = _str_or_none(getattr(handle, "lane", None))
+    result_str = getattr(result_obj, "result", None) if result_obj is not None else None
+    error_str = getattr(result_obj, "error", None) if result_obj is not None else None
+    return _worker_dict(
+        worker_id=getattr(handle, "worker_id", None) or worker_id,
+        status=status,
+        lane=handle_lane or lane_name,
+        task_id=task_id,
+        cancel_requested=cancel_requested,
+        goal=_worker_goal_from_lane(lane, worker_id),
+        result=result_str,
+        error=error_str,
+    )
+
+
+def _workers_from_lane(lane: Any) -> list[dict[str, Any]]:
+    """All workers a single lane knows about, via ``worker_ids()`` then per-id probes.
+
+    Falls back to the lane's whole-lane ``snapshot()`` when ``worker_ids()`` is not
+    available; that fallback can raise on a non-JSON-safe spec, so it too is
+    best-effort.
+    """
+    lane_name = _str_or_none(getattr(lane, "name", None))
+    ids = _safe_call(getattr(lane, "worker_ids", None))
+    if ids is not None:
+        try:
+            id_list = list(ids)
+        except TypeError:
+            id_list = []
+        return [_worker_from_lane_by_id(lane, str(wid), lane_name) for wid in id_list]
+    snap = _safe_call(getattr(lane, "snapshot", None))
+    if isinstance(snap, dict) and _is_plain_iterable(snap.get("workers")):
+        return [
+            _worker_item_to_dict(w, default_lane=_str_or_none(snap.get("lane")) or lane_name)
+            for w in snap["workers"]
+        ]
+    return []
+
+
+def _worker_item_to_dict(item: Any, *, default_lane: str | None = None) -> dict[str, Any]:
+    """Coerce a single handle-ish thing (a dict, a :class:`WorkerHandle`, a
+    :class:`WorkerResult`, a ``snapshot_dict``) into a presentation worker dict."""
+    if isinstance(item, dict):
+        spec = item.get("spec") if isinstance(item.get("spec"), dict) else {}
+        task_id = item.get("task_id")
+        if task_id is None:
+            task_id = spec.get("task_id")
+        goal = item.get("goal")
+        if not isinstance(goal, str) or not goal:
+            goal = spec.get("goal")
+        return _worker_dict(
+            worker_id=item.get("worker_id"),
+            status=item.get("status"),
+            lane=item.get("lane") or default_lane,
+            task_id=task_id,
+            cancel_requested=item.get("cancel_requested", False),
+            goal=goal,
+            result=item.get("result"),
+            error=item.get("error"),
+        )
+    spec = getattr(item, "spec", None)
+    spec_goal = getattr(spec, "goal", None)
+    return _worker_dict(
+        worker_id=getattr(item, "worker_id", None),
+        status=getattr(item, "status", None),
+        lane=getattr(item, "lane", None) or default_lane,
+        task_id=getattr(item, "task_id", None),
+        cancel_requested=getattr(item, "cancel_requested", False),
+        goal=getattr(item, "goal", None) or spec_goal,
+        result=getattr(item, "result", None),
+        error=getattr(item, "error", None),
+    )
+
+
+def _collect_tasks(source: Any, *, session_key: str | None, active_only: bool) -> list[dict[str, Any]]:
+    """Resolve *source* into a list of presentation task dicts.
+
+    *source* may be an :class:`OrchestrationSnapshot`, a duck-typed task registry
+    (anything with ``list_tasks``), a list of :class:`~agent.task_registry.FocusedTask`-ish
+    objects or task dicts, or ``None``.  ``active_only`` only applies when *source*
+    is a registry (a registry is the "live" handle, so a status command reading one
+    shows the active set by default); a snapshot or explicit list is shown as given.
+    """
+    if source is None:
+        return []
+    if isinstance(source, OrchestrationSnapshot):
+        return [dict(t) for t in source.tasks]
+    list_tasks = getattr(source, "list_tasks", None)
+    if callable(list_tasks):
+        try:
+            tasks = list_tasks(session_key=session_key, active_only=active_only)
+        except TypeError:
+            # A registry whose list_tasks does not take those kwargs.
+            tasks = list_tasks()
+        return [_task_to_dict(t) for t in (tasks or [])]
+    if _is_plain_iterable(source):
+        out: list[dict[str, Any]] = []
+        for t in source:
+            out.append(_task_to_dict(t))
+        return out
+    return []
+
+
+def _collect_workers(source: Any) -> list[dict[str, Any]]:
+    """Resolve *source* into a list of presentation worker dicts.
+
+    *source* may be an :class:`OrchestrationSnapshot`, a :class:`WorkerLaneRegistry`
+    (``lane_names`` + ``get_lane``), a single lane (``name`` + ``worker_ids`` /
+    ``snapshot``), a ``{"lane": ..., "workers": [...]}`` dict, a list of handle-ish
+    objects / dicts, or ``None``.
+    """
+    if source is None:
+        return []
+    if isinstance(source, OrchestrationSnapshot):
+        return [dict(w) for w in source.workers]
+    # WorkerLaneRegistry: enumerate lanes, then workers within each.
+    lane_names = getattr(source, "lane_names", None)
+    get_lane = getattr(source, "get_lane", None)
+    if callable(lane_names) and callable(get_lane):
+        out: list[dict[str, Any]] = []
+        for name in (_safe_call(lane_names) or []):
+            lane = _safe_call1(get_lane, name)
+            if lane is not None:
+                out.extend(_workers_from_lane(lane))
+        return out
+    # A single lane: it can enumerate its own workers.
+    if callable(getattr(source, "worker_ids", None)) or (
+        _str_or_none(getattr(source, "name", None)) and callable(getattr(source, "snapshot", None))
+    ):
+        return _workers_from_lane(source)
+    # A lane snapshot dict.
+    if isinstance(source, dict) and _is_plain_iterable(source.get("workers")):
+        default_lane = _str_or_none(source.get("lane"))
+        return [_worker_item_to_dict(w, default_lane=default_lane) for w in source["workers"]]
+    # A plain list of handle-ish things.
+    if _is_plain_iterable(source):
+        return [_worker_item_to_dict(w) for w in source]
+    return []
+
+
+# --------------------------------------------------------------------------
+# OrchestrationSnapshot
+# --------------------------------------------------------------------------
+@dataclass
+class OrchestrationSnapshot:
+    """A flat, JSON-safe point-in-time view of the orchestration state.
+
+    ``tasks`` and ``workers`` are lists of compact presentation dicts (see
+    :func:`_task_to_dict` / :func:`_worker_dict`).  ``counts`` is a small summary
+    (``tasks_total`` / ``tasks_active`` / ``tasks_blocked`` / ``tasks_error`` /
+    ``workers_total`` / ``workers_active`` / ``workers_running`` / ``workers_error``
+    / ``workers_cancel_requested`` / ``followups_pending``).  ``warnings`` are
+    cheap cross-consistency notes (a task pointing at an unknown worker; a worker
+    pointing at an unknown task) -- empty when only one side was supplied or
+    everything lines up.  Every value is a plain string / int / ``None`` / list /
+    dict, so :meth:`to_dict` round-trips through ``json.dumps`` cleanly.
+    """
+
+    tasks: list[dict[str, Any]] = field(default_factory=list)
+    workers: list[dict[str, Any]] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """A JSON-safe copy (fresh lists/dicts; nested values are already plain)."""
+        return {
+            "tasks": [dict(t) for t in self.tasks],
+            "workers": [dict(w) for w in self.workers],
+            "counts": dict(self.counts),
+            "warnings": list(self.warnings),
+        }
+
+
+def _count_state(tasks: list[dict[str, Any]], workers: list[dict[str, Any]]) -> dict[str, int]:
+    running = _WorkerStatus.RUNNING
+    return {
+        "tasks_total": len(tasks),
+        "tasks_active": sum(1 for t in tasks if t.get("active")),
+        "tasks_blocked": sum(1 for t in tasks if t.get("blocked")),
+        "tasks_error": sum(1 for t in tasks if t.get("error")),
+        "workers_total": len(workers),
+        "workers_active": sum(1 for w in workers if w.get("active")),
+        "workers_running": sum(1 for w in workers if w.get("status") == running),
+        "workers_error": sum(1 for w in workers if w.get("status") == _WorkerStatus.ERROR),
+        "workers_cancel_requested": sum(1 for w in workers if w.get("cancel_requested")),
+        "followups_pending": sum(int(t.get("followups") or 0) for t in tasks),
+    }
+
+
+def _consistency_warnings(tasks: list[dict[str, Any]], workers: list[dict[str, Any]]) -> list[str]:
+    """Cheap, deterministic cross-checks -- only when *both* sides were supplied."""
+    if not tasks or not workers:
+        return []
+    worker_ids = {w.get("worker_id") for w in workers if w.get("worker_id")}
+    task_ids = {t.get("task_id") for t in tasks if t.get("task_id")}
+    warnings: list[str] = []
+    for t in tasks:
+        wid = t.get("worker_id")
+        if wid and wid not in worker_ids:
+            warnings.append(
+                f"task {t.get('task_id')} references worker {wid} which is not in any lane"
+            )
+    for w in workers:
+        tid = w.get("task_id")
+        if tid and tid not in task_ids:
+            warnings.append(
+                f"worker {w.get('worker_id')} references task {tid} which is not registered"
+            )
+    return warnings
+
+
+def build_snapshot(
+    task_registry: Any = None,
+    worker_registry: Any = None,
+    *,
+    session_key: str | None = None,
+) -> OrchestrationSnapshot:
+    """Build an :class:`OrchestrationSnapshot` from a task source and/or a worker source.
+
+    *task_registry* is read via ``list_tasks(session_key=..., active_only=False)``
+    when it is a registry (so the snapshot captures *all* tasks for the session,
+    terminal ones included -- the active/total split lives in ``counts``); it may
+    also be an :class:`OrchestrationSnapshot`, a list of tasks, or ``None``.
+    *worker_registry* may be a :class:`WorkerLaneRegistry`, a single lane, a list
+    of handle-ish objects, or ``None``.  Either may be omitted; an all-``None``
+    call yields an empty snapshot.
+    """
+    tasks = _collect_tasks(task_registry, session_key=session_key, active_only=False)
+    workers = _collect_workers(worker_registry)
+    return OrchestrationSnapshot(
+        tasks=tasks,
+        workers=workers,
+        counts=_count_state(tasks, workers),
+        warnings=_consistency_warnings(tasks, workers),
+    )
+
+
+# --------------------------------------------------------------------------
+# Formatting
+# --------------------------------------------------------------------------
+def _goal_limit(compact: bool) -> int:
+    return _GOAL_COMPACT if compact else _GOAL_FULL
+
+
+def _detail_limit(compact: bool) -> int:
+    return _DETAIL_COMPACT if compact else _DETAIL_FULL
+
+
+def _format_task_block(task: dict[str, Any], *, compact: bool, worker_index: dict[str, dict[str, Any]]) -> str:
+    """One task rendered as a header line plus optional worker / counts lines."""
+    task_id = task.get("task_id") or "?"
+    status = task.get("status") or "?"
+    head = f"- {task_id} [{status}]"
+    goal = _truncate(task.get("goal"), _goal_limit(compact))
+    if goal:
+        head += f" {goal}"
+    if task.get("blocked"):
+        head += " — needs you"
+    elif task.get("error"):
+        head += " — failed"
+    lines = [head]
+
+    worker_id = task.get("worker_id")
+    if worker_id:
+        wline = f"  worker: {worker_id}"
+        kind = task.get("worker_kind")
+        if kind:
+            wline += f" ({kind})"
+        live = worker_index.get(worker_id)
+        if live is not None:
+            wline += f" [{live.get('status') or '?'}]"
+            if live.get("cancel_requested"):
+                wline += " (cancel requested)"
+        lines.append(wline)
+
+    bits: list[str] = []
+    if task.get("followups"):
+        bits.append(_plural(int(task["followups"]), "follow-up") + " queued")
+    if task.get("notes"):
+        bits.append(_plural(int(task["notes"]), "note"))
+    if not compact and task.get("artifacts"):
+        bits.append(_plural(int(task["artifacts"]), "artifact"))
+    if bits:
+        lines.append("  " + " · ".join(bits))
+    return "\n".join(lines)
+
+
+def _format_worker_line(worker: dict[str, Any], *, compact: bool) -> str:
+    worker_id = worker.get("worker_id") or "?"
+    status = worker.get("status") or "?"
+    line = f"- {worker_id} [{status}]"
+    lane = worker.get("lane")
+    if lane:
+        line += f" lane={lane}"
+    task_id = worker.get("task_id")
+    if task_id:
+        line += f" task={task_id}"
+    limit = _detail_limit(compact)
+    if status == _WorkerStatus.ERROR:
+        detail = _truncate(worker.get("error"), limit) or _truncate(worker.get("goal"), limit)
+        if detail:
+            line += f' error="{detail}"' if worker.get("error") else f' goal="{detail}"'
+    elif status == _WorkerStatus.DONE:
+        result = _truncate(worker.get("result"), limit)
+        if result:
+            line += f' result="{result}"'
+        else:
+            goal = _truncate(worker.get("goal"), limit)
+            if goal:
+                line += f' goal="{goal}"'
+    elif status == _WorkerStatus.CANCELLED:
+        goal = _truncate(worker.get("goal"), limit)
+        if goal:
+            line += f' goal="{goal}"'
+    else:  # queued / running / unknown-active
+        goal = _truncate(worker.get("goal"), limit)
+        if goal:
+            line += f' goal="{goal}"'
+    if worker.get("cancel_requested"):
+        line += " (cancel requested)"
+    return line
+
+
+def _tasks_header(tasks: list[dict[str, Any]]) -> str:
+    return "Active tasks:" if all(t.get("active") for t in tasks) else "Tasks:"
+
+
+def _workers_header(workers: list[dict[str, Any]]) -> str:
+    return "Active workers:" if all(w.get("active") for w in workers) else "Workers:"
+
+
+def format_tasks(
+    snapshot_or_registry: Any = None,
+    *,
+    compact: bool = True,
+    session_key: str | None = None,
+) -> str:
+    """Render the focused-task board.
+
+    *snapshot_or_registry* may be an :class:`OrchestrationSnapshot` (rendered as
+    captured, terminal tasks included), a duck-typed task registry (rendered as
+    its *active* tasks for *session_key*), a list of tasks / task dicts, or
+    ``None`` (empty board).  When given a snapshot, a task's recorded worker is
+    annotated with that worker's *live* status if the snapshot also captured it.
+    The result is bullets-and-labels text, never a markdown table; an empty board
+    is the single line ``"No active tasks are currently registered."``.
+    """
+    is_snapshot = isinstance(snapshot_or_registry, OrchestrationSnapshot)
+    tasks = _collect_tasks(snapshot_or_registry, session_key=session_key, active_only=not is_snapshot)
+    if not tasks:
+        return _EMPTY_TASKS
+    worker_index: dict[str, dict[str, Any]] = {}
+    if is_snapshot:
+        for w in snapshot_or_registry.workers:
+            wid = w.get("worker_id")
+            if wid:
+                worker_index[wid] = w
+    blocks = [_format_task_block(t, compact=compact, worker_index=worker_index) for t in tasks]
+    return _tasks_header(tasks) + "\n" + "\n".join(blocks)
+
+
+def format_agents(
+    snapshot_or_registry: Any = None,
+    *,
+    compact: bool = True,
+) -> str:
+    """Render the worker/agent board.
+
+    *snapshot_or_registry* may be an :class:`OrchestrationSnapshot`, a
+    :class:`WorkerLaneRegistry`, a single lane, a list of handle-ish objects /
+    worker dicts, or ``None`` (empty board).  Each worker line carries its id,
+    status, lane, linked task, a compact goal/result/error, and a cancel-requested
+    marker when set; an empty board is
+    ``"No active workers are currently registered."``.
+    """
+    if isinstance(snapshot_or_registry, OrchestrationSnapshot):
+        workers = [dict(w) for w in snapshot_or_registry.workers]
+    else:
+        workers = _collect_workers(snapshot_or_registry)
+    if not workers:
+        return _EMPTY_AGENTS
+    lines = [_format_worker_line(w, compact=compact) for w in workers]
+    return _workers_header(workers) + "\n" + "\n".join(lines)
+
+
+def _overview_header(counts: dict[str, int]) -> str:
+    parts = [_plural(int(counts.get("tasks_active", 0)), "active task")]
+    blocked = int(counts.get("tasks_blocked", 0))
+    if blocked:
+        parts.append(f"{blocked} blocked")
+    if int(counts.get("workers_total", 0)) > 0:
+        parts.append(_plural(int(counts.get("workers_running", 0)), "running worker"))
+    cancelling = int(counts.get("workers_cancel_requested", 0))
+    if cancelling:
+        parts.append(f"{cancelling} cancelling")
+    followups = int(counts.get("followups_pending", 0))
+    if followups:
+        parts.append(_plural(followups, "follow-up") + " queued")
+    return "Orchestration status — " + ", ".join(parts) + "."
+
+
+def format_overview(
+    snapshot_or_task_registry: Any = None,
+    worker_registry: Any = None,
+    *,
+    session_key: str | None = None,
+    compact: bool = True,
+) -> str:
+    """Render the combined status board: a one-line summary, then tasks, then workers.
+
+    The first positional argument may already be an :class:`OrchestrationSnapshot`
+    (in which case *worker_registry* is ignored); otherwise it is treated as a task
+    source and a snapshot is built from ``(task_source, worker_registry,
+    session_key)``.  Sections are separated by blank lines; any consistency
+    ``warnings`` (and a callout when something is blocked) follow at the end.  When
+    there are neither tasks nor workers the whole thing collapses to
+    ``"No active tasks or workers are currently registered."``.
+    """
+    if isinstance(snapshot_or_task_registry, OrchestrationSnapshot):
+        snap = snapshot_or_task_registry
+    else:
+        snap = build_snapshot(
+            task_registry=snapshot_or_task_registry,
+            worker_registry=worker_registry,
+            session_key=session_key,
+        )
+    if not snap.tasks and not snap.workers:
+        return _EMPTY_OVERVIEW
+
+    sections = [_overview_header(snap.counts)]
+
+    if snap.tasks:
+        blocks = [_format_task_block(t, compact=compact, worker_index={w["worker_id"]: w for w in snap.workers if w.get("worker_id")}) for t in snap.tasks]
+        sections.append(_tasks_header(snap.tasks) + "\n" + "\n".join(blocks))
+    if snap.workers:
+        lines = [_format_worker_line(w, compact=compact) for w in snap.workers]
+        sections.append(_workers_header(snap.workers) + "\n" + "\n".join(lines))
+
+    callouts: list[str] = []
+    blocked = int(snap.counts.get("tasks_blocked", 0))
+    if blocked:
+        verb = "is" if blocked == 1 else "are"
+        callouts.append(f"⚠ {_plural(blocked, 'task')} {verb} blocked and waiting on you.")
+    for w in snap.warnings:
+        callouts.append(f"⚠ {w}.")
+    if callouts:
+        sections.append("\n".join(callouts))
+
+    return "\n\n".join(sections)
+
+
+# --------------------------------------------------------------------------
+# OrchestrationStatusFormatter -- the namespaced façade the packet sketches
+# --------------------------------------------------------------------------
+class OrchestrationStatusFormatter:
+    """Thin namespace over :func:`build_snapshot` / :func:`format_tasks` /
+    :func:`format_agents` / :func:`format_overview`.
+
+    Stateless (every method is static); kept as a class so a later phase can give
+    it configuration -- a default ``compact`` mode, a locale, an injected runtime
+    registry -- without changing call sites.
+    """
+
+    @staticmethod
+    def snapshot(
+        task_registry: Any = None,
+        worker_registry: Any = None,
+        *,
+        session_key: str | None = None,
+    ) -> OrchestrationSnapshot:
+        return build_snapshot(task_registry, worker_registry, session_key=session_key)
+
+    @staticmethod
+    def format_tasks(
+        snapshot_or_registry: Any = None,
+        *,
+        compact: bool = True,
+        session_key: str | None = None,
+    ) -> str:
+        return format_tasks(snapshot_or_registry, compact=compact, session_key=session_key)
+
+    @staticmethod
+    def format_agents(snapshot_or_registry: Any = None, *, compact: bool = True) -> str:
+        return format_agents(snapshot_or_registry, compact=compact)
+
+    @staticmethod
+    def format_overview(
+        snapshot_or_task_registry: Any = None,
+        worker_registry: Any = None,
+        *,
+        session_key: str | None = None,
+        compact: bool = True,
+    ) -> str:
+        return format_overview(
+            snapshot_or_task_registry,
+            worker_registry,
+            session_key=session_key,
+            compact=compact,
+        )
+
+
+# --------------------------------------------------------------------------
+# Natural-language status-query predicate (a hint only -- routes nothing).
+#
+# Like agent.followup_router's trigger lists this is the documented set, not an
+# exhaustive grammar: a later LLM phase can refine the genuinely ambiguous text.
+# Matching is plain case-insensitive substring (Korean is unaffected by casing) --
+# deliberately a touch generous, because this predicate decides nothing on its
+# own; it only lets a later gateway/CLI layer choose to call the formatter.
+# --------------------------------------------------------------------------
+_STATUS_QUERY_TRIGGERS: tuple[str, ...] = (
+    # --- Korean: "what are you doing / what's running / which tasks / agents" ---
+    "뭐 하고 있", "뭐하고 있", "뭐 하고있", "뭐하고있", "뭐 하는 중", "뭐하는 중",
+    "뭐 하는중", "뭐하는중", "뭐 하는 거", "뭐 하고 계", "지금 뭐 해", "지금 뭐 하",
+    "지금 뭐하", "뭐 하니", "뭐 하고 있니", "뭐 하는 중이", "뭐 진행", "뭐 작업",
+    "무슨 작업", "어떤 작업", "뭐 돌아가", "뭐 돌고", "뭐가 돌아", "뭐가 돌고",
+    "돌고 있는 작업", "돌고있는 작업", "돌아가는 작업", "돌고 있는 거", "돌고있는 거",
+    "진행 중인 작업", "진행중인 작업", "진행 중인 거", "진행중인 거", "진행 중인 일", "진행중인 일",
+    "작업 목록", "작업 리스트", "작업 있어", "작업 있나", "작업 뭐", "작업 몇 개", "작업 몇개",
+    "활성 작업", "활성화된 작업", "남은 작업",
+    "에이전트 뭐", "에이전트 목록", "에이전트 리스트", "에이전트 돌", "에이전트 있", "에이전트 몇",
+    "무슨 에이전트", "어떤 에이전트", "워커 뭐", "워커 목록", "워커 돌", "워커 있", "일꾼",
+    "대기 중인", "대기중인", "막힌 거", "막혀 있는", "막혀있는", "기다리는 거", "내가 봐야",
+    "내가 확인해야", "후속 작업", "후속 요청", "팔로업", "팔로우업", "follow-up 뭐",
+    # --- English ---
+    "what are you working on", "what're you working on", "what you working on",
+    "what are you doing", "what're you doing", "what you doing",
+    "are you working on anything", "anything you're working on", "anything you are working on",
+    "what's running", "whats running", "what is running", "anything running",
+    "anything active", "what's active", "whats active",
+    "active task", "active tasks", "active worker", "active workers",
+    "any active task", "any tasks", "any task running", "tasks running", "tasks active",
+    "what tasks", "which tasks", "what task is", "list tasks", "show tasks",
+    "show me the tasks", "task list", "the task board",
+    "any agents", "any agent running", "agents running", "what agents", "which agents",
+    "agent list", "list agents", "show agents", "any workers", "what workers",
+    "which workers", "workers running", "worker list",
+    "what's in progress", "whats in progress", "what is in progress", "in progress right now",
+    "what's queued", "whats queued", "anything queued", "follow-ups queued",
+    "followups queued", "follow ups queued",
+    "anything blocked", "what's blocked", "whats blocked", "is anything blocked",
+    "anything waiting for me", "waiting for me", "waiting on me",
+    "anything need me", "anything needs me", "need my input", "needs my input",
+    "status board", "orchestration status", "orchestrator status",
+)
+
+
+def looks_like_orchestration_status_query(text: Any) -> bool:
+    """True when *text* reads like a request for the orchestration status board.
+
+    Examples that match: ``"지금 뭐 하고 있어?"``, ``"돌고 있는 작업 있어?"``,
+    ``"에이전트 뭐 돌아가?"``, ``"what are you working on?"``, ``"active tasks?"``,
+    ``"any agents running?"``.  This is a *hint*: it neither parses nor routes the
+    message -- a later gateway/CLI layer may use it to decide to call
+    :func:`format_overview` (or :func:`format_tasks` / :func:`format_agents`).
+    Non-strings, empty strings, and ordinary prose all return ``False``.
+    """
+    if not isinstance(text, str):
+        return False
+    low = text.strip().lower()
+    if not low:
+        return False
+    return any(trigger in low for trigger in _STATUS_QUERY_TRIGGERS)

--- a/agent/pending_turn_queue.py
+++ b/agent/pending_turn_queue.py
@@ -1,0 +1,587 @@
+"""Structured pending-turn input queue for Hermes (orchestrator Phase 2).
+
+Hermes receives user input from several surfaces (Telegram, CLI, TUI, API) and,
+when it is already busy, that input piles up in ad-hoc shapes: raw strings,
+``(text, images)`` tuples, an identity-tagged "captured while busy" tuple, a
+per-session single ``MessageEvent`` slot, etc.  That is enough for simple
+queueing but it flattens *boundaries* and *provenance* -- a follow-up that is a
+slash command, a media attachment, a correction, or a hard "new topic" wall
+looks the same as a stray prose fragment once it has been merged.
+
+This module introduces a small, explicit, *serializable* representation of one
+pending input -- :class:`PendingTurnItem` -- plus a tiny ordered container --
+:class:`PendingTurnQueue` -- and conversion helpers that round-trip the existing
+legacy payloads losslessly.  The point is to preserve order, coalescing
+boundaries, media metadata and source/session info so a later orchestrator can
+decide whether a follow-up should *append to the current focus*, *steer the
+active worker*, *start a new focused task*, or *ask for clarification* -- without
+that decision being made (or precluded) here.
+
+Scope discipline:
+
+* This is **not** a task registry, a worker/background lane, a model-based
+  follow-up classifier, or any "Ralph" focused-agent implementation.  Those are
+  later phases.  This is only the *input substrate* they will build on.
+* This module is a leaf: it imports nothing from ``cli.py`` or the ``gateway``
+  package, holds no global mutable state, and every :class:`PendingTurnItem`
+  field except ``raw`` is a plain JSON-serializable value -- so an item is safe
+  to log, persist, or eventually move across a process boundary.  ``raw`` is the
+  one local-process passthrough (the original legacy payload / ``MessageEvent``)
+  and is intentionally dropped by :meth:`PendingTurnItem.to_dict`.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field, fields, replace
+from typing import Any, Iterable, Iterator
+
+__all__ = [
+    "SOURCE_TELEGRAM",
+    "SOURCE_CLI",
+    "SOURCE_TUI",
+    "SOURCE_API",
+    "SOURCE_UNKNOWN",
+    "KIND_TEXT",
+    "KIND_COMMAND",
+    "KIND_MEDIA",
+    "KIND_ATTACHMENT",
+    "KIND_CONTROL",
+    "BOUNDARY_COALESCE",
+    "BOUNDARY_HARD",
+    "BOUNDARY_CAPTION",
+    "BOUNDARY_COMMAND",
+    "INTEGRATED_BUSY_PAYLOAD",
+    "PendingTurnItem",
+    "PendingTurnQueue",
+    "make_integrated_busy_payload",
+    "is_integrated_busy_payload",
+    "unwrap_integrated_busy_payload",
+    "looks_like_slash_command",
+    "legacy_cli_payload_is_coalescible_text",
+    "from_legacy_cli_payload",
+    "maybe_to_legacy_cli_payload",
+    "from_gateway_event",
+    "coalesced_text",
+]
+
+# --------------------------------------------------------------------------
+# Vocabulary -- plain strings on purpose (boring, serializable, forward-compat).
+# Unknown values are tolerated everywhere; these constants are the documented
+# set, not an enum that rejects newcomers.
+# --------------------------------------------------------------------------
+
+# Where the input came from.
+SOURCE_TELEGRAM = "telegram"
+SOURCE_CLI = "cli"
+SOURCE_TUI = "tui"
+SOURCE_API = "api"
+SOURCE_UNKNOWN = "unknown"
+
+# What the input *is*.
+KIND_TEXT = "text"            # a plain prose fragment
+KIND_COMMAND = "command"      # a slash command / control message ("/busy", "/stop")
+KIND_MEDIA = "media"          # inline media (photo, video, voice, audio, sticker)
+KIND_ATTACHMENT = "attachment"  # a file-like attachment (document)
+KIND_CONTROL = "control"      # non-text structured payload (location, opaque)
+
+# How the item relates to its neighbours when coalescing adjacent fragments.
+BOUNDARY_COALESCE = "coalesce"  # may merge with adjacent coalescible text
+BOUNDARY_HARD = "hard"          # a wall: never merge across it
+BOUNDARY_CAPTION = "caption"    # text that belongs to an adjacent media item
+BOUNDARY_COMMAND = "command"    # a command: a wall, and never folded into text
+
+_KNOWN_SOURCES = frozenset(
+    {SOURCE_TELEGRAM, SOURCE_CLI, SOURCE_TUI, SOURCE_API, SOURCE_UNKNOWN}
+)
+_KNOWN_KINDS = frozenset(
+    {KIND_TEXT, KIND_COMMAND, KIND_MEDIA, KIND_ATTACHMENT, KIND_CONTROL}
+)
+_KNOWN_BOUNDARIES = frozenset(
+    {BOUNDARY_COALESCE, BOUNDARY_HARD, BOUNDARY_CAPTION, BOUNDARY_COMMAND}
+)
+
+
+# --------------------------------------------------------------------------
+# Integrated-busy sentinel
+#
+# The CLI tags a plain-text fragment typed while Hermes is busy under
+# ``/busy integrated`` as ``(INTEGRATED_BUSY_PAYLOAD, text)`` so the drain step
+# can tell busy-time follow-ups apart from ordinary idle messages.  The sentinel
+# lives here (next to the structured representation that understands it) and is
+# re-exported by ``cli.py``.  It must NOT be a string: image payloads are also
+# two-tuples ``(caption, images)`` and a caption such as ``"integrated_busy"``
+# must stay a normal image payload.  It is identity-only and deliberately not
+# serializable -- it never crosses a process boundary; a ``PendingTurnItem``
+# carries the same information in the JSON-safe ``origin_busy`` flag instead.
+# --------------------------------------------------------------------------
+INTEGRATED_BUSY_PAYLOAD = object()
+
+
+def make_integrated_busy_payload(text: str) -> tuple:
+    """Wrap *text* as an integrated busy-time CLI fragment."""
+    return (INTEGRATED_BUSY_PAYLOAD, text)
+
+
+def is_integrated_busy_payload(item: Any) -> bool:
+    """Return True if *item* is an integrated busy-time CLI fragment."""
+    return (
+        isinstance(item, tuple)
+        and len(item) == 2
+        and item[0] is INTEGRATED_BUSY_PAYLOAD
+    )
+
+
+def unwrap_integrated_busy_payload(item: Any) -> Any:
+    """Return the inner payload of an integrated fragment, else *item* unchanged."""
+    return item[1] if is_integrated_busy_payload(item) else item
+
+
+# --------------------------------------------------------------------------
+# Slash-command detection
+#
+# Mirrors ``cli._looks_like_slash_command`` on purpose: keeping a faithful copy
+# here means this module stays a leaf (no import of the multi-thousand-line
+# ``cli`` module just to classify a string).  ``/busy`` is a command;
+# ``/Users/foo/bar.md fix this`` is a pasted path that merely starts with ``/``.
+# --------------------------------------------------------------------------
+def looks_like_slash_command(text: Any) -> bool:
+    if not isinstance(text, str) or not text.startswith("/"):
+        return False
+    parts = text.split()
+    if not parts:
+        return False
+    first_word = parts[0]
+    # After the leading "/", a command name contains no further "/"; a path does.
+    return "/" not in first_word[1:]
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+# --------------------------------------------------------------------------
+# PendingTurnItem
+# --------------------------------------------------------------------------
+@dataclass
+class PendingTurnItem:
+    """One unit of pending user input, with its boundary and provenance.
+
+    Construct with keyword arguments.  Every field except ``raw`` is a plain
+    JSON-serializable value; ``raw`` holds the original payload (a legacy CLI
+    ``str`` / tuple, a gateway ``MessageEvent``, ...) for lossless local
+    round-tripping and is excluded from :meth:`to_dict`.
+    """
+
+    source: str = SOURCE_UNKNOWN
+    kind: str = KIND_TEXT
+    text: str | None = None
+    media_refs: list[str] = field(default_factory=list)
+    media_types: list[str] = field(default_factory=list)
+    boundary: str = BOUNDARY_COALESCE
+    session_key: str | None = None
+    reply_to: str | None = None
+    # Free-form hint about which task/focus this input is about (e.g. a task id
+    # or a short label).  A later orchestrator may populate/consume it; nothing
+    # in Phase 2 sets it automatically.
+    task_hint: str | None = None
+    # True when this fragment was captured while a foreground agent was busy
+    # (e.g. CLI ``/busy integrated``).  Lets a later orchestrator tell
+    # "follow-up to what I'm doing right now" apart from "a fresh idle message".
+    origin_busy: bool = False
+    created_at: float = field(default_factory=time.time)
+    id: str = field(default_factory=_new_id)
+    raw: Any | None = None
+
+    # -- introspection ----------------------------------------------------
+    @property
+    def is_text(self) -> bool:
+        return self.kind == KIND_TEXT
+
+    @property
+    def is_command(self) -> bool:
+        return self.kind == KIND_COMMAND
+
+    @property
+    def has_media(self) -> bool:
+        return bool(self.media_refs)
+
+    def is_coalescible_text(self) -> bool:
+        """True when this item may be joined with adjacent coalescible text.
+
+        A non-empty plain-text fragment whose boundary is ``coalesce``.
+        Commands, media, attachments, captions and hard boundaries are not
+        coalescible.
+        """
+        return (
+            self.kind == KIND_TEXT
+            and self.boundary == BOUNDARY_COALESCE
+            and isinstance(self.text, str)
+            and bool(self.text)
+        )
+
+    # -- serialization ----------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict.  Drops ``raw`` without touching it."""
+        data: dict[str, Any] = {}
+        for f in fields(self):
+            if f.name == "raw":
+                continue
+            value = getattr(self, f.name)
+            # Copy mutable list fields so callers cannot mutate this item via the
+            # serialized view.  Do not deep-copy arbitrary objects here: every
+            # serialized field is intentionally plain/JSON-safe, while ``raw``
+            # may be an uncopyable local gateway event and is skipped entirely.
+            if isinstance(value, list):
+                value = list(value)
+            data[f.name] = value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PendingTurnItem":
+        """Rebuild from :meth:`to_dict` output (unknown keys ignored)."""
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    def copy(self, **overrides: Any) -> "PendingTurnItem":
+        return replace(self, **overrides)
+
+
+# --------------------------------------------------------------------------
+# PendingTurnQueue
+# --------------------------------------------------------------------------
+class PendingTurnQueue:
+    """An ordered, in-memory queue of :class:`PendingTurnItem`.
+
+    A thin wrapper over a ``deque`` -- intentionally *not* a ``queue.Queue``
+    subclass: callers that need cross-thread safety should hold their own lock
+    (the CLI uses this only transiently inside its single-threaded drain loop;
+    the gateway, when it adopts this, runs on one asyncio loop).
+    """
+
+    def __init__(self, items: Iterable[PendingTurnItem] | None = None) -> None:
+        self._items: deque[PendingTurnItem] = deque(items or ())
+
+    # -- container protocol ----------------------------------------------
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __bool__(self) -> bool:
+        return bool(self._items)
+
+    def __iter__(self) -> Iterator[PendingTurnItem]:
+        # Non-consuming: iterate a snapshot so callers can drain afterwards.
+        return iter(list(self._items))
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"PendingTurnQueue({list(self._items)!r})"
+
+    # -- mutation ---------------------------------------------------------
+    def append(self, item: PendingTurnItem) -> None:
+        self._items.append(item)
+
+    def appendleft(self, item: PendingTurnItem) -> None:
+        self._items.appendleft(item)
+
+    def extend(self, items: Iterable[PendingTurnItem]) -> None:
+        self._items.extend(items)
+
+    def clear(self) -> None:
+        self._items.clear()
+
+    # -- inspection -------------------------------------------------------
+    def peek(self) -> PendingTurnItem | None:
+        return self._items[0] if self._items else None
+
+    def snapshot(self) -> list[PendingTurnItem]:
+        return list(self._items)
+
+    # -- consumption ------------------------------------------------------
+    def pop(self) -> PendingTurnItem | None:
+        """Remove and return the head item, or None when empty."""
+        return self._items.popleft() if self._items else None
+
+    def drain_coalescible_text_until_boundary(
+        self, *, origin_busy: bool | None = None
+    ) -> list[PendingTurnItem]:
+        """Pop and return the leading run of coalescible-text items.
+
+        Items are removed from the front of the queue as long as
+        :meth:`PendingTurnItem.is_coalescible_text` holds and -- when
+        *origin_busy* is not None -- their ``origin_busy`` flag equals
+        *origin_busy*.  The first item that breaks the run (a command, media,
+        attachment, a hard boundary, or a text fragment with a different
+        ``origin_busy``) is left in place, so what remains in the queue starts at
+        that boundary.  Returns the popped items in order (possibly empty).
+        """
+        run: list[PendingTurnItem] = []
+        while self._items:
+            head = self._items[0]
+            if not head.is_coalescible_text():
+                break
+            if origin_busy is not None and head.origin_busy != origin_busy:
+                break
+            run.append(self._items.popleft())
+        return run
+
+
+# --------------------------------------------------------------------------
+# Conversion helpers -- legacy CLI payloads
+# --------------------------------------------------------------------------
+def legacy_cli_payload_is_coalescible_text(payload: Any) -> bool:
+    """True when a legacy CLI ``_pending_input`` payload is a coalescible text.
+
+    Matches the predicate the CLI's plain ``queue``-mode coalescer uses for its
+    *first* item: a ``str`` that does not look like a slash command.  (Empty
+    strings qualify here -- mirroring the legacy guard -- but never start a merge
+    run because :meth:`PendingTurnItem.is_coalescible_text` requires non-empty
+    text, mirroring the legacy loop check.)
+    """
+    return isinstance(payload, str) and not looks_like_slash_command(payload)
+
+
+def from_legacy_cli_payload(
+    payload: Any,
+    *,
+    source: str = SOURCE_CLI,
+    session_key: str | None = None,
+) -> PendingTurnItem:
+    """Lift a legacy CLI ``_pending_input`` payload into a :class:`PendingTurnItem`.
+
+    Recognised shapes:
+
+    * ``str`` -> a ``command`` item if it looks like a slash command, else a
+      ``coalesce`` text item.
+    * ``(INTEGRATED_BUSY_PAYLOAD, inner)`` -> the inner payload, lifted as above
+      but with ``origin_busy=True`` (a non-``str`` inner becomes an opaque
+      ``control`` item).
+    * ``(caption, [paths...])`` -> a ``media`` item with a hard boundary
+      (``caption`` rides in ``text``; the list contents become ``media_refs``).
+    * anything else -> an opaque ``control`` item with a hard boundary.
+
+    ``raw`` is always set to the original *payload* so
+    :func:`maybe_to_legacy_cli_payload` can hand it back unchanged.
+    """
+    # Integrated busy-time tag: unwrap, then classify the inner value.
+    if is_integrated_busy_payload(payload):
+        inner = unwrap_integrated_busy_payload(payload)
+        if isinstance(inner, str):
+            if looks_like_slash_command(inner):
+                return PendingTurnItem(
+                    source=source,
+                    kind=KIND_COMMAND,
+                    text=inner,
+                    boundary=BOUNDARY_COMMAND,
+                    session_key=session_key,
+                    origin_busy=True,
+                    raw=payload,
+                )
+            return PendingTurnItem(
+                source=source,
+                kind=KIND_TEXT,
+                text=inner,
+                boundary=BOUNDARY_COALESCE,
+                session_key=session_key,
+                origin_busy=True,
+                raw=payload,
+            )
+        # Pathological: integrated tag wrapping a non-string.  Preserve it.
+        return PendingTurnItem(
+            source=source,
+            kind=KIND_CONTROL,
+            text=None,
+            boundary=BOUNDARY_HARD,
+            session_key=session_key,
+            origin_busy=True,
+            raw=payload,
+        )
+
+    # Plain string: slash command vs prose.
+    if isinstance(payload, str):
+        if looks_like_slash_command(payload):
+            return PendingTurnItem(
+                source=source,
+                kind=KIND_COMMAND,
+                text=payload,
+                boundary=BOUNDARY_COMMAND,
+                session_key=session_key,
+                raw=payload,
+            )
+        return PendingTurnItem(
+            source=source,
+            kind=KIND_TEXT,
+            text=payload,
+            boundary=BOUNDARY_COALESCE,
+            session_key=session_key,
+            raw=payload,
+        )
+
+    # ``(caption, [paths...])`` image/media tuple as produced by the CLI.
+    if (
+        isinstance(payload, tuple)
+        and len(payload) == 2
+        and isinstance(payload[1], list)
+    ):
+        caption, refs = payload
+        return PendingTurnItem(
+            source=source,
+            kind=KIND_MEDIA,
+            text=caption if isinstance(caption, str) and caption else None,
+            media_refs=[str(r) for r in refs],
+            boundary=BOUNDARY_HARD,
+            session_key=session_key,
+            raw=payload,
+        )
+
+    # Anything else: keep it intact behind an opaque control item.
+    return PendingTurnItem(
+        source=source,
+        kind=KIND_CONTROL,
+        text=None,
+        boundary=BOUNDARY_HARD,
+        session_key=session_key,
+        raw=payload,
+    )
+
+
+def maybe_to_legacy_cli_payload(item: PendingTurnItem) -> Any:
+    """Best-effort inverse of :func:`from_legacy_cli_payload`.
+
+    If *item* still carries its original ``raw`` payload, that is returned
+    verbatim (the lossless common case).  Otherwise a payload is reconstructed
+    from the structured fields: a ``media``/``attachment`` item with refs becomes
+    ``(text or "", media_refs)``; anything with text becomes that text; an empty
+    item falls back to ``""``.
+    """
+    if item.raw is not None:
+        return item.raw
+    if item.media_refs and item.kind in (KIND_MEDIA, KIND_ATTACHMENT):
+        return (item.text or "", list(item.media_refs))
+    if isinstance(item.text, str):
+        return item.text
+    return ""
+
+
+# --------------------------------------------------------------------------
+# Conversion helpers -- gateway MessageEvent
+# --------------------------------------------------------------------------
+# Map ``MessageType`` *values* (the enum's lowercase string values) to a
+# (kind, boundary) pair.  Duck-typed on ``.value`` so this module need not import
+# ``gateway.platforms.base``.
+_GATEWAY_MESSAGE_TYPE_MAP: dict[str, tuple[str, str]] = {
+    "text": (KIND_TEXT, BOUNDARY_COALESCE),
+    "command": (KIND_COMMAND, BOUNDARY_COMMAND),
+    "photo": (KIND_MEDIA, BOUNDARY_HARD),
+    "video": (KIND_MEDIA, BOUNDARY_HARD),
+    "audio": (KIND_MEDIA, BOUNDARY_HARD),
+    "voice": (KIND_MEDIA, BOUNDARY_HARD),
+    "sticker": (KIND_MEDIA, BOUNDARY_HARD),
+    "document": (KIND_ATTACHMENT, BOUNDARY_HARD),
+    "location": (KIND_CONTROL, BOUNDARY_HARD),
+}
+
+
+def _gateway_source_name(event: Any) -> str:
+    platform = getattr(getattr(event, "source", None), "platform", None)
+    if isinstance(platform, str) and platform:
+        return platform.lower()
+    name = getattr(platform, "value", None) or getattr(platform, "name", None)
+    if isinstance(name, str) and name:
+        return name.lower()
+    return SOURCE_UNKNOWN
+
+
+def _gateway_message_type_value(event: Any) -> str:
+    message_type = getattr(event, "message_type", None)
+    if isinstance(message_type, str):
+        return message_type.lower()
+    value = getattr(message_type, "value", None)
+    if isinstance(value, str):
+        return value.lower()
+    name = getattr(message_type, "name", None)
+    if isinstance(name, str):
+        return name.lower()
+    return ""
+
+
+def _gateway_created_at(event: Any) -> float:
+    ts = getattr(event, "timestamp", None)
+    to_ts = getattr(ts, "timestamp", None)
+    if callable(to_ts):
+        try:
+            return float(to_ts())
+        except Exception:
+            pass
+    return time.time()
+
+
+def from_gateway_event(event: Any, session_key: str | None = None) -> PendingTurnItem:
+    """Lift a gateway ``MessageEvent`` into a :class:`PendingTurnItem`.
+
+    Duck-typed (reads ``text``, ``message_type``, ``media_urls``,
+    ``media_types``, ``reply_to_message_id``, ``source.platform``, ``timestamp``)
+    so it does not depend on the ``gateway`` package -- which keeps this module a
+    leaf and the conversion usable as a one-way bridge while the gateway still
+    owns its ``Dict[str, MessageEvent]`` slot model.
+
+    Slash-command text is classified as a ``command`` item even when the
+    underlying ``message_type`` is ``TEXT`` (Telegram delivers ``/foo`` as TEXT),
+    so commands keep a hard boundary and are never folded into a coalesced text
+    run.  Media events keep ``boundary=hard`` and their caption (if any) in
+    ``text`` -- the album/burst *merge* behaviour stays where it is today
+    (``gateway.platforms.base.merge_pending_message_event``); this representation
+    just refuses to dissolve media into a text run.  ``raw`` is the original
+    event.
+    """
+    text = getattr(event, "text", None)
+    text = text if isinstance(text, str) and text else None
+    media_refs = list(getattr(event, "media_urls", None) or [])
+    media_types = list(getattr(event, "media_types", None) or [])
+
+    mtype = _gateway_message_type_value(event)
+    kind, boundary = _GATEWAY_MESSAGE_TYPE_MAP.get(
+        mtype,
+        (KIND_TEXT, BOUNDARY_COALESCE),
+    )
+
+    # Unknown/future/plugin-specific message types may still carry media refs.
+    # Preserve media as a hard boundary even when the message_type string is not
+    # in our map, otherwise captions from new adapters could be folded into plain
+    # text and lose attachment provenance.
+    if kind == KIND_TEXT and media_refs:
+        kind, boundary = KIND_MEDIA, BOUNDARY_HARD
+    # Telegram (and friends) deliver "/cmd" as a TEXT message; treat it as a
+    # command so it is never coalesced into prose.  Conversely, some adapters may
+    # over-eagerly mark any slash-prefixed path as COMMAND; preserve path-like
+    # text as coalescible prose rather than making it a hard command boundary.
+    if kind == KIND_TEXT and looks_like_slash_command(text):
+        kind, boundary = KIND_COMMAND, BOUNDARY_COMMAND
+    elif kind == KIND_COMMAND and text and not looks_like_slash_command(text):
+        kind, boundary = KIND_TEXT, BOUNDARY_COALESCE
+    # A media/attachment event with no refs but with text is really just text.
+    if kind in (KIND_MEDIA, KIND_ATTACHMENT) and not media_refs and text:
+        kind, boundary = KIND_TEXT, BOUNDARY_COALESCE
+
+    reply_to = getattr(event, "reply_to_message_id", None)
+    return PendingTurnItem(
+        source=_gateway_source_name(event),
+        kind=kind,
+        text=text,
+        media_refs=media_refs,
+        media_types=media_types,
+        boundary=boundary,
+        session_key=session_key,
+        reply_to=str(reply_to) if reply_to is not None else None,
+        created_at=_gateway_created_at(event),
+        raw=event,
+    )
+
+
+# --------------------------------------------------------------------------
+# Misc
+# --------------------------------------------------------------------------
+def coalesced_text(items: Iterable[PendingTurnItem], *, sep: str = "\n\n") -> str:
+    """Join the ``text`` of *items* with *sep* (blanks/None skipped)."""
+    return sep.join(it.text for it in items if isinstance(it.text, str) and it.text)

--- a/agent/task_registry.py
+++ b/agent/task_registry.py
@@ -1,0 +1,591 @@
+"""Focused task registry substrate for Hermes (orchestrator Phase 3).
+
+Hermes is moving toward a concierge / front-desk / butler orchestrator: it stays
+accountable for user intent, prioritisation, synthesis and final output, but
+heavy work may eventually be delegated to workers, and late user follow-ups must
+still find their way back to the *task* they belong to -- not merely the chat
+session that produced them.  Today there is nowhere to write down "which focused
+task is Woo actually on right now, what state is it in, and what follow-ups have
+piled up against it".
+
+This module is that place.  :class:`FocusedTask` is a small, serialisable record
+of one focused user task -- its identity (``task_id`` / ``session_key`` /
+``origin``), its lifecycle ``status``, the pending follow-ups attached to it
+(Phase 2 :class:`~agent.pending_turn_queue.PendingTurnItem` objects, in arrival
+order), an optional worker linkage (``active_worker_id`` / ``worker_kind``) for
+whoever runs the work later, plus free-form ``artifacts`` and ``notes``.
+:class:`TaskRegistry` is a tiny in-memory collection with create / get / list /
+status-update / cancel / attach helpers, JSON serialisation, and *optional*
+atomic-write file persistence.
+
+Scope discipline (Phase 3 is the *substrate*, not the behaviour):
+
+* This is **not** the Ralph / focused-agent runtime, **not** a follow-up
+  classifier or intent model, **not** a worker lane or background-delegation
+  mechanism, and **not** automatic routing of CLI/Telegram messages into tasks.
+  Those are Phase 4/5.  Nothing here decides whether a given follow-up is an
+  append, a correction, a steer, a status query, or a new task -- it only gives
+  later phases somewhere to *record* such a decision once it is made.
+* This module is a leaf: it imports only the standard library and the Phase 2
+  :mod:`agent.pending_turn_queue`, holds no global mutable state, and everything
+  produced by :meth:`TaskRegistry.to_dict` is plain JSON-safe data.  Pending
+  follow-ups are serialised via :meth:`PendingTurnItem.to_dict`, which drops the
+  one local-process passthrough (``PendingTurnItem.raw``) without touching it;
+  no raw payload is ever serialised or deep-copied.
+* File persistence is intentionally minimal: a single JSON document written
+  atomically (temp file + ``os.replace``).  It is optional -- a registry with no
+  bound path is a perfectly good in-memory registry with explicit serialisation
+  helpers; durable multi-writer storage (SQLite, per-task files, ...) is
+  explicitly Phase 4/5 if it is ever needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field, fields, replace
+from typing import Any
+
+from agent.pending_turn_queue import PendingTurnItem, from_legacy_cli_payload
+
+__all__ = [
+    "STATUS_PROPOSED",
+    "STATUS_QUEUED",
+    "STATUS_RUNNING",
+    "STATUS_STEERABLE",
+    "STATUS_BLOCKED",
+    "STATUS_DONE",
+    "STATUS_ERROR",
+    "STATUS_CANCELLED",
+    "TASK_STATUSES",
+    "ACTIVE_STATUSES",
+    "TERMINAL_STATUSES",
+    "WORKER_DELEGATE",
+    "WORKER_CLAUDE_CODE",
+    "WORKER_TERMINAL",
+    "WORKER_RALPH",
+    "TaskOrigin",
+    "FocusedTask",
+    "TaskRegistry",
+]
+
+# --------------------------------------------------------------------------
+# Task lifecycle vocabulary.
+#
+# Unlike the pending-turn ``kind`` / ``boundary`` strings (which are deliberately
+# open -- unknown future values are tolerated), the task status set is *closed*:
+# a status outside this set is a bug, so it is rejected with a clear error
+# wherever a status is assigned (construction, ``update_status``, ``from_dict``).
+# --------------------------------------------------------------------------
+STATUS_PROPOSED = "proposed"     # created, not yet accepted/queued
+STATUS_QUEUED = "queued"         # accepted, waiting to start
+STATUS_RUNNING = "running"       # actively being worked (by Hermes or a worker)
+STATUS_STEERABLE = "steerable"   # running and at a point where steering is safe
+STATUS_BLOCKED = "blocked"       # needs user input / an external unblock
+STATUS_DONE = "done"             # finished successfully
+STATUS_ERROR = "error"           # finished with a failure
+STATUS_CANCELLED = "cancelled"   # cancelled / reclaimed before completion
+
+TASK_STATUSES = frozenset(
+    {
+        STATUS_PROPOSED,
+        STATUS_QUEUED,
+        STATUS_RUNNING,
+        STATUS_STEERABLE,
+        STATUS_BLOCKED,
+        STATUS_DONE,
+        STATUS_ERROR,
+        STATUS_CANCELLED,
+    }
+)
+# Terminal statuses: a task in one of these is finished and is excluded from the
+# "active tasks" view by default.
+TERMINAL_STATUSES = frozenset({STATUS_DONE, STATUS_ERROR, STATUS_CANCELLED})
+ACTIVE_STATUSES = frozenset(TASK_STATUSES - TERMINAL_STATUSES)
+
+# Documented ``worker_kind`` hints for the worker-linkage fields.  These are
+# *documentation*, not a rejecting enum -- ``worker_kind`` is a free-form string
+# (or None) so Phase 4 can name new lanes without touching this module.  Nothing
+# in Phase 3 starts a worker; these names just make the linkage intent concrete.
+WORKER_DELEGATE = "delegate_task"   # an in-process delegate_task subagent
+WORKER_CLAUDE_CODE = "claude_code"  # a Claude Code CLI worker
+WORKER_TERMINAL = "terminal"        # a detached terminal / background process
+WORKER_RALPH = "ralph"              # the future focused-agent ("Ralph") runtime
+
+
+def _new_task_id() -> str:
+    return f"task-{uuid.uuid4().hex}"
+
+
+def _validate_status(status: Any) -> str:
+    if status not in TASK_STATUSES:
+        raise ValueError(
+            f"unknown task status {status!r}; expected one of {sorted(TASK_STATUSES)}"
+        )
+    return status
+
+
+def _as_float(value: Any, default: float) -> float:
+    # ``bool`` is an ``int`` subclass; reject it so ``created_at: true`` from
+    # mangled data does not silently become ``1.0``.
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return default
+
+
+def _json_safe_copy(value: Any, *, label: str) -> Any:
+    """Return a detached JSON-safe copy of *value* or raise TypeError.
+
+    The registry promises JSON-safe serialization for task metadata.  Validate
+    local artifact/note-style payloads at insertion time so persistence cannot
+    fail much later, and use a JSON round-trip to detach nested mutable values.
+    This helper is only used for registry metadata; it never touches
+    ``PendingTurnItem.raw``.
+    """
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{label} must be JSON-serializable") from exc
+
+
+# --------------------------------------------------------------------------
+# TaskOrigin
+# --------------------------------------------------------------------------
+@dataclass
+class TaskOrigin:
+    """Where a focused task came from.  All fields are plain strings or ``None``."""
+
+    platform: str | None = None
+    chat_id: str | None = None
+    thread_id: str | None = None
+    user_id: str | None = None
+    session_key: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "platform": self.platform,
+            "chat_id": self.chat_id,
+            "thread_id": self.thread_id,
+            "user_id": self.user_id,
+            "session_key": self.session_key,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> TaskOrigin:
+        if not data:
+            return cls()
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+# --------------------------------------------------------------------------
+# FocusedTask
+# --------------------------------------------------------------------------
+@dataclass
+class FocusedTask:
+    """One focused user task: identity, lifecycle state, follow-ups, linkage.
+
+    Constructed via :meth:`TaskRegistry.create_task` in normal use.  Every field
+    is JSON-serialisable except the per-follow-up ``PendingTurnItem.raw``
+    passthrough, which :meth:`PendingTurnItem.to_dict` drops -- so :meth:`to_dict`
+    is always safe to log, persist, or move across a process boundary.
+    """
+
+    task_id: str
+    user_goal: str
+    status: str = STATUS_PROPOSED
+    session_key: str | None = None
+    origin: TaskOrigin = field(default_factory=TaskOrigin)
+    active_worker_id: str | None = None
+    worker_kind: str | None = None
+    pending_followups: list[PendingTurnItem] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        _validate_status(self.status)
+
+    # -- introspection ----------------------------------------------------
+    @property
+    def is_active(self) -> bool:
+        return self.status not in TERMINAL_STATUSES
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+    def touch(self, *, now: float | None = None) -> None:
+        """Bump ``updated_at`` -- to *now* if given, else the current time."""
+        self.updated_at = time.time() if now is None else float(now)
+
+    # -- serialization ----------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict.
+
+        ``pending_followups`` are serialised via :meth:`PendingTurnItem.to_dict`
+        (which drops ``raw`` without touching it). ``artifacts`` are returned as
+        detached JSON-round-trip copies so nested metadata cannot alias live task
+        state; ``notes`` are copied as a fresh list.
+        """
+        return {
+            "task_id": self.task_id,
+            "user_goal": self.user_goal,
+            "status": self.status,
+            "session_key": self.session_key,
+            "origin": self.origin.to_dict(),
+            "active_worker_id": self.active_worker_id,
+            "worker_kind": self.worker_kind,
+            "pending_followups": [it.to_dict() for it in self.pending_followups],
+            "artifacts": [_json_safe_copy(a, label="artifact") for a in self.artifacts],
+            "notes": list(self.notes),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FocusedTask:
+        """Rebuild from :meth:`to_dict` output (unknown keys ignored).
+
+        An invalid ``status`` is rejected (via ``__post_init__``).  Pending
+        follow-ups are rebuilt with :meth:`PendingTurnItem.from_dict`, so they
+        come back with ``raw is None`` -- the local passthrough does not survive a
+        serialisation round-trip, by design.
+        """
+        origin = TaskOrigin.from_dict(data.get("origin"))
+        session_key = data.get("session_key")
+        if session_key is None:
+            session_key = origin.session_key
+        followups = [
+            PendingTurnItem.from_dict(d)
+            for d in (data.get("pending_followups") or [])
+            if isinstance(d, dict)
+        ]
+        artifacts = [
+            _json_safe_copy(a, label="artifact")
+            for a in (data.get("artifacts") or [])
+            if isinstance(a, dict)
+        ]
+        notes = [str(n) for n in (data.get("notes") or [])]
+        created_at = _as_float(data.get("created_at"), time.time())
+        updated_at = _as_float(data.get("updated_at"), created_at)
+        return cls(
+            task_id=str(data.get("task_id") or _new_task_id()),
+            user_goal=str(data.get("user_goal") or ""),
+            status=data.get("status", STATUS_PROPOSED),
+            session_key=session_key,
+            origin=origin,
+            active_worker_id=data.get("active_worker_id"),
+            worker_kind=data.get("worker_kind"),
+            pending_followups=followups,
+            artifacts=artifacts,
+            notes=notes,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+# --------------------------------------------------------------------------
+# TaskRegistry
+# --------------------------------------------------------------------------
+class TaskRegistry:
+    """An ordered, in-memory collection of :class:`FocusedTask` records.
+
+    Not thread-safe: callers that touch it from multiple threads / event loops
+    should hold their own lock (mirroring
+    :class:`~agent.pending_turn_queue.PendingTurnQueue`).  An optional bound
+    *path* enables :meth:`save` / :meth:`load` JSON persistence; a registry with
+    ``path=None`` is in-memory only, and :meth:`save` then requires an explicit
+    path argument.
+    """
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, *, path: str | os.PathLike[str] | None = None) -> None:
+        self._tasks: dict[str, FocusedTask] = {}
+        self._path: str | None = os.fspath(path) if path is not None else None
+
+    # -- container-ish ----------------------------------------------------
+    def __len__(self) -> int:
+        return len(self._tasks)
+
+    def __contains__(self, task_id: object) -> bool:
+        return task_id in self._tasks
+
+    @property
+    def path(self) -> str | None:
+        """The bound persistence path, or ``None`` for an in-memory registry."""
+        return self._path
+
+    # -- internals --------------------------------------------------------
+    def _require(self, task_id: str) -> FocusedTask:
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise KeyError(f"unknown task id: {task_id!r}")
+        return task
+
+    # -- creation ---------------------------------------------------------
+    def create_task(
+        self,
+        user_goal: str,
+        *,
+        session_key: str | None = None,
+        origin: TaskOrigin | dict[str, Any] | None = None,
+        status: str = STATUS_PROPOSED,
+        active_worker_id: str | None = None,
+        worker_kind: str | None = None,
+        task_id: str | None = None,
+    ) -> FocusedTask:
+        """Create and register a new focused task.
+
+        *origin* may be a :class:`TaskOrigin`, a plain dict (lifted via
+        :meth:`TaskOrigin.from_dict`), or ``None``.  A passed-in :class:`TaskOrigin`
+        is shallow-copied so the registry does not alias the caller's object.  If
+        *session_key* is given it becomes ``task.session_key`` (and fills
+        ``origin.session_key`` when that is empty); otherwise ``task.session_key``
+        falls back to ``origin.session_key``.  An invalid *status* raises
+        ``ValueError``; a duplicate *task_id* raises ``ValueError``.
+        """
+        _validate_status(status)
+        if isinstance(origin, dict):
+            resolved_origin = TaskOrigin.from_dict(origin)
+        elif isinstance(origin, TaskOrigin):
+            resolved_origin = replace(origin)  # private copy; do not alias caller's
+        elif origin is None:
+            resolved_origin = TaskOrigin()
+        else:
+            raise TypeError("origin must be a TaskOrigin, a dict, or None")
+
+        if session_key is not None:
+            if resolved_origin.session_key is None:
+                resolved_origin.session_key = session_key
+            effective_session_key: str | None = session_key
+        else:
+            effective_session_key = resolved_origin.session_key
+
+        tid = task_id or _new_task_id()
+        if tid in self._tasks:
+            raise ValueError(f"task id already exists: {tid!r}")
+
+        task = FocusedTask(
+            task_id=tid,
+            user_goal=user_goal,
+            status=status,
+            session_key=effective_session_key,
+            origin=resolved_origin,
+            active_worker_id=active_worker_id,
+            worker_kind=worker_kind,
+        )
+        self._tasks[tid] = task
+        return task
+
+    # -- lookup -----------------------------------------------------------
+    def get_task(self, task_id: str) -> FocusedTask | None:
+        return self._tasks.get(task_id)
+
+    def list_tasks(
+        self,
+        *,
+        session_key: str | None = None,
+        active_only: bool = False,
+    ) -> list[FocusedTask]:
+        """Return tasks in creation order, optionally filtered.
+
+        *session_key* (when given) keeps only tasks whose ``session_key`` matches
+        exactly.  *active_only* drops terminal tasks (``done`` / ``error`` /
+        ``cancelled``).
+        """
+        out = list(self._tasks.values())
+        if session_key is not None:
+            out = [t for t in out if t.session_key == session_key]
+        if active_only:
+            out = [t for t in out if t.is_active]
+        return out
+
+    # -- mutation ---------------------------------------------------------
+    def update_status(
+        self,
+        task_id: str,
+        status: str,
+        *,
+        note: str | None = None,
+    ) -> FocusedTask:
+        """Set *task_id*'s status (rejecting unknown statuses) and bump ``updated_at``.
+
+        An optional *note* is appended (string-coerced) to the task's notes.
+        """
+        _validate_status(status)
+        task = self._require(task_id)
+        task.status = status
+        if note is not None:
+            task.notes.append(str(note))
+        task.touch()
+        return task
+
+    def assign_worker(
+        self,
+        task_id: str,
+        worker_id: str,
+        *,
+        worker_kind: str | None = None,
+    ) -> FocusedTask:
+        """Record a worker linkage on *task_id*.  Does **not** start anything."""
+        task = self._require(task_id)
+        task.active_worker_id = worker_id
+        task.worker_kind = worker_kind
+        task.touch()
+        return task
+
+    def clear_worker(self, task_id: str) -> FocusedTask:
+        """Drop *task_id*'s worker linkage (``active_worker_id`` / ``worker_kind`` -> None)."""
+        task = self._require(task_id)
+        task.active_worker_id = None
+        task.worker_kind = None
+        task.touch()
+        return task
+
+    def attach_followup(self, task_id: str, item: Any) -> PendingTurnItem:
+        """Append a pending follow-up to *task_id*, preserving arrival order.
+
+        *item* may be:
+
+        * a :class:`PendingTurnItem` -- stored as-is, so an in-memory ``raw``
+          passthrough is kept locally (it is still dropped on serialisation);
+        * a ``dict`` -- rebuilt via :meth:`PendingTurnItem.from_dict`;
+        * a legacy CLI payload -- a ``str``, a ``(caption, [paths])`` tuple, or an
+          ``(INTEGRATED_BUSY_PAYLOAD, text)`` tag -- which is lifted with
+          :func:`from_legacy_cli_payload` (threading the task's ``session_key``).
+
+        Returns the stored :class:`PendingTurnItem`.
+        """
+        task = self._require(task_id)
+        if isinstance(item, PendingTurnItem):
+            pending = item
+        elif isinstance(item, dict):
+            pending = PendingTurnItem.from_dict(item)
+        else:
+            pending = from_legacy_cli_payload(item, session_key=task.session_key)
+        task.pending_followups.append(pending)
+        task.touch()
+        return pending
+
+    def attach_artifact(self, task_id: str, artifact: dict[str, Any]) -> dict[str, Any]:
+        """Append an artifact record (a dict) to *task_id*; return the stored copy.
+
+        The artifact is copied into a detached JSON-safe representation on the
+        way in so later mutation of the caller's dict (including nested values)
+        does not reach into the task.  Non-JSON-serializable keys/values raise
+        ``TypeError`` immediately rather than failing later during persistence.
+        """
+        if not isinstance(artifact, dict):
+            raise TypeError("artifact must be a dict")
+        task = self._require(task_id)
+        stored = _json_safe_copy(artifact, label="artifact")
+        task.artifacts.append(stored)
+        task.touch()
+        return stored
+
+    def add_note(self, task_id: str, note: str) -> FocusedTask:
+        """Append a (string-coerced) note to *task_id*."""
+        task = self._require(task_id)
+        task.notes.append(str(note))
+        task.touch()
+        return task
+
+    def cancel_task(self, task_id: str, *, reason: str | None = None) -> FocusedTask:
+        """Mark *task_id* ``cancelled``; record *reason* as a note when given."""
+        task = self._require(task_id)
+        task.status = STATUS_CANCELLED
+        if reason is not None:
+            task.notes.append(f"cancelled: {reason}")
+        task.touch()
+        return task
+
+    # -- serialization ----------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe document: ``{"version": N, "tasks": [...]}``.
+
+        ``tasks`` preserves creation order; each task is serialised via
+        :meth:`FocusedTask.to_dict` (so no ``raw`` payload is included).
+        """
+        return {
+            "version": self.SCHEMA_VERSION,
+            "tasks": [t.to_dict() for t in self._tasks.values()],
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any] | None,
+        *,
+        path: str | os.PathLike[str] | None = None,
+    ) -> TaskRegistry:
+        """Rebuild a registry from :meth:`to_dict` output (unknown keys ignored).
+
+        An invalid ``status`` in any task raises ``ValueError``.  If two tasks
+        share a ``task_id`` the later one wins.  The returned registry is bound to
+        *path* (if given) so a later :meth:`save` round-trips.
+        """
+        reg = cls(path=path)
+        if data:
+            for raw_task in (data.get("tasks") or []):
+                if not isinstance(raw_task, dict):
+                    continue
+                task = FocusedTask.from_dict(raw_task)
+                reg._tasks[task.task_id] = task
+        return reg
+
+    # -- persistence (optional) -------------------------------------------
+    def save(self, path: str | os.PathLike[str] | None = None) -> str:
+        """Atomically write the registry to *path* (or the bound path) as JSON.
+
+        Writes a temp file in the destination directory, ``fsync``s it, then
+        ``os.replace``s it over the target, so a concurrent reader never sees a
+        half-written file.  Passing an explicit *path* also binds it for later
+        ``save()`` calls.  Returns the path written.  Raises ``ValueError`` when
+        no path is available.
+        """
+        target = os.fspath(path) if path is not None else self._path
+        if not target:
+            raise ValueError("no path given and this registry has no bound path")
+        directory = os.path.dirname(target) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".task_registry_", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(self.to_dict(), fh, indent=2, ensure_ascii=False)
+                fh.write("\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, target)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        if path is not None:
+            self._path = target
+        return target
+
+    @classmethod
+    def load(cls, path: str | os.PathLike[str]) -> TaskRegistry:
+        """Load a registry from *path*; an absent file yields an empty registry.
+
+        A present-but-corrupt file raises (``json``/``ValueError`` propagate) -- a
+        truncated or malformed registry should be visible, not silently dropped.
+        The returned registry is bound to *path* so a later :meth:`save`
+        round-trips.
+        """
+        target = os.fspath(path)
+        if not os.path.exists(target):
+            return cls(path=target)
+        with open(target, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            raise ValueError(f"task registry file is not a JSON object: {target!r}")
+        return cls.from_dict(data, path=target)

--- a/agent/worker_lanes.py
+++ b/agent/worker_lanes.py
@@ -1,0 +1,751 @@
+"""Worker-lane / detached-execution substrate for Hermes (orchestrator Phase 4).
+
+Hermes is moving toward a concierge / front-desk / butler orchestrator: the main
+process stays accountable for user intent, prioritisation, review and synthesis,
+but long implementation / research work should eventually run in *worker lanes*
+so the foreground orchestrator can acknowledge dispatch and remain available for
+the next Telegram/CLI/TUI turn.  Phase 3 gave focused tasks an explicit identity
+and state (:mod:`agent.task_registry`).  This module is the next layer down: a
+small, explicit *worker-lane* abstraction plus one local, fully-testable lane
+implementation that can start, track, cancel and retrieve results for detached
+work without blocking the caller until completion.
+
+What this module is -- and isn't:
+
+* It is a *library substrate*.  :class:`WorkerLane` is a structural protocol;
+  :class:`ThreadWorkerLane` is one purpose-fit lane that runs a caller-supplied
+  ``runner`` callable in a daemon thread; :class:`WorkerLaneRegistry` is a tiny
+  name -> lane index with a worker-id -> lane back-pointer so callers can address
+  a worker by id without tracking which lane owns it.  :func:`link_worker_to_task`
+  is a one-line convenience that records ``active_worker_id`` / ``worker_kind`` on
+  a supplied :class:`~agent.task_registry.TaskRegistry`.
+* It is **not** the Ralph / focused-agent runtime, **not** a follow-up
+  classifier, **not** automatic Telegram/gateway routing into workers, **not**
+  the user-facing ``/tasks`` / ``/agents`` / ``/stop`` commands, and **not** the
+  ``delegate_task(background=True)`` tool API.  It deliberately ships no Claude
+  Code process lane, no Kanban lane, and no SQLite / multi-process durable worker
+  database.  Those are later phases; this module is only the foundation they will
+  connect to.
+
+Scope discipline (mirrors the Phase 2/3 leaf modules):
+
+* This module is a leaf: it imports only the standard library and the Phase 2
+  :mod:`agent.pending_turn_queue` (for :class:`~agent.pending_turn_queue.PendingTurnItem`,
+  used by :meth:`WorkerLane.append_followup`).  The optional task-registry
+  linkage helper is duck-typed -- it calls ``registry.assign_worker(...)`` and
+  never imports :mod:`agent.task_registry` at runtime -- so this module stays a
+  leaf and works even where the registry is not present.
+* Everything produced by a ``to_dict`` / ``snapshot`` method is plain JSON-safe
+  data.  Follow-ups are serialised via :meth:`PendingTurnItem.to_dict`, which
+  drops the one local-process passthrough (``PendingTurnItem.raw``) without
+  touching it.  ``WorkerSpec.metadata`` is documented to be JSON-safe and the
+  snapshot path *enforces* it (a non-JSON-safe value raises ``TypeError`` rather
+  than being silently serialised) so a snapshot never lies about JSON safety.
+* Cancellation is *cooperative*.  :meth:`ThreadWorkerLane.cancel` sets a
+  :class:`CancelToken` (and, if the worker has not yet entered its runner, the
+  worker transitions straight to ``cancelled``); it never forcibly stops a
+  running thread.  A runner that observes the token and raises
+  :class:`WorkerCancelled` ends as ``cancelled``; one that ignores the token and
+  returns normally ends as ``done`` -- ``cancel_requested`` independently records
+  that a cancellation was asked for.  Full kill semantics for arbitrary external
+  processes are explicitly out of scope.
+* In-process thread-safety is handled here (each lane and the registry hold their
+  own lock); the optional :class:`~agent.task_registry.TaskRegistry` linkage is
+  *not* thread-safe and that is the caller's responsibility, exactly as the
+  registry's own docstring says.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field, fields
+from typing import TYPE_CHECKING, Any, Callable, Protocol
+
+from agent.pending_turn_queue import PendingTurnItem
+
+if TYPE_CHECKING:  # pragma: no cover - typing only; never imported at runtime
+    from agent.task_registry import FocusedTask, TaskRegistry
+
+__all__ = [
+    "WorkerStatus",
+    "WORKER_STATUSES",
+    "ACTIVE_WORKER_STATUSES",
+    "TERMINAL_WORKER_STATUSES",
+    "LANE_THREAD",
+    "FOLLOWUP_ACCEPTED",
+    "FOLLOWUP_DEFERRED",
+    "FOLLOWUP_REJECTED",
+    "WorkerSpec",
+    "WorkerHandle",
+    "WorkerResult",
+    "WorkerLane",
+    "WorkerCancelled",
+    "CancelToken",
+    "ThreadWorkerLane",
+    "WorkerLaneRegistry",
+    "link_worker_to_task",
+]
+
+
+# --------------------------------------------------------------------------
+# Vocabulary.
+#
+# The worker status set is *closed* (like ``task_registry``'s task statuses, and
+# unlike ``pending_turn_queue``'s open ``kind`` / ``boundary`` strings): every
+# transition is driven internally by a lane, so a status outside this set is a
+# bug.  ``WorkerStatus`` is a plain namespace of the five strings, not an enum.
+# --------------------------------------------------------------------------
+class WorkerStatus:
+    """The five worker lifecycle states (a namespace of strings, not an enum)."""
+
+    QUEUED = "queued"        # accepted by a lane, runner not yet entered
+    RUNNING = "running"      # runner is executing
+    DONE = "done"            # runner returned normally
+    ERROR = "error"          # runner raised a non-cancel exception
+    CANCELLED = "cancelled"  # cancelled before/while running (cooperatively)
+
+
+TERMINAL_WORKER_STATUSES = frozenset(
+    {WorkerStatus.DONE, WorkerStatus.ERROR, WorkerStatus.CANCELLED}
+)
+ACTIVE_WORKER_STATUSES = frozenset({WorkerStatus.QUEUED, WorkerStatus.RUNNING})
+WORKER_STATUSES = ACTIVE_WORKER_STATUSES | TERMINAL_WORKER_STATUSES
+
+# Default lane name.  Free-form: later phases can name new lanes ("claude_code",
+# "terminal", "ralph", ...) without touching this module -- this is the one this
+# module actually implements.
+LANE_THREAD = "thread"
+
+# Disposition strings returned by :meth:`WorkerLane.append_followup`.  This lane
+# only *stores* follow-ups (it does not yet inject them into a running worker), so
+# a follow-up accepted onto a live worker is reported as ``deferred``; a follow-up
+# offered to an already-finished worker is ``rejected``.  A future steerable lane
+# may return ``accepted`` once it can actually splice a follow-up into a run.
+FOLLOWUP_ACCEPTED = "accepted"
+FOLLOWUP_DEFERRED = "deferred"
+FOLLOWUP_REJECTED = "rejected"
+
+
+def _new_worker_id() -> str:
+    return f"worker-{uuid.uuid4().hex}"
+
+
+def _json_safe_copy(value: Any, *, label: str) -> Any:
+    """Return a detached JSON-safe copy of *value* or raise ``TypeError``.
+
+    Used only for ``WorkerSpec.metadata`` on the snapshot path -- it never touches
+    ``PendingTurnItem.raw``.  ``allow_nan=False`` so ``float('nan')`` / ``inf`` are
+    rejected too (matching :mod:`agent.task_registry`).
+    """
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{label} must be JSON-serializable") from exc
+
+
+def _coerce_result(value: Any) -> str | None:
+    """Coerce a runner return value to the ``str | None`` shape of ``WorkerResult.result``."""
+    if value is None:
+        return None
+    return value if isinstance(value, str) else str(value)
+
+
+# --------------------------------------------------------------------------
+# Cooperative cancellation
+# --------------------------------------------------------------------------
+class WorkerCancelled(Exception):
+    """Raised by a runner to signal it observed a cancellation request and stopped.
+
+    A runner that raises this ends with status ``cancelled``.  A runner that does
+    not cooperate (ignores the :class:`CancelToken` and returns/raises something
+    else) is not interrupted -- this substrate's cancellation is cooperative.
+    """
+
+
+class CancelToken:
+    """A one-shot cancellation flag handed to a worker runner.
+
+    A runner should poll :attr:`cancelled` (or call :meth:`raise_if_cancelled`) at
+    safe checkpoints, or block on :meth:`wait`.  Setting the token does not
+    interrupt the running thread; it only requests that the runner stop on its own.
+    """
+
+    __slots__ = ("_event",)
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._event.is_set()
+
+    def request(self) -> None:
+        """Request cancellation (idempotent)."""
+        self._event.set()
+
+    def raise_if_cancelled(self) -> None:
+        """Raise :class:`WorkerCancelled` if cancellation has been requested."""
+        if self._event.is_set():
+            raise WorkerCancelled("cancellation requested")
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Block up to *timeout* seconds; return ``True`` if cancelled meanwhile."""
+        return self._event.wait(timeout)
+
+
+# --------------------------------------------------------------------------
+# Public dataclasses: WorkerSpec / WorkerHandle / WorkerResult
+# --------------------------------------------------------------------------
+@dataclass
+class WorkerSpec:
+    """What to run in a worker lane.
+
+    *goal* is the human description of the work; *context* is optional extra prose
+    (the equivalent of a delegate-task "context" blob); *task_id* optionally links
+    to a :class:`~agent.task_registry.FocusedTask`; *lane* names the desired lane
+    (a registry uses it as the default target); *metadata* is free-form,
+    *documented to be JSON-safe* descriptive data (it must be a ``dict`` -- the
+    runner is supplied to the lane, never smuggled through here).
+    """
+
+    goal: str
+    context: str | None = None
+    task_id: str | None = None
+    lane: str = LANE_THREAD
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.goal, str):
+            raise TypeError("WorkerSpec.goal must be a string")
+        if not isinstance(self.lane, str) or not self.lane.strip():
+            raise TypeError("WorkerSpec.lane must be a non-empty string")
+        if self.context is not None and not isinstance(self.context, str):
+            raise TypeError("WorkerSpec.context must be a string or None")
+        if self.task_id is not None and not isinstance(self.task_id, str):
+            raise TypeError("WorkerSpec.task_id must be a string or None")
+        if not isinstance(self.metadata, dict):
+            raise TypeError("WorkerSpec.metadata must be a dict")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict; raises ``TypeError`` on non-JSON-safe metadata."""
+        return {
+            "goal": self.goal,
+            "context": self.context,
+            "task_id": self.task_id,
+            "lane": self.lane,
+            "metadata": _json_safe_copy(self.metadata, label="WorkerSpec.metadata"),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "WorkerSpec":
+        """Rebuild from :meth:`to_dict` output (unknown keys ignored)."""
+        known = {f.name for f in fields(cls)}
+        kw = {k: v for k, v in (data or {}).items() if k in known}
+        return cls(**kw)
+
+
+@dataclass
+class WorkerHandle:
+    """A point-in-time view of a worker's identity and lifecycle state.
+
+    Returned by :meth:`WorkerLane.start` / :meth:`WorkerLane.status`.  ``lane`` is
+    the *name of the lane actually running it* (which a registry may have chosen
+    over ``WorkerSpec.lane``).  ``cancel_requested`` makes a cancellation request
+    observable without a second call -- the suggested shape lists the core fields;
+    this one extra keeps "the cancellation request is represented" honest.
+    """
+
+    worker_id: str
+    task_id: str | None
+    lane: str
+    status: str
+    created_at: float
+    updated_at: float
+    cancel_requested: bool = False
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_WORKER_STATUSES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "task_id": self.task_id,
+            "lane": self.lane,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "cancel_requested": self.cancel_requested,
+        }
+
+
+@dataclass
+class WorkerResult:
+    """The outcome of a finished worker.
+
+    Obtained from :meth:`WorkerLane.result`, which returns ``None`` until the
+    worker is terminal.  ``result`` is set only on ``done``; ``error`` is set only
+    on ``error`` (``cancelled`` carries neither -- ``cancel_requested`` on the
+    handle is where a cancellation shows up).
+    """
+
+    worker_id: str
+    status: str
+    result: str | None = None
+    error: str | None = None
+    started_at: float | None = None
+    finished_at: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "status": self.status,
+            "result": self.result,
+            "error": self.error,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+        }
+
+
+# --------------------------------------------------------------------------
+# WorkerLane protocol
+# --------------------------------------------------------------------------
+class WorkerLane(Protocol):
+    """Structural interface every worker lane implements.
+
+    A lane owns a set of workers it identifies by ``worker_id`` strings it mints.
+    :meth:`start` must return promptly -- it must not block until the worker
+    finishes.  :meth:`status` returns the current :class:`WorkerHandle`;
+    :meth:`result` returns a :class:`WorkerResult` once (and only once) the worker
+    is terminal, else ``None``.  :meth:`append_followup` records a
+    :class:`~agent.pending_turn_queue.PendingTurnItem` against the worker and
+    returns a disposition string (one of ``FOLLOWUP_ACCEPTED`` /
+    ``FOLLOWUP_DEFERRED`` / ``FOLLOWUP_REJECTED``).  :meth:`cancel` requests
+    cancellation and returns ``True`` if the worker was still active, ``False`` if
+    it had already finished (a safe no-op).  Unknown ``worker_id`` raises
+    ``KeyError`` everywhere it is accepted.
+    """
+
+    name: str
+
+    def start(self, spec: "WorkerSpec") -> "WorkerHandle": ...
+
+    def status(self, worker_id: str) -> "WorkerHandle": ...
+
+    def append_followup(self, worker_id: str, item: PendingTurnItem) -> str: ...
+
+    def cancel(self, worker_id: str) -> bool: ...
+
+    def result(self, worker_id: str) -> "WorkerResult | None": ...
+
+
+# --------------------------------------------------------------------------
+# Internal per-worker state
+# --------------------------------------------------------------------------
+@dataclass
+class _WorkerEntry:
+    """A lane's private record for one worker.  Never serialised as-is; the
+    thread / cancel token / done-event are local-only, and :meth:`snapshot` builds
+    a JSON-safe view."""
+
+    worker_id: str
+    spec: WorkerSpec
+    lane_name: str
+    status: str
+    created_at: float
+    updated_at: float
+    started_at: float | None = None
+    finished_at: float | None = None
+    result: str | None = None
+    error: str | None = None
+    cancel_requested: bool = False
+    cancel_token: CancelToken = field(default_factory=CancelToken)
+    followups: list[PendingTurnItem] = field(default_factory=list)
+    thread: threading.Thread | None = None
+    done_event: threading.Event = field(default_factory=threading.Event)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_WORKER_STATUSES
+
+    def touch(self, *, now: float | None = None) -> None:
+        self.updated_at = time.time() if now is None else float(now)
+
+    def handle(self) -> WorkerHandle:
+        return WorkerHandle(
+            worker_id=self.worker_id,
+            task_id=self.spec.task_id,
+            lane=self.lane_name,
+            status=self.status,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            cancel_requested=self.cancel_requested,
+        )
+
+    def result_snapshot(self) -> WorkerResult:
+        return WorkerResult(
+            worker_id=self.worker_id,
+            status=self.status,
+            result=self.result,
+            error=self.error,
+            started_at=self.started_at,
+            finished_at=self.finished_at,
+        )
+
+    def snapshot_dict(self) -> dict[str, Any]:
+        """JSON-safe view: the handle fields plus result/error/timestamps, the
+        appended follow-ups (via :meth:`PendingTurnItem.to_dict`, which drops
+        ``raw``), and the originating spec (via :meth:`WorkerSpec.to_dict`, which
+        raises ``TypeError`` on non-JSON-safe metadata -- a snapshot does not
+        pretend a non-serialisable spec is fine)."""
+        data = self.handle().to_dict()
+        data.update(
+            {
+                "result": self.result,
+                "error": self.error,
+                "started_at": self.started_at,
+                "finished_at": self.finished_at,
+                "followups": [it.to_dict() for it in self.followups],
+                "spec": self.spec.to_dict(),
+            }
+        )
+        return data
+
+
+# --------------------------------------------------------------------------
+# ThreadWorkerLane
+# --------------------------------------------------------------------------
+class ThreadWorkerLane:
+    """A purpose-fit, in-process worker lane that runs each worker in a daemon thread.
+
+    Construction takes a *runner* callable, ``runner(spec: WorkerSpec, token:
+    CancelToken) -> str | None``.  The runner does the actual work; this lane only
+    tracks lifecycle, captures the return value (coerced to ``str | None``) or the
+    exception, holds appended follow-ups, and exposes a cancellation request the
+    runner may observe via *token*.
+
+    Lifecycle: a worker is created ``queued``; the thread flips it to ``running``
+    just before invoking the runner; then ``done`` (runner returned), ``error``
+    (runner raised anything other than :class:`WorkerCancelled`, with
+    ``"<ExcType>: <msg>"`` recorded in ``error``), or ``cancelled`` (the runner
+    raised :class:`WorkerCancelled`, or :meth:`cancel` was called before the
+    runner was entered).  If :meth:`cancel` is called while the runner is running
+    and the runner returns normally anyway, the worker ends ``done`` -- the work
+    completed -- but ``cancel_requested`` stays ``True`` so the request is not lost.
+
+    All shared state is guarded by a single lock; the runner is invoked *without*
+    the lock held, so :meth:`status` / :meth:`cancel` / :meth:`append_followup`
+    stay responsive while a worker runs.
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: Callable[[WorkerSpec, CancelToken], Any],
+        name: str = LANE_THREAD,
+    ) -> None:
+        if not callable(runner):
+            raise TypeError("runner must be callable")
+        if not isinstance(name, str) or not name:
+            raise TypeError("lane name must be a non-empty string")
+        self._runner = runner
+        self.name = name
+        self._lock = threading.Lock()
+        self._workers: dict[str, _WorkerEntry] = {}
+
+    # -- internals --------------------------------------------------------
+    def _require(self, worker_id: str) -> _WorkerEntry:
+        entry = self._workers.get(worker_id)
+        if entry is None:
+            raise KeyError(f"unknown worker id: {worker_id!r}")
+        return entry
+
+    def _finalize_locked(
+        self,
+        entry: _WorkerEntry,
+        status: str,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        entry.status = status
+        entry.result = result
+        entry.error = error
+        entry.finished_at = time.time()
+        entry.touch()
+        entry.done_event.set()
+
+    def _run(self, worker_id: str) -> None:
+        with self._lock:
+            entry = self._workers[worker_id]
+            if entry.cancel_token.cancelled:
+                # Cancelled in the narrow window between start() and the thread
+                # acquiring this lock: never enter the runner.
+                self._finalize_locked(entry, WorkerStatus.CANCELLED)
+                return
+            entry.status = WorkerStatus.RUNNING
+            entry.started_at = time.time()
+            entry.touch()
+            spec = entry.spec
+            token = entry.cancel_token
+        runner = self._runner
+        try:
+            out = runner(spec, token)
+        except WorkerCancelled:
+            with self._lock:
+                self._finalize_locked(self._workers[worker_id], WorkerStatus.CANCELLED)
+            return
+        except BaseException as exc:  # noqa: BLE001 - capture *any* runner failure
+            detail = f"{type(exc).__name__}: {exc}".strip().rstrip(":").strip()
+            with self._lock:
+                self._finalize_locked(
+                    self._workers[worker_id], WorkerStatus.ERROR, error=detail or type(exc).__name__
+                )
+            return
+        with self._lock:
+            # Runner returned normally.  Even if a cancellation was requested
+            # mid-run, the work completed -- record it as done; cancel_requested
+            # already preserves that a cancellation was asked for.
+            self._finalize_locked(
+                self._workers[worker_id], WorkerStatus.DONE, result=_coerce_result(out)
+            )
+
+    # -- WorkerLane protocol ---------------------------------------------
+    def start(self, spec: WorkerSpec) -> WorkerHandle:
+        """Register a worker and start its thread; return its (``queued``) handle."""
+        if not isinstance(spec, WorkerSpec):
+            raise TypeError("spec must be a WorkerSpec")
+        now = time.time()
+        worker_id = _new_worker_id()
+        with self._lock:
+            if worker_id in self._workers:  # astronomically unlikely; be explicit
+                raise RuntimeError(f"worker id collision: {worker_id!r}")
+            entry = _WorkerEntry(
+                worker_id=worker_id,
+                spec=spec,
+                lane_name=self.name,
+                status=WorkerStatus.QUEUED,
+                created_at=now,
+                updated_at=now,
+            )
+            self._workers[worker_id] = entry
+            thread = threading.Thread(
+                target=self._run,
+                args=(worker_id,),
+                name=f"worker-lane-{self.name}-{worker_id[7:15]}",
+                daemon=True,
+            )
+            entry.thread = thread
+            # Start the thread while still holding the lock: the new thread blocks
+            # on this lock inside _run, so the handle we return below is a clean
+            # "queued" snapshot rather than a race against the transition to
+            # "running".
+            thread.start()
+            return entry.handle()
+
+    def status(self, worker_id: str) -> WorkerHandle:
+        with self._lock:
+            return self._require(worker_id).handle()
+
+    def result(self, worker_id: str) -> WorkerResult | None:
+        with self._lock:
+            entry = self._require(worker_id)
+            return entry.result_snapshot() if entry.is_terminal else None
+
+    def append_followup(self, worker_id: str, item: PendingTurnItem) -> str:
+        """Record a follow-up against the worker; see ``FOLLOWUP_*`` for the result.
+
+        Stores the :class:`~agent.pending_turn_queue.PendingTurnItem` in arrival
+        order without injecting it into a running worker (that is a later
+        steerable-lane concern) -- so a live worker yields ``FOLLOWUP_DEFERRED`` and
+        a finished one yields ``FOLLOWUP_REJECTED``.  Non-``PendingTurnItem`` input
+        raises ``TypeError`` (lift legacy payloads with
+        :func:`agent.pending_turn_queue.from_legacy_cli_payload` first).
+        """
+        if not isinstance(item, PendingTurnItem):
+            raise TypeError(
+                "append_followup expects a PendingTurnItem; lift legacy payloads "
+                "with agent.pending_turn_queue.from_legacy_cli_payload first"
+            )
+        with self._lock:
+            entry = self._require(worker_id)
+            if entry.is_terminal:
+                return FOLLOWUP_REJECTED
+            entry.followups.append(item)
+            entry.touch()
+            return FOLLOWUP_DEFERRED
+
+    def cancel(self, worker_id: str) -> bool:
+        """Request cancellation.  ``True`` if the worker was still active; ``False``
+        (a safe no-op) if it had already finished.  Cooperative: the runner must
+        observe the token to actually stop early."""
+        with self._lock:
+            entry = self._require(worker_id)
+            if entry.is_terminal:
+                return False
+            entry.cancel_requested = True
+            entry.cancel_token.request()
+            entry.touch()
+            return True
+
+    # -- extras (not part of the WorkerLane protocol) --------------------
+    def wait(self, worker_id: str, timeout: float | None = None) -> bool:
+        """Block until the worker is terminal; ``True`` if it is (within *timeout*),
+        ``False`` on timeout.  Unknown ``worker_id`` raises ``KeyError``."""
+        with self._lock:
+            entry = self._require(worker_id)
+            if entry.is_terminal:
+                return True
+            done = entry.done_event
+        return done.wait(timeout)
+
+    def followups(self, worker_id: str) -> list[PendingTurnItem]:
+        """A shallow copy of the worker's appended follow-ups, in arrival order."""
+        with self._lock:
+            return list(self._require(worker_id).followups)
+
+    def worker_ids(self) -> list[str]:
+        """The ids of all workers this lane has started, in creation order."""
+        with self._lock:
+            return list(self._workers.keys())
+
+    def snapshot(self, worker_id: str | None = None) -> dict[str, Any]:
+        """A JSON-safe snapshot.  With *worker_id*: just that worker's
+        :meth:`_WorkerEntry.snapshot_dict`.  Without: ``{"lane": name, "workers":
+        [<per-worker dict>, ...]}``.  Each per-worker dict embeds the spec, so a
+        worker carrying non-JSON-safe metadata makes the snapshot raise
+        ``TypeError`` -- a snapshot will not silently drop or fake JSON safety."""
+        with self._lock:
+            if worker_id is not None:
+                return self._require(worker_id).snapshot_dict()
+            return {
+                "lane": self.name,
+                "workers": [e.snapshot_dict() for e in self._workers.values()],
+            }
+
+
+# --------------------------------------------------------------------------
+# WorkerLaneRegistry
+# --------------------------------------------------------------------------
+class WorkerLaneRegistry:
+    """A tiny registry of named :class:`WorkerLane` instances plus a worker-id ->
+    lane index, so callers can :meth:`start` on a lane by name and then
+    :meth:`status` / :meth:`result` / :meth:`append_followup` / :meth:`cancel` a
+    worker by id without tracking which lane owns it.
+
+    It starts nothing on its own and reacts to no completion: routing of user
+    follow-ups into workers, gateway notification on completion, and the
+    user-facing ``/tasks`` / ``/agents`` / ``/stop`` surface are all later phases.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._lanes: dict[str, WorkerLane] = {}
+        self._worker_lane: dict[str, str] = {}
+
+    # -- registration -----------------------------------------------------
+    def register(self, lane: WorkerLane) -> None:
+        """Register *lane* under ``lane.name``; a duplicate name raises ``ValueError``."""
+        name = getattr(lane, "name", None)
+        if not isinstance(name, str) or not name:
+            raise TypeError("lane must expose a non-empty string 'name'")
+        with self._lock:
+            if name in self._lanes:
+                raise ValueError(f"worker lane already registered: {name!r}")
+            self._lanes[name] = lane
+
+    def lane_names(self) -> list[str]:
+        with self._lock:
+            return list(self._lanes.keys())
+
+    def get_lane(self, name: str) -> WorkerLane | None:
+        with self._lock:
+            return self._lanes.get(name)
+
+    # -- internals --------------------------------------------------------
+    def _require_lane(self, name: str) -> WorkerLane:
+        with self._lock:
+            lane = self._lanes.get(name)
+        if lane is None:
+            raise KeyError(f"unknown worker lane: {name!r}")
+        return lane
+
+    def _lane_for_worker(self, worker_id: str) -> WorkerLane:
+        with self._lock:
+            name = self._worker_lane.get(worker_id)
+        if name is None:
+            raise KeyError(f"unknown worker id: {worker_id!r}")
+        return self._require_lane(name)
+
+    # -- routed operations ------------------------------------------------
+    def start(self, spec: WorkerSpec, *, lane_name: str | None = None) -> WorkerHandle:
+        """Start *spec* on lane *lane_name* (default: ``spec.lane``) and remember
+        which lane owns the resulting worker.  Unknown lane raises ``KeyError``.
+
+        (The packet sketch shows ``start(lane_name, spec)``; reading ``spec.lane``
+        with an optional override means a caller who already set ``spec.lane`` does
+        not have to repeat it.)
+        """
+        if not isinstance(spec, WorkerSpec):
+            raise TypeError("spec must be a WorkerSpec")
+        name = lane_name if lane_name is not None else spec.lane
+        lane = self._require_lane(name)
+        handle = lane.start(spec)
+        with self._lock:
+            if handle.worker_id in self._worker_lane:
+                cancel = getattr(lane, "cancel", None)
+                if callable(cancel):
+                    cancel(handle.worker_id)
+                raise RuntimeError(f"worker id collision across lanes: {handle.worker_id!r}")
+            self._worker_lane[handle.worker_id] = name
+        return handle
+
+    def status(self, worker_id: str) -> WorkerHandle:
+        return self._lane_for_worker(worker_id).status(worker_id)
+
+    def result(self, worker_id: str) -> WorkerResult | None:
+        return self._lane_for_worker(worker_id).result(worker_id)
+
+    def append_followup(self, worker_id: str, item: PendingTurnItem) -> str:
+        return self._lane_for_worker(worker_id).append_followup(worker_id, item)
+
+    def cancel(self, worker_id: str) -> bool:
+        return self._lane_for_worker(worker_id).cancel(worker_id)
+
+    def wait(self, worker_id: str, timeout: float | None = None) -> bool:
+        """Delegate to the owning lane's ``wait`` if it has one; otherwise raise
+        ``TypeError`` (the bare :class:`WorkerLane` protocol does not require it,
+        but :class:`ThreadWorkerLane` provides it)."""
+        lane = self._lane_for_worker(worker_id)
+        waiter = getattr(lane, "wait", None)
+        if not callable(waiter):
+            raise TypeError(f"lane {getattr(lane, 'name', lane)!r} does not support wait()")
+        return waiter(worker_id, timeout)
+
+
+# --------------------------------------------------------------------------
+# Optional task-registry linkage (duck-typed; no runtime import of task_registry)
+# --------------------------------------------------------------------------
+def link_worker_to_task(
+    registry: "TaskRegistry",
+    task_id: str,
+    handle: "WorkerHandle",
+    *,
+    worker_kind: str | None = None,
+) -> "FocusedTask":
+    """Record *handle* as the active worker for *task_id* on *registry*.
+
+    A thin convenience over :meth:`TaskRegistry.assign_worker`: it links *identity*
+    only.  It does **not** start a worker, classify follow-ups, route gateway
+    messages, or react to the worker finishing -- those are later phases.
+    ``worker_kind`` defaults to the worker's lane name (e.g. ``"thread"``).  The
+    registry is not thread-safe; serialising access to it is the caller's job, as
+    its own docstring says.  Returns whatever ``assign_worker`` returns (the
+    :class:`~agent.task_registry.FocusedTask`).
+    """
+    return registry.assign_worker(
+        task_id, handle.worker_id, worker_kind=worker_kind or handle.lane
+    )

--- a/cli.py
+++ b/cli.py
@@ -4847,6 +4847,28 @@ class HermesCLI:
         agent_running = getattr(self, "_agent_running", False)
         _cprint(f"  Agent: {'running' if agent_running else 'idle'}")
 
+    def _handle_frontdesk_command(self, cmd: str):
+        """Handle /frontdesk status — show live control-plane readiness."""
+        parts = cmd.strip().split(maxsplit=1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else "status"
+        if arg and arg != "status":
+            _cprint("  Usage: /frontdesk status")
+            return
+
+        from agent.frontdesk_live import ensure_default_worker_lane
+        from agent.orchestration_runtime import get_or_create_orchestration_runtime
+
+        live_enabled = bool(getattr(self, "frontdesk_live_enabled", False))
+        if live_enabled:
+            ensure_default_worker_lane(self, session_key=getattr(self, "session_id", None))
+        runtime = get_or_create_orchestration_runtime(self)
+        lanes = runtime.worker_registry.lane_names()
+        default_lane_available = "main" in lanes
+        _cprint("  Frontdesk status")
+        _cprint(f"  Frontdesk live: {'enabled' if live_enabled else 'disabled'}")
+        _cprint(f"  Default worker lane: {'available' if default_lane_available else 'missing'}")
+        _cprint("  Available worker lanes: " + (", ".join(lanes) if lanes else "none"))
+
     def _handle_paste_command(self):
         """Handle /paste — explicitly check clipboard for an image.
 
@@ -7607,6 +7629,8 @@ class HermesCLI:
             self._handle_stop_command()
         elif canonical == "agents":
             self._handle_agents_command()
+        elif canonical == "frontdesk":
+            self._handle_frontdesk_command(cmd_original)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "queue":

--- a/cli.py
+++ b/cli.py
@@ -8574,6 +8574,38 @@ class HermesCLI:
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
 
+    def _classify_busy_input(self, text: str) -> "ControlPlaneDecision":  # type: ignore[name-defined]
+        """Frontdesk control-plane adapter — Phase 2 substrate, no callers wired.
+
+        Returns a :class:`agent.control_plane.ControlPlaneDecision` for *text*
+        derived from the pure-classifier output.  ``frontdesk_mode_active`` is
+        sourced from ``self.frontdesk_mode_enabled`` when that attribute
+        exists; otherwise it defaults to ``False`` so the decision is
+        guaranteed to downgrade WORKER_LANE → MAIN under legacy mode.
+
+        This method is **deliberately not yet called from any code path**.
+        Phase 5 (``/mode frontdesk`` opt-in) is the first phase that wires it
+        into ``cli.py:11634-11650`` (integrated-busy capture) and
+        ``cli.py:8714-8736`` (slash-command dispatch).  Phase 2's job is to
+        land the schema and the classifier so transcript-replay fixtures and
+        unit tests can already be written against a stable contract while the
+        default user-visible behaviour stays bit-identical.
+
+        Hard boundaries this respects (PRD §9.2 / design review §9.2):
+
+        * No mutation of ``self._pending_input``.
+        * No mutation of ``self.busy_input_mode``.
+        * No call into ``self._handle_busy_command`` or
+          ``self._coalesce_pending_integrated_busy_queue``.
+        * No persona / prompt-builder change.
+        """
+        # Lazy import: keeps cli.py module-import cost flat and ensures a future
+        # circular-import regression is loud rather than silent.
+        from agent.control_plane import classify as _classify
+
+        frontdesk_active = bool(getattr(self, "frontdesk_mode_enabled", False))
+        return _classify(text, frontdesk_mode_active=frontdesk_active)
+
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
         if not self._fast_command_available():

--- a/cli.py
+++ b/cli.py
@@ -328,6 +328,10 @@ def load_cli_config() -> Dict[str, Any]:
             "enabled": True,      # Auto-compress when approaching context limit
             "threshold": 0.50,    # Compress at 50% of model's context limit
         },
+        "orchestration": {
+            "status_queries_enabled": False,
+            "frontdesk_live_enabled": False,
+        },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)
             "verbose": False,
@@ -8606,6 +8610,36 @@ class HermesCLI:
         frontdesk_active = bool(getattr(self, "frontdesk_mode_enabled", False))
         return _classify(text, frontdesk_mode_active=frontdesk_active)
 
+    def _handle_frontdesk_live_input(
+        self,
+        text: str,
+        *,
+        main_in_flight: bool = False,
+    ):
+        """Consume an opt-in frontdesk control input before queue/model paths."""
+        def _cancel_active(_payload: str) -> None:
+            agent = getattr(self, "agent", None)
+            if agent is not None and hasattr(agent, "interrupt"):
+                agent.interrupt(_payload)
+
+        def _steer_active(_payload: str):
+            agent = getattr(self, "agent", None)
+            if agent is not None and hasattr(agent, "steer"):
+                return agent.steer(_payload)
+            return False
+
+        from agent.frontdesk_live import handle_frontdesk_live_input
+
+        return handle_frontdesk_live_input(
+            self,
+            text,
+            session_key=getattr(self, "session_id", None),
+            source_surface="cli",
+            main_in_flight=main_in_flight,
+            steer_callback=_steer_active if main_in_flight else None,
+            cancel_callback=_cancel_active if main_in_flight else None,
+        )
+
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
         if not self._fast_command_available():
@@ -10321,6 +10355,17 @@ class HermesCLI:
         # leave it False, which is correct — those aren't user interrupts.
         self._last_turn_interrupted = False
 
+        if images is None and isinstance(message, str):
+            frontdesk_result = self._handle_frontdesk_live_input(
+                message,
+                main_in_flight=bool(getattr(self, "_agent_running", False)),
+            )
+            if frontdesk_result is not None:
+                response = frontdesk_result.message
+                if response:
+                    _cprint(response)
+                return response
+
         # Refresh provider credentials if needed (handles key rotation transparently)
         if not self._ensure_runtime_credentials():
             return None
@@ -11447,6 +11492,16 @@ class HermesCLI:
                 event.app.invalidate()
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
+                if not images and text:
+                    frontdesk_result = self._handle_frontdesk_live_input(
+                        text,
+                        main_in_flight=bool(self._agent_running),
+                    )
+                    if frontdesk_result is not None:
+                        if frontdesk_result.message:
+                            _cprint(f"  {_ACCENT}{frontdesk_result.message}{_RST}")
+                        event.app.current_buffer.reset(append_to_history=True)
+                        return
                 if self._agent_running and not (text and _looks_like_slash_command(text)):
                     _effective_mode = self.busy_input_mode
                     if _effective_mode == "steer":
@@ -13053,6 +13108,16 @@ class HermesCLI:
                             if app.is_running:
                                 app.exit()
                         continue
+
+                    if not submit_images and isinstance(user_input, str):
+                        frontdesk_result = self._handle_frontdesk_live_input(
+                            user_input,
+                            main_in_flight=False,
+                        )
+                        if frontdesk_result is not None:
+                            if frontdesk_result.message:
+                                _cprint(frontdesk_result.message)
+                            continue
                     
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')

--- a/docs/plans/2026-05-12-claude-phase2-task-packet.md
+++ b/docs/plans/2026-05-12-claude-phase2-task-packet.md
@@ -1,0 +1,298 @@
+# Claude Code Task Packet — Phase 2 Structured Pending Input Queue
+
+You are preparing to implement **one narrow Hermes phase** in an isolated git worktree.
+
+> IMPORTANT: This is a task packet. Do not broaden the scope. Do not implement task registry, background worker lanes, or follow-up classifier beyond the minimal structured pending queue foundation.
+
+## Worktree
+
+```text
+/tmp/hermes-orchestrator-phase-2
+```
+
+## Baseline
+
+Phase 1 was committed on `main` as:
+
+```text
+afd8b7f72 feat(cli): add integrated busy input mode
+```
+
+Phase 1 added:
+- `/busy integrated` in CLI command handling and command registry.
+- Integrated CLI busy payload tagging via identity-only sentinel.
+- Gateway recognition of `display.busy_input_mode: integrated` with queue-like fallback.
+- Tests proving queue/steer/interrupt semantics remain intact.
+
+## Source plans
+
+Read these files for context:
+
+```text
+docs/plans/2026-05-12-hermes-orchestrator-first-update-plan.md
+docs/plans/2026-05-12-integrated-busy-queue.md
+docs/plans/2026-05-12-orchestrator-implementation-handoff.md
+docs/plans/2026-05-12-claude-phase1-task-packet.md
+docs/plans/2026-05-12-claude-phase2-task-packet.md
+```
+
+## Current phase
+
+Phase 2 — Structured Pending Input Queue.
+
+## Product intent
+
+Hermes currently has several pending-input paths that rely on raw strings, image tuples, per-session pending slots, and ad-hoc merge behavior. That is enough for simple queueing, but not for Telegram-style fragmented input where a follow-up may be text, command, media, correction, status query, or a hard boundary.
+
+Phase 2 should introduce a **small, explicit, structured pending input representation** that preserves boundaries and order without changing user-facing semantics.
+
+The goal is a foundation, not the full Manus-like task fabric.
+
+### Deeper product purpose
+
+This is not a generic queue refactor. The long-term product direction is to make Hermes a **focused orchestrator agent for Woo**:
+
+- Hermes remains the accountable main orchestrator: understanding Woo's intent, preserving context, deciding what belongs in the current task, and deciding what should become a separate focused worker task.
+- Claude Code, delegate_task subagents, and future workers are implementation/review lanes, not replacements for Hermes' judgment.
+- The user experience target is: Woo can send fragmented Telegram/CLI/TUI follow-ups naturally, and Hermes can preserve their order, boundaries, and purpose instead of flattening them into ambiguous text.
+- Phase 2 exists because Hermes cannot safely create focused agents or route work later unless the pending inputs are first represented explicitly.
+
+### Ralph concept / focused-agent framing
+
+Treat **Ralph** as the conceptual name for the future focused worker/task unit that Hermes may eventually create and manage.
+
+For Phase 2, do **not** implement Ralph, task registry, worker lanes, or background agents. Instead, design the pending-turn structure so it can later support Ralph-like focused agents by preserving:
+
+- what the user actually sent;
+- whether the input is a continuation, correction, command, media/caption, or hard boundary;
+- source/session metadata;
+- ordering and coalescing boundaries;
+- enough metadata for Hermes to later decide: "append to current focus", "steer current worker", "create a new Ralph/focused task", or "ask user for clarification".
+
+In other words: Phase 2 is the **input substrate** for future Ralph/focused-agent orchestration, not the Ralph implementation itself.
+
+## Phase 2 goal
+
+Create a structured pending-turn queue abstraction that can represent:
+
+```text
+text fragments
+slash commands / control messages
+media / image / document attachments
+caption-like boundaries
+source/session metadata
+created_at ordering
+```
+
+Then apply it minimally where it reduces current fragility, while keeping existing behavior green.
+
+## Scope boundaries
+
+### Do
+
+1. Inspect current pending-input paths before editing:
+   - `cli.py`
+   - `gateway/platforms/base.py`
+   - `gateway/run.py`
+   - `tui_gateway/server.py`
+   - `ui-tui/src/app/useSubmission.ts`
+   - relevant tests under `tests/cli`, `tests/gateway`, `tests/tui*` if present.
+
+2. Propose/implement a minimal structured type, likely in a new file such as:
+
+```text
+agent/pending_turn_queue.py
+```
+
+Suggested dataclass shape:
+
+```python
+@dataclass
+class PendingTurnItem:
+    id: str
+    session_key: str | None
+    source: str                 # telegram|cli|tui|api|unknown
+    kind: str                   # text|command|media|attachment|control
+    text: str | None
+    media_refs: list[str]
+    media_types: list[str]
+    created_at: float
+    reply_to: str | None
+    task_hint: str | None
+    boundary: str               # coalesce|hard|caption|command
+    raw: Any | None = None
+```
+
+A helper/container may also be appropriate:
+
+```python
+class PendingTurnQueue:
+    append(item)
+    drain_coalescible_text_until_boundary()
+    peek()
+    pop()
+    __len__()
+```
+
+3. Add conversion helpers so existing legacy payloads can round-trip safely:
+
+```python
+from_legacy_cli_payload(payload) -> PendingTurnItem
+maybe_to_legacy_cli_payload(item) -> payload
+from_gateway_event(event, session_key) -> PendingTurnItem
+```
+
+4. Preserve Phase 1 behavior:
+   - `/busy integrated` still works.
+   - Integrated CLI tagged payload does not collide with image tuples.
+   - Gateway `integrated` remains queue-like fallback until full gateway structured routing exists.
+
+5. Preserve command/media boundaries:
+   - Slash commands must not be swallowed into text coalescing.
+   - Image/document/media payloads must not be merged into plain text.
+   - Telegram album/media merge behavior must remain intact.
+
+6. Add focused unit tests for the new structured queue abstraction.
+
+7. Add/adjust integration tests only where the new abstraction is wired into existing CLI/gateway paths.
+
+### Do not
+
+- Do not implement Phase 3 task registry.
+- Do not implement Phase 4 detached/background worker lanes.
+- Do not add `delegate_task(background=True)` yet.
+- Do not implement a model-based follow-up classifier.
+- Do not change default busy mode.
+- Do not redefine `/busy interrupt|queue|steer|integrated` semantics.
+- Do not do broad TUI/gateway refactors unless required for a narrow queue boundary fix.
+- Do not commit changes.
+- Do not touch credentials, `.env`, auth files, or unrelated local config.
+
+## Preferred implementation strategy
+
+Use a **compatibility-first, purpose-fit** approach:
+
+```text
+Step 1: Create structured data model + tests.
+Step 2: Add legacy conversion helpers + tests.
+Step 3: Wire the CLI coalescing path to use helpers if low-risk.
+Step 4: Wire gateway pending merge only if it can be done without broad behavior changes.
+Step 5: Leave TUI changes as documented follow-up if direct wiring is too broad for Phase 2.
+```
+
+If a full gateway replacement is too risky, implement the abstraction and tests first, then adapt only the safest path and document remaining bridge points. Phase 2 should be mergeable and safe, not maximal.
+
+### Deliberation and time-boxing guidance
+
+Before editing code, spend real reasoning time on the smallest useful design. This is an Opus-level design/implementation task, not a mechanical refactor.
+
+Use this decision rule:
+
+```text
+Implement until Phase 2 has a coherent, testable, reviewable foundation.
+Stop before the work becomes architectural expansion.
+```
+
+Do not optimize for "more code". Optimize for **purpose-fit leverage**:
+
+- If a small dataclass + queue + conversion helpers + two safe integration points solves the Phase 2 purpose, stop there.
+- If replacing every pending-message path would require broad gateway/TUI surgery, do not do it in Phase 2; document bridge points instead.
+- If you find yourself inventing task lifecycle, worker state, model classification, routing policy, or Ralph behavior, stop and report it as Phase 3+ design material.
+- Prefer boring, explicit, serializable shapes over clever abstractions.
+- Prefer compatibility wrappers over call-site churn.
+- Prefer tests that protect semantics over abstractions that merely look elegant.
+
+### Model and effort expectation
+
+Use the strongest available Claude Code reasoning model for this worker run: **Claude Opus 4.7 / Opus-class model**. Use high/max effort reasoning. Do not silently downgrade to a cheaper model unless the controller explicitly approves it.
+
+## Likely files allowed
+
+```text
+agent/pending_turn_queue.py
+cli.py
+gateway/platforms/base.py
+gateway/run.py
+tests/agent/test_pending_turn_queue.py
+tests/cli/test_busy_queue_coalescing.py
+tests/gateway/test_*pending*.py
+tests/gateway/test_session_race_guard.py
+```
+
+Potentially inspect-only unless truly needed:
+
+```text
+tui_gateway/server.py
+ui-tui/src/app/useSubmission.ts
+```
+
+If you modify TUI files, explain why and add appropriate tests or a clear manual verification note.
+
+## Required tests
+
+Run the narrowest relevant tests first:
+
+```bash
+python -m pytest tests/agent/test_pending_turn_queue.py -q
+python -m pytest tests/cli/test_busy_queue_coalescing.py tests/cli/test_busy_input_mode_command.py -q
+python -m pytest tests/gateway/test_restart_drain.py tests/gateway/test_session_race_guard.py -q
+```
+
+Then run any additional tests covering files you changed.
+
+If possible, also run:
+
+```bash
+python -m pytest tests/gateway -q
+```
+
+If broader gateway/CLI tests fail for unrelated environment reasons, report exact failures and keep targeted tests green.
+
+## Acceptance criteria
+
+Phase 2 can be accepted only if:
+
+- A structured pending item representation exists with tests.
+- Text fragments preserve order.
+- Slash commands are represented as command/control or hard boundaries, not swallowed into text.
+- Media/attachment payloads keep explicit boundaries and metadata.
+- Existing CLI busy queue coalescing still works.
+- Phase 1 `/busy integrated` behavior remains green.
+- Gateway `integrated` remains queue-like fallback and does not interrupt active sessions.
+- No broad task registry / worker lane / classifier code is introduced.
+- Targeted tests pass.
+- `git diff --check` passes.
+- Runtime Python files compile.
+
+## Review risks to watch
+
+- Dataclass or sentinel shape that cannot be safely serialized if it later crosses process boundaries.
+- Accidentally changing legacy pending payload semantics before all call sites are migrated.
+- Treating slash commands as model text.
+- Treating image tuples as integrated text payloads.
+- Breaking Telegram media group / album merge behavior.
+- Adding a large abstraction but not using it anywhere meaningful.
+- Overbuilding Phase 2 into task registry or worker lane behavior.
+
+## Return format
+
+At the end, report:
+
+```text
+SUMMARY:
+PURPOSE-FIT DESIGN RATIONALE:
+WHAT YOU INTENTIONALLY DID NOT BUILD:
+RALPH/FUTURE FOCUSED-AGENT NOTES:
+CHANGED FILES:
+TESTS RUN:
+RESULTS:
+KNOWN RISKS:
+OPEN QUESTIONS:
+SUGGESTED NEXT REVIEW COMMANDS:
+```
+
+## Controller note
+
+Hermes main orchestrator will review your diff, run tests, request independent spec/quality reviews, and only then import accepted changes back to main.
+
+The controller expects a focused, purpose-fit foundation for future Ralph/focused-agent orchestration — not an impressive-looking broad rewrite.

--- a/docs/plans/2026-05-12-claude-phase3-task-packet.md
+++ b/docs/plans/2026-05-12-claude-phase3-task-packet.md
@@ -1,0 +1,200 @@
+# Claude Code Task Packet — Phase 3 Focused Task Registry Substrate
+
+IMPORTANT: This is a narrow Phase 3 task packet. Implement a coherent, testable task registry substrate only. Do not build Ralph/focused-agent runtime, follow-up classifier, worker lanes, background delegation, or synthesis delivery in this phase.
+
+## Worktree
+
+```text
+/tmp/hermes-orchestrator-phase-3
+```
+
+## Baseline
+
+```text
+63554cbd6 fix(cli): lock pending input drain and enqueue
+```
+
+## Source plans/context
+
+- `docs/plans/2026-05-12-hermes-orchestrator-first-update-plan.md`
+- `docs/plans/2026-05-12-integrated-busy-queue.md`
+- `docs/plans/2026-05-12-orchestrator-implementation-handoff.md`
+- `docs/plans/2026-05-12-claude-phase2-task-packet.md`
+- `docs/plans/2026-05-12-phase2-structured-pending-queue-notes.md`
+- `docs/plans/2026-05-12-claude-phase3-task-packet.md`
+
+## Product intent
+
+Hermes is evolving toward a concierge/front-desk/butler orchestrator:
+
+- The main Hermes process remains accountable for user intent, prioritization, synthesis, and final output.
+- Heavy work may be delegated to workers later, but Hermes must remember the active task identity and late user follow-ups.
+- When Woo sends many fragmented messages, Hermes eventually needs to decide whether each message is:
+  - a follow-up to the active task,
+  - a correction/refinement to a running delegated task,
+  - a status/cancel request,
+  - or a new task.
+
+Phase 3 does NOT make that routing decision. It only provides the task identity/state substrate that Phase 4/5 will use.
+
+## Current phase
+
+```text
+Phase 3 — Focused Task Registry Substrate
+```
+
+## Goals
+
+Introduce a small `agent/task_registry.py` module that can represent and manage focused user tasks across CLI/gateway/TUI surfaces without changing existing user-facing behavior.
+
+The registry should support:
+
+1. Creating a task from user goal + origin/session metadata.
+2. Task statuses:
+   - `proposed`
+   - `queued`
+   - `running`
+   - `steerable`
+   - `blocked`
+   - `done`
+   - `error`
+   - `cancelled`
+3. Attaching pending follow-ups as structured `PendingTurnItem` objects from Phase 2.
+4. Tracking worker linkage fields without starting workers yet:
+   - `active_worker_id`
+   - `worker_kind`
+5. Tracking artifacts and notes.
+6. Listing active tasks by session key and/or all tasks.
+7. Safe serialization/deserialization that excludes or safely serializes any local-only raw payloads.
+8. Optional lightweight JSON file persistence if it can be done cleanly with atomic writes. If persistence becomes broad or risky, keep an in-memory registry with explicit serialization helpers and document that durable storage is Phase 4/5.
+
+## Suggested files
+
+Likely new:
+
+```text
+agent/task_registry.py
+tests/agent/test_task_registry.py
+docs/plans/2026-05-12-phase3-task-registry-notes.md
+```
+
+Optional only if small and clean:
+
+```text
+hermes_cli/commands.py      # add /tasks alias only if cheap and non-invasive
+cli.py                     # minimal display hook only if cheap and non-invasive
+```
+
+Avoid touching gateway/runtime paths unless strictly necessary for tests. This phase should be a substrate, not behavior rollout.
+
+## Suggested data shape
+
+A reasonable design is:
+
+```python
+@dataclass
+class TaskOrigin:
+    platform: str | None
+    chat_id: str | None
+    thread_id: str | None
+    user_id: str | None
+    session_key: str | None
+
+@dataclass
+class FocusedTask:
+    task_id: str
+    session_key: str | None
+    user_goal: str
+    status: str
+    origin: TaskOrigin
+    active_worker_id: str | None = None
+    worker_kind: str | None = None
+    pending_followups: list[PendingTurnItem] = field(default_factory=list)
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    created_at: float = ...
+    updated_at: float = ...
+```
+
+Registry operations:
+
+```python
+create_task(...)
+get_task(task_id)
+list_tasks(session_key=None, active_only=False)
+update_status(task_id, status, ...)
+attach_followup(task_id, PendingTurnItem | legacy payload)
+attach_artifact(task_id, ...)
+add_note(task_id, ...)
+cancel_task(task_id, reason=None)
+to_dict()/from_dict()
+save()/load() if persistence is included
+```
+
+## Non-goals / do not build
+
+Do NOT implement:
+
+- Ralph/focused-agent runtime.
+- Follow-up classifier or intent model.
+- Automatic routing from Telegram/CLI messages into tasks.
+- Background worker lanes.
+- `delegate_task(background=True)`.
+- Gateway delivery/notification changes.
+- `/stop <task>` behavior beyond data model helpers.
+- Broad SQLite migration unless it is clearly smaller and safer than JSON/in-memory helpers.
+- Any credentials, tokens, or secret persistence.
+
+## Acceptance criteria
+
+- Task registry can create, list, update, cancel, and serialize tasks.
+- Follow-ups are represented using Phase 2 `PendingTurnItem` and preserve order.
+- `raw` payloads from pending items are not serialized/deep-copied.
+- Active task filtering excludes `done`, `error`, and `cancelled` by default.
+- Unknown/invalid statuses are rejected with clear errors.
+- Tests cover:
+  - create/list/status transitions
+  - follow-up attachment order
+  - serialization roundtrip
+  - raw passthrough exclusion
+  - artifact/note storage
+  - active filtering
+  - optional JSON persistence if implemented
+- Existing Phase 1/2 tests continue passing.
+
+## Required tests
+
+Run at least:
+
+```bash
+venv/bin/python -m pytest tests/agent/test_task_registry.py tests/agent/test_pending_turn_queue.py -q
+venv/bin/python -m pytest tests/cli/test_busy_queue_coalescing.py tests/cli/test_busy_input_mode_command.py -q
+venv/bin/python -m compileall -q agent/task_registry.py agent/pending_turn_queue.py cli.py
+```
+
+Also run `git diff --check`.
+
+If you modify CLI command registry or runtime files, add and run targeted tests for those files.
+
+## Return format
+
+Return a concise implementation report with these required sections:
+
+```text
+SUMMARY
+PURPOSE-FIT DESIGN RATIONALE
+WHAT YOU INTENTIONALLY DID NOT BUILD
+RALPH/FUTURE FOCUSED-AGENT NOTES
+CHANGED FILES
+TESTS RUN
+RISKS / OPEN QUESTIONS
+```
+
+## Worker constraints
+
+- Use Claude Opus-class / `--model opus` if available, `--effort max`.
+- Do not silently downgrade to a cheaper model.
+- Do not commit.
+- Do not push.
+- Keep changes within the Phase 3 scope.
+- Stop once the substrate is coherent, testable, and reviewable.

--- a/docs/plans/2026-05-12-claude-phase4-task-packet.md
+++ b/docs/plans/2026-05-12-claude-phase4-task-packet.md
@@ -1,0 +1,257 @@
+# Claude Code Task Packet — Phase 4 Worker Lane / Detached Execution Substrate
+
+IMPORTANT: This is a narrow Phase 4 substrate task. Do **not** broaden into full Ralph runtime, follow-up classifier, automatic Telegram routing, or user-facing task UX. Implement only the smallest coherent, testable foundation for detached/background worker lanes that later phases can connect to the task registry and gateway.
+
+## Worktree
+
+```text
+/tmp/hermes-orchestrator-phase-4
+```
+
+## Baseline
+
+```text
+63ac3fffe feat(agent): add focused task registry substrate
+```
+
+## Source context
+
+Read these first:
+
+```text
+docs/plans/2026-05-12-hermes-orchestrator-first-update-plan.md
+docs/plans/2026-05-12-integrated-busy-queue.md
+docs/plans/2026-05-12-claude-phase2-task-packet.md
+docs/plans/2026-05-12-claude-phase3-task-packet.md
+docs/plans/2026-05-12-phase3-task-registry-notes.md
+agent/pending_turn_queue.py
+agent/task_registry.py
+tools/delegate_tool.py
+```
+
+## Product intent
+
+Hermes is evolving toward a front-desk / concierge / butler orchestration model:
+
+- Hermes main remains accountable for user intent, prioritization, review, and synthesis.
+- Focused tasks have explicit identity/state via Phase 3 `TaskRegistry`.
+- Long-running implementation/research work should eventually run in worker lanes so the foreground orchestrator can acknowledge dispatch and remain available.
+- Ralph is a future focused worker/task unit concept. Phase 4 should create substrate that could support a Ralph-like worker later, but must not implement Ralph runtime now.
+
+## Current phase
+
+Phase 4: **Worker Lane / Detached Execution Substrate**.
+
+The goal is to define a small, explicit worker-lane abstraction and at least one local/testable lane implementation that can start, track, cancel, and retrieve results for detached work without blocking the caller until completion.
+
+This phase should be useful even before gateway/TUI integration. It should be a library-level substrate with tests.
+
+## Required scope
+
+Create a small module, likely:
+
+```text
+agent/worker_lanes.py
+```
+
+Suggested concepts:
+
+```python
+class WorkerStatus:
+    QUEUED = "queued"
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+@dataclass
+class WorkerSpec:
+    goal: str
+    context: str | None = None
+    task_id: str | None = None
+    lane: str = "thread"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+@dataclass
+class WorkerHandle:
+    worker_id: str
+    task_id: str | None
+    lane: str
+    status: str
+    created_at: float
+    updated_at: float
+
+@dataclass
+class WorkerResult:
+    worker_id: str
+    status: str
+    result: str | None = None
+    error: str | None = None
+    started_at: float | None = None
+    finished_at: float | None = None
+```
+
+Define a lane protocol or base class like:
+
+```python
+class WorkerLane(Protocol):
+    name: str
+    def start(self, spec: WorkerSpec) -> WorkerHandle: ...
+    def status(self, worker_id: str) -> WorkerHandle: ...
+    def append_followup(self, worker_id: str, item: PendingTurnItem) -> str: ...
+    def cancel(self, worker_id: str) -> bool: ...
+    def result(self, worker_id: str) -> WorkerResult | None: ...
+```
+
+Implement one purpose-fit local lane for tests, e.g. `ThreadWorkerLane` or `InMemoryWorkerLane`:
+
+- Starts a callable or simple worker function in a background thread.
+- Returns immediately after starting.
+- Tracks status transitions.
+- Stores result/error.
+- Supports cancellation request state at least cooperatively.
+- Supports append_followup by storing Phase 2 `PendingTurnItem` followups; it does not need to inject them into a running worker yet.
+- Uses locks around shared state.
+- Provides JSON-safe snapshot methods where useful.
+
+Optionally implement a small registry/manager:
+
+```python
+class WorkerLaneRegistry:
+    register(lane)
+    start(lane_name, spec)
+    status(worker_id)
+    append_followup(worker_id, item)
+    cancel(worker_id)
+    result(worker_id)
+```
+
+If integrating with Phase 3 `TaskRegistry`, keep it shallow and optional:
+
+- It is acceptable for `WorkerSpec.task_id` / `WorkerHandle.task_id` to link to `FocusedTask.task_id`.
+- It is acceptable to provide a helper that records `active_worker_id` / `worker_kind` on a supplied `TaskRegistry`.
+- Do not build automatic routing from gateway/CLI into task registry or workers.
+
+## Explicit non-goals
+
+Do **not** implement:
+
+- Ralph runtime.
+- Follow-up classifier.
+- Automatic Telegram/gateway routing to workers.
+- `/tasks`, `/agents`, `/stop <task>` user-facing commands.
+- `delegate_task(background=True)` tool schema/user-facing API unless it is a very thin internal stub and fully tested. Prefer library substrate first.
+- Claude Code process lane unless it remains small and deterministic in tests. Do not spawn real Claude Code in tests.
+- Kanban lane.
+- SQLite/multi-process durable worker database.
+- Gateway notification delivery on completion.
+- Full cancellation/kill semantics for arbitrary external processes.
+- Broad refactors of `tools/delegate_tool.py`, `gateway/run.py`, or `cli.py`.
+
+## Files likely allowed
+
+Prefer adding small new files and tests:
+
+```text
+agent/worker_lanes.py
+tests/agent/test_worker_lanes.py
+docs/plans/2026-05-12-phase4-worker-lanes-notes.md
+```
+
+Allowed only if truly necessary and small:
+
+```text
+agent/task_registry.py
+agent/pending_turn_queue.py
+```
+
+Avoid editing unless there is a compelling, narrow reason:
+
+```text
+tools/delegate_tool.py
+gateway/run.py
+gateway/platforms/base.py
+gateway/platforms/telegram.py
+cli.py
+```
+
+If you believe a user-facing `delegate_task(background=True)` change is necessary, stop and document the proposed design instead of implementing it broadly.
+
+## Acceptance criteria
+
+- Starting a worker returns quickly without waiting for completion.
+- Worker status transitions are observable: queued/running → done/error/cancelled.
+- Worker results can be retrieved after completion.
+- Worker errors are captured without crashing the caller.
+- Cancellation request is represented deterministically; if a worker already finished, cancel is a safe no-op/false.
+- Follow-ups can be appended and preserved as `PendingTurnItem` order without being routed into model text.
+- Worker handle/result snapshots are JSON-safe and do not serialize local-only raw payloads.
+- Optional task registry linkage updates `active_worker_id` / `worker_kind` without starting a classifier or gateway routing system.
+- Thread-safety is reasonable for in-process substrate.
+
+## Required tests
+
+Add targeted tests for:
+
+```text
+tests/agent/test_worker_lanes.py
+```
+
+Test cases should include:
+
+- start returns before worker completes
+- successful completion stores result
+- raised exception stores error/status=error
+- cancel before/during worker records cancellation request/status behavior
+- followups preserve order and `PendingTurnItem.raw` is not serialized/touched
+- manager/registry routes status/result/cancel to the right lane
+- duplicate/unknown worker IDs return clear errors
+- optional TaskRegistry linkage records worker metadata on the focused task
+- JSON snapshots reject or avoid non-JSON-safe metadata as appropriate
+```
+
+Run at minimum:
+
+```bash
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_worker_lanes.py tests/agent/test_task_registry.py tests/agent/test_pending_turn_queue.py -q
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_busy_queue_coalescing.py tests/cli/test_busy_input_mode_command.py -q
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py
+git diff --check
+```
+
+If broad tests fail, compare against baseline and distinguish pre-existing environment failures from Phase 4 regressions.
+
+## Required final notes
+
+Create:
+
+```text
+docs/plans/2026-05-12-phase4-worker-lanes-notes.md
+```
+
+Include sections:
+
+```text
+## Summary
+## PURPOSE-FIT DESIGN RATIONALE
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+## Validation
+## Risks / Follow-up
+```
+
+## Claude Code instructions
+
+Use Claude Opus-class model and max effort.
+
+Implement exactly this phase. Do not commit. Do not push. Stop once there is a coherent, testable, reviewable substrate. Return:
+
+```text
+Summary
+Changed files
+Tests run + results
+Purpose-fit rationale
+Intentional non-goals
+Ralph/future focused-agent notes
+Known risks/questions
+```

--- a/docs/plans/2026-05-12-claude-phase6-task-packet.md
+++ b/docs/plans/2026-05-12-claude-phase6-task-packet.md
@@ -1,0 +1,259 @@
+# Claude Code Task Packet — Phase 6 Orchestration Observatory
+
+IMPORTANT: This is a narrow Phase 6 visibility/status UX task. The user explicitly compared Manus-like smooth orchestration and Claude's recent agent-view style visibility. Build the first read-only observability layer for tasks/workers and minimal `/tasks` / `/agents` command surfaces where appropriate. Do **not** implement Ralph runtime, LLM classifier, automatic Telegram routing, background delegate API, force kill, durable routing DB, or broad gateway refactor.
+
+## Worktree
+
+```text
+/tmp/hermes-orchestrator-phase-6
+```
+
+## Baseline
+
+```text
+d875d6c15 feat(agent): add conservative follow-up router
+```
+
+## Product intent
+
+The desired UX is not command-heavy. Woo should be able to speak naturally while Hermes coordinates work behind the scenes.
+
+However, once Hermes has tasks and workers, the user needs a lightweight observatory:
+
+```text
+What tasks are active?
+Which workers/agents are running?
+What follow-ups are queued?
+Is anything blocked or waiting for me?
+```
+
+This should feel like a front-desk/concierge status board, not a developer-only dump.
+
+## Current substrate
+
+Existing phases already provide:
+
+- Phase 2: `agent/pending_turn_queue.py` — structured input/follow-up units.
+- Phase 3: `agent/task_registry.py` — focused task identity/status/followups/artifacts/notes/worker linkage.
+- Phase 4: `agent/worker_lanes.py` — worker specs/handles/results/cancel/followups/registry.
+- Phase 5: `agent/followup_router.py` — conservative follow-up routing decisions.
+
+Phase 6 should add a **read-only presentation/status layer** over those pieces.
+
+## Required scope
+
+Prefer a new module:
+
+```text
+agent/orchestration_status.py
+```
+
+Suggested concepts:
+
+```python
+@dataclass
+class OrchestrationSnapshot:
+    tasks: list[dict]
+    workers: list[dict]
+    counts: dict
+    warnings: list[str]
+
+class OrchestrationStatusFormatter:
+    def snapshot(task_registry=None, worker_registry=None, *, session_key=None) -> OrchestrationSnapshot: ...
+    def format_tasks(snapshot_or_registry, *, compact=True, session_key=None) -> str: ...
+    def format_agents(snapshot_or_registry, *, compact=True) -> str: ...
+    def format_overview(...) -> str: ...
+```
+
+Also add minimal command registry entries if the command system supports it cleanly:
+
+```text
+/tasks
+/agents
+```
+
+But keep the handler integration conservative. If full runtime registry wiring is not yet available, command handlers may return a graceful message such as:
+
+```text
+No focused tasks are currently registered in this session.
+```
+
+or use duck-typed registries if the CLI/gateway later injects them. Do not invent a global durable registry just to make the command non-empty.
+
+## UX expectations
+
+`/tasks` should answer:
+
+```text
+Active tasks:
+- task_ab12 [running] Hermes Phase 6 observability
+  worker: worker_cd34 (claude_code) [running]
+  follow-ups: 2
+  notes: 1
+```
+
+`/agents` should answer:
+
+```text
+Workers:
+- worker_cd34 [running] lane=thread task=task_ab12 goal="Implement Phase 6"
+- worker_ef56 [done] lane=review task=task_ab12
+```
+
+When empty:
+
+```text
+No active tasks/workers are currently registered.
+```
+
+The output should be concise and Telegram-friendly: bullets and labels, no markdown tables.
+
+## Optional natural-language status helper
+
+Add deterministic helper functions only if they fit cleanly:
+
+```python
+looks_like_orchestration_status_query(text) -> bool
+```
+
+Examples:
+
+- `지금 뭐 하고 있어?`
+- `돌고 있는 작업 있어?`
+- `에이전트 뭐 돌아가?`
+- `what are you working on?`
+- `active tasks?`
+- `any agents running?`
+
+This helper should not route messages by itself; it only lets later gateway wiring call the formatter.
+
+## Explicit non-goals
+
+Do **not** implement:
+
+- Ralph runtime.
+- LLM/model classifier.
+- automatic Telegram/gateway routing of natural language.
+- real worker process dashboard with live polling beyond existing `WorkerLaneRegistry` snapshots.
+- force kill / force cancel.
+- public `delegate_task(background=True)` API.
+- durable routing DB or SQLite schema.
+- long-lived global singleton registry unless an existing runtime already has one.
+- broad gateway/CLI/TUI refactor.
+- worker result delivery/synthesis pipeline.
+
+## Allowed files
+
+Prefer:
+
+```text
+agent/orchestration_status.py
+tests/agent/test_orchestration_status.py
+docs/plans/2026-05-12-phase6-orchestration-observatory-notes.md
+```
+
+Allowed if needed and small:
+
+```text
+hermes_cli/commands.py
+cli.py
+gateway/run.py
+tests/cli/test_*commands*.py
+tests/gateway/test_*commands*.py
+```
+
+But avoid editing `cli.py` / `gateway/run.py` unless the command integration path is obvious, small, and well-tested. A pure formatter/status module is acceptable if runtime wiring is too broad for this phase.
+
+## Acceptance criteria
+
+- Can build a snapshot from `TaskRegistry` with zero, one, and multiple tasks.
+- Can build a snapshot from `WorkerLaneRegistry` with zero, running, done, error, and cancelled workers.
+- Task formatting includes id, status, compact goal, worker linkage, follow-up count, note count, and blocked/error indicators.
+- Agent/worker formatting includes worker id, status, lane, task id, compact goal, cancel-requested marker, and error/result summary when available.
+- Output is concise, deterministic, and Telegram-friendly.
+- Empty state is graceful.
+- No `PendingTurnItem.raw` traversal/serialization/deepcopy.
+- Snapshot/formatter outputs are JSON-safe where advertised, using strict JSON behavior for metadata if needed.
+- `/tasks` and `/agents` command registry entries exist only if they can be wired without broad refactor; otherwise document why they are deferred.
+- No production gateway behavior changes unless covered by targeted tests.
+
+## Required tests
+
+Add targeted tests for:
+
+```text
+tests/agent/test_orchestration_status.py
+```
+
+Cover:
+
+- empty snapshot/formatting
+- one running task
+- multiple active tasks ordered predictably
+- task with worker linkage/followups/notes/artifacts
+- blocked/error/cancelled/done task formatting
+- worker registry running/done/error/cancelled handles/results
+- cancel-requested marker
+- compact truncation
+- JSON-safe snapshot if `to_dict()` is provided
+- no `PendingTurnItem.raw` touch with raw object that raises on deepcopy/access
+- Korean/English natural-language status query helper if implemented
+
+If slash commands are integrated, add command tests for `/tasks` and `/agents` help/registry/handler behavior.
+
+Run at minimum:
+
+```bash
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/agent/test_orchestration_status.py \
+  tests/agent/test_followup_router.py \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/agent/test_pending_turn_queue.py -q
+
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/cli/test_busy_queue_coalescing.py \
+  tests/cli/test_busy_input_mode_command.py \
+  tests/gateway/test_restart_drain.py \
+  tests/gateway/test_session_race_guard.py -q
+
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q \
+  agent/orchestration_status.py agent/followup_router.py agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py gateway/run.py
+
+git diff --check
+```
+
+## Required final notes
+
+Create:
+
+```text
+docs/plans/2026-05-12-phase6-orchestration-observatory-notes.md
+```
+
+Include:
+
+```text
+## Summary
+## PURPOSE-FIT DESIGN RATIONALE
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+## Validation
+## Risks / Follow-up
+```
+
+## Claude Code instructions
+
+Use Claude Opus-class model and max effort.
+
+Implement exactly this phase. Do not commit. Do not push. Stop once there is a coherent, testable, reviewable observability/status foundation. Return:
+
+```text
+Summary
+Changed files
+Tests run + results
+Purpose-fit rationale
+Intentional non-goals
+Ralph/future focused-agent notes
+Known risks/questions
+```

--- a/docs/plans/2026-05-12-claude-phase7-task-packet.md
+++ b/docs/plans/2026-05-12-claude-phase7-task-packet.md
@@ -1,0 +1,273 @@
+# Claude Code Task Packet — Phase 7 Runtime Orchestration Context + Minimal Status Commands
+
+IMPORTANT: This is a narrow Phase 7 runtime/context + read-only status-command task. Build the smallest safe bridge between the Phase 6 status formatter and future `/tasks` / `/agents` / natural-language status UX. Do **not** implement gateway natural-language routing, append/correction attachment, worker dispatch, cancel UX, durable DB, Ralph runtime, LLM classifier, or broad CLI/gateway/TUI refactors.
+
+## Worktree
+
+```text
+/tmp/hermes-orchestrator-phase-7
+```
+
+## Baseline
+
+```text
+eddabc597 feat(agent): add orchestration status observatory
+```
+
+## Source plans
+
+```text
+docs/plans/2026-05-12-hermes-orchestrator-roadmap-phase7-plus.md
+docs/plans/2026-05-12-hermes-orchestrator-first-update-plan.md
+docs/plans/2026-05-12-phase6-orchestration-observatory-notes.md
+docs/plans/2026-05-12-claude-phase6-task-packet.md
+```
+
+## Product intent
+
+Woo compared the desired Hermes behavior to a smooth Manus-like coordinator and Claude's recent agent view: the user can keep talking naturally, while a visible coordinator knows which task/agent is doing what.
+
+Phase 6 created the read-only formatter:
+
+```text
+TaskRegistry + WorkerLaneRegistry
+→ OrchestrationStatusFormatter
+```
+
+Phase 7 should create the smallest runtime context that lets CLI/gateway code later access a live `TaskRegistry` + `WorkerLaneRegistry`, and should wire minimal read-only status commands **only if** they can safely read that runtime context without fake state.
+
+This is the bridge from formatter-only to actual observability UX.
+
+## Current substrate
+
+Already exists:
+
+```text
+agent/pending_turn_queue.py       # PendingTurnItem / queue
+agent/task_registry.py            # TaskRegistry / FocusedTask
+agent/worker_lanes.py             # WorkerLaneRegistry / ThreadWorkerLane
+agent/followup_router.py          # conservative router
+agent/orchestration_status.py     # format_tasks / format_agents / format_overview
+```
+
+## Required scope
+
+Prefer a small new module:
+
+```text
+agent/orchestration_runtime.py
+```
+
+Suggested minimal API:
+
+```python
+@dataclass
+class OrchestrationRuntime:
+    task_registry: TaskRegistry
+    worker_registry: WorkerLaneRegistry
+
+    @classmethod
+    def create(cls) -> "OrchestrationRuntime": ...
+
+    def snapshot(self, *, session_key: str | None = None) -> OrchestrationSnapshot: ...
+    def format_tasks(self, *, session_key: str | None = None, compact: bool = True) -> str: ...
+    def format_agents(self, *, compact: bool = True) -> str: ...
+    def format_overview(self, *, session_key: str | None = None, compact: bool = True) -> str: ...
+```
+
+Also consider helper functions that make integration safe and duck-typed:
+
+```python
+get_or_create_orchestration_runtime(owner) -> OrchestrationRuntime
+get_orchestration_runtime(owner) -> OrchestrationRuntime | None
+set_orchestration_runtime(owner, runtime) -> OrchestrationRuntime
+format_runtime_tasks(owner, ...)
+format_runtime_agents(owner, ...)
+```
+
+The `owner` may later be a `HermesCLI`, gateway runner, session object, or test dummy. Keep it simple: store on a private attribute such as `_orchestration_runtime`. Do not create a global singleton.
+
+## Minimal command wiring
+
+If the central command registry and handler path are straightforward, add read-only commands:
+
+```text
+/tasks
+/agents
+```
+
+Expected UX:
+
+```text
+/tasks
+→ No active tasks are currently registered.
+```
+
+```text
+/agents
+→ No active workers are currently registered.
+```
+
+With injected runtime in tests:
+
+```text
+/tasks
+→ Active tasks:
+  - task_ab12 [running] Phase 7 runtime wiring
+    worker: worker_cd34 (claude_code) [running]
+```
+
+```text
+/agents
+→ Workers:
+  - worker_cd34 [running] lane=thread task=task_ab12 goal="Phase 7 runtime wiring"
+```
+
+If command wiring would require broad `cli.py` / `gateway/run.py` refactor, stop at the runtime helper module and document why command wiring is deferred. But first inspect the existing command registry/handler pattern; adding read-only command handlers may be small.
+
+## Explicit non-goals
+
+Do **not** implement:
+
+- Telegram/gateway natural-language status auto-routing.
+- append/correction attachment from live Telegram messages.
+- worker dispatch or new task creation.
+- cancel / stop task behavior.
+- force kill.
+- durable routing DB or SQLite schema.
+- public `delegate_task(background=True)` API.
+- Ralph runtime.
+- LLM classifier.
+- global singleton runtime.
+- broad TUI/gateway refactor.
+- worker result synthesis pipeline.
+
+## Allowed files
+
+Prefer:
+
+```text
+agent/orchestration_runtime.py
+tests/agent/test_orchestration_runtime.py
+docs/plans/2026-05-12-phase7-runtime-status-notes.md
+```
+
+Allowed if small and well-tested:
+
+```text
+hermes_cli/commands.py
+cli.py
+gateway/run.py
+tests/cli/test_orchestration_status_commands.py
+tests/gateway/test_orchestration_status_commands.py
+```
+
+Also include the roadmap doc in this phase artifact if it remains uncommitted:
+
+```text
+docs/plans/2026-05-12-hermes-orchestrator-roadmap-phase7-plus.md
+```
+
+## Acceptance criteria
+
+- `OrchestrationRuntime.create()` creates a fresh in-memory `TaskRegistry` and `WorkerLaneRegistry`.
+- Runtime formatting delegates to Phase 6 `format_tasks`, `format_agents`, `format_overview`.
+- Helper functions can attach runtime to a CLI/gateway-like owner object without global singleton behavior.
+- Empty state is graceful.
+- Injected runtime with one task/worker formats correctly.
+- Runtime snapshots remain JSON-safe.
+- If `/tasks` and `/agents` are wired:
+  - central command registry/help recognizes them;
+  - CLI handler returns formatter output;
+  - gateway handler, if touched, returns read-only formatter output;
+  - missing runtime creates safe empty runtime or returns empty state;
+  - no normal chat/gateway behavior changes.
+- No `PendingTurnItem.raw` traversal/serialization/deepcopy.
+- Existing Phase 1-6 targeted suites remain green.
+
+## Required tests
+
+Add agent tests:
+
+```text
+tests/agent/test_orchestration_runtime.py
+```
+
+Cover:
+
+- create runtime
+- explicit registries injection
+- get/set/get-or-create helpers on dummy owner
+- no global singleton leakage between owners
+- format empty tasks/agents/overview
+- format injected task/worker state
+- JSON-safe snapshot
+- `PendingTurnItem.raw` safety if a follow-up exists on a task
+
+If command wiring is implemented, add tests for command registry and handler behavior. Possible files:
+
+```text
+tests/cli/test_orchestration_status_commands.py
+tests/gateway/test_orchestration_status_commands.py
+```
+
+At minimum run:
+
+```bash
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/agent/test_orchestration_runtime.py \
+  tests/agent/test_orchestration_status.py \
+  tests/agent/test_followup_router.py \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/agent/test_pending_turn_queue.py -q
+
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/cli/test_busy_queue_coalescing.py \
+  tests/cli/test_busy_input_mode_command.py \
+  tests/gateway/test_restart_drain.py \
+  tests/gateway/test_session_race_guard.py -q
+
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q \
+  agent/orchestration_runtime.py agent/orchestration_status.py agent/followup_router.py \
+  agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py gateway/run.py
+
+git diff --check
+```
+
+If slash command files are changed, include their targeted tests too.
+
+## Required notes
+
+Create:
+
+```text
+docs/plans/2026-05-12-phase7-runtime-status-notes.md
+```
+
+Include:
+
+```text
+## Summary
+## PURPOSE-FIT DESIGN RATIONALE
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+## Validation
+## Risks / Follow-up
+```
+
+## Claude Code instructions
+
+Use Claude Opus-class model and max effort.
+
+Implement exactly this phase. Do not commit. Do not push. Stop once there is a coherent, testable, reviewable runtime/status bridge. Return:
+
+```text
+Summary
+Changed files
+Tests run + results
+Purpose-fit rationale
+Intentional non-goals
+Ralph/future focused-agent notes
+Known risks/questions
+```

--- a/docs/plans/2026-05-12-hermes-orchestrator-roadmap-phase7-plus.md
+++ b/docs/plans/2026-05-12-hermes-orchestrator-roadmap-phase7-plus.md
@@ -1,0 +1,563 @@
+# Hermes Orchestrator Roadmap — Phase 7+
+
+> **For Hermes:** Use the controller/worker/reviewer loop for each phase. Write a task packet, create an isolated worktree, delegate implementation to Claude Code only after the packet is clear, run targeted tests, run independent spec + quality review, import to main only after approval, and commit each phase separately.
+
+**Goal:** Continue evolving Hermes into Woo's front-desk / concierge / butler orchestrator: the main Hermes remains accountable and conversational while focused task/workers handle long or specialized work behind the scenes.
+
+**Current baseline:**
+
+```text
+eddabc597 feat(agent): add orchestration status observatory
+```
+
+**Current built substrate:**
+
+```text
+Phase 1  /busy integrated foundation
+Phase 2  structured PendingTurnItem / PendingTurnQueue
+Phase 2.1 CLI pending-input producer/drain ordering hardening
+Phase 3  Focused Task Registry substrate
+Phase 4  Worker Lane substrate
+Phase 5  Conservative Follow-up Router
+Phase 6  Orchestration Status Observatory
+```
+
+**North-star UX:**
+
+```text
+Woo speaks naturally in Telegram/CLI
+→ Hermes identifies task or follow-up
+→ Hermes records task/follow-up state
+→ Worker lanes execute focused work
+→ Woo can ask what is running
+→ Hermes shows /tasks /agents style status when useful
+→ Worker result returns to Hermes
+→ Hermes reviews, applies late follow-ups, and synthesizes final answer
+```
+
+---
+
+## 0. Product Principles for Remaining Phases
+
+### 0.1 Main Hermes remains the front desk
+
+Hermes should not become a thin command launcher. It should:
+
+- understand the user's intent and context;
+- decide whether direct answer, foreground work, or background worker is appropriate;
+- keep the user relationship and accountability;
+- inspect/review worker results before delivery;
+- incorporate late follow-ups naturally into the final answer.
+
+### 0.2 Commands are useful, but natural language is primary
+
+`/tasks` and `/agents` are useful observability shortcuts, especially for debugging and confidence. But the core UX should also support:
+
+```text
+지금 뭐 하고 있어?
+돌고 있는 작업 있어?
+이것도 방금 작업에 추가해줘
+새 작업으로 따로 해줘
+그건 취소하지 말고 기존 작업에 붙여
+```
+
+### 0.3 Conservative first, automation later
+
+For routing and cancellation:
+
+- status query is safe;
+- append-only follow-up is usually safe;
+- correction note is safe if append-only;
+- new task is safe only when explicit;
+- cooperative cancel needs an unambiguous target;
+- force kill requires a separate phase and confirmation;
+- LLM classifier should be advisory only until deterministic gates are strong.
+
+### 0.4 No fake availability
+
+Do not claim Hermes is always available if the current implementation still blocks the active parent turn. Real availability requires gateway/runtime wiring and worker lanes that continue independently of the foreground response.
+
+---
+
+## Phase 7 — Runtime Orchestration Context + Minimal Status Commands
+
+**Goal:** Provide a session/runtime place where CLI/gateway can hold or access `TaskRegistry` and `WorkerLaneRegistry`, then expose minimal `/tasks` and `/agents` status surfaces using Phase 6 formatters.
+
+**Why now:** Phase 6 intentionally did not wire `/tasks` and `/agents` because there was no live registry for commands to read. This phase creates the smallest safe runtime context so observability becomes real rather than a formatter library only.
+
+**Likely new/modified files:**
+
+```text
+agent/orchestration_runtime.py          # if a small runtime container is useful
+agent/orchestration_status.py           # only if small adapter hooks are needed
+hermes_cli/commands.py                  # register /tasks and /agents if not present
+cli.py                                  # minimal command handlers if runtime context exists
+gateway/run.py                          # optional minimal command handler, behind safe empty-state behavior
+tests/agent/test_orchestration_runtime.py
+tests/cli/test_orchestration_status_commands.py
+tests/gateway/test_orchestration_status_commands.py
+```
+
+**Do:**
+
+- Create a small `OrchestrationRuntime` or equivalent container if needed:
+
+```python
+@dataclass
+class OrchestrationRuntime:
+    task_registry: TaskRegistry
+    worker_registry: WorkerLaneRegistry
+```
+
+- Add a safe empty state for `/tasks` and `/agents`:
+
+```text
+No active tasks are currently registered.
+No active workers are currently registered.
+```
+
+- Use `format_tasks(...)` and `format_agents(...)` from Phase 6.
+- Keep runtime in-memory only unless an existing session store integration is trivial and tested.
+- Make command handlers read-only.
+
+**Do not:**
+
+- start workers from `/tasks` or `/agents`;
+- implement gateway natural-language auto-routing yet;
+- create durable DB;
+- add force cancel;
+- expose a complex task management UI.
+
+**Acceptance:**
+
+- `/tasks` and `/agents` are discoverable in command registry/help if wired.
+- Empty state is graceful.
+- A test-injected runtime with tasks/workers formats correctly.
+- No production behavior changes except read-only status commands.
+- Existing Phase 1-6 targeted suites remain green.
+
+---
+
+## Phase 8 — Gateway Minimal Natural-Language Status Routing
+
+**Goal:** Let Telegram/gateway answer safe status questions such as “지금 뭐 하고 있어?” by calling the Phase 6 status formatter against the Phase 7 runtime.
+
+**Why:** This is the first step toward Manus-like conversational smoothness: the user should not need to remember `/tasks`.
+
+**Likely files:**
+
+```text
+gateway/run.py
+gateway/session.py
+agent/followup_router.py or agent/orchestration_status.py
+tests/gateway/test_orchestration_status_routing.py
+```
+
+**Do:**
+
+- Use `looks_like_orchestration_status_query(text)` as a deterministic predicate.
+- Only answer status; do not mutate tasks/workers.
+- Restrict to safe, obvious status-query texts.
+- If no runtime is available, return graceful empty state.
+- Keep behind a config flag if the gateway path is high risk:
+
+```yaml
+orchestration:
+  status_queries_enabled: false   # default initially if needed
+```
+
+**Do not:**
+
+- auto-route append/correction/cancel/new task yet;
+- run an LLM classifier;
+- change normal chat behavior broadly;
+- hijack unrelated questions like calorie estimates or pharma research.
+
+**Acceptance:**
+
+- “지금 뭐 하고 있어?” returns overview when active tasks/workers exist.
+- Ordinary unrelated messages still go to normal agent conversation.
+- Slash commands remain boundaries.
+- Tests cover Korean and English status queries, empty state, and unrelated messages.
+
+---
+
+## Phase 9 — Append-Only Follow-up Attachment in Gateway
+
+**Goal:** When exactly one active task exists in the chat/session, safe append/correction follow-ups can be recorded to the task without interrupting or replacing worker execution.
+
+**Why:** This is the core Manus-like smoothness: Woo can keep adding requirements while work is running.
+
+**Likely files:**
+
+```text
+gateway/run.py
+gateway/platforms/base.py
+agent/followup_router.py
+agent/task_registry.py
+tests/gateway/test_followup_attachment.py
+```
+
+**Do:**
+
+- Convert incoming message to `PendingTurnItem`.
+- Use `FollowupRouter` for deterministic classification.
+- For a single active task:
+  - append plain text follow-up;
+  - record correction as append-only note/follow-up;
+  - defer command/media/ambiguous cases.
+- Preserve original message order and metadata.
+- Send a concise acknowledgement only when useful:
+
+```text
+방금 작업에 추가해둘게요.
+```
+
+**Do not:**
+
+- mutate worker prompt destructively;
+- force re-run worker;
+- cancel or create new task unless explicit;
+- use LLM classifier yet.
+
+**Acceptance:**
+
+- “이것도 포함해줘” attaches to single active task.
+- “아니 그건 빼고…” is captured as correction note/follow-up.
+- Multiple active tasks cause conservative defer/ask, not guessing.
+- Commands/media are not swallowed.
+
+---
+
+## Phase 10 — Worker Result Synthesis Contract
+
+**Goal:** When a worker completes, Hermes main synthesizes the final user-facing answer from original task + follow-ups + worker result + artifacts + errors.
+
+**Why:** The user should receive a coherent final result, not raw worker output. This is the “concierge” accountability layer.
+
+**Likely new file:**
+
+```text
+agent/orchestration_synthesis.py
+```
+
+**Inputs:**
+
+```text
+FocusedTask
+Pending follow-ups / notes
+WorkerResult
+Artifacts
+Original user goal
+Review/test metadata if available
+```
+
+**Do:**
+
+- Define a `SynthesisPacket` / `SynthesisResult` data structure.
+- Mark which follow-ups were applied, deferred, or require user decision.
+- Include artifact verification status.
+- Produce concise Telegram-friendly final answer blocks.
+- Support failure synthesis:
+
+```text
+작업 실패 / 원인 / 다음 선택지 / 재시도 가능 여부
+```
+
+**Do not:**
+
+- blindly forward worker output;
+- auto-publish artifacts without verification;
+- run new workers automatically on failure unless explicitly scoped.
+
+**Acceptance:**
+
+- Worker raw result is transformed into final summary.
+- Late follow-ups appear in the final synthesis.
+- Artifact paths are verified before mention.
+- Error result produces actionable recovery options.
+
+---
+
+## Phase 11 — Background Worker Dispatch: Claude Code Lane MVP
+
+**Goal:** Turn the worker-lane substrate into a practical Claude Code background worker for repo-local implementation tasks.
+
+**Why:** This is where Hermes becomes materially closer to Manus-like orchestration for code work: main Hermes can acknowledge, spawn work, and later synthesize/review.
+
+**Likely files:**
+
+```text
+agent/worker_lanes.py
+agent/claude_code_lane.py              # likely new
+cli.py or gateway/run.py               # only minimal dispatch hook if needed
+tests/agent/test_claude_code_lane.py
+```
+
+**Do:**
+
+- Implement a lane that launches Claude Code print-mode in an isolated worktree or specified cwd.
+- Store worker id, status, stdout/stderr path, result summary, exit code.
+- Ensure no direct commit/import by the worker unless explicitly requested.
+- Support cooperative cancel if process still running.
+- Require task packet / goal / workdir metadata.
+
+**Do not:**
+
+- make all delegation background by default;
+- expose unsafe arbitrary shell process killing;
+- auto-import worker diffs without review;
+- skip task packet/review gates for Hermes repo work.
+
+**Acceptance:**
+
+- A test/dummy Claude Code command can run through the lane.
+- Status is visible through Phase 6/7 observatory.
+- Completion produces a worker result that Phase 10 can synthesize.
+- Cancellation is cooperative and safe.
+
+---
+
+## Phase 12 — Review/Import Automation for Code Workers
+
+**Goal:** Codify the pattern used in Phases 1-6: worker diff → targeted tests → spec review → quality review → import → commit.
+
+**Why:** Hermes should be able to manage code-work lifecycle reliably without re-inventing the manual sequence each time.
+
+**Likely new file:**
+
+```text
+agent/code_workflow.py
+```
+
+**Do:**
+
+- Represent a code-work phase packet.
+- Track diff artifact path, tests run, review verdicts, import status, commit sha.
+- Provide helper functions or templates for:
+  - saving diff;
+  - running targeted tests;
+  - recording reviewer results;
+  - generating final report.
+
+**Do not:**
+
+- auto-merge without approvals;
+- hide test failures;
+- push to upstream remote automatically.
+
+**Acceptance:**
+
+- Phase-style code work can be represented as a structured lifecycle record.
+- Failed review blocks import.
+- Accepted review enables import/commit with traceable metadata.
+
+---
+
+## Phase 13 — Conservative New Task Creation from Natural Language
+
+**Goal:** Let explicit natural-language “new task” requests create a focused task record through the gateway/CLI runtime.
+
+**Examples:**
+
+```text
+이건 새 작업으로 따로 해줘
+별도 리서치로 돌려줘
+new task: analyze CELMoD market
+```
+
+**Do:**
+
+- Use deterministic `FollowupRouter` new-task classification.
+- Create `FocusedTask` with origin/session/user goal.
+- Return a concise acknowledgement and task id/title.
+- No automatic worker dispatch unless configured/explicit.
+
+**Do not:**
+
+- infer new task from ambiguous topic shift;
+- auto-fanout to many workers;
+- launch costly workers without a policy gate.
+
+**Acceptance:**
+
+- Explicit new task creates task.
+- Ambiguous text asks/defers.
+- `/tasks` shows the new task.
+
+---
+
+## Phase 14 — Cooperative Cancel UX
+
+**Goal:** Support safe cancellation requests for a single unambiguous task/worker.
+
+**Do:**
+
+- Route “멈춰/취소/cancel” only when target is unambiguous.
+- Mark task `cancelled` or `blocked/cancel_requested` according to worker capability.
+- Call `WorkerLane.cancel(worker_id)` for cooperative cancellation.
+- Report whether cancellation was requested, completed, or not possible.
+
+**Do not:**
+
+- force kill processes;
+- cancel when multiple active tasks exist without asking;
+- treat negated phrases as cancel:
+
+```text
+취소하지 마
+don't stop
+not cancel
+```
+
+**Acceptance:**
+
+- Single active worker receives cooperative cancel.
+- Multiple active workers asks which one.
+- Negated cancel phrases are safe.
+
+---
+
+## Phase 15 — Optional LLM-Assisted Ambiguity Classifier
+
+**Goal:** Add an advisory classifier only for ambiguous follow-ups that deterministic rules refuse to route.
+
+**Do:**
+
+- Keep deterministic router as the safety gate.
+- LLM can suggest `append/status/new_task/ambiguous`, but destructive actions require deterministic confirmation or user confirmation.
+- Include confidence and rationale.
+- Log classifier decisions for audit.
+
+**Do not:**
+
+- let LLM classifier cancel/force kill/create costly workers alone;
+- replace deterministic hard boundaries for commands/media;
+- silently route ambiguous messages.
+
+**Acceptance:**
+
+- Ambiguous text can produce a suggested route.
+- Low confidence asks user.
+- Deterministic safety rules override LLM.
+
+---
+
+## Phase 16 — Durable Runtime Persistence
+
+**Goal:** Persist active tasks/workers/routing state across gateway restarts when the runtime is mature enough to need it.
+
+**Do:**
+
+- Start with append-only JSONL or SQLite only after schema is stable.
+- Persist task registry and worker metadata, not secrets/raw payloads.
+- On restart, mark unknown in-flight workers explicitly:
+
+```text
+recovered | unknown | failed | needs_user_review
+```
+
+**Do not:**
+
+- serialize `PendingTurnItem.raw`;
+- persist credentials or command outputs with secrets;
+- promise live process recovery if only metadata is recovered.
+
+**Acceptance:**
+
+- Restart shows prior task state clearly.
+- In-flight non-recoverable workers are marked unknown/needs-review.
+- No raw/secrets persisted.
+
+---
+
+## Phase 17 — Ralph Runtime Naming Layer
+
+**Goal:** Only after runtime, routing, observability, synthesis, and persistence are coherent, introduce Ralph as a focused worker/task unit abstraction if still useful.
+
+**Definition candidate:**
+
+```text
+Ralph = a named focused-agent unit bound to one FocusedTask, one WorkerLane handle, follow-up routing, status visibility, and synthesis contract.
+```
+
+**Do:**
+
+- Make Ralph a user-comprehensible abstraction, not a premature class name.
+- Keep Hermes as accountable orchestrator above Ralph.
+- Support task-scoped personality/tooling only if needed.
+
+**Do not:**
+
+- introduce Ralph before it simplifies user experience;
+- make Ralph compete with Hermes main;
+- hide worker provenance.
+
+**Acceptance:**
+
+- User can understand “Ralph is working on X” and see status.
+- Hermes can synthesize Ralph output into final answer.
+- No loss of accountability.
+
+---
+
+## Recommended Execution Order
+
+Short version:
+
+```text
+7. Runtime context + /tasks /agents minimal status
+8. Gateway natural-language status query
+9. Append-only follow-up attachment
+10. Worker result synthesis contract
+11. Claude Code background worker lane MVP
+12. Review/import automation for code workers
+13. Explicit new-task creation
+14. Cooperative cancel UX
+15. Optional LLM ambiguity classifier
+16. Durable runtime persistence
+17. Ralph runtime naming layer, only if it now simplifies UX
+```
+
+Practical checkpoint groups:
+
+```text
+Visibility block:
+  Phase 7-8
+
+Smooth conversation block:
+  Phase 9-10
+
+Real worker execution block:
+  Phase 11-12
+
+Control/recovery block:
+  Phase 13-16
+
+Product naming/runtime block:
+  Phase 17
+```
+
+---
+
+## Immediate Next Step
+
+Do **not** jump directly to Ralph runtime.
+
+Next task packet should be:
+
+```text
+Claude Code Task Packet — Phase 7 Runtime Orchestration Context + Minimal Status Commands
+```
+
+This phase should be small and concrete:
+
+```text
+- Create/inject a minimal runtime context for TaskRegistry + WorkerLaneRegistry.
+- Wire read-only /tasks and /agents only if handlers can access that context safely.
+- Empty state must be graceful.
+- No natural-language gateway auto-routing yet.
+- No worker dispatch/cancel/new-task behavior yet.
+```
+
+This is the right bridge between the completed Phase 6 formatter and the Manus/Claude Agent View-like UX Woo is asking for.

--- a/docs/plans/2026-05-12-phase2-structured-pending-queue-notes.md
+++ b/docs/plans/2026-05-12-phase2-structured-pending-queue-notes.md
@@ -1,0 +1,136 @@
+# Phase 2 — Structured Pending Input Queue: implementation notes
+
+> Companion to `docs/plans/2026-05-12-claude-phase2-task-packet.md`. Written by the
+> Phase 2 implementation worker for the Hermes controller's review. No commits made.
+
+## What shipped
+
+- **`agent/pending_turn_queue.py`** — a leaf module (stdlib-only imports, no
+  global state) with:
+  - `PendingTurnItem` — a small dataclass for one pending input: `source`,
+    `kind` (`text|command|media|attachment|control`), `text`, `media_refs`,
+    `media_types`, `boundary` (`coalesce|hard|caption|command`), `session_key`,
+    `reply_to`, `task_hint`, `origin_busy`, `created_at`, `id`, `raw`. Every
+    field except `raw` is JSON-serializable; `to_dict()` drops `raw` and
+    `from_dict()` rebuilds. `is_coalescible_text()` is the single boundary
+    predicate.
+  - `PendingTurnQueue` — an ordered `deque`-backed container: `append`,
+    `appendleft`, `extend`, `clear`, `peek`, `snapshot`, `pop`, `__len__`,
+    `__bool__`, `__iter__` (non-consuming), and
+    `drain_coalescible_text_until_boundary(*, origin_busy=None)`.
+  - Conversion helpers: `from_legacy_cli_payload` / `maybe_to_legacy_cli_payload`
+    (lossless round-trip of `str`, `(caption, [paths])`, and the
+    `(INTEGRATED_BUSY_PAYLOAD, text)` tag), `from_gateway_event` (duck-typed
+    one-way bridge from a gateway `MessageEvent`), `looks_like_slash_command`
+    (faithful mirror of `cli._looks_like_slash_command`), `legacy_cli_payload_is_coalescible_text`,
+    `coalesced_text`, and the `INTEGRATED_BUSY_PAYLOAD` sentinel + its
+    `make_/is_/unwrap_` helpers.
+- **`cli.py`** — now imports the `INTEGRATED_BUSY_PAYLOAD` sentinel from the new
+  module (single source of truth) and re-implements `_coalesce_pending_busy_queue`
+  and `_coalesce_pending_integrated_busy_queue` as thin shims that build a
+  `PendingTurnQueue` from the drained legacy payloads, call
+  `drain_coalescible_text_until_boundary(...)`, and re-queue the tail in order.
+  External behavior is unchanged — only the `queue.Queue` plumbing stays in
+  `cli.py`; the "what is a mergeable text fragment / where is a boundary" rule
+  now lives in the structured module. `_prepare_pending_input_for_turn` and the
+  `_make_/_is_/_unwrap_integrated_busy_payload` / `_busy_payload_for_mode` /
+  `_format_integrated_busy_input` helpers are untouched.
+- **`tests/agent/test_pending_turn_queue.py`** — focused unit tests for the new
+  module (item shape + boundary rules, queue ops + drain, legacy CLI round-trip,
+  gateway event conversion, JSON serializability, sentinel helpers). It includes
+  regression coverage for uncopyable `raw` payloads and raw-string gateway duck
+  typing.
+
+## Why this shape (purpose-fit, not a rewrite)
+
+Phase 2 is the *input substrate* for future focused-agent orchestration ("Ralph"
+is only the conceptual name for that future focused worker/task unit — not built
+here). The structure deliberately preserves, per pending unit:
+
+- *what the user sent* (`text` / `media_refs` / `media_types` / `raw`);
+- *what kind of input it is* (`kind`) and *how it relates to its neighbours*
+  (`boundary`) — so a command, a media attachment, a caption, or a hard "new
+  topic" wall is never silently flattened into a coalesced text run;
+- *provenance* (`source`, `session_key`, `created_at`, `reply_to`,
+  `origin_busy`) — enough for a later orchestrator to decide "append to current
+  focus", "steer the active worker", "start a new focused task", or "ask the
+  user", without that policy being baked in here;
+- *order* — `PendingTurnQueue` is an ordered queue, not a single replaceable
+  slot, and `drain_coalescible_text_until_boundary` only consumes the leading
+  run of mergeable text.
+
+Boring, explicit, serializable shapes were preferred over clever abstractions;
+compatibility wrappers (`from_/maybe_to_legacy_cli_payload`) over call-site
+churn. The `raw` passthrough keeps every legacy payload reconstructable, so the
+CLI rewrite is provably behavior-preserving (the existing
+`tests/cli/test_busy_queue_coalescing.py` / `test_busy_input_mode_command.py`
+suite is the contract).
+
+## What was intentionally NOT built (out of scope for Phase 2)
+
+- No task registry (Phase 3), no detached/background worker lanes (Phase 4), no
+  `delegate_task(background=True)`, no model-based follow-up classifier (Phase 5),
+  no "Ralph" focused-agent runtime.
+- No change to `/busy interrupt|queue|steer|integrated` semantics, no change to
+  the default busy mode.
+- No change to the gateway's pending-message model. `gateway/platforms/base.py`
+  `merge_pending_message_event` and the `adapter._pending_messages: Dict[str,
+  MessageEvent]` single-slot model are untouched: that function is directly
+  unit-tested (`tests/gateway/test_session_race_guard.py`) and feeds ~6 call
+  sites and the restart-drain / race-guard paths — swapping it to a
+  `PendingTurnQueue` is exactly the "broad gateway surgery" the packet says to
+  defer. `from_gateway_event` is provided and tested as the one-way bridge for
+  whoever does that migration.
+- No TUI changes. `tui_gateway/server.py` has its own `_load_busy_input_mode`
+  and the queue is currently frontend-owned (`ui-tui/src/app/useSubmission.ts`
+  `queueRef` / `composerActions.enqueue`). Wiring it to the structured queue is
+  a follow-up (see bridge points).
+
+## Bridge points for later phases
+
+1. **Gateway adoption.** Replace `adapter._pending_messages: Dict[str,
+   MessageEvent]` with `Dict[str, PendingTurnQueue]` (or keep the dict and store
+   a `PendingTurnQueue` per session). On ingress, `from_gateway_event(event,
+   session_key)` → `queue.append(item)`. At drain (`_dequeue_pending_event` /
+   `_drain_pending_after_session_command` / the post-run pickup in
+   `gateway/run.py`), `queue.drain_coalescible_text_until_boundary()` for the
+   text run, then pop the next non-text item separately. `merge_pending_message_event`'s
+   photo-burst / album / `merge_text` logic becomes a small `PendingTurnQueue.append`
+   policy (coalesce adjacent media with the same group; absorb captions into the
+   adjacent media item via `boundary=caption`). Keep the restart-drain semantics:
+   a multi-item queue should redeliver in order on resume.
+2. **CLI `_pending_input`.** It could eventually *be* a `PendingTurnQueue` instead
+   of a `queue.Queue` of mixed legacy payloads, but it is also written from the
+   prompt_toolkit UI thread and read from `process_loop`, so that swap needs a
+   thread-safety wrapper (a lock, or keep `queue.Queue` and store
+   `PendingTurnItem`s in it). Not needed for Phase 2 — the current shims already
+   route the *logic* through the structured module.
+3. **TUI.** Port `useSubmission.ts`'s queue behavior to mirror `PendingTurnItem`
+   boundaries (commands and media are hard boundaries; adjacent plain text
+   coalesces), and have `tui_gateway/server.py` recognize `display.busy_input_mode:
+   integrated` like the gateway already does. Longer term, move queue ownership to
+   the backend `PendingTurnQueue`.
+4. **Follow-up classification (Phase 5).** A classifier would consume
+   `PendingTurnItem`s (and the `origin_busy` / `boundary` / `task_hint` hints)
+   and decide append vs steer vs new-task vs clarify. Nothing in this module
+   makes that decision; `task_hint` is reserved for it.
+
+## Known risks / open questions
+
+- The CLI shims drain the *entire* `_pending_input` queue, then re-queue the
+  tail. `process_loop` is the sole runtime consumer of `_pending_input.get`, so
+  this is equivalent to the prior "pull until boundary, then drain the rest into
+  `restore`" behavior. There is still a theoretical producer/consumer race if a
+  prompt-toolkit producer enqueues exactly between drain-empty and tail restore;
+  that race already existed in the Phase 1 coalescer and is not widened here.
+  Closing it properly requires changing `_pending_input` ownership/locking (for
+  example a `PendingTurnQueue` plus lock, or an atomic front-restore wrapper), so
+  it is intentionally documented as a Phase 3/4 queue-ownership hardening item
+  rather than hidden inside this compatibility shim.
+- `agent/pending_turn_queue.py` keeps a faithful copy of
+  `cli._looks_like_slash_command` to stay a leaf module; if the CLI's version
+  ever changes, the copy must be kept in sync (cross-reference comments are in
+  both files).
+- Open: should the gateway's album/caption merge become a `PendingTurnQueue`
+  `append` policy (option 1 above) or stay a separate pre-queue step? Either
+  works; the structured shape supports both.

--- a/docs/plans/2026-05-12-phase3-task-registry-notes.md
+++ b/docs/plans/2026-05-12-phase3-task-registry-notes.md
@@ -1,0 +1,54 @@
+# Phase 3 Structured Task Registry Notes
+
+## SUMMARY
+
+Phase 3 adds a purpose-fit focused task registry substrate for Hermes' concierge/front-desk direction. It gives Hermes a small, explicit place to record user task identity, status, origin metadata, pending follow-ups, artifacts, notes, and future worker linkage fields without yet changing routing behavior.
+
+## PURPOSE-FIT DESIGN RATIONALE
+
+The registry is intentionally small and boring:
+
+- `FocusedTask` records the task Hermes is accountable for.
+- `TaskOrigin` records where the task came from.
+- `TaskRegistry` creates, lists, updates, cancels, serializes, and optionally persists tasks.
+- Pending follow-ups use Phase 2 `PendingTurnItem`, preserving order and boundaries.
+- `active_worker_id` and `worker_kind` are recorded for Phase 4 but do not start workers.
+- JSON persistence is optional and atomic; SQLite/durable multi-writer behavior is deferred.
+
+This supports the final concierge goal by letting the orchestrator remember “which user goal is active” and attach late refinements without prematurely deciding routing semantics.
+
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+
+Not included in Phase 3:
+
+- Ralph/focused-agent runtime.
+- Follow-up classifier.
+- Automatic Telegram/CLI/TUI routing into tasks.
+- Background or detached worker lanes.
+- `delegate_task(background=True)`.
+- Gateway delivery or notification changes.
+- `/stop <task>` behavior.
+- Broad SQLite migration.
+
+## RALPH / FUTURE FOCUSED-AGENT NOTES
+
+Future phases can use this registry as the control plane:
+
+- Phase 4 worker lanes can create/claim tasks and set `active_worker_id`.
+- Phase 5 follow-up routing can attach `PendingTurnItem` objects as corrections, appends, or status/cancel intents.
+- Phase 6 synthesis can compare worker output against `user_goal`, pending follow-ups, artifacts, and notes before delivering to Woo.
+
+The registry deliberately stores worker linkage fields now so those phases do not need to redefine task identity later.
+
+## TEST NOTES
+
+Target tests should cover:
+
+- create/list/session filtering
+- status transitions and invalid status rejection
+- worker linkage recording only
+- follow-up order preservation
+- raw passthrough exclusion from serialization
+- artifact/note storage
+- active filtering
+- optional JSON persistence

--- a/docs/plans/2026-05-12-phase4-worker-lanes-notes.md
+++ b/docs/plans/2026-05-12-phase4-worker-lanes-notes.md
@@ -1,0 +1,93 @@
+# Phase 4 Worker Lane / Detached Execution Substrate Notes
+
+## Summary
+
+Phase 4 adds a small library-level worker-lane substrate in `agent/worker_lanes.py` plus targeted tests in `tests/agent/test_worker_lanes.py`.
+
+The implementation introduces:
+
+- `WorkerSpec`, `WorkerHandle`, and `WorkerResult` JSON-safe shapes.
+- `WorkerStatus` lifecycle strings: `queued`, `running`, `done`, `error`, `cancelled`.
+- `CancelToken` and `WorkerCancelled` for cooperative cancellation.
+- `WorkerLane` protocol.
+- `ThreadWorkerLane`, a local in-process lane that runs a caller-supplied runner in a daemon thread.
+- `WorkerLaneRegistry`, a small lane manager that routes status/result/cancel/follow-up operations by `worker_id`.
+- `link_worker_to_task()`, an optional helper that records worker metadata on Phase 3 `TaskRegistry` tasks.
+
+## PURPOSE-FIT DESIGN RATIONALE
+
+This phase intentionally builds the minimum substrate needed before Hermes can safely grow toward detached/background execution:
+
+- It proves that worker dispatch can return immediately without blocking for completion.
+- It gives long-running work a stable `worker_id`, observable lifecycle, and retrievable result/error record.
+- It stores late follow-ups as ordered Phase 2 `PendingTurnItem` objects without turning them into model text.
+- It links workers to Phase 3 task identity via metadata, while keeping task routing and synthesis in later phases.
+- It uses in-process locks for deterministic thread-safe state transitions in the first implementation.
+
+The `ThreadWorkerLane` is deliberately simple and deterministic enough for unit tests. More capable lanes can later wrap Claude Code, terminal background processes, `delegate_task`, Kanban, or Ralph-like focused workers behind the same conceptual API.
+
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+
+This phase does **not** implement:
+
+- Ralph runtime.
+- Follow-up classifier.
+- Automatic gateway/Telegram routing into active workers.
+- User-facing `/tasks`, `/agents`, or `/stop <task>` commands.
+- `delegate_task(background=True)` tool schema or public API.
+- Claude Code process lane.
+- Kanban lane.
+- Durable SQLite/multi-process worker database.
+- Gateway completion notifications.
+- Force-kill semantics for arbitrary external processes.
+
+Cancellation is cooperative: `cancel()` records a request and sets a token; a runner must observe that token to finish as `cancelled`. Uncooperative work may still complete as `done`, with `cancel_requested=True` preserved.
+
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+
+Ralph can later be implemented as a focused worker lane or a higher-level worker runtime that conforms to this substrate:
+
+- Task identity remains in `TaskRegistry`.
+- Worker execution state remains in a lane.
+- Follow-ups can be attached first, then later routed/steered by Phase 5 policy.
+- Hermes main can stay accountable for final synthesis and review in Phase 6.
+
+The current API is intentionally generic: a future `RalphWorkerLane`, `ClaudeCodeWorkerLane`, or `DelegateTaskWorkerLane` can provide the same start/status/follow-up/cancel/result surface without rewriting the task registry.
+
+## Validation
+
+Controller-run targeted validation after fixing two test expectation issues:
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/agent/test_pending_turn_queue.py -q
+
+72 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/cli/test_busy_queue_coalescing.py \
+  tests/cli/test_busy_input_mode_command.py -q
+
+31 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q \
+  agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py
+
+git diff --check
+
+passed
+```
+
+## Risks / Follow-up
+
+- `ThreadWorkerLane` is in-process only and not durable across process restart.
+- Cancellation is cooperative only.
+- Snapshot JSON-safety currently validates metadata and follow-up serialization but worker result is coerced to string rather than structured JSON.
+- Later phases should decide how completion delivery, task registry persistence, and gateway availability interact.
+- Phase 5 should add conservative follow-up routing policy, not direct mutation of running worker contexts.

--- a/docs/plans/2026-05-12-phase6-orchestration-observatory-notes.md
+++ b/docs/plans/2026-05-12-phase6-orchestration-observatory-notes.md
@@ -1,0 +1,102 @@
+# Phase 6 Orchestration Observatory Notes
+
+## Summary
+
+Phase 6 adds a read-only orchestration observability layer in `agent/orchestration_status.py` with tests in `tests/agent/test_orchestration_status.py`.
+
+It formats the existing task/worker substrates into concise, Telegram-friendly status boards:
+
+- `build_snapshot(...)`
+- `format_tasks(...)`
+- `format_agents(...)`
+- `format_overview(...)`
+- `looks_like_orchestration_status_query(...)`
+- `OrchestrationStatusFormatter` facade
+
+## PURPOSE-FIT DESIGN RATIONALE
+
+Woo compared the desired Hermes experience to a smooth Manus-like coordinator with worker agents behind it, and to Claude's agent view. The immediate need is visibility, not a heavy new runtime.
+
+The module therefore gives Hermes a read-only "front desk board" over the already-built substrates:
+
+- Phase 3 `TaskRegistry`: focused tasks, statuses, follow-ups, notes, artifacts, worker linkage.
+- Phase 4 `WorkerLaneRegistry`: worker handles, result/error/cancel status, lane/task linkage.
+- Phase 5 `FollowupRouter`: later natural-language status queries can call this board without mutating state.
+
+This is enough to answer "what are you working on?", "what agents are running?", and "is anything blocked?" once a runtime registry is injected, without prematurely building a full dashboard or DB.
+
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+
+This phase does not implement:
+
+- Ralph runtime.
+- LLM/model classifier.
+- automatic Telegram/gateway natural-language routing.
+- force kill / force cancel.
+- public `delegate_task(background=True)` API.
+- durable routing DB / SQLite schema.
+- global singleton task/worker registry.
+- broad CLI/TUI/gateway refactor.
+- worker result delivery/synthesis pipeline.
+
+It also does not wire `/tasks` and `/agents` into production command handlers yet. There is not yet a long-lived runtime task/worker registry for those commands to read, so adding command strings now would risk a misleading empty dashboard. The formatter is ready for a thin command handler once registry injection exists.
+
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+
+A future Ralph/focused-agent layer can use this status module as its visibility surface:
+
+```text
+Ralph/focused task runtime
+→ TaskRegistry + WorkerLaneRegistry
+→ OrchestrationStatusFormatter
+→ natural-language status / /tasks / /agents
+```
+
+This separates concerns cleanly:
+
+- runtime owns work
+- registry owns state
+- router owns follow-up policy
+- status formatter owns presentation
+- Hermes main owns synthesis/accountability
+
+## Validation
+
+Controller-run validation:
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/agent/test_orchestration_status.py \
+  tests/agent/test_followup_router.py \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/agent/test_pending_turn_queue.py -q
+
+117 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/cli/test_busy_queue_coalescing.py \
+  tests/cli/test_busy_input_mode_command.py \
+  tests/gateway/test_restart_drain.py \
+  tests/gateway/test_session_race_guard.py -q
+
+65 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q \
+  agent/orchestration_status.py agent/followup_router.py agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py gateway/run.py
+
+git diff --check
+
+passed
+```
+
+## Risks / Follow-up
+
+- `/tasks` and `/agents` commands should be added only once there is an injected runtime registry or a clear session-local registry surface to inspect.
+- Natural-language gateway status routing should be a later thin integration phase using `looks_like_orchestration_status_query(...)` plus `format_overview(...)`.
+- Durable DB remains deferred until restart recovery becomes a concrete requirement.
+- The formatter is intentionally read-only and best-effort; missing/foreign worker metadata should degrade to compact lines rather than fail the user-facing status request.

--- a/docs/plans/2026-05-12-phase7-runtime-status-notes.md
+++ b/docs/plans/2026-05-12-phase7-runtime-status-notes.md
@@ -1,0 +1,218 @@
+# Phase 7 Runtime Orchestration Context Notes
+
+## Summary
+
+Phase 7 adds the smallest live "place" where CLI/gateway/session code can hold
+and reach the Phase 3 `TaskRegistry` + Phase 4 `WorkerLaneRegistry`, so the
+Phase 6 read-only status formatter becomes an *observable runtime* rather than a
+formatter library only.
+
+New module: `agent/orchestration_runtime.py`
+
+- `OrchestrationRuntime` — a tiny dataclass holding one `TaskRegistry` and one
+  `WorkerLaneRegistry`, with thin pass-throughs to Phase 6:
+  - `OrchestrationRuntime.create()` → fresh, empty, in-memory `TaskRegistry`
+    (`path=None` — no file persistence) + empty `WorkerLaneRegistry` (no lanes).
+  - `snapshot(*, session_key=None)` → `OrchestrationSnapshot` (JSON-safe `to_dict`).
+  - `format_tasks(*, session_key=None, compact=True)` → delegates to
+    `orchestration_status.format_tasks` against the held task registry.
+  - `format_agents(*, compact=True)` → delegates to `orchestration_status.format_agents`.
+  - `format_overview(*, session_key=None, compact=True)` → delegates to
+    `orchestration_status.format_overview`.
+- Per-owner helpers (no global singleton; storage attribute is `RUNTIME_ATTR =
+  "_orchestration_runtime"`):
+  - `get_orchestration_runtime(owner) -> OrchestrationRuntime | None`
+  - `set_orchestration_runtime(owner, runtime) -> OrchestrationRuntime`
+    (rejects a non-`OrchestrationRuntime`)
+  - `get_or_create_orchestration_runtime(owner) -> OrchestrationRuntime`
+    (attaches a fresh empty runtime if absent)
+  - `format_runtime_tasks(owner, ...)` / `format_runtime_agents(owner, ...)` /
+    `format_runtime_overview(owner, ...)` — get-or-create on `owner`, then format.
+
+New tests: `tests/agent/test_orchestration_runtime.py` (12 tests).
+
+Slash command wiring (`/tasks`, `/agents`) is **deferred** — see "Risks /
+Follow-up" for why; the runtime helpers above are exactly what a later, focused
+command-wiring phase builds on.
+
+## PURPOSE-FIT DESIGN RATIONALE
+
+Phase 6 deliberately did not wire `/tasks` / `/agents` because "there is not yet a
+long-lived runtime task/worker registry for those commands to read". Phase 7's
+*only* job is to remove that blocker with the minimum surface:
+
+- A **container, not a runtime engine.** `OrchestrationRuntime` owns no threads,
+  no locks, no background work, no worker dispatch. It holds the two registries
+  the substrate already provides and forwards reads to the Phase 6 formatter.
+  Construction is "explicit injection" (`OrchestrationRuntime(task_registry=...,
+  worker_registry=...)`, used by tests / a future phase that already owns them)
+  with `create()` as the only sugar — there is no implicit shared default.
+- **Per-owner attachment, not a module global.** The packet was explicit: no
+  global singleton. So a runtime lives on whatever object owns it (`HermesCLI`,
+  a gateway runner, a session object, a test dummy) under one private
+  `_orchestration_runtime` attribute, reached only via `getattr`/`setattr` —
+  fully duck-typed about the owner, zero module-level mutable state, two owners
+  get two independent runtimes.
+- **"Create if absent" attaches an *empty* runtime, never a fabricated one.**
+  `get_or_create_orchestration_runtime` / the `format_runtime_*` helpers attach a
+  fresh empty `OrchestrationRuntime.create()` when the owner has none, so a
+  status surface always has *something truthful* to read — an empty board
+  ("No active tasks are currently registered.") — and later work that populates
+  the registries is visible through the same handle. No fake state, no
+  misleading dashboard.
+- **Read-only on the same path Phase 6 already vetted.** `snapshot()` /
+  `format_*` go through `build_snapshot` / `format_tasks` / `format_agents` /
+  `format_overview`, which count `pending_followups` via `len(...)` and never
+  iterate their payloads — so `PendingTurnItem.raw` is never inspected,
+  serialised, copied, or deep-copied anywhere on this path. Everything
+  `snapshot().to_dict()` returns is plain JSON-safe data.
+- **No Phase 6 changes.** `agent/orchestration_status.py` already exposes exactly
+  the functions a runtime needs; `OrchestrationRuntime` just calls them. No
+  "small adapter hook" turned out to be necessary. `runtime.format_tasks()`
+  therefore inherits Phase 6's documented registry behaviour — active-only,
+  session-scoped, worker *linkage* shown (`worker: <id> (<kind>)`); the live
+  worker *status* annotation (`… [running]`) appears in `format_agents()` and is
+  cross-linked into the task block by `format_overview()` (which builds a
+  snapshot of both registries internally).
+
+## WHAT YOU INTENTIONALLY DID NOT BUILD
+
+This phase does not implement:
+
+- `/tasks` / `/agents` slash-command rewiring (deferred — see below).
+- gateway/Telegram natural-language status auto-routing.
+- append/correction attachment from live gateway messages.
+- worker dispatch or new-task creation (the runtime starts/polls/kills no
+  workers; a future phase that wants a lane calls
+  `runtime.worker_registry.register(lane)` itself).
+- cancel / stop / force-kill task behaviour.
+- a durable routing DB / SQLite schema (the task registry stays `path=None`
+  in-memory; no persistence is wired).
+- the public `delegate_task(background=True)` API.
+- the Ralph / focused-agent runtime.
+- an LLM / model-based follow-up classifier.
+- a global singleton runtime.
+- a broad CLI / gateway / TUI refactor.
+- a worker result synthesis / delivery pipeline.
+
+## RALPH/FUTURE FOCUSED-AGENT NOTES
+
+The layering is now:
+
+```text
+(future) Ralph / focused-agent runtime, worker dispatch
+  → OrchestrationRuntime            # Phase 7: holds the live registries on an owner
+    → TaskRegistry + WorkerLaneRegistry   # Phase 3/4: state
+      → orchestration_status.*      # Phase 6: read-only presentation
+        → /tasks /agents, natural-language status   # later: thin handlers
+```
+
+Concretely, a later phase:
+
+- **Command wiring** — once the integration surface is chosen, a thin handler is
+  `format_runtime_overview(self)` (for a combined view) or
+  `format_runtime_tasks(self)` / `format_runtime_agents(self)` against the
+  CLI/gateway object — no new plumbing, the helper get-or-creates an empty
+  runtime so even a not-yet-populated owner answers gracefully. (It must pick
+  fresh command names, or consciously repurpose the existing `/tasks` / `/agents`
+  — see below.)
+- **Natural-language status (gateway)** — gate on
+  `orchestration_status.looks_like_orchestration_status_query(text)`, then call
+  `format_runtime_overview(session_or_runner, session_key=...)`. Read-only;
+  mutates nothing.
+- **Follow-up routing / worker dispatch** — `FollowupRouter.route(...)` already
+  takes a `TaskRegistry` (+ optional `WorkerLaneRegistry`); pass
+  `runtime.task_registry` / `runtime.worker_registry`. A worker lane (Claude
+  Code, terminal, …) is registered with `runtime.worker_registry.register(lane)`;
+  task↔worker linkage uses `worker_lanes.link_worker_to_task(runtime.task_registry,
+  task_id, handle)`.
+- **A "Ralph" unit** is then naturally "one `FocusedTask` + one `WorkerLane`
+  handle, observable through this runtime" — no new abstraction needed yet.
+
+This keeps the separation clean: runtime owns *where the state lives*, the
+registries own *state*, the router owns *follow-up policy*, the status module
+owns *presentation*, and Hermes main owns *synthesis / accountability*.
+
+## Validation
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/agent/test_orchestration_runtime.py \
+  tests/agent/test_orchestration_status.py \
+  tests/agent/test_followup_router.py \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/agent/test_pending_turn_queue.py -q
+
+129 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m pytest \
+  tests/cli/test_busy_queue_coalescing.py \
+  tests/cli/test_busy_input_mode_command.py \
+  tests/gateway/test_restart_drain.py \
+  tests/gateway/test_session_race_guard.py -q
+
+65 passed, 8 warnings
+```
+
+```text
+/Users/wookim/.hermes/hermes-agent/venv/bin/python -m compileall -q \
+  agent/orchestration_runtime.py agent/orchestration_status.py agent/followup_router.py \
+  agent/worker_lanes.py agent/task_registry.py agent/pending_turn_queue.py cli.py gateway/run.py
+
+git diff --check
+
+both clean / passed
+```
+
+New-test coverage (`tests/agent/test_orchestration_runtime.py`):
+
+- `create()` → fresh empty in-memory registries; two creates independent.
+- explicit registry injection used as-is.
+- `get` / `set` / `get_or_create` helpers on a dummy owner; idempotent;
+  replacement; `set` rejects non-runtime; `get` ignores a foreign value in the slot.
+- no global-singleton leakage between owners; a brand-new owner reads empty.
+- empty runtime → graceful empty `format_tasks` / `format_agents` / `format_overview`
+  and an empty, JSON-safe snapshot; `format_runtime_*` helpers create an empty
+  runtime on a missing owner.
+- injected task + running worker → correct `format_runtime_tasks` /
+  `format_runtime_agents` / `format_runtime_overview` (active-only tasks, live
+  worker line, cross-linked worker status in the overview), correct snapshot
+  counts, no consistency warnings; JSON-safe.
+- `runtime.snapshot()` JSON-safe and not deep-copy-traversed even when a task has
+  a follow-up carrying a non-JSON, deepcopy-hostile `raw` passthrough.
+- `runtime.format_tasks()` session-scoped and active-only.
+- a worker carrying non-JSON-safe spec metadata degrades (no goal) instead of
+  raising, through the runtime.
+
+## Risks / Follow-up
+
+- **Command wiring deferred — why.** `/agents` (with `/tasks` as an alias)
+  *already exists* in `hermes_cli/commands.py::COMMAND_REGISTRY` and resolves to
+  `_handle_agents_command` in both `cli.py` and `gateway/run.py`, where it lists
+  *background processes / subagent state* — an unrelated, established feature.
+  Pointing those names at the orchestration runtime would change existing
+  behaviour (the packet requires "no normal chat/gateway behavior changes"), and
+  *adding* runtime output to those handlers means threading an `OrchestrationRuntime`
+  through CLI construction / gateway session dispatch — touching the 600k-char
+  `cli.py` and `gateway/run.py` — which is exactly the broad CLI/gateway refactor
+  this phase stops short of. So Phase 7 ships the runtime + helpers and leaves the
+  command surface to a later, focused phase that decides: new names
+  (`/orchestration`, `/board`, …) vs. consciously merging into the existing
+  `/agents`. The `format_runtime_*` one-liners make either path small.
+- Natural-language gateway status routing remains a later thin integration
+  (`looks_like_orchestration_status_query` + `format_runtime_overview`).
+- Durable persistence stays deferred: `OrchestrationRuntime.create()` builds an
+  in-memory `TaskRegistry` (`path=None`); restart recovery is a later phase and
+  must still avoid serialising `PendingTurnItem.raw`.
+- The runtime helpers `getattr`/`setattr` a private attribute on the owner; an
+  owner with restrictive `__slots__` lacking that slot would raise on `set` —
+  acceptable, since the intended owners (`HermesCLI`, gateway runner, session,
+  test dummy) all allow attribute assignment.
+- `runtime.format_tasks()` inherits Phase 6's registry behaviour, so the inline
+  worker line is linkage-only (`worker: <id> (<kind>)`); the live worker status
+  shows in `format_agents()` / `format_overview()`. If a future `/tasks` wants the
+  live status inline too, that is a small Phase 6 adapter (a `worker_registry=`
+  kwarg on `format_tasks`) — intentionally not done now.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1250,6 +1250,17 @@ class GatewayRunner:
         self._fallback_model = self._load_fallback_model()
         self._orchestration_status_queries_enabled = self._load_orchestration_status_queries_enabled()
         self.frontdesk_live_enabled = self._load_frontdesk_live_enabled()
+        if self.frontdesk_live_enabled:
+            try:
+                from agent.frontdesk_live import ensure_default_worker_lane
+
+                ensure_default_worker_lane(self)
+                logger.info("Frontdesk live default worker lane registered")
+            except Exception:
+                logger.warning(
+                    "Frontdesk live enabled but default worker lane registration failed",
+                    exc_info=True,
+                )
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6592,6 +6592,9 @@ class GatewayRunner:
         if canonical == "status":
             return await self._handle_status_command(event)
 
+        if canonical == "frontdesk":
+            return await self._handle_frontdesk_command(event)
+
         if canonical == "agents":
             return await self._handle_agents_command(event)
 
@@ -8858,6 +8861,35 @@ class GatewayRunner:
         ])
 
         return "\n".join(lines)
+
+    async def _handle_frontdesk_command(self, event: MessageEvent) -> str:
+        """Handle /frontdesk status — report live gate and worker-lane readiness."""
+        args = (event.get_command_args() or "").strip().lower()
+        if args and args not in {"status", ""}:
+            return "Usage: /frontdesk status"
+
+        from agent.frontdesk_live import ensure_default_worker_lane
+        from agent.orchestration_runtime import get_or_create_orchestration_runtime
+
+        live_enabled = bool(getattr(self, "frontdesk_live_enabled", False))
+        if live_enabled:
+            ensure_default_worker_lane(self)
+        runtime = get_or_create_orchestration_runtime(self)
+        lanes = runtime.worker_registry.lane_names()
+        default_lane_available = "main" in lanes
+        current_session_key = self._session_key_for_source(event.source)
+        overview = self._format_session_scoped_orchestration_overview(current_session_key)
+
+        return "\n".join(
+            [
+                "Frontdesk status",
+                f"Frontdesk live: {'enabled' if live_enabled else 'disabled'}",
+                f"Default worker lane: {'available' if default_lane_available else 'missing'}",
+                "Available worker lanes: " + (", ".join(lanes) if lanes else "none"),
+                "",
+                overview,
+            ]
+        )
 
     async def _handle_agents_command(self, event: MessageEvent) -> str:
         """Handle /agents command - list active agents and running tasks."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1193,6 +1193,7 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _orchestration_status_queries_enabled: bool = False
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -1212,6 +1213,7 @@ class GatewayRunner:
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._orchestration_status_queries_enabled = self._load_orchestration_status_queries_enabled()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -2385,6 +2387,38 @@ class GatewayRunner:
         if mode == "steer":
             return "steer"
         return "interrupt"
+
+    @staticmethod
+    def _load_orchestration_status_queries_enabled() -> bool:
+        """Load the safe natural-language orchestration status-query gate.
+
+        This gateway wiring is intentionally off by default because it intercepts
+        ordinary user text before the main agent sees it.  Operators can enable
+        it with either config.yaml:
+
+            orchestration:
+              status_queries_enabled: true
+
+        or the environment variable HERMES_GATEWAY_ORCHESTRATION_STATUS_QUERIES.
+        The handler is read-only: it formats the per-runner orchestration
+        runtime and never mutates tasks, dispatches workers, or routes follow-ups.
+        """
+        raw = os.getenv("HERMES_GATEWAY_ORCHESTRATION_STATUS_QUERIES", "").strip()
+        if raw:
+            return is_truthy_value(raw, default=False)
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                return is_truthy_value(
+                    cfg_get(cfg, "orchestration", "status_queries_enabled"),
+                    default=False,
+                )
+        except Exception:
+            pass
+        return False
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -5935,6 +5969,20 @@ class GatewayRunner:
             # clearly moved on.
             _slash_confirm_mod.clear_if_stale(_quick_key)
 
+        # Optional, read-only natural-language status queries.  This is the
+        # first production-facing bridge from the orchestration runtime to the
+        # gateway, so it is feature-gated and intentionally narrow: text only,
+        # no slash commands, no media, no mutation, no worker dispatch.  It runs
+        # after pending prompt/confirmation handling but before the busy/running
+        # guard so "지금 뭐 하고 있어?" can be a safe status check rather than an
+        # interrupt/queued follow-up.
+        orchestration_status_reply = self._maybe_handle_orchestration_status_query(
+            event,
+            session_key=_quick_key,
+        )
+        if orchestration_status_reply is not None:
+            return orchestration_status_reply
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.
@@ -8487,6 +8535,99 @@ class GatewayRunner:
         if len(output) > 3800:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
+
+    def _maybe_handle_orchestration_status_query(
+        self,
+        event: MessageEvent,
+        *,
+        session_key: str,
+    ) -> Optional[str]:
+        """Return orchestration status text for safe natural-language queries.
+
+        This is deliberately a pure read-only gate.  It does not mutate the
+        task registry, attach follow-ups, start workers, cancel work, or call an
+        LLM.  It only intercepts obvious TEXT messages when the feature flag is
+        enabled; slash commands, media/documents, internal events, and ordinary
+        prose all fall through to the existing gateway path.
+        """
+        if not getattr(self, "_orchestration_status_queries_enabled", False):
+            return None
+        if bool(getattr(event, "internal", False)):
+            return None
+        if event.message_type != MessageType.TEXT:
+            return None
+        if event.get_command():
+            return None
+        try:
+            from agent.orchestration_status import looks_like_orchestration_status_query
+        except Exception:
+            return None
+        if not looks_like_orchestration_status_query(event.text):
+            return None
+        try:
+            return self._format_session_scoped_orchestration_overview(session_key)
+        except Exception as exc:
+            logger.warning("Failed to format orchestration status for %s: %s", session_key, exc)
+            return "Orchestration status is temporarily unavailable."
+
+    def _format_session_scoped_orchestration_overview(self, session_key: str) -> str:
+        """Format an orchestration overview without leaking cross-session workers.
+
+        Phase 6/7 status helpers can format a whole runtime.  A gateway runner,
+        however, serves multiple chats/sessions, and worker lines may include
+        goals/results/errors.  For a natural-language gateway status reply we
+        therefore scope tasks to the requesting session and include only workers
+        linked to those visible tasks (by task_id or by active_worker_id).
+        """
+        from agent.orchestration_runtime import get_or_create_orchestration_runtime
+        from agent.orchestration_status import OrchestrationSnapshot, build_snapshot, format_overview
+
+        runtime = get_or_create_orchestration_runtime(self)
+        task_snapshot = build_snapshot(
+            runtime.task_registry,
+            None,
+            session_key=session_key,
+        )
+        visible_task_ids = {
+            t.get("task_id") for t in task_snapshot.tasks if t.get("task_id")
+        }
+        visible_worker_ids = {
+            t.get("worker_id") for t in task_snapshot.tasks if t.get("worker_id")
+        }
+        worker_snapshot = build_snapshot(None, runtime.worker_registry)
+        visible_workers = [
+            w for w in worker_snapshot.workers
+            if (
+                (w.get("task_id") and w.get("task_id") in visible_task_ids)
+                or (
+                    not w.get("task_id")
+                    and w.get("worker_id")
+                    and w.get("worker_id") in visible_worker_ids
+                )
+            )
+        ]
+        visible_worker_ids_after_filter = {
+            w.get("worker_id") for w in visible_workers if w.get("worker_id")
+        }
+        visible_tasks = []
+        for task in task_snapshot.tasks:
+            task_copy = dict(task)
+            if task_copy.get("worker_id") not in visible_worker_ids_after_filter:
+                task_copy["worker_id"] = None
+                task_copy["worker_kind"] = None
+            visible_tasks.append(task_copy)
+        scoped_snapshot = build_snapshot(visible_tasks, visible_workers)
+        # build_snapshot(list, list) is already JSON-safe, but wrapping as an
+        # explicit snapshot makes the privacy boundary obvious to future edits.
+        return format_overview(
+            OrchestrationSnapshot(
+                tasks=scoped_snapshot.tasks,
+                workers=scoped_snapshot.workers,
+                counts=scoped_snapshot.counts,
+                warnings=scoped_snapshot.warnings,
+            ),
+            compact=True,
+        )
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1171,6 +1171,40 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+def _classify_incoming(
+    event: Any, *, frontdesk_mode_active: bool = False
+) -> "ControlPlaneDecision":  # type: ignore[name-defined]
+    """Frontdesk control-plane adapter — Phase 2 substrate, no callers wired.
+
+    Duck-typed on *event*: reads ``.text`` (str-like, optional), ``.message_type``
+    (with ``.value`` or ``.name``).  Anything else is treated as missing.  The
+    function returns a :class:`agent.control_plane.ControlPlaneDecision`
+    derived purely from the textual content of the event; the gateway's own
+    queueing / drain / merge semantics are NOT consulted.
+
+    This adapter is **deliberately not yet called from any code path** in the
+    gateway.  Phase 6 (gateway parity) is the first phase that wires it into
+    ``gateway/run.py`` capture (``:2588-2602``) and drain (``:6243-6285``)
+    branches, gated by ``mode.frontdesk.gateway_parity`` config (PRD §12.1 /
+    design review §4.4).  Until then it is *function-only*, callable from
+    tests / replay fixtures / future wiring but invisible to live traffic.
+
+    Hard boundaries this respects (PRD §9.2 / design review §9.2):
+
+    * No mutation of any platform adapter, pending-message slot, or
+      ``MessageEvent``.
+    * No interaction with ``merge_pending_message_event`` semantics.
+    * No process-level side effect (INV-5: zero mid-task gateway restart).
+    """
+    # Lazy import so gateway/run.py module-load cost stays flat and a future
+    # accidental circular import becomes loud rather than silent.
+    from agent.control_plane import classify as _classify
+
+    text_attr = getattr(event, "text", None)
+    text = text_attr if isinstance(text_attr, str) else ""
+    return _classify(text, frontdesk_mode_active=frontdesk_mode_active)
+
+
 class GatewayRunner:
     """
     Main gateway controller.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1217,6 +1217,7 @@ class GatewayRunner:
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
     _busy_input_mode: str = "interrupt"
+    frontdesk_live_enabled: bool = False
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -1248,6 +1249,7 @@ class GatewayRunner:
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
         self._orchestration_status_queries_enabled = self._load_orchestration_status_queries_enabled()
+        self.frontdesk_live_enabled = self._load_frontdesk_live_enabled()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -2455,6 +2457,26 @@ class GatewayRunner:
         return False
 
     @staticmethod
+    def _load_frontdesk_live_enabled() -> bool:
+        """Load the opt-in live frontdesk pre-dispatch gate."""
+        raw = os.getenv("HERMES_FRONTDESK_LIVE", "").strip()
+        if raw:
+            return is_truthy_value(raw, default=False)
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                return is_truthy_value(
+                    cfg_get(cfg, "orchestration", "frontdesk_live_enabled"),
+                    default=False,
+                )
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
     def _load_restart_drain_timeout() -> float:
         """Load graceful gateway restart/stop drain timeout in seconds."""
         raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
@@ -2614,6 +2636,31 @@ class GatewayRunner:
             return False  # let default path handle it
 
         running_agent = self._running_agents.get(session_key)
+
+        frontdesk_reply = await self._maybe_handle_frontdesk_live_input(
+            event,
+            session_key=session_key,
+            main_in_flight=running_agent is not None and running_agent is not _AGENT_PENDING_SENTINEL,
+        )
+        if frontdesk_reply is not None:
+            reply_anchor = self._reply_anchor_for_event(event)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            try:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=frontdesk_reply,
+                    reply_to=(
+                        reply_anchor
+                        if event.source.platform == Platform.TELEGRAM
+                        and event.source.chat_type == "dm"
+                        and event.source.thread_id
+                        else (None if event.source.platform == Platform.TELEGRAM and event.source.thread_id else event.message_id)
+                    ),
+                    metadata=thread_meta,
+                )
+            except Exception as e:
+                logger.debug("Failed to send frontdesk control reply: %s", e)
+            return True
 
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
@@ -6017,6 +6064,17 @@ class GatewayRunner:
         if orchestration_status_reply is not None:
             return orchestration_status_reply
 
+        frontdesk_live_reply = await self._maybe_handle_frontdesk_live_input(
+            event,
+            session_key=_quick_key,
+            main_in_flight=(
+                (running_agent := self._running_agents.get(_quick_key)) is not None
+                and running_agent is not _AGENT_PENDING_SENTINEL
+            ),
+        )
+        if frontdesk_live_reply is not None:
+            return frontdesk_live_reply
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.
@@ -8603,6 +8661,47 @@ class GatewayRunner:
         except Exception as exc:
             logger.warning("Failed to format orchestration status for %s: %s", session_key, exc)
             return "Orchestration status is temporarily unavailable."
+
+    async def _maybe_handle_frontdesk_live_input(
+        self,
+        event: MessageEvent,
+        *,
+        session_key: str,
+        main_in_flight: bool = False,
+    ) -> Optional[str]:
+        """Consume opt-in frontdesk control input before queue/model dispatch."""
+        if bool(getattr(event, "internal", False)):
+            return None
+        if event.message_type != MessageType.TEXT:
+            return None
+        if event.get_command():
+            return None
+
+        running_agent = self._running_agents.get(session_key)
+
+        def _cancel_active(payload: str) -> None:
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL and hasattr(running_agent, "interrupt"):
+                running_agent.interrupt(payload)
+
+        def _steer_active(payload: str):
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL and hasattr(running_agent, "steer"):
+                return running_agent.steer(payload)
+            return False
+
+        from agent.frontdesk_live import handle_frontdesk_live_input
+
+        result = handle_frontdesk_live_input(
+            self,
+            event.text or "",
+            session_key=session_key,
+            source_surface="gateway",
+            main_in_flight=main_in_flight,
+            steer_callback=_steer_active if main_in_flight else None,
+            cancel_callback=_cancel_active if main_in_flight else None,
+        )
+        if result is None:
+            return None
+        return result.message
 
     def _format_session_scoped_orchestration_overview(self, session_key: str) -> str:
         """Format an orchestration overview without leaking cross-session workers.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8688,6 +8688,28 @@ class GatewayRunner:
                 return running_agent.steer(payload)
             return False
 
+        adapter = self.adapters.get(event.source.platform)
+        loop = asyncio.get_running_loop()
+
+        def _notify_worker_done(payload: str) -> None:
+            if adapter is None:
+                return
+            try:
+                fut = asyncio.run_coroutine_threadsafe(
+                    adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=payload,
+                        metadata=self._thread_metadata_for_source(
+                            event.source,
+                            getattr(event, "message_id", None),
+                        ),
+                    ),
+                    loop,
+                )
+                fut.result(timeout=30)
+            except Exception:
+                logger.debug("Failed to send frontdesk worker completion", exc_info=True)
+
         from agent.frontdesk_live import handle_frontdesk_live_input
 
         result = handle_frontdesk_live_input(
@@ -8698,6 +8720,7 @@ class GatewayRunner:
             main_in_flight=main_in_flight,
             steer_callback=_steer_active if main_in_flight else None,
             cancel_callback=_cancel_active if main_in_flight else None,
+            notify_callback=_notify_worker_done,
         )
         if result is None:
             return None

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -105,6 +105,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | pause | resume | clear | status]"),
     CommandDef("status", "Show session info", "Session"),
+    CommandDef("frontdesk", "Show or manage frontdesk live control-plane status", "Session",
+               args_hint="[status]", subcommands=("status",)),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -448,6 +448,9 @@ DEFAULT_CONFIG = {
         # a normal agent turn.  Mutation/worker dispatch/follow-up attachment
         # remain separate gated phases.
         "status_queries_enabled": False,
+        # Full live pre-dispatch frontdesk gate. Off by default because it can
+        # consume natural-language inputs before the main model sees them.
+        "frontdesk_live_enabled": False,
     },
 
     "agent": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -440,6 +440,16 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "orchestration": {
+        # Conservative, off-by-default gateway wiring for Hermes-as-orchestrator
+        # status questions.  When enabled, obvious natural-language status
+        # queries (for example "지금 뭐 하고 있어?" / "what's running?") are
+        # answered from the read-only orchestration runtime instead of starting
+        # a normal agent turn.  Mutation/worker dispatch/follow-up attachment
+        # remain separate gated phases.
+        "status_queries_enabled": False,
+    },
+
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/skills/software-development/frontdesk-control-plane-development/SKILL.md
+++ b/skills/software-development/frontdesk-control-plane-development/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: frontdesk-control-plane-development
+description: Use when designing, testing, or wiring Hermes frontdesk/orchestrator behavior so STOP/STATUS/STEER/WORKER routing stays separate from /busy integrated queue replay and main Hermes remains an available reviewer/orchestrator.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [frontdesk, orchestration, worker-lanes, control-plane, hermes-agent]
+    related_skills: [hermes-agent, test-driven-development, subagent-driven-development, systematic-debugging]
+---
+
+# Frontdesk Control-Plane Development
+
+## Overview
+
+Use this skill when building or reviewing Hermes `frontdesk` behavior: a first-class orchestration/control-plane path where Hermes stays available as frontdesk/reviewer while long work goes to worker lanes. The goal is not a persona prompt and not a tweak to `/busy integrated`; the goal is a structural split between control events, main-agent turns, steering, status, and worker dispatch.
+
+The core invariant: **STOP/STATUS/STEER/WORKER decisions are control-plane routing decisions, not text to be queued and replayed into a future model turn.** In particular, stop/cancel input must never be preserved as pending user text that later re-enters the transcript as "additional input".
+
+## When to Use
+
+Use this skill for:
+
+- Implementing or reviewing frontdesk mode, worker-lane MVPs, task registries, control-plane classifiers, or live surface wiring.
+- Fixing bugs where `/stop`, "그만", "멈춰", status queries, or steering messages get queued/replayed incorrectly.
+- Deciding whether a request should be handled by main Hermes, a worker lane, status surface, or steer callback.
+- Connecting frontdesk behavior to CLI, Gateway, or TUI while keeping it opt-in and rollback-safe.
+- Writing PRDs/design reviews for Hermes as an always-available orchestrator/reviewer.
+
+Do **not** use this skill for:
+
+- Generic project management; use `kanban-orchestrator` or `kanban-worker` for board workflows.
+- Pure code-debugging unrelated to orchestration; use `systematic-debugging`.
+- Adding a frontdesk-looking prompt/persona without real runtime capability.
+
+## Vocabulary
+
+- **Main Hermes:** the foreground conversational agent accountable for user intent, review, synthesis, and final response.
+- **Frontdesk:** the structural control plane that receives inputs, classifies them, and routes to STOP/STATUS/STEER/WORKER/MAIN.
+- **Task:** the logical user objective, recorded in a task registry.
+- **Worker:** an execution unit/lane that works on a task asynchronously or detached from the main turn.
+- **STEER:** a follow-up intended for a currently running main/worker turn, not a new standalone task.
+- **STATUS:** a local state read (`/tasks`, `/agents`, "지금 뭐 하고 있어?") that should not launch a model turn.
+- **STOP:** a high-priority control event. It cancels/purges; it is not normal user text.
+
+## Routing Thresholds
+
+Treat a request as a worker-lane candidate when any of these are true:
+
+- Expected to need 3+ tool calls.
+- Expected to take more than about 2 minutes.
+- Produces an artifact/report/code change/research package.
+- Needs background progress, status, cancellation, or later import/review.
+
+Conservative default: if frontdesk mode is not explicitly active, downgrade worker/steer-shaped advice to `MAIN`. This preserves legacy behavior and avoids fake delegation.
+
+## Required Architecture
+
+A real frontdesk path needs all of the following:
+
+1. **Pure classifier/control-plane schema**
+   - Deterministic classification.
+   - No I/O, no dispatch, no runtime mutation.
+   - Closed intent vocabulary: STOP, STATUS, STEER, NEW_TASK_MAIN, NEW_TASK_WORKER, ACK, DUPLICATE, NOISE.
+
+2. **Task registry**
+   - Records focused user tasks, status, origin/session, pending follow-ups, active worker linkage, artifacts, and notes.
+   - JSON-safe serialization; never serialize raw local passthroughs.
+
+3. **Worker-lane registry**
+   - Registers lane names.
+   - Starts workers via explicit `WorkerSpec`.
+   - Tracks status/result/cancellation by worker id.
+   - Links workers back to tasks.
+
+4. **Runtime container**
+   - Holds task + worker registries for a specific owner/session.
+   - Provides read-only status formatting.
+   - Exposes an explicit frontdesk loop only when the caller intentionally uses it.
+
+5. **Surface adapters**
+   - CLI/Gateway/TUI should be opt-in initially.
+   - Status and cancellation commands must bypass active-session guards.
+   - Live wiring must have clear rollback and tests for every surface.
+
+## Minimal Frontdesk Loop
+
+A safe library-level loop should do this:
+
+```text
+input text
+  -> classify/control-plane decision
+  -> if STOP: cancel active tasks/workers; do not queue/replay text
+  -> if STATUS: return local overview; do not launch an LLM turn
+  -> if STEER: call explicit steer callback only if a turn is in flight
+  -> if WORKER: create task, start registered lane, link task<->worker
+  -> otherwise: route to MAIN
+```
+
+Reference smoke-test shape:
+
+```python
+from agent.orchestration_runtime import OrchestrationRuntime
+from agent.worker_lanes import ThreadWorkerLane, WorkerSpec, CancelToken
+
+rt = OrchestrationRuntime.create()
+
+def runner(spec: WorkerSpec, token: CancelToken):
+    return "done"
+
+rt.worker_registry.register(ThreadWorkerLane(runner=runner, name="thread"))
+
+worker = rt.handle_frontdesk_input(
+    "draft a report.md with the audit",
+    frontdesk_mode_active=True,
+    session_key="smoke-session",
+)
+assert worker.action == "worker_started"
+
+status = rt.handle_frontdesk_input(
+    "지금 뭐 하고 있어?",
+    frontdesk_mode_active=True,
+    session_key="smoke-session",
+)
+assert status.action == "status"
+
+stop = rt.handle_frontdesk_input("그만", frontdesk_mode_active=True, session_key="smoke-session")
+assert stop.action == "stopped"
+```
+
+## Implementation Workflow
+
+Follow strict TDD for behavior changes.
+
+1. **Write failing tests first**
+   - STOP cancels active tasks/workers and does not create follow-ups.
+   - STATUS returns local runtime overview without launching a worker/model turn.
+   - STEER calls a callback only when `main_in_flight=True` and a callback exists.
+   - WORKER creates a task, starts a registered lane, and links task to worker.
+   - Worker-unavailable path is honest: do not claim a worker started.
+
+2. **Run the RED test**
+
+```bash
+cd <worktree>
+uv run pytest tests/agent/test_frontdesk_runtime_loop.py -q
+```
+
+3. **Implement the smallest library-level change**
+
+Prefer leaf/library modules before touching live surfaces:
+
+- `agent/control_plane.py`
+- `agent/task_registry.py`
+- `agent/worker_lanes.py`
+- `agent/orchestration_runtime.py`
+- `agent/orchestration_status.py`
+
+4. **Run targeted regression tests**
+
+```bash
+uv run pytest \
+  tests/agent/test_frontdesk_runtime_loop.py \
+  tests/agent/test_control_plane.py \
+  tests/agent/test_orchestration_runtime.py \
+  tests/agent/test_worker_lanes.py \
+  tests/agent/test_task_registry.py \
+  tests/gateway/test_status_command.py \
+  tests/gateway/test_command_bypass_active_session.py \
+  -q
+python -m py_compile agent/orchestration_runtime.py
+
+git diff --check
+```
+
+5. **Commit separately by layer**
+
+Recommended commit split:
+
+- `feat: add frontdesk control-plane substrate`
+- `feat: add frontdesk worker mvp loop`
+- `docs(skills): add frontdesk control-plane development skill`
+- Surface wiring commits separately for CLI, Gateway, and TUI if they are non-trivial.
+
+## Live Surface Wiring Rules
+
+Before connecting CLI/Gateway/TUI live paths:
+
+- Keep it opt-in initially (`frontdesk_mode_active=True` only from a clear config/mode gate).
+- Do not expose a frontdesk persona unless worker capability actually exists.
+- Do not mutate `/busy integrated` drain semantics as a shortcut.
+- Do not replace pending queue structures casually; add explicit bridges/adapters.
+- Ensure `/stop`, `/tasks`, `/agents`, `/status` bypass active-session guards.
+- Provide rollback: one config flag or one isolated branch revert should disable the new path.
+- Add tests for each surface before wiring:
+  - command bypass while active session exists,
+  - no LLM turn for status,
+  - STOP not queued,
+  - worker-start path creates visible task/worker state,
+  - mode-off legacy behavior unchanged.
+
+## Codex/Worker Execution Notes
+
+For Woo's Mac setup, prefer Codex-first for coding/review worker lanes unless quota/auth/capability forces fallback.
+
+Use an explicit trusted workdir when invoking Codex:
+
+```bash
+/Users/wookim/.local/bin/codex exec -C /Users/wookim/.hermes/hermes-agent \
+  "Smoke test only. Reply exactly: CODEX_OK"
+```
+
+Avoid broad home-directory scans in autonomous workers. Use scoped repo commands (`git ls-files`, `find .`, targeted paths) rather than `find /Users/wookim ...`.
+
+## Common Pitfalls
+
+1. **Persona without capability.** A `frontdesk` prompt/skill/mode alone does not make Hermes an orchestrator. Build the control plane and worker lane first.
+
+2. **STOP as text.** If STOP is stored as a pending input, it can replay later as a new task. STOP must be consumed by the control plane.
+
+3. **Status launching work.** Status queries should read local runtime state, not spawn a model turn or worker.
+
+4. **Steer with no target.** STEER only makes sense when a main/worker turn is actually in flight. Otherwise fall back safely.
+
+5. **Fake worker dispatch.** If no lane is registered, say worker unavailable or keep task blocked/cancelled. Do not tell the user a worker is running.
+
+6. **Default-on surface wiring.** Do not silently route all CLI/Gateway/TUI input through an unfinished frontdesk path. Gate it.
+
+7. **Mixing `/busy integrated` with frontdesk.** `/busy integrated` is a queue/input-mode abstraction. Frontdesk is a first-class control plane. Keep them separate.
+
+8. **Unbounded autonomous scans.** Worker agents must not scan the whole user home directory. Bound them to the repo/worktree.
+
+## Verification Checklist
+
+- [ ] Classifier/control-plane is deterministic and mode-gated.
+- [ ] STOP cancels active tasks/workers and is not queued/replayed.
+- [ ] STATUS returns local task/worker overview without model execution.
+- [ ] STEER uses an explicit callback and only when a turn is in flight.
+- [ ] WORKER creates task, starts registered lane, and links task to worker.
+- [ ] No-worker path is honest and tested.
+- [ ] Task/worker snapshots are JSON-safe and do not touch raw passthroughs.
+- [ ] CLI/Gateway/TUI wiring remains opt-in until tested.
+- [ ] Targeted agent + gateway regression tests pass.
+- [ ] `git diff --check` and py_compile pass.

--- a/tests/agent/data/frontdesk_intents_ko.yaml
+++ b/tests/agent/data/frontdesk_intents_ko.yaml
@@ -1,0 +1,551 @@
+# Korean intent corpus for the frontdesk control-plane classifier (Phase 2).
+# Schema: id, text, expected_intent, expected_recommendation, notes
+#
+# Verified against agent.control_plane.classify / agent.frontdesk_policy.classify_request.
+# Every row's expected_intent / expected_recommendation was confirmed by running
+# the classifier directly.  For NEW_TASK_WORKER rows, classify() is called with
+# frontdesk_mode_active=True.  All other rows use frontdesk_mode_active=False
+# (or True when noted) — the recommendation column reflects the effective output.
+#
+# DUPLICATE: classifier does not detect duplicates (no history). Two placeholder
+# rows are included tagged with expected_intent: NEW_TASK_MAIN and a note
+# explaining the surface handles deduplication, not the classifier.
+
+# --------------------------------------------------------------------------
+# STOP  (10 rows)
+# --------------------------------------------------------------------------
+- id: 1
+  text: "그만"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token"
+
+- id: 2
+  text: "그만해"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token (extended form)"
+
+- id: 3
+  text: "중단"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token"
+
+- id: 4
+  text: "취소"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token (cancel)"
+
+- id: 5
+  text: "됐어"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token (dismissive)"
+
+- id: 6
+  text: "멈춰"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token (halt)"
+
+- id: 7
+  text: "잠깐만"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "soft pause folded into STOP-graceful per design review §8.2"
+
+- id: 8
+  text: "잠깐"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "short pause folded into STOP-graceful"
+
+- id: 9
+  text: "기다려"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "wait command folded into STOP-graceful"
+
+- id: 10
+  text: "그만둬"
+  expected_intent: STOP
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean stop token (quit form)"
+
+# --------------------------------------------------------------------------
+# ACK  (10 rows)
+# --------------------------------------------------------------------------
+- id: 11
+  text: "고마워"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean ack token"
+
+- id: 12
+  text: "고맙습니다"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "formal whole-body Korean ack"
+
+- id: 13
+  text: "감사"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean ack (short form)"
+
+- id: 14
+  text: "감사합니다"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "formal whole-body Korean ack"
+
+- id: 15
+  text: "수고"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean ack (good work)"
+
+- id: 16
+  text: "수고했어"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "whole-body Korean ack (you worked hard)"
+
+- id: 17
+  text: "고마워 ㅎㅎ"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "ack with Korean smiley suffix — stripped by _strip_trailing_noise"
+
+- id: 18
+  text: "감사합니다!"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "ack with trailing punctuation — stripped by whole-body match"
+
+- id: 19
+  text: "수고했어."
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "ack with trailing period — stripped"
+
+- id: 20
+  text: "고마워ㅋㅋ"
+  expected_intent: ACK
+  expected_recommendation: CONTROL
+  notes: "ack with Korean laughter suffix ㅋㅋ — stripped"
+
+# --------------------------------------------------------------------------
+# STATUS  (10 rows)
+# --------------------------------------------------------------------------
+- id: 21
+  text: "지금 뭐 해?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 뭐 해"
+
+- id: 22
+  text: "뭐 했어?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 뭐 했어"
+
+- id: 23
+  text: "어디까지 갔어?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 어디까지"
+
+- id: 24
+  text: "진행 상황은?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 진행"
+
+- id: 25
+  text: "상태 알려줘"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 상태"
+
+- id: 26
+  text: "뭐해?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 뭐해 (compact form)"
+
+- id: 27
+  text: "지금 뭐 하는 중이야?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 지금 뭐"
+
+- id: 28
+  text: "어떤 워커 돌고 있어?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 어떤 워커"
+
+- id: 29
+  text: "진행 중인 작업 알려줘"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 진행"
+
+- id: 30
+  text: "어떤 lane 쓰고 있어?"
+  expected_intent: STATUS
+  expected_recommendation: MAIN
+  notes: "status anchor: 어떤 lane"
+
+# --------------------------------------------------------------------------
+# NEW_TASK_MAIN  (10 rows — classify with frontdesk_mode_active=False)
+# --------------------------------------------------------------------------
+- id: 31
+  text: "이 파일 읽어줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "simple foreground request, no worker anchors"
+
+- id: 32
+  text: "방금 결과 설명해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explanation request stays on main"
+
+- id: 33
+  text: "이게 뭔지 알려줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "question stays on main"
+
+- id: 34
+  text: "직접 해"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (직접 해)"
+
+- id: 35
+  text: "직접해"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (compact form)"
+
+- id: 36
+  text: "지금 보여줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (지금 보여줘)"
+
+- id: 37
+  text: "메인에서 해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (메인에서)"
+
+- id: 38
+  text: "바로 해"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (바로 해)"
+
+- id: 39
+  text: "지금해"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (지금해 compact)"
+
+- id: 40
+  text: "여기서 해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "explicit main override (여기서 해)"
+
+# --------------------------------------------------------------------------
+# NEW_TASK_WORKER  (10 rows — classify with frontdesk_mode_active=True)
+# --------------------------------------------------------------------------
+- id: 41
+  text: "조사해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "research anchor (조사해); frontdesk_mode_active=True required"
+
+- id: 42
+  text: "보고서 써줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "artifact anchor (보고서); frontdesk_mode_active=True"
+
+- id: 43
+  text: "리포트 작성해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "artifact anchor (리포트 + 작성해줘); frontdesk_mode_active=True"
+
+- id: 44
+  text: "수정해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "code_edit anchor (수정해줘); frontdesk_mode_active=True"
+
+- id: 45
+  text: "구현해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "code_edit anchor (구현해줘); frontdesk_mode_active=True"
+
+- id: 46
+  text: "크롤링해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "research anchor (크롤링); frontdesk_mode_active=True"
+
+- id: 47
+  text: "백그라운드로 돌려"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "explicit worker override (백그라운드); frontdesk_mode_active=True"
+
+- id: 48
+  text: "워커에 맡겨"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "explicit worker override (워커에 맡겨); frontdesk_mode_active=True"
+
+- id: 49
+  text: "초안 잡아줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "artifact anchor (초안); frontdesk_mode_active=True"
+
+- id: 50
+  text: "분석해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "research anchor (분석해); frontdesk_mode_active=True"
+
+# --------------------------------------------------------------------------
+# STEER  (12 rows)
+# --------------------------------------------------------------------------
+- id: 51
+  text: "근데 이거도 봐줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 근데 (direct)"
+
+- id: 52
+  text: "그리고 저것도 확인해줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 그리고 (direct)"
+
+- id: 53
+  text: "추가로 이 파일도 봐줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 추가로 (direct)"
+
+- id: 54
+  text: "참, 이것도 포함해줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 참, (direct)"
+
+- id: 55
+  text: "아 그리고 이것도 해줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 아 그리고 (direct)"
+
+- id: 56
+  text: "그만, 근데 이거 봐줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "stop-leading-but-steer: post-comma steer prefix, no worker anchors"
+
+- id: 57
+  text: "고마워, 근데 zanu도 같이 봐줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "ack-leading-but-steer: post-comma 근데, no worker anchors"
+
+- id: 58
+  text: "됐어, 근데 이 부분도 체크해줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "stop-leading-but-steer: post-comma 근데, no worker anchors"
+
+- id: 59
+  text: "참 이거도 넣어줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 참 (no comma variant)"
+
+- id: 60
+  text: "아, 그리고 결과도 로그에 남겨줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "steer prefix 아, 그리고 (direct)"
+
+- id: 61
+  text: "수고, 근데 마지막 파일 경로도 알려줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "ack-leading-but-steer: post-comma 근데, no worker anchors"
+
+- id: 62
+  text: "중단, 근데 그 에러 메시지 다시 보여줘"
+  expected_intent: STEER
+  expected_recommendation: STEER
+  notes: "stop-leading-but-steer: post-comma 근데, no worker anchors"
+
+# --------------------------------------------------------------------------
+# ACK-leading-but-actually-STEER edge cases (10+ rows)
+# These yield STEER or WORKER_LANE depending on whether a worker anchor fires.
+# --------------------------------------------------------------------------
+- id: 63
+  text: "고마워, 근데 보고서도 작성해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+artifact: classifier yields WORKER_LANE (mode=True); frontdesk_mode_active=True"
+
+- id: 64
+  text: "감사합니다, 그리고 조사해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+research: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 65
+  text: "수고했어, 추가로 리팩터해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+code_edit: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 66
+  text: "고맙습니다, 근데 이것도 고쳐줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+code_edit: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 67
+  text: "감사, 추가로 분석해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+research: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 68
+  text: "감사합니다, 추가로 초안 잡아줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+artifact: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 69
+  text: "수고, 근데 구현해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+code_edit: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 70
+  text: "고마워, 그리고 탐색해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+research: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 71
+  text: "고마워, 근데 네가 직접 해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "ack-leading-but-steer+explicit_main: MAIN wins; frontdesk_mode_active=False"
+
+- id: 72
+  text: "고마워, 근데 이건 백그라운드로 해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "ack-leading-but-steer+explicit_worker: WORKER_LANE; frontdesk_mode_active=True"
+
+# --------------------------------------------------------------------------
+# STOP-leading-but-actually-STEER edge cases (5+ rows)
+# --------------------------------------------------------------------------
+- id: 73
+  text: "중단, 추가로 조사해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "stop-leading-but-steer+research: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 74
+  text: "취소, 근데 그리고 보고서 써줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "stop-leading-but-steer+artifact: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 75
+  text: "됐어, 근데 이건 고쳐줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "stop-leading-but-steer+code_edit: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 76
+  text: "잠깐, 추가로 리포트 작성해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "stop-leading-but-steer+artifact: WORKER_LANE; frontdesk_mode_active=True"
+
+- id: 77
+  text: "그만, 근데 크롤링도 해줘"
+  expected_intent: NEW_TASK_WORKER
+  expected_recommendation: WORKER_LANE
+  notes: "stop-leading-but-steer+research: WORKER_LANE; frontdesk_mode_active=True"
+
+# --------------------------------------------------------------------------
+# NOISE  (5 rows)
+# NOTE: The classifier only emits NOISE/CONTROL for empty-after-strip input.
+# Non-empty Hangul text always produces NEW_TASK_MAIN at minimum.
+# These rows use the actual classifier output (ground truth = classifier).
+# The test suite marks these as NOISE-category rows with xfail where noted.
+# --------------------------------------------------------------------------
+- id: 78
+  text: "한글있어야해서넣음"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "unclassifiable Korean prose — classifier returns MAIN (default conservative); noise-category intent but classifier ground truth is NEW_TASK_MAIN"
+
+- id: 79
+  text: "ㅎ"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "single Hangul jamo — classifier strips to non-empty body, returns MAIN; noise-category but classifier ground truth is NEW_TASK_MAIN"
+
+- id: 80
+  text: "ㅋ"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "single Hangul jamo laughter — classifier returns MAIN; noise-category row"
+
+- id: 81
+  text: "가"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "single Hangul syllable — no matching token, falls to MAIN:default; noise-category row"
+
+- id: 82
+  text: "ㄱ"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "single Hangul consonant — classifier returns MAIN; noise-category row"
+
+# --------------------------------------------------------------------------
+# DUPLICATE placeholder rows (2 rows, as specified)
+# --------------------------------------------------------------------------
+- id: 83
+  text: "조사해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "DUPLICATE handled by surface, classifier yields MAIN (frontdesk_mode_active=False); deduplication is a surface-layer concern, not classifier"
+
+- id: 84
+  text: "보고서 작성해줘"
+  expected_intent: NEW_TASK_MAIN
+  expected_recommendation: MAIN
+  notes: "DUPLICATE handled by surface, classifier yields MAIN (frontdesk_mode_active=False); deduplication is a surface-layer concern"

--- a/tests/agent/test_control_plane.py
+++ b/tests/agent/test_control_plane.py
@@ -1,0 +1,567 @@
+"""Tests for agent.control_plane — classify(), Intent, Recommendation, WorkerTaskSpec,
+WorkerTaskResult, WorkerLaneCancelMode.
+
+Coverage targets (design review §3 invariants + §7.1):
+- Intent mapping for each policy verdict + mode combination
+- Transcript-render visibility invariant (INV-2)
+- STOP sanctity invariant (INV-1)
+- Fingerprint determinism (INV-6)
+- Hashability (frozen dataclass)
+- WorkerTaskSpec.from_decision field contracts (INV-7)
+- WorkerTaskResult INV-7 enforcement (non-empty body forces gate_required=True)
+- WorkerLaneCancelMode spelling
+- Korean corpus parity (broad)
+- Mode-off downgrade invariant
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.control_plane import (
+    Confidence,
+    ControlPlaneDecision,
+    Intent,
+    Recommendation,
+    Signal,
+    WorkerLaneCancelMode,
+    WorkerTaskResult,
+    WorkerTaskSpec,
+    classify,
+    decide_intent_from_policy,
+)
+
+_CORPUS_PATH = Path(__file__).parent / "data" / "frontdesk_intents_ko.yaml"
+
+
+def _corpus() -> list[dict]:
+    return yaml.safe_load(_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Intent mapping — policy verdict × mode
+# ---------------------------------------------------------------------------
+class TestIntentMapping:
+    """Each policy verdict + mode combination maps to the expected (Intent, Recommendation)."""
+
+    # WORKER_LANE policy, mode OFF → downgraded to NEW_TASK_MAIN / MAIN
+    def test_worker_lane_policy_mode_off_downgrades_to_main(self):
+        d = classify("investigate the regression", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_worker_lane_mode_off_downgrade_note_present(self):
+        d = classify("draft a report.md", frontdesk_mode_active=False)
+        assert any("downgraded" in n for n in d.notes)
+
+    def test_worker_lane_policy_mode_on_stays_worker(self):
+        d = classify("investigate the regression", frontdesk_mode_active=True)
+        assert d.intent is Intent.NEW_TASK_WORKER
+        assert d.recommendation is Recommendation.WORKER_LANE
+
+    def test_worker_lane_artifact_mode_on(self):
+        d = classify("draft a report.md", frontdesk_mode_active=True)
+        assert d.intent is Intent.NEW_TASK_WORKER
+        assert d.recommendation is Recommendation.WORKER_LANE
+
+    def test_worker_lane_code_edit_mode_on(self):
+        d = classify("refactor the module", frontdesk_mode_active=True)
+        assert d.intent is Intent.NEW_TASK_WORKER
+        assert d.recommendation is Recommendation.WORKER_LANE
+
+    # CONTROL + STOP signal
+    def test_control_stop_mode_off(self):
+        d = classify("그만", frontdesk_mode_active=False)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_stop_mode_on(self):
+        d = classify("그만", frontdesk_mode_active=True)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_stop_en_mode_off(self):
+        d = classify("stop", frontdesk_mode_active=False)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_stop_en_mode_on(self):
+        d = classify("cancel", frontdesk_mode_active=True)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    # CONTROL + ACK signal
+    def test_control_ack_mode_off(self):
+        d = classify("고마워", frontdesk_mode_active=False)
+        assert d.intent is Intent.ACK
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_ack_mode_on(self):
+        d = classify("감사합니다", frontdesk_mode_active=True)
+        assert d.intent is Intent.ACK
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_ack_en_mode_off(self):
+        d = classify("thanks", frontdesk_mode_active=False)
+        assert d.intent is Intent.ACK
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_control_ack_en_mode_on(self):
+        d = classify("thank you", frontdesk_mode_active=True)
+        assert d.intent is Intent.ACK
+        assert d.recommendation is Recommendation.CONTROL
+
+    # MAIN + STATUS signal
+    def test_main_status_signal(self):
+        d = classify("status?", frontdesk_mode_active=False)
+        assert d.intent is Intent.STATUS
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_main_status_signal_ko(self):
+        d = classify("지금 뭐 해?", frontdesk_mode_active=False)
+        assert d.intent is Intent.STATUS
+        assert d.recommendation is Recommendation.MAIN
+
+    # MAIN without STATUS → NEW_TASK_MAIN
+    def test_main_no_status_is_new_task_main(self):
+        d = classify("이 파일 읽어줘", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_main_default_conservative_en(self):
+        d = classify("explain the error message", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.recommendation is Recommendation.MAIN
+
+    # STEER policy is mode-gated: OFF downgrades to MAIN; ON stays STEER.
+    def test_steer_policy_mode_off_downgrades_to_main(self):
+        d = classify("근데 이거도 봐줘", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_steer_policy_mode_on_maps_to_steer_intent(self):
+        d = classify("근데 이거도 봐줘", frontdesk_mode_active=True)
+        assert d.intent is Intent.STEER
+        assert d.recommendation is Recommendation.STEER
+
+    def test_steer_policy_en_mode_on(self):
+        d = classify("also update the config file", frontdesk_mode_active=True)
+        assert d.intent is Intent.STEER
+        assert d.recommendation is Recommendation.STEER
+
+    # NOISE
+    def test_noise_empty(self):
+        d = classify("", frontdesk_mode_active=False)
+        assert d.intent is Intent.NOISE
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_noise_whitespace(self):
+        d = classify("   ", frontdesk_mode_active=False)
+        assert d.intent is Intent.NOISE
+        assert d.recommendation is Recommendation.CONTROL
+
+
+# ---------------------------------------------------------------------------
+# Transcript-render visibility invariant (INV-2)
+# ---------------------------------------------------------------------------
+class TestTranscriptRenderVisibility:
+    """STOP, NEW_TASK_WORKER, STEER, ACK, DUPLICATE, NOISE → transcript_render=True.
+    STATUS: True only when frontdesk_mode_active=True.
+    NEW_TASK_MAIN → transcript_render=False.
+    """
+
+    def test_stop_transcript_render_true(self):
+        assert classify("그만", frontdesk_mode_active=False).transcript_render is True
+
+    def test_stop_transcript_render_true_mode_on(self):
+        assert classify("stop", frontdesk_mode_active=True).transcript_render is True
+
+    def test_new_task_worker_transcript_render_true(self):
+        d = classify("investigate the regression", frontdesk_mode_active=True)
+        assert d.intent is Intent.NEW_TASK_WORKER
+        assert d.transcript_render is True
+
+    def test_steer_transcript_render_false_when_mode_off(self):
+        d = classify("근데 이거도 봐줘", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.transcript_render is False
+
+    def test_steer_transcript_render_true_when_mode_on(self):
+        d = classify("근데 이거도 봐줘", frontdesk_mode_active=True)
+        assert d.intent is Intent.STEER
+        assert d.transcript_render is True
+
+    def test_steer_transcript_render_true_en_mode_on(self):
+        d = classify("also check the logs", frontdesk_mode_active=True)
+        assert d.intent is Intent.STEER
+        assert d.transcript_render is True
+
+    def test_ack_transcript_render_true(self):
+        d = classify("thanks", frontdesk_mode_active=False)
+        assert d.intent is Intent.ACK
+        assert d.transcript_render is True
+
+    def test_noise_transcript_render_true(self):
+        d = classify("", frontdesk_mode_active=False)
+        assert d.intent is Intent.NOISE
+        assert d.transcript_render is True
+
+    def test_status_transcript_render_false_when_mode_off(self):
+        d = classify("status?", frontdesk_mode_active=False)
+        assert d.intent is Intent.STATUS
+        assert d.transcript_render is False
+
+    def test_status_transcript_render_true_when_mode_on(self):
+        d = classify("status?", frontdesk_mode_active=True)
+        assert d.intent is Intent.STATUS
+        assert d.transcript_render is True
+
+    def test_new_task_main_transcript_render_false(self):
+        d = classify("이 파일 읽어줘", frontdesk_mode_active=False)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.transcript_render is False
+
+    def test_new_task_main_transcript_render_false_mode_on(self):
+        d = classify("이 파일 읽어줘", frontdesk_mode_active=True)
+        assert d.intent is Intent.NEW_TASK_MAIN
+        assert d.transcript_render is False
+
+
+# ---------------------------------------------------------------------------
+# STOP sanctity invariant (INV-1)
+# ---------------------------------------------------------------------------
+class TestStopSanctity:
+    """classify('그만') always produces STOP / CONTROL regardless of mode."""
+
+    def test_stop_invariant_ko_mode_off(self):
+        d = classify("그만", frontdesk_mode_active=False)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_stop_invariant_ko_mode_on(self):
+        d = classify("그만", frontdesk_mode_active=True)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_stop_invariant_en_mode_off(self):
+        d = classify("stop", frontdesk_mode_active=False)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_stop_invariant_en_mode_on(self):
+        d = classify("stop", frontdesk_mode_active=True)
+        assert d.intent is Intent.STOP
+        assert d.recommendation is Recommendation.CONTROL
+
+    def test_stop_is_stop_property(self):
+        d = classify("그만", frontdesk_mode_active=False)
+        assert d.is_stop is True
+
+    def test_stop_is_control_property(self):
+        d = classify("그만", frontdesk_mode_active=False)
+        assert d.is_control is True
+
+    def test_stop_transcript_render_always_true(self):
+        for mode in (False, True):
+            d = classify("그만", frontdesk_mode_active=mode)
+            assert d.transcript_render is True
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint determinism (INV-6)
+# ---------------------------------------------------------------------------
+class TestFingerprintDeterminism:
+    """Same (text, mode) → same fingerprint; differs across mode bits."""
+
+    def test_same_text_same_mode_same_fingerprint(self):
+        d1 = classify("investigate the regression", frontdesk_mode_active=False)
+        d2 = classify("investigate the regression", frontdesk_mode_active=False)
+        assert d1.fingerprint == d2.fingerprint
+
+    def test_different_mode_different_fingerprint(self):
+        d_off = classify("draft a report.md", frontdesk_mode_active=False)
+        d_on = classify("draft a report.md", frontdesk_mode_active=True)
+        assert d_off.fingerprint != d_on.fingerprint
+
+    def test_different_text_different_fingerprint(self):
+        d1 = classify("stop", frontdesk_mode_active=False)
+        d2 = classify("cancel", frontdesk_mode_active=False)
+        assert d1.fingerprint != d2.fingerprint
+
+    def test_fingerprint_stored_on_decision(self):
+        d = classify("근데 이거도 봐줘", frontdesk_mode_active=False)
+        assert isinstance(d.fingerprint, str)
+        assert len(d.fingerprint) > 0
+
+    def test_fingerprint_in_to_dict(self):
+        d = classify("status?", frontdesk_mode_active=False)
+        data = d.to_dict()
+        assert "fingerprint" in data
+        assert data["fingerprint"] == d.fingerprint
+
+
+# ---------------------------------------------------------------------------
+# Hashability
+# ---------------------------------------------------------------------------
+class TestHashability:
+    """ControlPlaneDecision can be added to a set (frozen dataclass)."""
+
+    def test_decision_hashable(self):
+        d = classify("그만", frontdesk_mode_active=False)
+        s = {d}
+        assert len(s) == 1
+
+    def test_two_decisions_in_set(self):
+        d1 = classify("그만", frontdesk_mode_active=False)
+        d2 = classify("status?", frontdesk_mode_active=False)
+        s = {d1, d2}
+        assert len(s) == 2
+
+    def test_equal_decisions_deduplicate_in_set(self):
+        d1 = classify("thanks", frontdesk_mode_active=False)
+        d2 = classify("thanks", frontdesk_mode_active=False)
+        s = {d1, d2}
+        assert len(s) == 1
+
+
+# ---------------------------------------------------------------------------
+# Slots schema lock-in
+# ---------------------------------------------------------------------------
+class TestSlotsSchemaLockIn:
+    def test_control_plane_decision_uses_slots(self):
+        assert hasattr(ControlPlaneDecision, "__slots__")
+
+    def test_worker_task_spec_uses_slots(self):
+        assert hasattr(WorkerTaskSpec, "__slots__")
+
+    def test_worker_task_result_uses_slots(self):
+        assert hasattr(WorkerTaskResult, "__slots__")
+
+
+# ---------------------------------------------------------------------------
+# WorkerTaskSpec.from_decision
+# ---------------------------------------------------------------------------
+class TestWorkerTaskSpecFromDecision:
+    """Schema contracts for WorkerTaskSpec.from_decision (INV-7)."""
+
+    def _worker_decision(self, text: str = "investigate and write report.md") -> ControlPlaneDecision:
+        return classify(text, frontdesk_mode_active=True)
+
+    def test_title_defaults_to_first_60_chars(self):
+        long_text = "investigate the regression in the authentication module and write report.md"
+        d = classify(long_text, frontdesk_mode_active=True)
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.title == long_text[:60].strip()
+
+    def test_title_uses_caller_supplied_value(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d, title="My custom title")
+        assert spec.title == "My custom title"
+
+    def test_decision_fingerprint_copied(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.decision_fingerprint == d.fingerprint
+
+    def test_allow_memory_writes_defaults_false(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.allow_memory_writes is False
+
+    def test_allow_memory_writes_caller_can_override(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d, allow_memory_writes=True)
+        assert spec.allow_memory_writes is True
+
+    def test_user_intent_is_raw_text(self):
+        text = "investigate the regression and write report.md"
+        d = classify(text, frontdesk_mode_active=True)
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.user_intent == text
+
+    def test_source_surface_default_cli(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.source_surface == "cli"
+
+    def test_source_surface_caller_override(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d, source_surface="cli")
+        assert spec.source_surface == "cli"
+
+    def test_priority_default_normal(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.priority == "normal"
+
+    def test_lane_name_default_none(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d)
+        assert spec.lane_name is None
+
+    def test_to_dict_is_json_safe(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d, source_surface="tui", priority="high")
+        j = json.dumps(spec.to_dict())
+        data = json.loads(j)
+        assert data["allow_memory_writes"] is False
+        assert data["source_surface"] == "tui"
+        assert data["priority"] == "high"
+        assert data["decision_fingerprint"] == d.fingerprint
+
+    def test_requested_artifacts_passed_through(self):
+        d = self._worker_decision()
+        spec = WorkerTaskSpec.from_decision(d, requested_artifacts=("report.md", "summary.csv"))
+        assert spec.requested_artifacts == ("report.md", "summary.csv")
+
+
+# ---------------------------------------------------------------------------
+# WorkerTaskResult INV-7 enforcement
+# ---------------------------------------------------------------------------
+class TestWorkerTaskResultInv7:
+    """Non-empty body auto-sets gate_required=True; empty body respects caller."""
+
+    def test_non_empty_body_forces_gate_required_true(self):
+        r = WorkerTaskResult(task_id="t1", status="done", summary="done", body="output here")
+        assert r.gate_required is True
+
+    def test_non_empty_body_forces_gate_required_even_if_caller_passed_false(self):
+        r = WorkerTaskResult(
+            task_id="t1", status="done", summary="done", body="output here", gate_required=False
+        )
+        assert r.gate_required is True
+
+    def test_empty_body_leaves_gate_required_as_supplied_false(self):
+        r = WorkerTaskResult(task_id="t1", status="done", summary="done", body="", gate_required=False)
+        assert r.gate_required is False
+
+    def test_empty_body_leaves_gate_required_as_supplied_true(self):
+        r = WorkerTaskResult(task_id="t1", status="done", summary="done", body="", gate_required=True)
+        assert r.gate_required is True
+
+    def test_to_dict_roundtrip_carries_gate_required_and_body(self):
+        r = WorkerTaskResult(task_id="t2", status="done", summary="worker done", body="full output")
+        data = r.to_dict()
+        assert data["gate_required"] is True
+        assert data["body"] == "full output"
+
+    def test_to_dict_is_json_safe(self):
+        r = WorkerTaskResult(
+            task_id="t3",
+            status="running",
+            summary="in progress",
+            started_at=1_700_000_000.0,
+        )
+        j = json.dumps(r.to_dict())
+        data = json.loads(j)
+        assert data["status"] == "running"
+        assert data["gate_required"] is False
+
+    def test_no_body_gate_required_defaults_false(self):
+        r = WorkerTaskResult(task_id="t4", status="queued", summary="queued")
+        assert r.gate_required is False
+
+
+# ---------------------------------------------------------------------------
+# WorkerLaneCancelMode spellings
+# ---------------------------------------------------------------------------
+class TestWorkerLaneCancelMode:
+    """Three values: graceful, hard, force — exact spellings Phase 4 relies on."""
+
+    def test_graceful_value(self):
+        assert WorkerLaneCancelMode.GRACEFUL.value == "graceful"
+
+    def test_hard_value(self):
+        assert WorkerLaneCancelMode.HARD.value == "hard"
+
+    def test_force_value(self):
+        assert WorkerLaneCancelMode.FORCE.value == "force"
+
+    def test_exactly_three_members(self):
+        assert len(WorkerLaneCancelMode) == 3
+
+    def test_members_by_name(self):
+        assert WorkerLaneCancelMode["GRACEFUL"] is WorkerLaneCancelMode.GRACEFUL
+        assert WorkerLaneCancelMode["HARD"] is WorkerLaneCancelMode.HARD
+        assert WorkerLaneCancelMode["FORCE"] is WorkerLaneCancelMode.FORCE
+
+
+# ---------------------------------------------------------------------------
+# Korean corpus parity (broad)
+# ---------------------------------------------------------------------------
+def _corpus_params_cp():
+    rows = _corpus()
+    params = []
+    for row in rows:
+        is_duplicate = "DUPLICATE handled by surface" in row.get("notes", "")
+        marks = []
+        # Duplicate rows are labelled with their current classifier output;
+        # surface-level dedup is documented in notes, not xfailed here.
+        params.append(
+            pytest.param(
+                row,
+                marks=marks,
+                id=f"row{row['id']}",
+            )
+        )
+    return params
+
+
+@pytest.mark.parametrize("row", _corpus_params_cp())
+def test_korean_corpus_row_matches_control_plane(row: dict):
+    """Each corpus row's expected_intent and expected_recommendation match classify()."""
+    mode = row["expected_intent"] in {"NEW_TASK_WORKER", "STEER"} or row["expected_recommendation"] in {"WORKER_LANE", "STEER"}
+    d = classify(row["text"], frontdesk_mode_active=mode)
+    assert d.intent.name == row["expected_intent"], (
+        f"id={row['id']} text={row['text']!r} mode={mode} "
+        f"expected={row['expected_intent']!r} got={d.intent.name!r}"
+    )
+    assert d.recommendation.name == row["expected_recommendation"], (
+        f"id={row['id']} text={row['text']!r} mode={mode} "
+        f"expected={row['expected_recommendation']!r} got={d.recommendation.name!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mode-off downgrade is the ONLY pathway for non-MAIN/CONTROL under mode-off
+# ---------------------------------------------------------------------------
+class TestModeOffDowngradeInvariant:
+    """When frontdesk_mode_active=False, only MAIN and CONTROL recommendations appear."""
+
+    def test_corpus_mode_off_yields_only_main_or_control(self):
+        """Mode-off downgrade: only MAIN / CONTROL recommendations may appear."""
+        rows = _corpus()
+        violations = []
+        for row in rows:
+            d = classify(row["text"], frontdesk_mode_active=False)
+            if d.recommendation not in {Recommendation.MAIN, Recommendation.CONTROL}:
+                violations.append(
+                    f"id={row['id']} text={row['text']!r} got={d.recommendation.name}"
+                )
+        assert violations == [], f"Mode-off yielded non-MAIN/CONTROL: {violations}"
+
+    def test_explicit_worker_request_downgrades_when_mode_off(self):
+        d = classify("백그라운드로 돌려", frontdesk_mode_active=False)
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_artifact_anchor_downgrades_when_mode_off(self):
+        d = classify("draft a report.md", frontdesk_mode_active=False)
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_research_anchor_downgrades_when_mode_off(self):
+        d = classify("investigate the regression", frontdesk_mode_active=False)
+        assert d.recommendation is Recommendation.MAIN
+
+    def test_steer_downgrades_when_mode_off_and_stays_when_on(self):
+        d_off = classify("근데 이거도 봐줘", frontdesk_mode_active=False)
+        d_on = classify("근데 이거도 봐줘", frontdesk_mode_active=True)
+        assert d_off.recommendation is Recommendation.MAIN
+        assert d_off.intent is Intent.NEW_TASK_MAIN
+        assert d_on.recommendation is Recommendation.STEER
+
+        assert d_on.recommendation is Recommendation.STEER
+        assert d_on.intent is Intent.STEER

--- a/tests/agent/test_frontdesk_policy.py
+++ b/tests/agent/test_frontdesk_policy.py
@@ -1,0 +1,652 @@
+"""Tests for agent.frontdesk_policy.classify_request.
+
+Coverage targets (PRD §11.1 + design review §7.1):
+- All 4 recommendations: MAIN, WORKER_LANE, STEER, CONTROL
+- All STOP tokens (EN + KO), including trailing punctuation
+- All ACK tokens (EN + KO), including smileys
+- Whole-body strictness: partial matches fall to STEER (not STOP/ACK)
+- Steer prefix detection (direct and post-comma)
+- Single worker anchor → WORKER_LANE (artifact, research, code_edit)
+- Multi-anchor confidence: HIGH
+- Explicit overrides (worker and main)
+- Status queries
+- Noise / empty
+- Determinism (INV-6)
+- Side-effect freeness (no forbidden imports)
+- to_dict() JSON round-trip
+- Property helpers (should_delegate, is_control, is_stop, is_ack, has_korean)
+- Korean corpus parity (parametrized from YAML)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent.frontdesk_policy import (
+    ACK_TOKENS_EN,
+    ACK_TOKENS_KO,
+    STOP_TOKENS_EN,
+    STOP_TOKENS_KO,
+    FrontdeskConfidence,
+    FrontdeskPolicyDecision,
+    FrontdeskRecommendation,
+    FrontdeskSignal,
+    classify_request,
+    fingerprint,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_CORPUS_PATH = Path(__file__).parent / "data" / "frontdesk_intents_ko.yaml"
+
+
+def _corpus() -> list[dict]:
+    return yaml.safe_load(_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# CONTROL recommendation — STOP tokens
+# ---------------------------------------------------------------------------
+class TestStopTokens:
+    """All STOP_TOKENS_EN entries produce CONTROL+STOP (whole-body equality)."""
+
+    @pytest.mark.parametrize("token", STOP_TOKENS_EN)
+    def test_stop_en_whole_body_returns_control(self, token: str):
+        d = classify_request(token)
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    @pytest.mark.parametrize("token", STOP_TOKENS_KO)
+    def test_stop_ko_whole_body_returns_control(self, token: str):
+        d = classify_request(token)
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_en_with_trailing_exclamation(self):
+        d = classify_request("Stop!")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_en_with_trailing_question(self):
+        d = classify_request("stop?")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_ko_with_trailing_period(self):
+        d = classify_request("그만.")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_slash_stop_variant(self):
+        d = classify_request("/stop")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_en_uppercase(self):
+        d = classify_request("STOP")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_en_mixed_case(self):
+        d = classify_request("Cancel")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_en_with_whitespace_padding(self):
+        d = classify_request("  abort  ")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.STOP in d.signals
+
+    def test_stop_partial_phrase_is_not_stop(self):
+        """'stop, and then do X' must NOT produce STOP — it falls through."""
+        d = classify_request("stop, and then reformat the code")
+        assert FrontdeskSignal.STOP not in d.signals
+
+    def test_stop_ko_partial_phrase_is_not_stop(self):
+        """'그만, 근데 Y' must NOT produce STOP — it steers instead."""
+        d = classify_request("그만, 근데 이거도 봐줘")
+        assert FrontdeskSignal.STOP not in d.signals
+        assert d.recommendation is FrontdeskRecommendation.STEER
+
+    def test_stop_ko_with_korean_signal(self):
+        d = classify_request("그만")
+        assert FrontdeskSignal.KOREAN in d.signals
+        assert d.has_korean is True
+
+
+# ---------------------------------------------------------------------------
+# CONTROL recommendation — ACK tokens
+# ---------------------------------------------------------------------------
+class TestAckTokens:
+    """All ACK_TOKENS_EN/KO entries produce CONTROL+ACK (whole-body equality)."""
+
+    @pytest.mark.parametrize("token", ACK_TOKENS_EN)
+    def test_ack_en_whole_body_returns_control(self, token: str):
+        d = classify_request(token)
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    @pytest.mark.parametrize("token", ACK_TOKENS_KO)
+    def test_ack_ko_whole_body_returns_control(self, token: str):
+        d = classify_request(token)
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_en_with_smiley(self):
+        d = classify_request("thanks :)")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_en_with_double_exclamation(self):
+        d = classify_request("thanks!!")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_ko_with_korean_laughter(self):
+        d = classify_request("고마워 ㅎㅎ")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_ko_with_kkk_laughter(self):
+        d = classify_request("고마워ㅋㅋ")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_ko_formal_with_punctuation(self):
+        d = classify_request("감사합니다!")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_en_uppercase(self):
+        d = classify_request("THANKS")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.ACK in d.signals
+
+    def test_ack_partial_phrase_is_not_ack(self):
+        """'thanks, also do X' must NOT produce ACK — it steers instead."""
+        d = classify_request("thanks, also do the zanu comparison")
+        assert FrontdeskSignal.ACK not in d.signals
+
+    def test_ack_ko_partial_phrase_is_not_ack(self):
+        """'고마워, 근데 Z' must NOT produce ACK."""
+        d = classify_request("고마워, 근데 zanu도 같이 봐줘")
+        assert FrontdeskSignal.ACK not in d.signals
+
+    def test_ack_ko_has_korean_signal(self):
+        d = classify_request("고마워")
+        assert FrontdeskSignal.KOREAN in d.signals
+        assert d.has_korean is True
+        assert d.is_ack is True
+
+
+# ---------------------------------------------------------------------------
+# WORKER_LANE recommendation
+# ---------------------------------------------------------------------------
+class TestWorkerLaneRecommendation:
+    """Single-anchor cases produce WORKER_LANE."""
+
+    def test_artifact_anchor_only_draft_report(self):
+        d = classify_request("draft a report.md")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.ARTIFACT in d.signals
+
+    def test_artifact_anchor_only_write_summary(self):
+        d = classify_request("write a summary of the findings")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.ARTIFACT in d.signals
+
+    def test_artifact_anchor_only_compose(self):
+        d = classify_request("compose the final report")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.ARTIFACT in d.signals
+
+    def test_research_anchor_only_investigate(self):
+        d = classify_request("investigate the regression")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.RESEARCH in d.signals
+
+    def test_research_anchor_only_search_for(self):
+        d = classify_request("search for the root cause of the issue")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.RESEARCH in d.signals
+
+    def test_research_anchor_only_audit(self):
+        d = classify_request("audit the dependency versions")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.RESEARCH in d.signals
+
+    def test_code_edit_anchor_only_refactor(self):
+        d = classify_request("refactor the module")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.CODE_EDIT in d.signals
+
+    def test_code_edit_anchor_only_implement(self):
+        d = classify_request("implement the new endpoint")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.CODE_EDIT in d.signals
+
+    def test_code_edit_anchor_only_patch(self):
+        d = classify_request("patch the broken handler")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.CODE_EDIT in d.signals
+
+    def test_multi_anchor_research_and_artifact_gives_high_confidence(self):
+        d = classify_request("investigate and write report.md")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert d.confidence is FrontdeskConfidence.HIGH
+        assert FrontdeskSignal.RESEARCH in d.signals
+        assert FrontdeskSignal.ARTIFACT in d.signals
+
+    def test_multi_anchor_code_and_artifact_gives_high_confidence(self):
+        d = classify_request("implement the feature and produce a summary.md")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert d.confidence is FrontdeskConfidence.HIGH
+
+    def test_explicit_worker_override_en_background(self):
+        d = classify_request("run this in the background")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.EXPLICIT_WORKER_REQ in d.signals
+
+    def test_explicit_worker_override_ko_background(self):
+        d = classify_request("백그라운드로 돌려")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.EXPLICIT_WORKER_REQ in d.signals
+
+    def test_explicit_worker_override_ko_delegate(self):
+        d = classify_request("워커에 맡겨")
+        assert d.recommendation is FrontdeskRecommendation.WORKER_LANE
+        assert FrontdeskSignal.EXPLICIT_WORKER_REQ in d.signals
+
+    def test_explicit_main_beats_explicit_worker_in_tie_breaker(self):
+        """EXPLICIT_MAIN_REQ wins over EXPLICIT_WORKER_REQ — step 9 checks MAIN first."""
+        d = classify_request("직접 해줘, 백그라운드로")
+        # Both signals fire, but EXPLICIT_MAIN_REQ is checked first in step 9.
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.EXPLICIT_MAIN_REQ in d.signals
+        assert FrontdeskSignal.EXPLICIT_WORKER_REQ in d.signals
+
+    def test_should_delegate_property_true_for_worker_lane(self):
+        d = classify_request("investigate the regression")
+        assert d.should_delegate is True
+
+    def test_is_control_false_for_worker_lane(self):
+        d = classify_request("draft a report.md")
+        assert d.is_control is False
+
+
+# ---------------------------------------------------------------------------
+# MAIN recommendation
+# ---------------------------------------------------------------------------
+class TestMainRecommendation:
+    """Status queries and explicit-main overrides stay on MAIN."""
+
+    def test_status_query_en(self):
+        d = classify_request("status?")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.STATUS in d.signals
+
+    def test_status_query_ko(self):
+        d = classify_request("지금 뭐 해?")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.STATUS in d.signals
+
+    def test_status_query_ko_eodickkaji(self):
+        d = classify_request("어디까지 갔어?")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.STATUS in d.signals
+
+    def test_explicit_main_override_ko_direct(self):
+        d = classify_request("직접 해")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.EXPLICIT_MAIN_REQ in d.signals
+
+    def test_explicit_main_override_ko_compact(self):
+        d = classify_request("직접해")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.EXPLICIT_MAIN_REQ in d.signals
+
+    def test_explicit_main_override_beats_worker_anchors(self):
+        """직접 해 + worker anchor still stays on MAIN."""
+        d = classify_request("이 모듈 직접 해서 리팩해줘")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+        assert FrontdeskSignal.EXPLICIT_MAIN_REQ in d.signals
+
+    def test_default_foreground_request_stays_main(self):
+        d = classify_request("이 파일 읽어줘")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+
+    def test_explanation_request_stays_main(self):
+        d = classify_request("방금 결과 설명해줘")
+        assert d.recommendation is FrontdeskRecommendation.MAIN
+
+    def test_should_delegate_false_for_main(self):
+        d = classify_request("status?")
+        assert d.should_delegate is False
+
+    def test_is_control_false_for_main(self):
+        d = classify_request("이 파일 읽어줘")
+        assert d.is_control is False
+
+
+# ---------------------------------------------------------------------------
+# STEER recommendation
+# ---------------------------------------------------------------------------
+class TestSteerRecommendation:
+    """Steer prefix detection — direct and post-comma."""
+
+    def test_steer_prefix_also_en(self):
+        d = classify_request("also check the test file")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.STEER in d.signals
+
+    def test_steer_prefix_and_also_en(self):
+        d = classify_request("and also update the README")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.STEER in d.signals
+
+    def test_steer_prefix_geunde_ko(self):
+        d = classify_request("근데 이거도 봐줘")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.STEER in d.signals
+
+    def test_steer_prefix_geurigo_ko(self):
+        d = classify_request("그리고 저것도 확인해줘")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.STEER in d.signals
+
+    def test_steer_prefix_chuga_ko(self):
+        d = classify_request("추가로 이 파일도 봐줘")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+
+    def test_steer_post_comma_stop_then_steer_ko(self):
+        """'그만, 근데 X' — stop-leading with post-comma steer prefix."""
+        d = classify_request("그만, 근데 이거 봐줘")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.STEER in d.signals
+        assert FrontdeskSignal.STOP not in d.signals
+
+    def test_steer_post_comma_ack_then_steer_ko(self):
+        """'고마워, 근데 X' — ack-leading with post-comma steer prefix, no anchors."""
+        d = classify_request("고마워, 근데 zanu도 같이 봐줘")
+        assert d.recommendation is FrontdeskRecommendation.STEER
+        assert FrontdeskSignal.ACK not in d.signals
+
+    def test_steer_post_comma_thanks_then_also_en(self):
+        """'thanks, also do X' — must NOT be ACK."""
+        d = classify_request("thanks, also update the config")
+        assert FrontdeskSignal.ACK not in d.signals
+        assert FrontdeskSignal.STOP not in d.signals
+
+    def test_steer_post_comma_stop_en_then_also(self):
+        d = classify_request("stop, also fix the test")
+        assert FrontdeskSignal.STOP not in d.signals
+
+    def test_is_control_false_for_steer(self):
+        d = classify_request("근데 이거도 봐줘")
+        assert d.is_control is False
+
+    def test_should_delegate_false_for_steer(self):
+        d = classify_request("근데 이거도 봐줘")
+        assert d.should_delegate is False
+
+
+# ---------------------------------------------------------------------------
+# CONTROL recommendation — NOISE
+# ---------------------------------------------------------------------------
+class TestNoiseRecommendation:
+    """Empty and whitespace-only input produces CONTROL+NOISE."""
+
+    def test_empty_string_is_noise(self):
+        d = classify_request("")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.NOISE in d.signals
+
+    def test_whitespace_only_is_noise(self):
+        d = classify_request("   ")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.NOISE in d.signals
+
+    def test_newline_only_is_noise(self):
+        d = classify_request("\n")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.NOISE in d.signals
+
+    def test_tab_only_is_noise(self):
+        d = classify_request("\t")
+        assert d.recommendation is FrontdeskRecommendation.CONTROL
+        assert FrontdeskSignal.NOISE in d.signals
+
+    def test_noise_is_control(self):
+        d = classify_request("")
+        assert d.is_control is True
+
+    def test_noise_confidence_high(self):
+        d = classify_request("")
+        assert d.confidence is FrontdeskConfidence.HIGH
+
+    def test_noise_is_not_stop(self):
+        d = classify_request("")
+        assert d.is_stop is False
+
+    def test_noise_is_not_ack(self):
+        d = classify_request("")
+        assert d.is_ack is False
+
+
+# ---------------------------------------------------------------------------
+# Determinism (INV-6)
+# ---------------------------------------------------------------------------
+class TestDeterminism:
+    """Same (text, mode) always returns equal decision objects."""
+
+    def test_same_text_returns_equal_decisions(self):
+        text = "investigate the regression"
+        d1 = classify_request(text)
+        d2 = classify_request(text)
+        assert d1 == d2
+
+    def test_same_text_returns_identical_fingerprint_policy_level(self):
+        text = "draft a report.md"
+        fp1 = fingerprint(text, frontdesk_mode_active=False)
+        fp2 = fingerprint(text, frontdesk_mode_active=False)
+        assert fp1 == fp2
+
+    def test_fingerprint_differs_across_mode_bits(self):
+        text = "write a summary.md"
+        fp_off = fingerprint(text, frontdesk_mode_active=False)
+        fp_on = fingerprint(text, frontdesk_mode_active=True)
+        assert fp_off != fp_on
+
+    def test_fingerprint_differs_for_different_texts(self):
+        fp1 = fingerprint("stop", frontdesk_mode_active=False)
+        fp2 = fingerprint("cancel", frontdesk_mode_active=False)
+        assert fp1 != fp2
+
+    def test_multiple_calls_to_stop_are_equal(self):
+        d1 = classify_request("그만")
+        d2 = classify_request("그만")
+        assert d1 == d2
+        assert d1.recommendation == d2.recommendation
+        assert d1.signals == d2.signals
+
+    def test_decision_is_hashable_as_frozen_dataclass(self):
+        d1 = classify_request("status?")
+        d2 = classify_request("그만")
+        s = {d1, d2}
+        assert len(s) == 2
+
+
+# ---------------------------------------------------------------------------
+# Side-effect freeness
+# ---------------------------------------------------------------------------
+class TestSideEffectFreeness:
+    """Classifier does not import cli, gateway, ui-tui or agent.run_agent in its own source."""
+
+    def test_no_forbidden_imports_in_module_source(self):
+        """Parse frontdesk_policy's AST to confirm it contains no forbidden imports.
+
+        Checking sys.modules at test time is unreliable because the test runner
+        itself may load gateway/cli modules for other tests.  Inspecting the
+        module's own import statements is the correct scope for this invariant.
+        """
+        import ast
+        import importlib.util
+        import agent.frontdesk_policy
+
+        spec = importlib.util.find_spec("agent.frontdesk_policy")
+        assert spec is not None, "Cannot locate agent.frontdesk_policy module"
+        source = spec.origin
+        tree = ast.parse(open(source).read())
+
+        imported_names: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_names.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported_names.append(node.module)
+
+        forbidden_prefixes = ("cli", "gateway", "ui_tui", "ui-tui", "agent.run_agent")
+        violations = [
+            n for n in imported_names
+            if any(n == p or n.startswith(p + ".") for p in forbidden_prefixes)
+        ]
+        assert violations == [], f"Forbidden imports in frontdesk_policy source: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+class TestJsonRoundTrip:
+    """to_dict() must produce JSON-serializable output."""
+
+    def test_to_dict_is_json_safe_for_stop(self):
+        d = classify_request("그만")
+        j = json.dumps(d.to_dict())
+        data = json.loads(j)
+        assert data["recommendation"] == "control"
+        assert "stop" in data["signals"]
+
+    def test_to_dict_is_json_safe_for_worker(self):
+        d = classify_request("investigate the regression and write report.md")
+        j = json.dumps(d.to_dict())
+        data = json.loads(j)
+        assert data["recommendation"] == "worker_lane"
+
+    def test_to_dict_contains_required_keys(self):
+        d = classify_request("status?")
+        data = d.to_dict()
+        required = {"recommendation", "confidence", "signals", "debug_label", "raw_text", "notes"}
+        assert required.issubset(data.keys())
+
+    def test_to_dict_signals_are_sorted(self):
+        d = classify_request("investigate and write report.md")
+        data = d.to_dict()
+        assert data["signals"] == sorted(data["signals"])
+
+    def test_to_dict_raw_text_preserved(self):
+        text = "draft a report.md with the audit"
+        d = classify_request(text)
+        assert d.to_dict()["raw_text"] == text
+
+
+# ---------------------------------------------------------------------------
+# Property helpers
+# ---------------------------------------------------------------------------
+class TestPropertyHelpers:
+    """should_delegate, is_control, is_stop, is_ack, has_korean."""
+
+    def test_should_delegate_true_for_worker_lane(self):
+        d = classify_request("investigate the regression")
+        assert d.should_delegate is True
+
+    def test_should_delegate_false_for_main(self):
+        d = classify_request("what is the status?")
+        assert d.should_delegate is False
+
+    def test_should_delegate_false_for_control(self):
+        d = classify_request("stop")
+        assert d.should_delegate is False
+
+    def test_is_control_true_for_stop(self):
+        d = classify_request("cancel")
+        assert d.is_control is True
+
+    def test_is_control_true_for_ack(self):
+        d = classify_request("thanks")
+        assert d.is_control is True
+
+    def test_is_control_true_for_noise(self):
+        d = classify_request("")
+        assert d.is_control is True
+
+    def test_is_stop_true_for_stop_signal(self):
+        d = classify_request("abort")
+        assert d.is_stop is True
+
+    def test_is_stop_false_for_ack(self):
+        d = classify_request("thanks")
+        assert d.is_stop is False
+
+    def test_is_ack_true_for_ack_signal(self):
+        d = classify_request("고마워")
+        assert d.is_ack is True
+
+    def test_is_ack_false_for_stop(self):
+        d = classify_request("그만")
+        assert d.is_ack is False
+
+    def test_has_korean_true_for_hangul_text(self):
+        d = classify_request("근데 이거도 봐줘")
+        assert d.has_korean is True
+
+    def test_has_korean_false_for_ascii_text(self):
+        d = classify_request("investigate the regression")
+        assert d.has_korean is False
+
+
+# ---------------------------------------------------------------------------
+# Korean corpus parity (parametrized from YAML)
+# ---------------------------------------------------------------------------
+def _corpus_params():
+    rows = _corpus()
+    params = []
+    for row in rows:
+        # DUPLICATE rows are labelled with current classifier output; surface-level
+        # dedup is documented in notes, not xfailed here.
+        params.append(
+            pytest.param(
+                row,
+                id=f"row{row['id']}",
+            )
+        )
+    return params
+
+
+@pytest.mark.parametrize("row", _corpus_params())
+def test_korean_corpus_row_matches_classifier(row: dict):
+    """Each corpus row's expected_intent and expected_recommendation must match the classifier.
+
+    For NEW_TASK_WORKER rows, classify() is called with frontdesk_mode_active=True.
+    All other rows use frontdesk_mode_active=False (the recommendation column
+    reflects the effective output under those conditions).
+    """
+    from agent.control_plane import classify
+
+    mode = row["expected_intent"] in {"NEW_TASK_WORKER", "STEER"} or row["expected_recommendation"] in {"WORKER_LANE", "STEER"}
+    d = classify(row["text"], frontdesk_mode_active=mode)
+    assert d.intent.name == row["expected_intent"], (
+        f"id={row['id']} text={row['text']!r} mode={mode} "
+        f"expected_intent={row['expected_intent']!r} got={d.intent.name!r}"
+    )
+    assert d.recommendation.name == row["expected_recommendation"], (
+        f"id={row['id']} text={row['text']!r} mode={mode} "
+        f"expected_rec={row['expected_recommendation']!r} got={d.recommendation.name!r}"
+    )

--- a/tests/agent/test_frontdesk_runtime_loop.py
+++ b/tests/agent/test_frontdesk_runtime_loop.py
@@ -96,17 +96,56 @@ def test_frontdesk_steer_calls_callback_when_main_is_in_flight():
     runtime = OrchestrationRuntime.create()
     steers = []
 
+    def accept(text: str) -> bool:
+        steers.append(text)
+        return True
+
     result = runtime.handle_frontdesk_input(
         "also update the config file",
         frontdesk_mode_active=True,
         main_in_flight=True,
-        steer_callback=steers.append,
+        steer_callback=accept,
     )
 
     assert result.decision.intent is Intent.STEER
     assert result.action == "steered"
     assert steers == ["also update the config file"]
     assert result.message.startswith("control: steered")
+
+
+def test_frontdesk_steer_false_callback_falls_back_to_main():
+    runtime = OrchestrationRuntime.create()
+    steers = []
+
+    result = runtime.handle_frontdesk_input(
+        "also update the config file",
+        frontdesk_mode_active=True,
+        main_in_flight=True,
+        steer_callback=lambda text: steers.append(text) and False,
+    )
+
+    assert result.decision.intent is Intent.STEER
+    assert result.action == "main"
+    assert result.message != "control: steered active main turn"
+    assert steers == ["also update the config file"]
+
+
+def test_frontdesk_steer_raising_callback_falls_back_to_main():
+    runtime = OrchestrationRuntime.create()
+
+    def reject(_text: str) -> bool:
+        raise RuntimeError("not ready")
+
+    result = runtime.handle_frontdesk_input(
+        "also update the config file",
+        frontdesk_mode_active=True,
+        main_in_flight=True,
+        steer_callback=reject,
+    )
+
+    assert result.decision.intent is Intent.STEER
+    assert result.action == "main"
+    assert result.message != "control: steered active main turn"
 
 
 def test_frontdesk_steer_without_running_main_falls_back_to_main():

--- a/tests/agent/test_frontdesk_runtime_loop.py
+++ b/tests/agent/test_frontdesk_runtime_loop.py
@@ -60,6 +60,21 @@ def test_frontdesk_status_returns_local_overview_without_starting_worker():
     assert result.worker_id is None
 
 
+def test_frontdesk_status_shows_available_lane_when_idle():
+    runtime = OrchestrationRuntime.create()
+    runtime.worker_registry.register(ThreadWorkerLane(runner=lambda spec, token: "ok", name="main"))
+
+    result = runtime.handle_frontdesk_input(
+        "지금 뭐 하고 있어?",
+        frontdesk_mode_active=True,
+        session_key="s1",
+    )
+
+    assert result.decision.intent is Intent.STATUS
+    assert result.action == "status"
+    assert "Available worker lanes: main" in result.message
+
+
 def test_frontdesk_stop_cancels_active_workers_and_tasks_without_replay():
     runtime = OrchestrationRuntime.create()
     release = threading.Event()

--- a/tests/agent/test_frontdesk_runtime_loop.py
+++ b/tests/agent/test_frontdesk_runtime_loop.py
@@ -1,0 +1,123 @@
+"""Tests for the minimal frontdesk control-loop runtime."""
+
+import threading
+
+from agent.control_plane import Intent, Recommendation
+from agent.orchestration_runtime import OrchestrationRuntime
+from agent.task_registry import STATUS_CANCELLED, STATUS_RUNNING
+from agent.worker_lanes import CancelToken, ThreadWorkerLane, WorkerSpec, WorkerStatus
+
+
+def test_frontdesk_worker_decision_creates_task_and_starts_registered_worker_lane():
+    runtime = OrchestrationRuntime.create()
+    entered = threading.Event()
+
+    def runner(spec: WorkerSpec, token: CancelToken):  # noqa: ARG001
+        entered.set()
+        return f"done:{spec.goal}"
+
+    runtime.worker_registry.register(ThreadWorkerLane(runner=runner, name="thread"))
+
+    result = runtime.handle_frontdesk_input(
+        "draft a report.md with the audit",
+        frontdesk_mode_active=True,
+        session_key="s1",
+        source_surface="gateway",
+    )
+
+    assert result.decision.intent is Intent.NEW_TASK_WORKER
+    assert result.decision.recommendation is Recommendation.WORKER_LANE
+    assert result.action == "worker_started"
+    assert result.task_id is not None
+    assert result.worker_id is not None
+    task = runtime.task_registry.get_task(result.task_id)
+    assert task is not None
+    assert task.status == STATUS_RUNNING
+    assert task.active_worker_id == result.worker_id
+    assert task.worker_kind == "thread"
+    assert entered.wait(2.0)
+    assert runtime.worker_registry.wait(result.worker_id, timeout=2.0)
+    worker_result = runtime.worker_registry.result(result.worker_id)
+    assert worker_result is not None
+    assert worker_result.status == WorkerStatus.DONE
+
+
+def test_frontdesk_status_returns_local_overview_without_starting_worker():
+    runtime = OrchestrationRuntime.create()
+    runtime.task_registry.create_task("existing", session_key="s1", status=STATUS_RUNNING)
+
+    result = runtime.handle_frontdesk_input(
+        "지금 뭐 하고 있어?",
+        frontdesk_mode_active=True,
+        session_key="s1",
+    )
+
+    assert result.decision.intent is Intent.STATUS
+    assert result.action == "status"
+    assert "Tasks:" in result.message or "Active tasks:" in result.message
+    assert "existing" in result.message
+    assert result.task_id is None
+    assert result.worker_id is None
+
+
+def test_frontdesk_stop_cancels_active_workers_and_tasks_without_replay():
+    runtime = OrchestrationRuntime.create()
+    release = threading.Event()
+
+    def runner(spec: WorkerSpec, token: CancelToken):  # noqa: ARG001
+        release.wait(2.0)
+        token.raise_if_cancelled()
+        return "should not matter"
+
+    runtime.worker_registry.register(ThreadWorkerLane(runner=runner, name="thread"))
+    started = runtime.handle_frontdesk_input(
+        "draft a report.md with the audit",
+        frontdesk_mode_active=True,
+        session_key="s1",
+    )
+    assert started.worker_id is not None
+    assert started.task_id is not None
+
+    stopped = runtime.handle_frontdesk_input("그만", frontdesk_mode_active=True, session_key="s1")
+
+    assert stopped.decision.intent is Intent.STOP
+    assert stopped.action == "stopped"
+    assert stopped.cancelled_tasks == 1
+    assert stopped.cancelled_workers == 1
+    task = runtime.task_registry.get_task(started.task_id)
+    assert task is not None
+    assert task.status == STATUS_CANCELLED
+    release.set()
+    assert runtime.worker_registry.wait(started.worker_id, timeout=2.0)
+    assert runtime.worker_registry.status(started.worker_id).cancel_requested is True
+
+
+def test_frontdesk_steer_calls_callback_when_main_is_in_flight():
+    runtime = OrchestrationRuntime.create()
+    steers = []
+
+    result = runtime.handle_frontdesk_input(
+        "also update the config file",
+        frontdesk_mode_active=True,
+        main_in_flight=True,
+        steer_callback=steers.append,
+    )
+
+    assert result.decision.intent is Intent.STEER
+    assert result.action == "steered"
+    assert steers == ["also update the config file"]
+    assert result.message.startswith("control: steered")
+
+
+def test_frontdesk_steer_without_running_main_falls_back_to_main():
+    runtime = OrchestrationRuntime.create()
+
+    result = runtime.handle_frontdesk_input(
+        "also update the config file",
+        frontdesk_mode_active=True,
+        main_in_flight=False,
+    )
+
+    assert result.decision.intent is Intent.STEER
+    assert result.action == "main"
+    assert "no active main turn" in result.message

--- a/tests/agent/test_orchestration_runtime.py
+++ b/tests/agent/test_orchestration_runtime.py
@@ -4,9 +4,17 @@ import threading
 
 import pytest
 
+from agent.control_plane import (
+    Confidence,
+    ControlPlaneDecision,
+    Intent,
+    Recommendation,
+    Signal,
+)
 from agent.orchestration_runtime import (
     RUNTIME_ATTR,
     OrchestrationRuntime,
+    advise_frontdesk_for_owner,
     format_runtime_agents,
     format_runtime_overview,
     format_runtime_tasks,
@@ -261,6 +269,58 @@ def test_runtime_format_tasks_is_session_scoped_and_active_only():
     assert "active in s1" in text_all
     assert "active in s2" in text_all
     assert "done in s1" not in text_all
+
+
+# --------------------------------------------------------------------------
+# Frontdesk policy advisory (read-only pass-through)
+# --------------------------------------------------------------------------
+def test_advise_frontdesk_routes_a_research_artifact_request_to_worker_lane():
+    rt = OrchestrationRuntime.create()
+    decision = rt.advise_frontdesk(
+        "investigate the regression and write a report.md with the findings",
+        frontdesk_mode_active=True,
+    )
+    assert isinstance(decision, ControlPlaneDecision)
+    assert decision.recommendation == Recommendation.WORKER_LANE
+    assert decision.intent is Intent.NEW_TASK_WORKER
+    assert decision.confidence == Confidence.HIGH
+    assert Signal.RESEARCH in decision.signals
+    assert Signal.ARTIFACT in decision.signals
+
+
+def test_advise_frontdesk_keeps_short_status_query_on_main():
+    rt = OrchestrationRuntime.create()
+    decision = rt.advise_frontdesk("status?")
+    assert decision.recommendation == Recommendation.MAIN
+    assert not decision.should_delegate
+
+
+def test_advise_frontdesk_does_not_mutate_runtime_state():
+    rt = OrchestrationRuntime.create()
+    before_tasks = len(rt.task_registry)
+    before_lanes = list(rt.worker_registry.lane_names())
+    rt.advise_frontdesk("delegate this in the background", frontdesk_mode_active=True)
+    assert len(rt.task_registry) == before_tasks
+    assert list(rt.worker_registry.lane_names()) == before_lanes
+
+
+def test_advise_frontdesk_for_owner_creates_runtime_if_absent():
+    owner = _DummyOwner()
+    assert get_orchestration_runtime(owner) is None
+    decision = advise_frontdesk_for_owner(
+        owner, "draft a report.md with the audit", frontdesk_mode_active=True
+    )
+    assert decision.should_delegate
+    rt = get_orchestration_runtime(owner)
+    assert isinstance(rt, OrchestrationRuntime)
+    assert advise_frontdesk_for_owner(owner, "status?").recommendation == Recommendation.MAIN
+
+
+def test_advise_frontdesk_for_owner_does_not_inspect_other_owners():
+    owner_a = _DummyOwner()
+    owner_b = _DummyOwner()
+    advise_frontdesk_for_owner(owner_a, "write a report.md")
+    assert get_orchestration_runtime(owner_b) is None
 
 
 def test_worker_with_non_json_safe_metadata_degrades_without_raising_through_runtime():

--- a/tests/agent/test_orchestration_runtime.py
+++ b/tests/agent/test_orchestration_runtime.py
@@ -1,0 +1,279 @@
+import copy
+import json
+import threading
+
+import pytest
+
+from agent.orchestration_runtime import (
+    RUNTIME_ATTR,
+    OrchestrationRuntime,
+    format_runtime_agents,
+    format_runtime_overview,
+    format_runtime_tasks,
+    get_or_create_orchestration_runtime,
+    get_orchestration_runtime,
+    set_orchestration_runtime,
+)
+from agent.orchestration_status import OrchestrationSnapshot
+from agent.pending_turn_queue import PendingTurnItem
+from agent.task_registry import STATUS_DONE, STATUS_RUNNING, TaskRegistry
+from agent.worker_lanes import (
+    CancelToken,
+    ThreadWorkerLane,
+    WorkerLaneRegistry,
+    WorkerSpec,
+    WorkerStatus,
+    link_worker_to_task,
+)
+
+TIMEOUT = 2.0
+
+
+class _DummyOwner:
+    """Stand-in for a HermesCLI / gateway runner / session object."""
+
+
+def _gated_runner():
+    """A runner that blocks at ``release`` so its worker stays ``running``."""
+    entered = threading.Event()
+    release = threading.Event()
+
+    def runner(spec, token: CancelToken):  # noqa: ARG001
+        entered.set()
+        release.wait(TIMEOUT)
+        token.raise_if_cancelled()
+        return "done"
+
+    return runner, entered, release
+
+
+# --------------------------------------------------------------------------
+# Construction
+# --------------------------------------------------------------------------
+def test_create_makes_fresh_empty_in_memory_registries():
+    rt = OrchestrationRuntime.create()
+    assert isinstance(rt.task_registry, TaskRegistry)
+    assert isinstance(rt.worker_registry, WorkerLaneRegistry)
+    assert len(rt.task_registry) == 0
+    assert rt.task_registry.path is None  # in-memory only -- no file persistence
+    assert rt.worker_registry.lane_names() == []
+    # Two creates are fully independent.
+    other = OrchestrationRuntime.create()
+    assert other.task_registry is not rt.task_registry
+    assert other.worker_registry is not rt.worker_registry
+
+
+def test_explicit_registry_injection_is_used_as_is():
+    tr = TaskRegistry()
+    wr = WorkerLaneRegistry()
+    rt = OrchestrationRuntime(task_registry=tr, worker_registry=wr)
+    assert rt.task_registry is tr
+    assert rt.worker_registry is wr
+    tr.create_task("injected goal", session_key="s1", status=STATUS_RUNNING)
+    assert "injected goal" in rt.format_tasks(session_key="s1")
+
+
+# --------------------------------------------------------------------------
+# Per-owner attach / fetch helpers (no global state)
+# --------------------------------------------------------------------------
+def test_get_set_get_or_create_helpers_on_dummy_owner():
+    owner = _DummyOwner()
+    assert get_orchestration_runtime(owner) is None  # nothing attached yet
+    assert not hasattr(owner, RUNTIME_ATTR)
+
+    created = get_or_create_orchestration_runtime(owner)
+    assert isinstance(created, OrchestrationRuntime)
+    assert getattr(owner, RUNTIME_ATTR) is created
+    # Idempotent: a second get-or-create returns the same object.
+    assert get_or_create_orchestration_runtime(owner) is created
+    assert get_orchestration_runtime(owner) is created
+
+    replacement = OrchestrationRuntime.create()
+    assert set_orchestration_runtime(owner, replacement) is replacement
+    assert get_orchestration_runtime(owner) is replacement
+    assert get_or_create_orchestration_runtime(owner) is replacement
+
+
+def test_set_orchestration_runtime_rejects_non_runtime():
+    owner = _DummyOwner()
+    with pytest.raises(TypeError):
+        set_orchestration_runtime(owner, object())  # type: ignore[arg-type]
+    assert not hasattr(owner, RUNTIME_ATTR)
+
+
+def test_get_helpers_ignore_a_foreign_value_in_the_slot():
+    owner = _DummyOwner()
+    setattr(owner, RUNTIME_ATTR, "not a runtime")
+    assert get_orchestration_runtime(owner) is None
+    # get-or-create replaces the bad value with a real runtime.
+    rt = get_or_create_orchestration_runtime(owner)
+    assert isinstance(rt, OrchestrationRuntime)
+    assert getattr(owner, RUNTIME_ATTR) is rt
+
+
+def test_no_global_singleton_leakage_between_owners():
+    a = _DummyOwner()
+    b = _DummyOwner()
+    ra = get_or_create_orchestration_runtime(a)
+    rb = get_or_create_orchestration_runtime(b)
+    assert ra is not rb
+    assert ra.task_registry is not rb.task_registry
+    assert ra.worker_registry is not rb.worker_registry
+
+    ra.task_registry.create_task("only on a", session_key="s1", status=STATUS_RUNNING)
+    assert "only on a" in format_runtime_tasks(a, session_key="s1")
+    assert format_runtime_tasks(b, session_key="s1") == "No active tasks are currently registered."
+
+    # A brand-new owner the helpers have never seen also stays empty.
+    assert format_runtime_overview(_DummyOwner()) == "No active tasks or workers are currently registered."
+
+
+# --------------------------------------------------------------------------
+# Empty-state formatting is graceful
+# --------------------------------------------------------------------------
+def test_empty_runtime_formats_gracefully_and_snapshot_is_empty():
+    rt = OrchestrationRuntime.create()
+    assert rt.format_tasks() == "No active tasks are currently registered."
+    assert rt.format_agents() == "No active workers are currently registered."
+    assert rt.format_overview() == "No active tasks or workers are currently registered."
+    snap = rt.snapshot()
+    assert isinstance(snap, OrchestrationSnapshot)
+    assert snap.tasks == []
+    assert snap.workers == []
+    assert snap.counts["tasks_total"] == 0
+    assert snap.counts["workers_total"] == 0
+    json.dumps(snap.to_dict(), allow_nan=False)
+
+
+def test_format_runtime_helpers_create_empty_runtime_when_missing():
+    owner = _DummyOwner()
+    assert format_runtime_tasks(owner) == "No active tasks are currently registered."
+    # The helper attached a real runtime so later work is visible through it.
+    rt = get_orchestration_runtime(owner)
+    assert isinstance(rt, OrchestrationRuntime)
+    assert format_runtime_agents(owner) == "No active workers are currently registered."
+    assert format_runtime_overview(owner) == "No active tasks or workers are currently registered."
+    assert get_orchestration_runtime(owner) is rt  # still the same one
+
+
+# --------------------------------------------------------------------------
+# Injected task / worker state formats correctly
+# --------------------------------------------------------------------------
+def test_injected_task_and_worker_state_formats_through_runtime_and_helpers():
+    rt = OrchestrationRuntime.create()
+    task = rt.task_registry.create_task(
+        "Phase 7 runtime wiring", session_key="s1", status=STATUS_RUNNING
+    )
+    rt.task_registry.create_task("already finished", session_key="s1", status=STATUS_DONE)
+
+    runner, entered, release = _gated_runner()
+    lane = ThreadWorkerLane(runner=runner, name="thread")
+    rt.worker_registry.register(lane)
+    handle = rt.worker_registry.start(
+        WorkerSpec(goal="Phase 7 runtime wiring", task_id=task.task_id, lane="thread")
+    )
+    link_worker_to_task(rt.task_registry, task.task_id, handle, worker_kind="claude_code")
+    assert entered.wait(TIMEOUT)
+
+    try:
+        # Attach this runtime to an owner and drive everything through the helpers.
+        owner = _DummyOwner()
+        set_orchestration_runtime(owner, rt)
+
+        # /tasks-style board: active tasks only, worker linkage shown.
+        tasks_text = format_runtime_tasks(owner, session_key="s1")
+        assert "Active tasks:" in tasks_text
+        assert task.task_id in tasks_text
+        assert "Phase 7 runtime wiring" in tasks_text
+        assert f"worker: {handle.worker_id} (claude_code)" in tasks_text
+        assert "already finished" not in tasks_text  # active-only by default
+
+        # /agents-style board: live worker status / lane / task / goal.
+        agents_text = format_runtime_agents(owner)
+        assert "Workers:" in agents_text or "Active workers:" in agents_text
+        assert f"{handle.worker_id} [running]" in agents_text
+        assert "lane=thread" in agents_text
+        assert f"task={task.task_id}" in agents_text
+        assert 'goal="Phase 7 runtime wiring"' in agents_text
+
+        # Combined overview: cross-links the live worker status into the task block.
+        overview_text = format_runtime_overview(owner, session_key="s1")
+        assert "Orchestration status" in overview_text
+        assert task.task_id in overview_text
+        assert f"worker: {handle.worker_id} (claude_code) [running]" in overview_text
+        assert handle.worker_id in overview_text
+
+        snap = rt.snapshot(session_key="s1")
+        assert snap.counts["tasks_total"] == 2
+        assert snap.counts["tasks_active"] == 1
+        assert snap.counts["workers_total"] == 1
+        assert snap.counts["workers_running"] == 1
+        assert snap.warnings == []  # task<->worker linkage is consistent
+        json.dumps(snap.to_dict(), allow_nan=False)
+    finally:
+        release.set()
+        lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+
+def test_runtime_snapshot_is_json_safe_with_a_followup_carrying_raw():
+    """A follow-up with a non-JSON, non-copyable ``raw`` passthrough must not be
+    inspected, serialised, or deep-copied anywhere on the runtime/snapshot path."""
+
+    class RawBomb:
+        def __deepcopy__(self, memo):  # pragma: no cover - must never be called
+            raise AssertionError("raw was deep-copied")
+
+        def __getattribute__(self, name):
+            if name not in {"__class__", "__deepcopy__", "__repr__"}:
+                raise AssertionError("raw was inspected")
+            return object.__getattribute__(self, name)
+
+    rt = OrchestrationRuntime.create()
+    task = rt.task_registry.create_task("raw-safe task", session_key="s1", status=STATUS_RUNNING)
+    rt.task_registry.attach_followup(
+        task.task_id, PendingTurnItem(text="also include X", session_key="s1", raw=RawBomb())
+    )
+
+    snap = rt.snapshot(session_key="s1")
+    assert snap.counts["followups_pending"] == 1
+    json.dumps(snap.to_dict(), allow_nan=False)
+    copy.deepcopy(snap.to_dict())
+
+    owner = _DummyOwner()
+    set_orchestration_runtime(owner, rt)
+    text = format_runtime_tasks(owner, session_key="s1")
+    assert "1 follow-up queued" in text
+
+
+def test_runtime_format_tasks_is_session_scoped_and_active_only():
+    rt = OrchestrationRuntime.create()
+    a_active = rt.task_registry.create_task("active in s1", session_key="s1", status=STATUS_RUNNING)
+    rt.task_registry.create_task("done in s1", session_key="s1", status=STATUS_DONE)
+    rt.task_registry.create_task("active in s2", session_key="s2", status=STATUS_RUNNING)
+
+    text_s1 = rt.format_tasks(session_key="s1")
+    assert a_active.task_id in text_s1
+    assert "done in s1" not in text_s1
+    assert "active in s2" not in text_s1
+
+    # No session filter: every active task across sessions, terminal ones dropped.
+    text_all = rt.format_tasks()
+    assert "active in s1" in text_all
+    assert "active in s2" in text_all
+    assert "done in s1" not in text_all
+
+
+def test_worker_with_non_json_safe_metadata_degrades_without_raising_through_runtime():
+    rt = OrchestrationRuntime.create()
+    lane = ThreadWorkerLane(runner=lambda spec, token: "ok")
+    rt.worker_registry.register(lane)
+    handle = rt.worker_registry.start(WorkerSpec(goal="metadata unsafe", task_id="task-x"))
+    # Simulate a future/foreign lane carrying non-JSON-safe spec metadata.
+    lane._workers[handle.worker_id].spec.metadata["bad"] = object()  # noqa: SLF001
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+    text = rt.format_agents()
+    assert handle.worker_id in text
+    # The done worker still shows up; goal lookup via snapshot may be dropped.
+    statuses = {w["worker_id"]: w["status"] for w in rt.snapshot().workers}
+    assert statuses[handle.worker_id] == WorkerStatus.DONE

--- a/tests/agent/test_orchestration_status.py
+++ b/tests/agent/test_orchestration_status.py
@@ -1,0 +1,291 @@
+import copy
+import json
+import threading
+import time
+
+from agent.orchestration_status import (
+    OrchestrationSnapshot,
+    OrchestrationStatusFormatter,
+    build_snapshot,
+    format_agents,
+    format_overview,
+    format_tasks,
+    looks_like_orchestration_status_query,
+)
+from agent.pending_turn_queue import PendingTurnItem
+from agent.task_registry import (
+    STATUS_BLOCKED,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_RUNNING,
+    TaskRegistry,
+)
+from agent.worker_lanes import (
+    CancelToken,
+    ThreadWorkerLane,
+    WorkerLaneRegistry,
+    WorkerSpec,
+    WorkerStatus,
+    link_worker_to_task,
+)
+
+TIMEOUT = 2.0
+
+
+def _gated_runner():
+    entered = threading.Event()
+    release = threading.Event()
+
+    def runner(spec, token: CancelToken):  # noqa: ARG001
+        entered.set()
+        release.wait(TIMEOUT)
+        token.raise_if_cancelled()
+        return "done"
+
+    return runner, entered, release
+
+
+def test_empty_snapshot_and_empty_formatting_are_graceful():
+    snap = build_snapshot()
+    assert snap.tasks == []
+    assert snap.workers == []
+    assert snap.counts["tasks_total"] == 0
+    assert snap.counts["workers_total"] == 0
+    assert snap.warnings == []
+    assert format_tasks(snap) == "No active tasks are currently registered."
+    assert format_agents(snap) == "No active workers are currently registered."
+    assert format_overview(snap) == "No active tasks or workers are currently registered."
+    json.dumps(snap.to_dict(), allow_nan=False)
+
+
+def test_task_snapshot_and_formatting_includes_counts_worker_and_state():
+    reg = TaskRegistry()
+    task = reg.create_task("Draft the MM market research report", session_key="s1", status=STATUS_RUNNING)
+    reg.assign_worker(task.task_id, "worker-1", worker_kind="claude_code")
+    reg.attach_followup(task.task_id, PendingTurnItem(text="include CELMoD", session_key="s1", raw=object()))
+    reg.add_note(task.task_id, "correction: exclude old pathway")
+    reg.attach_artifact(task.task_id, {"path": "report.md", "kind": "markdown"})
+    reg.create_task("Need Woo decision", session_key="s1", status=STATUS_BLOCKED)
+    reg.create_task("Already done", session_key="s1", status=STATUS_DONE)
+
+    snap = build_snapshot(reg, session_key="s1")
+    assert snap.counts["tasks_total"] == 3
+    assert snap.counts["tasks_active"] == 2
+    assert snap.counts["tasks_blocked"] == 1
+    assert snap.counts["followups_pending"] == 1
+    json.dumps(snap.to_dict(), allow_nan=False)
+
+    text = format_tasks(snap)
+    assert "Tasks:" in text
+    assert task.task_id in text
+    assert "Draft the MM market research" in text
+    assert "worker: worker-1 (claude_code)" in text
+    assert "1 follow-up queued" in text
+    assert "1 note" in text
+    assert "needs you" in text
+
+
+def test_format_tasks_registry_defaults_to_active_tasks_only_and_session_scope():
+    reg = TaskRegistry()
+    active_s1 = reg.create_task("active one", session_key="s1", status=STATUS_RUNNING)
+    reg.create_task("done one", session_key="s1", status=STATUS_DONE)
+    reg.create_task("active other session", session_key="s2", status=STATUS_RUNNING)
+
+    text = format_tasks(reg, session_key="s1")
+    assert "Active tasks:" in text
+    assert active_s1.task_id in text
+    assert "done one" not in text
+    assert "active other session" not in text
+
+
+def test_worker_registry_snapshot_formats_running_done_error_cancelled_and_cancel_requested():
+    wlr = WorkerLaneRegistry()
+
+    # running + cancel requested
+    runner, entered, release = _gated_runner()
+    running_lane = ThreadWorkerLane(runner=runner, name="running")
+    wlr.register(running_lane)
+    running_handle = wlr.start(
+        WorkerSpec(goal="long running implementation", task_id="task-run", lane="running")
+    )
+    assert entered.wait(TIMEOUT)
+    assert wlr.cancel(running_handle.worker_id) is True
+
+    # done
+    done_lane = ThreadWorkerLane(runner=lambda spec, token: "finished", name="done")
+    wlr.register(done_lane)
+    done = done_lane.start(WorkerSpec(goal="write final answer", task_id="task-done", lane="done"))
+    assert done_lane.wait(done.worker_id, timeout=TIMEOUT)
+
+    # error
+    def boom(spec, token):  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    error_lane = ThreadWorkerLane(runner=boom, name="error")
+    wlr.register(error_lane)
+    err = error_lane.start(WorkerSpec(goal="explode", task_id="task-error", lane="error"))
+    assert error_lane.wait(err.worker_id, timeout=TIMEOUT)
+
+    # cancelled terminal
+    release.set()
+    assert running_lane.wait(running_handle.worker_id, timeout=TIMEOUT)
+
+    snap = build_snapshot(worker_registry=wlr)
+    assert snap.counts["workers_total"] == 3
+    statuses = {w["worker_id"]: w["status"] for w in snap.workers}
+    assert statuses[done.worker_id] == WorkerStatus.DONE
+    assert statuses[err.worker_id] == WorkerStatus.ERROR
+    assert statuses[running_handle.worker_id] == WorkerStatus.CANCELLED
+    json.dumps(snap.to_dict(), allow_nan=False)
+
+    text = format_agents(snap, compact=False)
+    assert done.worker_id in text and 'result="finished"' in text
+    assert err.worker_id in text and 'error="RuntimeError: boom"' in text
+    assert running_handle.worker_id in text and "cancel requested" in text
+
+
+def test_overview_cross_links_task_and_worker_and_warns_on_mismatches():
+    reg = TaskRegistry()
+    task = reg.create_task("linked work", session_key="s1", status=STATUS_RUNNING)
+    lane = ThreadWorkerLane(runner=lambda spec, token: "ok", name="linked")
+    wlr = WorkerLaneRegistry()
+    wlr.register(lane)
+    handle = wlr.start(WorkerSpec(goal="linked work", task_id=task.task_id, lane="linked"))
+    link_worker_to_task(reg, task.task_id, handle)
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+    snap = build_snapshot(reg, wlr, session_key="s1")
+    text = format_overview(snap)
+    assert "Orchestration status" in text
+    assert handle.worker_id in text
+    assert f"worker: {handle.worker_id}" in text
+    assert "Workers:" in text
+    assert snap.warnings == []
+
+    reg.assign_worker(task.task_id, "missing-worker")
+    warning_snap = build_snapshot(reg, wlr, session_key="s1")
+    assert warning_snap.warnings
+    assert "missing-worker" in format_overview(warning_snap)
+
+
+def test_snapshot_does_not_touch_pending_turn_raw():
+    class RawBomb:
+        def __deepcopy__(self, memo):  # pragma: no cover - should never be called
+            raise AssertionError("raw was deep-copied")
+
+        def __getattribute__(self, name):
+            if name not in {"__class__", "__deepcopy__", "__repr__"}:
+                raise AssertionError("raw was inspected")
+            return object.__getattribute__(self, name)
+
+    reg = TaskRegistry()
+    task = reg.create_task("raw-safe task", session_key="s1")
+    item = PendingTurnItem(text="follow-up", session_key="s1", raw=RawBomb())
+    reg.attach_followup(task.task_id, item)
+
+    snap = build_snapshot(reg, session_key="s1")
+    assert snap.counts["followups_pending"] == 1
+    json.dumps(snap.to_dict(), allow_nan=False)
+    copy.deepcopy(snap.to_dict())
+    assert "1 follow-up queued" in format_tasks(snap)
+
+
+def test_worker_with_non_json_safe_metadata_degrades_without_raising():
+    lane = ThreadWorkerLane(runner=lambda spec, token: "ok")
+    handle = lane.start(WorkerSpec(goal="metadata unsafe", task_id="task-x", metadata={"ok": "yes"}))
+    # Mutate after validation to simulate a future/foreign lane with unsafe metadata.
+    lane._workers[handle.worker_id].spec.metadata["bad"] = object()  # noqa: SLF001
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+    text = format_agents(lane)
+    assert handle.worker_id in text
+    # Goal lookup through snapshot may be dropped, but formatting must not raise.
+
+
+def test_natural_language_status_query_helper_korean_and_english():
+    for text in (
+        "지금 뭐 하고 있어?",
+        "돌고 있는 작업 있어?",
+        "에이전트 뭐 돌아가?",
+        "내가 봐야 하는 거 있어?",
+        "what are you working on?",
+        "any agents running?",
+        "show tasks",
+        "anything blocked?",
+    ):
+        assert looks_like_orchestration_status_query(text), text
+    for text in ("부대찌개 칼로리 알려줘", "이것도 반영해줘", "stop", ""):
+        assert not looks_like_orchestration_status_query(text), text
+
+
+def test_formatter_facade_matches_module_functions():
+    reg = TaskRegistry()
+    reg.create_task("facade", session_key="s1", status=STATUS_ERROR)
+    snap = OrchestrationStatusFormatter.snapshot(reg, session_key="s1")
+    assert isinstance(snap, OrchestrationSnapshot)
+    assert OrchestrationStatusFormatter.format_tasks(snap) == format_tasks(snap)
+    assert OrchestrationStatusFormatter.format_agents(snap) == format_agents(snap)
+    assert OrchestrationStatusFormatter.format_overview(snap) == format_overview(snap)
+
+
+def test_plain_task_dict_inputs_are_normalized_to_json_safe_snapshot():
+    snap = build_snapshot([
+        {
+            "task_id": "task-dict",
+            "status": STATUS_RUNNING,
+            "goal": object(),
+            "worker_id": object(),
+            "worker_kind": object(),
+            "session_key": object(),
+            "followups": [object(), object()],
+            "notes": {"nested": object()},
+            "artifacts": object(),
+            "active": object(),
+            "blocked": object(),
+            "error": object(),
+        }
+    ])
+
+    task = snap.tasks[0]
+    assert task["task_id"] == "task-dict"
+    assert task["goal"] == ""
+    assert task["worker_id"] is None
+    assert task["worker_kind"] is None
+    assert task["session_key"] is None
+    assert task["followups"] == 2
+    assert task["notes"] == 1
+    assert task["artifacts"] == 0
+    assert task["active"] is True
+    json.dumps(snap.to_dict(), allow_nan=False)
+
+
+def test_formatting_accepts_plain_worker_dicts_and_lists():
+    workers = [
+        {
+            "worker_id": "worker-a",
+            "status": WorkerStatus.RUNNING,
+            "lane": "review",
+            "task_id": "task-a",
+            "goal": "review the implementation",
+            "cancel_requested": False,
+        }
+    ]
+    text = format_agents(workers)
+    assert "worker-a [running] lane=review task=task-a" in text
+    assert 'goal="review the implementation"' in text
+
+    tasks = [
+        {
+            "task_id": "task-a",
+            "status": STATUS_CANCELLED,
+            "goal": "cancelled task",
+            "active": False,
+            "followups": 0,
+            "notes": 0,
+            "artifacts": 0,
+            "blocked": False,
+            "error": False,
+        }
+    ]
+    assert "Tasks:" in format_tasks(tasks)

--- a/tests/agent/test_pending_turn_queue.py
+++ b/tests/agent/test_pending_turn_queue.py
@@ -1,0 +1,489 @@
+"""Tests for the structured pending-turn queue (orchestrator Phase 2).
+
+These cover the leaf module ``agent.pending_turn_queue`` in isolation: the
+:class:`PendingTurnItem` shape and its boundary/coalescing rules, the
+:class:`PendingTurnQueue` container, lossless round-tripping of legacy CLI
+payloads, the one-way gateway ``MessageEvent`` bridge, and JSON serializability.
+"""
+
+import json
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+
+from agent import pending_turn_queue as ptq
+
+
+# --------------------------------------------------------------------------
+# PendingTurnItem
+# --------------------------------------------------------------------------
+class TestPendingTurnItem(unittest.TestCase):
+    def test_defaults_are_a_coalescible_text_item_once_text_is_set(self):
+        item = ptq.PendingTurnItem(text="hello")
+        self.assertEqual(item.kind, ptq.KIND_TEXT)
+        self.assertEqual(item.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertEqual(item.source, ptq.SOURCE_UNKNOWN)
+        self.assertTrue(item.is_text)
+        self.assertFalse(item.is_command)
+        self.assertFalse(item.has_media)
+        self.assertTrue(item.is_coalescible_text())
+        self.assertFalse(item.origin_busy)
+        self.assertIsInstance(item.id, str)
+        self.assertTrue(item.id)
+        self.assertIsInstance(item.created_at, float)
+
+    def test_empty_text_is_not_coalescible(self):
+        self.assertFalse(ptq.PendingTurnItem(text="").is_coalescible_text())
+        self.assertFalse(ptq.PendingTurnItem(text=None).is_coalescible_text())
+
+    def test_command_and_media_and_hard_boundaries_are_not_coalescible(self):
+        cmd = ptq.PendingTurnItem(kind=ptq.KIND_COMMAND, text="/busy", boundary=ptq.BOUNDARY_COMMAND)
+        media = ptq.PendingTurnItem(kind=ptq.KIND_MEDIA, media_refs=["/tmp/a.png"], boundary=ptq.BOUNDARY_HARD)
+        hard_text = ptq.PendingTurnItem(kind=ptq.KIND_TEXT, text="x", boundary=ptq.BOUNDARY_HARD)
+        caption = ptq.PendingTurnItem(kind=ptq.KIND_TEXT, text="cap", boundary=ptq.BOUNDARY_CAPTION)
+        for it in (cmd, media, hard_text, caption):
+            self.assertFalse(it.is_coalescible_text(), it)
+        self.assertTrue(cmd.is_command)
+        self.assertTrue(media.has_media)
+
+    def test_unknown_kind_or_boundary_is_tolerated(self):
+        # The vocabulary constants are documentation, not a rejecting enum.
+        item = ptq.PendingTurnItem(kind="weird-future-kind", boundary="weird-future-boundary", text="x")
+        self.assertEqual(item.kind, "weird-future-kind")
+        self.assertFalse(item.is_coalescible_text())
+
+    def test_to_dict_is_json_safe_and_drops_raw(self):
+        item = ptq.PendingTurnItem(
+            source=ptq.SOURCE_CLI, text="hi", task_hint="task-7", origin_busy=True, raw=object()
+        )
+        d = item.to_dict()
+        self.assertNotIn("raw", d)
+        json.dumps(d)  # must not raise
+        self.assertEqual(d["text"], "hi")
+        self.assertEqual(d["task_hint"], "task-7")
+        self.assertTrue(d["origin_busy"])
+
+    def test_to_dict_does_not_copy_or_touch_uncopyable_raw(self):
+        class UncopyableRaw:
+            def __deepcopy__(self, memo):  # pragma: no cover - only called on regression
+                raise RuntimeError("raw should not be copied")
+
+        item = ptq.PendingTurnItem(text="hi", raw=UncopyableRaw())
+        d = item.to_dict()
+
+        self.assertNotIn("raw", d)
+        self.assertEqual(d["text"], "hi")
+        json.dumps(d)  # must not raise
+
+    def test_to_dict_copies_mutable_lists_without_deepcopying_raw(self):
+        item = ptq.PendingTurnItem(
+            kind=ptq.KIND_MEDIA,
+            media_refs=["/tmp/a.png"],
+            media_types=["image/png"],
+            raw=object(),
+        )
+        d = item.to_dict()
+        d["media_refs"].append("/tmp/b.png")
+        d["media_types"].append("image/jpeg")
+
+        self.assertEqual(item.media_refs, ["/tmp/a.png"])
+        self.assertEqual(item.media_types, ["image/png"])
+
+    def test_from_dict_round_trips_and_ignores_unknown_keys(self):
+        item = ptq.PendingTurnItem(source=ptq.SOURCE_TUI, text="hi", media_refs=["/tmp/x"], kind=ptq.KIND_MEDIA)
+        d = item.to_dict()
+        d["some_future_field"] = 123
+        rebuilt = ptq.PendingTurnItem.from_dict(d)
+        self.assertEqual(rebuilt.source, ptq.SOURCE_TUI)
+        self.assertEqual(rebuilt.text, "hi")
+        self.assertEqual(rebuilt.media_refs, ["/tmp/x"])
+        self.assertEqual(rebuilt.kind, ptq.KIND_MEDIA)
+
+    def test_copy_overrides(self):
+        item = ptq.PendingTurnItem(text="a", boundary=ptq.BOUNDARY_COALESCE)
+        clone = item.copy(boundary=ptq.BOUNDARY_HARD)
+        self.assertEqual(item.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertEqual(clone.boundary, ptq.BOUNDARY_HARD)
+        self.assertEqual(clone.text, "a")
+
+
+# --------------------------------------------------------------------------
+# PendingTurnQueue
+# --------------------------------------------------------------------------
+class TestPendingTurnQueue(unittest.TestCase):
+    @staticmethod
+    def _text(t, *, origin_busy=False):
+        return ptq.PendingTurnItem(text=t, source=ptq.SOURCE_CLI, origin_busy=origin_busy)
+
+    def test_container_protocol(self):
+        q = ptq.PendingTurnQueue()
+        self.assertEqual(len(q), 0)
+        self.assertFalse(q)
+        self.assertIsNone(q.peek())
+        self.assertIsNone(q.pop())
+
+        a, b = self._text("a"), self._text("b")
+        q.append(a)
+        q.append(b)
+        self.assertEqual(len(q), 2)
+        self.assertTrue(q)
+        self.assertIs(q.peek(), a)
+        self.assertEqual([it.text for it in q], ["a", "b"])  # iteration is non-consuming
+        self.assertEqual(len(q), 2)
+        self.assertIs(q.pop(), a)
+        self.assertEqual(len(q), 1)
+        q.appendleft(a)
+        self.assertEqual([it.text for it in q.snapshot()], ["a", "b"])
+        q.extend([self._text("c")])
+        self.assertEqual([it.text for it in q], ["a", "b", "c"])
+        q.clear()
+        self.assertEqual(len(q), 0)
+
+    def test_constructor_accepts_iterable(self):
+        q = ptq.PendingTurnQueue(self._text(t) for t in ("x", "y"))
+        self.assertEqual([it.text for it in q], ["x", "y"])
+
+    def test_drain_coalescible_run_stops_at_first_non_text(self):
+        q = ptq.PendingTurnQueue([
+            self._text("a"),
+            self._text("b"),
+            ptq.PendingTurnItem(kind=ptq.KIND_MEDIA, media_refs=["/tmp/a.png"], boundary=ptq.BOUNDARY_HARD),
+            self._text("c"),
+        ])
+        run = q.drain_coalescible_text_until_boundary()
+        self.assertEqual([it.text for it in run], ["a", "b"])
+        # The media item and everything after it stay, in order.
+        self.assertEqual(len(q), 2)
+        self.assertEqual(q.peek().kind, ptq.KIND_MEDIA)
+        self.assertEqual(ptq.coalesced_text(run), "a\n\nb")
+
+    def test_drain_stops_at_slash_command_item(self):
+        q = ptq.PendingTurnQueue([
+            self._text("a"),
+            ptq.PendingTurnItem(kind=ptq.KIND_COMMAND, text="/busy", boundary=ptq.BOUNDARY_COMMAND),
+            self._text("b"),
+        ])
+        run = q.drain_coalescible_text_until_boundary()
+        self.assertEqual([it.text for it in run], ["a"])
+        self.assertEqual([it.text for it in q], ["/busy", "b"])
+
+    def test_drain_with_origin_busy_filter(self):
+        q = ptq.PendingTurnQueue([
+            self._text("a", origin_busy=True),
+            self._text("b", origin_busy=True),
+            self._text("c", origin_busy=False),  # different origin -> boundary
+            self._text("d", origin_busy=True),
+        ])
+        run = q.drain_coalescible_text_until_boundary(origin_busy=True)
+        self.assertEqual([it.text for it in run], ["a", "b"])
+        self.assertEqual([it.text for it in q], ["c", "d"])
+
+        # The opposite filter on a queue that starts with a non-busy item:
+        q2 = ptq.PendingTurnQueue([self._text("p", origin_busy=False), self._text("q", origin_busy=True)])
+        run2 = q2.drain_coalescible_text_until_boundary(origin_busy=False)
+        self.assertEqual([it.text for it in run2], ["p"])
+        self.assertEqual([it.text for it in q2], ["q"])
+
+    def test_drain_empty_queue_returns_empty_run(self):
+        q = ptq.PendingTurnQueue()
+        self.assertEqual(q.drain_coalescible_text_until_boundary(), [])
+
+    def test_drain_when_head_is_already_a_boundary(self):
+        q = ptq.PendingTurnQueue([
+            ptq.PendingTurnItem(kind=ptq.KIND_COMMAND, text="/x", boundary=ptq.BOUNDARY_COMMAND),
+            self._text("a"),
+        ])
+        run = q.drain_coalescible_text_until_boundary()
+        self.assertEqual(run, [])
+        self.assertEqual(len(q), 2)
+
+
+# --------------------------------------------------------------------------
+# Integrated-busy sentinel helpers
+# --------------------------------------------------------------------------
+class TestIntegratedBusySentinel(unittest.TestCase):
+    def test_make_is_unwrap_round_trip(self):
+        payload = ptq.make_integrated_busy_payload("hello")
+        self.assertTrue(ptq.is_integrated_busy_payload(payload))
+        self.assertEqual(ptq.unwrap_integrated_busy_payload(payload), "hello")
+
+    def test_non_tagged_values_pass_through(self):
+        self.assertFalse(ptq.is_integrated_busy_payload("hello"))
+        self.assertEqual(ptq.unwrap_integrated_busy_payload("hello"), "hello")
+        # A plain (caption, images) tuple is NOT an integrated payload, and a
+        # caption that happens to spell "integrated_busy" must stay an image.
+        img = ("integrated_busy", ["/tmp/a.png"])
+        self.assertFalse(ptq.is_integrated_busy_payload(img))
+        self.assertEqual(ptq.unwrap_integrated_busy_payload(img), img)
+        self.assertFalse(ptq.is_integrated_busy_payload(("a", "b", "c")))
+
+    def test_sentinel_is_identity_only_not_a_string(self):
+        self.assertNotEqual(ptq.INTEGRATED_BUSY_PAYLOAD, "integrated_busy")
+        self.assertIsNot(ptq.INTEGRATED_BUSY_PAYLOAD, object())
+
+
+# --------------------------------------------------------------------------
+# looks_like_slash_command
+# --------------------------------------------------------------------------
+class TestLooksLikeSlashCommand(unittest.TestCase):
+    def test_commands_vs_paths_vs_prose(self):
+        self.assertTrue(ptq.looks_like_slash_command("/busy"))
+        self.assertTrue(ptq.looks_like_slash_command("/model gpt-4"))
+        self.assertTrue(ptq.looks_like_slash_command("/q"))
+        # A pasted absolute path that merely starts with "/" is not a command.
+        self.assertFalse(ptq.looks_like_slash_command("/Users/foo/bar.md fix this"))
+        self.assertFalse(ptq.looks_like_slash_command("just text"))
+        self.assertFalse(ptq.looks_like_slash_command(""))
+        self.assertFalse(ptq.looks_like_slash_command(None))
+        self.assertFalse(ptq.looks_like_slash_command(("/busy", [])))
+
+
+# --------------------------------------------------------------------------
+# Legacy CLI payload conversion
+# --------------------------------------------------------------------------
+class TestLegacyCliPayloadConversion(unittest.TestCase):
+    def test_plain_text(self):
+        it = ptq.from_legacy_cli_payload("hello world")
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertEqual(it.text, "hello world")
+        self.assertEqual(it.source, ptq.SOURCE_CLI)
+        self.assertFalse(it.origin_busy)
+        self.assertTrue(it.is_coalescible_text())
+        self.assertEqual(it.raw, "hello world")
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), "hello world")
+
+    def test_slash_command_text_becomes_command_item(self):
+        it = ptq.from_legacy_cli_payload("/busy status")
+        self.assertEqual(it.kind, ptq.KIND_COMMAND)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COMMAND)
+        self.assertFalse(it.is_coalescible_text())
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), "/busy status")
+
+    def test_pasted_path_is_text_not_command(self):
+        it = ptq.from_legacy_cli_payload("/Users/foo/bar.md please fix")
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertTrue(it.is_coalescible_text())
+
+    def test_empty_string_is_coalescible_payload_but_not_a_merge_starter(self):
+        # Mirrors the legacy CLI guard/loop asymmetry: an empty string is a
+        # "coalescible text" *payload* (the guard lets it through) yet does not
+        # itself start a merge run (the loop check requires non-empty text).
+        self.assertTrue(ptq.legacy_cli_payload_is_coalescible_text(""))
+        self.assertFalse(ptq.from_legacy_cli_payload("").is_coalescible_text())
+
+    def test_image_tuple_becomes_hard_media_item(self):
+        payload = ("caption here", ["/tmp/a.png", "/tmp/b.jpg"])
+        it = ptq.from_legacy_cli_payload(payload)
+        self.assertEqual(it.kind, ptq.KIND_MEDIA)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+        self.assertEqual(it.text, "caption here")
+        self.assertEqual(it.media_refs, ["/tmp/a.png", "/tmp/b.jpg"])
+        self.assertFalse(it.is_coalescible_text())
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), payload)
+
+    def test_image_tuple_without_caption(self):
+        payload = ("", ["/tmp/a.png"])
+        it = ptq.from_legacy_cli_payload(payload)
+        self.assertEqual(it.kind, ptq.KIND_MEDIA)
+        self.assertIsNone(it.text)
+        self.assertEqual(it.media_refs, ["/tmp/a.png"])
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), payload)
+
+    def test_integrated_busy_text_payload(self):
+        payload = ptq.make_integrated_busy_payload("busy fragment")
+        it = ptq.from_legacy_cli_payload(payload)
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertEqual(it.text, "busy fragment")
+        self.assertTrue(it.origin_busy)
+        self.assertTrue(it.is_coalescible_text())
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), payload)
+
+    def test_integrated_busy_slash_command_payload(self):
+        payload = ptq.make_integrated_busy_payload("/busy status")
+        it = ptq.from_legacy_cli_payload(payload)
+        self.assertEqual(it.kind, ptq.KIND_COMMAND)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COMMAND)
+        self.assertTrue(it.origin_busy)
+        self.assertFalse(it.is_coalescible_text())
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(it), payload)
+
+    def test_unknown_payload_becomes_opaque_control_item(self):
+        sentinel = object()
+        it = ptq.from_legacy_cli_payload(sentinel)
+        self.assertEqual(it.kind, ptq.KIND_CONTROL)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+        self.assertIsNone(it.text)
+        self.assertFalse(it.is_coalescible_text())
+        self.assertIs(ptq.maybe_to_legacy_cli_payload(it), sentinel)
+
+    def test_maybe_to_legacy_reconstructs_when_raw_missing(self):
+        # Items minted by hand (no `raw`) still degrade to a sensible payload.
+        self.assertEqual(
+            ptq.maybe_to_legacy_cli_payload(ptq.PendingTurnItem(text="hi")), "hi"
+        )
+        self.assertEqual(
+            ptq.maybe_to_legacy_cli_payload(
+                ptq.PendingTurnItem(kind=ptq.KIND_MEDIA, text="cap", media_refs=["/tmp/x"])
+            ),
+            ("cap", ["/tmp/x"]),
+        )
+        self.assertEqual(ptq.maybe_to_legacy_cli_payload(ptq.PendingTurnItem()), "")
+
+    def test_session_key_is_threaded_through(self):
+        it = ptq.from_legacy_cli_payload("hi", session_key="cli:main")
+        self.assertEqual(it.session_key, "cli:main")
+
+    def test_round_trip_through_a_queue_preserves_order_and_boundaries(self):
+        legacy = [
+            "first",
+            ptq.make_integrated_busy_payload("busy-a"),
+            "/busy status",
+            ("cap", ["/tmp/a.png"]),
+            "last",
+        ]
+        q = ptq.PendingTurnQueue(ptq.from_legacy_cli_payload(p) for p in legacy)
+        # Only the leading non-busy text coalesces.
+        run = q.drain_coalescible_text_until_boundary(origin_busy=False)
+        self.assertEqual([it.text for it in run], ["first"])
+        leftover = [ptq.maybe_to_legacy_cli_payload(it) for it in q]
+        self.assertEqual(leftover, legacy[1:])
+
+
+# --------------------------------------------------------------------------
+# Gateway MessageEvent conversion (duck-typed, no gateway import)
+# --------------------------------------------------------------------------
+class _FakeType:
+    def __init__(self, value):
+        self.value = value
+
+
+def _fake_event(*, text="", mtype="text", media_urls=None, media_types=None,
+                platform="telegram", reply_to=None, ts=None):
+    return SimpleNamespace(
+        text=text,
+        message_type=_FakeType(mtype),
+        media_urls=list(media_urls or []),
+        media_types=list(media_types or []),
+        reply_to_message_id=reply_to,
+        source=SimpleNamespace(platform=_FakeType(platform)),
+        timestamp=ts or datetime(2026, 5, 12, 10, 0, 0),
+    )
+
+
+class TestGatewayEventConversion(unittest.TestCase):
+    def test_text_event(self):
+        it = ptq.from_gateway_event(_fake_event(text="hello"), session_key="telegram:42")
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertEqual(it.text, "hello")
+        self.assertEqual(it.source, ptq.SOURCE_TELEGRAM)
+        self.assertEqual(it.session_key, "telegram:42")
+        self.assertTrue(it.is_coalescible_text())
+        self.assertIsInstance(it.created_at, float)
+
+    def test_slash_command_text_event_is_classified_as_command(self):
+        it = ptq.from_gateway_event(_fake_event(text="/restart"))
+        self.assertEqual(it.kind, ptq.KIND_COMMAND)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COMMAND)
+        self.assertFalse(it.is_coalescible_text())
+
+    def test_photo_album_event_is_hard_media_with_caption_in_text(self):
+        it = ptq.from_gateway_event(
+            _fake_event(text="album caption", mtype="photo",
+                        media_urls=["/tmp/1.jpg", "/tmp/2.jpg"], media_types=["image/jpeg", "image/jpeg"])
+        )
+        self.assertEqual(it.kind, ptq.KIND_MEDIA)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+        self.assertEqual(it.text, "album caption")
+        self.assertEqual(it.media_refs, ["/tmp/1.jpg", "/tmp/2.jpg"])
+        self.assertFalse(it.is_coalescible_text())
+
+    def test_document_event_is_attachment(self):
+        it = ptq.from_gateway_event(_fake_event(mtype="document", media_urls=["/tmp/x.pdf"]))
+        self.assertEqual(it.kind, ptq.KIND_ATTACHMENT)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+        self.assertFalse(it.is_coalescible_text())
+
+    def test_location_event_is_control(self):
+        it = ptq.from_gateway_event(_fake_event(mtype="location", text=""))
+        self.assertEqual(it.kind, ptq.KIND_CONTROL)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+
+    def test_media_type_with_no_refs_but_text_degrades_to_text(self):
+        it = ptq.from_gateway_event(_fake_event(text="just a caption", mtype="photo", media_urls=[]))
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertTrue(it.is_coalescible_text())
+
+    def test_reply_to_is_stringified(self):
+        it = ptq.from_gateway_event(_fake_event(text="re", reply_to=12345))
+        self.assertEqual(it.reply_to, "12345")
+
+    def test_unknown_message_type_defaults_to_text(self):
+        it = ptq.from_gateway_event(_fake_event(text="weird", mtype="future-type"))
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+
+    def test_unknown_message_type_with_media_refs_is_hard_media_boundary(self):
+        it = ptq.from_gateway_event(
+            _fake_event(text="future caption", mtype="image", media_urls=["/tmp/future.webp"])
+        )
+        self.assertEqual(it.kind, ptq.KIND_MEDIA)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_HARD)
+        self.assertEqual(it.media_refs, ["/tmp/future.webp"])
+        self.assertFalse(it.is_coalescible_text())
+
+    def test_raw_string_platform_and_message_type_are_supported(self):
+        ev = SimpleNamespace(
+            text="/busy status",
+            message_type="text",
+            media_urls=[],
+            media_types=[],
+            source=SimpleNamespace(platform="telegram"),
+            timestamp=datetime(2026, 5, 12, 10, 0, 0),
+        )
+        it = ptq.from_gateway_event(ev, session_key="tg:1")
+        self.assertEqual(it.source, ptq.SOURCE_TELEGRAM)
+        self.assertEqual(it.kind, ptq.KIND_COMMAND)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COMMAND)
+        self.assertEqual(it.session_key, "tg:1")
+
+    def test_command_message_type_with_path_like_text_degrades_to_text(self):
+        it = ptq.from_gateway_event(_fake_event(text="/Users/foo/bar.md please inspect", mtype="command"))
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertEqual(it.boundary, ptq.BOUNDARY_COALESCE)
+        self.assertTrue(it.is_coalescible_text())
+
+    def test_missing_attributes_are_tolerated(self):
+        it = ptq.from_gateway_event(SimpleNamespace())
+        self.assertEqual(it.source, ptq.SOURCE_UNKNOWN)
+        self.assertEqual(it.kind, ptq.KIND_TEXT)
+        self.assertIsNone(it.text)
+        self.assertIsInstance(it.created_at, float)
+
+    def test_raw_event_is_kept(self):
+        ev = _fake_event(text="x")
+        it = ptq.from_gateway_event(ev)
+        self.assertIs(it.raw, ev)
+        # ...but is excluded from the serializable form.
+        self.assertNotIn("raw", it.to_dict())
+
+
+# --------------------------------------------------------------------------
+# coalesced_text helper
+# --------------------------------------------------------------------------
+class TestCoalescedText(unittest.TestCase):
+    def test_joins_text_skipping_blanks(self):
+        items = [
+            ptq.PendingTurnItem(text="a"),
+            ptq.PendingTurnItem(text=""),
+            ptq.PendingTurnItem(text=None),
+            ptq.PendingTurnItem(text="b"),
+        ]
+        self.assertEqual(ptq.coalesced_text(items), "a\n\nb")
+        self.assertEqual(ptq.coalesced_text(items, sep=" | "), "a | b")
+        self.assertEqual(ptq.coalesced_text([]), "")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/agent/test_task_registry.py
+++ b/tests/agent/test_task_registry.py
@@ -1,0 +1,185 @@
+"""Tests for the focused task registry substrate."""
+
+import copy
+import json
+
+import pytest
+
+from agent.pending_turn_queue import PendingTurnItem, KIND_TEXT, KIND_MEDIA, BOUNDARY_HARD
+from agent.task_registry import (
+    STATUS_BLOCKED,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_ERROR,
+    STATUS_PROPOSED,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    WORKER_CLAUDE_CODE,
+    TaskOrigin,
+    TaskRegistry,
+)
+
+
+class UncopyableRaw:
+    def __deepcopy__(self, memo):  # pragma: no cover - should never be called
+        raise AssertionError("raw should not be deep-copied")
+
+
+def test_create_list_and_session_filtering():
+    reg = TaskRegistry()
+    origin = TaskOrigin(platform="telegram", chat_id="chat-1", user_id="woo", session_key="s1")
+
+    t1 = reg.create_task("draft briefing", origin=origin)
+    t2 = reg.create_task("review code", session_key="s2", status=STATUS_QUEUED)
+
+    assert len(reg) == 2
+    assert t1.task_id in reg
+    assert t1.session_key == "s1"
+    assert t1.origin.platform == "telegram"
+    assert [t.task_id for t in reg.list_tasks()] == [t1.task_id, t2.task_id]
+    assert reg.list_tasks(session_key="s1") == [t1]
+    assert reg.list_tasks(session_key="missing") == []
+
+
+def test_status_updates_worker_assignment_notes_and_cancel():
+    reg = TaskRegistry()
+    task = reg.create_task("heavy implementation", session_key="s1")
+
+    reg.update_status(task.task_id, STATUS_RUNNING, note="started")
+    reg.assign_worker(task.task_id, "worker-1", worker_kind=WORKER_CLAUDE_CODE)
+    reg.add_note(task.task_id, "needs review")
+
+    assert task.status == STATUS_RUNNING
+    assert task.active_worker_id == "worker-1"
+    assert task.worker_kind == WORKER_CLAUDE_CODE
+    assert task.notes == ["started", "needs review"]
+
+    reg.clear_worker(task.task_id)
+    assert task.active_worker_id is None
+    assert task.worker_kind is None
+
+    reg.cancel_task(task.task_id, reason="user reclaimed")
+    assert task.status == STATUS_CANCELLED
+    assert task.notes[-1] == "cancelled: user reclaimed"
+
+
+def test_invalid_status_rejected_on_create_update_and_load():
+    reg = TaskRegistry()
+    with pytest.raises(ValueError, match="unknown task status"):
+        reg.create_task("bad", status="mystery")
+
+    task = reg.create_task("ok")
+    with pytest.raises(ValueError, match="unknown task status"):
+        reg.update_status(task.task_id, "mystery")
+
+    payload = task.to_dict()
+    payload["status"] = "mystery"
+    with pytest.raises(ValueError, match="unknown task status"):
+        TaskRegistry.from_dict({"version": 1, "tasks": [payload]})
+
+
+def test_followups_attach_in_order_and_legacy_payloads_gain_session_key():
+    reg = TaskRegistry()
+    task = reg.create_task("collect fragmented input", session_key="s1")
+
+    first = PendingTurnItem(text="first", session_key="s1")
+    reg.attach_followup(task.task_id, first)
+    second = reg.attach_followup(task.task_id, "second")
+    media = reg.attach_followup(task.task_id, ("caption", ["/tmp/a.png"]))
+
+    assert task.pending_followups[0] is first
+    assert [item.text for item in task.pending_followups] == ["first", "second", "caption"]
+    assert second.session_key == "s1"
+    assert media.kind == KIND_MEDIA
+    assert media.boundary == BOUNDARY_HARD
+    assert media.media_refs == ["/tmp/a.png"]
+
+
+def test_serialization_roundtrip_excludes_raw_without_touching_it():
+    reg = TaskRegistry()
+    task = reg.create_task("serialize safely", origin={"platform": "cli", "session_key": "s1"})
+    reg.attach_followup(
+        task.task_id,
+        PendingTurnItem(text="rawful", session_key="s1", raw=UncopyableRaw()),
+    )
+    reg.attach_artifact(task.task_id, {"path": "/tmp/report.md", "kind": "markdown"})
+    reg.add_note(task.task_id, "review before delivery")
+
+    data = reg.to_dict()
+    assert "raw" not in data["tasks"][0]["pending_followups"][0]
+    json.dumps(data)  # JSON-safe
+
+    restored = TaskRegistry.from_dict(copy.deepcopy(data))
+    restored_task = restored.get_task(task.task_id)
+    assert restored_task is not None
+    assert restored_task.origin.platform == "cli"
+    assert restored_task.pending_followups[0].text == "rawful"
+    assert restored_task.pending_followups[0].raw is None
+    assert restored_task.artifacts == [{"path": "/tmp/report.md", "kind": "markdown"}]
+    assert restored_task.notes == ["review before delivery"]
+
+
+def test_active_filter_excludes_terminal_statuses():
+    reg = TaskRegistry()
+    active = reg.create_task("active", status=STATUS_PROPOSED)
+    queued = reg.create_task("queued", status=STATUS_QUEUED)
+    done = reg.create_task("done", status=STATUS_DONE)
+    error = reg.create_task("error", status=STATUS_ERROR)
+    cancelled = reg.create_task("cancelled", status=STATUS_CANCELLED)
+
+    assert [t.task_id for t in reg.list_tasks(active_only=True)] == [
+        active.task_id,
+        queued.task_id,
+    ]
+    assert not done.is_active
+    assert not error.is_active
+    assert not cancelled.is_active
+
+
+def test_artifacts_are_detached_json_safe_copies():
+    reg = TaskRegistry()
+    task = reg.create_task("artifact work")
+    artifact = {"path": "/tmp/out.pdf", "kind": "pdf", "meta": {"page": 1}}
+
+    stored = reg.attach_artifact(task.task_id, artifact)
+    artifact["path"] = "/tmp/mutated.pdf"
+    artifact["meta"]["page"] = 99
+
+    assert stored == {"path": "/tmp/out.pdf", "kind": "pdf", "meta": {"page": 1}}
+    serialized = task.to_dict()
+    serialized["artifacts"][0]["meta"]["page"] = 2
+    assert task.artifacts[0]["meta"]["page"] == 1
+
+    with pytest.raises(TypeError, match="artifact must be a dict"):
+        reg.attach_artifact(task.task_id, ["not", "dict"])
+
+    with pytest.raises(TypeError, match="artifact must be JSON-serializable"):
+        reg.attach_artifact(task.task_id, {"bad": object()})
+
+    with pytest.raises(TypeError, match="artifact must be JSON-serializable"):
+        reg.attach_artifact(task.task_id, {"metric": float("nan")})
+
+    with pytest.raises(TypeError, match="artifact must be JSON-serializable"):
+        reg.attach_artifact(task.task_id, {"metric": float("inf")})
+
+    json.dumps(reg.to_dict(), allow_nan=False)
+
+
+def test_json_persistence_roundtrip_and_missing_file(tmp_path):
+    path = tmp_path / "registry.json"
+    missing = TaskRegistry.load(path)
+    assert missing.path == str(path)
+    assert missing.list_tasks() == []
+
+    task = missing.create_task("persist me", session_key="s1")
+    missing.attach_followup(task.task_id, PendingTurnItem(kind=KIND_TEXT, text="late note"))
+    written = missing.save()
+
+    assert written == str(path)
+    loaded = TaskRegistry.load(path)
+    assert loaded.path == str(path)
+    assert [t.user_goal for t in loaded.list_tasks()] == ["persist me"]
+    assert loaded.get_task(task.task_id).pending_followups[0].text == "late note"
+
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    assert doc["version"] == TaskRegistry.SCHEMA_VERSION

--- a/tests/agent/test_worker_lanes.py
+++ b/tests/agent/test_worker_lanes.py
@@ -1,0 +1,514 @@
+"""Tests for the worker-lane / detached-execution substrate (orchestrator Phase 4).
+
+These cover the leaf module ``agent.worker_lanes`` in isolation: the
+:class:`WorkerSpec` / :class:`WorkerHandle` / :class:`WorkerResult` shapes, the
+:class:`ThreadWorkerLane` lifecycle (start returns before completion; success
+stores a result; a raised exception stores an error; cooperative cancellation),
+follow-up storage and order (with ``PendingTurnItem.raw`` neither serialised nor
+touched), the :class:`WorkerLaneRegistry` routing, clear errors for unknown /
+duplicate ids, optional :class:`~agent.task_registry.TaskRegistry` linkage, and
+JSON-safety of the snapshot path (including rejection of non-JSON-safe metadata).
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from agent.pending_turn_queue import KIND_MEDIA, PendingTurnItem, from_legacy_cli_payload
+from agent.task_registry import TaskRegistry
+from agent import worker_lanes as wl
+from agent.worker_lanes import (
+    CancelToken,
+    FOLLOWUP_DEFERRED,
+    FOLLOWUP_REJECTED,
+    LANE_THREAD,
+    ThreadWorkerLane,
+    WorkerCancelled,
+    WorkerHandle,
+    WorkerLaneRegistry,
+    WorkerResult,
+    WorkerSpec,
+    WorkerStatus,
+    link_worker_to_task,
+)
+
+TIMEOUT = 5.0
+
+
+class UncopyableRaw:
+    """A ``PendingTurnItem.raw`` payload that explodes if anything deep-copies it."""
+
+    def __deepcopy__(self, memo):  # pragma: no cover - only hit on a regression
+        raise AssertionError("PendingTurnItem.raw must not be deep-copied")
+
+
+def _instant_runner(result="ok"):
+    def runner(spec, token):  # noqa: ARG001 - signature is the contract
+        return result
+
+    return runner
+
+
+def _gated_runner(*, entered: threading.Event, release: threading.Event, after=lambda spec, token: "done"):
+    """A runner that signals *entered*, parks on *release*, then runs *after*."""
+
+    def runner(spec, token):
+        entered.set()
+        if not release.wait(TIMEOUT):  # pragma: no cover - would mean a hung test
+            raise AssertionError("release event was never set")
+        return after(spec, token)
+
+    return runner
+
+
+# --------------------------------------------------------------------------
+# WorkerSpec / WorkerHandle / WorkerResult
+# --------------------------------------------------------------------------
+def test_worker_spec_defaults_and_roundtrip():
+    spec = WorkerSpec(goal="draft the briefing")
+    assert spec.context is None
+    assert spec.task_id is None
+    assert spec.lane == LANE_THREAD
+    assert spec.metadata == {}
+
+    full = WorkerSpec(
+        goal="g", context="c", task_id="task-1", lane="thread", metadata={"priority": 2}
+    )
+    d = full.to_dict()
+    json.dumps(d)  # JSON-safe
+    assert d == {
+        "goal": "g",
+        "context": "c",
+        "task_id": "task-1",
+        "lane": "thread",
+        "metadata": {"priority": 2},
+    }
+    assert WorkerSpec.from_dict({**d, "future_key": 1}) == full
+
+    with pytest.raises(TypeError, match="metadata must be a dict"):
+        WorkerSpec(goal="g", metadata=["not", "a", "dict"])
+    with pytest.raises(TypeError, match="goal must be a string"):
+        WorkerSpec(goal=object())
+    with pytest.raises(TypeError, match="goal must be a string"):
+        WorkerSpec(goal=float("nan"))
+    with pytest.raises(TypeError, match="context must be a string or None"):
+        WorkerSpec(goal="g", context=object())
+    with pytest.raises(TypeError, match="task_id must be a string or None"):
+        WorkerSpec(goal="g", task_id=object())
+    with pytest.raises(TypeError, match="lane must be a non-empty string"):
+        WorkerSpec(goal="g", lane="")
+    json.dumps(full.to_dict(), allow_nan=False)
+
+
+def test_worker_handle_and_result_to_dict_are_json_safe():
+    h = WorkerHandle(
+        worker_id="worker-1",
+        task_id="task-1",
+        lane="thread",
+        status=WorkerStatus.RUNNING,
+        created_at=1.0,
+        updated_at=2.0,
+        cancel_requested=True,
+    )
+    assert h.is_terminal is False
+    json.dumps(h.to_dict())
+    assert h.to_dict()["cancel_requested"] is True
+
+    r = WorkerResult(
+        worker_id="worker-1",
+        status=WorkerStatus.DONE,
+        result="payload",
+        started_at=1.0,
+        finished_at=3.0,
+    )
+    json.dumps(r.to_dict())
+    assert r.to_dict()["result"] == "payload"
+    assert r.to_dict()["error"] is None
+
+
+# --------------------------------------------------------------------------
+# CancelToken
+# --------------------------------------------------------------------------
+def test_cancel_token_behavior():
+    token = CancelToken()
+    assert token.cancelled is False
+    token.raise_if_cancelled()  # no-op while not cancelled
+    assert token.wait(timeout=0) is False
+
+    token.request()
+    token.request()  # idempotent
+    assert token.cancelled is True
+    assert token.wait(timeout=0) is True
+    with pytest.raises(WorkerCancelled):
+        token.raise_if_cancelled()
+
+
+# --------------------------------------------------------------------------
+# ThreadWorkerLane -- lifecycle
+# --------------------------------------------------------------------------
+def test_start_returns_before_worker_completes_and_status_progresses():
+    entered = threading.Event()
+    release = threading.Event()
+    lane = ThreadWorkerLane(runner=_gated_runner(entered=entered, release=release))
+
+    t0 = time.monotonic()
+    handle = lane.start(WorkerSpec(goal="slow work", task_id="task-1"))
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 1.0  # start() did not block on the runner
+    assert isinstance(handle, WorkerHandle)
+    assert handle.status == WorkerStatus.QUEUED  # clean snapshot: thread is parked on the lane lock
+    assert handle.task_id == "task-1"
+    assert handle.lane == LANE_THREAD
+    assert lane.result(handle.worker_id) is None  # not terminal yet
+
+    assert entered.wait(TIMEOUT)  # the runner did start on its own
+    assert lane.status(handle.worker_id).status == WorkerStatus.RUNNING
+
+    release.set()
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    assert lane.status(handle.worker_id).status == WorkerStatus.DONE
+
+
+def test_successful_completion_stores_result():
+    lane = ThreadWorkerLane(runner=_instant_runner("the answer"))
+    handle = lane.start(WorkerSpec(goal="quick"))
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+    res = lane.result(handle.worker_id)
+    assert isinstance(res, WorkerResult)
+    assert res.status == WorkerStatus.DONE
+    assert res.result == "the answer"
+    assert res.error is None
+    assert res.started_at is not None and res.finished_at is not None
+    assert res.finished_at >= res.started_at
+    handle2 = lane.status(handle.worker_id)
+    assert handle2.status == WorkerStatus.DONE
+    assert handle2.is_terminal is True
+    assert handle2.cancel_requested is False
+
+
+def test_non_string_runner_return_is_coerced_to_str():
+    lane = ThreadWorkerLane(runner=_instant_runner({"k": "v"}))
+    handle = lane.start(WorkerSpec(goal="dict result"))
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    assert lane.result(handle.worker_id).result == str({"k": "v"})
+
+    lane2 = ThreadWorkerLane(runner=_instant_runner(None))
+    h2 = lane2.start(WorkerSpec(goal="none result"))
+    assert lane2.wait(h2.worker_id, timeout=TIMEOUT)
+    assert lane2.result(h2.worker_id).result is None
+
+
+def test_raised_exception_stores_error_and_status_error_without_crashing_caller():
+    def boom(spec, token):  # noqa: ARG001
+        raise ValueError("kaboom")
+
+    lane = ThreadWorkerLane(runner=boom)
+    handle = lane.start(WorkerSpec(goal="will fail"))
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+
+    res = lane.result(handle.worker_id)
+    assert res.status == WorkerStatus.ERROR
+    assert res.result is None
+    assert "ValueError" in res.error
+    assert "kaboom" in res.error
+    # The caller is unscathed: a separate healthy lane can still be used normally.
+    healthy_lane = ThreadWorkerLane(runner=_instant_runner("recovered"))
+    ok = healthy_lane.start(WorkerSpec(goal="recovers"))
+    assert healthy_lane.wait(ok.worker_id, timeout=TIMEOUT)
+    assert healthy_lane.result(ok.worker_id).status == WorkerStatus.DONE
+
+
+# --------------------------------------------------------------------------
+# ThreadWorkerLane -- cancellation
+# --------------------------------------------------------------------------
+def test_cancel_before_and_during_worker_cooperative():
+    entered = threading.Event()
+    release = threading.Event()
+    # The runner parks on *release* before doing anything, then cooperates.
+    lane = ThreadWorkerLane(
+        runner=_gated_runner(
+            entered=entered, release=release, after=lambda spec, token: token.raise_if_cancelled() or "unreached"
+        )
+    )
+    handle = lane.start(WorkerSpec(goal="cancellable"))
+    assert entered.wait(TIMEOUT)
+    assert lane.status(handle.worker_id).status == WorkerStatus.RUNNING
+    assert lane.status(handle.worker_id).cancel_requested is False
+
+    assert lane.cancel(handle.worker_id) is True
+    assert lane.status(handle.worker_id).cancel_requested is True
+
+    release.set()
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    res = lane.result(handle.worker_id)
+    assert res.status == WorkerStatus.CANCELLED
+    assert res.result is None
+    assert res.error is None
+    assert lane.status(handle.worker_id).cancel_requested is True
+
+    # Cancelling a finished worker is a safe no-op.
+    assert lane.cancel(handle.worker_id) is False
+
+
+def test_cancel_after_completion_is_a_safe_noop():
+    lane = ThreadWorkerLane(runner=_instant_runner("done"))
+    handle = lane.start(WorkerSpec(goal="fast"))
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    assert lane.status(handle.worker_id).status == WorkerStatus.DONE
+
+    assert lane.cancel(handle.worker_id) is False
+    # Status and result are untouched; cancel_requested stays False.
+    assert lane.status(handle.worker_id).status == WorkerStatus.DONE
+    assert lane.status(handle.worker_id).cancel_requested is False
+    assert lane.result(handle.worker_id).result == "done"
+
+
+def test_cancel_during_uncooperative_runner_still_completes_as_done():
+    entered = threading.Event()
+    release = threading.Event()
+    # This runner ignores the token and returns a result anyway.
+    lane = ThreadWorkerLane(runner=_gated_runner(entered=entered, release=release, after=lambda s, t: "ignored cancel"))
+    handle = lane.start(WorkerSpec(goal="uncooperative"))
+    assert entered.wait(TIMEOUT)
+    assert lane.cancel(handle.worker_id) is True
+
+    release.set()
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    res = lane.result(handle.worker_id)
+    # The work completed, so it is DONE -- but the cancellation request is not lost.
+    assert res.status == WorkerStatus.DONE
+    assert res.result == "ignored cancel"
+    assert lane.status(handle.worker_id).cancel_requested is True
+
+
+# --------------------------------------------------------------------------
+# ThreadWorkerLane -- follow-ups
+# --------------------------------------------------------------------------
+def test_followups_preserve_order_and_raw_is_neither_serialized_nor_touched():
+    entered = threading.Event()
+    release = threading.Event()
+    lane = ThreadWorkerLane(runner=_gated_runner(entered=entered, release=release))
+    handle = lane.start(WorkerSpec(goal="receives followups"))
+    assert entered.wait(TIMEOUT)
+
+    a = PendingTurnItem(text="first")
+    b = PendingTurnItem(text="second", raw=UncopyableRaw())  # raw must survive untouched
+    c = from_legacy_cli_payload(("caption", ["/tmp/a.png"]))  # a media item
+
+    assert lane.append_followup(handle.worker_id, a) == FOLLOWUP_DEFERRED
+    assert lane.append_followup(handle.worker_id, b) == FOLLOWUP_DEFERRED
+    assert lane.append_followup(handle.worker_id, c) == FOLLOWUP_DEFERRED
+
+    stored = lane.followups(handle.worker_id)
+    assert [it.text for it in stored] == ["first", "second", "caption"]
+    assert stored[0] is a and stored[1] is b  # stored as-is, not copied
+    assert isinstance(stored[1].raw, UncopyableRaw)  # raw untouched, still present
+    assert stored[2].kind == KIND_MEDIA and stored[2].media_refs == ["/tmp/a.png"]
+
+    # Non-PendingTurnItem input is rejected with a clear error.
+    with pytest.raises(TypeError, match="expects a PendingTurnItem"):
+        lane.append_followup(handle.worker_id, "raw string follow-up")
+
+    # The JSON snapshot includes follow-ups via PendingTurnItem.to_dict, which
+    # drops `raw` without touching it.
+    snap = lane.snapshot(handle.worker_id)
+    fu_dicts = snap["followups"]
+    assert [d["text"] for d in fu_dicts] == ["first", "second", "caption"]
+    assert all("raw" not in d for d in fu_dicts)
+    json.dumps(snap)  # JSON-safe end to end
+
+    release.set()
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    # Appending to a finished worker is rejected (not stored).
+    assert lane.append_followup(handle.worker_id, PendingTurnItem(text="too late")) == FOLLOWUP_REJECTED
+    assert [it.text for it in lane.followups(handle.worker_id)] == ["first", "second", "caption"]
+
+
+# --------------------------------------------------------------------------
+# Unknown / duplicate worker ids and lanes
+# --------------------------------------------------------------------------
+def test_unknown_worker_id_raises_clear_keyerror_everywhere():
+    lane = ThreadWorkerLane(runner=_instant_runner())
+    for call in (
+        lambda: lane.status("worker-nope"),
+        lambda: lane.result("worker-nope"),
+        lambda: lane.cancel("worker-nope"),
+        lambda: lane.append_followup("worker-nope", PendingTurnItem(text="x")),
+        lambda: lane.wait("worker-nope", timeout=0),
+        lambda: lane.followups("worker-nope"),
+        lambda: lane.snapshot("worker-nope"),
+    ):
+        with pytest.raises(KeyError, match="unknown worker id"):
+            call()
+
+
+def test_worker_id_collision_is_rejected(monkeypatch):
+    monkeypatch.setattr(wl, "_new_worker_id", lambda: "worker-fixed")
+    lane = ThreadWorkerLane(runner=_instant_runner())
+    first = lane.start(WorkerSpec(goal="one"))
+    assert first.worker_id == "worker-fixed"
+    with pytest.raises(RuntimeError, match="worker id collision"):
+        lane.start(WorkerSpec(goal="two"))
+
+
+def test_lane_construction_rejects_bad_args():
+    with pytest.raises(TypeError, match="runner must be callable"):
+        ThreadWorkerLane(runner="not callable")
+    with pytest.raises(TypeError, match="lane name must be a non-empty string"):
+        ThreadWorkerLane(runner=_instant_runner(), name="")
+    with pytest.raises(TypeError, match="spec must be a WorkerSpec"):
+        ThreadWorkerLane(runner=_instant_runner()).start({"goal": "not a spec"})
+
+
+# --------------------------------------------------------------------------
+# WorkerLaneRegistry
+# --------------------------------------------------------------------------
+def test_registry_routes_status_result_cancel_followup_to_the_right_lane():
+    entered_a = threading.Event()
+    release_a = threading.Event()
+    lane_a = ThreadWorkerLane(
+        runner=_gated_runner(
+            entered=entered_a,
+            release=release_a,
+            after=lambda spec, token: token.raise_if_cancelled() or "unreached",
+        ),
+        name="thread",
+    )
+    lane_b = ThreadWorkerLane(runner=_instant_runner("from b"), name="thread-b")
+
+    reg = WorkerLaneRegistry()
+    reg.register(lane_a)
+    reg.register(lane_b)
+    assert set(reg.lane_names()) == {"thread", "thread-b"}
+    assert reg.get_lane("thread") is lane_a
+
+    # spec.lane drives the default target...
+    h_a = reg.start(WorkerSpec(goal="on a", lane="thread"))
+    # ...and an explicit lane_name override wins.
+    h_b = reg.start(WorkerSpec(goal="on b", lane="thread"), lane_name="thread-b")
+
+    assert entered_a.wait(TIMEOUT)
+    assert reg.status(h_a.worker_id).status == WorkerStatus.RUNNING
+    assert reg.status(h_a.worker_id).lane == "thread"
+    assert reg.append_followup(h_a.worker_id, PendingTurnItem(text="steer a")) == FOLLOWUP_DEFERRED
+    assert lane_a.followups(h_a.worker_id)[0].text == "steer a"
+
+    assert reg.cancel(h_a.worker_id) is True
+    release_a.set()
+    assert reg.wait(h_a.worker_id, timeout=TIMEOUT)
+    assert reg.result(h_a.worker_id).status == WorkerStatus.CANCELLED
+
+    assert reg.wait(h_b.worker_id, timeout=TIMEOUT)
+    assert reg.result(h_b.worker_id).status == WorkerStatus.DONE
+    assert reg.result(h_b.worker_id).result == "from b"
+    assert reg.status(h_b.worker_id).lane == "thread-b"
+
+
+def test_registry_rejects_duplicate_lane_and_unknown_lane_or_worker():
+    reg = WorkerLaneRegistry()
+    reg.register(ThreadWorkerLane(runner=_instant_runner(), name="thread"))
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(ThreadWorkerLane(runner=_instant_runner(), name="thread"))
+    with pytest.raises(TypeError, match="non-empty string 'name'"):
+        reg.register(object())
+
+    with pytest.raises(KeyError, match="unknown worker lane"):
+        reg.start(WorkerSpec(goal="x", lane="ghost"))
+    with pytest.raises(KeyError, match="unknown worker lane"):
+        reg.start(WorkerSpec(goal="x"), lane_name="ghost")
+
+    for call in (
+        lambda: reg.status("worker-nope"),
+        lambda: reg.result("worker-nope"),
+        lambda: reg.cancel("worker-nope"),
+        lambda: reg.append_followup("worker-nope", PendingTurnItem(text="x")),
+        lambda: reg.wait("worker-nope", timeout=0),
+    ):
+        with pytest.raises(KeyError, match="unknown worker id"):
+            call()
+
+    with pytest.raises(TypeError, match="spec must be a WorkerSpec"):
+        reg.start({"goal": "nope"})
+
+
+def test_registry_rejects_cross_lane_worker_id_collision(monkeypatch):
+    monkeypatch.setattr(wl, "_new_worker_id", lambda: "worker-fixed")
+    lane_a = ThreadWorkerLane(runner=_instant_runner("a"), name="thread-a")
+    lane_b = ThreadWorkerLane(runner=_instant_runner("b"), name="thread-b")
+    reg = WorkerLaneRegistry()
+    reg.register(lane_a)
+    reg.register(lane_b)
+
+    first = reg.start(WorkerSpec(goal="a", lane="thread-a"))
+    assert first.worker_id == "worker-fixed"
+    with pytest.raises(RuntimeError, match="worker id collision across lanes"):
+        reg.start(WorkerSpec(goal="b", lane="thread-b"))
+
+    assert reg.wait(first.worker_id, timeout=TIMEOUT)
+    assert reg.result(first.worker_id).result == "a"
+    assert reg.status(first.worker_id).lane == "thread-a"
+
+
+# --------------------------------------------------------------------------
+# Optional TaskRegistry linkage
+# --------------------------------------------------------------------------
+def test_link_worker_to_task_records_worker_metadata_on_the_focused_task():
+    reg = TaskRegistry()
+    task = reg.create_task("heavy implementation", session_key="s1")
+    lane = ThreadWorkerLane(runner=_instant_runner("done"))
+    handle = lane.start(WorkerSpec(goal="heavy implementation", task_id=task.task_id))
+
+    returned = link_worker_to_task(reg, task.task_id, handle)
+    assert returned is task
+    assert task.active_worker_id == handle.worker_id
+    assert task.worker_kind == LANE_THREAD  # defaults to the lane name
+
+    # An explicit worker_kind overrides the default.
+    link_worker_to_task(reg, task.task_id, handle, worker_kind="ralph")
+    assert task.worker_kind == "ralph"
+
+    # No classifier / routing was started: the registry still has exactly one task,
+    # and the task's status is whatever we set it to (linkage does not touch it).
+    assert len(reg) == 1
+    assert task.status == "proposed"
+
+    assert lane.wait(handle.worker_id, timeout=TIMEOUT)
+    assert lane.result(handle.worker_id).status == WorkerStatus.DONE
+
+
+# --------------------------------------------------------------------------
+# JSON snapshots vs non-JSON-safe metadata
+# --------------------------------------------------------------------------
+def test_snapshots_reject_non_json_safe_metadata():
+    # WorkerSpec.to_dict refuses non-JSON-safe metadata loudly...
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        WorkerSpec(goal="g", metadata={"bad": object()}).to_dict()
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        WorkerSpec(goal="g", metadata={"nan": float("nan")}).to_dict()
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        WorkerSpec(goal="g", metadata={"inf": float("inf")}).to_dict()
+
+    # ...and a lane snapshot that would have to embed such a spec raises too,
+    # rather than silently dropping or faking it.
+    lane = ThreadWorkerLane(runner=_instant_runner())
+    bad = lane.start(WorkerSpec(goal="bad metadata", metadata={"obj": object()}))
+    assert lane.wait(bad.worker_id, timeout=TIMEOUT)
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        lane.snapshot(bad.worker_id)
+    with pytest.raises(TypeError, match="metadata must be JSON-serializable"):
+        lane.snapshot()
+
+    # A worker with JSON-safe metadata snapshots cleanly.
+    ok = lane.start(WorkerSpec(goal="fine", task_id="task-9", metadata={"depth": 3}))
+    assert lane.wait(ok.worker_id, timeout=TIMEOUT)
+    snap = lane.snapshot(ok.worker_id)
+    json.dumps(snap)
+    assert snap["worker_id"] == ok.worker_id
+    assert snap["status"] == WorkerStatus.DONE
+    assert snap["spec"]["metadata"] == {"depth": 3}
+    assert snap["spec"]["task_id"] == "task-9"
+    assert snap["followups"] == []

--- a/tests/cli/test_frontdesk_live_predispatch.py
+++ b/tests/cli/test_frontdesk_live_predispatch.py
@@ -1,0 +1,132 @@
+import os
+import queue
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from agent.orchestration_runtime import get_orchestration_runtime
+from agent.task_registry import STATUS_CANCELLED
+from tests.cli.test_cli_init import _make_cli
+
+
+def test_status_consumed_before_model_run():
+    cli = _make_cli()
+    cli.frontdesk_live_enabled = True
+    cli.agent = MagicMock()
+    cli.agent.run_conversation.return_value = {"final_response": "model"}
+
+    response = cli.chat("지금 뭐 하고 있어?")
+
+    cli.agent.run_conversation.assert_not_called()
+    assert isinstance(response, str)
+    assert (
+        "Tasks:" in response
+        or "Active tasks:" in response
+        or "No active tasks" in response
+    )
+
+
+def test_stop_never_enters_pending_queue_when_busy():
+    cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
+    cli.frontdesk_live_enabled = True
+    cli._agent_running = True
+    cli._pending_input = MagicMock()
+    cli._interrupt_queue = queue.Queue()
+    cli.agent = MagicMock()
+
+    result = cli._handle_frontdesk_live_input("멈춰", main_in_flight=True)
+
+    assert result is not None
+    assert result.action == "stopped"
+    cli._pending_input.put.assert_not_called()
+    cli.agent.interrupt.assert_called_once_with("멈춰")
+
+
+def test_worker_request_does_not_fall_through_to_main_when_frontdesk_enabled():
+    cli = _make_cli()
+    cli.frontdesk_live_enabled = True
+    cli.agent = MagicMock()
+    cli.agent.run_conversation.return_value = {"final_response": "model"}
+
+    response = cli.chat("워커 레인에 배당해서 이 회귀를 조사해줘")
+
+    cli.agent.run_conversation.assert_not_called()
+    assert "worker lane unavailable" in response
+    runtime = get_orchestration_runtime(cli)
+    assert runtime is not None
+    tasks = runtime.task_registry.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].status == STATUS_CANCELLED
+    assert "no worker lane" in " ".join(tasks[0].notes)
+
+
+def test_korean_followups_steer_when_live_and_agent_accepts():
+    cli = _make_cli()
+    cli.frontdesk_live_enabled = True
+    cli.agent = MagicMock()
+    cli.agent.steer.return_value = True
+
+    for text in ("중국집은 없나", "빠니니를 파는 곳도 찾아보고 있어야지"):
+        result = cli._handle_frontdesk_live_input(text, main_in_flight=True)
+        assert result is not None
+        assert result.action == "steered"
+
+    assert cli.agent.steer.call_args_list[0].args == ("중국집은 없나",)
+    assert cli.agent.steer.call_args_list[1].args == ("빠니니를 파는 곳도 찾아보고 있어야지",)
+
+
+def test_korean_followup_rejected_by_steer_callback_falls_through():
+    cli = _make_cli()
+    cli.frontdesk_live_enabled = True
+    cli.agent = MagicMock()
+    cli.agent.steer.return_value = False
+
+    result = cli._handle_frontdesk_live_input("중국집은 없나", main_in_flight=True)
+
+    assert result is None
+    cli.agent.steer.assert_called_once_with("중국집은 없나")
+
+
+def test_frontdesk_mode_enabled_alone_does_not_enable_live_interception():
+    cli = _make_cli()
+    cli.frontdesk_mode_enabled = True
+    cli.agent = MagicMock()
+    cli.agent.max_iterations = 90
+    cli.agent.run_conversation.return_value = {"final_response": "model"}
+    cli._active_agent_route_signature = "sig"
+
+    with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": "sig",
+             "model": None,
+             "runtime": None,
+             "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        response = cli.chat("지금 뭐 하고 있어?")
+
+    cli.agent.run_conversation.assert_called_once()
+    assert response == "model"
+
+
+def test_frontdesk_disabled_preserves_existing_behavior():
+    cli = _make_cli()
+    cli.frontdesk_live_enabled = False
+    cli.agent = MagicMock()
+    cli.agent.max_iterations = 90
+    cli.agent.run_conversation.return_value = {"final_response": "model"}
+    cli._active_agent_route_signature = "sig"
+
+    with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": "sig",
+             "model": None,
+             "runtime": None,
+             "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        response = cli.chat("지금 뭐 하고 있어?")
+
+    cli.agent.run_conversation.assert_called_once()
+    assert response == "model"

--- a/tests/cli/test_frontdesk_live_predispatch.py
+++ b/tests/cli/test_frontdesk_live_predispatch.py
@@ -43,22 +43,25 @@ def test_stop_never_enters_pending_queue_when_busy():
     cli.agent.interrupt.assert_called_once_with("멈춰")
 
 
-def test_worker_request_does_not_fall_through_to_main_when_frontdesk_enabled():
+def test_worker_request_starts_default_worker_when_frontdesk_enabled():
     cli = _make_cli()
     cli.frontdesk_live_enabled = True
     cli.agent = MagicMock()
     cli.agent.run_conversation.return_value = {"final_response": "model"}
 
-    response = cli.chat("워커 레인에 배당해서 이 회귀를 조사해줘")
+    with patch("agent.frontdesk_live._run_default_worker_subprocess", return_value="worker done"):
+        response = cli.chat("워커 레인에 배당해서 이 회귀를 조사해줘")
 
     cli.agent.run_conversation.assert_not_called()
-    assert "worker lane unavailable" in response
+    assert "worker started" in response
     runtime = get_orchestration_runtime(cli)
     assert runtime is not None
+    assert "main" in runtime.worker_registry.lane_names()
     tasks = runtime.task_registry.list_tasks()
     assert len(tasks) == 1
-    assert tasks[0].status == STATUS_CANCELLED
-    assert "no worker lane" in " ".join(tasks[0].notes)
+    assert tasks[0].status != STATUS_CANCELLED
+    assert tasks[0].active_worker_id
+    assert "worker started" in " ".join(tasks[0].notes)
 
 
 def test_korean_followups_steer_when_live_and_agent_accepts():

--- a/tests/gateway/test_frontdesk_live_predispatch.py
+++ b/tests/gateway/test_frontdesk_live_predispatch.py
@@ -125,6 +125,21 @@ async def test_gateway_pending_sentinel_does_not_consume_korean_followup():
 
 
 @pytest.mark.asyncio
+async def test_frontdesk_status_command_reports_live_gate_and_worker_lane():
+    from gateway.run import GatewayRunner
+
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    event = _make_event(text="/frontdesk status")
+
+    result = await GatewayRunner._handle_frontdesk_command(runner, event)
+
+    assert "Frontdesk live: enabled" in result
+    assert "Default worker lane: available" in result
+    assert "Available worker lanes: main" in result
+
+
+@pytest.mark.asyncio
 async def test_frontdesk_mode_enabled_alone_does_not_enable_gateway_live_interception():
     from gateway.run import GatewayRunner
 

--- a/tests/gateway/test_frontdesk_live_predispatch.py
+++ b/tests/gateway/test_frontdesk_live_predispatch.py
@@ -28,6 +28,7 @@ async def test_status_consumed_before_model_run():
         "Tasks:" in result
         or "Active tasks:" in result
         or "No active tasks" in result
+        or "Available worker lanes" in result
     )
 
 

--- a/tests/gateway/test_frontdesk_live_predispatch.py
+++ b/tests/gateway/test_frontdesk_live_predispatch.py
@@ -1,0 +1,160 @@
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.orchestration_runtime import get_orchestration_runtime
+from agent.task_registry import STATUS_CANCELLED
+from gateway.platforms.base import MessageType, build_session_key
+from tests.gateway.test_busy_session_ack import _make_adapter, _make_event, _make_runner
+
+
+@pytest.mark.asyncio
+async def test_status_consumed_before_model_run():
+    from gateway.run import GatewayRunner
+
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    adapter = _make_adapter()
+    event = _make_event(text="지금 뭐 하고 있어?")
+    runner.adapters[event.source.platform] = adapter
+
+    with patch.object(GatewayRunner, "_run_agent", autospec=True) as run_agent:
+        result = await GatewayRunner._handle_message(runner, event)
+
+    run_agent.assert_not_called()
+    assert isinstance(result, str)
+    assert (
+        "Tasks:" in result
+        or "Active tasks:" in result
+        or "No active tasks" in result
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_never_enters_pending_queue_when_busy():
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    runner._busy_input_mode = "queue"
+    adapter = _make_adapter()
+    event = _make_event(text="멈춰")
+    sk = build_session_key(event.source)
+    agent = MagicMock()
+    runner._running_agents[sk] = agent
+    runner._running_agents_ts[sk] = time.time()
+    runner.adapters[event.source.platform] = adapter
+
+    with patch("gateway.run.merge_pending_message_event") as merge:
+        handled = await runner._handle_active_session_busy_message(event, sk)
+
+    assert handled is True
+    merge.assert_not_called()
+    assert sk not in adapter._pending_messages
+    agent.interrupt.assert_called_once_with("멈춰")
+
+
+@pytest.mark.asyncio
+async def test_worker_request_does_not_fall_through_to_main_when_frontdesk_enabled():
+    from gateway.run import GatewayRunner
+
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    adapter = _make_adapter()
+    event = _make_event(text="워커 레인에 배당해서 이 회귀를 조사해줘")
+    runner.adapters[event.source.platform] = adapter
+
+    with patch.object(GatewayRunner, "_run_agent", autospec=True) as run_agent:
+        result = await GatewayRunner._handle_message(runner, event)
+
+    run_agent.assert_not_called()
+    assert isinstance(result, str)
+    assert "worker lane unavailable" in result
+    runtime = get_orchestration_runtime(runner)
+    assert runtime is not None
+    tasks = runtime.task_registry.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].status == STATUS_CANCELLED
+    assert "no worker lane" in " ".join(tasks[0].notes)
+
+
+@pytest.mark.asyncio
+async def test_korean_followup_steers_active_agent_when_live_enabled():
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    adapter = _make_adapter()
+    event = _make_event(text="중국집은 없나")
+    sk = build_session_key(event.source)
+    agent = MagicMock()
+    agent.steer.return_value = True
+    runner._running_agents[sk] = agent
+    runner.adapters[event.source.platform] = adapter
+
+    with patch("gateway.run.merge_pending_message_event") as merge:
+        handled = await runner._handle_active_session_busy_message(event, sk)
+
+    assert handled is True
+    agent.steer.assert_called_once_with("중국집은 없나")
+    merge.assert_not_called()
+    assert sk not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_gateway_pending_sentinel_does_not_consume_korean_followup():
+    from gateway.run import GatewayRunner
+
+    runner, sentinel = _make_runner()
+    runner.frontdesk_live_enabled = True
+    adapter = _make_adapter()
+    event = _make_event(text="빠니니를 파는 곳도 찾아보고 있어야지")
+    sk = build_session_key(event.source)
+    runner._running_agents[sk] = sentinel
+    runner.adapters[event.source.platform] = adapter
+
+    with patch.object(GatewayRunner, "_run_agent", autospec=True) as run_agent:
+        result = await GatewayRunner._handle_message(runner, event)
+
+    assert result is None
+    run_agent.assert_not_called()
+    assert sk in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_frontdesk_mode_enabled_alone_does_not_enable_gateway_live_interception():
+    from gateway.run import GatewayRunner
+
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_mode_enabled = True
+    runner.frontdesk_live_enabled = False
+    adapter = _make_adapter()
+    event = _make_event(text="지금 뭐 하고 있어?")
+    runner.adapters[event.source.platform] = adapter
+
+    with patch.object(
+        GatewayRunner,
+        "_handle_message_with_agent",
+        new=AsyncMock(return_value="model"),
+    ) as handle_with_agent:
+        result = await GatewayRunner._handle_message(runner, event)
+
+    assert result == "model"
+    handle_with_agent.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_frontdesk_disabled_preserves_existing_busy_behavior():
+    runner, _sentinel = _make_runner()
+    runner.frontdesk_live_enabled = False
+    runner._busy_input_mode = "queue"
+    adapter = _make_adapter()
+    event = _make_event(text="멈춰")
+    event.message_type = MessageType.TEXT
+    sk = build_session_key(event.source)
+    agent = MagicMock()
+    runner._running_agents[sk] = agent
+    runner.adapters[event.source.platform] = adapter
+
+    with patch("gateway.run.merge_pending_message_event") as merge:
+        await runner._handle_active_session_busy_message(event, sk)
+
+    merge.assert_called_once()
+    agent.interrupt.assert_not_called()

--- a/tests/gateway/test_frontdesk_live_predispatch.py
+++ b/tests/gateway/test_frontdesk_live_predispatch.py
@@ -54,7 +54,7 @@ async def test_stop_never_enters_pending_queue_when_busy():
 
 
 @pytest.mark.asyncio
-async def test_worker_request_does_not_fall_through_to_main_when_frontdesk_enabled():
+async def test_worker_request_starts_default_worker_when_frontdesk_enabled():
     from gateway.run import GatewayRunner
 
     runner, _sentinel = _make_runner()
@@ -63,18 +63,23 @@ async def test_worker_request_does_not_fall_through_to_main_when_frontdesk_enabl
     event = _make_event(text="워커 레인에 배당해서 이 회귀를 조사해줘")
     runner.adapters[event.source.platform] = adapter
 
-    with patch.object(GatewayRunner, "_run_agent", autospec=True) as run_agent:
+    with patch.object(GatewayRunner, "_run_agent", autospec=True) as run_agent, patch(
+        "agent.frontdesk_live._run_default_worker_subprocess",
+        return_value="worker done",
+    ):
         result = await GatewayRunner._handle_message(runner, event)
 
     run_agent.assert_not_called()
     assert isinstance(result, str)
-    assert "worker lane unavailable" in result
+    assert "worker started" in result
     runtime = get_orchestration_runtime(runner)
     assert runtime is not None
+    assert "main" in runtime.worker_registry.lane_names()
     tasks = runtime.task_registry.list_tasks()
     assert len(tasks) == 1
-    assert tasks[0].status == STATUS_CANCELLED
-    assert "no worker lane" in " ".join(tasks[0].notes)
+    assert tasks[0].status != STATUS_CANCELLED
+    assert tasks[0].active_worker_id
+    assert "worker started" in " ".join(tasks[0].notes)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -107,6 +107,29 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 
 
+def test_load_orchestration_status_queries_prefers_env_then_config_then_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("HERMES_GATEWAY_ORCHESTRATION_STATUS_QUERIES", raising=False)
+
+    assert gateway_run.GatewayRunner._load_orchestration_status_queries_enabled() is False
+
+    (tmp_path / "config.yaml").write_text(
+        "orchestration:\n  status_queries_enabled: true\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_orchestration_status_queries_enabled() is True
+
+    (tmp_path / "config.yaml").write_text(
+        "orchestration:\n  status_queries_enabled: false\n", encoding="utf-8"
+    )
+    assert gateway_run.GatewayRunner._load_orchestration_status_queries_enabled() is False
+
+    monkeypatch.setenv("HERMES_GATEWAY_ORCHESTRATION_STATUS_QUERIES", "1")
+    assert gateway_run.GatewayRunner._load_orchestration_status_queries_enabled() is True
+
+    monkeypatch.setenv("HERMES_GATEWAY_ORCHESTRATION_STATUS_QUERIES", "off")
+    assert gateway_run.GatewayRunner._load_orchestration_status_queries_enabled() is False
+
+
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(
     tmp_path, monkeypatch, caplog
 ):

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -13,6 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agent.orchestration_runtime import OrchestrationRuntime, set_orchestration_runtime
+from agent.task_registry import STATUS_RUNNING, TaskRegistry
+from agent.worker_lanes import ThreadWorkerLane, WorkerLaneRegistry, WorkerSpec
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, merge_pending_message_event
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
@@ -59,6 +62,7 @@ def _make_runner():
     runner._stop_task = None
     runner._exit_code = None
     runner._update_runtime_status = MagicMock()
+    runner._orchestration_status_queries_enabled = False
     runner._is_user_authorized = lambda _source: True
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
@@ -75,8 +79,240 @@ def _make_event(text="hello", chat_id="12345"):
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
 
 
+def _install_runtime_with_worker(
+    runner,
+    *,
+    session_key: str,
+    task_goal: str,
+    worker_goal: str,
+    worker_result: str = "done",
+):
+    task_registry = TaskRegistry()
+    worker_registry = WorkerLaneRegistry()
+    lane = ThreadWorkerLane(name="thread", runner=lambda _spec, _token: worker_result)
+    worker_registry.register(lane)
+    task = task_registry.create_task(
+        task_goal,
+        session_key=session_key,
+        status=STATUS_RUNNING,
+    )
+    handle = worker_registry.start(
+        WorkerSpec(goal=worker_goal, task_id=task.task_id, lane="thread")
+    )
+    assert lane.wait(handle.worker_id, timeout=2)
+    task_registry.assign_worker(task.task_id, handle.worker_id, worker_kind="thread")
+    set_orchestration_runtime(
+        runner,
+        OrchestrationRuntime(
+            task_registry=task_registry,
+            worker_registry=worker_registry,
+        ),
+    )
+    return task, handle
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_disabled_falls_through_to_agent():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = False
+    event = _make_event(text="지금 뭐 하고 있어?")
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        return "agent-handled"
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        result = await runner._handle_message(event)
+
+    assert result == "agent-handled"
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_enabled_returns_empty_overview_without_agent():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="지금 뭐 하고 있어?")
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", AsyncMock()) as inner:
+        result = await runner._handle_message(event)
+
+    assert result == "No active tasks or workers are currently registered."
+    inner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_is_read_only_while_agent_running():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="what's running?")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time()
+
+    result = await runner._handle_message(event)
+
+    assert result == "No active tasks or workers are currently registered."
+    fake_agent.interrupt.assert_not_called()
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_does_not_swallow_slash_command():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="/status")
+    runner._handle_status_command = AsyncMock(return_value="session status")
+
+    result = await runner._handle_message(event)
+
+    assert result == "session status"
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_does_not_swallow_unrelated_text():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="부대찌개 칼로리 대충 얼마야?")
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        return "agent-handled"
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        result = await runner._handle_message(event)
+
+    assert result == "agent-handled"
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_does_not_swallow_media():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="u1"
+    )
+    event = MessageEvent(
+        text="지금 뭐 하고 있어?",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/screenshot.png"],
+        media_types=["image/png"],
+    )
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        return "agent-handled"
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        result = await runner._handle_message(event)
+
+    assert result == "agent-handled"
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_is_scoped_to_requesting_session():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="what's running?", chat_id="session-a")
+    requesting_session = build_session_key(event.source)
+    foreign_source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="session-b", chat_type="dm", user_id="u1"
+    )
+    foreign_session = build_session_key(foreign_source)
+    _install_runtime_with_worker(
+        runner,
+        session_key=foreign_session,
+        task_goal="foreign private task",
+        worker_goal="foreign private worker goal",
+        worker_result="foreign private result",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "No active tasks or workers are currently registered."
+    assert "foreign private" not in result
+    assert requesting_session != foreign_session
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_shows_only_same_session_worker_details():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="what's running?", chat_id="session-a")
+    requesting_session = build_session_key(event.source)
+    task, handle = _install_runtime_with_worker(
+        runner,
+        session_key=requesting_session,
+        task_goal="same session task",
+        worker_goal="same session worker goal",
+        worker_result="same session result",
+    )
+    # Add an unlinked foreign worker to the same runner-owned runtime; it must
+    # not leak into this session-scoped gateway reply.
+    runtime = runner._orchestration_runtime
+    foreign_lane = runtime.worker_registry.get_lane("thread")
+    foreign = foreign_lane.start(
+        WorkerSpec(goal="foreign unlinked worker goal", task_id="foreign-task", lane="thread")
+    )
+    assert foreign_lane.wait(foreign.worker_id, timeout=2)
+
+    result = await runner._handle_message(event)
+
+    assert task.task_id in result
+    assert handle.worker_id in result
+    assert "same session task" in result
+    assert "same session result" in result
+    assert "foreign unlinked" not in result
+    assert "foreign-task" not in result
+
+
+@pytest.mark.asyncio
+async def test_orchestration_status_query_hides_worker_with_foreign_task_id_even_if_visible_task_points_to_it():
+    runner = _make_runner()
+    runner._orchestration_status_queries_enabled = True
+    event = _make_event(text="what's running?", chat_id="session-a")
+    requesting_session = build_session_key(event.source)
+
+    task_registry = TaskRegistry()
+    worker_registry = WorkerLaneRegistry()
+    lane = ThreadWorkerLane(name="thread", runner=lambda _spec, _token: "foreign private result")
+    worker_registry.register(lane)
+    visible_task = task_registry.create_task(
+        "visible task",
+        session_key=requesting_session,
+        status=STATUS_RUNNING,
+    )
+    foreign_worker = worker_registry.start(
+        WorkerSpec(
+            goal="foreign private worker goal",
+            task_id="foreign-private-task-id",
+            lane="thread",
+        )
+    )
+    assert lane.wait(foreign_worker.worker_id, timeout=2)
+    # Simulate inconsistent linkage: visible task points to the worker id, but
+    # the worker itself declares a foreign task_id. Gateway status must prefer
+    # the worker's own task_id privacy boundary and hide worker details.
+    task_registry.assign_worker(visible_task.task_id, foreign_worker.worker_id, worker_kind="thread")
+    set_orchestration_runtime(
+        runner,
+        OrchestrationRuntime(task_registry=task_registry, worker_registry=worker_registry),
+    )
+
+    result = await runner._handle_message(event)
+
+    assert "visible task" in result
+    assert visible_task.task_id in result
+    assert foreign_worker.worker_id not in result
+    assert "foreign-private-task-id" not in result
+    assert "foreign private worker goal" not in result
+    assert "foreign private result" not in result
+    assert "references task foreign-private-task-id" not in result
+
+
 # ------------------------------------------------------------------
-# Test 1: Sentinel is placed before _handle_message_with_agent runs
+# Test 1: Sentinel is placed before agent setup
 # ------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_sentinel_placed_before_agent_setup():

--- a/tests/tui_gateway/test_frontdesk_live_predispatch.py
+++ b/tests/tui_gateway/test_frontdesk_live_predispatch.py
@@ -1,0 +1,189 @@
+import io
+import importlib
+import json
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.task_registry import STATUS_CANCELLED
+
+
+@pytest.fixture()
+def server():
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+        mod._methods.clear()
+        importlib.reload(mod)
+
+
+def _session(frontdesk_enabled: bool = True, running: bool = False):
+    agent = MagicMock()
+    agent.run_conversation.return_value = {"final_response": "model", "messages": []}
+    return {
+        "agent": agent,
+        "agent_error": None,
+        "agent_ready": threading.Event(),
+        "attached_images": [],
+        "cols": 80,
+        "frontdesk_live_enabled": frontdesk_enabled,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "pending_title": None,
+        "running": running,
+        "session_key": "s1",
+        "transport": None,
+    }
+
+
+def _events(buf: io.StringIO):
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_stop_never_returns_busy_when_frontdesk_enabled(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=True, running=True)
+    session["agent_ready"].set()
+    server._sessions[sid] = session
+    buf = io.StringIO()
+    server._real_stdout = buf
+
+    resp = server.handle_request({
+        "id": "r1",
+        "method": "prompt.submit",
+        "params": {"session_id": sid, "text": "멈춰"},
+    })
+
+    assert "error" not in resp
+    assert resp["result"]["status"] == "frontdesk"
+    session["agent"].interrupt.assert_called_once_with("멈춰")
+    assert any(
+        msg.get("params", {}).get("type") == "message.complete"
+        and "stopped" in msg.get("params", {}).get("payload", {}).get("text", "")
+        for msg in _events(buf)
+    )
+
+
+def test_status_consumed_before_agent_build_when_frontdesk_enabled(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=True, running=False)
+    session["agent_ready"].set()
+    server._sessions[sid] = session
+    buf = io.StringIO()
+    server._real_stdout = buf
+
+    with patch.object(server, "_start_agent_build") as start_build:
+        resp = server.handle_request({
+            "id": "r-status",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "지금 뭐 하고 있어?"},
+        })
+
+    assert "error" not in resp
+    assert resp["result"]["status"] == "frontdesk"
+    start_build.assert_not_called()
+    session["agent"].run_conversation.assert_not_called()
+    assert any(
+        msg.get("params", {}).get("type") == "message.complete"
+        and (
+            "Tasks:" in msg.get("params", {}).get("payload", {}).get("text", "")
+            or "No active tasks" in msg.get("params", {}).get("payload", {}).get("text", "")
+        )
+        for msg in _events(buf)
+    )
+
+
+def test_worker_request_does_not_start_agent_build_when_no_lane(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=True, running=False)
+    session["agent_ready"].set()
+    server._sessions[sid] = session
+    buf = io.StringIO()
+    server._real_stdout = buf
+
+    with patch.object(server, "_start_agent_build") as start_build:
+        resp = server.handle_request({
+            "id": "r-worker",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "워커 레인에 배당해서 이 회귀를 조사해줘"},
+        })
+
+    assert "error" not in resp
+    assert resp["result"]["status"] == "frontdesk"
+    start_build.assert_not_called()
+    session["agent"].run_conversation.assert_not_called()
+    assert any(
+        msg.get("params", {}).get("type") == "message.complete"
+        and "worker lane unavailable" in msg.get("params", {}).get("payload", {}).get("text", "")
+        for msg in _events(buf)
+    )
+    runtime = session.get("_orchestration_runtime")
+    assert runtime is not None
+    tasks = runtime.task_registry.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].status == STATUS_CANCELLED
+
+
+def test_korean_followup_steers_when_frontdesk_enabled(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=True, running=True)
+    session["agent_ready"].set()
+    session["agent"].steer.return_value = True
+    server._sessions[sid] = session
+
+    resp = server.handle_request({
+        "id": "r-steer",
+        "method": "prompt.submit",
+        "params": {"session_id": sid, "text": "빠니니를 파는 곳도 찾아보고 있어야지"},
+    })
+
+    assert "error" not in resp
+    assert resp["result"]["status"] == "frontdesk"
+    session["agent"].steer.assert_called_once_with("빠니니를 파는 곳도 찾아보고 있어야지")
+
+
+def test_frontdesk_disabled_preserves_existing_busy_behavior(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=False, running=True)
+    session["agent_ready"].set()
+    server._sessions[sid] = session
+
+    resp = server.handle_request({
+        "id": "r2",
+        "method": "prompt.submit",
+        "params": {"session_id": sid, "text": "멈춰"},
+    })
+
+    assert resp["error"]["code"] == 4009
+    assert "session busy" in resp["error"]["message"]
+    session["agent"].interrupt.assert_not_called()
+
+
+def test_frontdesk_disabled_starts_existing_model_path_when_idle(server):
+    sid = "s1"
+    session = _session(frontdesk_enabled=False, running=False)
+    session["agent_ready"].set()
+    server._sessions[sid] = session
+
+    with patch.object(server, "_start_agent_build") as start_build, \
+         patch.object(server, "_run_prompt_submit") as run_prompt:
+        resp = server.handle_request({
+            "id": "r-disabled",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "지금 뭐 하고 있어?"},
+        })
+
+    assert "error" not in resp
+    assert resp["result"]["status"] == "streaming"
+    start_build.assert_called_once_with(sid, session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -272,6 +272,13 @@ def _load_busy_input_mode() -> str:
     return raw if raw in {"queue", "steer", "interrupt"} else "interrupt"
 
 
+def _load_frontdesk_live_enabled() -> bool:
+    orchestration = _load_cfg().get("orchestration")
+    if not isinstance(orchestration, dict):
+        return False
+    return is_truthy_value(orchestration.get("frontdesk_live_enabled"), default=False)
+
+
 def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
     """Fire session lifecycle hooks with CLI parity."""
     try:
@@ -1922,6 +1929,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "show_reasoning": _load_show_reasoning(),
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
+        "frontdesk_live_enabled": _load_frontdesk_live_enabled(),
         "tool_started_at": {},
         # Pin async event emissions to whichever transport created the
         # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
@@ -2103,6 +2111,7 @@ def _(rid, params: dict) -> dict:
         "attached_images": [],
         "cols": cols,
         "edit_snapshots": {},
+        "frontdesk_live_enabled": _load_frontdesk_live_enabled(),
         "history": [],
         "history_lock": threading.Lock(),
         "history_version": 0,
@@ -2993,6 +3002,53 @@ def _(rid, params: dict) -> dict:
 # ── Methods: prompt ──────────────────────────────────────────────────
 
 
+def _maybe_handle_frontdesk_prompt(
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    main_in_flight: bool,
+):
+    """Consume opt-in frontdesk control input before TUI queue/model paths."""
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    agent = session.get("agent")
+
+    def _cancel_active(payload: str) -> None:
+        if agent is not None and hasattr(agent, "interrupt"):
+            agent.interrupt(payload)
+
+    def _steer_active(payload: str):
+        if agent is not None and hasattr(agent, "steer"):
+            return agent.steer(payload)
+        return False
+
+    from agent.frontdesk_live import handle_frontdesk_live_input
+
+    result = handle_frontdesk_live_input(
+        session,
+        text,
+        session=session,
+        session_key=session.get("session_key") or sid,
+        source_surface="tui",
+        main_in_flight=main_in_flight,
+        steer_callback=_steer_active if main_in_flight else None,
+        cancel_callback=_cancel_active if main_in_flight else None,
+    )
+    if result is None:
+        return None
+
+    raw = result.message
+    payload = {"text": raw, "usage": {}, "status": "complete"}
+    rendered = render_message(raw, int(session.get("cols", 80) or 80))
+    if rendered:
+        payload["rendered"] = rendered
+    _emit("message.start", sid)
+    _emit("message.complete", sid, payload)
+    return result
+
+
 @method("prompt.submit")
 def _(rid, params: dict) -> dict:
     sid, text = params.get("session_id", ""), params.get("text", "")
@@ -3001,7 +3057,23 @@ def _(rid, params: dict) -> dict:
         return err
     with session["history_lock"]:
         if session.get("running"):
+            frontdesk_result = _maybe_handle_frontdesk_prompt(
+                sid,
+                session,
+                text,
+                main_in_flight=True,
+            )
+            if frontdesk_result is not None:
+                return _ok(rid, {"status": "frontdesk"})
             return _err(rid, 4009, "session busy")
+        frontdesk_result = _maybe_handle_frontdesk_prompt(
+            sid,
+            session,
+            text,
+            main_in_flight=False,
+        )
+        if frontdesk_result is not None:
+            return _ok(rid, {"status": "frontdesk"})
         session["running"] = True
 
     _start_agent_build(sid, session)

--- a/ui-tui/src/app/frontdesk_policy_shim.ts
+++ b/ui-tui/src/app/frontdesk_policy_shim.ts
@@ -1,0 +1,631 @@
+// Frontdesk routing policy — TypeScript shim (Phase 2 substrate).
+//
+// This module is the TypeScript mirror of `agent/frontdesk_policy.py`.  Python
+// is the source of truth; this shim exists so the TUI can classify a user
+// fragment *before* it round-trips through the gateway/process boundary, which
+// keeps the status bar's "control: ..." line reactive.
+//
+// Phase 2 contract — read-only and not wired:
+//   * No imports from `busyIntegrated`, `useSubmission`, or any other surface
+//     module.  This file is a leaf.
+//   * No callers in Phase 2.  Phase 5 (`/mode frontdesk` opt-in) is the first
+//     phase that calls `classifyFrontdeskFragment` from `useSubmission.ts`.
+//   * Behaviour parity with the Python policy is validated in Phase 3 via the
+//     shared `tests/agent/data/frontdesk_intents_ko.yaml` corpus.
+//
+// Hard boundaries this respects (PRD §9.2 / design review §9.2):
+//   * No `/mode frontdesk` exposure.
+//   * No persona / prompt change.
+//   * No `_pending_input` / queue mutation.
+//   * No worker dispatch.
+
+// ---------------------------------------------------------------------------
+// Enums (string literal unions; vitest-friendly, no `enum` runtime cost)
+// ---------------------------------------------------------------------------
+
+export type FrontdeskRecommendation = 'main' | 'worker_lane' | 'steer' | 'control'
+
+export type FrontdeskConfidence = 'low' | 'medium' | 'high'
+
+export type FrontdeskSignal =
+  | 'research'
+  | 'artifact'
+  | 'code_edit'
+  | 'long'
+  | 'many_tools'
+  | 'status'
+  | 'stop'
+  | 'steer'
+  | 'ack'
+  | 'duplicate'
+  | 'noise'
+  | 'korean'
+  | 'explicit_worker_req'
+  | 'explicit_main_req'
+
+export interface FrontdeskPolicyDecision {
+  readonly recommendation: FrontdeskRecommendation
+  readonly signals: ReadonlySet<FrontdeskSignal>
+  readonly confidence: FrontdeskConfidence
+  readonly debugLabel: string
+  readonly rawText: string
+  readonly hasKorean: boolean
+  readonly shouldDelegate: boolean
+  readonly isControl: boolean
+  readonly isStop: boolean
+  readonly isAck: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Vocabularies — kept in sync with `agent/frontdesk_policy.py`.  Any edit here
+// MUST be mirrored on the Python side and re-validated against the corpus.
+// ---------------------------------------------------------------------------
+
+const STOP_TOKENS_EN: readonly string[] = [
+  'stop',
+  'cancel',
+  'abort',
+  'halt',
+  'nevermind',
+  'never mind',
+  'forget it',
+  '/stop',
+  '/cancel',
+  '/abort',
+  '/kill',
+]
+
+const STOP_TOKENS_KO: readonly string[] = [
+  '그만',
+  '그만해',
+  '그만둬',
+  '중단',
+  '취소',
+  '됐어',
+  '멈춰',
+  '잠깐만',
+  '잠깐',
+  '기다려',
+]
+
+const ACK_TOKENS_EN: readonly string[] = [
+  'thanks',
+  'thanks!',
+  'thank you',
+  'thank you!',
+  'thx',
+  'ty',
+]
+
+const ACK_TOKENS_KO: readonly string[] = [
+  '고마워',
+  '고맙습니다',
+  '감사',
+  '감사합니다',
+  '수고',
+  '수고했어',
+]
+
+const STATUS_ANCHORS_EN: readonly string[] = [
+  'status',
+  'what are you doing',
+  "what's running",
+  'show me',
+  'list',
+  '/tasks',
+  '/agents',
+  '/mode',
+]
+
+const STATUS_ANCHORS_KO: readonly string[] = [
+  '상태',
+  '어디까지',
+  '뭐 했어',
+  '뭐해',
+  '뭐 해',
+  '진행',
+  '어떤 lane',
+  '어떤 워커',
+  '지금 뭐',
+]
+
+const ARTIFACT_ANCHORS_EN: readonly string[] = [
+  '.md',
+  'report',
+  'report.md',
+  'summary',
+  'summary.md',
+  'draft',
+  'write up',
+  'writeup',
+  'write a',
+  'write the',
+  'compose',
+  'produce a',
+  '.csv',
+  '.svg',
+  '.png',
+  '.pdf',
+  '.tsv',
+  '.json',
+]
+
+const ARTIFACT_ANCHORS_KO: readonly string[] = [
+  '리포트',
+  '보고서',
+  '정리해',
+  '정리해줘',
+  '작성해',
+  '작성해줘',
+  '초안',
+  '문서로',
+]
+
+const RESEARCH_ANCHORS_EN: readonly string[] = [
+  'investigate',
+  'research',
+  'search for',
+  'look up',
+  'find out',
+  'crawl',
+  'scrape',
+  'audit',
+  'deep dive',
+  'deep-dive',
+  'explore the',
+  'study the',
+]
+
+const RESEARCH_ANCHORS_KO: readonly string[] = [
+  '조사',
+  '조사해',
+  '조사해줘',
+  '찾아봐',
+  '리서치',
+  '크롤',
+  '크롤링',
+  '탐색',
+  '분석해',
+]
+
+const CODE_EDIT_ANCHORS_EN: readonly string[] = [
+  'implement',
+  'refactor',
+  'fix the',
+  'patch',
+  'rewrite',
+  'port the',
+  'migrate the',
+  'build the',
+  'add a tool',
+]
+
+const CODE_EDIT_ANCHORS_KO: readonly string[] = [
+  '구현해',
+  '구현해줘',
+  '고쳐',
+  '고쳐줘',
+  '수정해',
+  '수정해줘',
+  '리팩',
+  '리팩터',
+  '재작성',
+]
+
+const EXPLICIT_WORKER_ANCHORS_EN: readonly string[] = [
+  'in the background',
+  'background',
+  'delegate this',
+  'delegate it',
+  'delegate to',
+  'give it to a worker',
+  'worker lane',
+  'kick off a worker',
+  'spawn a worker',
+]
+
+const EXPLICIT_WORKER_ANCHORS_KO: readonly string[] = [
+  '백그라운드',
+  '워커에 맡겨',
+  '워커에게 맡겨',
+  '워커한테 맡겨',
+  '클로드한테 맡겨',
+  '위임해',
+  '위임해줘',
+  '맡겨줘',
+]
+
+const EXPLICIT_MAIN_ANCHORS_EN: readonly string[] = [
+  'do it yourself',
+  'do it now',
+  'right now',
+  'yourself',
+  'main thread',
+  'in line',
+  'inline',
+  'directly',
+  'no worker',
+  'no workers',
+]
+
+const EXPLICIT_MAIN_ANCHORS_KO: readonly string[] = [
+  '직접 해',
+  '직접해',
+  '지금 해',
+  '지금해',
+  '지금 보여줘',
+  '바로 해',
+  '바로해',
+  '여기서 해',
+  '메인에서',
+]
+
+const STEER_PREFIXES_EN: readonly string[] = [
+  'also ',
+  'and also ',
+  'additionally ',
+  'btw ',
+  'by the way ',
+  'actually ',
+  'wait ',
+  'oh, ',
+  'oh ',
+]
+
+const STEER_PREFIXES_KO: readonly string[] = [
+  '근데 ',
+  '그리고 ',
+  '추가로 ',
+  '참, ',
+  '참 ',
+  '아 그리고 ',
+  '아, 그리고 ',
+]
+
+const LONG_WORDS_EN: readonly string[] = [
+  'all the',
+  'every',
+  'across the codebase',
+  'across the repo',
+  'the whole',
+  'comprehensive',
+  'thorough',
+  'deep',
+  'end-to-end',
+  'end to end',
+]
+
+const LONG_WORDS_KO: readonly string[] = ['전체', '모든', '꼼꼼', '철저', '전반']
+
+const TOOL_ACTION_KEYWORDS_EN: readonly string[] = [
+  'read',
+  'grep',
+  'search',
+  'find',
+  'write',
+  'edit',
+  'patch',
+  'fetch',
+  'crawl',
+  'build',
+  'run',
+  'test',
+  'deploy',
+  'list',
+  'show',
+]
+
+const TOOL_ACTION_KEYWORDS_KO: readonly string[] = ['읽어', '찾아', '써', '수정', '빌드', '테스트', '실행', '보여']
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Hangul detection.  Matches the regex used in the Python policy.
+const HANGUL_RE = /[가-힯ᄀ-ᇿ㄰-㆏]/u
+
+const TRAILING_NOISE_RE = /[\s.!?…~^"'`)\-:,;]+$/u
+const TRAILING_EMOTE_RE = /(?:[:;][-]?[)dpo](?:[)dpo])*|ㅎ+|ㅋ+)$/iu
+
+function stripTrailingNoise(body: string): string {
+  let trimmed = body.trim()
+  for (let i = 0; i < 3; i++) {
+    const before = trimmed
+    trimmed = trimmed.replace(TRAILING_NOISE_RE, '').replace(TRAILING_EMOTE_RE, '').trim()
+    if (trimmed === before) break
+  }
+  return trimmed
+}
+
+function isWholeBodyMatch(lowBody: string, vocab: readonly string[]): boolean {
+  const core = stripTrailingNoise(lowBody)
+  if (!core) return false
+  const target = core
+  return vocab.some(v => v.toLowerCase() === target)
+}
+
+function containsAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some(n => haystack.includes(n))
+}
+
+function startsWithAny(body: string, prefixes: readonly string[]): boolean {
+  return prefixes.some(p => body.startsWith(p))
+}
+
+function looksKorean(text: string): boolean {
+  return HANGUL_RE.test(text)
+}
+
+function looksLikeSteer(lowBody: string, body: string): boolean {
+  if (startsWithAny(lowBody, STEER_PREFIXES_EN)) return true
+  if (startsWithAny(body, STEER_PREFIXES_KO)) return true
+  for (const sep of [', ', ',\n', ',  ', '， ', '，\n', '，  ']) {
+    const cutLow = lowBody.indexOf(sep)
+    if (cutLow !== -1) {
+      const tailLow = lowBody.slice(cutLow + sep.length).trimStart()
+      if (STEER_PREFIXES_EN.some(p => tailLow.startsWith(p))) return true
+    }
+    const cutRaw = body.indexOf(sep)
+    if (cutRaw !== -1) {
+      const tailRaw = body.slice(cutRaw + sep.length).trimStart()
+      if (STEER_PREFIXES_KO.some(p => tailRaw.startsWith(p))) return true
+    }
+  }
+  return false
+}
+
+function estimateToolCalls(lowBody: string, body: string): number {
+  const seen = new Set<string>()
+  let count = 0
+  for (const kw of TOOL_ACTION_KEYWORDS_EN) {
+    if (lowBody.includes(kw) && !seen.has(kw)) {
+      seen.add(kw)
+      count += 1
+    }
+  }
+  for (const kw of TOOL_ACTION_KEYWORDS_KO) {
+    if (body.includes(kw) && !seen.has(kw)) {
+      seen.add(kw)
+      count += 1
+    }
+  }
+  // " and then " always adds; " and " adds half-bucket.
+  const andThen = (lowBody.match(/ and then /g) ?? []).length
+  const ands = (lowBody.match(/ and /g) ?? []).length
+  count += andThen + Math.floor(ands / 2)
+  return count
+}
+
+function looksLong(body: string, lowBody: string): boolean {
+  if (containsAny(lowBody, LONG_WORDS_EN)) return true
+  if (containsAny(body, LONG_WORDS_KO)) return true
+  if (body.length >= 240) return true
+  return false
+}
+
+function isStatusQuery(body: string, lowBody: string): boolean {
+  if (containsAny(lowBody, STATUS_ANCHORS_EN)) return true
+  if (containsAny(body, STATUS_ANCHORS_KO)) return true
+  if (body.length <= 12 && body.endsWith('?')) return true
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Decision builder
+// ---------------------------------------------------------------------------
+
+interface DecisionInit {
+  recommendation: FrontdeskRecommendation
+  signals: ReadonlySet<FrontdeskSignal>
+  confidence: FrontdeskConfidence
+  debugLabel: string
+  rawText: string
+}
+
+function buildDecision(init: DecisionInit): FrontdeskPolicyDecision {
+  return {
+    recommendation: init.recommendation,
+    signals: init.signals,
+    confidence: init.confidence,
+    debugLabel: init.debugLabel,
+    rawText: init.rawText,
+    hasKorean: init.signals.has('korean'),
+    shouldDelegate: init.recommendation === 'worker_lane',
+    isControl: init.recommendation === 'control',
+    isStop: init.signals.has('stop'),
+    isAck: init.signals.has('ack'),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public classifier
+// ---------------------------------------------------------------------------
+
+export interface ClassifyOptions {
+  readonly langHint?: 'ko' | 'en' | null
+}
+
+/**
+ * Pure mirror of `agent.frontdesk_policy.classify_request`.  Same `(text,
+ * langHint)` → same decision.  No side effects, no async, no I/O.
+ *
+ * Phase 2: function-only.  No surface adapter calls this yet.
+ */
+export function classifyFrontdeskFragment(
+  text: string,
+  options: ClassifyOptions = {},
+): FrontdeskPolicyDecision {
+  const raw = typeof text === 'string' ? text : ''
+  const body = raw.trim().normalize('NFC')
+  const lowBody = body.toLowerCase()
+
+  const signals = new Set<FrontdeskSignal>()
+
+  // 1. Empty / whitespace
+  if (!body) {
+    signals.add('noise')
+    return buildDecision({
+      recommendation: 'control',
+      signals,
+      confidence: 'high',
+      debugLabel: 'noise:empty',
+      rawText: raw,
+    })
+  }
+
+  // 2. Korean detection
+  const isKorean = options.langHint === 'ko' || looksKorean(body)
+  if (isKorean) signals.add('korean')
+
+  // 3. Whole-body STOP
+  if (isWholeBodyMatch(lowBody, STOP_TOKENS_EN) || isWholeBodyMatch(body, STOP_TOKENS_KO)) {
+    signals.add('stop')
+    return buildDecision({
+      recommendation: 'control',
+      signals,
+      confidence: 'high',
+      debugLabel: 'stop',
+      rawText: raw,
+    })
+  }
+
+  // 4. Whole-body ACK
+  if (isWholeBodyMatch(lowBody, ACK_TOKENS_EN) || isWholeBodyMatch(body, ACK_TOKENS_KO)) {
+    signals.add('ack')
+    return buildDecision({
+      recommendation: 'control',
+      signals,
+      confidence: 'high',
+      debugLabel: 'ack',
+      rawText: raw,
+    })
+  }
+
+  // 5. Explicit overrides — collected; applied as tie-breakers below.
+  if (containsAny(lowBody, EXPLICIT_WORKER_ANCHORS_EN) || containsAny(body, EXPLICIT_WORKER_ANCHORS_KO)) {
+    signals.add('explicit_worker_req')
+  }
+  if (containsAny(lowBody, EXPLICIT_MAIN_ANCHORS_EN) || containsAny(body, EXPLICIT_MAIN_ANCHORS_KO)) {
+    signals.add('explicit_main_req')
+  }
+
+  // 6. Status query (beats worker anchors so "status of report.md?" stays MAIN).
+  if (isStatusQuery(body, lowBody)) {
+    signals.add('status')
+    return buildDecision({
+      recommendation: 'main',
+      signals,
+      confidence: 'medium',
+      debugLabel: 'status',
+      rawText: raw,
+    })
+  }
+
+  // 7. Steer candidate (prefix-based; surface verifies main-in-flight)
+  const steerCandidate = looksLikeSteer(lowBody, body)
+  if (steerCandidate) signals.add('steer')
+
+  // 8. Worker-candidate signals
+  if (containsAny(lowBody, ARTIFACT_ANCHORS_EN) || containsAny(body, ARTIFACT_ANCHORS_KO)) {
+    signals.add('artifact')
+  }
+  if (containsAny(lowBody, RESEARCH_ANCHORS_EN) || containsAny(body, RESEARCH_ANCHORS_KO)) {
+    signals.add('research')
+  }
+  if (containsAny(lowBody, CODE_EDIT_ANCHORS_EN) || containsAny(body, CODE_EDIT_ANCHORS_KO)) {
+    signals.add('code_edit')
+  }
+  if (looksLong(body, lowBody)) signals.add('long')
+  if (estimateToolCalls(lowBody, body) >= 3) signals.add('many_tools')
+
+  // 9. Tie-breakers
+  if (signals.has('explicit_main_req')) {
+    return buildDecision({
+      recommendation: 'main',
+      signals,
+      confidence: 'high',
+      debugLabel: 'main:explicit',
+      rawText: raw,
+    })
+  }
+  if (signals.has('explicit_worker_req')) {
+    return buildDecision({
+      recommendation: 'worker_lane',
+      signals,
+      confidence: 'high',
+      debugLabel: 'worker:explicit',
+      rawText: raw,
+    })
+  }
+
+  // 10. Strong worker signals
+  const strong = (['artifact', 'research', 'code_edit'] as const).filter(s => signals.has(s))
+  if (strong.length > 0) {
+    const hasShape = signals.has('long') || signals.has('many_tools')
+    const confidence: FrontdeskConfidence = strong.length >= 2 || hasShape ? 'high' : 'medium'
+    return buildDecision({
+      recommendation: 'worker_lane',
+      signals,
+      confidence,
+      debugLabel: `worker:${strong.sort().join('+')}`,
+      rawText: raw,
+    })
+  }
+
+  // 11. Weak worker shape (LONG + MANY_TOOLS together)
+  if (signals.has('long') && signals.has('many_tools')) {
+    return buildDecision({
+      recommendation: 'worker_lane',
+      signals,
+      confidence: 'medium',
+      debugLabel: 'worker:shape',
+      rawText: raw,
+    })
+  }
+
+  // 12. Steer candidate without worker signal → STEER recommendation
+  if (steerCandidate) {
+    return buildDecision({
+      recommendation: 'steer',
+      signals,
+      confidence: 'low',
+      debugLabel: 'steer:candidate',
+      rawText: raw,
+    })
+  }
+
+  // 13. Default → MAIN
+  return buildDecision({
+    recommendation: 'main',
+    signals,
+    confidence: signals.size > 0 ? 'medium' : 'low',
+    debugLabel: 'main:default',
+    rawText: raw,
+  })
+}
+
+// Re-export the vocabularies so a parity test (Phase 3) can verify the TS and
+// Python sides see the same anchors.  Marked `_` -prefixed because they are
+// internal-by-convention; the corpus parity test imports them via the named
+// re-exports without surfacing them in the editor's autocomplete for general
+// app code.
+export const __FRONTDESK_VOCAB__ = {
+  STOP_TOKENS_EN,
+  STOP_TOKENS_KO,
+  ACK_TOKENS_EN,
+  ACK_TOKENS_KO,
+  STATUS_ANCHORS_EN,
+  STATUS_ANCHORS_KO,
+  ARTIFACT_ANCHORS_EN,
+  ARTIFACT_ANCHORS_KO,
+  RESEARCH_ANCHORS_EN,
+  RESEARCH_ANCHORS_KO,
+  CODE_EDIT_ANCHORS_EN,
+  CODE_EDIT_ANCHORS_KO,
+  EXPLICIT_WORKER_ANCHORS_EN,
+  EXPLICIT_WORKER_ANCHORS_KO,
+  EXPLICIT_MAIN_ANCHORS_EN,
+  EXPLICIT_MAIN_ANCHORS_KO,
+  STEER_PREFIXES_EN,
+  STEER_PREFIXES_KO,
+} as const


### PR DESCRIPTION
## Summary
- Adds frontdesk control-plane substrate, task/worker registries, and worker-lane MVP.
- Wires opt-in live pre-dispatch gates for CLI, Gateway, and TUI so STATUS/STOP/STEER/WORKER are handled before busy queue/model dispatch.
- Registers a conservative default `main` worker lane at live gateway startup.
- Adds `/frontdesk status` UX plus existing `/agents`/`/tasks` and `/stop` readiness for live operations.
- Adds the `frontdesk-control-plane-development` skill/runbook.

## Safety / routing invariants
- STOP/`멈춰` is consumed as control-plane cancellation, not queued/replayed as user text.
- STATUS/`지금 뭐 하고 있어?` returns local task/worker state and does not launch an LLM turn.
- WORKER-shaped requests start a worker lane instead of falling through to main-agent tool spam.
- Korean follow-ups such as `중국집은 없나` steer active targets when accepted; pending sentinels do not consume/drop them.
- Live interception remains opt-in through `orchestration.frontdesk_live_enabled` / env override; broad frontdesk persona flags alone do not enable it.

## Test plan
- `python -m pytest tests/agent/test_frontdesk_runtime_loop.py tests/cli/test_frontdesk_live_predispatch.py tests/gateway/test_frontdesk_live_predispatch.py tests/tui_gateway/test_frontdesk_live_predispatch.py -q -o 'addopts='`
  - `29 passed, 1 warning`
- `python -m pytest tests/cli/test_cli_init.py tests/cli/test_cli_steer_busy_path.py tests/cli/test_frontdesk_live_predispatch.py tests/gateway/test_busy_session_ack.py tests/gateway/test_session_race_guard.py tests/gateway/test_frontdesk_live_predispatch.py tests/tui_gateway/test_frontdesk_live_predispatch.py -q -o 'addopts='`
  - `103 passed, 1 warning`
- `python -m py_compile agent/frontdesk_live.py agent/orchestration_runtime.py gateway/run.py cli.py tui_gateway/server.py hermes_cli/commands.py tests/gateway/test_frontdesk_live_predispatch.py`
- `git diff --check`
- `cd ui-tui && npm ci && npm run type-check -- --pretty false`
- Gateway-path synthetic acceptance saved locally under `agent-work/live-acceptance-20260514-1734.md`:
  - STATUS no model: PASS
  - STOP no queue: PASS
  - WORKER no main spam: PASS
  - Korean STEER: PASS
  - Pending sentinel no-drop: PASS
  - Real default-worker subprocess smoke: `WORKER_OK`

## Notes
- The only remaining warning is an existing asyncio event-loop deprecation warning from `tests/conftest.py`.
- `npm ci` reports one moderate audit warning from the existing dependency graph; type-check passes.
