### PR TITLE
feat(plugins): allow silent CLI message injection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3442,6 +3442,56 @@ class HermesCLI:
 
         return paste_ref_re.sub(_expand_ref, text)
 
+    def _is_injected_message(self, value: Any) -> bool:
+        """Return True when a queued item is the plugin injection envelope."""
+        return (
+            hasattr(value, "content")
+            and hasattr(value, "visible")
+            and getattr(getattr(value, "__class__", None), "__name__", "") == "InjectedMessage"
+        )
+
+    def _unwrap_queued_input(self, value: Any) -> tuple[Any, bool, Any]:
+        """Return queued content plus its visibility metadata."""
+        if self._is_injected_message(value):
+            content = value.content
+            visible = bool(value.visible)
+            preview = value.preview if value.preview is not None else value.content
+            return content, visible, preview
+        return value, True, value
+
+    def _combine_queued_inputs(self, items: list[Any]) -> tuple[Any, bool, str]:
+        """Combine queued interrupt messages without leaking hidden previews."""
+        contents: list[str] = []
+        visible_previews: list[str] = []
+        saw_injected = False
+
+        for item in items:
+            content, visible, preview = self._unwrap_queued_input(item)
+            contents.append(str(content))
+            if self._is_injected_message(item):
+                saw_injected = True
+            if visible:
+                visible_previews.append(str(preview))
+
+        combined_content = "\n".join(contents)
+        if not saw_injected:
+            return combined_content, True, combined_content
+
+        combined_visible = bool(visible_previews)
+        combined_preview = "\n".join(visible_previews) if visible_previews else ""
+
+        from hermes_cli.plugins import InjectedMessage
+
+        return (
+            InjectedMessage(
+                content=combined_content,
+                visible=combined_visible,
+                preview=combined_preview,
+            ),
+            combined_visible,
+            combined_preview,
+        )
+
     def _print_user_message_preview(self, user_input: str) -> None:
         """Render a user message using the normal chat scrollback style."""
         ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
@@ -10553,21 +10603,25 @@ class HermesCLI:
             # by the Enter key binding (routed to the clarify response queue),
             # so we skip interrupt processing to avoid stealing that input.
             interrupt_msg = None
+            interrupt_item = None
             while agent_thread.is_alive():
                 if hasattr(self, '_interrupt_queue'):
                     try:
-                        interrupt_msg = self._interrupt_queue.get(timeout=0.1)
+                        raw_interrupt = self._interrupt_queue.get(timeout=0.1)
+                        interrupt_msg, interrupt_visible, interrupt_preview = self._unwrap_queued_input(raw_interrupt)
                         if interrupt_msg:
                             # If clarify is active, the Enter handler routes
                             # input directly; this queue shouldn't have anything.
                             # But if it does (race condition), don't interrupt.
                             if self._clarify_state or self._clarify_freetext:
                                 continue
-                            print("\n⚡ New message detected, interrupting...")
+                            if interrupt_visible:
+                                print("\n⚡ New message detected, interrupting...")
                             # Signal TTS to stop on interrupt
                             if stop_event is not None:
                                 stop_event.set()
                             self.agent.interrupt(interrupt_msg)
+                            interrupt_item = raw_interrupt
                             # Debug: log to file (stdout may be devnull from redirect_stdout)
                             try:
                                 _dbg = _hermes_home / "interrupt_debug.log"
@@ -10719,7 +10773,7 @@ class HermesCLI:
             # so they can skip themselves when the turn was user-cancelled.
             self._last_turn_interrupted = _interrupted_this_turn
             if _interrupted_this_turn:
-                pending_message = result.get("interrupt_message") or interrupt_msg
+                pending_message = interrupt_item or result.get("interrupt_message") or interrupt_msg
                 # Add indicator that we were interrupted
                 if response and pending_message:
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
@@ -10823,13 +10877,15 @@ class HermesCLI:
                             all_parts.append(extra)
                     except queue.Empty:
                         break
-                combined = "\n".join(all_parts)
+                combined, combined_visible, combined_preview = self._combine_queued_inputs(all_parts)
                 n = len(all_parts)
-                preview = combined[:50] + ("..." if len(combined) > 50 else "")
-                if n > 1:
-                    print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
-                else:
-                    print(f"\n⚡ Sending after interrupt: '{preview}'")
+                preview_source = str(combined_preview)
+                preview = preview_source[:50] + ("..." if len(preview_source) > 50 else "")
+                if combined_visible:
+                    if n > 1:
+                        print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
+                    else:
+                        print(f"\n⚡ Sending after interrupt: '{preview}'")
                 self._pending_input.put(combined)
 
             # If a /steer was left over (agent finished before another tool
@@ -12960,6 +13016,7 @@ class HermesCLI:
                     # Check for pending input with timeout
                     try:
                         user_input = self._pending_input.get(timeout=0.1)
+                        user_input, input_visible, input_preview = self._unwrap_queued_input(user_input)
                     except queue.Empty:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:
@@ -13027,8 +13084,9 @@ class HermesCLI:
                     paste_refs = list(_paste_ref_re.finditer(user_input)) if isinstance(user_input, str) else []
                     if paste_refs:
                         user_input = self._expand_paste_references(user_input)
