### PR TITLE
fix: use dynamic profile paths in dashboard Config and Keys tabs

### DIFF
--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -37,7 +37,7 @@ import {
   FileOutput,
   RefreshCw,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, type StatusResponse } from "@/lib/api";
 import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
@@ -118,6 +118,7 @@ export default function ConfigPage() {
   const [yamlLoading, setYamlLoading] = useState(false);
   const [yamlSaving, setYamlSaving] = useState(false);
   const [activeCategory, setActiveCategory] = useState<string>("");
+  const [status, setStatus] = useState<StatusResponse | null>(null);
   const { toast, showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { t } = useI18n();
@@ -174,6 +175,10 @@ export default function ConfigPage() {
     api
       .getDefaults()
       .then(setDefaults)
+      .catch(() => {});
+    api
+      .getStatus()
+      .then(setStatus)
       .catch(() => {});
   }, []);
 
@@ -408,7 +413,7 @@ export default function ConfigPage() {
         <div className="flex items-center gap-2">
           <Settings2 className="h-4 w-4 text-muted-foreground" />
           <code className="text-xs text-muted-foreground bg-muted/50 px-2 py-0.5">
-            {t.config.configPath}
+            {status?.config_path}
           </code>
         </div>
         <div className="flex items-center gap-1.5">

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -14,7 +14,7 @@ import {
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { api, type StatusResponse } from "@/lib/api";
 import type { EnvVarInfo } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { Toast } from "@/components/Toast";
@@ -491,6 +491,7 @@ export default function EnvPage() {
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(true); // Show all providers by default
+  const [status, setStatus] = useState<StatusResponse | null>(null);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
 
@@ -498,6 +499,10 @@ export default function EnvPage() {
     api
       .getEnvVars()
       .then(setVars)
+      .catch(() => {});
+    api
+      .getStatus()
+      .then(setStatus)
       .catch(() => {});
   }, []);
 
@@ -686,7 +691,7 @@ export default function EnvPage() {
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <p className="text-sm text-muted-foreground">
-            {t.env.description} <code>~/.hermes/.env</code>
+            {t.env.description} <code>{status?.env_path}</code>
           </p>
           <p className="text-[0.7rem] text-muted-foreground/70">
             {t.env.changesNote}


### PR DESCRIPTION
## Problem

Dashboard shows hardcoded `~/.hermes/config.yaml` and `~/.hermes/.env` paths in the Config and Keys tabs regardless of which profile is active.

Backend already returns correct profile-aware paths via the StatusResponse API (`config_path`, `env_path`), but the frontend UI was ignoring them.

## Fix

Fetch `StatusResponse` on mount in both pages and render the dynamic paths instead of hardcoded strings.

### Files changed

- `web/src/pages/ConfigPage.tsx` - replace static config path with `status?.config_path`
- `web/src/pages/EnvPage.tsx` - replace static env path with `status?.env_path`

### Behavior

- When using default profile: shows `~/.hermes/config.yaml` (same as before)
- When using a named profile (e.g. `-p mbchelper`): shows `~/.hermes/profiles/mbchelper/config.yaml` (now correct)
- Falls back gracefully if status API hasn't loaded yet (renders empty until fetch completes)

No breaking changes. No new dependencies.