### PR TITLE
feat(gateway): add HTML detection and multipart/alternative support to email adapter

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -151,6 +151,24 @@ def _strip_html(html: str) -> str:
     return text.strip()
 
 
+def _is_html(text: str) -> bool:
+    """Return True if text appears to be HTML content."""
+    stripped = text.strip()
+    if stripped.startswith(("<!DOCTYPE", "<html", "<HTML", "<!doctype")):
+        return True
+    return bool(re.search(r"<(p|div|br|h[1-6]|ul|ol|table|html)\b", stripped, re.IGNORECASE))
+
+
+def _build_body_part(body: str) -> MIMEText | MIMEMultipart:
+    """Return a MIME part for the body — multipart/alternative if HTML detected."""
+    if _is_html(body):
+        alt = MIMEMultipart("alternative")
+        alt.attach(MIMEText(_strip_html(body), "plain", "utf-8"))
+        alt.attach(MIMEText(body, "html", "utf-8"))
+        return alt
+    return MIMEText(body, "plain", "utf-8")
+
+
 def _extract_email_address(raw: str) -> str:
     """Extract bare email address from 'Name <addr>' format."""
     match = re.search(r"<([^>]+)>", raw)
@@ -509,7 +527,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
-        msg.attach(MIMEText(body, "plain", "utf-8"))
+        msg.attach(_build_body_part(body))
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
@@ -619,7 +637,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(_build_body_part(body))
 
         for file_path in file_paths:
             p = Path(file_path)
@@ -700,7 +718,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(_build_body_part(body))
 
         # Attach file
         p = Path(file_path)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -929,6 +929,135 @@ class TestSendEmailStandalone(unittest.TestCase):
         self.assertIn("not configured", result["error"])
 
 