-                    print()
-                    self._print_user_message_preview(user_input)
+                    if input_visible:
+                        print()
+                        self._print_user_message_preview(input_preview)
                     
                     # Show image attachment count
                     if submit_images:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -280,6 +280,15 @@ class LoadedPlugin:
     error: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class InjectedMessage:
+    """Message injected by a plugin into the active CLI session."""
+
+    content: str
+    visible: bool = True
+    preview: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # PluginContext  – handed to each plugin's ``register()`` function
 # ---------------------------------------------------------------------------
@@ -345,7 +354,13 @@ class PluginContext:
 
     # -- message injection --------------------------------------------------
 
-    def inject_message(self, content: str, role: str = "user") -> bool:
+    def inject_message(
+        self,
+        content: str,
+        role: str = "user",
+        *,
+        visible: bool = True,
+    ) -> bool:
         """Inject a message into the active conversation.
 
         If the agent is idle (waiting for user input), this starts a new turn.
@@ -354,7 +369,14 @@ class PluginContext:
         This enables plugins (e.g. remote control viewers, messaging bridges)
         to send messages into the conversation from external sources.
 
-        Returns True if the message was queued successfully.
+        Args:
+            content: Message content to send to the active CLI conversation.
+            role: Logical role label. Non-user roles are prefixed as before.
+            visible: If False, suppress rendering this injected message in the
+                live CLI UI.
+
+        Returns:
+            True if the message was queued successfully.
         """
         cli = self._manager._cli_ref
         if cli is None:
@@ -362,13 +384,14 @@ class PluginContext:
             return False
 
         msg = content if role == "user" else f"[{role}] {content}"
+        payload = msg if visible else InjectedMessage(content=msg, visible=False)
 
         if getattr(cli, "_agent_running", False):
             # Agent is mid-turn — interrupt with the message
-            cli._interrupt_queue.put(msg)
+            cli._interrupt_queue.put(payload)
         else:
             # Agent is idle — queue as next input
-            cli._pending_input.put(msg)
+            cli._pending_input.put(payload)
         return True
 
     # -- CLI command registration --------------------------------------------

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -162,6 +162,51 @@ class TestBusyInputMode:
         assert cli._pending_input.empty()
 
 
+class TestSilentInjectedMessages:
+    def test_unwrap_queued_input_marks_hidden_injections_invisible(self):
+        from hermes_cli.plugins import InjectedMessage
+
+        cli = _make_cli()
+        item = InjectedMessage(content="hidden event", visible=False)
+
+        content, visible, preview = cli._unwrap_queued_input(item)
+
+        assert content == "hidden event"
+        assert visible is False
+        assert preview == "hidden event"
+
+    def test_combine_queued_inputs_does_not_leak_hidden_preview_text(self):
+        from hermes_cli.plugins import InjectedMessage
+
+        cli = _make_cli()
+        hidden = InjectedMessage(content="SECRET_HIDDEN_EVENT", visible=False)
+
+        combined, combined_visible, combined_preview = cli._combine_queued_inputs(
+            ["visible user message", hidden]
+        )
+
+        assert combined_visible is True
+        assert combined_preview == "visible user message"
+        assert "SECRET_HIDDEN_EVENT" not in combined_preview
+        assert combined.content == "visible user message\nSECRET_HIDDEN_EVENT"
+        assert combined.visible is True
+        assert combined.preview == "visible user message"
+
+    def test_combine_queued_inputs_with_only_hidden_messages_stays_silent(self):
+        from hermes_cli.plugins import InjectedMessage
+
+        cli = _make_cli()
+        hidden = InjectedMessage(content="SECRET_HIDDEN_EVENT", visible=False)
+
+        combined, combined_visible, combined_preview = cli._combine_queued_inputs([hidden])
+
+        assert combined_visible is False
+        assert combined_preview == ""
+        assert combined.content == "SECRET_HIDDEN_EVENT"
+        assert combined.visible is False
+        assert combined.preview == ""
+
+
 class TestPromptToolkitTerminalCompatibility:
     def test_lf_enter_binds_to_submit_handler_posix(self):
         """Some thin PTYs deliver Enter as LF/c-j instead of CR/enter.

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import queue
 import sys
 import types
 from pathlib import Path
@@ -12,6 +13,7 @@ import yaml
 
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
+    InjectedMessage,
     VALID_HOOKS,
     LoadedPlugin,
     PluginContext,
@@ -544,6 +546,17 @@ class TestPreToolCallBlocking:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    @staticmethod
+    def _make_context(*, busy: bool = False) -> tuple[PluginContext, types.SimpleNamespace]:
+        cli = types.SimpleNamespace(
+            _agent_running=busy,
+            _pending_input=queue.Queue(),
+            _interrupt_queue=queue.Queue(),
+        )
+        manager = types.SimpleNamespace(_cli_ref=cli)
+        manifest = PluginManifest(name="test_plugin", version="0.1.0")
+        return PluginContext(manifest, manager), cli
+
     def test_register_tool_adds_to_registry(self, tmp_path, monkeypatch):
         """PluginContext.register_tool() puts the tool in the global registry."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"
