### PR TITLE
fix(agent): emit context compaction status (#25394)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10341,6 +10341,9 @@ class AIAgent:
             f"{approx_tokens:,}" if approx_tokens else "unknown", self.model,
             focus_topic,
         )
+        self._emit_status(
+            "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+        )
 
         # Notify external memory provider before compression discards context
         if self._memory_manager:

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -415,6 +415,32 @@ class TestHTTP413Compression:
 class TestPreflightCompression:
     """Preflight compression should compress history before the first API call."""
 
+    def test_compress_context_emits_lifecycle_status_before_work(self, agent):
+        """Direct context compression should tell gateway users why the turn paused."""
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            compressed, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+        assert new_system_prompt == "new system prompt"
+        assert events[0][0] == "lifecycle"
+        assert "Compacting context" in events[0][1]
+        assert events[1] == ("compress", "started")
+
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True


### PR DESCRIPTION
When a session enters context compaction, the gateway previously had no signal — users saw the agent freeze for tens of seconds with no explanation.

Adds a single `_emit_status` call before compression starts so platforms can surface 'Compacting context...' before the operation begins. Regression test included.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25394 by @raymaylee.