### PR TITLE
feat(vision): auto-convert GIF to PNG (first frame) before vision API call

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -13,7 +13,9 @@ from tools.vision_tools import (
     _validate_image_url,
     _handle_vision_analyze,
     _determine_mime_type,
+    _detect_image_mime_type,
     _image_to_base64_data_url,
+    _maybe_convert_gif_to_png,
     _resize_image_for_vision,
     _is_image_size_error,
     _MAX_BASE64_BYTES,
@@ -887,6 +889,72 @@ class TestResizeImageForVision:
                 result = _resize_image_for_vision(path, max_base64_bytes=100)
                 # Should return the original (oversized) data url
                 assert len(result) > 100
+
+
+# ---------------------------------------------------------------------------
+# _maybe_convert_gif_to_png — GIF auto-convert (#25433)
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeConvertGifToPng:
+    """Tests for the GIF -> PNG auto-conversion helper.
+
+    Most vision providers (GLM-4.6V error 1210; local models) reject GIFs.
+    The helper produces a first-frame PNG sibling so the existing pipeline
+    can still analyze the visual content.
+    """
+
+    def test_gif_converted_to_png(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        img = Image.new("RGB", (4, 4), (200, 100, 50))
+        gif_path = tmp_path / "anim.gif"
+        img.save(gif_path, "GIF")
+
+        result = _maybe_convert_gif_to_png(gif_path)
+        assert result is not None
+        assert result.exists()
+        assert result.suffix == ".png"
+        assert _detect_image_mime_type(result) == "image/png"
+
+    def test_animated_gif_takes_first_frame(self, tmp_path):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        red = Image.new("RGB", (4, 4), (255, 0, 0))
+        green = Image.new("RGB", (4, 4), (0, 255, 0))
+        gif_path = tmp_path / "two_frames.gif"
+        red.save(gif_path, "GIF", save_all=True, append_images=[green], loop=0)
+
+        result = _maybe_convert_gif_to_png(gif_path)
+        assert result is not None
+        with Image.open(result) as out:
+            r, g, b, *_ = out.convert("RGB").getpixel((0, 0))
+        # First frame should win — the (255, 0, 0) red, not (0, 255, 0) green.
+        assert (r, g, b) == (255, 0, 0)
+
+    def test_no_pillow_returns_none(self, tmp_path):
+        """Without Pillow, the helper should bail out cleanly so the caller
+        can keep going with the original GIF (provider may still error, but
+        we don't crash the tool call)."""
+        gif_path = tmp_path / "anim.gif"
+        gif_path.write_bytes(b"GIF89a" + b"\x00" * 100)
+        with patch.dict("sys.modules", {"PIL": None, "PIL.Image": None}):
+            assert _maybe_convert_gif_to_png(gif_path) is None
+
+    def test_corrupt_gif_returns_none(self, tmp_path):
+        try:
+            import PIL  # noqa: F401
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        gif_path = tmp_path / "corrupt.gif"
+        # Valid GIF magic but garbage after — Pillow may open it but fail
+        # on decode, or refuse outright. Either way we want None, not a raise.
+        gif_path.write_bytes(b"GIF89a\xff\xff\xff\xff garbage")
+        assert _maybe_convert_gif_to_png(gif_path) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -956,6 +956,27 @@ class TestMaybeConvertGifToPng:
         gif_path.write_bytes(b"GIF89a\xff\xff\xff\xff garbage")
         assert _maybe_convert_gif_to_png(gif_path) is None
 
+    def test_converted_png_lives_outside_source_dir(self, tmp_path):
+        """Regression guard: the converted PNG must not be written next to
+        the source GIF. A user-supplied local GIF could share a directory
+        with an existing PNG of the same stem, and a sibling-overwrite
+        followed by post-processing cleanup would delete the user's file.
+        The helper must place the PNG in the vision temp cache instead.
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        Image.new("RGB", (4, 4), (0, 0, 0)).save(tmp_path / "photo.gif", "GIF")
+        # Pre-existing sibling — must survive the conversion untouched.
+        sibling = tmp_path / "photo.png"
+        sibling.write_bytes(b"pre-existing user file")
+
+        result = _maybe_convert_gif_to_png(tmp_path / "photo.gif")
+        assert result is not None
+        assert result.parent != tmp_path
+        assert sibling.read_bytes() == b"pre-existing user file"
+
 
 # ---------------------------------------------------------------------------
 # _is_image_size_error — detect size-related API errors

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -152,12 +152,16 @@ def _is_retryable_download_error(error: Exception) -> bool:
 
 
 def _maybe_convert_gif_to_png(image_path: Path) -> Optional[Path]:
-    """Convert a GIF to a single-frame PNG sibling alongside the source.
+    """Convert a GIF to a single-frame PNG in the vision temp cache.
 
     Most vision providers (GLM-4.6V returns error 1210; several local models
     silently reject GIF) cannot accept ``image/gif`` payloads. Pillow is
     already a soft dependency for auto-resize, so reusing it to extract the
     first frame keeps GIFs analyzable without bringing in ffmpeg.
+
+    The PNG is written to the vision temp cache with a unique name so the
+    conversion can't overwrite a sibling file in the user's directory when
+    ``image_path`` points at a user-supplied local file.
 
     Returns the path to the new PNG on success, ``None`` if Pillow is
     missing or conversion failed — caller falls back to the original file.
@@ -171,7 +175,9 @@ def _maybe_convert_gif_to_png(image_path: Path) -> Optional[Path]:
         )
         return None
 
-    png_path = image_path.with_suffix(".png")
+    temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    png_path = temp_dir / f"gif_to_png_{uuid.uuid4().hex}.png"
     try:
         with Image.open(image_path) as img:
             # ``seek(0)`` is implicit on open; ``convert("RGBA")`` flattens
@@ -181,10 +187,33 @@ def _maybe_convert_gif_to_png(image_path: Path) -> Optional[Path]:
             frame.save(png_path, "PNG")
     except Exception as exc:
         logger.warning("GIF -> PNG conversion failed: %s", exc)
+        png_path.unlink(missing_ok=True)
         return None
 
-    logger.info("Auto-converted GIF -> PNG (first frame): %s", png_path.name)
+    logger.info("Auto-converted GIF -> PNG (first frame)")
     return png_path
+
+
+def _convert_gif_if_needed(
+    temp_image_path: Path,
+    detected_mime_type: str,
+    image_size_bytes: int,
+    should_cleanup: bool,
+) -> tuple[Path, str, int, bool]:
+    """Apply :func:`_maybe_convert_gif_to_png` and return updated state.
+
+    Encapsulates the unlink-old + reassign + recompute-size pattern shared
+    by both vision entry points so the two paths can't drift on cleanup
+    semantics. No-op for non-GIF input.
+    """
+    if detected_mime_type != "image/gif":
+        return temp_image_path, detected_mime_type, image_size_bytes, should_cleanup
+    converted = _maybe_convert_gif_to_png(temp_image_path)
+    if converted is None:
+        return temp_image_path, detected_mime_type, image_size_bytes, should_cleanup
+    if should_cleanup:
+        temp_image_path.unlink(missing_ok=True)
+    return converted, "image/png", converted.stat().st_size, True
 
 
 async def _download_image(image_url: str, destination: Path, max_retries: int = 3) -> Path:
@@ -699,15 +728,11 @@ async def _vision_analyze_native(
                 success=False,
             )
 
-        if detected_mime_type == "image/gif":
-            converted = _maybe_convert_gif_to_png(temp_image_path)
-            if converted is not None:
-                if should_cleanup:
-                    temp_image_path.unlink(missing_ok=True)
-                temp_image_path = converted
-                should_cleanup = True
-                detected_mime_type = "image/png"
-                image_size_bytes = temp_image_path.stat().st_size
+        temp_image_path, detected_mime_type, image_size_bytes, should_cleanup = (
+            _convert_gif_if_needed(
+                temp_image_path, detected_mime_type, image_size_bytes, should_cleanup,
+            )
+        )
 
         image_data_url = _image_to_base64_data_url(
             temp_image_path, mime_type=detected_mime_type,
@@ -860,15 +885,11 @@ async def vision_analyze_tool(
         if not detected_mime_type:
             raise ValueError("Only real image files are supported for vision analysis.")
 
-        if detected_mime_type == "image/gif":
-            converted = _maybe_convert_gif_to_png(temp_image_path)
-            if converted is not None:
-                if should_cleanup:
-                    temp_image_path.unlink(missing_ok=True)
-                temp_image_path = converted
-                should_cleanup = True
-                detected_mime_type = "image/png"
-                image_size_bytes = temp_image_path.stat().st_size
+        temp_image_path, detected_mime_type, image_size_bytes, should_cleanup = (
+            _convert_gif_if_needed(
+                temp_image_path, detected_mime_type, image_size_bytes, should_cleanup,
+            )
+        )
 
         # Convert image to base64 — send at full resolution first.
         # If the provider rejects it as too large, we auto-resize and retry.

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -151,6 +151,42 @@ def _is_retryable_download_error(error: Exception) -> bool:
     return True
 
 
+def _maybe_convert_gif_to_png(image_path: Path) -> Optional[Path]:
+    """Convert a GIF to a single-frame PNG sibling alongside the source.
+
+    Most vision providers (GLM-4.6V returns error 1210; several local models
+    silently reject GIF) cannot accept ``image/gif`` payloads. Pillow is
+    already a soft dependency for auto-resize, so reusing it to extract the
+    first frame keeps GIFs analyzable without bringing in ffmpeg.
+
+    Returns the path to the new PNG on success, ``None`` if Pillow is
+    missing or conversion failed — caller falls back to the original file.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        logger.info(
+            "GIF detected but Pillow not installed — sending as-is "
+            "(may be rejected by vision provider)"
+        )
+        return None
+
+    png_path = image_path.with_suffix(".png")
+    try:
+        with Image.open(image_path) as img:
+            # ``seek(0)`` is implicit on open; ``convert("RGBA")`` flattens
+            # palette + transparency into a clean truecolor frame so PNG
+            # save is deterministic regardless of GIF's source mode.
+            frame = img.convert("RGBA")
+            frame.save(png_path, "PNG")
+    except Exception as exc:
+        logger.warning("GIF -> PNG conversion failed: %s", exc)
+        return None
+
+    logger.info("Auto-converted GIF -> PNG (first frame): %s", png_path.name)
+    return png_path
+
+
 async def _download_image(image_url: str, destination: Path, max_retries: int = 3) -> Path:
     """
     Download an image from a URL to a local destination (async) with retry logic.
@@ -663,6 +699,16 @@ async def _vision_analyze_native(
                 success=False,
             )
 
+        if detected_mime_type == "image/gif":
+            converted = _maybe_convert_gif_to_png(temp_image_path)
+            if converted is not None:
+                if should_cleanup:
+                    temp_image_path.unlink(missing_ok=True)
+                temp_image_path = converted
+                should_cleanup = True
+                detected_mime_type = "image/png"
+                image_size_bytes = temp_image_path.stat().st_size
+
         image_data_url = _image_to_base64_data_url(
             temp_image_path, mime_type=detected_mime_type,
         )
@@ -813,7 +859,17 @@ async def vision_analyze_tool(
         detected_mime_type = _detect_image_mime_type(temp_image_path)
         if not detected_mime_type:
             raise ValueError("Only real image files are supported for vision analysis.")
-        
+
+        if detected_mime_type == "image/gif":
+            converted = _maybe_convert_gif_to_png(temp_image_path)
+            if converted is not None:
+                if should_cleanup:
+                    temp_image_path.unlink(missing_ok=True)
+                temp_image_path = converted
+                should_cleanup = True
+                detected_mime_type = "image/png"
+                image_size_bytes = temp_image_path.stat().st_size
+
         # Convert image to base64 — send at full resolution first.
         # If the provider rejects it as too large, we auto-resize and retry.
         logger.info("Converting image to base64...")


### PR DESCRIPTION
## What does this PR do?

Most vision providers reject `image/gif` payloads (GLM-4.6V returns error 1210; several local models silently drop the image), but `_detect_image_mime_type` happily returns `image/gif` and the existing pipeline forwards the bytes verbatim. The user-visible failure is a provider error far from the actual cause, and the workaround (manual `ffmpeg -vframes 1`) is enough friction that GIFs are effectively unanalyzable in `vision_analyze_tool` today.

This PR reuses the existing Pillow soft-dependency (already wired for `_resize_image_for_vision`) to extract the first frame of any `image/gif` and swap the temp path + mime in both call sites: `_build_native_vision_result` (native fast path) and `vision_analyze_tool` (legacy auxiliary path). Animation is irrelevant for vision analysis (first frame is the only frame the model would look at anyway). Pillow over ffmpeg because it's already a soft-dep in `tools/vision_tools.py` — no subprocess spawn, no PATH lookup.

## Related Issue

Fixes #25433

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/vision_tools.py` — add `_maybe_convert_gif_to_png(image_path: Path) -> Optional[Path]` (lazy `PIL.Image` import, `convert("RGBA")` for palette/transparency, saves PNG sibling, swallows Pillow exceptions). Both vision entry points call it when `detected_mime_type == "image/gif"` and swap `temp_image_path`/`should_cleanup`/`detected_mime_type`/`image_size_bytes` consistently.
- `tests/tools/test_vision_tools.py` — `TestMaybeConvertGifToPng` covering single-frame conversion, first-frame extraction from animated GIF, no-Pillow fallback (`patch.dict("sys.modules", {"PIL": None})`), and corrupt-GIF exception swallow.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with Pillow python3 -m pytest tests/tools/test_vision_tools.py tests/tools/test_vision_native_fast_path.py -v`
2. Expected: 92 passed.
3. Regression guard: revert the production line in `_build_native_vision_result` / `vision_analyze_tool` — pipeline sends GIF bytes to provider (fails out-of-process). Restore — transparently re-encoded as PNG.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (92/92)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Pillow is cross-platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #25433.

> Sibling code paths that may need the same treatment: WebP isn't universally supported either (some local models reject `image/webp`). Intentionally left out of this PR's scope to keep the diff small and the lossy-conversion decision narrow to GIF — happy to widen to WebP if preferred.
