### PR TITLE
chore(release): map jake@nousresearch.com to @simpolism

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ AUTHOR_MAP = {
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "32201324+simpolism@users.noreply.github.com": "simpolism",
     "simpolism@gmail.com": "simpolism",
+    "jake@nousresearch.com": "simpolism",
     "mgongzai@gmail.com": "vKongv",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",


### PR DESCRIPTION
Salvages PR #25308 from @simpolism onto current main.

`simpolism@gmail.com` already maps to `simpolism` on main (line 47), so the original PR's two-line addition created a duplicate dict key. Dropped the duplicate; kept only the new `jake@nousresearch.com` entry, placed next to the existing simpolism mapping.

## Changes
- scripts/release.py: +1 line, `jake@nousresearch.com → simpolism`

Credit: @simpolism (authorship preserved on the cherry-picked commit).