### PR TITLE
chore: add contributors to AUTHOR_MAP for #20714 batch salvage

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1014,6 +1014,9 @@ AUTHOR_MAP = {
     "zhaowh3613@outlook.com": "VinceZcrikl",  # PR #23647 salvage (npm UTF-8 decode on GBK Windows)
     "anton.kuenzi@gmail.com": "ZeterMordio",  # PR #11754 salvage (zsh completion compdef + _arguments syntax)
     "23yntong@stu.edu.cn": "iuyup",  # PR #6155 salvage (shell=True hardening)
+    "32869278+dusterbloom@users.noreply.github.com": "dusterbloom",  # PR #20750 salvage (CJK/emoji panel width, #20621)
+    "antonka@vk.com": "jimmyjonezz",  # PR #20646 salvage (Termux TUI build, #20645)
+    "android@termux": "jimmyjonezz",  # PR #20646 salvage (Termux TUI build, #20645)
 }
 
 


### PR DESCRIPTION
## Summary

Adds three email→GitHub mappings to `AUTHOR_MAP` so `contributor_audit.py` strict mode stays green when the salvage PRs for #20663/#20669/#20621/#20645 land.

| Email | GitHub | Provenance |
|-------|--------|------------|
| `32869278+dusterbloom@users.noreply.github.com` | `dusterbloom` | PR #20750 (CJK/emoji panel width, fixes #20621) |
| `antonka@vk.com` | `jimmyjonezz` | PR #20646 merge commits |
| `android@termux` | `jimmyjonezz` | PR #20646 work commits (Termux TUI build, fixes #20645) |

## Context

PR #20714 bundled four unrelated fixes; review found three were superseded by stronger community PRs (#20806, #20750, #20646) and one was a regression. This PR is the AUTHOR_MAP prerequisite for those three salvages.

Per the salvage workflow, this must merge before the salvage PRs land so the audit runs against main with the mappings already in place.

## Test plan

- `python scripts/contributor_audit.py --strict` runs against main and includes the new commits.
