### PR TITLE
fix(clipboard): normalize Wayland clipboard images to real PNG files

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -440,7 +440,8 @@ def _convert_to_png(path: Path) -> bool:
 def _is_png_file(path: Path) -> bool:
     """Return True when *path* starts with the PNG file signature."""
     try:
-        return path.read_bytes().startswith(_PNG_SIGNATURE)
+        with path.open("rb") as f:
+            return f.read(len(_PNG_SIGNATURE)) == _PNG_SIGNATURE
     except OSError:
         return False
 

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from hermes_constants import is_wsl as _is_wsl
 
 logger = logging.getLogger(__name__)
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
 def save_clipboard_image(dest: Path) -> bool:
@@ -378,10 +379,13 @@ def _wayland_save(dest: Path) -> bool:
             dest.unlink(missing_ok=True)
             return False
 
-        # BMP needs conversion to PNG (common in WSLg where only BMP
-        # is bridged from Windows clipboard via RDP).
-        if mime == "image/bmp":
-            return _convert_to_png(dest)
+        # save_clipboard_image() promises a PNG output path. Wayland can offer
+        # JPEG/GIF/WebP/BMP payloads, so normalize every non-PNG result before
+        # returning success.
+        if mime != "image/png":
+            if not _convert_to_png(dest) or not _is_png_file(dest):
+                dest.unlink(missing_ok=True)
+                return False
 
         return True
 
@@ -431,6 +435,14 @@ def _convert_to_png(path: Path) -> bool:
 
     # Can't convert — BMP is still usable as-is for most APIs
     return path.exists() and path.stat().st_size > 0
+
+
+def _is_png_file(path: Path) -> bool:
+    """Return True when *path* starts with the PNG file signature."""
+    try:
+        return path.read_bytes().startswith(_PNG_SIGNATURE)
+    except OSError:
+        return False
 
 
 # ── X11 (xclip) ─────────────────────────────────────────────────────────

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -39,6 +39,7 @@ from cli import _should_auto_attach_clipboard_image_on_paste
 
 FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
 FAKE_BMP = b"BM" + b"\x00" * 100
+FAKE_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 100
 
 
 # ═════════════════════════════════════════════════════════════════════════
@@ -393,9 +394,53 @@ class TestWaylandSave:
             if "stdout" in kw and hasattr(kw["stdout"], "write"):
                 kw["stdout"].write(FAKE_BMP)
             return MagicMock(returncode=0)
+
+        def fake_convert(path):
+            assert path == dest
+            path.write_bytes(FAKE_PNG)
+            return True
+
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+            with patch("hermes_cli.clipboard._convert_to_png", side_effect=fake_convert):
+                assert _wayland_save(dest) is True
+
+    def test_jpeg_extraction_converts_to_real_png(self, tmp_path):
+        dest = tmp_path / "out.png"
+
+        def fake_run(cmd, **kw):
+            if "--list-types" in cmd:
+                return MagicMock(stdout="image/jpeg\ntext/plain\n", returncode=0)
+            if "stdout" in kw and hasattr(kw["stdout"], "write"):
+                kw["stdout"].write(FAKE_JPEG)
+            return MagicMock(returncode=0)
+
+        def fake_convert(path):
+            assert path == dest
+            path.write_bytes(FAKE_PNG)
+            return True
+
+        with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
+            with patch("hermes_cli.clipboard._convert_to_png", side_effect=fake_convert) as mock_convert:
+                assert _wayland_save(dest) is True
+
+        mock_convert.assert_called_once_with(dest)
+        assert dest.read_bytes() == FAKE_PNG
+
+    def test_non_png_conversion_failure_cleans_up(self, tmp_path):
+        dest = tmp_path / "out.png"
+
+        def fake_run(cmd, **kw):
+            if "--list-types" in cmd:
+                return MagicMock(stdout="image/jpeg\n", returncode=0)
+            if "stdout" in kw and hasattr(kw["stdout"], "write"):
+                kw["stdout"].write(FAKE_JPEG)
+            return MagicMock(returncode=0)
+
         with patch("hermes_cli.clipboard.subprocess.run", side_effect=fake_run):
             with patch("hermes_cli.clipboard._convert_to_png", return_value=True):
-                assert _wayland_save(dest) is True
+                assert _wayland_save(dest) is False
+
+        assert not dest.exists()
 
     def test_no_image_types(self, tmp_path):
         dest = tmp_path / "out.png"


### PR DESCRIPTION
Salvages PR #6168 by @Dusk1e onto current main.

## Summary
Wayland clipboard path now normalizes ALL non-PNG image payloads (JPEG/GIF/WebP/BMP) to real PNG before returning success. Previously only BMP was converted — JPEG/GIF/WebP got written under a `.png` extension with raw non-PNG bytes, breaking downstream MIME-sensitive consumers (multimodal, image preview).

## Changes
- `hermes_cli/clipboard.py`: `_wayland_save` converts any non-PNG mime via `_convert_to_png`, verifies result with new `_is_png_file` signature check, unlinks on failure.
- `_is_png_file` reads only the 8-byte PNG signature via `open()+read(8)` instead of slurping the whole file (follow-up commit on top of the salvage).
- `tests/tools/test_clipboard.py`: JPEG conversion + cleanup-on-failure regression cases.

## Validation
`scripts/run_tests.sh tests/tools/test_clipboard.py` → 107 passed in 1.82s.

Closes #6168. Original author Dusk1e preserved on the salvage commit.