### PR TITLE
fix(memory): hit prefix cache in background review fork (salvage #17276 + #25427)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1339,6 +1339,21 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
 
 
+_thread_tool_whitelist = threading.local()
+
+
+def set_thread_tool_whitelist(
+    allowed: Optional[Set[str]],
+    deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
+) -> None:
+    _thread_tool_whitelist.allowed = allowed
+    _thread_tool_whitelist.fmt = deny_msg_fmt
+
+
+def clear_thread_tool_whitelist() -> None:
+    _thread_tool_whitelist.allowed = None
+
+
 def get_pre_tool_call_block_message(
     tool_name: str,
     args: Optional[Dict[str, Any]],
@@ -1357,6 +1372,11 @@ def get_pre_tool_call_block_message(
     directive wins.  Invalid or irrelevant hook return values are
     silently ignored so existing observer-only hooks are unaffected.
     """
+    allowed = getattr(_thread_tool_whitelist, "allowed", None)
+    if allowed is not None and tool_name not in allowed:
+        fmt = getattr(_thread_tool_whitelist, "fmt", "Tool '{tool_name}' denied")
+        return fmt.format(tool_name=tool_name)
+
     hook_results = invoke_hook(
         "pre_tool_call",
         tool_name=tool_name,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4289,7 +4289,6 @@ class AIAgent:
                         api_key=_parent_runtime.get("api_key") or None,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
-                        enabled_toolsets=["memory", "skills"],
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"
@@ -4306,11 +4305,50 @@ class AIAgent:
                     # _vprint and leak past the stdout redirect (they go via
                     # _print_fn/status_callback, which bypass sys.stdout).
                     review_agent.suppress_status_output = True
+                    # Inherit the parent's cached system prompt verbatim so
+                    # the review fork's outbound HTTP request hits the same
+                    # Anthropic/OpenRouter prefix cache the parent warmed.
+                    # Without this, the fork rebuilds the system prompt from
+                    # scratch (fresh _hermes_now() timestamp, fresh
+                    # session_id, narrower toolset → different skills_prompt)
+                    # and the byte-exact prefix-cache key misses. See
+                    # issue #25322 and PR #17276 for the full analysis +
+                    # measured impact (~26% end-to-end cost reduction on
+                    # Sonnet 4.5).
+                    review_agent._cached_system_prompt = self._cached_system_prompt
 
-                    review_agent.run_conversation(
-                        user_message=prompt,
-                        conversation_history=messages_snapshot,
+                    from model_tools import get_tool_definitions
+                    from hermes_cli.plugins import (
+                        set_thread_tool_whitelist,
+                        clear_thread_tool_whitelist,
                     )
+
+                    review_whitelist = {
+                        t["function"]["name"]
+                        for t in get_tool_definitions(
+                            enabled_toolsets=["memory", "skills"],
+                            quiet_mode=True,
+                        )
+                    }
+                    set_thread_tool_whitelist(
+                        review_whitelist,
+                        deny_msg_fmt=(
+                            "Background review denied non-whitelisted tool: "
+                            "{tool_name}. Only memory/skill tools are allowed."
+                        ),
+                    )
+                    try:
+                        review_agent.run_conversation(
+                            user_message=(
+                                prompt
+                                + "\n\nYou can only call memory and skill "
+                                "management tools. Other tools will be denied "
+                                "at runtime — do not attempt them."
+                            ),
+                            conversation_history=messages_snapshot,
+                        )
+                    finally:
+                        clear_thread_tool_whitelist()
 
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user. Tool messages

--- a/run_agent.py
+++ b/run_agent.py
@@ -4316,6 +4316,15 @@ class AIAgent:
                     # measured impact (~26% end-to-end cost reduction on
                     # Sonnet 4.5).
                     review_agent._cached_system_prompt = self._cached_system_prompt
+                    # Defensive: pin session_start + session_id to the
+                    # parent's so any code path that re-renders parts of
+                    # the system prompt (compression, plugin hooks) still
+                    # produces byte-identical output. The cached-prompt
+                    # assignment above already short-circuits the normal
+                    # rebuild path, but these pins guarantee parity even
+                    # if a future code path bypasses the cache.
+                    review_agent.session_start = self.session_start
+                    review_agent.session_id = self.session_id
 
                     from model_tools import get_tool_definitions
                     from hermes_cli.plugins import (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,8 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
+    "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "mgongzai@gmail.com": "vKongv",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,8 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
+    "32201324+simpolism@users.noreply.github.com": "simpolism",
+    "simpolism@gmail.com": "simpolism",
     "mgongzai@gmail.com": "vKongv",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -538,6 +538,95 @@ class TestPreToolCallBlocking:
         assert get_pre_tool_call_block_message("terminal", {}) == "first blocker"
 
 
+class TestThreadToolWhitelist:
+    """Tests for the thread-local tool whitelist used by background review forks."""
+
+    def test_allowed_tool_passes_through_to_hooks(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist({"memory", "skill_manage"})
+        try:
+            assert get_pre_tool_call_block_message("memory", {}) is None
+        finally:
+            clear_thread_tool_whitelist()
+
+    def test_disallowed_tool_blocked_with_message(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist(
+            {"memory"}, deny_msg_fmt="denied: {tool_name}"
+        )
+        try:
+            msg = get_pre_tool_call_block_message("terminal", {})
+            assert msg == "denied: terminal"
+        finally:
+            clear_thread_tool_whitelist()
+
+    def test_clear_restores_unrestricted_behavior(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist({"memory"})
+        clear_thread_tool_whitelist()
+        # After clearing, any tool should pass through to plugin hooks (which
+        # return [] here, so result is None).
+        assert get_pre_tool_call_block_message("terminal", {}) is None
+
+    def test_whitelist_is_thread_local(self, monkeypatch):
+        """Setting a whitelist in one thread must NOT leak into another."""
+        import threading
+
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+
+        # Main thread: install a restrictive whitelist.
+        set_thread_tool_whitelist({"memory"})
+        try:
+            assert get_pre_tool_call_block_message("terminal", {}) is not None
+
+            # Worker thread: should NOT inherit main thread's whitelist.
+            result = {}
+
+            def worker():
+                result["msg"] = get_pre_tool_call_block_message("terminal", {})
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+            assert result["msg"] is None, (
+                "thread-local whitelist leaked across threads"
+            )
+        finally:
+            clear_thread_tool_whitelist()
+
+
 # ── TestPluginContext ──────────────────────────────────────────────────────
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -20,6 +20,9 @@ def _bare_agent() -> AIAgent:
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
+    agent._cached_system_prompt = "test-cached-system-prompt"
+    import datetime as _dt
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -1,0 +1,185 @@
+"""Tests that the background review fork inherits the parent's cached system prompt.
+
+Regression coverage for issue #25322 (and PR #17276's first root cause): the
+background review's outbound HTTP request must carry the same system bytes as
+the parent's so Anthropic/OpenRouter's exact-prefix cache key matches.
+
+Without this, every review rebuilds the system prompt from scratch — fresh
+``_hermes_now()`` timestamp, fresh ``session_id``, and a different skills
+prompt under the (former) narrow toolset — and the prefix-cache miss costs
+roughly the full uncached system-prompt cost per nudge (~26% end-to-end on
+Sonnet 4.5 per the contributor's measurement).
+"""
+
+from unittest.mock import patch
+
+
+def _make_agent_stub(agent_cls):
+    """Create a minimal AIAgent-like object with just enough state for _spawn_background_review."""
+    agent = object.__new__(agent_cls)
+    agent.model = "test-model"
+    agent.platform = "test"
+    agent.provider = "openai"
+    agent.session_id = "sess-123"
+    agent.quiet_mode = True
+    agent._memory_store = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._memory_nudge_interval = 5
+    agent._skill_nudge_interval = 5
+    agent.background_review_callback = None
+    agent.status_callback = None
+    agent._cached_system_prompt = (
+        "PARENT-SYSTEM-PROMPT-BYTES — must be inherited verbatim "
+        "for prefix-cache parity"
+    )
+    import datetime as _dt
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    return agent
+
+
+class _SyncThread:
+    """Drop-in replacement for threading.Thread that runs the target inline."""
+
+    def __init__(self, *, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+class _ReviewAgentRecorder:
+    """Stand-in for the review-fork AIAgent that records the prompt assignment."""
+
+    def __init__(self, *args, **kwargs):
+        self._cached_system_prompt = None
+        self._memory_write_origin = None
+        self._memory_write_context = None
+        self._memory_store = None
+        self._memory_enabled = None
+        self._user_profile_enabled = None
+        self._memory_nudge_interval = None
+        self._skill_nudge_interval = None
+        self.suppress_status_output = None
+
+    def run_conversation(self, *args, **kwargs):
+        raise RuntimeError("stop after recording state — don't actually call the API")
+
+    def shutdown_memory_provider(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_review_fork_inherits_parent_cached_system_prompt():
+    """The review fork's _cached_system_prompt must equal the parent's byte-for-byte.
+
+    Anthropic's prefix cache keys on exact bytes; any divergence (timestamp
+    minute tick, fresh session_id, narrower skills_prompt) shifts the key
+    and forces a full re-cache. Inheriting the parent's cached prompt is
+    the cheap, mechanical fix.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+    parent_prompt = agent._cached_system_prompt
+
+    # Hook the assignment site: record what gets put on the review agent.
+    real_recorder_init = _ReviewAgentRecorder.__init__
+
+    def _recorder_init(self, *args, **kwargs):
+        real_recorder_init(self, *args, **kwargs)
+        # The actual production code assigns _cached_system_prompt AFTER __init__,
+        # so we need to capture it on attribute set. Use a property-style sentinel
+        # via __setattr__ on this instance.
+
+    with patch.object(run_agent, "AIAgent", _ReviewAgentRecorder), \
+         patch("threading.Thread", _SyncThread):
+        # Wrap the recorder's __setattr__ so we can see the _cached_system_prompt
+        # write that _spawn_background_review performs after construction.
+        orig_setattr = _ReviewAgentRecorder.__setattr__
+
+        def _spy_setattr(self, name, value):
+            if name == "_cached_system_prompt":
+                captured["written_prompt"] = value
+            orig_setattr(self, name, value)
+
+        with patch.object(_ReviewAgentRecorder, "__setattr__", _spy_setattr):
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=True,
+                review_skills=False,
+            )
+
+    assert "written_prompt" in captured, (
+        "_spawn_background_review never assigned _cached_system_prompt on the review agent"
+    )
+    assert captured["written_prompt"] == parent_prompt, (
+        f"Review fork's _cached_system_prompt diverged from parent's. "
+        f"Got {captured['written_prompt']!r}, expected {parent_prompt!r}. "
+        "This breaks Anthropic/OpenRouter prefix-cache parity (#25322)."
+    )
+
+
+def test_review_fork_pins_session_start_and_session_id():
+    """Defensive complement to cached-system-prompt inheritance.
+
+    Even though ``_cached_system_prompt`` inheritance short-circuits the
+    normal rebuild path, pinning ``session_start`` and ``session_id`` to
+    the parent's guarantees byte-identical output from any code path that
+    re-renders parts of the system prompt (compression, plugin hooks).
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+
+    class _Recorder:
+        def __init__(self, *args, **kwargs):
+            self._cached_system_prompt = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+            self._memory_store = None
+            self._memory_enabled = None
+            self._user_profile_enabled = None
+            self._memory_nudge_interval = None
+            self._skill_nudge_interval = None
+            self.suppress_status_output = None
+            self.session_start = None
+            self.session_id = None
+
+        def run_conversation(self, *args, **kwargs):
+            captured["session_start"] = self.session_start
+            captured["session_id"] = self.session_id
+            raise RuntimeError("stop after recording")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("session_start") == agent.session_start, (
+        "Review fork did not inherit parent's session_start — "
+        "system-prompt rebuild paths would diverge."
+    )
+    assert captured.get("session_id") == agent.session_id, (
+        "Review fork did not inherit parent's session_id — "
+        "system-prompt rebuild paths would diverge."
+    )

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -1,8 +1,16 @@
-"""Tests that the background review agent is restricted to memory+skills toolsets.
+"""Tests that the background review agent restricts tools at runtime, not at schema time.
 
-Regression coverage for issue #15204: the background skill-review agent
-inherited the full default toolset, allowing it to perform non-skill side
-effects (terminal, send_message, delegate_task, etc.).
+Regression coverage for issue #15204 (the background skill-review agent must
+not perform non-skill side effects like terminal, send_message, delegate_task)
+combined with issue #25322 / PR #17276 (the review fork must hit the parent's
+Anthropic/OpenRouter prefix cache).
+
+Reconciling the two: the fork now inherits the parent's full ``tools`` schema
+so the cache-key matches, and enforces the memory+skills restriction at
+runtime via a thread-local whitelist on the existing
+``get_pre_tool_call_block_message`` gate. Safety is preserved mechanically
+(any non-whitelisted dispatch is blocked) without the schema-level narrowing
+that caused the prefix-cache miss.
 """
 
 import threading
@@ -24,6 +32,9 @@ def _make_agent_stub(agent_cls):
     agent._skill_nudge_interval = 5
     agent.background_review_callback = None
     agent.status_callback = None
+    agent._cached_system_prompt = None
+    import datetime as _dt
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"
@@ -41,15 +52,20 @@ class _SyncThread:
             self._target()
 
 
-def test_background_review_agent_uses_restricted_toolsets():
-    """The review agent must only have access to 'memory' and 'skills' toolsets."""
+def test_background_review_does_not_narrow_toolset_schema():
+    """The review fork must NOT pass enabled_toolsets to AIAgent.
+
+    Narrowing the schema diverges the ``tools`` cache key from the parent's,
+    which sits above ``system`` in Anthropic's cache hierarchy and forces a
+    full prefix-cache miss on every review (see #25322, PR #17276).
+    """
     import run_agent
 
     agent = _make_agent_stub(run_agent.AIAgent)
     captured = {}
 
     def _capture_init(self, *args, **kwargs):
-        captured["enabled_toolsets"] = kwargs.get("enabled_toolsets")
+        captured["enabled_toolsets"] = kwargs.get("enabled_toolsets", "UNSET")
         raise RuntimeError("stop after capturing init args")
 
     with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
@@ -61,11 +77,71 @@ def test_background_review_agent_uses_restricted_toolsets():
         )
 
     assert "enabled_toolsets" in captured, "AIAgent.__init__ was not called"
-    assert sorted(captured["enabled_toolsets"]) == ["memory", "skills"]
+    # The kwarg must be absent — letting AIAgent inherit the default full
+    # toolset so the schema bytes match the parent's.
+    assert captured["enabled_toolsets"] == "UNSET", (
+        f"Review fork narrowed the toolset schema (got {captured['enabled_toolsets']!r}), "
+        "which breaks prefix-cache parity with the parent."
+    )
+
+
+def test_background_review_installs_thread_local_whitelist():
+    """The review fork must install a memory/skills-only thread-local whitelist.
+
+    The schema-level toolset narrowing was lifted (for prefix-cache parity),
+    so #15204's safety contract now relies on the runtime whitelist gate to
+    deny terminal/send_message/delegate_task at dispatch time. Verify the
+    whitelist is set with exactly the memory+skills tool names.
+    """
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        captured["deny_msg_fmt"] = deny_msg_fmt
+        # Stop here — we just want to see what gets installed.
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    def _no_init(self, *args, **kwargs):
+        # Don't crash AIAgent.__init__; let execution flow reach
+        # set_thread_tool_whitelist.
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), \
+         patch.object(_plugins, "set_thread_tool_whitelist", _capture_whitelist), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured, "set_thread_tool_whitelist was not called"
+    whitelist = captured["whitelist"]
+    # memory + skills tools must be allowed
+    assert "memory" in whitelist
+    assert "skill_manage" in whitelist
+    assert "skill_view" in whitelist
+    assert "skills_list" in whitelist
+    # dangerous tools must NOT be in the whitelist
+    assert "terminal" not in whitelist
+    assert "send_message" not in whitelist
+    assert "delegate_task" not in whitelist
+    assert "web_search" not in whitelist
+    assert "execute_code" not in whitelist
 
 
 def test_background_review_agent_tools_are_limited():
