### PR TITLE
chore(release): add AUTHOR_MAP entries for 25-PR new-contributor batch

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1015,6 +1015,18 @@ AUTHOR_MAP = {
     "zhaowh3613@outlook.com": "VinceZcrikl",  # PR #23647 salvage (npm UTF-8 decode on GBK Windows)
     "anton.kuenzi@gmail.com": "ZeterMordio",  # PR #11754 salvage (zsh completion compdef + _arguments syntax)
     "23yntong@stu.edu.cn": "iuyup",  # PR #6155 salvage (shell=True hardening)
+    "86501179+1RB@users.noreply.github.com": "1RB",  # PR #25462 salvage (discord forwarded messages)
+    "44045943+ayushere@users.noreply.github.com": "ayushere",  # PR #25342 salvage (memory teardown leak)
+    "15791290+domtriola@users.noreply.github.com": "domtriola",  # PR #25424 salvage (docs tirith link)
+    "284216128+ephron-ren@users.noreply.github.com": "ephron-ren",  # PR #25358 salvage (MiMo reasoning echo-back)
+    "96843562+freqyfreqy@users.noreply.github.com": "freqyfreqy",  # PR #25423 salvage (docs LSP worktree -> repo)
+    "54306477+fu576@users.noreply.github.com": "fu576",  # PR #25369 salvage (api_mode not inherited cross-provider)
+    "258095375+kfa-ai@users.noreply.github.com": "kfa-ai",  # PR #25398 salvage (whatsapp quoted reply metadata)
+    "99181308+magic524@users.noreply.github.com": "magic524",  # PR #25361 salvage (QQBot reconnect loop)
+    "9150277+PaTTeeL@users.noreply.github.com": "PaTTeeL",  # PR #25359 salvage (custom_providers in compression length)
+    "1700913+pearjelly@users.noreply.github.com": "pearjelly",  # PR #25388 salvage (feishu ws connect override sync)
+    "100820567+raymaylee@users.noreply.github.com": "raymaylee",  # PR #25394 salvage (context compaction status)
+    "122434621+Tianyu199509@users.noreply.github.com": "Tianyu199509",  # PR #25421 salvage (gateway PID Windows)
 }
 
 


### PR DESCRIPTION
Pre-stages AUTHOR_MAP for 12 new contributors whose PRs are being salvaged in this batch. Lands first so the follow-up salvage PRs don't get blocked by AUTHOR_MAP CI.

Contributors:
- 1RB (#25462)
- ayushere (#25342)
- domtriola (#25424)
- ephron-ren (#25358)
- freqyfreqy (#25423)
- fu576 (#25369)
- kfa-ai (#25398)
- magic524 (#25361)
- PaTTeeL (#25359)
- pearjelly (#25388)
- raymaylee (#25394)
- Tianyu199509 (#25421)