### PR TITLE
feat(gateway): expose inbound message timestamp in session context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7989,7 +7989,8 @@ class GatewayRunner:
             })
         
         # Build session context
-        context = build_session_context(source, self.config, session_entry)
+        context = build_session_context(source, self.config, session_entry,
+                                        message_timestamp=getattr(event, "timestamp", None))
         
         # Set session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -176,6 +176,7 @@ class SessionContext:
     session_id: str = ""
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    message_timestamp: Optional[datetime] = None
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -313,6 +314,10 @@ def build_session_context_prompt(
         if redact_pii:
             uid = _hash_sender_id(uid)
         lines.append(f"**User ID:** {uid}")
+
+    # Message timestamp
+    if context.message_timestamp:
+        lines.append(f"**Message time:** {context.message_timestamp.strftime('%Y-%m-%d %H:%M %Z').strip()}")
 
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
@@ -1313,21 +1318,22 @@ class SessionStore:
 def build_session_context(
     source: SessionSource,
     config: GatewayConfig,
-    session_entry: Optional[SessionEntry] = None
+    session_entry: Optional[SessionEntry] = None,
+    message_timestamp: Optional[datetime] = None,
 ) -> SessionContext:
     """
     Build a full session context from a source and config.
-    
+
     This is used to inject context into the agent's system prompt.
     """
     connected = config.get_connected_platforms()
-    
+
     home_channels = {}
     for platform in connected:
         home = config.get_home_channel(platform)
         if home:
             home_channels[platform] = home
-    
+
     context = SessionContext(
         source=source,
         connected_platforms=connected,
@@ -1337,12 +1343,13 @@ def build_session_context(
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         ),
+        message_timestamp=message_timestamp,
     )
-    
+
     if session_entry:
         context.session_key = session_entry.session_key
         context.session_id = session_entry.session_id
         context.created_at = session_entry.created_at
         context.updated_at = session_entry.updated_at
-    
+
     return context


### PR DESCRIPTION
## Summary

Threads the inbound platform event timestamp through `build_session_context()`
so the agent's system prompt includes a `**Message time:**` line.

## Motivation

Agents have no built-in way to know exactly when a user's message arrived.
They guess based on the current time at response generation, which is
misleading on async platforms (Telegram, queued cron deliveries, slow
conversations) where the gap between message-send and response-generation
can be substantial — sometimes minutes or hours.

Without the original timestamp in the system context, an agent has no
anchor for "when did the user say this?" — leading to either fabricated
times, vague hedging, or quiet errors when the agent assumes "now" equals
"when the user wrote this."

## Changes

- Add `message_timestamp: Optional[datetime]` to the `SessionContext` dataclass
- Add an optional `message_timestamp` parameter to `build_session_context()`
- Render a `**Message time:** YYYY-MM-DD HH:MM TZ` line in
  `build_session_context_prompt()` when the timestamp is present
- Thread `event.timestamp` from `GatewayRunner.run_session()` into the call
  (uses `getattr` so platforms that don't expose `timestamp` continue to work)

## Compatibility

Fully backward-compatible:

- The parameter is optional and defaults to `None`
- The prompt line only renders when a timestamp is provided
- Platforms whose events don't expose `timestamp` are unaffected
  (the `getattr(event, "timestamp", None)` lookup returns `None` safely)
- No existing test changes are required

## Test plan

- [ ] Existing session-context tests pass with no behavior change when
      `message_timestamp` is omitted
- [ ] Manual: Telegram message delivers; agent sees `**Message time:** ...`
      in its system context
- [ ] Manual: CLI message delivers; behavior matches Telegram path
- [ ] Manual: a platform whose `event` has no `timestamp` attribute still
      works without error
