### PR TITLE
fix(gateway): PID detection fails on Windows — two issues (#25421)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -128,6 +128,7 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
 
     On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
     platforms without /proc, falls back to ``ps -p <pid> -o command=``.
+    On Windows (no /proc, no ps), uses psutil.
     """
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
@@ -148,6 +149,16 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    # Windows fallback: psutil (already used by _pid_exists)
+    try:
+        import psutil  # type: ignore
+        proc = psutil.Process(pid)
+        cmdline_parts = proc.cmdline()
+        if cmdline_parts:
+            return " ".join(cmdline_parts)
+    except Exception:
         pass
 
     return None
@@ -178,7 +189,8 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
     if not isinstance(argv, list) or not argv:
         return False
 
-    cmdline = " ".join(str(part) for part in argv)
+    # Normalize Windows backslashes so patterns match cross-platform.
+    cmdline = " ".join(str(part) for part in argv).replace("\\", "/")
     patterns = (
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",


### PR DESCRIPTION
Two Windows-specific bugs in gateway PID detection:

1. `_read_process_cmdline` had no psutil fallback path for Windows
   (only `/proc` and POSIX `ps`) — always returned empty on Win.
2. `_record_looks_like_gateway` didn't normalize backslashes in path
   matching, so Windows-style `C:\Users\…\hermes_cli\main.py` paths
   never matched.

Both fixes are minimal and Windows-gated.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25421 by @Tianyu199509.