### PR TITLE
fix(auxiliary): forward custom_providers to compression model context-length detection (#25359)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2204,6 +2204,10 @@ class AIAgent:
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
 
+        # Store for reuse by _check_compression_model_feasibility (auxiliary
+        # compression model context-length detection needs the same list).
+        self._custom_providers = _custom_providers
+
         # Check custom_providers per-model context_length
         if _config_context_length is None and _custom_providers:
             try:
@@ -3246,6 +3250,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=self._custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least


### PR DESCRIPTION
`get_model_context_length` accepts `custom_providers` (so users with custom provider configs get correct context-length resolution), but `_check_compression_model_feasibility` was calling it without passing custom_providers — so users on custom providers got wrong context-length values for compression decisions.

5-line forward fix.

Salvage of https://github.com/NousResearch/hermes-agent/pull/25359 by @PaTTeeL.