### PR TITLE
fix: invalidate stale update-check cache

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -151,6 +151,36 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
+def _git_rev_parse(repo_dir: Path, rev: str) -> Optional[str]:
+    """Resolve a git revision to a full hash, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", rev],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            parsed = result.stdout.strip()
+            if parsed:
+                return parsed
+    except Exception:
+        pass
+    return None
+
+
+def _local_git_cache_rev(repo_dir: Path) -> Optional[str]:
+    """Return a cache key component for local update-check inputs."""
+    head = _git_rev_parse(repo_dir, "HEAD")
+    if not head:
+        return None
+
+    # The update result depends on both HEAD and the fetched upstream ref. If an
+    # external process updates origin/main while HEAD stays fixed, a HEAD-only
+    # cache key can falsely keep reporting "Up to date" until the TTL expires.
+    upstream = _git_rev_parse(repo_dir, "refs/remotes/origin/main") or "unknown"
+    return f"git:{repo_dir}:HEAD={head}:origin/main={upstream}"
+
+
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     """Count commits behind origin/main in a local checkout."""
     try:
@@ -189,15 +219,27 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    if embedded_rev:
+        cache_rev = f"embedded:{embedded_rev}"
+    else:
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is None:
+            return None
+        cache_rev = _local_git_cache_rev(repo_dir)
+
+    # Read cache — invalidate if the checked revision has changed since last check.
+    # Older cache files did not include a local git revision, so do not trust them
+    # for git checkouts; otherwise an already-updated checkout can keep reporting
+    # a stale "N commits behind" result until the TTL expires.
     now = time.time()
     try:
-        if cache_file.exists():
+        if cache_file.exists() and cache_rev is not None:
             cached = json.loads(cache_file.read_text())
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
+                and cached.get("rev") == cache_rev
             ):
                 return cached.get("behind")
     except Exception:
@@ -206,18 +248,11 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            return None
+        assert repo_dir is not None
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": cache_rev}))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -25,11 +25,13 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
+    cache_rev = f"git:{repo_dir}:abc123"
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "rev": cache_rev}))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.banner._local_git_cache_rev", return_value=cache_rev), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
     assert result == 3
@@ -44,18 +46,71 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
+    cache_rev = f"git:{repo_dir}:abc123"
+
     # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 1, "rev": cache_rev}))
 
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with patch("hermes_cli.banner._local_git_cache_rev", return_value=cache_rev), \
+         patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
         result = check_for_updates()
 
     assert result == 5
     assert mock_run.call_count == 2  # git fetch + git rev-list
+
+
+def test_check_for_updates_invalidates_stale_local_cache(tmp_path, monkeypatch):
+    """Fresh local-git caches without the current HEAD must not be trusted."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # This is the historical stale cache shape that caused `hermes --version`
+    # to keep reporting a false commits-behind notice after the checkout updated.
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 174}))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner._local_git_cache_rev", return_value=f"git:{repo_dir}:current"), \
+         patch("hermes_cli.banner.subprocess.run", return_value=MagicMock(returncode=0, stdout="0\n")) as mock_run:
+        result = check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 2  # git fetch + git rev-list
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["rev"] == f"git:{repo_dir}:current"
+
+
+def test_check_for_updates_invalidates_when_upstream_ref_changes(tmp_path, monkeypatch):
+    """Fresh cache with same HEAD but old origin/main must not be trusted."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    old_cache_rev = f"git:{repo_dir}:HEAD=current:origin/main=old-upstream"
+    new_cache_rev = f"git:{repo_dir}:HEAD=current:origin/main=new-upstream"
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 0, "rev": old_cache_rev}))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner._local_git_cache_rev", return_value=new_cache_rev), \
+         patch("hermes_cli.banner.subprocess.run", return_value=MagicMock(returncode=0, stdout="20\n")) as mock_run:
+        result = check_for_updates()
+
+    assert result == 20
+    assert mock_run.call_count == 2  # git fetch + git rev-list
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 20
+    assert cached["rev"] == new_cache_rev
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Include local `HEAD` and `origin/main` in the update-check cache key.
- Reuse the active checkout resolver so stale profile clones do not drive local-git update checks.
- Add regression coverage for stale cache shapes and upstream-ref changes.

## Verification
- `uv run pytest tests/hermes_cli/test_update_check.py`
- `uv run ruff check hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `git diff --check origin/main...HEAD`

Note: `uv run ty check hermes_cli/banner.py tests/hermes_cli/test_update_check.py` still reports pre-existing diagnostics in `build_welcome_banner` optional defaults plus missing `pytest` typing in the fresh local env; no new touched-line type diagnostics were found by the targeted test/ruff checks.
