### PR TITLE
fix(gateway): make Feishu ws connect override sync to preserve context manager (#25388)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1300,12 +1300,12 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    async def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
         if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
+        return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:


### PR DESCRIPTION
The Feishu adapter wraps lark-oapi's `Connect()` callable to inject `ping_interval`/`ping_timeout` overrides, but the wrapper was async. The underlying library uses `Connect()` as an async context manager (`async with Connect(...) as ws:`), which requires the call itself to be sync and return an AsyncContextManager — making it async meant the wrapper was awaited eagerly and `ws` never bound.

Restoring the sync wrapper preserves the protocol while still injecting the overrides.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25388 by @pearjelly. Manually re-applied — original branch was severely stale against current main.