@@ -572,6 +585,34 @@ class TestPluginContext:
 
         from tools.registry import registry
         assert "plugin_echo" in registry._tools
+
+    def test_inject_message_default_behavior_remains_visible_when_idle(self):
+        ctx, cli = self._make_context(busy=False)
+
+        assert ctx.inject_message("hello") is True
+        assert cli._pending_input.get_nowait() == "hello"
+
+    def test_inject_message_hidden_message_is_wrapped_when_idle(self):
+        ctx, cli = self._make_context(busy=False)
+
+        assert ctx.inject_message("hidden event", visible=False) is True
+
+        item = cli._pending_input.get_nowait()
+        assert isinstance(item, InjectedMessage)
+        assert item.content == "hidden event"
+        assert item.visible is False
+        assert item.preview is None
+
+    def test_inject_message_hidden_message_is_wrapped_when_busy(self):
+        ctx, cli = self._make_context(busy=True)
+
+        assert ctx.inject_message("hidden interrupt", visible=False) is True
+
+        item = cli._interrupt_queue.get_nowait()
+        assert isinstance(item, InjectedMessage)
+        assert item.content == "hidden interrupt"
+        assert item.visible is False
+        assert item.preview is None
 
 
 # ── TestPluginToolVisibility ───────────────────────────────────────────────

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -102,7 +102,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Add slash commands | `ctx.register_command(name, handler, description)` — adds `/name` in CLI and gateway sessions |
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
-| Inject messages | `ctx.inject_message(content, role="user")` — see [Injecting Messages](#injecting-messages) |
+| Inject messages | `ctx.inject_message(content, role="user", visible=True)` — see [Injecting Messages](#injecting-messages) |
 | Ship data files | `Path(__file__).parent / "data" / "file.yaml"` |
 | Bundle skills | `ctx.register_skill(name, path)` — namespaced as `plugin:skill`, loaded via `skill_view("plugin:skill")` |
 | Gate on env vars | `requires_env: [API_KEY]` in plugin.yaml — prompted during `hermes plugins install` |
@@ -328,19 +328,32 @@ Plugins can inject messages into the active conversation using `ctx.inject_messa
 ctx.inject_message("New data arrived from the webhook", role="user")
 ```
 
-**Signature:** `ctx.inject_message(content: str, role: str = "user") -> bool`
+To inject a message without rendering it as a visible user message in the live CLI UI:
+
+```python
+ctx.inject_message(
+    "Webhook event received. Check the latest app state and continue.",
+    role="user",
+    visible=False,
+)
+```
+
+**Signature:** `ctx.inject_message(content: str, role: str = "user", *, visible: bool = True) -> bool`
 
 How it works:
 
 - If the agent is **idle** (waiting for user input), the message is queued as the next input and starts a new turn.
 - If the agent is **mid-turn** (actively running), the message interrupts the current operation — the same as a user typing a new message and pressing Enter.
 - For non-`"user"` roles, the content is prefixed with `[role]` (e.g. `[system] ...`).
+- If `visible=False`, the message is still sent to the model but is not rendered as a submitted user message in the live CLI UI.
 - Returns `True` if the message was queued successfully, `False` if no CLI reference is available (e.g. in gateway mode).
 
 This enables plugins like remote control viewers, messaging bridges, or webhook receivers to feed messages into the conversation from external sources.
 
 :::note
 `inject_message` is only available in CLI mode. In gateway mode, there is no CLI reference and the method returns `False`.
+
+Setting `visible=False` only affects live CLI rendering. The injected message still follows the normal session/history flow.
 :::
 
 See the **[full guide](/docs/guides/build-a-hermes-plugin)** for handler contracts, schema format, hook behavior, error handling, and common mistakes.


### PR DESCRIPTION
## What changed

Adds `visible=False` to `PluginContext.inject_message()` so plugins can inject
messages into the active CLI conversation without rendering the injected text as
a submitted user message in the terminal.

This only changes live CLI rendering. It does not change persistence semantics:
the injected message is still sent to the model and follows existing
conversation history/session behavior.

Implementation details:
- Add `InjectedMessage` envelope for plugin-injected queue items.
- Extend `ctx.inject_message(..., visible=True)`.
- Suppress submitted-message preview for hidden injected messages.
- Suppress interrupt/requeue previews for hidden injected messages.
- Preserve existing behavior for normal visible injections.
- Update plugin docs.
- Add regression tests for idle and busy injection paths.

## Why

This is useful for app state integrations, webhook bridges, and secondary
inputs where the injected prompt is not meaningful user chat content. External
events can trigger agent action without adding noise to the chat.

## How to test

- Run `tests/hermes_cli/test_plugins.py -k "inject_message or TestPluginContext"`
- Run `tests/cli/test_cli_init.py -k "SilentInjectedMessages or BusyInputMode"`
- Launch `hermes` and verify that plugin-injected messages with
  `visible=False` still advance the conversation without appearing as
  submitted chat in the CLI

## Tested on

- macOS
