### PR TITLE
fix(discord): keep free-response channels inline

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4223,7 +4223,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels)
+            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -446,6 +446,37 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
     assert event.source.chat_type == "group"
 
 
+@pytest.mark.asyncio
+async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypatch):
+    """Free-response channels should reply inline, never spawn a new thread.
+
+    Without this, every message in a free-response channel would auto-create
+    a fresh thread (since the channel bypasses the @mention gate, every
+    message looks like a fresh trigger).  That turns a "lightweight chat"
+    channel into a thread-spawning machine — see the docs at
+    website/docs/user-guide/messaging/discord.md which already describe
+    this as the intended behavior.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="casual chat in free-response channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "casual chat in free-response channel"
+    assert event.source.chat_type == "group"
+
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Salvage of #25311 by @simpolism onto current main.

Free-response Discord channels now skip auto-threading and reply inline, matching the documented behavior at `website/docs/user-guide/messaging/discord.md:347`.

## Changes
- `gateway/platforms/discord.py`: OR `is_free_channel` into `skip_thread` (same pattern as `is_voice_linked_channel` three lines down).
- `tests/gateway/test_discord_free_response.py`: regression test asserting `_auto_create_thread` is not awaited for free-response channels.

## Validation
- Without fix: new test fails with `Expected mock to not have been awaited. Awaited 1 times.` (bug confirmed reproducible on main).
- With fix: `tests/gateway/test_discord_free_response.py` 22/22 pass (was 21).

Closes #25310.
Closes #25311.