-    """Verify the resolved memory+skills toolsets only contain memory and skill tools."""
+    """Verify the resolved memory+skills toolsets only contain memory and skill tools.
+
+    Sanity check on the source of truth for what the runtime whitelist is
+    derived from — if a future PR adds e.g. `terminal` to the `memory`
+    toolset, the review-fork safety contract silently breaks.
+    """
     from toolsets import resolve_multiple_toolsets
 
     expected_tools = set(resolve_multiple_toolsets(["memory", "skills"]))


### PR DESCRIPTION
## Summary
Background self-improvement review fork now produces byte-identical `tools` + `system` cache-key elements as the parent's main turn, restoring Anthropic/OpenRouter prefix-cache hits across the parent → review boundary. Measured by @WorldWriter: ~89% reduction in per-review-call cost, ~26% end-to-end on Sonnet 4.5.

Closes #25322. Salvages #17276 (@WorldWriter, primary implementation) and incorporates the defensive pinning idea from #25427 (@simpolism).

## Root cause
Three independent system-prompt bytes-difference sources between parent and review-fork:
1. `Conversation started:` timestamp regenerated from `_hermes_now()` per spawn (minute precision)
2. Fresh `session_id` UUID per spawn
3. Skills_prompt + tool-aware guidance vary with the (now-removed) narrow toolset

