### PR TITLE
feat(codex-runtime): skip unavailable plugins during migration

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -397,6 +397,22 @@ def _query_codex_plugins(
             installed = bool(plugin.get("installed", False))
             if not installed:
                 continue
+            # Skip plugins codex itself reports as unavailable (broken
+            # install, missing OAuth, removed from marketplace, etc.).
+            # Cf. openclaw/openclaw#80815 — OpenClaw learned to gate
+            # migration on app readiness to avoid writing config that
+            # would fail at activation time. Our migration writes to
+            # codex's config.toml directly, so a broken plugin would
+            # surface as a codex error on first use. Skipping it here
+            # keeps the migrated config clean and the user's first
+            # codex turn from failing.
+            availability = str(plugin.get("availability") or "").upper()
+            if availability and availability != "AVAILABLE":
+                logger.debug(
+                    "skipping plugin %s: availability=%s",
+                    plugin.get("name"), availability,
+                )
+                continue
             name = str(plugin.get("name") or "")
             if not name:
                 continue

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -353,13 +353,61 @@ class TestMigrate:
             ], None
         monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
 
-        report = migrate({}, codex_home=tmp_path, discover_plugins=True, expose_hermes_tools=False)
+        report = migrate({}, codex_home=tmp_path, discover_plugins=True)
         text = (tmp_path / "config.toml").read_text()
         assert '[plugins."github@openai-curated"]' in text
         assert '[plugins."google-calendar@openai-curated"]' in text
         assert "enabled = true" in text
         assert "google-calendar@openai-curated" in report.migrated_plugins
         assert "github@openai-curated" in report.migrated_plugins
+
+    def test_plugin_discovery_skips_unavailable_plugins(self):
+        """Plugins where codex reports availability != AVAILABLE should
+        be skipped — they're broken/uninstallable on codex's side, so
+        migrating them would write config that fails at activation
+        time. Cf. openclaw#80815."""
+        from hermes_cli.codex_runtime_plugin_migration import _query_codex_plugins
+        from unittest.mock import patch
+
+        # Fake a plugin/list response where one plugin is unavailable
+        fake_response = {
+            "marketplaces": [{
+                "name": "openai-curated",
+                "plugins": [
+                    {"name": "good-plugin", "installed": True,
+                     "enabled": True, "availability": "AVAILABLE"},
+                    {"name": "broken-plugin", "installed": True,
+                     "enabled": True, "availability": "UNAVAILABLE"},
+                    {"name": "auth-pending", "installed": True,
+                     "enabled": True, "availability": "REQUIRES_AUTH"},
+                    # Plugin without availability field — pass through
+                    # (older codex versions or marketplaces that don't
+                    # set it should still work).
+                    {"name": "legacy-plugin", "installed": True,
+                     "enabled": True},
+                ]
+            }]
+        }
+
+        class FakeClient:
+            def __init__(self, **kw): pass
+            def initialize(self, **kw): pass
+            def request(self, method, params, timeout=None):
+                return fake_response
+            def close(self): pass
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        with patch("agent.transports.codex_app_server.CodexAppServerClient",
+                   FakeClient):
+            plugins, err = _query_codex_plugins()
+
+        assert err is None
+        names = [p["name"] for p in plugins]
+        assert "good-plugin" in names
+        assert "legacy-plugin" in names  # no field → don't skip
+        assert "broken-plugin" not in names
+        assert "auth-pending" not in names
 
     def test_plugin_discovery_failure_non_fatal(self, tmp_path, monkeypatch):
         """If codex isn't installed or RPC fails, MCP migration still

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -340,7 +340,8 @@ Plugins installed via `codex plugin` (Linear, GitHub, Gmail, Calendar, Canva, et
 This means: when your friend says "I have Calendar and GitHub set up in my Codex CLI" and they enable Hermes' codex runtime, Hermes activates those automatically. No re-configuration needed.
 
 What's NOT migrated:
-- Plugins not yet installed in Codex CLI. Install them via `codex plugin` first.
+- Plugins you haven't installed yet — install them in Codex first.
+- Plugins where codex reports `availability != AVAILABLE` (broken install, expired OAuth, removed from marketplace, etc.). These are skipped to avoid writing config that would fail at activation time.
 - ChatGPT app marketplace entries (the per-account `app/list` results — these are already enabled inside codex by virtue of your account auth).
 - Plugin OAuth — you authorize each plugin once in Codex itself; Hermes doesn't touch credentials.
 


### PR DESCRIPTION
## Summary

Followup to merged PR #24182. Audited recent OpenClaw codex PRs for fixes we should consider; landed one real gap as a new commit.

## What this PR changes

**The actual fix:** when migrating native Codex plugins into `~/.codex/config.toml`, skip plugins where codex itself reports `availability != AVAILABLE`. These are plugins installed but broken — expired OAuth, removed from marketplace, install corrupted. Writing them into config causes the user's first codex turn after enabling the runtime to fail.

Cf. [openclaw/openclaw#80815](https://github.com/openclaw/openclaw/pull/80815) — they hit the same footgun.

## Why this matters

Our `/codex-runtime codex_app_server` enable flow queries codex's `plugin/list` and trusts `installed=true`. But codex also exposes an `availability` field on each plugin entry. If a user has `google-calendar@openai-curated` installed but its OAuth has expired, codex reports `installed: true, availability: REQUIRES_AUTH`. We were migrating it anyway, and the user's next codex turn would fail with an activation error.

The fix is one filter in `_query_codex_plugins()`:

```python
availability = str(plugin.get("availability") or "").upper()
if availability and availability != "AVAILABLE":
    continue
```

Backward compat: empty/missing field falls through (older codex versions or marketplaces that don't set it still work).

## OpenClaw codex PRs I reviewed and chose NOT to apply

Documented in the commit message for the record:

| OpenClaw PR | Title | Decision |
|---|---|---|
| #81591 | Load Codex for selectable OpenAI agent models | No — we resolve runtime per-call, no startup-time gating to fix |
| #81510 | restore Codex cron automation compatibility | No — their fix is for OpenClaw-specific cron orchestration; we documented cron as untested |
| #81223 | rotate incompatible context-engine threads | No — we don't have a Lossless context engine equivalent |
| #80688 | constrain Codex app-server sandbox | No — we don't have an outer-sandbox concept |
| #80616 | release interrupted app-server turns on `turn_aborted` | No — we already handle `status=interrupted` in `turn/completed` correctly |
| #80278 | expose activeModel plugin context | No — not our surface |
| #80792 | default destructive_actions on | No — we don't expose that config knob |

## Tests

```
test_plugin_discovery_skips_unavailable_plugins — 4 cases:
  good-plugin   (installed=True, availability=AVAILABLE)      → migrated
  broken-plugin (installed=True, availability=UNAVAILABLE)    → skipped
  auth-pending  (installed=True, availability=REQUIRES_AUTH)  → skipped
  legacy-plugin (installed=True, no availability field)        → migrated
                  (older codex versions; preserve backward compat)
```

56 codex-runtime migration tests, all green.

## Docs

Added a bullet to the docs page's "What's NOT migrated" section explaining the availability filter and why.

Docs URL (live after next deploy):
https://hermes-agent.nousresearch.com/docs/user-guide/features/codex-app-server-runtime