+class TestHtmlDetection(unittest.TestCase):
+    """Test _is_html detection and _build_body_part multipart/alternative logic."""
+
+    def test_plain_text_not_detected_as_html(self):
+        from gateway.platforms.email import _is_html
+        self.assertFalse(_is_html("Hello, this is plain text."))
+        self.assertFalse(_is_html("No tags here.\nJust lines."))
+        self.assertFalse(_is_html(""))
+
+    def test_doctype_detected(self):
+        from gateway.platforms.email import _is_html
+        self.assertTrue(_is_html("<!DOCTYPE html><html><body>Hi</body></html>"))
+        self.assertTrue(_is_html("<!doctype html>\n<html>"))
+
+    def test_html_tag_detected(self):
+        from gateway.platforms.email import _is_html
+        self.assertTrue(_is_html("<html><body>Content</body></html>"))
+        self.assertTrue(_is_html("<HTML><BODY>Content</BODY></HTML>"))
+
+    def test_block_level_tags_detected(self):
+        from gateway.platforms.email import _is_html
+        self.assertTrue(_is_html("<p>A paragraph</p>"))
+        self.assertTrue(_is_html("<div>A div</div>"))
+        self.assertTrue(_is_html("Hello<br>World"))
+        self.assertTrue(_is_html("<h1>Title</h1>"))
+        self.assertTrue(_is_html("<h6>Heading</h6>"))
+        self.assertTrue(_is_html("<ul><li>Item</li></ul>"))
+        self.assertTrue(_is_html("<ol><li>Item</li></ol>"))
+        self.assertTrue(_is_html("<table><tr><td>Cell</td></tr></table>"))
+
+    def test_inline_tags_not_detected(self):
+        from gateway.platforms.email import _is_html
+        self.assertFalse(_is_html("Use <b>bold</b> text"))
+        self.assertFalse(_is_html("<span>inline</span>"))
+        self.assertFalse(_is_html("<a href='x'>link</a>"))
+
+    def test_angle_brackets_in_prose_not_detected(self):
+        from gateway.platforms.email import _is_html
+        self.assertFalse(_is_html("if x < 10 and y > 5"))
+        self.assertFalse(_is_html("use <your_name> as placeholder"))
+
+    def test_leading_whitespace_ignored(self):
+        from gateway.platforms.email import _is_html
+        self.assertTrue(_is_html("  \n  <!DOCTYPE html><html>"))
+        self.assertTrue(_is_html("\n\n<html><body>X</body></html>"))
+
+    def test_build_body_part_plain_text(self):
+        from gateway.platforms.email import _build_body_part
+        part = _build_body_part("Hello, plain text.")
+        self.assertEqual(part.get_content_type(), "text/plain")
+        self.assertIn("Hello, plain text.", part.get_payload(decode=True).decode())
+
+    def test_build_body_part_html_returns_alternative(self):
+        from gateway.platforms.email import _build_body_part
+        html = "<html><body><h1>Hello</h1><p>World</p></body></html>"
+        part = _build_body_part(html)
+        self.assertEqual(part.get_content_type(), "multipart/alternative")
+        subparts = part.get_payload()
+        self.assertEqual(len(subparts), 2)
+        self.assertEqual(subparts[0].get_content_type(), "text/plain")
+        self.assertEqual(subparts[1].get_content_type(), "text/html")
+        # Plain part should have tags stripped
+        plain_body = subparts[0].get_payload(decode=True).decode()
+        self.assertNotIn("<h1>", plain_body)
+        self.assertIn("Hello", plain_body)
+        # HTML part should preserve original
+        html_body = subparts[1].get_payload(decode=True).decode()
+        self.assertIn("<h1>Hello</h1>", html_body)
+
+    def test_build_body_part_with_div_content(self):
+        from gateway.platforms.email import _build_body_part
+        html = "<div>Report: <p>Revenue is up 20%</p></div>"
+        part = _build_body_part(html)
+        self.assertEqual(part.get_content_type(), "multipart/alternative")
+
+    def test_send_email_uses_multipart_alternative_for_html(self):
+        """_send_email should produce multipart/alternative when body is HTML."""
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        html_body = "<html><body><h1>Report</h1><p>Details here.</p></body></html>"
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", html_body, None)
+
+            sent_msg = mock_server.send_message.call_args[0][0]
+            # The outer message is multipart/mixed, containing a multipart/alternative
+            payloads = sent_msg.get_payload()
+            alt_part = payloads[0] if isinstance(payloads, list) else sent_msg
+            self.assertEqual(alt_part.get_content_type(), "multipart/alternative")
+            sub = alt_part.get_payload()
+            self.assertEqual(sub[0].get_content_type(), "text/plain")
+            self.assertEqual(sub[1].get_content_type(), "text/html")
+
+    def test_send_email_plain_text_unchanged(self):
+        """_send_email should send plain MIMEText when body is not HTML."""
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Just plain text.", None)
+
+            sent_msg = mock_server.send_message.call_args[0][0]
+            payloads = sent_msg.get_payload()
+            # Should be a single text/plain part inside the multipart/mixed
+            text_part = payloads[0] if isinstance(payloads, list) else sent_msg
+            self.assertEqual(text_part.get_content_type(), "text/plain")
+
+
 class TestSmtpConnectionCleanup(unittest.TestCase):
     """Verify SMTP connections are closed even when send_message raises."""
 


### PR DESCRIPTION
## What does this PR do?

Adds automatic HTML detection to the email gateway adapter's outbound path. When the response body contains HTML content, the adapter now sends a `multipart/alternative` email with both a plain-text fallback and the original HTML — ensuring proper rendering across all email clients while maintaining backward compatibility for text-only responses.

## Related Issue

Fixes #11941 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/email.py`: Added `_is_html(text)` — detects HTML by checking for `<!DOCTYPE`/`<html>` prefixes and common block-level tags (`<p>`, `<div>`, `<br>`, `<h1>`–`<h6>`, `<ul>`, `<ol>`, `<table>`)
- `gateway/platforms/email.py`: Added `_build_body_part(body)` — returns `multipart/alternative` (plain + HTML) when HTML detected, otherwise plain `MIMEText` as before
- `gateway/platforms/email.py`: Updated `_send_email`, `_send_email_with_attachment`, and `_send_email_with_attachments` to use `_build_body_part()` instead of hardcoded `MIMEText(body, "plain", ...)`

## How to Test

1. Configure the email gateway with valid IMAP/SMTP credentials
2. Send a message that triggers the agent to respond with HTML content (e.g., a skill that generates an HTML report)
3. Verify the received email renders HTML properly in Gmail/Outlook/Apple Mail
4. Send a message that triggers a plain-text response — verify it still arrives as plain text (no behavior change)
5. Verify that text-only email clients (e.g., `mustrstripe`) show the plain-text fallback from the `multipart/alternative`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 24.3.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)