### PR TITLE
Fix gateway heartbeat handling for inactive and blocked sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -174,6 +174,200 @@ def _float_env(name: str, default: float) -> float:
         return float(default)
 
 
+def _safe_int(value, default=0):
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_bool(value, default=False):
+    if value is None:
+        return default
+    return bool(value)
+
+# -- Heartbeat / long-running notification internal state ----------------------
+# Per-card blocked-reminder rate-limit tracker.
+# key: task_id  value: (last_sent_timestamp, blocked_reason_fingerprint)
+# Sentinels: last_sent_timestamp = -1 means "never notified for this card".
+_blocked_notified_at: dict[str, tuple[float, str]] = {}
+
+# Default 3600s (60 min) between repeated blocked-card Telegram notifications.
+# Configurable via HERMES_BLOCKED_REMINDER_INTERVAL env var.
+_BLOCKED_REMINDER_INTERVAL_DEFAULT = 3600
+
+
+def _heartbeat_eligibility(session_state, board_state, process_state):
+    """Return (should_send: bool, state_label: str)."""
+    status = session_state.get("status", "unknown")
+    if status == "terminal":
+        return False, "terminal"
+    active_processes = _safe_int(process_state.get("active_process_count", 0), 0)
+    active_kanban = _safe_int(process_state.get("active_kanban_count", 0), 0)
+    has_active_process = active_processes > 0 or active_kanban > 0
+    agent_active = _safe_bool(session_state.get("agent_active"), False)
+    is_kanban = session_state.get("is_kanban_worker", False)
+    if is_kanban:
+        task_status = (board_state or {}).get("status", "unknown")
+        if task_status in ("done", "completed", "cancelled", "archived"):
+            logger.debug(
+                "heartbeat skip: kanban task %s is terminal (%s)",
+                session_state.get("kanban_task_id", "?"),
+                task_status,
+            )
+            return False, "completed"
+        if task_status == "blocked":
+            return True, "blocked"
+        if not has_active_process and not agent_active:
+            return False, "idle"
+        return True, "active"
+    if board_state and board_state.get("status") == "blocked":
+        return True, "blocked"
+    if has_active_process:
+        return True, "active"
+    if not agent_active:
+        return False, "idle"
+    return True, "active"
+
+
+def _reset_blocked_tracker(
+    tracker: Optional[dict[str, tuple[float, str]]] = None,
+) -> None:
+    (tracker if tracker is not None else _blocked_notified_at).clear()
+
+
+def _blocked_reminder_should_send(
+    task_id: str,
+    blocked_reason: str,
+    now: float,
+    reminder_interval: float | None = None,
+    tracker: Optional[dict[str, tuple[float, str]]] = None,
+) -> bool:
+    """Return True if a blocked-card reminder should be sent now.
+
+    Rate-limits blocked Telegram notifications so the same card is not
+    spammed every 3 minutes.  A reminder is allowed when:
+      - the card has never been notified (first block), OR
+      - the configured reminder_interval has elapsed since last send, OR
+      - the blocked_reason fingerprint has changed since last send.
+
+    The in-memory tracker (_blocked_notified_at) is shared across all
+    sessions within the same Gateway process.
+    """
+    if reminder_interval is None:
+        reminder_interval = _BLOCKED_REMINDER_INTERVAL_DEFAULT
+    reminder_tracker = tracker if tracker is not None else _blocked_notified_at
+    fp = str(blocked_reason or "")
+    last_ts, last_fp = reminder_tracker.get(task_id, (-1.0, ""))
+    # -1.0 sentinel means "never notified" -> always send the first time.
+    if last_ts < 0 or now - last_ts >= reminder_interval or fp != last_fp:
+        reminder_tracker[task_id] = (now, fp)
+        return True
+    return False
+
+
+def _agent_env_value(agent: Any, name: str) -> str:
+    env = getattr(agent, "env", None)
+    if isinstance(env, dict):
+        value = env.get(name)
+        if value:
+            return str(value)
+    return os.environ.get(name, "")
+
+
+def _latest_kanban_block_reason(kb: Any, conn: Any, task_id: str) -> str:
+    try:
+        for event in reversed(kb.list_events(conn, task_id)):
+            if event.kind != "blocked" or not isinstance(event.payload, dict):
+                continue
+            return str(event.payload.get("reason") or "")
+    except Exception:
+        pass
+    try:
+        for run in reversed(kb.list_runs(conn, task_id, include_active=False)):
+            if run.outcome == "blocked":
+                return str(run.summary or "")
+    except Exception:
+        pass
+    return ""
+
+
+def _load_kanban_board_state(
+    task_id: str,
+    *,
+    board: str = "",
+    db_path: str = "",
+) -> Optional[dict]:
+    """Load minimal kanban task state using the canonical board path resolver."""
+    if not task_id:
+        return None
+    try:
+        from hermes_cli import kanban_db as kb
+
+        conn = (
+            kb.connect(db_path=Path(db_path).expanduser())
+            if db_path
+            else kb.connect(board=board or None)
+        )
+        try:
+            task = kb.get_task(conn, task_id)
+            if not task:
+                return None
+            state = {
+                "status": task.status,
+                "title": task.title,
+            }
+            if task.status == "blocked":
+                state["blocked_reason"] = _latest_kanban_block_reason(kb, conn, task_id)
+            return state
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("heartbeat board query failed: %s", exc)
+        return None
+
+
+def _format_heartbeat_message(state_label, session_state, board_state, process_state, elapsed_mins):
+    session_id = session_state.get("session_id", "?")
+    is_kanban = session_state.get("is_kanban_worker", False)
+    task_id = session_state.get("kanban_task_id")
+    task_title = (board_state or {}).get("title", "")
+    blocked_reason = (board_state or {}).get("blocked_reason", "")
+    parent_id = (board_state or {}).get("parent_session_id", "")
+    current_tool = process_state.get("current_tool", "") or ""
+    iteration = process_state.get("iteration", "") or ""
+    if state_label == "blocked":
+        parts = [f"Blocked for approval ({elapsed_mins} min)"]
+        if task_title:
+            parts.append(f"Card: {task_title}")
+        if task_id:
+            parts.append(f"Task: {task_id}")
+        if blocked_reason:
+            parts.append(f"Reason: {blocked_reason}")
+        if parent_id:
+            parts.append(f"Parent session: {parent_id}")
+        return "\n".join(parts)
+    if state_label == "terminal":
+        return f"Task completed ({session_id})"
+    if not is_kanban:
+        parts = [f"Still working... ({elapsed_mins} min elapsed"]
+        if iteration:
+            parts.append(f"iteration {iteration}")
+        if current_tool:
+            parts.append(f"running: {current_tool}")
+        detail = " — " + ", ".join(p for p in parts[1:] if p) if len(parts) > 1 else ""
+        return parts[0] + detail + ")"
+    parts = [f"Working on card: {task_title or task_id or '?'} ({elapsed_mins} min"]
+    if iteration:
+        parts.append(f"iteration {iteration}")
+    if current_tool:
+        parts.append(f"running: {current_tool}")
+    detail = " — " + ", ".join(p for p in parts[1:] if p) if len(parts) > 1 else ""
+    return parts[0] + detail + ")"
+
+
 def _is_fresh_gateway_interruption(
     value: Any,
     *,
@@ -1238,6 +1432,7 @@ class GatewayRunner:
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        self._blocked_notified_at: dict[str, tuple[float, str]] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
@@ -15751,6 +15946,9 @@ class GatewayRunner:
         # 0 = disable notifications.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        # HERMES_BLOCKED_REMINDER_INTERVAL env var.  Default 60 min.
+        # How long to wait before re-notifying about the same blocked card.
+        _blocked_reminder_interval = _float_env("HERMES_BLOCKED_REMINDER_INTERVAL", _BLOCKED_REMINDER_INTERVAL_DEFAULT)
         _notify_start = time.time()
 
         async def _notify_long_running():
@@ -15764,22 +15962,88 @@ class GatewayRunner:
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
-                _status_detail = ""
+                _process_state = {
+                    "active_process_count": 0,
+                    "active_kanban_count": 0,
+                    "current_tool": None,
+                    "iteration": None,
+                }
+                _session_state = {
+                    "session_id": session_id or "unknown",
+                    "agent_active": bool(_agent_ref),
+                }
+                _board_state = None
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
-                        _parts = [f"iteration {_a['api_call_count']}/{_a['max_iterations']}"]
-                        if _a.get("current_tool"):
-                            _parts.append(f"running: {_a['current_tool']}")
-                        else:
-                            _parts.append(_a.get("last_activity_desc", ""))
-                        _status_detail = " — " + ", ".join(_parts)
+                        _tool = _a.get("current_tool")
+                        if _tool:
+                            _process_state["current_tool"] = _tool
+                            _process_state["active_process_count"] = 1
+                        _api_n = _a.get("api_call_count", 0)
+                        _api_max = _a.get("max_iterations", 0)
+                        if _api_n or _api_max:
+                            _process_state["iteration"] = f"{_api_n}/{_api_max}"
+                        if _a.get("is_idle") is None:
+                            _session_state["agent_active"] = True
+                        elif not _safe_bool(_a.get("is_idle"), True):
+                            _session_state["agent_active"] = True
                     except Exception:
                         pass
+                _kanban_task = _agent_env_value(_agent_ref, "HERMES_KANBAN_TASK")
+                if _kanban_task:
+                    _session_state["is_kanban_worker"] = True
+                    _session_state["kanban_task_id"] = _kanban_task
+                if not _kanban_task and hasattr(_agent_ref, "system_prompt"):
+                    _sp = getattr(_agent_ref, "system_prompt", "") or ""
+                    _hb_match = re.search(
+                        r"work kanban task (t_[a-f0-9]+)", _sp
+                    )
+                    if _hb_match:
+                        _kanban_task = _hb_match.group(1)
+                        _session_state["is_kanban_worker"] = True
+                        _session_state["kanban_task_id"] = _kanban_task
+                if _kanban_task:
+                    _board_state = _load_kanban_board_state(
+                        _kanban_task,
+                        board=_agent_env_value(_agent_ref, "HERMES_KANBAN_BOARD"),
+                        db_path=_agent_env_value(_agent_ref, "HERMES_KANBAN_DB"),
+                    )
+                _should_send, _state_label = _heartbeat_eligibility(
+                    _session_state, _board_state, _process_state
+                )
+                if not _should_send:
+                    logger.debug(
+                        "heartbeat skipped: session=%s state=%s task=%s",
+                        session_id, _state_label,
+                        _session_state.get("kanban_task_id", "N/A"),
+                    )
+                    continue
+                # -- blocked-card rate-limiting --------------------------------
+                if _state_label == "blocked":
+                    _blocked_key = _session_state.get("kanban_task_id")
+                    if _blocked_key:
+                        _blocked_fp = str(_board_state.get("blocked_reason", "") if _board_state else "")
+                        if not _blocked_reminder_should_send(
+                            _blocked_key,
+                            _blocked_fp,
+                            time.time(),
+                            _blocked_reminder_interval,
+                            tracker=getattr(self, "_blocked_notified_at", None),
+                        ):
+                            logger.debug(
+                                "heartbeat blocked reminder skipped (rate-limited): "
+                                "task=%s reason=%s",
+                                _blocked_key, _blocked_fp,
+                            )
+                            continue
+                _msg = _format_heartbeat_message(
+                    _state_label, _session_state, _board_state, _process_state, _elapsed_mins
+                )
                 try:
                     _notify_res = await _notify_adapter.send(
                         source.chat_id,
-                        f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
+                        _msg,
                         metadata=_status_thread_metadata,
                     )
                     if (

--- a/tests/gateway/test_heartbeat_eligibility.py
+++ b/tests/gateway/test_heartbeat_eligibility.py
@@ -1,0 +1,386 @@
+import pytest
+from gateway.run import (
+    _safe_int,
+    _safe_bool,
+    _heartbeat_eligibility,
+    _format_heartbeat_message,
+    _blocked_reminder_should_send,
+    _blocked_notified_at,
+    _reset_blocked_tracker,
+    _load_kanban_board_state,
+    _BLOCKED_REMINDER_INTERVAL_DEFAULT,
+)
+
+class TestSafeInt:
+    def test_none_returns_default(self):
+        assert _safe_int(None) == 0
+        assert _safe_int(None, 5) == 5
+
+    def test_valid_int(self):
+        assert _safe_int(5) == 5
+        assert _safe_int(10, 99) == 10
+
+    def test_invalid_type(self):
+        assert _safe_int("abc") == 0
+        assert _safe_int("abc", 7) == 7
+        assert _safe_int([1,2]) == 0
+
+    def test_float_coercion(self):
+        assert _safe_int(3.7) == 3
+
+
+class TestSafeBool:
+    def test_none_returns_default(self):
+        assert _safe_bool(None) is False
+        assert _safe_bool(None, True) is True
+
+    def test_valid_bool(self):
+        assert _safe_bool(True) is True
+        assert _safe_bool(False) is False
+
+    def test_truthy_values(self):
+        assert _safe_bool(1) is True
+        assert _safe_bool("yes") is True
+        assert _safe_bool([1]) is True
+
+    def test_falsey_values(self):
+        assert _safe_bool(0) is False
+        assert _safe_bool("") is False
+        assert _safe_bool([]) is False
+
+
+class TestHeartbeatEligibility:
+    def _eligibility(self, session, board, process):
+        return _heartbeat_eligibility(session, board, process)
+
+    def test_terminal_session_never_sends(self):
+        result, label = self._eligibility({"status": "terminal", "is_kanban_worker": False}, {}, {})
+        assert result is False
+        assert label == "terminal"
+
+    def test_completed_kanban_task(self):
+        for status in ["done", "completed", "cancelled", "archived"]:
+            result, label = self._eligibility(
+                {"is_kanban_worker": True, "kanban_task_id": "t_123"},
+                {"status": status},
+                {},
+            )
+            assert result is False
+            assert label == "completed"
+
+    def test_blocked_kanban_sends(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": True, "kanban_task_id": "t_123"},
+            {"status": "blocked"},
+            {},
+        )
+        assert result is True
+        assert label == "blocked"
+
+    def test_idle_kanban_no_agent(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": True, "kanban_task_id": "t_123", "agent_active": False},
+            {},
+            {},
+        )
+        assert result is False
+        assert label == "idle"
+
+    def test_active_kanban_with_agent(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": True, "kanban_task_id": "t_123", "agent_active": True},
+            {},
+            {},
+        )
+        assert result is True
+        assert label == "active"
+
+    def test_blocked_board_non_kanban(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": False},
+            {"status": "blocked"},
+            {},
+        )
+        assert result is True
+        assert label == "blocked"
+
+    def test_empty_process_idle(self):
+        result, label = self._eligibility({}, {}, {})
+        assert result is False
+        assert label == "idle"
+
+    def test_active_process_sends(self):
+        result, label = self._eligibility({}, {}, {"active_process_count": 1})
+        assert result is True
+        assert label == "active"
+
+    def test_active_process_sends_even_if_agent_active_false(self):
+        result, label = self._eligibility(
+            {"agent_active": False, "is_kanban_worker": False},
+            {},
+            {"active_process_count": 1, "active_kanban_count": 0},
+        )
+        assert result is True
+        assert label == "active"
+
+    def test_active_kanban_count_sends(self):
+        result, label = self._eligibility({}, {}, {"active_process_count": 0, "active_kanban_count": 1})
+        assert result is True
+        assert label == "active"
+
+    def test_idle_non_kanban_no_active_process(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": False, "agent_active": False},
+            {},
+            {"active_process_count": 0, "active_kanban_count": 0},
+        )
+        assert result is False
+        assert label == "idle"
+
+    def test_active_non_kanban_with_process(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": False, "agent_active": True},
+            {},
+            {"active_process_count": 1},
+        )
+        assert result is True
+        assert label == "active"
+
+    def test_no_kanban_no_board_idle(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": False},
+            None,
+            {"active_process_count": 0, "active_kanban_count": 0},
+        )
+        assert result is False
+        assert label == "idle"
+
+
+class TestHeartbeatNoneState:
+    def _eligibility(self, session, board, process):
+        return _heartbeat_eligibility(session, board, process)
+
+    def test_process_count_none(self):
+        result, label = self._eligibility({}, {}, {"active_process_count": None})
+        assert result is False
+        assert label == "idle"
+
+    def test_kanban_count_none(self):
+        result, label = self._eligibility({}, {}, {"active_process_count": 0, "active_kanban_count": None})
+        assert result is False
+        assert label == "idle"
+
+    def test_active_kanban_count_none_with_active_process(self):
+        result, label = self._eligibility(
+            {"is_kanban_worker": False},
+            {},
+            {"active_process_count": 1, "active_kanban_count": None},
+        )
+        assert result is True
+        assert label == "active"
+
+    def test_agent_active_none_with_active_process(self):
+        result, label = self._eligibility(
+            {"agent_active": None, "is_kanban_worker": False},
+            {},
+            {"active_process_count": 1},
+        )
+        assert result is True
+        assert label == "active"
+
+
+class TestBlockedRateLimit:
+    """Tests for blocked-card reminder rate-limiting."""
+
+    def setup_method(self):
+        # Save and restore so parallel workers with shared module state
+        # don't corrupt each other's tracker.
+        self._saved = dict(_blocked_notified_at)
+        _reset_blocked_tracker()
+
+    def teardown_method(self):
+        _reset_blocked_tracker()
+        _blocked_notified_at.update(self._saved)
+
+    def test_first_blocked_notification_sent(self):
+        # First time a card is blocked — should always send.
+        assert _blocked_reminder_should_send("t_first", "needs approval", 1000.0) is True
+        # Tracker was updated.
+        assert _blocked_notified_at["t_first"] == (1000.0, "needs approval")
+
+    def test_same_card_within_interval_skipped(self):
+        # Notify at t=1000.
+        assert _blocked_reminder_should_send("t_same", "needs approval", 1000.0) is True
+        # Same card, same reason, 60 s later — well within 60-min default -> blocked.
+        assert _blocked_reminder_should_send("t_same", "needs approval", 1060.0) is False
+
+    def test_same_card_after_long_interval_sent(self):
+        # Notify at t=1000.
+        assert _blocked_reminder_should_send("t_long", "needs approval", 1000.0) is True
+        # 61 minutes later — past the 60-min (3600 s) default -> allowed.
+        assert _blocked_reminder_should_send("t_long", "needs approval", 4660.0) is True
+        # Tracker updated to new timestamp.
+        assert _blocked_notified_at["t_long"][0] == 4660.0
+
+    def test_changed_blocked_reason_triggers_immediately(self):
+        # Notify at t=1000.
+        assert _blocked_reminder_should_send("t_reason", "needs approval", 1000.0) is True
+        # Same card but different reason — should send immediately (fp mismatch).
+        assert _blocked_reminder_should_send("t_reason", "user replied", 1060.0) is True
+        # Tracker updated with new fingerprint.
+        assert _blocked_notified_at["t_reason"] == (1060.0, "user replied")
+
+    def test_empty_reason_tracked_correctly(self):
+        # Empty string and None both normalise to "" fingerprint.
+        # First call with empty reason on a new card — sent.
+        assert _blocked_reminder_should_send("t_empty", "", 1000.0) is True
+        # Second call with None on same card, 60 s later — same fp, blocked.
+        assert _blocked_reminder_should_send("t_empty", None, 1060.0) is False
+
+    def test_custom_reminder_interval_short(self):
+        # When interval is set very short (e.g. 10 s), next tick within that
+        # interval is still blocked.
+        assert _blocked_reminder_should_send("t_short", "a", 1000.0, reminder_interval=10.0) is True
+        assert _blocked_reminder_should_send("t_short", "a", 1005.0, reminder_interval=10.0) is False
+        assert _blocked_reminder_should_send("t_short", "a", 1011.0, reminder_interval=10.0) is True
+
+    def test_custom_reminder_interval_zero_disables(self):
+        # Zero interval means always send (no rate-limiting).
+        assert _blocked_reminder_should_send("t_zero", "a", 1000.0, reminder_interval=0.0) is True
+        assert _blocked_reminder_should_send("t_zero", "a", 1001.0, reminder_interval=0.0) is True
+
+    def test_different_cards_independent(self):
+        # Each card has its own entry in the tracker.
+        assert _blocked_reminder_should_send("t_card_A", "reason1", 1000.0) is True
+        assert _blocked_reminder_should_send("t_card_B", "reason2", 1000.0) is True
+        # t_card_A checked again 61 min later — interval expired -> allowed.
+        assert _blocked_reminder_should_send("t_card_A", "reason1", 4660.0) is True
+        # t_card_B checked again just 60 s later — still within 60-min -> blocked.
+        assert _blocked_reminder_should_send("t_card_B", "reason2", 1060.0) is False
+
+    def test_default_interval_is_60_minutes(self):
+        assert _BLOCKED_REMINDER_INTERVAL_DEFAULT == 3600
+
+    def test_custom_tracker_is_isolated(self):
+        tracker = {}
+        assert _blocked_reminder_should_send("t_local", "a", 1000.0, tracker=tracker) is True
+        assert tracker == {"t_local": (1000.0, "a")}
+        assert "t_local" not in _blocked_notified_at
+        _reset_blocked_tracker(tracker)
+        assert tracker == {}
+
+
+class TestKanbanBoardState:
+    def test_load_state_uses_canonical_db_path_and_block_reason(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        db_path = tmp_path / "kanban.db"
+        with kb.connect(db_path=db_path) as conn:
+            task_id = kb.create_task(conn, title="Review deployment", body="check", assignee=None)
+            assert kb.block_task(conn, task_id, reason="needs human approval") is True
+
+        state = _load_kanban_board_state(task_id, db_path=str(db_path))
+
+        assert state == {
+            "status": "blocked",
+            "title": "Review deployment",
+            "blocked_reason": "needs human approval",
+        }
+
+    def test_load_state_handles_done_task(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        db_path = tmp_path / "kanban.db"
+        with kb.connect(db_path=db_path) as conn:
+            task_id = kb.create_task(conn, title="Ship patch", body="done", assignee=None)
+            assert kb.complete_task(conn, task_id, result="merged") is True
+
+        state = _load_kanban_board_state(task_id, db_path=str(db_path))
+
+        assert state == {
+            "status": "done",
+            "title": "Ship patch",
+        }
+
+
+class TestFormatHeartbeat:
+    def _format(self, state_label, session, board, process, elapsed=5):
+        return _format_heartbeat_message(state_label, session, board, process, elapsed)
+
+    def test_blocked_message(self):
+        msg = self._format(
+            "blocked",
+            {"is_kanban_worker": True, "kanban_task_id": "t_abc", "session_id": "s_1"},
+            {"title": "My Card", "blocked_reason": "needs approval"},
+            {},
+            10,
+        )
+        assert "10 min" in msg
+        assert "My Card" in msg
+        assert "t_abc" in msg
+        assert "needs approval" in msg
+
+    def test_terminal_message(self):
+        msg = self._format(
+            "terminal",
+            {"session_id": "s_xyz"},
+            None,
+            {},
+            1,
+        )
+        assert "s_xyz" in msg
+
+    def test_non_kanban_working(self):
+        msg = self._format(
+            "active",
+            {"is_kanban_worker": False},
+            None,
+            {},
+            7,
+        )
+        assert "7 min" in msg
+
+    def test_non_kanban_with_iteration(self):
+        msg = self._format(
+            "active",
+            {"is_kanban_worker": False},
+            None,
+            {"iteration": "3/10"},
+            7,
+        )
+        assert "iteration 3/10" in msg
+
+    def test_non_kanban_with_tool(self):
+        msg = self._format(
+            "active",
+            {"is_kanban_worker": False},
+            None,
+            {"current_tool": "bash"},
+            7,
+        )
+        assert "running: bash" in msg
+
+    def test_kanban_card_message(self):
+        msg = self._format(
+            "active",
+            {"is_kanban_worker": True, "kanban_task_id": "t_xyz"},
+            {"title": "Implement login"},
+            {},
+            15,
+        )
+        assert "15 min" in msg
+        assert "Implement login" in msg or "t_xyz" in msg
+
+    def test_kanban_blocked_no_heartbeat(self):
+        msg = self._format(
+            "blocked",
+            {"is_kanban_worker": True, "kanban_task_id": "t_xyz"},
+            {"title": "My Card"},
+            {},
+            5,
+        )
+        assert "5 min" in msg
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes gateway long-running heartbeat handling for active, idle, completed kanban, and blocked kanban sessions.

- Avoids crashes when activity summary fields are missing or `None`.
- Keeps normal active-session heartbeats working even when the activity summary does not expose an `is_idle` field.
- Stops completed/cancelled/archived kanban cards from continuing to emit progress heartbeats.
- Sends blocked-card approval reminders immediately once, then rate-limits repeat reminders with `HERMES_BLOCKED_REMINDER_INTERVAL` defaulting to 3600 seconds.
- Loads kanban task state through `hermes_cli.kanban_db` so `HERMES_KANBAN_DB`, default-board paths, and board selection stay consistent with the dispatcher.
- Preserves platform thread metadata when sending long-running heartbeat messages.

## Root Cause

The previous heartbeat message path assumed every activity summary exposed fully populated iteration/tool fields. The first PR draft also inferred idleness from an `is_idle` summary field that the current `AIAgent.get_activity_summary()` does not provide, which would have suppressed normal active heartbeats. It also built kanban DB paths manually and queried a non-existent `blocked_reason` task column.

## Changes

### `gateway/run.py`
- Adds small safe coercion helpers for optional activity values.
- Splits heartbeat eligibility and message formatting into testable helpers.
- Treats active process/tool evidence as active even if `agent_active` is false.
- Reads kanban task state through the canonical kanban DB API.
- Derives blocked reasons from kanban events or closed run summaries.
- Adds per-task blocked reminder rate limiting with an explicit reset helper and per-runner tracker support.
- Restores `metadata=_status_thread_metadata` on heartbeat sends.

### `tests/gateway/test_heartbeat_eligibility.py`
- Covers terminal, completed, blocked, idle, and active states.
- Covers `None`/missing activity fields.
- Covers blocked reminder rate limiting.
- Adds regression coverage for active process heartbeats when `agent_active=False`.
- Adds regression coverage for canonical kanban DB state loading and blocked reasons.

## Tests

```bash
python3 -m compileall gateway/run.py tests/gateway/test_heartbeat_eligibility.py -q
pytest -o addopts="" tests/gateway/test_heartbeat_eligibility.py -q
pytest -o addopts="" tests/gateway/test_run_cleanup_progress.py -q
pytest -o addopts="" tests/gateway/test_telegram_thread_fallback.py -q
.venv/bin/ruff check gateway/run.py tests/gateway/test_heartbeat_eligibility.py
git diff --check upstream/main...HEAD
```

Results:
- Heartbeat eligibility: 44 passed
- Cleanup progress: 5 passed
- Telegram thread fallback: 34 passed
- Compile, ruff, and diff whitespace checks passed

## Risk / Compatibility

- Active-session heartbeat behavior is preserved.
- Blocked approval reminders are intentionally reduced from every heartbeat interval to hourly by default.
- Set `HERMES_BLOCKED_REMINDER_INTERVAL=0` to restore repeat reminders every heartbeat interval.
- Reminder rate-limit state is process-local, so gateway restarts send the first blocked notification again.
