### PR TITLE
fix(honcho): respect HOME-anchored default-profile fallback

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from hermes_cli.profiles import _get_default_hermes_home
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -73,7 +74,7 @@ def resolve_config_path() -> Path:
         return local_path
 
     # Default profile's config — host blocks accumulate here via setup/clone
-    default_path = Path.home() / ".hermes" / "honcho.json"
+    default_path = _get_default_hermes_home() / "honcho.json"
     if default_path != local_path and default_path.exists():
         return default_path
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -352,20 +352,23 @@ class TestResolveConfigPath:
         assert result == local_cfg
 
     def test_falls_back_to_default_profile_when_no_local(self, tmp_path, monkeypatch):
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir()
+        # Profile mode: HERMES_HOME points at ~/.hermes/profiles/<name>, so
+        # _get_default_hermes_home() must resolve back to ~/.hermes — that's
+        # the bug the HOME-anchored helper fixes (vs. blindly using Path.home()).
         fake_home = tmp_path / "fakehome"
         fake_home.mkdir()
-        default_cfg = fake_home / ".hermes" / "honcho.json"
-        default_cfg.parent.mkdir(parents=True)
+        default_home = fake_home / ".hermes"
+        profile_home = default_home / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        default_cfg = default_home / "honcho.json"
         default_cfg.write_text('{"apiKey": "default-key"}')
 
         monkeypatch.setattr(Path, "home", lambda: fake_home)
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
 
         result = resolve_config_path()
 
-        assert _get_default_hermes_home() == fake_home / ".hermes"
+        assert _get_default_hermes_home() == default_home
         assert result == default_cfg
 
     def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
@@ -390,19 +393,21 @@ class TestResolveConfigPath:
             assert resolve_config_path() == fake_home / ".honcho" / "config.json"
 
     def test_from_global_config_uses_default_profile_fallback(self, tmp_path, monkeypatch):
-        hermes_home = tmp_path / "hermes"
-        hermes_home.mkdir()
+        # Profile mode: from_global_config() reads the default-profile honcho.json
+        # via the HOME-anchored helper, not Path.home() / ".hermes".
         fake_home = tmp_path / "fakehome"
         fake_home.mkdir()
-        default_cfg = fake_home / ".hermes" / "honcho.json"
-        default_cfg.parent.mkdir(parents=True)
+        default_home = fake_home / ".hermes"
+        profile_home = default_home / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        default_cfg = default_home / "honcho.json"
         default_cfg.write_text(json.dumps({
             "apiKey": "default-key",
             "workspace": "default-ws",
         }))
 
         monkeypatch.setattr(Path, "home", lambda: fake_home)
-        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
 
         config = HonchoClientConfig.from_global_config()
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+from hermes_cli.profiles import _get_default_hermes_home
+
 import pytest
 
 from plugins.memory.honcho.client import (
@@ -349,18 +351,22 @@ class TestResolveConfigPath:
             result = resolve_config_path()
         assert result == local_cfg
 
-    def test_falls_back_to_global_when_no_local(self, tmp_path):
+    def test_falls_back_to_default_profile_when_no_local(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
-        # No honcho.json in HERMES_HOME — also isolate ~/.hermes so
-        # the default-profile fallback doesn't hit the real filesystem.
         fake_home = tmp_path / "fakehome"
         fake_home.mkdir()
+        default_cfg = fake_home / ".hermes" / "honcho.json"
+        default_cfg.parent.mkdir(parents=True)
+        default_cfg.write_text('{"apiKey": "default-key"}')
 
-        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
-             patch.object(Path, "home", return_value=fake_home):
-            result = resolve_config_path()
-        assert result == fake_home / ".honcho" / "config.json"
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = resolve_config_path()
+
+        assert _get_default_hermes_home() == fake_home / ".hermes"
+        assert result == default_cfg
 
     def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
         fake_home = tmp_path / "fakehome"
@@ -382,6 +388,26 @@ class TestResolveConfigPath:
              patch.object(Path, "home", return_value=fake_home):
             assert resolve_global_config_path() == fake_home / ".honcho" / "config.json"
             assert resolve_config_path() == fake_home / ".honcho" / "config.json"
+
+    def test_from_global_config_uses_default_profile_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        default_cfg = fake_home / ".hermes" / "honcho.json"
+        default_cfg.parent.mkdir(parents=True)
+        default_cfg.write_text(json.dumps({
+            "apiKey": "default-key",
+            "workspace": "default-ws",
+        }))
+
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = HonchoClientConfig.from_global_config()
+
+        assert config.api_key == "default-key"
+        assert config.workspace_id == "default-ws"
 
     def test_from_global_config_uses_local_path(self, tmp_path):
         hermes_home = tmp_path / "hermes"


### PR DESCRIPTION
Salvages #6173 onto current main.

## Summary
Honcho's default-profile config fallback now uses `_get_default_hermes_home()` instead of a hardcoded `Path.home() / ".hermes"`. In profile mode (`HERMES_HOME=~/.hermes/profiles/foo`) and in Docker / custom-root deployments, the previous code ignored the active root resolution and either looked at the wrong directory or silently fell through to the global `~/.honcho/config.json`.

This is the natural counterpart to #13320 (already merged), which fixed the global-path side of the same function.

## Changes
- `plugins/memory/honcho/client.py`: swap `Path.home() / ".hermes" / "honcho.json"` for `_get_default_hermes_home() / "honcho.json"` (helper already used 4 other places in the codebase).
- `tests/honcho_plugin/test_client.py`: two new regression tests — path resolution + actual `from_global_config()` loading through the default-profile fallback.

## Follow-up fix on top of contributor's commit
The contributor's tests set `HERMES_HOME` to a path outside `Path.home()/.hermes`, which forces `get_default_hermes_root()` down its Docker branch — `_get_default_hermes_home()` then returns the env var directly and never resolves to `fake_home/.hermes`. Both asserts failed.

Rewired both tests to a real profile layout (`HERMES_HOME=~/.hermes/profiles/work`) so the helper resolves back to `~/.hermes` and the default-profile fallback is actually exercised.

## Validation
`scripts/run_tests.sh tests/honcho_plugin/test_client.py -q` — 82/82 pass.

Closes #6173. Credit: @iacker — original commit authorship preserved.