### PR TITLE
fix(agent): add Xiaomi MiMo to reasoning_content echo-back providers (#25358)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10049,11 +10049,12 @@ class AIAgent:
 
         DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
         of assistant tool-call messages that omit ``reasoning_content`` (refs
-        #15250, #17400).
+        #15250, #17400). Xiaomi MiMo thinking mode has the same requirement.
         """
         return (
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
+            or self._needs_mimo_tool_reasoning()
         )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
@@ -10083,6 +10084,22 @@ class AIAgent:
             provider == "deepseek"
             or "deepseek" in model
             or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+    def _needs_mimo_tool_reasoning(self) -> bool:
+        """Return True when the current provider is Xiaomi MiMo thinking mode.
+
+        MiMo thinking mode requires ``reasoning_content`` on every assistant
+        tool-call message when replaying history; omitting it causes HTTP 400.
+        Refs: https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content
+        """
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "xiaomi"
+            or "mimo" in model
+            or base_url_host_matches(self.base_url, "api.xiaomimimo.com")
+            or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:


### PR DESCRIPTION
Xiaomi MiMo emits reasoning via OpenAI's `reasoning_content` field and requires it on every assistant tool-call message when replaying history. Without echo-back, subsequent API calls fail with HTTP 400 — same shape as DeepSeek and Kimi/Moonshot thinking modes (refs #15250, #17400).

Adds `_needs_mimo_tool_reasoning()` detection (provider == 'xiaomi', 'mimo' in model, or xiaomimimo.com base url) and wires it into the `_needs_thinking_reasoning_pad()` check.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25358 by @ephron-ren. Manually re-applied — original branch was severely stale against current main (130k+ deletions would have inverse-reverted unrelated work).