Anthropic's prefix cache keys on `tools` + `system` (in that order). The historical `enabled_toolsets=["memory", "skills"]` narrowing alone was enough to bust the `tools` cache key, even before the system-prompt divergences mattered.

## Changes
- `hermes_cli/plugins.py`: new `set_thread_tool_whitelist` / `clear_thread_tool_whitelist` on the existing `get_pre_tool_call_block_message` gate. Mirrors the per-thread approval-callback pattern.
- `run_agent.py` `_spawn_background_review`:
  - Drop `enabled_toolsets=["memory", "skills"]` from the AIAgent constructor → review's outbound `tools` schema matches parent's verbatim.
  - Inherit `_cached_system_prompt` from parent → review's outbound `system` bytes match parent's verbatim.
  - Defensively pin `session_start` + `session_id` to parent's (belt-and-suspenders for any future code path that re-renders parts of the system prompt).
  - Install thread-local whitelist of `{memory, skills_list, skill_view, skill_manage}` on the bg-review daemon thread → non-memory/skill tools are denied at dispatch time, preserving the #15204 safety contract mechanically (not via prompt-trust).
  - Append soft prompt instruction so the model knows up-front.
- `scripts/release.py`: AUTHOR_MAP entries for @WorldWriter + @simpolism.
- Tests: inverted `test_background_review_agent_uses_restricted_toolsets` (the schema-level narrowing it asserted was the cause of #25322's miss); added 4 new tests covering `tools` parity, `_cached_system_prompt` inheritance, `session_start`/`session_id` pinning, and the runtime whitelist allow/deny pattern.

## Why we did NOT take simpolism's Option A or pure Option B
- Option A (inherit cached prompt, keep narrow toolset): does NOT fix the cache miss. Anthropic's cache hashes `tools` before `system`, so byte-identical system bytes can't help when the `tools` array differs.
- Pure Option B (inherit cached prompt + parent's enabled_toolsets, rely purely on prompt-layer instruction): cache hits the same as this PR, but loses #15204's mechanical safety claim. This PR keeps the schema broadening (for cache parity) AND adds the runtime gate (for safety), so we get both.
- @simpolism's PR #25427 also dropped the `codex_app_server` → `codex_responses` downgrade — that downgrade is load-bearing for review forks on `codex_app_server` runtime (which bypasses Hermes' own dispatch). This PR keeps it.

## Validation

E2E bytes-equality (run on this branch):

| | Before | After |
|---|---|---|
| Parent vs review `tools` schema (sha256) | mismatched (30 vs 4 tools) | **identical** (sha `14b725bf...`) |
| Parent vs review `system` bytes (sha256) | mismatched (timestamp + session_id + skills_prompt) | **identical** (sha `1dd9e294...`, 3327 bytes) |
| Anthropic prefix cache key | mismatch on `tools` field | match through end of `system` |

Runtime whitelist (live, on this branch):

| Tool | Result |
|---|---|
| memory, skill_view, skills_list, skill_manage | allowed (in whitelist) |
| terminal, send_message, delegate_task, web_search, execute_code | denied at dispatch |
| Other threads | unaffected (thread-local) |
| After `clear_thread_tool_whitelist()` | gate returns to no-op |

Tests:

```
scripts/run_tests.sh \
  tests/run_agent/test_background_review.py \
  tests/run_agent/test_background_review_summary.py \
  tests/run_agent/test_background_review_toolset_restriction.py \
  tests/run_agent/test_background_review_cache_parity.py \
  tests/run_agent/test_codex_app_server_integration.py \
  tests/hermes_cli/test_plugins.py
============================== 97 passed in 3.56s ==============================
```

Cost numbers from @WorldWriter's original E2E (real Sonnet 4.5 run with auto-triggered review):
- Per review-call cost: $0.331 → $0.035 (~89% reduction)
- End-to-end per run: $0.848 → $0.629 (~26% reduction)
- Review fork `cache_create` / `cache_read`: 88,385 / **0** → 1,234 / **94,404**

## Credit
- @WorldWriter — original implementation (#17276), runtime-whitelist design, E2E measurement
- @simpolism — bug filing + diagnosis (#25322), reference Option-B impl (#25427), session_start/session_id pinning idea