### PR TITLE
fix: handle stale low context metadata for curated models

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1079,6 +1079,38 @@ def _model_name_suggests_kimi(model: str) -> bool:
     return lower.startswith("kimi") or "moonshot" in lower
 
 
+def _lookup_hardcoded_default_context(model: str) -> Optional[int]:
+    """Return the broad-family fallback context for *model*, if any.
+
+    ``DEFAULT_CONTEXT_LENGTHS`` intentionally uses longest-first substring
+    matching. Keep that logic in one place so early metadata/cache guards can
+    ask, "do we already have a curated fallback that proves this 32K value is
+    stale?" without duplicating the matching rules.
+    """
+    model_lower = model.lower()
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if default_model in model_lower:
+            return length
+    return None
+
+
+def _metadata_underreports_curated_model(model: str, context_length: int | None) -> bool:
+    """Return True when metadata/cache is below the floor but curated defaults are usable.
+
+    This generalizes the Kimi 32K guard: provider metadata and persisted cache
+    entries sometimes report a 32K-ish output-token limit as the full context
+    window for newly-added large-context models. When Hermes has a curated
+    family fallback at or above the minimum, prefer that over taking the bot
+    down with the 64K pre-flight guard.
+    """
+    if not isinstance(context_length, int) or context_length >= MINIMUM_CONTEXT_LENGTH:
+        return False
+    fallback = _lookup_hardcoded_default_context(model)
+    return bool(fallback and fallback >= MINIMUM_CONTEXT_LENGTH)
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx
@@ -1456,12 +1488,16 @@ def get_model_context_length(
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
-            # Invalidate stale 32k cache entries for Kimi-family models.
-            elif cached <= 32768 and _model_name_suggests_kimi(model):
+            # Invalidate stale low cache entries for curated large-context families.
+            elif _metadata_underreports_curated_model(model, cached):
                 logger.info(
-                    "Dropping stale Kimi cache entry %s@%s -> %s (OpenRouter underreport); "
-                    "re-resolving via hardcoded defaults",
-                    model, base_url, f"{cached:,}",
+                    "Dropping stale context cache entry %s@%s -> %s "
+                    "(below %s but curated fallback is %s); re-resolving",
+                    model,
+                    base_url,
+                    f"{cached:,}",
+                    f"{MINIMUM_CONTEXT_LENGTH:,}",
+                    f"{_lookup_hardcoded_default_context(model):,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
             else:
@@ -1601,12 +1637,17 @@ def get_model_context_length(
         metadata = fetch_model_metadata()
         if model in metadata:
             or_ctx = metadata[model].get("context_length", DEFAULT_FALLBACK_CONTEXT)
-            # Guard against stale OpenRouter metadata for Kimi-family models.
-            if or_ctx == 32768 and _model_name_suggests_kimi(model):
+            # Guard against stale OpenRouter metadata for curated large-context
+            # families (e.g. Kimi or Nemotron) where OpenRouter can report a
+            # 32K-ish output-token cap as the full context window.
+            if _metadata_underreports_curated_model(model, or_ctx):
                 logger.info(
                     "Rejecting OpenRouter metadata context=%s for %r "
-                    "(Kimi-family underreport); falling through to hardcoded defaults",
-                    or_ctx, model,
+                    "(below %s but curated fallback is %s); falling through",
+                    or_ctx,
+                    model,
+                    f"{MINIMUM_CONTEXT_LENGTH:,}",
+                    f"{_lookup_hardcoded_default_context(model):,}",
                 )
             else:
                 return or_ctx
@@ -1617,12 +1658,9 @@ def get_model_context_length(
     # Only check `default_model in model` (is the key a substring of the input).
     # The reverse (`model in default_model`) causes shorter names like
     # "claude-sonnet-4" to incorrectly match "claude-sonnet-4-6" and return 1M.
-    model_lower = model.lower()
-    for default_model, length in sorted(
-        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
-    ):
-        if default_model in model_lower:
-            return length
+    hardcoded_ctx = _lookup_hardcoded_default_context(model)
+    if hardcoded_ctx is not None:
+        return hardcoded_ctx
 
     # 9. Query local server as last resort
     if base_url and is_local_endpoint(base_url):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -486,6 +486,48 @@ class TestGetModelContextLength:
         assert get_model_context_length("test/model") == 32000
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_stale_openrouter_underreport_yields_curated_default(self, mock_fetch):
+        """OpenRouter can report 32K output-token caps as full context for
+        new large-context models. If a curated family fallback exists above
+        Hermes' 64K floor, the stale metadata must not brick startup.
+        """
+        mock_fetch.return_value = {
+            "nvidia/nemotron-3-120b": {"context_length": 32768}
+        }
+
+        assert get_model_context_length("nvidia/nemotron-3-120b") == 131072
+
+    def test_stale_low_cache_for_curated_model_is_invalidated(self, tmp_path, monkeypatch):
+        """Persisted 32K cache values from bad metadata must be dropped for
+        curated large-context families such as Nemotron.
+        """
+        from agent import model_metadata as mm
+        import yaml as _yaml
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://openrouter.ai/api/v1"
+        stale_key = f"nvidia/nemotron-3-120b@{base_url}"
+        other_key = f"some/model@{base_url}"
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            stale_key: 32768,
+            other_key: 32768,
+        }}))
+
+        with patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=None):
+            ctx = get_model_context_length(
+                "nvidia/nemotron-3-120b",
+                base_url=base_url,
+            )
+
+        assert ctx == 131072
+        remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
+        assert stale_key not in remaining
+        assert remaining.get(other_key) == 32768
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_fallback_to_defaults(self, mock_fetch):
         mock_fetch.return_value = {}
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000


### PR DESCRIPTION
## Summary
- generalizes the existing Kimi underreport guard to any curated large-context fallback
- invalidates stale sub-64K cache entries when a curated fallback is available
- adds Nemotron-3-120B regression coverage for issue #24140

## Test Plan
- python -m pytest tests/agent/test_model_metadata.py tests/run_agent/test_compression_feasibility.py -q

Fixes #24140